### PR TITLE
fixed multipart utf8 string (fails on android)

### DIFF
--- a/CodenameOne/src/com/codename1/io/MultipartRequest.java
+++ b/CodenameOne/src/com/codename1/io/MultipartRequest.java
@@ -189,7 +189,7 @@ public class MultipartRequest extends ConnectionRequest {
                 length += baseTextLength;
                 length += key.length();
                 if(ignoreEncoding.contains(key)) {
-                    length += ((String)value).length(); 
+                    length += value.toString().getBytes().length; 
                 } else {
                     length += Util.encodeBody((String)value).length();
                 }

--- a/CodenameOne/src/com/codename1/io/MultipartRequest.java
+++ b/CodenameOne/src/com/codename1/io/MultipartRequest.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.util.Enumeration;
 import java.util.Hashtable;
@@ -189,7 +190,11 @@ public class MultipartRequest extends ConnectionRequest {
                 length += baseTextLength;
                 length += key.length();
                 if(ignoreEncoding.contains(key)) {
-                    length += value.toString().getBytes().length; 
+                    try {
+                        length += value.toString().getBytes("UTF-8").length;
+                    } catch (UnsupportedEncodingException ex) {
+                        length += value.toString().getBytes().length;
+                    }
                 } else {
                     length += Util.encodeBody((String)value).length();
                 }


### PR DESCRIPTION
There is a problem with special characters when creating a multipart request in Android at least, the string length of special characters is not the same as byte length. I've noticed it does not fail in the simulator but does fail in Android.

Ex.: addArgumentNoEncoding("city", "São Paulo");