### PR TITLE
Fix an additional error loop in the VM socket implementation

### DIFF
--- a/Ports/Android/src/com/codename1/impl/android/AndroidAsyncView.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidAsyncView.java
@@ -735,14 +735,16 @@ public class AndroidAsyncView extends View implements CodenameOneSurface {
              });*/
         }
 
+        private CodenameOneTextPaint font;
+
         @Override
         void setFont(final CodenameOneTextPaint font) {
-            super.setFont(font);
+            this.font = font;
         }
 
         @Override
         Paint getFont() {
-            return super.getFont();
+            return font;
         }
 
         @Override

--- a/Ports/Android/src/com/codename1/impl/android/AndroidAsyncView.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidAsyncView.java
@@ -438,9 +438,11 @@ public class AndroidAsyncView extends View implements CodenameOneSurface {
             if (alpha == 0) {
                 return;
             }
+            final int al = alpha;
             pendingRenderingOperations.add(new AsyncOp(clip) {
                 @Override
                 public void execute(AndroidGraphics underlying) {
+                    underlying.setAlpha(al);
                     underlying.fillLinearGradient(startColor, endColor, x, y, width, height, horizontal);
                 }
             });
@@ -452,9 +454,11 @@ public class AndroidAsyncView extends View implements CodenameOneSurface {
             if (alpha == 0) {
                 return;
             }
+            final int al = alpha;
             pendingRenderingOperations.add(new AsyncOp(clip) {
                 @Override
                 public void execute(AndroidGraphics underlying) {
+                    underlying.setAlpha(al);
                     underlying.fillRectRadialGradient(startColor, endColor, x, y, width, height, relativeX, relativeY, relativeSize);
                 }
             });
@@ -465,9 +469,11 @@ public class AndroidAsyncView extends View implements CodenameOneSurface {
             if (alpha == 0) {
                 return;
             }
+            final int al = alpha;
             pendingRenderingOperations.add(new AsyncOp(clip) {
                 @Override
                 public void execute(AndroidGraphics underlying) {
+                    underlying.setAlpha(al);
                     underlying.fillRadialGradient(startColor, endColor, x, y, width, height);
                 }
             });
@@ -478,9 +484,11 @@ public class AndroidAsyncView extends View implements CodenameOneSurface {
             if (alpha == 0 || width <= 0 || height <= 0) {
                 return;
             }
+            final int al = alpha;
             pendingRenderingOperations.add(new AsyncOp(clip) {
                 @Override
                 public void execute(AndroidGraphics underlying) {
+                    underlying.setAlpha(al);
                     underlying.paintComponentBackground(x, y, width, height, s);
                 }
             });
@@ -495,9 +503,11 @@ public class AndroidAsyncView extends View implements CodenameOneSurface {
             } else {
                 clip = clip.intersection(cmpX, cmpY, cmpWidth, cmpHeight);
             }
+            final int al = alpha;
             pendingRenderingOperations.add(new AsyncOp(clip) {
                 @Override
                 public void execute(AndroidGraphics underlying) {
+                    underlying.setAlpha(al);
                     underlying.drawLabelComponent(cmpX, cmpY, cmpHeight, cmpWidth, style, text, icon, stateIcon, preserveSpaceForState,
                             gap, rtl, isOppositeSide, textPosition, stringWidth, isTickerRunning, tickerShiftText, endsWith3Points, valign);
                 }

--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -3578,10 +3578,6 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
         }
         
         public void setProperty(final String key, final Object value) {
-            if(key.equals("compatPaintMode")) {
-                compatPaintMode = true;
-                return;
-            }
             act.runOnUiThread(new Runnable() {
                 public void run() {
                     WebSettings s = web.getSettings();


### PR DESCRIPTION
If the socket is closed by the remote server, IOException was thrown without
marking the socket as unusable, which allowed to caller to keep trying.