### PR TITLE
fix for keyboard sometimes not showing up in the Android WebBrowser

### DIFF
--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -3263,7 +3263,7 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
         @Override
         protected void initComponent() {
             super.initComponent();
-			blockNativeFocus(false);
+            blockNativeFocus(false);
             setPeerImage(null);
         }
         

--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -3263,6 +3263,7 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
         @Override
         protected void initComponent() {
             super.initComponent();
+			blockNativeFocus(false);
             setPeerImage(null);
         }
         


### PR DESCRIPTION
this will fix the issue that sometimes keyboard doesn't show up if a text input is selected.

This only occured if the WebBrowser component was initialized before it got focused. 
In this case the AndroidPeer is blocking the focusability of its descendents, which includes the WebView.

This should fix the issue #812 
And propably the problems described in the threads: https://groups.google.com/forum/?hl=en#!topic/codenameone-discussions/6bnQoaQeSgY
and 
https://groups.google.com/forum/?hl=en#!topic/codenameone-discussions/Ni628RJmTOw/aK3EjzPJ8bgJ
