### PR TITLE
IOS Translator improvements (

### DIFF
--- a/CodenameOne/src/com/codename1/ui/TextArea.java
+++ b/CodenameOne/src/com/codename1/ui/TextArea.java
@@ -781,6 +781,7 @@ public class TextArea extends Component {
                 return;
             }
         }
+        System.out.println("Test5");
         Style style = getUnselectedStyle();
         rowStrings= new ArrayList();
         widthForRowCalculations = getWidth() - style.getPadding(false, RIGHT) - style.getPadding(false, LEFT);

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeClass.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeClass.java
@@ -86,6 +86,9 @@ public class ByteCodeClass {
     }
 
     public static void markDependencies(List<ByteCodeClass> lst) {
+        if (mainClass == null) {
+            throw new RuntimeException("Missing main class..");
+        }
         mainClass.markDependent(lst);
         for(ByteCodeClass bc : lst) {
             if(bc.clsName.equals("java_lang_Boolean")) {
@@ -1522,5 +1525,8 @@ public class ByteCodeClass {
         return usedByNative;
     }
 
-    
+    @Override
+    public String toString() {
+        return "[ByteCodeClass "+clsName+"]";
+    }
 }

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeTranslator.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeTranslator.java
@@ -204,7 +204,7 @@ public class ByteCodeTranslator {
 
             Parser.writeOutput(srcRoot);
             
-            File templateInfoPlist = new File(srcRoot, appName + "-Info.plist");
+            File templateInfoPlist = new File(srcRoot, appName + "-Info.plist" + PreservingFileOutputStream.NEW_SUFFIX);
             copy(ByteCodeTranslator.class.getResourceAsStream("/template/template/template-Info.plist"), new FileOutputStream(templateInfoPlist));
             
             File templatePch = new File(srcRoot, appName + "-Prefix.pch");
@@ -213,12 +213,12 @@ public class ByteCodeTranslator {
             File xmlvm = new File(srcRoot, "xmlvm.h");
             copy(ByteCodeTranslator.class.getResourceAsStream("/xmlvm.h"), new FileOutputStream(xmlvm));
             
-            File projectWorkspaceData = new File(projectXCworkspace, "contents.xcworkspacedata");
+            File projectWorkspaceData = new File(projectXCworkspace, "contents.xcworkspacedata"+ PreservingFileOutputStream.NEW_SUFFIX);
             copy(ByteCodeTranslator.class.getResourceAsStream("/template/template.xcodeproj/project.xcworkspace/contents.xcworkspacedata"), new FileOutputStream(projectWorkspaceData));
             replaceInFile(projectWorkspaceData, "KitchenSink", appName);
             
             
-            File projectPbx = new File(xcproj, "project.pbxproj");
+            File projectPbx = new File(xcproj, "project.pbxproj"+ PreservingFileOutputStream.NEW_SUFFIX);
             copy(ByteCodeTranslator.class.getResourceAsStream("/template/template.xcodeproj/project.pbxproj"), new FileOutputStream(projectPbx));            
             
             String[] sourceFiles = srcRoot.list(new FilenameFilter() {
@@ -278,6 +278,11 @@ public class ByteCodeTranslator {
             arr.addAll(Arrays.asList(sourceFiles));
             
             for(String file : arr) {
+                if (file.endsWith(PreservingFileOutputStream.NEW_SUFFIX)) {
+                    file = file.substring(0, file.length()-PreservingFileOutputStream.NEW_SUFFIX.length());
+                } else {
+                    if (arr.contains(file + PreservingFileOutputStream.NEW_SUFFIX)) continue;   // remove duplicates
+                }
                 fileListEntry.append("		0");
                 currentValue++;
                 String fileOneValue = Integer.toHexString(currentValue).toUpperCase();
@@ -418,6 +423,9 @@ public class ByteCodeTranslator {
 
             String bundleVersion = System.getProperty("bundleVersionNumber", appVersion);
             replaceInFile(templateInfoPlist, "com.codename1pkg", appPackageName, "${PRODUCT_NAME}", appDisplayName, "VERSION_VALUE", appVersion, "VERSION_BUNDLE_VALUE", bundleVersion);
+            PreservingFileOutputStream.finishWithNewFile(projectPbx);
+            PreservingFileOutputStream.finishWithNewFile(templateInfoPlist);
+            PreservingFileOutputStream.finishWithNewFile(projectWorkspaceData);
         } else {
             b.execute(sources, dest);
             Parser.writeOutput(dest);

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
@@ -824,7 +824,12 @@ public class BytecodeMethod {
     }
     
     public void addLabel(Label l) {
-        addInstruction(new com.codename1.tools.translator.bytecodes.LabelInstruction(l));
+        addInstruction(new com.codename1.tools.translator.bytecodes.LabelInstruction(l) {
+            @Override
+            public String toString() {
+                return "BL_"+clsName+"__"+methodName+"__"+instructions.size();
+            }
+        });
     }
     
     public void addInvoke(int opcode, String owner, String name, String desc, boolean itf) {

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/Parser.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/Parser.java
@@ -398,32 +398,33 @@ public class Parser extends ClassVisitor {
                 }
                 bc.setBaseInterfacesObject(lst);
             }
-            System.out.println("Iterate second..");
+            if(ByteCodeTranslator.verbose) System.out.println("Iterate second..");
             for(ByteCodeClass bc : classes) {
                 file = bc.getClsName();
                 bc.updateAllDependencies();
             }
-            System.out.println("Mark deps..");
+            if(ByteCodeTranslator.verbose) System.out.println("Mark deps..");
             ByteCodeClass.markDependencies(classes);
             classes = ByteCodeClass.clearUnmarked(classes);
 
             // load the native sources (including user native code) 
-            System.out.println("Load natives..");
+            if(ByteCodeTranslator.verbose) System.out.println("Load natives..");
             readNativeFiles(outputDirectory);
 
             // loop over methods and start eliminating the body of unused methods
-            //System.out.println("Eliminate unused..");
-            //eliminateUnusedMethods();
+            if(ByteCodeTranslator.verbose) System.out.println("Eliminate unused..");
+            if (!ByteCodeTranslator.draft)
+                eliminateUnusedMethods();
 
-            System.out.println("Generate common header..");
+            if(ByteCodeTranslator.verbose) System.out.println("Generate common header..");
             generateClassAndMethodIndexHeader(outputDirectory);
-            System.out.println("Generate all classes..");
+            if(ByteCodeTranslator.verbose) System.out.println("Generate all classes..");
             for(ByteCodeClass bc : classes) {
                 file = bc.getClsName();
                 writeFile(bc.getClsName(), bc, outputDirectory);
             }
             int created = PreservingFileOutputStream.total - PreservingFileOutputStream.preserved;
-            System.out.println("Updated/created: "+created+" files");
+            if(ByteCodeTranslator.verbose) System.out.println("Updated/created: "+created+" files");
         } catch(Throwable t) {
             System.out.println("Error while working with the class: " + file);
             t.printStackTrace();

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/PreservingFileOutputStream.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/PreservingFileOutputStream.java
@@ -1,0 +1,101 @@
+package com.codename1.tools.translator;
+
+import java.io.*;
+import java.util.Arrays;
+
+/**
+ * Created by admin on 8/17/15.
+ */
+public class PreservingFileOutputStream extends OutputStream {
+
+    final public static String NEW_SUFFIX = ".new_by_translator";
+
+    static int total;
+    static int preserved;
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    File file;
+
+    public PreservingFileOutputStream(File file) throws FileNotFoundException {
+        this.file = file;
+        total++;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        baos.write(b);
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (file.exists() && file.length() == baos.size()) {
+            byte[] oldCopy = new byte[baos.size()];
+            FileInputStream fis = new FileInputStream(file);
+            fis.read(oldCopy);
+            fis.close();
+            final byte[] thisCopy = baos.toByteArray();
+            boolean equal = true;
+            for (int i = 0; i < thisCopy.length; i++) {
+                if (thisCopy[i] != oldCopy[i]) {
+                    equal = false;
+                    break;
+                }
+            }
+            if (equal) {
+                preserved++;
+                return;
+            }
+        }
+        if(ByteCodeTranslator.verbose) {
+            System.out.println("Producing: " + file.getName());
+        }
+        FileOutputStream x = new FileOutputStream(file);
+        baos.writeTo(x);
+        x.close();
+    }
+
+
+    /**
+     * move temporary created file to its final destination. If final destination doesn't differ from
+     * new file, do nothing (remove new file), thus keeping timestamps.
+     */
+    public static boolean preservingMove(File from, File to) throws IOException {
+        if (from.exists() && to.exists() && to.length() == from.length()) {
+            byte[] thisCopy = new byte[(int)from.length()];
+            FileInputStream fis = new FileInputStream(from);
+            fis.read(thisCopy);
+            fis.close();
+
+            byte[] oldCopy = new byte[(int)to.length()];
+            fis = new FileInputStream(to);
+            fis.read(oldCopy);
+            fis.close();
+
+            boolean equal = true;
+            for (int i = 0; i < thisCopy.length; i++) {
+                if (thisCopy[i] != thisCopy[i]) {
+                    equal = false;
+                    break;
+                }
+            }
+
+            if (equal) {
+                // preserve
+                return from.delete();   // keep old
+            }
+        }
+        if(ByteCodeTranslator.verbose) {
+            System.out.println("Producing: " + to.getName());
+        }
+        return to.delete() && from.renameTo(to);
+    }
+
+    public static boolean finishWithNewFile(File newFile) throws IOException {
+        String path = newFile.getPath();
+        if (path.endsWith(NEW_SUFFIX)) {
+            String finalDestination = path.substring(0, path.length() - NEW_SUFFIX.length());
+            return preservingMove(newFile, new File(finalDestination));
+        }
+        return true;    // not a new file
+    }
+}

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/PreservingFileOutputStream.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/PreservingFileOutputStream.java
@@ -87,7 +87,8 @@ public class PreservingFileOutputStream extends OutputStream {
         if(ByteCodeTranslator.verbose) {
             System.out.println("Producing: " + to.getName());
         }
-        return to.delete() && from.renameTo(to);
+        to.delete();
+        return from.renameTo(to);
     }
 
     public static boolean finishWithNewFile(File newFile) throws IOException {

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/PreservingFileOutputStream.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/PreservingFileOutputStream.java
@@ -2,6 +2,7 @@ package com.codename1.tools.translator;
 
 import java.io.*;
 import java.util.Arrays;
+import java.util.HashSet;
 
 /**
  * Created by admin on 8/17/15.
@@ -12,9 +13,11 @@ public class PreservingFileOutputStream extends OutputStream {
 
     static int total;
     static int preserved;
+    boolean equal;
 
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     File file;
+
 
     public PreservingFileOutputStream(File file) throws FileNotFoundException {
         this.file = file;
@@ -28,13 +31,14 @@ public class PreservingFileOutputStream extends OutputStream {
 
     @Override
     public void close() throws IOException {
+        equal = false;
         if (file.exists() && file.length() == baos.size()) {
             byte[] oldCopy = new byte[baos.size()];
             FileInputStream fis = new FileInputStream(file);
             fis.read(oldCopy);
             fis.close();
             final byte[] thisCopy = baos.toByteArray();
-            boolean equal = true;
+            equal = true;
             for (int i = 0; i < thisCopy.length; i++) {
                 if (thisCopy[i] != oldCopy[i]) {
                     equal = false;
@@ -46,9 +50,7 @@ public class PreservingFileOutputStream extends OutputStream {
                 return;
             }
         }
-        if(ByteCodeTranslator.verbose) {
-            System.out.println("Producing: " + file.getName());
-        }
+        System.out.println("Producing(stream): " + file.getName());
         FileOutputStream x = new FileOutputStream(file);
         baos.writeTo(x);
         x.close();
@@ -85,7 +87,7 @@ public class PreservingFileOutputStream extends OutputStream {
             }
         }
         if(ByteCodeTranslator.verbose) {
-            System.out.println("Producing: " + to.getName());
+            System.out.println("Producing(move): " + to.getName());
         }
         to.delete();
         return from.renameTo(to);

--- a/vm/ByteCodeTranslator/src/template/template/template-Info.plist
+++ b/vm/ByteCodeTranslator/src/template/template/template-Info.plist
@@ -50,5 +50,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+    <key>UIAppFonts</key>
+    <array>${APP_FONTS}</array>
 </dict>
 </plist>


### PR DESCRIPTION
These changes are for the local workflow with the IOS ByteCode generator.
Initially, if you ran codegen several times, it produced different results, causing XCode to reparse and recompile lots of objc dode. This happened due to the 1) timestamp modifications 2) assembler labels to depend on JVM hashcode() which is random each time.
This pull request contains following changes:
1) it offers PreservingOutputStream (drop-in replacement for FileOutputStream) which preserves timestamps if content did not change
2) for template-based files, where in-file replacements are made, it initially creates file with suffix ".new", then it replaces it to original file name, keeping timestamp if content is equal to existing one.
3) for labels, it overrides toString() adding integer sequences local to the classname, thus producting stable results each time.
 
Also pull request contains auto-generation of UIAppFonts array in -Info.plist file, because TTF file dropped into src dir did not work for me without this entry.

Also pull request contains .verbose and .draft flags of codegen taken from from System properties. "draft" flag (new) skips unused methods elimination, because for iterative development, it consumes biggest part of CPU time, and reduces generated objc linecount only by few percents (bug?)

Of course, default behaviour of flags is unchanged.

