### PR TITLE
Added native android tiling support

### DIFF
--- a/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
+++ b/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
@@ -1541,6 +1541,7 @@ public abstract class CodenameOneImplementation {
         int clipW = getClipWidth(graphics);
         int clipY = getClipY(graphics);
         int clipH = getClipHeight(graphics);
+        clipRect(graphics, x, y, w, h);
         for (int xPos = 0; xPos <= w; xPos += iW) {
             for (int yPos = 0; yPos < h; yPos += iH) {
                 int actualX = xPos + x;
@@ -1560,6 +1561,7 @@ public abstract class CodenameOneImplementation {
                 drawImage(graphics, img, actualX, actualY);
             }
         }
+        setClip(graphics, clipX, clipY, clipW, clipH);
         
     }
 

--- a/CodenameOne/src/com/codename1/ui/plaf/Border.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/Border.java
@@ -1161,10 +1161,6 @@ public class Border {
                 }
                 break;
             case TYPE_IMAGE: {
-                int clipX = g.getClipX();
-                int clipY = g.getClipY();
-                int clipWidth = g.getClipWidth();
-                int clipHeight = g.getClipHeight();
                 Image topLeft = images[4]; 
                 Image topRight = images[5];
                 Image bottomLeft = images[6];
@@ -1173,16 +1169,13 @@ public class Border {
                 y += topLeft.getHeight();
                 height -= (topLeft.getHeight() + bottomLeft.getHeight());
                 width -= (topLeft.getWidth() + topRight.getWidth());
-                g.clipRect(x, y, width, height);
                 if(center != null){
                     g.tileImage(center, x, y, width, height);
                 }
                 Image top = images[0];  Image bottom = images[1];
                 Image left = images[2]; Image right = images[3];
                 Image bottomRight = images[7];
-                
-                setClipScaled(g, clipX, clipY, clipWidth, clipHeight);
-                
+                                
                 x = xParameter;
                 y = yParameter;
                 width = widthParameter;
@@ -1230,16 +1223,11 @@ public class Border {
                     }
                 }
 
-                setClipScaled(g, clipX, clipY, clipWidth, clipHeight);
                 drawImageBorderLine(g, topLeft, topRight, top, x, y, width, arrowUpImage, arrowPosition, false);
-                setClipScaled(g, clipX, clipY, clipWidth, clipHeight);
                 drawImageBorderLine(g, bottomLeft, bottomRight, bottom, x, y + height - bottom.getHeight(), width, arrowDownImage, arrowPosition, true);
-                setClipScaled(g, clipX, clipY, clipWidth, clipHeight);
                 drawImageBorderColumn(g, topLeft, bottomLeft, left, x, y, height, arrowLeftImage, arrowPosition, false);
-                setClipScaled(g, clipX, clipY, clipWidth, clipHeight);
                 drawImageBorderColumn(g, topRight, bottomRight, right, x + width - right.getWidth(), y, height, arrowRightImage, arrowPosition, true);
                                 
-                g.setClip(clipX, clipY, clipWidth, clipHeight);
                 break;
             }
             case TYPE_IMAGE_SCALED: {
@@ -1289,11 +1277,6 @@ public class Border {
                 break;
             }
             case TYPE_IMAGE_HORIZONTAL: {
-                int clipX = g.getClipX();
-                int clipY = g.getClipY();
-                int clipWidth = g.getClipWidth();
-                int clipHeight = g.getClipHeight();
-                //g.pushClip();
                 Image left = images[0];
                 Image right = images[1];
                 Image center = images[2];
@@ -1304,37 +1287,16 @@ public class Border {
 
                 g.drawImage(left, x, y);
                 g.drawImage(right, x + width - right.getWidth(), y);
-                x += left.getWidth();
-                width -= (left.getWidth() + right.getWidth());
-                g.clipRect(x, y, width, height);
-                int centerWidth = center.getWidth();
-                for(int xCount = x ; xCount < x + width ; xCount += centerWidth) {
-                    g.drawImage(center, xCount, y);
-                }
-                g.setClip(clipX, clipY, clipWidth, clipHeight);
-                //g.popClip();
+                g.tileImage(center, x + left.getWidth(), y, width - left.getWidth() - right.getWidth(), height);
                 break;
             }
             case TYPE_IMAGE_VERTICAL: {
-                int clipX = g.getClipX();
-                int clipY = g.getClipY();
-                int clipWidth = g.getClipWidth();
-                int clipHeight = g.getClipHeight();
-                //g.pushClip();
                 Image top = images[0];
                 Image bottom = images[1];
                 Image center = images[2];
                 g.drawImage(top, x, y);
                 g.drawImage(bottom, x, y + height - bottom.getHeight());
-                y += top.getHeight();
-                height -= (top.getHeight() + bottom.getHeight());
-                g.clipRect(x, y, width, height);
-                int centerHeight = center.getHeight();
-                for(int yCount = y ; yCount < y + height ; yCount += centerHeight) {
-                    g.drawImage(center, x, yCount);
-                }
-                g.setClip(clipX, clipY, clipWidth, clipHeight);
-                //g.popClip();
+                g.tileImage(center, x, y + top.getHeight(), width, height - top.getHeight() - bottom.getHeight());
                 break;
             }
         }
@@ -1669,66 +1631,31 @@ public class Border {
     }
     
     private void drawImageBorderLine(Graphics g, Image left, Image right, Image center, final int x, int y, int width, Image arrow, int imagePosition, boolean farEdge) {
-        int currentWidth = width - right.getWidth();
-        if(currentWidth > 0) {
-            int currentX = x;
-            currentX += left.getWidth();
-            int cx = g.getClipX();
-            int cy = g.getClipY();
-            int cw = g.getClipWidth();
-            int ch = g.getClipHeight();
-            //g.pushClip();
-            g.clipRect(currentX, y, currentWidth - left.getWidth(), center.getHeight());
+        if(width - right.getWidth() > 0) {
+            g.tileImage(center, x + left.getWidth(), y, width - right.getWidth() - left.getWidth(), center.getHeight());
             if(arrow != null) {
-                int destX = currentX + currentWidth;
-                int centerWidth = center.getWidth();
-                for(; currentX < destX ; currentX += centerWidth) {
-                    g.drawImage(center, currentX, y);
-                }
                 imagePosition = Math.max(imagePosition, left.getWidth());
-                imagePosition = Math.min(imagePosition, destX - x - arrow.getWidth() - right.getWidth());
-                g.setClip(cx, cy, cw, ch);
-                //g.popClip();
+                imagePosition = Math.min(imagePosition, width - arrow.getWidth() - right.getWidth());
                 if(farEdge) {
                     g.drawImage(arrow, x + imagePosition, y + center.getHeight() - arrow.getHeight());
                 } else {
                     g.drawImage(arrow, x + imagePosition, y);
                 }
-            } else {
-                g.tileImage(center, currentX, y, currentWidth, center.getHeight());
-                //g.popClip();
             }
         }
     }
 
     private void drawImageBorderColumn(Graphics g, Image top, Image bottom, Image center, int x, final int y, int height, Image arrow, int imagePosition, boolean farEdge) {
-        int currentHeight = height - bottom.getHeight();
-        if(currentHeight > 0) {
-            int currentY = y + top.getHeight();
-            int cx = g.getClipX();
-            int cy = g.getClipY();
-            int cw = g.getClipWidth();
-            int ch = g.getClipHeight();
-            //g.pushClip();
-            g.clipRect(x, currentY, center.getWidth(), currentHeight - top.getHeight());
+        if(height - bottom.getHeight() > 0) {
+            g.tileImage(center, x, y + top.getHeight(), center.getWidth(), height - top.getHeight() - bottom.getHeight());
             if(arrow != null) {
-                int destY = currentY + currentHeight;
-                int centerHeight = center.getHeight();
-                for(; currentY < destY ; currentY += centerHeight) {
-                    g.drawImage(center, x, currentY);
-                }
                 imagePosition = Math.max(imagePosition, top.getHeight());
-                imagePosition = Math.min(imagePosition, destY - y - arrow.getHeight() - bottom.getHeight());
-                g.setClip(cx, cy, cw, ch);
-                //g.popClip();
+                imagePosition = Math.min(imagePosition, height - arrow.getHeight() - bottom.getHeight());
                 if(farEdge) {
                     g.drawImage(arrow, x + center.getWidth() - arrow.getWidth(), y + imagePosition);
                 } else {
                     g.drawImage(arrow, x, y + imagePosition);
                 }
-            } else {
-                g.tileImage(center, x, currentY, center.getWidth(), currentHeight);
-                //g.popClip();
             }
         } 
     }

--- a/Ports/Android/src/com/codename1/impl/android/AndroidAsyncView.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidAsyncView.java
@@ -541,6 +541,21 @@ public class AndroidAsyncView extends View implements CodenameOneSurface {
         }
 
         @Override
+        public void tileImage(final Object img, final int x, final int y, final int w, final int h) {
+            final int alph = alpha;
+            pendingRenderingOperations.add(new AsyncOp(clip) {
+                @Override
+                public void execute(AndroidGraphics underlying) {
+                    Paint p = underlying.getPaint();
+                    underlying.setPaint(imagePaint);
+                    imagePaint.setAlpha(alph);
+                    underlying.tileImage(img, x, y, w, h);
+                    underlying.setPaint(p);
+                }
+            });
+        }
+                
+        @Override
         public void drawImage(final Object img, final int x, final int y, final int w, final int h) {
             final int alph = alpha;
             pendingRenderingOperations.add(new AsyncOp(clip) {

--- a/Ports/Android/src/com/codename1/impl/android/AndroidGraphics.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidGraphics.java
@@ -43,6 +43,7 @@ package com.codename1.impl.android;
 
 
 import android.graphics.Bitmap;
+import android.graphics.BitmapShader;
 import android.graphics.Canvas;
 import android.graphics.Matrix;
 import android.graphics.Paint;
@@ -52,6 +53,7 @@ import android.graphics.PorterDuffXfermode;
 import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.Region;
+import android.graphics.Shader;
 import com.codename1.ui.Stroke;
 
 import com.codename1.ui.Transform;
@@ -147,6 +149,24 @@ class AndroidGraphics {
         canvas.restore();
     }
 
+    void tileImage(Object img, int x, int y, int w, int h) {
+        Bitmap b = (Bitmap) img;
+        Rect dest = new Rect();
+        dest.top = 0;
+        dest.bottom = h;
+        dest.left = 0;
+        dest.right = w;
+        BitmapShader shader = new BitmapShader(b, Shader.TileMode.REPEAT, Shader.TileMode.REPEAT);
+        Paint tilePainter = new Paint(paint);
+        tilePainter.setShader(shader);
+        tilePainter.setAntiAlias(false);
+        canvas.save();
+        canvas.translate(x, y);
+        canvas.concat(getTransformMatrix());
+        canvas.drawRect(dest, tilePainter);
+        canvas.restore();
+    }
+    
     private Matrix getTransformMatrix(){
         if ( transformDirty ){
         	// Conversion from 4x4 to 3x3
@@ -478,5 +498,5 @@ class AndroidGraphics {
     public Transform getTransform() {
         return transform;
     }
-    
+
 }

--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -1399,6 +1399,11 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
     }
 
     @Override
+    public void tileImage(Object graphics, Object img, int x, int y, int w, int h) {
+        ((AndroidGraphics) graphics).tileImage(img, x, y, w, h);
+    }
+
+    @Override
     public void drawLine(Object graphics, int x1, int y1, int x2, int y2) {
         ((AndroidGraphics) graphics).drawLine(x1, y1, x2, y2);
     }


### PR DESCRIPTION
Border now uses the implementation tiling support
Default drawTile now deals with its own limits, no need to clip rect outside

PS: didn't have a use case for image border with an arrow here, please, double check this before merging. Also, please double check this with iOS just to be sure, couldn't test it here. I've also noticed it fixed the sidemenu covering the shadow.

PS2: android native tiling is fast :+1: 