### PR TITLE
Simple stack optimization & concatenated codegen

### DIFF
--- a/vm/ByteCodeTranslator/src/cn1_globals.h
+++ b/vm/ByteCodeTranslator/src/cn1_globals.h
@@ -186,395 +186,395 @@ typedef struct clazz*       JAVA_CLASS;
 
 
 #define BC_ILOAD(local) { \
-    stack[stackPointer].type = CN1_TYPE_INT; \
-    stack[stackPointer].data.i = ilocals_##local##_; \
-    stackPointer++; \
+    (*SP).type = CN1_TYPE_INT; \
+    (*SP).data.i = ilocals_##local##_; \
+    SP++; \
 }
 
 #define BC_LLOAD(local) { \
-    stack[stackPointer].type = CN1_TYPE_LONG; \
-    stack[stackPointer].data.l = llocals_##local##_; \
-    stackPointer++; \
+    (*SP).type = CN1_TYPE_LONG; \
+    (*SP).data.l = llocals_##local##_; \
+    SP++; \
 }
 
 #define BC_FLOAD(local) { \
-    stack[stackPointer].type = CN1_TYPE_FLOAT; \
-    stack[stackPointer].data.f = flocals_##local##_; \
-    stackPointer++; \
+    (*SP).type = CN1_TYPE_FLOAT; \
+    (*SP).data.f = flocals_##local##_; \
+    SP++; \
 }
 
 #define BC_DLOAD(local) { \
-    stack[stackPointer].type = CN1_TYPE_DOUBLE; \
-    stack[stackPointer].data.d = dlocals_##local##_; \
-    stackPointer++; \
+    (*SP).type = CN1_TYPE_DOUBLE; \
+    (*SP).data.d = dlocals_##local##_; \
+    SP++; \
 }
 
 #define BC_ALOAD(local) { \
-    stack[stackPointer].type = CN1_TYPE_INVALID; \
-    stack[stackPointer].data.o = locals[local].data.o; \
-    stack[stackPointer].type = CN1_TYPE_OBJECT; \
-    stackPointer++; \
+    (*SP).type = CN1_TYPE_INVALID; \
+    (*SP).data.o = locals[local].data.o; \
+    (*SP).type = CN1_TYPE_OBJECT; \
+    SP++; \
 }
 
 
-#define BC_ISTORE(local) { stackPointer--; \
-    ilocals_##local##_ = stack[stackPointer].data.i; \
+#define BC_ISTORE(local) { SP--; \
+    ilocals_##local##_ = (*SP).data.i; \
     }
 
-#define BC_LSTORE(local) { stackPointer--; \
-    llocals_##local##_ = stack[stackPointer].data.l; \
+#define BC_LSTORE(local) { SP--; \
+    llocals_##local##_ = (*SP).data.l; \
     }
 
-#define BC_FSTORE(local) { stackPointer--; \
-    flocals_##local##_ = stack[stackPointer].data.f; \
+#define BC_FSTORE(local) { SP--; \
+    flocals_##local##_ = (*SP).data.f; \
     }
 
-#define BC_DSTORE(local) { stackPointer--; \
-    dlocals_##local##_ = stack[stackPointer].data.d; \
+#define BC_DSTORE(local) { SP--; \
+    dlocals_##local##_ = (*SP).data.d; \
     }
 
-#define BC_ASTORE(local) { stackPointer--; \
+#define BC_ASTORE(local) { SP--; \
     locals[local].type = CN1_TYPE_INVALID; \
-    locals[local].data.o = stack[stackPointer].data.o; \
+    locals[local].data.o = (*SP).data.o; \
     locals[local].type = CN1_TYPE_OBJECT; \
     }
 
 // todo map instanceof and throw typecast exception
 #define BC_CHECKCAST(type)
 
-#define BC_SWAP() swapStack(stack, stackPointer)
+#define BC_SWAP() swapStack(SP)
 
 
-#define POP_INT() (*pop(stack, &stackPointer)).data.i
-#define POP_OBJ() (*pop(stack, &stackPointer)).data.o
-#define POP_OBJ_NO_RELEASE() (*pop(stack, &stackPointer)).data.o
-#define POP_LONG() (*pop(stack, &stackPointer)).data.l
-#define POP_DOUBLE() (*pop(stack, &stackPointer)).data.d
-#define POP_FLOAT() (*pop(stack, &stackPointer)).data.f
+#define POP_INT() pop(&SP)->data.i
+#define POP_OBJ() pop(&SP)->data.o
+#define POP_OBJ_NO_RELEASE() pop(&SP)->data.o
+#define POP_LONG() pop(&SP)->data.l
+#define POP_DOUBLE() pop(&SP)->data.d
+#define POP_FLOAT() pop(&SP)->data.f
 
-#define PEEK_INT(offset) stack[stackPointer - offset].data.i
-#define PEEK_OBJ(offset) stack[stackPointer - offset].data.o
-#define PEEK_LONG(offset) stack[stackPointer - offset].data.l
-#define PEEK_DOUBLE(offset) stack[stackPointer - offset].data.d
-#define PEEK_FLOAT(offset) stack[stackPointer - offset].data.f
+#define PEEK_INT(offset) SP[-offset].data.i
+#define PEEK_OBJ(offset) SP[-offset].data.o
+#define PEEK_LONG(offset) SP[-offset].data.l
+#define PEEK_DOUBLE(offset) SP[-offset].data.d
+#define PEEK_FLOAT(offset) SP[-offset].data.f
 
-#define POP_MANY(offset) popMany(threadStateData, offset, stack, &stackPointer)
+#define POP_MANY(offset) popMany(threadStateData, offset, &SP)
 
 #define BC_IADD() { \
-    stackPointer--; \
-    stack[stackPointer - 1].data.i = stack[stackPointer - 1].data.i + stack[stackPointer].data.i; \
+    SP--; \
+    SP[-1].data.i = SP[-1].data.i + (*SP).data.i; \
 }
 
 #define BC_LADD() { \
-    stackPointer--; \
-    stack[stackPointer - 1].data.l = stack[stackPointer - 1].data.l + stack[stackPointer].data.l; \
+    SP--; \
+    SP[-1].data.l = SP[-1].data.l + (*SP).data.l; \
 }
 
 #define BC_FADD() { \
-    stackPointer--; \
-    stack[stackPointer - 1].data.f = stack[stackPointer - 1].data.f + stack[stackPointer].data.f; \
+    SP--; \
+    SP[-1].data.f = SP[-1].data.f + (*SP).data.f; \
 }
 
 #define BC_DADD() { \
-    stackPointer--; \
-    stack[stackPointer - 1].data.d = stack[stackPointer - 1].data.d + stack[stackPointer].data.d; \
+    SP--; \
+    SP[-1].data.d = SP[-1].data.d + (*SP).data.d; \
 }
 
 #define BC_IMUL() { \
-    stackPointer--; \
-    stack[stackPointer - 1].data.i = stack[stackPointer - 1].data.i * stack[stackPointer].data.i; \
+    SP--; \
+    SP[-1].data.i = SP[-1].data.i * (*SP).data.i; \
 }
 
 #define BC_LMUL() { \
-    stackPointer--; \
-    stack[stackPointer - 1].data.l = stack[stackPointer - 1].data.l * stack[stackPointer].data.l; \
+    SP--; \
+    SP[-1].data.l = SP[-1].data.l * (*SP).data.l; \
 }
 
 #define BC_FMUL() { \
-    stackPointer--; \
-    stack[stackPointer - 1].data.f = stack[stackPointer - 1].data.f * stack[stackPointer].data.f; \
+    SP--; \
+    SP[-1].data.f = SP[-1].data.f * (*SP).data.f; \
 }
 
 #define BC_DMUL() { \
-    stackPointer--; \
-    stack[stackPointer - 1].data.d = stack[stackPointer - 1].data.d * stack[stackPointer].data.d; \
+    SP--; \
+    SP[-1].data.d = SP[-1].data.d * (*SP).data.d; \
 }
 
-#define BC_INEG() stack[stackPointer - 1].data.i *= -1
+#define BC_INEG() SP[-1].data.i *= -1
 
-#define BC_LNEG() stack[stackPointer - 1].data.l *= -1
+#define BC_LNEG() SP[-1].data.l *= -1
 
-#define BC_FNEG() stack[stackPointer - 1].data.f *= -1
+#define BC_FNEG() SP[-1].data.f *= -1
 
-#define BC_DNEG() stack[stackPointer - 1].data.d *= -1
+#define BC_DNEG() SP[-1].data.d *= -1
 
 #define BC_IAND() { \
-    stackPointer--; \
-    stack[stackPointer - 1].data.i = stack[stackPointer - 1].data.i & stack[stackPointer].data.i; \
+    SP--; \
+    SP[-1].data.i = SP[-1].data.i & (*SP).data.i; \
 }
 
 #define BC_LAND() { \
-    stackPointer--; \
-    stack[stackPointer - 1].data.l = stack[stackPointer - 1].data.l & stack[stackPointer].data.l; \
+    SP--; \
+    SP[-1].data.l = SP[-1].data.l & (*SP).data.l; \
 }
 
 #define BC_IOR() { \
-    stackPointer--; \
-    stack[stackPointer - 1].data.i = stack[stackPointer - 1].data.i | stack[stackPointer].data.i; \
+    SP--; \
+    SP[-1].data.i = SP[-1].data.i | (*SP).data.i; \
 }
 
 #define BC_LOR() { \
-    stackPointer--; \
-    stack[stackPointer - 1].data.l = stack[stackPointer - 1].data.l | stack[stackPointer].data.l; \
+    SP--; \
+    SP[-1].data.l = SP[-1].data.l | (*SP).data.l; \
 }
 
 #define BC_IXOR() { \
-    stackPointer--; \
-    stack[stackPointer - 1].data.i = stack[stackPointer - 1].data.i ^ stack[stackPointer].data.i; \
+    SP--; \
+    SP[-1].data.i = SP[-1].data.i ^ (*SP).data.i; \
 }
 
 #define BC_LXOR() { \
-    stackPointer--; \
-    stack[stackPointer - 1].data.l = stack[stackPointer - 1].data.l ^ stack[stackPointer].data.l; \
+    SP--; \
+    SP[-1].data.l = SP[-1].data.l ^ (*SP).data.l; \
 }
 
-#define BC_I2L() stack[stackPointer - 1].data.l = stack[stackPointer - 1].data.i
+#define BC_I2L() SP[-1].data.l = SP[-1].data.i
 
-#define BC_L2I() stack[stackPointer - 1].data.i = (JAVA_INT)stack[stackPointer - 1].data.l
+#define BC_L2I() SP[-1].data.i = (JAVA_INT)SP[-1].data.l
 
-#define BC_L2F() stack[stackPointer - 1].data.f = (JAVA_FLOAT)stack[stackPointer - 1].data.l
+#define BC_L2F() SP[-1].data.f = (JAVA_FLOAT)SP[-1].data.l
 
-#define BC_L2D() stack[stackPointer - 1].data.d = (JAVA_DOUBLE)stack[stackPointer - 1].data.l
+#define BC_L2D() SP[-1].data.d = (JAVA_DOUBLE)SP[-1].data.l
 
-#define BC_I2F() stack[stackPointer - 1].data.f = (JAVA_FLOAT)stack[stackPointer - 1].data.i 
+#define BC_I2F() SP[-1].data.f = (JAVA_FLOAT)SP[-1].data.i 
 
-#define BC_F2I() stack[stackPointer - 1].data.i = (JAVA_INT)stack[stackPointer - 1].data.f
+#define BC_F2I() SP[-1].data.i = (JAVA_INT)SP[-1].data.f
 
-#define BC_F2L() stack[stackPointer - 1].data.l = (JAVA_LONG)stack[stackPointer - 1].data.f
+#define BC_F2L() SP[-1].data.l = (JAVA_LONG)SP[-1].data.f
 
-#define BC_F2D() stack[stackPointer - 1].data.d = stack[stackPointer - 1].data.f
+#define BC_F2D() SP[-1].data.d = SP[-1].data.f
 
-#define BC_D2I() stack[stackPointer - 1].data.i = (JAVA_INT)stack[stackPointer - 1].data.d
+#define BC_D2I() SP[-1].data.i = (JAVA_INT)SP[-1].data.d
 
-#define BC_D2L() stack[stackPointer - 1].data.l = (JAVA_LONG)stack[stackPointer - 1].data.d
+#define BC_D2L() SP[-1].data.l = (JAVA_LONG)SP[-1].data.d
 
-#define BC_I2D() stack[stackPointer - 1].data.d = stack[stackPointer - 1].data.i
+#define BC_I2D() SP[-1].data.d = SP[-1].data.i
 
-#define BC_D2F() stack[stackPointer - 1].data.f = (JAVA_FLOAT)stack[stackPointer - 1].data.d
+#define BC_D2F() SP[-1].data.f = (JAVA_FLOAT)SP[-1].data.d
 
 #define BC_ARRAYLENGTH() { \
-    if(stack[stackPointer - 1].data.o == JAVA_NULL) { \
+    if(SP[-1].data.o == JAVA_NULL) { \
         throwException(threadStateData, __NEW_INSTANCE_java_lang_NullPointerException(threadStateData)); \
     }; \
-    stack[stackPointer - 1].type = CN1_TYPE_INT; \
-    stack[stackPointer - 1].data.i = (*((JAVA_ARRAY)stack[stackPointer - 1].data.o)).length; \
+    SP[-1].type = CN1_TYPE_INT; \
+    SP[-1].data.i = (*((JAVA_ARRAY)SP[-1].data.o)).length; \
 }
 
-#define BC_IF_ICMPEQ() stackPointer -= 2; if(stack[stackPointer].data.i == stack[stackPointer + 1].data.i)
+#define BC_IF_ICMPEQ() SP-=2; if((*SP).data.i == SP[1].data.i)
 
-#define BC_IF_ICMPNE() stackPointer -= 2; if(stack[stackPointer].data.i != stack[stackPointer + 1].data.i)
+#define BC_IF_ICMPNE() SP-=2; if((*SP).data.i != SP[1].data.i)
 
-#define BC_IF_ICMPLT() stackPointer -= 2; if(stack[stackPointer].data.i < stack[stackPointer + 1].data.i)
+#define BC_IF_ICMPLT() SP-=2; if((*SP).data.i < SP[1].data.i)
 
-#define BC_IF_ICMPGE() stackPointer -= 2; if(stack[stackPointer].data.i >= stack[stackPointer + 1].data.i)
+#define BC_IF_ICMPGE() SP-=2; if((*SP).data.i >= SP[1].data.i)
 
-#define BC_IF_ICMPGT() stackPointer -= 2; if(stack[stackPointer].data.i > stack[stackPointer + 1].data.i)
+#define BC_IF_ICMPGT() SP-=2; if((*SP).data.i > SP[1].data.i)
 
-#define BC_IF_ICMPLE() stackPointer -= 2; if(stack[stackPointer].data.i <= stack[stackPointer + 1].data.i)
+#define BC_IF_ICMPLE() SP-=2; if((*SP).data.i <= SP[1].data.i)
 
-#define BC_IF_ACMPEQ() stackPointer -= 2; if(stack[stackPointer].data.o == stack[stackPointer + 1].data.o)
+#define BC_IF_ACMPEQ() SP-=2; if((*SP).data.o == SP[1].data.o)
 
-#define BC_IF_ACMPNE() stackPointer -= 2; if(stack[stackPointer].data.o != stack[stackPointer + 1].data.o)
+#define BC_IF_ACMPNE() SP-=2; if((*SP).data.o != SP[1].data.o)
 
 //#define POP_TYPE(type) (*((type*)POP_OBJ()))
 
 // we assign the value to trigger the expression in the macro
 // then set the type to invalid first so we don't get a race condition where the value is
 // incomplete and the GC goes crazy
-#define PUSH_POINTER(value) { JAVA_OBJECT ppX = value; stack[stackPointer].type = CN1_TYPE_INVALID; \
-    stack[stackPointer].data.o = ppX; stack[stackPointer].type = CN1_TYPE_OBJECT; \
-    stackPointer++; }
+#define PUSH_POINTER(value) { JAVA_OBJECT ppX = value; (*SP).type = CN1_TYPE_INVALID; \
+    (*SP).data.o = ppX; (*SP).type = CN1_TYPE_OBJECT; \
+    SP++; }
 
-#define PUSH_OBJ(value)  { JAVA_OBJECT ppX = value; stack[stackPointer].type = CN1_TYPE_INVALID; \
-    stack[stackPointer].data.o = ppX; stack[stackPointer].type = CN1_TYPE_OBJECT; \
-    stackPointer++; }
+#define PUSH_OBJ(value)  { JAVA_OBJECT ppX = value; (*SP).type = CN1_TYPE_INVALID; \
+    (*SP).data.o = ppX; (*SP).type = CN1_TYPE_OBJECT; \
+    SP++; }
 
-#define PUSH_INT(value) { JAVA_INT pInt = value; stack[stackPointer].type = CN1_TYPE_INT; \
-    stack[stackPointer].data.i = pInt; \
-    stackPointer++; }
+#define PUSH_INT(value) { JAVA_INT pInt = value; (*SP).type = CN1_TYPE_INT; \
+    (*SP).data.i = pInt; \
+    SP++; }
 
-#define PUSH_LONG(value) { JAVA_LONG plong = value; stack[stackPointer].type = CN1_TYPE_LONG; \
-    stack[stackPointer].data.l = plong; \
-    stackPointer++; }
+#define PUSH_LONG(value) { JAVA_LONG plong = value; (*SP).type = CN1_TYPE_LONG; \
+    (*SP).data.l = plong; \
+    SP++; }
 
-#define PUSH_DOUBLE(value) { JAVA_DOUBLE pdob = value; stack[stackPointer].type = CN1_TYPE_DOUBLE; \
-    stack[stackPointer].data.d = pdob; \
-    stackPointer++; }
+#define PUSH_DOUBLE(value) { JAVA_DOUBLE pdob = value; (*SP).type = CN1_TYPE_DOUBLE; \
+    (*SP).data.d = pdob; \
+    SP++; }
 
-#define PUSH_FLOAT(value) { JAVA_FLOAT pFlo = value; stack[stackPointer].type = CN1_TYPE_FLOAT; \
-    stack[stackPointer].data.f = pFlo; \
-    stackPointer++; }
+#define PUSH_FLOAT(value) { JAVA_FLOAT pFlo = value; (*SP).type = CN1_TYPE_FLOAT; \
+    (*SP).data.f = pFlo; \
+    SP++; }
 
-#define POP_MANY_AND_PUSH_OBJ(value, offset) { int acOff = stackPointer - offset; \
-    JAVA_OBJECT pObj = value; stack[stackPointer - offset].type = CN1_TYPE_INVALID; \
-    stack[stackPointer - offset].data.o = pObj; stack[stackPointer - offset].type = CN1_TYPE_OBJECT; \
-    popMany(threadStateData, MAX(1, offset) - 1, stack, &stackPointer); }
+#define POP_MANY_AND_PUSH_OBJ(value, offset) {  \
+    JAVA_OBJECT pObj = value; SP[-offset].type = CN1_TYPE_INVALID; \
+    SP[-offset].data.o = pObj; SP[-offset].type = CN1_TYPE_OBJECT; \
+    popMany(threadStateData, MAX(1, offset) - 1, &SP); }
 
-#define POP_MANY_AND_PUSH_INT(value, offset) { int acOff = stackPointer - offset; \
-    JAVA_INT pInt = value; stack[stackPointer - offset].type = CN1_TYPE_INT; \
-    stack[stackPointer - offset].data.i = pInt; \
-    popMany(threadStateData, MAX(1, offset) - 1, stack, &stackPointer); }
+#define POP_MANY_AND_PUSH_INT(value, offset) {  \
+    JAVA_INT pInt = value; SP[-offset].type = CN1_TYPE_INT; \
+    SP[-offset].data.i = pInt; \
+    popMany(threadStateData, MAX(1, offset) - 1, &SP); }
 
-#define POP_MANY_AND_PUSH_LONG(value, offset) { int acOff = stackPointer - offset; \
-    JAVA_LONG pLong = value; stack[stackPointer - offset].type = CN1_TYPE_LONG; \
-    stack[stackPointer - offset].data.l = pLong; \
-    popMany(threadStateData, MAX(1, offset) - 1, stack, &stackPointer); }
+#define POP_MANY_AND_PUSH_LONG(value, offset) { \
+    JAVA_LONG pLong = value; SP[-offset].type = CN1_TYPE_LONG; \
+    SP[-offset].data.l = pLong; \
+    popMany(threadStateData, MAX(1, offset) - 1, &SP); }
 
-#define POP_MANY_AND_PUSH_DOUBLE(value, offset) { int acOff = stackPointer - offset; \
-    JAVA_DOUBLE pDob = value; stack[stackPointer - offset].type = CN1_TYPE_DOUBLE; \
-    stack[stackPointer - offset].data.d = pDob; \
-    popMany(threadStateData, MAX(1, offset) - 1, stack, &stackPointer); }
+#define POP_MANY_AND_PUSH_DOUBLE(value, offset) {\
+    JAVA_DOUBLE pDob = value; SP[-offset].type = CN1_TYPE_DOUBLE; \
+    SP[-offset].data.d = pDob; \
+    popMany(threadStateData, MAX(1, offset) - 1, &SP); }
 
-#define POP_MANY_AND_PUSH_FLOAT(value, offset) { int acOff = stackPointer - offset; \
-    JAVA_FLOAT pFlo = value; stack[stackPointer - offset].type = CN1_TYPE_FLOAT; \
-    stack[stackPointer - offset].data.f = pFlo; \
-    popMany(threadStateData, MAX(1, offset) - 1, stack, &stackPointer); }
+#define POP_MANY_AND_PUSH_FLOAT(value, offset) {  \
+    JAVA_FLOAT pFlo = value; SP[-offset].type = CN1_TYPE_FLOAT; \
+    SP[-offset].data.f = pFlo; \
+    popMany(threadStateData, MAX(1, offset) - 1, &SP); }
 
 
-#define BC_IDIV() stackPointer--; stack[stackPointer - 1].data.i = stack[stackPointer - 1].data.i / stack[stackPointer].data.i
+#define BC_IDIV() SP--; SP[-1].data.i = SP[-1].data.i / (*SP).data.i
 
-#define BC_LDIV() stackPointer--; stack[stackPointer - 1].data.l = stack[stackPointer - 1].data.l / stack[stackPointer].data.l
+#define BC_LDIV() SP--; SP[-1].data.l = SP[-1].data.l / (*SP).data.l
 
-#define BC_FDIV() stackPointer--; stack[stackPointer - 1].data.f = stack[stackPointer - 1].data.f / stack[stackPointer].data.f
+#define BC_FDIV() SP--; SP[-1].data.f = SP[-1].data.f / (*SP).data.f
 
-#define BC_DDIV() stackPointer--; stack[stackPointer - 1].data.d = stack[stackPointer - 1].data.d / stack[stackPointer].data.d
+#define BC_DDIV() SP--; SP[-1].data.d = SP[-1].data.d / (*SP).data.d
 
-#define BC_IREM() stackPointer--; stack[stackPointer - 1].data.i = stack[stackPointer - 1].data.i % stack[stackPointer].data.i
+#define BC_IREM() SP--; SP[-1].data.i = SP[-1].data.i % (*SP).data.i
 
-#define BC_LREM() stackPointer--; stack[stackPointer - 1].data.l = stack[stackPointer - 1].data.l % stack[stackPointer].data.l
+#define BC_LREM() SP--; SP[-1].data.l = SP[-1].data.l % (*SP).data.l
 
-#define BC_FREM() stackPointer--; stack[stackPointer - 1].data.f = fmod(stack[stackPointer - 1].data.f, stack[stackPointer].data.f)
+#define BC_FREM() SP--; SP[-1].data.f = fmod(SP[-1].data.f, (*SP).data.f)
 
-#define BC_DREM() stackPointer--; stack[stackPointer - 1].data.d = fmod(stack[stackPointer - 1].data.d, stack[stackPointer].data.d)
+#define BC_DREM() SP--; SP[-1].data.d = fmod(SP[-1].data.d, (*SP).data.d)
 
-#define BC_LCMP() stackPointer--; if(stack[stackPointer - 1].data.l == stack[stackPointer].data.l) { \
-        stack[stackPointer - 1].data.i = 0; \
+#define BC_LCMP() SP--; if(SP[-1].data.l == (*SP).data.l) { \
+        SP[-1].data.i = 0; \
     } else { \
-        if(stack[stackPointer - 1].data.l > stack[stackPointer].data.l) { \
-            stack[stackPointer - 1].data.i = 1; \
+        if(SP[-1].data.l > (*SP).data.l) { \
+            SP[-1].data.i = 1; \
         } else { \
-            stack[stackPointer - 1].data.i = -1; \
+            SP[-1].data.i = -1; \
         } \
     } \
-    stack[stackPointer - 1].type = CN1_TYPE_INT;
+    SP[-1].type = CN1_TYPE_INT;
 
-#define BC_FCMPL() stackPointer--; if(stack[stackPointer - 1].data.f == stack[stackPointer].data.f) { \
-        stack[stackPointer - 1].data.i = 0; \
+#define BC_FCMPL() SP--; if(SP[-1].data.f == (*SP).data.f) { \
+        SP[-1].data.i = 0; \
     } else { \
-        if(stack[stackPointer - 1].data.f > stack[stackPointer].data.f) { \
-            stack[stackPointer - 1].data.i = 1; \
+        if(SP[-1].data.f > (*SP).data.f) { \
+            SP[-1].data.i = 1; \
         } else { \
-            stack[stackPointer - 1].data.i = -1; \
+            SP[-1].data.i = -1; \
         } \
     } \
-    stack[stackPointer - 1].type = CN1_TYPE_INT;
+    SP[-1].type = CN1_TYPE_INT;
 
-#define BC_DCMPL() stackPointer--; if(stack[stackPointer - 1].data.d == stack[stackPointer].data.d) { \
-        stack[stackPointer - 1].data.i = 0; \
+#define BC_DCMPL() SP--; if(SP[-1].data.d == (*SP).data.d) { \
+        SP[-1].data.i = 0; \
     } else { \
-        if(stack[stackPointer - 1].data.d > stack[stackPointer].data.d) { \
-            stack[stackPointer - 1].data.i = 1; \
+        if(SP[-1].data.d > (*SP).data.d) { \
+            SP[-1].data.i = 1; \
         } else { \
-            stack[stackPointer - 1].data.i = -1; \
+            SP[-1].data.i = -1; \
         } \
     } \
-    stack[stackPointer - 1].type = CN1_TYPE_INT;
+    SP[-1].type = CN1_TYPE_INT;
 
 #define BC_DUP()  { \
-        JAVA_LONG plong = stack[stackPointer - 1].data.l; \
-        stack[stackPointer].type = CN1_TYPE_INVALID; \
-        stack[stackPointer].data.l = plong; stack[stackPointer].type = CN1_TYPE_LONG; \
-        stackPointer++; \
+        JAVA_LONG plong = SP[-1].data.l; \
+        (*SP).type = CN1_TYPE_INVALID; \
+        (*SP).data.l = plong; (*SP).type = CN1_TYPE_LONG; \
+        SP++; \
     } \
-    stack[stackPointer - 1].type = stack[stackPointer - 2].type; 
+    SP[-1].type = SP[-2].type; 
 
 #define BC_DUP2()  \
-if(stack[stackPointer - 1].type == CN1_TYPE_LONG || stack[stackPointer - 1].type == CN1_TYPE_DOUBLE) {\
+if(SP[-1].type == CN1_TYPE_LONG || SP[-1].type == CN1_TYPE_DOUBLE) {\
     BC_DUP(); \
 } else {\
     { \
-        JAVA_LONG plong = stack[stackPointer - 2].data.l; \
-        JAVA_LONG plong2 = stack[stackPointer - 1].data.l; \
-        stack[stackPointer].type = CN1_TYPE_INVALID; \
-        stack[stackPointer + 1].type = CN1_TYPE_INVALID; \
-        stack[stackPointer].data.l = plong; \
-        stack[stackPointer + 1].data.l = plong2; \
-        stackPointer+=2; \
+        JAVA_LONG plong = SP[-2].data.l; \
+        JAVA_LONG plong2 = SP[-1].data.l; \
+        (*SP).type = CN1_TYPE_INVALID; \
+        SP[1].type = CN1_TYPE_INVALID; \
+        (*SP).data.l = plong; \
+        SP[1].data.l = plong2; \
+        SP+=2; \
     } \
-    stack[stackPointer - 1].type = stack[stackPointer - 3].type; \
-    stack[stackPointer - 2].type = stack[stackPointer - 4].type; \
+    SP[-1].type = SP[-1].type; \
+    SP[-2].type = SP[-4].type; \
 }
 
 #define BC_DUP2_X1() {\
-    stack[stackPointer].data.l = stack[stackPointer - 1].data.l; \
-    stack[stackPointer - 1].data.l = stack[stackPointer - 2].data.l; \
-    stack[stackPointer - 2].data.l = stack[stackPointer].data.l; \
-    stack[stackPointer].type = stack[stackPointer - 1].type; \
-    stack[stackPointer - 1].type = stack[stackPointer - 2].type; \
-    stack[stackPointer - 2].type = stack[stackPointer].type; \
-    stackPointer++; \
+    (*SP).data.l = SP[-1].data.l; \
+    SP[-1].data.l = SP[-2].data.l; \
+    SP[-2].data.l = (*SP).data.l; \
+    (*SP).type = SP[-1].type; \
+    SP[-1].type = SP[-2].type; \
+    SP[-2].type = (*SP).type; \
+    SP++; \
 }
 
 #define BC_DUP2_X2() { \
-    if (stack[stackPointer-2].type == CN1_TYPE_LONG || stack[stackPointer-2].type == CN1_TYPE_DOUBLE) {\
-        stack[stackPointer].data.l = stack[stackPointer - 1].data.l; \
-        stack[stackPointer - 1].data.l = stack[stackPointer - 2].data.l; \
-        stack[stackPointer - 2].data.l = stack[stackPointer].data.l; \
-        stack[stackPointer].type = stack[stackPointer - 1].type; \
-        stack[stackPointer - 1].type = stack[stackPointer - 2].type; \
-        stack[stackPointer - 2].type = stack[stackPointer].type; \
+    if (SP[-2].type == CN1_TYPE_LONG || SP[-2].type == CN1_TYPE_DOUBLE) {\
+        (*SP).data.l = SP[-1].data.l; \
+        SP[-1].data.l = SP[-2].data.l; \
+        SP[-2].data.l = (*SP).data.l; \
+        (*SP).type = SP[-1].type; \
+        SP[-1].type = SP[-2].type; \
+        SP[-2].type = (*SP).type; \
     } else {\
-        stack[stackPointer].data.l = stack[stackPointer - 1].data.l; \
-        stack[stackPointer - 1].data.l = stack[stackPointer - 2].data.l; \
-        stack[stackPointer - 2].data.l = stack[stackPointer - 3].data.l; \
-        stack[stackPointer - 3].data.l = stack[stackPointer].data.l; \
-        stack[stackPointer].type = stack[stackPointer - 1].type; \
-        stack[stackPointer - 1].type = stack[stackPointer - 2].type; \
-        stack[stackPointer - 2].type = stack[stackPointer - 3].type; \
-        stack[stackPointer - 3].type = stack[stackPointer].type; \
+        (*SP).data.l = SP[-1].data.l; \
+        SP[-1].data.l = SP[-2].data.l; \
+        SP[-2].data.l = SP[-1].data.l; \
+        SP[-1].data.l = (*SP).data.l; \
+        (*SP).type = SP[-1].type; \
+        SP[-1].type = SP[-2].type; \
+        SP[-2].type = SP[-1].type; \
+        SP[-1].type = (*SP).type; \
     }\
-    stackPointer++; \
+    SP++; \
 }
 
-#define BC_I2B() stack[stackPointer - 1].data.i = ((stack[stackPointer - 1].data.i << 24) >> 24)
+#define BC_I2B() SP[-1].data.i = ((SP[-1].data.i << 24) >> 24)
 
-#define BC_I2S() stack[stackPointer - 1].data.i = ((stack[stackPointer - 1].data.i << 16) >> 16)
+#define BC_I2S() SP[-1].data.i = ((SP[-1].data.i << 16) >> 16)
 
-#define BC_I2C() stack[stackPointer - 1].data.i = (stack[stackPointer - 1].data.i & 0xffff)
+#define BC_I2C() SP[-1].data.i = (SP[-1].data.i & 0xffff)
 
-#define BC_ISHL() stackPointer--; stack[stackPointer - 1].data.i = (stack[stackPointer - 1].data.i << (0x1f & stack[stackPointer].data.i))
+#define BC_ISHL() SP--; SP[-1].data.i = (SP[-1].data.i << (0x1f & (*SP).data.i))
 
-#define BC_LSHL() stackPointer--; stack[stackPointer - 1].data.l = (stack[stackPointer - 1].data.l << (0x3f & stack[stackPointer].data.l))
+#define BC_LSHL() SP--; SP[-1].data.l = (SP[-1].data.l << (0x3f & (*SP).data.l))
 
-#define BC_ISHR() stackPointer--; stack[stackPointer - 1].data.i = (stack[stackPointer - 1].data.i >> (0x1f & stack[stackPointer].data.i))
+#define BC_ISHR() SP--; SP[-1].data.i = (SP[-1].data.i >> (0x1f & (*SP).data.i))
 
-#define BC_LSHR() stackPointer--; stack[stackPointer - 1].data.l = (stack[stackPointer - 1].data.l >> (0x3f & stack[stackPointer].data.l))
+#define BC_LSHR() SP--; SP[-1].data.l = (SP[-1].data.l >> (0x3f & (*SP).data.l))
 
-#define BC_IUSHL() stackPointer--; stack[stackPointer - 1].data.i = (((unsigned int)stack[stackPointer - 1]).data.i << (0x1f & ((unsigned int)stack[stackPointer].data.i)))
+#define BC_IUSHL() SP--; SP[-1].data.i = (((unsigned int)SP[-1]).data.i << (0x1f & ((unsigned int)(*SP).data.i)))
 
-#define BC_LUSHL() stackPointer--; stack[stackPointer - 1].data.l = (((unsigned long long)stack[stackPointer - 1].data.l) << (0x3f & ((unsigned long long)stack[stackPointer].data.l)))
+#define BC_LUSHL() SP--; SP[-1].data.l = (((unsigned long long)SP[-1].data.l) << (0x3f & ((unsigned long long)(*SP).data.l)))
 
-#define BC_IUSHR() stackPointer--; stack[stackPointer - 1].data.i = (((unsigned int)stack[stackPointer - 1].data.i) >> (0x1f & ((unsigned int)stack[stackPointer].data.i)))
+#define BC_IUSHR() SP--; SP[-1].data.i = (((unsigned int)SP[-1].data.i) >> (0x1f & ((unsigned int)(*SP).data.i)))
 
-#define BC_LUSHR() stackPointer--; stack[stackPointer - 1].data.l = (((unsigned long long)stack[stackPointer - 1].data.l) >> (0x3f & ((unsigned long long)stack[stackPointer].data.l)))
+#define BC_LUSHR() SP--; SP[-1].data.l = (((unsigned long long)SP[-1].data.l) >> (0x3f & ((unsigned long long)(*SP).data.l)))
 
-#define BC_ISUB() stackPointer--; stack[stackPointer - 1].data.i = (stack[stackPointer - 1].data.i - stack[stackPointer].data.i)
+#define BC_ISUB() SP--; SP[-1].data.i = (SP[-1].data.i - (*SP).data.i)
 
-#define BC_LSUB() stackPointer--; stack[stackPointer - 1].data.l = (stack[stackPointer - 1].data.l - stack[stackPointer].data.l)
+#define BC_LSUB() SP--; SP[-1].data.l = (SP[-1].data.l - (*SP).data.l)
 
-#define BC_FSUB() stackPointer--; stack[stackPointer - 1].data.f = (stack[stackPointer - 1].data.f - stack[stackPointer].data.f)
+#define BC_FSUB() SP--; SP[-1].data.f = (SP[-1].data.f - (*SP).data.f)
 
-#define BC_DSUB() stackPointer--; stack[stackPointer - 1].data.d = (stack[stackPointer - 1].data.d - stack[stackPointer].data.d)
+#define BC_DSUB() SP--; SP[-1].data.d = (SP[-1].data.d - (*SP).data.d)
 
 extern JAVA_OBJECT* constantPoolObjects;
 
@@ -591,80 +591,80 @@ extern int instanceofFunction(int sourceClass, int destId);
 #define GET_CLASS_ID(JavaObj) (*(*JavaObj).__codenameOneParentClsReference).classId
 
 #define BC_INSTANCEOF(typeOfInstanceOf) { \
-    if(stack[stackPointer - 1].data.o != JAVA_NULL) { \
-        int tmpInstanceOfId = GET_CLASS_ID(stack[stackPointer - 1].data.o); \
-        stack[stackPointer - 1].type = CN1_TYPE_INVALID; \
-        stack[stackPointer - 1].data.i = instanceofFunction( typeOfInstanceOf, tmpInstanceOfId ); \
+    if(SP[-1].data.o != JAVA_NULL) { \
+        int tmpInstanceOfId = GET_CLASS_ID(SP[-1].data.o); \
+        SP[-1].type = CN1_TYPE_INVALID; \
+        SP[-1].data.i = instanceofFunction( typeOfInstanceOf, tmpInstanceOfId ); \
     } \
-    stack[stackPointer - 1].type = CN1_TYPE_INT; \
+    SP[-1].type = CN1_TYPE_INT; \
 }
 
-#define BC_IALOAD() { CHECK_ARRAY_ACCESS(2, stack[stackPointer - 1].data.i); \
-    stackPointer--; stack[stackPointer - 1].type = CN1_TYPE_INT; \
-    stack[stackPointer - 1].data.i = ((JAVA_ARRAY_INT*) (*(JAVA_ARRAY)stack[stackPointer - 1].data.o).data)[stack[stackPointer].data.i]; \
+#define BC_IALOAD() { CHECK_ARRAY_ACCESS(2, SP[-1].data.i); \
+    SP--; SP[-1].type = CN1_TYPE_INT; \
+    SP[-1].data.i = ((JAVA_ARRAY_INT*) (*(JAVA_ARRAY)SP[-1].data.o).data)[(*SP).data.i]; \
     }
 
-#define BC_LALOAD() { CHECK_ARRAY_ACCESS(2, stack[stackPointer - 1].data.i); \
-    stackPointer--; stack[stackPointer - 1].type = CN1_TYPE_LONG; \
-    stack[stackPointer - 1].data.l = LONG_ARRAY_LOOKUP((JAVA_ARRAY)stack[stackPointer - 1].data.o, stack[stackPointer].data.i); \
+#define BC_LALOAD() { CHECK_ARRAY_ACCESS(2, SP[-1].data.i); \
+    SP--; SP[-1].type = CN1_TYPE_LONG; \
+    SP[-1].data.l = LONG_ARRAY_LOOKUP((JAVA_ARRAY)SP[-1].data.o, (*SP).data.i); \
     }
 
-#define BC_FALOAD() { CHECK_ARRAY_ACCESS(2, stack[stackPointer - 1].data.i); \
-    stackPointer--; stack[stackPointer - 1].type = CN1_TYPE_FLOAT; \
-    stack[stackPointer - 1].data.f = FLOAT_ARRAY_LOOKUP((JAVA_ARRAY)stack[stackPointer - 1].data.o, stack[stackPointer].data.i); \
+#define BC_FALOAD() { CHECK_ARRAY_ACCESS(2, SP[-1].data.i); \
+    SP--; SP[-1].type = CN1_TYPE_FLOAT; \
+    SP[-1].data.f = FLOAT_ARRAY_LOOKUP((JAVA_ARRAY)SP[-1].data.o, (*SP).data.i); \
     }
 
-#define BC_DALOAD() { CHECK_ARRAY_ACCESS(2, stack[stackPointer - 1].data.i); \
-    stackPointer--; stack[stackPointer - 1].type = CN1_TYPE_DOUBLE; \
-    stack[stackPointer - 1].data.d = DOUBLE_ARRAY_LOOKUP((JAVA_ARRAY)stack[stackPointer - 1].data.o, stack[stackPointer].data.i); \
+#define BC_DALOAD() { CHECK_ARRAY_ACCESS(2, SP[-1].data.i); \
+    SP--; SP[-1].type = CN1_TYPE_DOUBLE; \
+    SP[-1].data.d = DOUBLE_ARRAY_LOOKUP((JAVA_ARRAY)SP[-1].data.o, (*SP).data.i); \
     }
 
-#define BC_AALOAD() { CHECK_ARRAY_ACCESS(2, stack[stackPointer - 1].data.i); \
-    stackPointer--; stack[stackPointer - 1].type = CN1_TYPE_INVALID; \
-    stack[stackPointer - 1].data.o = ((JAVA_ARRAY_OBJECT*) (*(JAVA_ARRAY)stack[stackPointer - 1].data.o).data)[stack[stackPointer].data.i]; \
-    stack[stackPointer - 1].type = CN1_TYPE_OBJECT;  }
+#define BC_AALOAD() { CHECK_ARRAY_ACCESS(2, SP[-1].data.i); \
+    SP--; SP[-1].type = CN1_TYPE_INVALID; \
+    SP[-1].data.o = ((JAVA_ARRAY_OBJECT*) (*(JAVA_ARRAY)SP[-1].data.o).data)[(*SP).data.i]; \
+    SP[-1].type = CN1_TYPE_OBJECT;  }
 
-#define BC_BALOAD() { CHECK_ARRAY_ACCESS(2, stack[stackPointer - 1].data.i); \
-    stackPointer--; stack[stackPointer - 1].type = CN1_TYPE_INT; \
-    stack[stackPointer - 1].data.i = ((JAVA_ARRAY_BYTE*) (*(JAVA_ARRAY)stack[stackPointer - 1].data.o).data)[stack[stackPointer].data.i]; \
+#define BC_BALOAD() { CHECK_ARRAY_ACCESS(2, SP[-1].data.i); \
+    SP--; SP[-1].type = CN1_TYPE_INT; \
+    SP[-1].data.i = ((JAVA_ARRAY_BYTE*) (*(JAVA_ARRAY)SP[-1].data.o).data)[(*SP).data.i]; \
     }
 
-#define BC_CALOAD() { CHECK_ARRAY_ACCESS(2, stack[stackPointer - 1].data.i); \
-    stackPointer--; stack[stackPointer - 1].type = CN1_TYPE_INT; \
-    stack[stackPointer - 1].data.i = ((JAVA_ARRAY_CHAR*) (*(JAVA_ARRAY)stack[stackPointer - 1].data.o).data)[stack[stackPointer].data.i]; \
+#define BC_CALOAD() { CHECK_ARRAY_ACCESS(2, SP[-1].data.i); \
+    SP--; SP[-1].type = CN1_TYPE_INT; \
+    SP[-1].data.i = ((JAVA_ARRAY_CHAR*) (*(JAVA_ARRAY)SP[-1].data.o).data)[(*SP).data.i]; \
     }
 
-#define BC_SALOAD() { CHECK_ARRAY_ACCESS(2, stack[stackPointer - 1].data.i); \
-    stackPointer--; stack[stackPointer - 1].type = CN1_TYPE_INT; \
-    stack[stackPointer - 1].data.i = ((JAVA_ARRAY_SHORT*) (*(JAVA_ARRAY)stack[stackPointer - 1].data.o).data)[stack[stackPointer].data.i]; \
+#define BC_SALOAD() { CHECK_ARRAY_ACCESS(2, SP[-1].data.i); \
+    SP--; SP[-1].type = CN1_TYPE_INT; \
+    SP[-1].data.i = ((JAVA_ARRAY_SHORT*) (*(JAVA_ARRAY)SP[-1].data.o).data)[(*SP).data.i]; \
     }
 
 
-#define BC_BASTORE() CHECK_ARRAY_ACCESS(3, stack[stackPointer - 2].data.i); \
-    ((JAVA_ARRAY_BYTE*) (*(JAVA_ARRAY)stack[stackPointer - 3].data.o).data)[stack[stackPointer - 2].data.i] = stack[stackPointer - 1].data.i; stackPointer -= 3
+#define BC_BASTORE() CHECK_ARRAY_ACCESS(3, SP[-2].data.i); \
+    ((JAVA_ARRAY_BYTE*) (*(JAVA_ARRAY)SP[-1].data.o).data)[SP[-2].data.i] = SP[-1].data.i; SP-=3
 
-#define BC_CASTORE() CHECK_ARRAY_ACCESS(3, stack[stackPointer - 2].data.i); \
-    ((JAVA_ARRAY_CHAR*) (*(JAVA_ARRAY)stack[stackPointer - 3].data.o).data)[stack[stackPointer - 2].data.i] = stack[stackPointer - 1].data.i; stackPointer -= 3
+#define BC_CASTORE() CHECK_ARRAY_ACCESS(3, SP[-2].data.i); \
+    ((JAVA_ARRAY_CHAR*) (*(JAVA_ARRAY)SP[-1].data.o).data)[SP[-2].data.i] = SP[-1].data.i; SP-=3
 
-#define BC_SASTORE() CHECK_ARRAY_ACCESS(3, stack[stackPointer - 2].data.i); \
-    ((JAVA_ARRAY_SHORT*) (*(JAVA_ARRAY)stack[stackPointer - 3].data.o).data)[stack[stackPointer - 2].data.i] = stack[stackPointer - 1].data.i; stackPointer -= 3
+#define BC_SASTORE() CHECK_ARRAY_ACCESS(3, SP[-2].data.i); \
+    ((JAVA_ARRAY_SHORT*) (*(JAVA_ARRAY)SP[-1].data.o).data)[SP[-2].data.i] = SP[-1].data.i; SP-=3
 
-#define BC_IASTORE() CHECK_ARRAY_ACCESS(3, stack[stackPointer - 2].data.i); \
-    ((JAVA_ARRAY_INT*) (*(JAVA_ARRAY)stack[stackPointer - 3].data.o).data)[stack[stackPointer - 2].data.i] = stack[stackPointer - 1].data.i; stackPointer -= 3
+#define BC_IASTORE() CHECK_ARRAY_ACCESS(3, SP[-2].data.i); \
+    ((JAVA_ARRAY_INT*) (*(JAVA_ARRAY)SP[-1].data.o).data)[SP[-2].data.i] = SP[-1].data.i; SP-=3
 
-#define BC_LASTORE() CHECK_ARRAY_ACCESS(3, stack[stackPointer - 2].data.i); \
-    LONG_ARRAY_LOOKUP((JAVA_ARRAY)stack[stackPointer - 3].data.o, stack[stackPointer - 2].data.i) = stack[stackPointer - 1].data.l; stackPointer -= 3
+#define BC_LASTORE() CHECK_ARRAY_ACCESS(3, SP[-2].data.i); \
+    LONG_ARRAY_LOOKUP((JAVA_ARRAY)SP[-1].data.o, SP[-2].data.i) = SP[-1].data.l; SP-=3
 
-#define BC_FASTORE() CHECK_ARRAY_ACCESS(3, stack[stackPointer - 2].data.i); \
-    FLOAT_ARRAY_LOOKUP((JAVA_ARRAY)stack[stackPointer - 3].data.o, stack[stackPointer - 2].data.i) = stack[stackPointer - 1].data.f; stackPointer -= 3
+#define BC_FASTORE() CHECK_ARRAY_ACCESS(3, SP[-2].data.i); \
+    FLOAT_ARRAY_LOOKUP((JAVA_ARRAY)SP[-1].data.o, SP[-2].data.i) = SP[-1].data.f; SP-=3
 
-#define BC_DASTORE() CHECK_ARRAY_ACCESS(3, stack[stackPointer - 2].data.i); \
-    DOUBLE_ARRAY_LOOKUP((JAVA_ARRAY)stack[stackPointer - 3].data.o, stack[stackPointer - 2].data.i) = stack[stackPointer - 1].data.d; stackPointer -= 3
+#define BC_DASTORE() CHECK_ARRAY_ACCESS(3, SP[-2].data.i); \
+    DOUBLE_ARRAY_LOOKUP((JAVA_ARRAY)SP[-1].data.o, SP[-2].data.i) = SP[-1].data.d; SP-=3
 
-#define BC_AASTORE() CHECK_ARRAY_ACCESS(3, stack[stackPointer - 2].data.i); { \
-    JAVA_OBJECT aastoreTmp = stack[stackPointer - 3].data.o; \
-    ((JAVA_ARRAY_OBJECT*) (*(JAVA_ARRAY)aastoreTmp).data)[stack[stackPointer - 2].data.i] = stack[stackPointer - 1].data.o; \
-    stackPointer -= 3; \
+#define BC_AASTORE() CHECK_ARRAY_ACCESS(3, SP[-2].data.i); { \
+    JAVA_OBJECT aastoreTmp = SP[-1].data.o; \
+    ((JAVA_ARRAY_OBJECT*) (*(JAVA_ARRAY)aastoreTmp).data)[SP[-2].data.i] = SP[-1].data.o; \
+    SP-=3; \
 }
 
 
@@ -770,25 +770,25 @@ extern struct ThreadLocalData* getThreadLocalData();
         goto labelToJumpTo; \
     }
 
-extern void releaseForReturn(CODENAME_ONE_THREAD_STATE, int cn1LocalsBeginInThread, int stackPointer, int cn1SizeOfLocals, struct elementStruct* stack, struct elementStruct* locals);
+extern void releaseForReturn(CODENAME_ONE_THREAD_STATE, int cn1LocalsBeginInThread);
 
 
 #define RETURN_AND_RELEASE_FROM_METHOD(returnVal, cn1SizeOfLocals) { \
-        releaseForReturn(threadStateData, cn1LocalsBeginInThread, stackPointer - 1, cn1SizeOfLocals, stack, locals); \
+        releaseForReturn(threadStateData, cn1LocalsBeginInThread); \
         return returnVal; \
     }
 
 #define RETURN_AND_RELEASE_FROM_VOID(cn1SizeOfLocals) { \
-        releaseForReturn(threadStateData, cn1LocalsBeginInThread, stackPointer, cn1SizeOfLocals, stack, locals); \
+        releaseForReturn(threadStateData, cn1LocalsBeginInThread); \
         return; \
     }
 
-extern void releaseForReturnInException(CODENAME_ONE_THREAD_STATE, int cn1LocalsBeginInThread, int stackPointer, int cn1SizeOfLocals, struct elementStruct* stack, struct elementStruct* locals, int methodBlockOffset);
+extern void releaseForReturnInException(CODENAME_ONE_THREAD_STATE, int cn1LocalsBeginInThread, int methodBlockOffset);
 
-#define RETURN_FROM_METHOD(returnVal, cn1SizeOfLocals) releaseForReturnInException(threadStateData, cn1LocalsBeginInThread, stackPointer, cn1SizeOfLocals, stack, locals, methodBlockOffset); \
+#define RETURN_FROM_METHOD(returnVal, cn1SizeOfLocals) releaseForReturnInException(threadStateData, cn1LocalsBeginInThread, methodBlockOffset); \
         return returnVal; \
 
-#define RETURN_FROM_VOID(cn1SizeOfLocals) releaseForReturnInException(threadStateData, cn1LocalsBeginInThread, stackPointer, cn1SizeOfLocals, stack, locals, methodBlockOffset); \
+#define RETURN_FROM_VOID(cn1SizeOfLocals) releaseForReturnInException(threadStateData, cn1LocalsBeginInThread, methodBlockOffset); \
         return; \
 
 #define END_TRY() threadStateData->tryBlockOffset--
@@ -799,7 +799,7 @@ extern void releaseForReturnInException(CODENAME_ONE_THREAD_STATE, int cn1Locals
     if(setjmp(destinationJump)) { \
         threadStateData->callStackOffset = currentCodenameOneCallStackOffset; \
         threadStateData->threadObjectStackOffset = restoreToCn1LocalsBeginInThread; \
-        stackPointer = 1; \
+        SP = &stack[1]; \
         stack[0].data.o = threadStateData->exception; \
         stack[0].type = CN1_TYPE_OBJECT; \
         goto labelName; \
@@ -821,14 +821,14 @@ extern void throwArrayIndexOutOfBoundsException(CODENAME_ONE_THREAD_STATE, int i
 #define THROW_ARRAY_INDEX_EXCEPTION(index)    throwArrayIndexOutOfBoundsException(threadStateData, index)
 
 #ifdef CN1_INCLUDE_NPE_CHECKS
-    #define CHECK_NPE_TOP_OF_STACK() if(stack[stackPointer - 1].data.o == JAVA_NULL) { NSLog(@"Throwing NullPointerException!"); throwException(threadStateData, __NEW_INSTANCE_java_lang_NullPointerException(threadStateData)); }
-    #define CHECK_NPE_AT_STACK(pos) if(stack[stackPointer - pos].data.o == JAVA_NULL) { NSLog(@"Throwing NullPointerException!"); throwException(threadStateData, __NEW_INSTANCE_java_lang_NullPointerException(threadStateData)); }
+    #define CHECK_NPE_TOP_OF_STACK() if(SP[-1].data.o == JAVA_NULL) { NSLog(@"Throwing NullPointerException!"); throwException(threadStateData, __NEW_INSTANCE_java_lang_NullPointerException(threadStateData)); }
+    #define CHECK_NPE_AT_STACK(pos) if(SP[-pos].data.o == JAVA_NULL) { NSLog(@"Throwing NullPointerException!"); throwException(threadStateData, __NEW_INSTANCE_java_lang_NullPointerException(threadStateData)); }
 
     #ifdef CN1_INCLUDE_ARRAY_BOUND_CHECKS
-        #define CHECK_ARRAY_ACCESS(array_pos, bounds) if(stack[stackPointer - array_pos].data.o == JAVA_NULL) { NSLog(@"Throwing NullPointerException!"); throwException(threadStateData, __NEW_INSTANCE_java_lang_NullPointerException(threadStateData)); } \
-            if(bounds < 0 || bounds >= ((JAVA_ARRAY)stack[stackPointer - array_pos].data.o)->length) { THROW_ARRAY_INDEX_EXCEPTION(bounds); }
+        #define CHECK_ARRAY_ACCESS(array_pos, bounds) if(SP[- array_pos].data.o == JAVA_NULL) { NSLog(@"Throwing NullPointerException!"); throwException(threadStateData, __NEW_INSTANCE_java_lang_NullPointerException(threadStateData)); } \
+            if(bounds < 0 || bounds >= ((JAVA_ARRAY)SP[- array_pos].data.o)->length) { THROW_ARRAY_INDEX_EXCEPTION(bounds); }
     #else 
-        #define CHECK_ARRAY_ACCESS(array_pos, bounds) if(stack[stackPointer - array_pos].data.o == JAVA_NULL) { THROW_NULL_POINTER_EXCEPTION(); } 
+        #define CHECK_ARRAY_ACCESS(array_pos, bounds) if(SP[-array_pos].data.o == JAVA_NULL) { THROW_NULL_POINTER_EXCEPTION(); }
     #endif
 #else
     #define CHECK_NPE_TOP_OF_STACK()
@@ -905,7 +905,7 @@ extern void initMethodStack(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT __cn1ThisObje
     const int cn1LocalsBeginInThread = threadStateData->threadObjectStackOffset; \
     struct elementStruct* locals = &threadStateData->threadObjectStack[cn1LocalsBeginInThread]; \
     struct elementStruct* stack = &threadStateData->threadObjectStack[threadStateData->threadObjectStackOffset + localsStackSize]; \
-    int stackPointer = spPosition; \
+    struct elementStruct* SP = &stack[spPosition]; \
     initMethodStack(threadStateData, (JAVA_OBJECT)1, stackSize,localsStackSize, classNameId, methodNameId); \
     const int currentCodenameOneCallStackOffset = threadStateData->callStackOffset;
 
@@ -913,10 +913,11 @@ extern void initMethodStack(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT __cn1ThisObje
     const int cn1LocalsBeginInThread = threadStateData->threadObjectStackOffset; \
     struct elementStruct* locals = &threadStateData->threadObjectStack[cn1LocalsBeginInThread]; \
     struct elementStruct* stack = &threadStateData->threadObjectStack[threadStateData->threadObjectStackOffset + localsStackSize]; \
-    int stackPointer = spPosition; \
+    struct elementStruct* SP = &stack[spPosition]; \
     initMethodStack(threadStateData, __cn1ThisObject, stackSize,localsStackSize, classNameId, methodNameId); \
     const int currentCodenameOneCallStackOffset = threadStateData->callStackOffset;
 
+//#define stackPointer (SP-&stack[0])
 
 #ifdef __OBJC__
 extern JAVA_OBJECT fromNSString(CODENAME_ONE_THREAD_STATE, NSString* str);
@@ -982,14 +983,14 @@ static inline struct elementStruct* popAndRelease(CODENAME_ONE_THREAD_STATE, str
 }
 */
 
-extern struct elementStruct* pop(struct elementStruct* array, int* sp);
-extern void popMany(CODENAME_ONE_THREAD_STATE, int count, struct elementStruct* array, int* sp);
+extern struct elementStruct* pop(struct elementStruct** sp);
+extern void popMany(CODENAME_ONE_THREAD_STATE, int count, struct elementStruct** SP);
 
 
-#define swapStack(array, sp) { \
-    struct elementStruct t = array[sp-1]; \
-    array[sp-1] = array[sp - 2]; \
-    array[sp - 2] = t; \
+#define swapStack(sp) { \
+    struct elementStruct t = sp[-1]; \
+    sp[-1] = sp[-2]; \
+    sp[-2] = t; \
 }
 
 extern struct clazz class__java_lang_Class;

--- a/vm/ByteCodeTranslator/src/cn1_globals.h
+++ b/vm/ByteCodeTranslator/src/cn1_globals.h
@@ -245,12 +245,12 @@ typedef struct clazz*       JAVA_CLASS;
 #define BC_SWAP() swapStack(SP)
 
 
-#define POP_INT() pop(&SP)->data.i
-#define POP_OBJ() pop(&SP)->data.o
-#define POP_OBJ_NO_RELEASE() pop(&SP)->data.o
-#define POP_LONG() pop(&SP)->data.l
-#define POP_DOUBLE() pop(&SP)->data.d
-#define POP_FLOAT() pop(&SP)->data.f
+#define POP_INT() (*pop(&SP)).data.i
+#define POP_OBJ() (*pop(&SP)).data.o
+#define POP_OBJ_NO_RELEASE() (*pop(&SP)).data.o
+#define POP_LONG() (*pop(&SP)).data.l
+#define POP_DOUBLE() (*pop(&SP)).data.d
+#define POP_FLOAT() (*pop(&SP)).data.f
 
 #define PEEK_INT(offset) SP[-offset].data.i
 #define PEEK_OBJ(offset) SP[-offset].data.o
@@ -425,12 +425,12 @@ typedef struct clazz*       JAVA_CLASS;
     SP[-offset].data.i = pInt; \
     popMany(threadStateData, MAX(1, offset) - 1, &SP); }
 
-#define POP_MANY_AND_PUSH_LONG(value, offset) { \
+#define POP_MANY_AND_PUSH_LONG(value, offset) {  \
     JAVA_LONG pLong = value; SP[-offset].type = CN1_TYPE_LONG; \
     SP[-offset].data.l = pLong; \
     popMany(threadStateData, MAX(1, offset) - 1, &SP); }
 
-#define POP_MANY_AND_PUSH_DOUBLE(value, offset) {\
+#define POP_MANY_AND_PUSH_DOUBLE(value, offset) {  \
     JAVA_DOUBLE pDob = value; SP[-offset].type = CN1_TYPE_DOUBLE; \
     SP[-offset].data.d = pDob; \
     popMany(threadStateData, MAX(1, offset) - 1, &SP); }
@@ -511,7 +511,7 @@ if(SP[-1].type == CN1_TYPE_LONG || SP[-1].type == CN1_TYPE_DOUBLE) {\
         SP[1].data.l = plong2; \
         SP+=2; \
     } \
-    SP[-1].type = SP[-1].type; \
+    SP[-1].type = SP[-3].type; \
     SP[-2].type = SP[-4].type; \
 }
 
@@ -536,12 +536,12 @@ if(SP[-1].type == CN1_TYPE_LONG || SP[-1].type == CN1_TYPE_DOUBLE) {\
     } else {\
         (*SP).data.l = SP[-1].data.l; \
         SP[-1].data.l = SP[-2].data.l; \
-        SP[-2].data.l = SP[-1].data.l; \
-        SP[-1].data.l = (*SP).data.l; \
+        SP[-2].data.l = SP[-3].data.l; \
+        SP[-3].data.l = (*SP).data.l; \
         (*SP).type = SP[-1].type; \
         SP[-1].type = SP[-2].type; \
-        SP[-2].type = SP[-1].type; \
-        SP[-1].type = (*SP).type; \
+        SP[-2].type = SP[-3].type; \
+        SP[-3].type = (*SP).type; \
     }\
     SP++; \
 }
@@ -641,28 +641,28 @@ extern int instanceofFunction(int sourceClass, int destId);
 
 
 #define BC_BASTORE() CHECK_ARRAY_ACCESS(3, SP[-2].data.i); \
-    ((JAVA_ARRAY_BYTE*) (*(JAVA_ARRAY)SP[-1].data.o).data)[SP[-2].data.i] = SP[-1].data.i; SP-=3
+    ((JAVA_ARRAY_BYTE*) (*(JAVA_ARRAY)SP[-3].data.o).data)[SP[-2].data.i] = SP[-1].data.i; SP-=3
 
 #define BC_CASTORE() CHECK_ARRAY_ACCESS(3, SP[-2].data.i); \
-    ((JAVA_ARRAY_CHAR*) (*(JAVA_ARRAY)SP[-1].data.o).data)[SP[-2].data.i] = SP[-1].data.i; SP-=3
+    ((JAVA_ARRAY_CHAR*) (*(JAVA_ARRAY)SP[-3].data.o).data)[SP[-2].data.i] = SP[-1].data.i; SP-=3
 
 #define BC_SASTORE() CHECK_ARRAY_ACCESS(3, SP[-2].data.i); \
-    ((JAVA_ARRAY_SHORT*) (*(JAVA_ARRAY)SP[-1].data.o).data)[SP[-2].data.i] = SP[-1].data.i; SP-=3
+    ((JAVA_ARRAY_SHORT*) (*(JAVA_ARRAY)SP[-3].data.o).data)[SP[-2].data.i] = SP[-1].data.i; SP-=3
 
 #define BC_IASTORE() CHECK_ARRAY_ACCESS(3, SP[-2].data.i); \
-    ((JAVA_ARRAY_INT*) (*(JAVA_ARRAY)SP[-1].data.o).data)[SP[-2].data.i] = SP[-1].data.i; SP-=3
+    ((JAVA_ARRAY_INT*) (*(JAVA_ARRAY)SP[-3].data.o).data)[SP[-2].data.i] = SP[-1].data.i; SP-=3
 
 #define BC_LASTORE() CHECK_ARRAY_ACCESS(3, SP[-2].data.i); \
-    LONG_ARRAY_LOOKUP((JAVA_ARRAY)SP[-1].data.o, SP[-2].data.i) = SP[-1].data.l; SP-=3
+    LONG_ARRAY_LOOKUP((JAVA_ARRAY)SP[-3].data.o, SP[-2].data.i) = SP[-1].data.l; SP-=3
 
 #define BC_FASTORE() CHECK_ARRAY_ACCESS(3, SP[-2].data.i); \
-    FLOAT_ARRAY_LOOKUP((JAVA_ARRAY)SP[-1].data.o, SP[-2].data.i) = SP[-1].data.f; SP-=3
+    FLOAT_ARRAY_LOOKUP((JAVA_ARRAY)SP[-3].data.o, SP[-2].data.i) = SP[-1].data.f; SP-=3
 
 #define BC_DASTORE() CHECK_ARRAY_ACCESS(3, SP[-2].data.i); \
-    DOUBLE_ARRAY_LOOKUP((JAVA_ARRAY)SP[-1].data.o, SP[-2].data.i) = SP[-1].data.d; SP-=3
+    DOUBLE_ARRAY_LOOKUP((JAVA_ARRAY)SP[-3].data.o, SP[-2].data.i) = SP[-1].data.d; SP-=3
 
 #define BC_AASTORE() CHECK_ARRAY_ACCESS(3, SP[-2].data.i); { \
-    JAVA_OBJECT aastoreTmp = SP[-1].data.o; \
+    JAVA_OBJECT aastoreTmp = SP[-3].data.o; \
     ((JAVA_ARRAY_OBJECT*) (*(JAVA_ARRAY)aastoreTmp).data)[SP[-2].data.i] = SP[-1].data.o; \
     SP-=3; \
 }
@@ -917,7 +917,6 @@ extern void initMethodStack(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT __cn1ThisObje
     initMethodStack(threadStateData, __cn1ThisObject, stackSize,localsStackSize, classNameId, methodNameId); \
     const int currentCodenameOneCallStackOffset = threadStateData->callStackOffset;
 
-//#define stackPointer (SP-&stack[0])
 
 #ifdef __OBJC__
 extern JAVA_OBJECT fromNSString(CODENAME_ONE_THREAD_STATE, NSString* str);
@@ -983,8 +982,8 @@ static inline struct elementStruct* popAndRelease(CODENAME_ONE_THREAD_STATE, str
 }
 */
 
-extern struct elementStruct* pop(struct elementStruct** sp);
-extern void popMany(CODENAME_ONE_THREAD_STATE, int count, struct elementStruct** SP);
+extern struct elementStruct* pop(struct elementStruct**sp);
+extern void popMany(CODENAME_ONE_THREAD_STATE, int count, struct elementStruct**sp);
 
 
 #define swapStack(sp) { \

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -115,17 +115,15 @@ struct clazz class_array3__JAVA_DOUBLE = {
    DEBUG_GC_INIT 0, 999999, 0, 0, 0, 0, 0, 0, &gcMarkArrayObject, 0, cn1_array_3_id_JAVA_DOUBLE, "double[]", JAVA_TRUE, 3, &class__java_lang_Double, JAVA_TRUE, &class__java_lang_Object, EMPTY_INTERFACES, 0, 0, 0
 };
 
-
-struct elementStruct* pop(struct elementStruct* array, int* sp) {
+struct elementStruct* pop(struct elementStruct** sp) {
     --(*sp);
-    struct elementStruct* retVal = &array[*sp];
-    return retVal;
+    return *sp;
 }
 
-void popMany(CODENAME_ONE_THREAD_STATE, int count, struct elementStruct* array, int* sp) {
+void popMany(CODENAME_ONE_THREAD_STATE, int count, struct elementStruct** SP) {
     while(count > 0) {
-        --(*sp);
-        javaTypes t = array[*sp].type;
+        --(*SP);
+        javaTypes t = (*SP)->type;
         if(t == CN1_TYPE_DOUBLE || t == CN1_TYPE_LONG) {
             count -= 2;
         } else {

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeClass.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeClass.java
@@ -70,7 +70,11 @@ public class ByteCodeClass {
 
     public void addMethod(BytecodeMethod m) {
         if(m.isMain()) {
-            mainClass = this;
+            if (mainClass == null) {
+                mainClass = this;
+            } else {
+                throw new RuntimeException("Multiple main classes: "+mainClass.clsName+" and "+this.clsName);
+            }
         }
         m.setSourceFile(sourceFile);
         m.setForceVirtual(isInterface);

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeTranslator.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeTranslator.java
@@ -227,7 +227,7 @@ public class ByteCodeTranslator {
                     return string.endsWith(".bundle") || string.endsWith(".xcdatamodeld") || !pathname.isHidden() && !string.startsWith(".") && !"Images.xcassets".equals(string);
                 }
             });
-            
+
             StringBuilder fileOneEntry = new StringBuilder();
             StringBuilder fileTwoEntry = new StringBuilder();
             StringBuilder fileListEntry = new StringBuilder();

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
@@ -1449,7 +1449,7 @@ public class BytecodeMethod {
                             if (storeLiteral != null) {
                                 sb.append("    "+storeLiteral);
                             } else {
-                                sb.append("    stack[stackPointer].type = CN1_TYPE_INT; stack[stackPointer++].data.i = ");
+                                sb.append("    (*SP).type = CN1_TYPE_INT; (*(SP++)).data.i = ");
                             }
                             sb.append(leftLiteral).append(operator).append(rightLiteral)
                                     .append("; /* ").append(opName).append(" Optimized */\n");

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ConcatenatingFileOutputSteeam.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ConcatenatingFileOutputSteeam.java
@@ -1,9 +1,6 @@
 package com.codename1.tools.translator;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
+import java.io.*;
 
 /**
  * Created by san on 2/13/16.
@@ -49,7 +46,7 @@ public class ConcatenatingFileOutputSteeam extends java.io.OutputStream {
             if (dest == null || dest[i].size() ==0) {
                 destFile.delete();
             } else {
-                PreservingFileOutputStream pfos = new PreservingFileOutputStream(destFile);
+                FileOutputStream pfos = new FileOutputStream(destFile);
                 pfos.write(byteArrayOutputStream.toByteArray());
                 pfos.close();
             }

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ConcatenatingFileOutputSteeam.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ConcatenatingFileOutputSteeam.java
@@ -1,0 +1,58 @@
+package com.codename1.tools.translator;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+/**
+ * Created by san on 2/13/16.
+ */
+public class ConcatenatingFileOutputSteeam extends java.io.OutputStream {
+
+    public static final int MODULO = 32;
+
+    ByteArrayOutputStream []dest = new ByteArrayOutputStream[MODULO];
+    ByteArrayOutputStream current;
+    private File outputDirectory;
+
+    public ConcatenatingFileOutputSteeam(File outputDirectory) {
+
+        this.outputDirectory = outputDirectory;
+    }
+
+    public void beginNextFile(String fileid) {
+        int destIndex = Math.abs(fileid.hashCode() % MODULO);
+        current = dest[destIndex];
+        if (current == null) {
+            current = dest[destIndex] = new ByteArrayOutputStream();
+        }
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        if (current == null) {
+            throw new RuntimeException("beginNextFile() not called.");
+        }
+        current.write(b);
+    }
+
+    @Override
+    public void close() {
+        current.write('\n');
+    }
+
+    public void realClose() throws IOException {
+        for (int i = 0; i < dest.length; i++) {
+            ByteArrayOutputStream byteArrayOutputStream = dest[i];
+            File destFile = new File(outputDirectory, "concatenated_" + i+"."+ByteCodeTranslator.output.extension());
+            if (dest == null || dest[i].size() ==0) {
+                destFile.delete();
+            } else {
+                PreservingFileOutputStream pfos = new PreservingFileOutputStream(destFile);
+                pfos.write(byteArrayOutputStream.toByteArray());
+                pfos.close();
+            }
+        }
+    }
+}

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ConcatenatingFileOutputStream.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ConcatenatingFileOutputStream.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
 package com.codename1.tools.translator;
 
 import java.io.*;
@@ -5,7 +28,7 @@ import java.io.*;
 /**
  * Created by san on 2/13/16.
  */
-public class ConcatenatingFileOutputSteeam extends java.io.OutputStream {
+public class ConcatenatingFileOutputStream extends java.io.OutputStream {
 
     public static final int MODULO = 32;
 
@@ -13,7 +36,7 @@ public class ConcatenatingFileOutputSteeam extends java.io.OutputStream {
     ByteArrayOutputStream current;
     private File outputDirectory;
 
-    public ConcatenatingFileOutputSteeam(File outputDirectory) {
+    public ConcatenatingFileOutputStream(File outputDirectory) {
 
         this.outputDirectory = outputDirectory;
     }

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/Parser.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/Parser.java
@@ -398,7 +398,7 @@ public class Parser extends ClassVisitor {
             generateClassAndMethodIndexHeader(outputDirectory);
 
             boolean concatenate = "true".equals(System.getProperty("concatenateFiles", "false"));
-            ConcatenatingFileOutputSteeam cos = concatenate ? new ConcatenatingFileOutputSteeam(outputDirectory) : null;
+            ConcatenatingFileOutputStream cos = concatenate ? new ConcatenatingFileOutputStream(outputDirectory) : null;
 
             for(ByteCodeClass bc : classes) {
                 file = bc.getClsName();
@@ -579,14 +579,14 @@ public class Parser extends ClassVisitor {
         return false;
     }
 
-    private static void writeFile(ByteCodeClass cls, File outputDir, ConcatenatingFileOutputSteeam writeBufferInstead) throws Exception {
+    private static void writeFile(ByteCodeClass cls, File outputDir, ConcatenatingFileOutputStream writeBufferInstead) throws Exception {
         OutputStream outMain =
                 writeBufferInstead != null && ByteCodeTranslator.output == ByteCodeTranslator.OutputType.OUTPUT_TYPE_IOS ?
                         writeBufferInstead :
                         new FileOutputStream(new File(outputDir, cls.getClsName() + "." + ByteCodeTranslator.output.extension()));
 
-        if (outMain instanceof ConcatenatingFileOutputSteeam) {
-            ((ConcatenatingFileOutputSteeam)outMain).beginNextFile(cls.getClsName());
+        if (outMain instanceof ConcatenatingFileOutputStream) {
+            ((ConcatenatingFileOutputStream)outMain).beginNextFile(cls.getClsName());
         }
         if(ByteCodeTranslator.output == ByteCodeTranslator.OutputType.OUTPUT_TYPE_IOS) {
             outMain.write(cls.generateCCode(classes).getBytes());

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/BasicInstruction.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/BasicInstruction.java
@@ -133,103 +133,103 @@ public class BasicInstruction extends Instruction implements AssignableExpressio
                 break;
 
             case Opcodes.BALOAD:
-                b.append("    { CHECK_ARRAY_ACCESS(2, stack[stackPointer - 1].data.i); /* BALOAD */ \n" +
-                    "    stackPointer--; stack[stackPointer - 1].type = CN1_TYPE_INT; \n" +
-                    "    stack[stackPointer - 1].data.i = ((JAVA_ARRAY_BYTE*) (*(JAVA_ARRAY)stack[stackPointer - 1].data.o).data)[stack[stackPointer].data.i]; \n" +
+                b.append("    { CHECK_ARRAY_ACCESS(2, SP[-1].data.i); /* BALOAD */ \n" +
+                    "    SP--; SP[-1].type = CN1_TYPE_INT; \n" +
+                    "    SP[-1].data.i = ((JAVA_ARRAY_BYTE*) (*(JAVA_ARRAY)SP[-1].data.o).data)[(*SP).data.i]; \n" +
                     "    }\n");
                 break;
 
             case Opcodes.CALOAD:
-                b.append("    CHECK_ARRAY_ACCESS(2, stack[stackPointer - 1].data.i); /* CALOAD */\n" +
-                    "    stackPointer--; stack[stackPointer - 1].type = CN1_TYPE_INT; \n" +
-                    "    stack[stackPointer - 1].data.i = ((JAVA_ARRAY_CHAR*) (*(JAVA_ARRAY)stack[stackPointer - 1].data.o).data)[stack[stackPointer].data.i];\n");
+                b.append("    CHECK_ARRAY_ACCESS(2, SP[-1].data.i); /* CALOAD */\n" +
+                    "    SP--; SP[-1].type = CN1_TYPE_INT; \n" +
+                    "    SP[-1].data.i = ((JAVA_ARRAY_CHAR*) (*(JAVA_ARRAY)SP[-1].data.o).data)[(*SP).data.i];\n");
                 break;
                 
             case Opcodes.IALOAD:
-                b.append("    CHECK_ARRAY_ACCESS(2, stack[stackPointer - 1].data.i); /* IALOAD */\n" +
-                        "    stackPointer--; stack[stackPointer - 1].type = CN1_TYPE_INT; \n" +
-                        "    stack[stackPointer - 1].data.i = ((JAVA_ARRAY_INT*) (*(JAVA_ARRAY)stack[stackPointer - 1].data.o).data)[stack[stackPointer].data.i];\n");
+                b.append("    CHECK_ARRAY_ACCESS(2, SP[-1].data.i); /* IALOAD */\n" +
+                        "    SP--; SP[-1].type = CN1_TYPE_INT; \n" +
+                        "    SP[-1].data.i = ((JAVA_ARRAY_INT*) (*(JAVA_ARRAY)SP[-1].data.o).data)[(*SP).data.i];\n");
                 break;
 
             case Opcodes.SALOAD:
-                b.append("    CHECK_ARRAY_ACCESS(2, stack[stackPointer - 1].data.i); \n" +
-                        "    stackPointer--; stack[stackPointer - 1].type = CN1_TYPE_INT; \n" +
-                        "    stack[stackPointer - 1].data.i = ((JAVA_ARRAY_SHORT*) (*(JAVA_ARRAY)stack[stackPointer - 1].data.o).data)[stack[stackPointer].data.i]; /* SALOAD */\n");
+                b.append("    CHECK_ARRAY_ACCESS(2, SP[-1].data.i); \n" +
+                        "    SP--; SP[-1].type = CN1_TYPE_INT; \n" +
+                        "    SP[-1].data.i = ((JAVA_ARRAY_SHORT*) (*(JAVA_ARRAY)SP[-1].data.o).data)[(*SP).data.i]; /* SALOAD */\n");
                 break;
 
             case Opcodes.LALOAD:
-                b.append("    CHECK_ARRAY_ACCESS(2, stack[stackPointer - 1].data.i); /* LALOAD */\n" +
-                        "    stackPointer--; stack[stackPointer - 1].type = CN1_TYPE_LONG; \n" +
-                        "    stack[stackPointer - 1].data.l = LONG_ARRAY_LOOKUP((JAVA_ARRAY)stack[stackPointer - 1].data.o, stack[stackPointer].data.i);\n");
+                b.append("    CHECK_ARRAY_ACCESS(2, SP[-1].data.i); /* LALOAD */\n" +
+                        "    SP--; SP[-1].type = CN1_TYPE_LONG; \n" +
+                        "    SP[-1].data.l = LONG_ARRAY_LOOKUP((JAVA_ARRAY)SP[-1].data.o, (*SP).data.i);\n");
                 break;
 
             case Opcodes.FALOAD:
-                b.append("    CHECK_ARRAY_ACCESS(2, stack[stackPointer - 1].data.i); /* FALOAD */\n" +
-                        "    stackPointer--; stack[stackPointer - 1].type = CN1_TYPE_FLOAT; \n" +
-                        "    stack[stackPointer - 1].data.f = FLOAT_ARRAY_LOOKUP((JAVA_ARRAY)stack[stackPointer - 1].data.o, stack[stackPointer].data.i);\n");
+                b.append("    CHECK_ARRAY_ACCESS(2, SP[-1].data.i); /* FALOAD */\n" +
+                        "    SP--; SP[-1].type = CN1_TYPE_FLOAT; \n" +
+                        "    SP[-1].data.f = FLOAT_ARRAY_LOOKUP((JAVA_ARRAY)SP[-1].data.o, (*SP).data.i);\n");
                 break;
 
             case Opcodes.DALOAD:
-                b.append("    CHECK_ARRAY_ACCESS(2, stack[stackPointer - 1].data.i); /* DALOAD */\n" +
-                        "    stackPointer--; stack[stackPointer - 1].type = CN1_TYPE_DOUBLE; \n" +
-                        "    stack[stackPointer - 1].data.d = DOUBLE_ARRAY_LOOKUP((JAVA_ARRAY)stack[stackPointer - 1].data.o, stack[stackPointer].data.i);\n");
+                b.append("    CHECK_ARRAY_ACCESS(2, SP[-1].data.i); /* DALOAD */\n" +
+                        "    SP--; SP[-1].type = CN1_TYPE_DOUBLE; \n" +
+                        "    SP[-1].data.d = DOUBLE_ARRAY_LOOKUP((JAVA_ARRAY)SP[-1].data.o, (*SP).data.i);\n");
                 break;
 
             case Opcodes.AALOAD:
-                b.append("    CHECK_ARRAY_ACCESS(2, stack[stackPointer - 1].data.i); /* AALOAD */\n" +
-                        "    stackPointer--; stack[stackPointer - 1].type = CN1_TYPE_INVALID; \n" +
-                        "    stack[stackPointer - 1].data.o = ((JAVA_ARRAY_OBJECT*) (*(JAVA_ARRAY)stack[stackPointer - 1].data.o).data)[stack[stackPointer].data.i]; \n" +
-                        "    stack[stackPointer - 1].type = CN1_TYPE_OBJECT; \n");
+                b.append("    CHECK_ARRAY_ACCESS(2, SP[-1].data.i); /* AALOAD */\n" +
+                        "    SP--; SP[-1].type = CN1_TYPE_INVALID; \n" +
+                        "    SP[-1].data.o = ((JAVA_ARRAY_OBJECT*) (*(JAVA_ARRAY)SP[-1].data.o).data)[(*SP).data.i]; \n" +
+                        "    SP[-1].type = CN1_TYPE_OBJECT; \n");
                 break;
 
             case Opcodes.BASTORE:
-                b.append("    CHECK_ARRAY_ACCESS(3, stack[stackPointer - 2].data.i); /* BASTORE */\n" +
-                        "    ((JAVA_ARRAY_BYTE*) (*(JAVA_ARRAY)stack[stackPointer - 3].data.o).data)[stack[stackPointer - 2].data.i] = stack[stackPointer - 1].data.i; stackPointer -= 3;\n");
+                b.append("    CHECK_ARRAY_ACCESS(3, SP[-2].data.i); /* BASTORE */\n" +
+                        "    ((JAVA_ARRAY_BYTE*) (*(JAVA_ARRAY)SP[-3].data.o).data)[SP[-2].data.i] = SP[-1].data.i; SP -= 3;\n");
                 break;
 
             case Opcodes.CASTORE:
-                b.append("    CHECK_ARRAY_ACCESS(3, stack[stackPointer - 2].data.i); /* CASTORE */\n" +
-                        "    ((JAVA_ARRAY_CHAR*) (*(JAVA_ARRAY)stack[stackPointer - 3].data.o).data)[stack[stackPointer - 2].data.i] = stack[stackPointer - 1].data.i; stackPointer -= 3;\n\n");
+                b.append("    CHECK_ARRAY_ACCESS(3, SP[-2].data.i); /* CASTORE */\n" +
+                        "    ((JAVA_ARRAY_CHAR*) (*(JAVA_ARRAY)SP[-3].data.o).data)[SP[-2].data.i] = SP[-1].data.i; SP -= 3;\n\n");
                 break;
 
             case Opcodes.SASTORE:
-                b.append("    CHECK_ARRAY_ACCESS(3, stack[stackPointer - 2].data.i); /* SASTORE */\n" +
-                        "    ((JAVA_ARRAY_SHORT*) (*(JAVA_ARRAY)stack[stackPointer - 3].data.o).data)[stack[stackPointer - 2].data.i] = stack[stackPointer - 1].data.i; stackPointer -= 3;\n");
+                b.append("    CHECK_ARRAY_ACCESS(3, SP[-2].data.i); /* SASTORE */\n" +
+                        "    ((JAVA_ARRAY_SHORT*) (*(JAVA_ARRAY)SP[-3].data.o).data)[SP[-2].data.i] = SP[-1].data.i; SP -= 3;\n");
                 break;
 
             case Opcodes.IASTORE:
-                b.append("    CHECK_ARRAY_ACCESS(3, stack[stackPointer - 2].data.i); /* IASTORE */\n" +
-                        "    ((JAVA_ARRAY_INT*) (*(JAVA_ARRAY)stack[stackPointer - 3].data.o).data)[stack[stackPointer - 2].data.i] = stack[stackPointer - 1].data.i; stackPointer -= 3;\n");
+                b.append("    CHECK_ARRAY_ACCESS(3, SP[-2].data.i); /* IASTORE */\n" +
+                        "    ((JAVA_ARRAY_INT*) (*(JAVA_ARRAY)SP[-3].data.o).data)[SP[-2].data.i] = SP[-1].data.i; SP -= 3;\n");
                 break;
 
             case Opcodes.LASTORE:
-                b.append("    CHECK_ARRAY_ACCESS(3, stack[stackPointer - 2].data.i); /* LASTORE */\n" +
-                        "    LONG_ARRAY_LOOKUP((JAVA_ARRAY)stack[stackPointer - 3].data.o, stack[stackPointer - 2].data.i) = stack[stackPointer - 1].data.l; stackPointer -= 3;\n");
+                b.append("    CHECK_ARRAY_ACCESS(3, SP[-2].data.i); /* LASTORE */\n" +
+                        "    LONG_ARRAY_LOOKUP((JAVA_ARRAY)SP[-3].data.o, SP[-2].data.i) = SP[-1].data.l; SP -= 3;\n");
                 break;
 
             case Opcodes.FASTORE:
-                b.append("    CHECK_ARRAY_ACCESS(3, stack[stackPointer - 2].data.i); /* FASTORE */\n" +
-                        "    FLOAT_ARRAY_LOOKUP((JAVA_ARRAY)stack[stackPointer - 3].data.o, stack[stackPointer - 2].data.i) = stack[stackPointer - 1].data.f; stackPointer -= 3;\n");
+                b.append("    CHECK_ARRAY_ACCESS(3, SP[-2].data.i); /* FASTORE */\n" +
+                        "    FLOAT_ARRAY_LOOKUP((JAVA_ARRAY)SP[-3].data.o, SP[-2].data.i) = SP[-1].data.f; SP -= 3;\n");
                 break;
 
             case Opcodes.DASTORE:
-                b.append("    CHECK_ARRAY_ACCESS(3, stack[stackPointer - 2].data.i); /* DASTORE */\n" +
-                        "    DOUBLE_ARRAY_LOOKUP((JAVA_ARRAY)stack[stackPointer - 3].data.o, stack[stackPointer - 2].data.i) = stack[stackPointer - 1].data.d; stackPointer -= 3;\n");
+                b.append("    CHECK_ARRAY_ACCESS(3, SP[-2].data.i); /* DASTORE */\n" +
+                        "    DOUBLE_ARRAY_LOOKUP((JAVA_ARRAY)SP[-3].data.o, SP[-2].data.i) = SP[-1].data.d; SP -= 3;\n");
                 break;
 
             case Opcodes.AASTORE:
-                b.append("    CHECK_ARRAY_ACCESS(3, stack[stackPointer - 2].data.i); { /* BC_AASTORE */\n" +
-                        "    JAVA_OBJECT aastoreTmp = stack[stackPointer - 3].data.o; \n" +
-                        "    ((JAVA_ARRAY_OBJECT*) (*(JAVA_ARRAY)aastoreTmp).data)[stack[stackPointer - 2].data.i] = stack[stackPointer - 1].data.o; \n" +
-                        "    stackPointer -= 3; }\n");
+                b.append("    CHECK_ARRAY_ACCESS(3, SP[-2].data.i); { /* BC_AASTORE */\n" +
+                        "    JAVA_OBJECT aastoreTmp = SP[-3].data.o; \n" +
+                        "    ((JAVA_ARRAY_OBJECT*) (*(JAVA_ARRAY)aastoreTmp).data)[SP[-2].data.i] = SP[-1].data.o; \n" +
+                        "    SP -= 3; }\n");
                 break;
 
             case Opcodes.POP:
-                b.append("    stackPointer--; /* POP */\n");
+                b.append("    SP--; /* POP */\n");
                 break;
 
             case Opcodes.POP2:
-                b.append("    popMany(threadStateData, 2, stack, &stackPointer); /* POP2 */\n");
+                b.append("    popMany(threadStateData, 2, &SP); /* POP2 */\n");
                 break;
 
             /*case Opcodes.DUP:
@@ -269,211 +269,211 @@ public class BasicInstruction extends Instruction implements AssignableExpressio
                 break;
                 
             case Opcodes.SWAP:
-                b.append("    swapStack(stack, stackPointer); /* SWAP */\n");
+                b.append("    swapStack(SP); /* SWAP */\n");
                 break;
                 
             case Opcodes.IADD:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.i = stack[stackPointer - 1].data.i + stack[stackPointer].data.i; /* IADD */\n");
+                b.append("    SP--; SP[-1].data.i = SP[-1].data.i + (*SP).data.i; /* IADD */\n");
                 break;
                 
             case Opcodes.LADD:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.l = stack[stackPointer - 1].data.l + stack[stackPointer].data.l; /* LADD */\n");
+                b.append("    SP--; SP[-1].data.l = SP[-1].data.l + (*SP).data.l; /* LADD */\n");
                 break;
                 
             case Opcodes.FADD:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.f = stack[stackPointer - 1].data.f + stack[stackPointer].data.f; /* FADD */\n");
+                b.append("    SP--; SP[-1].data.f = SP[-1].data.f + (*SP).data.f; /* FADD */\n");
                 break;
                 
             case Opcodes.DADD:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.d = stack[stackPointer - 1].data.d + stack[stackPointer].data.d; /* DADD */\n");
+                b.append("    SP--; SP[-1].data.d = SP[-1].data.d + (*SP).data.d; /* DADD */\n");
                 break;
                 
             case Opcodes.ISUB:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.i = (stack[stackPointer - 1].data.i - stack[stackPointer].data.i); /* ISUB */\n");
+                b.append("    SP--; SP[-1].data.i = (SP[-1].data.i - (*SP).data.i); /* ISUB */\n");
                 break;
                 
             case Opcodes.LSUB:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.l = (stack[stackPointer - 1].data.l - stack[stackPointer].data.l); /* LSUB */\n");
+                b.append("    SP--; SP[-1].data.l = (SP[-1].data.l - (*SP).data.l); /* LSUB */\n");
                 break;
                 
             case Opcodes.FSUB:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.f = (stack[stackPointer - 1].data.f - stack[stackPointer].data.f); /* FSUB */\n");
+                b.append("    SP--; SP[-1].data.f = (SP[-1].data.f - (*SP).data.f); /* FSUB */\n");
                 break;
                 
             case Opcodes.DSUB:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.d = (stack[stackPointer - 1].data.d - stack[stackPointer].data.d); /* DSUB */\n");
+                b.append("    SP--; SP[-1].data.d = (SP[-1].data.d - (*SP).data.d); /* DSUB */\n");
                 break;
                 
             case Opcodes.IMUL:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.i = stack[stackPointer - 1].data.i * stack[stackPointer].data.i; /* IMUL */\n");
+                b.append("    SP--; SP[-1].data.i = SP[-1].data.i * (*SP).data.i; /* IMUL */\n");
                 break;
                 
             case Opcodes.LMUL:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.l = stack[stackPointer - 1].data.l * stack[stackPointer].data.l; /* LMUL */\n");
+                b.append("    SP--; SP[-1].data.l = SP[-1].data.l * (*SP).data.l; /* LMUL */\n");
                 break;
                 
             case Opcodes.FMUL:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.f = stack[stackPointer - 1].data.f * stack[stackPointer].data.f; /* FMUL */\n");
+                b.append("    SP--; SP[-1].data.f = SP[-1].data.f * (*SP).data.f; /* FMUL */\n");
                 break;
                 
             case Opcodes.DMUL:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.d = stack[stackPointer - 1].data.d * stack[stackPointer].data.d; /* DMUL */\n");
+                b.append("    SP--; SP[-1].data.d = SP[-1].data.d * (*SP).data.d; /* DMUL */\n");
                 break;
                 
             case Opcodes.IDIV:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.i = stack[stackPointer - 1].data.i / stack[stackPointer].data.i; /* IDIV */\n");
+                b.append("    SP--; SP[-1].data.i = SP[-1].data.i / (*SP).data.i; /* IDIV */\n");
                 break;
                 
             case Opcodes.LDIV:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.l = stack[stackPointer - 1].data.l / stack[stackPointer].data.l; /* LDIV */\n");
+                b.append("    SP--; SP[-1].data.l = SP[-1].data.l / (*SP).data.l; /* LDIV */\n");
                 break;
                 
             case Opcodes.FDIV:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.f = stack[stackPointer - 1].data.f / stack[stackPointer].data.f; /* FDIV */\n");
+                b.append("    SP--; SP[-1].data.f = SP[-1].data.f / (*SP).data.f; /* FDIV */\n");
                 break;
                 
             case Opcodes.DDIV:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.d = stack[stackPointer - 1].data.d / stack[stackPointer].data.d; /* DDIV */\n");
+                b.append("    SP--; SP[-1].data.d = SP[-1].data.d / (*SP).data.d; /* DDIV */\n");
                 break;
                 
             case Opcodes.IREM:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.i = stack[stackPointer - 1].data.i % stack[stackPointer].data.i; /* IREM */\n");
+                b.append("    SP--; SP[-1].data.i = SP[-1].data.i % (*SP).data.i; /* IREM */\n");
                 break;
                 
             case Opcodes.LREM:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.l = stack[stackPointer - 1].data.l % stack[stackPointer].data.l; /* LREM */\n");
+                b.append("    SP--; SP[-1].data.l = SP[-1].data.l % (*SP).data.l; /* LREM */\n");
                 break;
                 
             case Opcodes.FREM:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.f = fmod(stack[stackPointer - 1].data.f, stack[stackPointer].data.f); /* FREM */\n");
+                b.append("    SP--; SP[-1].data.f = fmod(SP[-1].data.f, (*SP).data.f); /* FREM */\n");
                 break;
                 
             case Opcodes.DREM:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.d = fmod(stack[stackPointer - 1].data.d, stack[stackPointer].data.d); /* DREM */\n");
+                b.append("    SP--; SP[-1].data.d = fmod(SP[-1].data.d, (*SP).data.d); /* DREM */\n");
                 break;
                 
             case Opcodes.INEG:
-                b.append("    stack[stackPointer - 1].data.i *= -1; /* INEG */\n");
+                b.append("    SP[-1].data.i *= -1; /* INEG */\n");
                 break;
                 
             case Opcodes.LNEG:
-                b.append("    stack[stackPointer - 1].data.l *= -1; /* LNEG */\n");
+                b.append("    SP[-1].data.l *= -1; /* LNEG */\n");
                 break;
                 
             case Opcodes.FNEG:
-                b.append("    stack[stackPointer - 1].data.f *= -1; /* FNEG */\n");
+                b.append("    SP[-1].data.f *= -1; /* FNEG */\n");
                 break;
                 
             case Opcodes.DNEG:
-                b.append("    stack[stackPointer - 1].data.d *= -1; /* DNEG */\n");
+                b.append("    SP[-1].data.d *= -1; /* DNEG */\n");
                 break;
                 
             case Opcodes.ISHL:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.i = (stack[stackPointer - 1].data.i << (0x1f & stack[stackPointer].data.i)); /* ISHL */\n");
+                b.append("    SP--; SP[-1].data.i = (SP[-1].data.i << (0x1f & (*SP).data.i)); /* ISHL */\n");
                 break;
                 
             case Opcodes.LSHL:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.l = (stack[stackPointer - 1].data.l << (0x3f & stack[stackPointer].data.l)); /* LSHL */\n");
+                b.append("    SP--; SP[-1].data.l = (SP[-1].data.l << (0x3f & (*SP).data.l)); /* LSHL */\n");
                 break;
                 
             case Opcodes.ISHR:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.i = (stack[stackPointer - 1].data.i >> (0x1f & stack[stackPointer].data.i)); /* ISHR */\n");
+                b.append("    SP--; SP[-1].data.i = (SP[-1].data.i >> (0x1f & (*SP).data.i)); /* ISHR */\n");
                 break;
                 
             case Opcodes.LSHR:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.l = (stack[stackPointer - 1].data.l >> (0x3f & stack[stackPointer].data.l)); /* LSHR */\n");
+                b.append("    SP--; SP[-1].data.l = (SP[-1].data.l >> (0x3f & (*SP).data.l)); /* LSHR */\n");
                 break;
                 
             case Opcodes.IUSHR:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.i = (((unsigned int)stack[stackPointer - 1].data.i) >> (0x1f & ((unsigned int)stack[stackPointer].data.i))); /* IUSHR */\n");
+                b.append("    SP--; SP[-1].data.i = (((unsigned int)SP[-1].data.i) >> (0x1f & ((unsigned int)(*SP).data.i))); /* IUSHR */\n");
                 break;
                 
             case Opcodes.LUSHR:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.l = (((unsigned long long)stack[stackPointer - 1].data.l) >> (0x3f & ((unsigned long long)stack[stackPointer].data.i))); /* LUSHR */\n");
+                b.append("    SP--; SP[-1].data.l = (((unsigned long long)SP[-1].data.l) >> (0x3f & ((unsigned long long)(*SP).data.i))); /* LUSHR */\n");
                 break;
                 
             case Opcodes.IAND:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.i = stack[stackPointer - 1].data.i & stack[stackPointer].data.i; /* IAND */\n") ;
+                b.append("    SP--; SP[-1].data.i = SP[-1].data.i & (*SP).data.i; /* IAND */\n") ;
                 break;
                 
             case Opcodes.LAND:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.l = stack[stackPointer - 1].data.l & stack[stackPointer].data.l; /* LAND */\n") ;
+                b.append("    SP--; SP[-1].data.l = SP[-1].data.l & (*SP).data.l; /* LAND */\n") ;
                 break;
                 
             case Opcodes.IOR:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.i = stack[stackPointer - 1].data.i | stack[stackPointer].data.i; /* IOR */\n") ;
+                b.append("    SP--; SP[-1].data.i = SP[-1].data.i | (*SP).data.i; /* IOR */\n") ;
                 break;
                 
             case Opcodes.LOR:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.l = stack[stackPointer - 1].data.l | stack[stackPointer].data.l; /* LOR */\n") ;
+                b.append("    SP--; SP[-1].data.l = SP[-1].data.l | (*SP).data.l; /* LOR */\n") ;
                 break;
                 
             case Opcodes.IXOR:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.i = stack[stackPointer - 1].data.i ^ stack[stackPointer].data.i; /* IXOR */\n") ;
+                b.append("    SP--; SP[-1].data.i = SP[-1].data.i ^ (*SP).data.i; /* IXOR */\n") ;
                 break;
                 
             case Opcodes.LXOR:
-                b.append("    stackPointer--; stack[stackPointer - 1].data.l = stack[stackPointer - 1].data.l ^ stack[stackPointer].data.l; /* LXOR */\n") ;
+                b.append("    SP--; SP[-1].data.l = SP[-1].data.l ^ (*SP).data.l; /* LXOR */\n") ;
                 break;
                 
             case Opcodes.I2L:
-                b.append("    stack[stackPointer - 1].data.l = stack[stackPointer - 1].data.i; /* I2L */\n");
+                b.append("    SP[-1].data.l = SP[-1].data.i; /* I2L */\n");
                 break;
                 
             case Opcodes.I2F:
-                b.append("    stack[stackPointer - 1].data.f = (JAVA_FLOAT)stack[stackPointer - 1].data.i; /* I2F */\n");
+                b.append("    SP[-1].data.f = (JAVA_FLOAT)SP[-1].data.i; /* I2F */\n");
                 break;
                 
             case Opcodes.I2D:
-                b.append("    stack[stackPointer - 1].data.d = stack[stackPointer - 1].data.i; /* I2D */;\n");
+                b.append("    SP[-1].data.d = SP[-1].data.i; /* I2D */;\n");
                 break;
                 
             case Opcodes.L2I:
-                b.append("    stack[stackPointer - 1].data.i = (JAVA_INT)stack[stackPointer - 1].data.l; /* L2I */\n");
+                b.append("    SP[-1].data.i = (JAVA_INT)SP[-1].data.l; /* L2I */\n");
                 break;
                 
             case Opcodes.L2F:
-                b.append("    stack[stackPointer - 1].data.f = (JAVA_FLOAT)stack[stackPointer - 1].data.l; /* L2F */\n");
+                b.append("    SP[-1].data.f = (JAVA_FLOAT)SP[-1].data.l; /* L2F */\n");
                 break;
                 
             case Opcodes.L2D:
-                b.append("    stack[stackPointer - 1].data.d = (JAVA_DOUBLE)stack[stackPointer - 1].data.l; /* L2D */\n");
+                b.append("    SP[-1].data.d = (JAVA_DOUBLE)SP[-1].data.l; /* L2D */\n");
                 break;
                 
             case Opcodes.F2I:
-                b.append("    stack[stackPointer - 1].data.i = (JAVA_INT)stack[stackPointer - 1].data.f; /* F2I */\n");
+                b.append("    SP[-1].data.i = (JAVA_INT)SP[-1].data.f; /* F2I */\n");
                 break;
                 
             case Opcodes.F2L:
-                b.append("    stack[stackPointer - 1].data.l = (JAVA_LONG)stack[stackPointer - 1].data.f; /* F2L */\n");
+                b.append("    SP[-1].data.l = (JAVA_LONG)SP[-1].data.f; /* F2L */\n");
                 break;
                 
             case Opcodes.F2D:
-                b.append("    stack[stackPointer - 1].data.d = stack[stackPointer - 1].data.f; /* F2D */\n");
+                b.append("    SP[-1].data.d = SP[-1].data.f; /* F2D */\n");
                 break;
                 
             case Opcodes.D2I:
-                b.append("    stack[stackPointer - 1].data.i = (JAVA_INT)stack[stackPointer - 1].data.d; /* D2I */\n");
+                b.append("    SP[-1].data.i = (JAVA_INT)SP[-1].data.d; /* D2I */\n");
                 break;
                 
             case Opcodes.D2L:
-                b.append("    stack[stackPointer - 1].data.l = (JAVA_LONG)stack[stackPointer - 1].data.d; /* D2L */\n");
+                b.append("    SP[-1].data.l = (JAVA_LONG)SP[-1].data.d; /* D2L */\n");
                 break;
                 
             case Opcodes.D2F:
-                b.append("    stack[stackPointer - 1].data.f = (JAVA_FLOAT)stack[stackPointer - 1].data.d; /* D2F */\n");
+                b.append("    SP[-1].data.f = (JAVA_FLOAT)SP[-1].data.d; /* D2F */\n");
                 break;
                 
             case Opcodes.I2B:
-                b.append("    stack[stackPointer - 1].data.i = ((stack[stackPointer - 1].data.i << 24) >> 24); /* I2B */\n");
+                b.append("    SP[-1].data.i = ((SP[-1].data.i << 24) >> 24); /* I2B */\n");
                 break;
                 
             case Opcodes.I2C:
-                b.append("    stack[stackPointer - 1].data.i = (stack[stackPointer - 1].data.i & 0xffff); /* I2C */\n");
+                b.append("    SP[-1].data.i = (SP[-1].data.i & 0xffff); /* I2C */\n");
                 break;
                 
             case Opcodes.I2S:
-                b.append("    stack[stackPointer - 1].data.i = ((stack[stackPointer - 1].data.i << 16) >> 16); /* I2S */\n");
+                b.append("    SP[-1].data.i = ((SP[-1].data.i << 16) >> 16); /* I2S */\n");
                 break;
                 
             case Opcodes.LCMP:
@@ -494,13 +494,13 @@ public class BasicInstruction extends Instruction implements AssignableExpressio
                 appendSynchronized(b);
                 
                 if(TryCatch.isTryCatchInMethod()) {
-                    b.append("    releaseForReturnInException(threadStateData, cn1LocalsBeginInThread, stackPointer, ");
-                    b.append(maxLocals);
-                    b.append(", stack, locals, methodBlockOffset); \n    return stack[stackPointer - 1].data.i;\n");
+                    b.append("    releaseForReturnInException(threadStateData, cn1LocalsBeginInThread, methodBlockOffset); return SP[-1].data.i;\n");
+//                    b.append(maxLocals);
+//                    b.append(", stack, locals, methodBlockOffset); \n    return SP[-1].data.i;\n");
                 } else {
-                    b.append("    releaseForReturn(threadStateData, cn1LocalsBeginInThread, stackPointer - 1, ");
-                    b.append(maxLocals);
-                    b.append(", stack, locals); \n    return stack[stackPointer - 1].data.i;\n");
+                    b.append("    releaseForReturn(threadStateData, cn1LocalsBeginInThread); return SP[-1].data.i;\n");
+//                    b.append(maxLocals);
+//                    b.append(", stack, locals); \n    return SP[-1].data.i;\n");
                 }
                 break;                
                 
@@ -508,13 +508,9 @@ public class BasicInstruction extends Instruction implements AssignableExpressio
                 appendSynchronized(b);
                                 
                 if(TryCatch.isTryCatchInMethod()) {
-                    b.append("    releaseForReturnInException(threadStateData, cn1LocalsBeginInThread, stackPointer, ");
-                    b.append(maxLocals);
-                    b.append(", stack, locals, methodBlockOffset); \n    return POP_LONG();\n");
+                    b.append("    releaseForReturnInException(threadStateData, cn1LocalsBeginInThread, methodBlockOffset); \n    return POP_LONG();\n");
                 } else {
-                    b.append("    releaseForReturn(threadStateData, cn1LocalsBeginInThread, stackPointer - 1, ");
-                    b.append(maxLocals);
-                    b.append(", stack, locals); \n    return POP_LONG();\n");
+                    b.append("    releaseForReturn(threadStateData, cn1LocalsBeginInThread); \n    return POP_LONG();\n");
                 }
                 break;                
                 
@@ -522,13 +518,9 @@ public class BasicInstruction extends Instruction implements AssignableExpressio
                 appendSynchronized(b);
                 
                 if(TryCatch.isTryCatchInMethod()) {
-                    b.append("    releaseForReturnInException(threadStateData, cn1LocalsBeginInThread, stackPointer, ");
-                    b.append(maxLocals);
-                    b.append(", stack, locals, methodBlockOffset); \n    return POP_FLOAT();\n");
+                    b.append("    releaseForReturnInException(threadStateData, cn1LocalsBeginInThread, methodBlockOffset); \n    return POP_FLOAT();\n");
                 } else {
-                    b.append("    releaseForReturn(threadStateData, cn1LocalsBeginInThread, stackPointer - 1, ");
-                    b.append(maxLocals);
-                    b.append(", stack, locals); \n    return POP_FLOAT();\n");
+                    b.append("    releaseForReturn(threadStateData, cn1LocalsBeginInThread); \n    return POP_FLOAT();\n");
                 }
                 break;                
                 
@@ -536,13 +528,9 @@ public class BasicInstruction extends Instruction implements AssignableExpressio
                 appendSynchronized(b);
                 
                 if(TryCatch.isTryCatchInMethod()) {
-                    b.append("    releaseForReturnInException(threadStateData, cn1LocalsBeginInThread, stackPointer, ");
-                    b.append(maxLocals);
-                    b.append(", stack, locals, methodBlockOffset); \n    return POP_DOUBLE();\n");
+                    b.append("    releaseForReturnInException(threadStateData, cn1LocalsBeginInThread, methodBlockOffset); \n    return POP_DOUBLE();\n");
                 } else {
-                    b.append("    releaseForReturn(threadStateData, cn1LocalsBeginInThread, stackPointer - 1, ");
-                    b.append(maxLocals);
-                    b.append(", stack, locals); \n    return POP_DOUBLE();\n");
+                    b.append("    releaseForReturn(threadStateData, cn1LocalsBeginInThread); \n    return POP_DOUBLE();\n");
                 }
                 break;
                 
@@ -550,13 +538,9 @@ public class BasicInstruction extends Instruction implements AssignableExpressio
                 appendSynchronized(b);
                 
                 if(TryCatch.isTryCatchInMethod()) {
-                    b.append("    releaseForReturnInException(threadStateData, cn1LocalsBeginInThread, stackPointer, ");
-                    b.append(maxLocals);
-                    b.append(", stack, locals, methodBlockOffset); \n    return POP_OBJ();\n");
+                    b.append("    releaseForReturnInException(threadStateData, cn1LocalsBeginInThread, methodBlockOffset); \n    return POP_OBJ();\n");
                 } else {
-                    b.append("    releaseForReturn(threadStateData, cn1LocalsBeginInThread, stackPointer - 1, ");
-                    b.append(maxLocals);
-                    b.append(", stack, locals); \n    return POP_OBJ();\n");
+                    b.append("    releaseForReturn(threadStateData, cn1LocalsBeginInThread); \n    return POP_OBJ();\n");
                 }
                 break;
                 
@@ -568,23 +552,19 @@ public class BasicInstruction extends Instruction implements AssignableExpressio
                     break;
                 }
                 if(TryCatch.isTryCatchInMethod()) {
-                    b.append("    releaseForReturnInException(threadStateData, cn1LocalsBeginInThread, stackPointer, ");
-                    b.append(maxLocals);
-                    b.append(", stack, locals, methodBlockOffset); \n    return;\n");
+                    b.append("    releaseForReturnInException(threadStateData, cn1LocalsBeginInThread, methodBlockOffset); \n    return;\n");
                 } else {
-                    b.append("    releaseForReturn(threadStateData, cn1LocalsBeginInThread, stackPointer - 1, ");
-                    b.append(maxLocals);
-                    b.append(", stack, locals); \n    return;\n");
+                    b.append("    releaseForReturn(threadStateData, cn1LocalsBeginInThread); \n    return;\n");
                 }
                 break;
                 
             case Opcodes.ARRAYLENGTH:
                 b.append("    { /* ARRAYLENGTH */\n" +
-                    "        if(stack[stackPointer - 1].data.o == JAVA_NULL) { \n" +
+                    "        if(SP[-1].data.o == JAVA_NULL) { \n" +
                     "            throwException(threadStateData, __NEW_INSTANCE_java_lang_NullPointerException(threadStateData)); \n" +
                     "        }; \n" +
-                    "        stack[stackPointer - 1].type = CN1_TYPE_INT; \n" +
-                    "        stack[stackPointer - 1].data.i = (*((JAVA_ARRAY)stack[stackPointer - 1].data.o)).length; \n" +
+                    "        SP[-1].type = CN1_TYPE_INT; \n" +
+                    "        SP[-1].data.i = (*((JAVA_ARRAY)SP[-1].data.o)).length; \n" +
                     "    }\n");
                 break;                
                 
@@ -612,28 +592,28 @@ public class BasicInstruction extends Instruction implements AssignableExpressio
             case Opcodes.NEWARRAY:
                 switch(value) {
                     case 4: // boolean
-                        b.append("    stackPointer--; PUSH_OBJ(allocArray(threadStateData, stack[stackPointer].data.i, &class_array1__JAVA_BOOLEAN, sizeof(JAVA_ARRAY_BOOLEAN), 1));\n");
+                        b.append("    SP--; PUSH_OBJ(allocArray(threadStateData, (*SP).data.i, &class_array1__JAVA_BOOLEAN, sizeof(JAVA_ARRAY_BOOLEAN), 1));\n");
                         break;
                     case 5: // char
-                        b.append("    stackPointer--; PUSH_OBJ(allocArray(threadStateData, stack[stackPointer].data.i, &class_array1__JAVA_CHAR, sizeof(JAVA_ARRAY_CHAR), 1));\n");
+                        b.append("    SP--; PUSH_OBJ(allocArray(threadStateData, (*SP).data.i, &class_array1__JAVA_CHAR, sizeof(JAVA_ARRAY_CHAR), 1));\n");
                         break;
                     case 6: // float
-                        b.append("    stackPointer--; PUSH_OBJ(allocArray(threadStateData, stack[stackPointer].data.i, &class_array1__JAVA_FLOAT, sizeof(JAVA_ARRAY_FLOAT), 1));\n");
+                        b.append("    SP--; PUSH_OBJ(allocArray(threadStateData, (*SP).data.i, &class_array1__JAVA_FLOAT, sizeof(JAVA_ARRAY_FLOAT), 1));\n");
                         break;
                     case 7: // double
-                        b.append("    stackPointer--; PUSH_OBJ(allocArray(threadStateData, stack[stackPointer].data.i, &class_array1__JAVA_DOUBLE, sizeof(JAVA_ARRAY_DOUBLE), 1));\n");
+                        b.append("    SP--; PUSH_OBJ(allocArray(threadStateData, (*SP).data.i, &class_array1__JAVA_DOUBLE, sizeof(JAVA_ARRAY_DOUBLE), 1));\n");
                         break;
                     case 8: // byte
-                        b.append("    stackPointer--; PUSH_OBJ(allocArray(threadStateData, stack[stackPointer].data.i, &class_array1__JAVA_BYTE, sizeof(JAVA_ARRAY_BYTE), 1));\n");
+                        b.append("    SP--; PUSH_OBJ(allocArray(threadStateData, (*SP).data.i, &class_array1__JAVA_BYTE, sizeof(JAVA_ARRAY_BYTE), 1));\n");
                         break;
                     case 9: // short
-                        b.append("    stackPointer--; PUSH_OBJ(allocArray(threadStateData, stack[stackPointer].data.i, &class_array1__JAVA_SHORT, sizeof(JAVA_ARRAY_SHORT), 1));\n");
+                        b.append("    SP--; PUSH_OBJ(allocArray(threadStateData, (*SP).data.i, &class_array1__JAVA_SHORT, sizeof(JAVA_ARRAY_SHORT), 1));\n");
                         break;
                     case 10: // int
-                        b.append("    stackPointer--; PUSH_OBJ(allocArray(threadStateData, stack[stackPointer].data.i, &class_array1__JAVA_INT, sizeof(JAVA_ARRAY_INT), 1));\n");
+                        b.append("    SP--; PUSH_OBJ(allocArray(threadStateData, (*SP).data.i, &class_array1__JAVA_INT, sizeof(JAVA_ARRAY_INT), 1));\n");
                         break;
                     case 11: // long 
-                        b.append("    stackPointer--; PUSH_OBJ(allocArray(threadStateData, stack[stackPointer].data.i, &class_array1__JAVA_LONG, sizeof(JAVA_ARRAY_LONG), 1));\n");
+                        b.append("    SP--; PUSH_OBJ(allocArray(threadStateData, (*SP).data.i, &class_array1__JAVA_LONG, sizeof(JAVA_ARRAY_LONG), 1));\n");
                         break;
                 }
                 break;

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/CustomInvoke.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/CustomInvoke.java
@@ -197,7 +197,7 @@ public class CustomInvoke extends Instruction {
         
         
         if(origOpcode != Opcodes.INVOKESTATIC) {
-            b.append(", stack[stackPointer - ");
+            b.append(", SP[-");
             b.append(args.size() + 1 - numLiteralArgs);
             b.append("].data.o");
         }
@@ -210,7 +210,7 @@ public class CustomInvoke extends Instruction {
             if (literalArgs != null && literalArgs[argIndex] != null) {
                 b.append(literalArgs[argIndex]);
             } else {
-                b.append("stack[stackPointer - ");
+                b.append("SP[-");
                 b.append(offset);
                 b.append("].data.");
                 b.append(a);
@@ -226,31 +226,31 @@ public class CustomInvoke extends Instruction {
             b.append(");\n");
             if(origOpcode != Opcodes.INVOKESTATIC) {
                 if(args.size() - numLiteralArgs > 0) {
-                    b.append("    stackPointer -= ");
+                    b.append("    SP -= ");
                     b.append(args.size() - numLiteralArgs);
                     b.append(";\n");
                 }
             } else {
                 if(args.size() - numLiteralArgs > 1) {
-                    b.append("    stackPointer -= ");
+                    b.append("    SP -= ");
                     b.append(args.size() - numLiteralArgs - 1);
                     b.append(";\n");
                 }
             }
             if(returnVal.equals("JAVA_OBJECT")) {
-                b.append("    stack[stackPointer - 1].data.o = tmpResult; stack[stackPointer - 1].type = CN1_TYPE_OBJECT; }\n");
+                b.append("    SP[-1].data.o = tmpResult; SP[-1].type = CN1_TYPE_OBJECT; }\n");
             } else {
                 if(returnVal.equals("JAVA_INT")) {
-                    b.append("    stack[stackPointer - 1].data.i = tmpResult; stack[stackPointer - 1].type = CN1_TYPE_INT; }\n");
+                    b.append("    SP[-1].data.i = tmpResult; SP[-1].type = CN1_TYPE_INT; }\n");
                 } else {
                     if(returnVal.equals("JAVA_LONG")) {
-                        b.append("    stack[stackPointer - 1].data.l = tmpResult; stack[stackPointer - 1].type = CN1_TYPE_LONG; }\n");
+                        b.append("    SP[-1].data.l = tmpResult; SP[-1].type = CN1_TYPE_LONG; }\n");
                     } else {
                         if(returnVal.equals("JAVA_DOUBLE")) {
-                            b.append("    stack[stackPointer - 1].data.d = tmpResult; stack[stackPointer - 1].type = CN1_TYPE_DOUBLE; }\n");
+                            b.append("    SP[-1].data.d = tmpResult; SP[-1].type = CN1_TYPE_DOUBLE; }\n");
                         } else {
                             if(returnVal.equals("JAVA_FLOAT")) {
-                                b.append("    stack[stackPointer - 1].data.f = tmpResult; stack[stackPointer - 1].type = CN1_TYPE_FLOAT; }\n");
+                                b.append("    SP[-1].data.f = tmpResult; SP[-1].type = CN1_TYPE_FLOAT; }\n");
                             } else {
                                 throw new UnsupportedOperationException("Unknown type: " + returnVal);
                             }
@@ -270,10 +270,7 @@ public class CustomInvoke extends Instruction {
             val = args.size() - numLiteralArgs;
         }
         if(val > 0) {
-            /*b.append("popMany(threadStateData, ");            
-            b.append(val);
-            b.append(", stack, &stackPointer); \n"); */
-            b.append("    stackPointer -= ");
+            b.append("    SP -= ");
             b.append(val);
             b.append(";\n");
         } else {

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Field.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Field.java
@@ -203,7 +203,7 @@ public class Field extends Instruction implements AssignableExpression {
                 switch(desc.charAt(0)) {
                     case 'L':
                     case '[':
-                        b.append("PEEK_OBJ(1));\n    stackPointer--;\n");
+                        b.append("PEEK_OBJ(1));\n    SP--;\n");
                         return;
                     case 'D':
                         b.append("POP_DOUBLE");
@@ -261,7 +261,7 @@ public class Field extends Instruction implements AssignableExpression {
                     case '[':
                         b.append("PEEK_OBJ");
                         if(useThis) {
-                            b.append("(1), __cn1ThisObject);\n    stackPointer--;\n");
+                            b.append("(1), __cn1ThisObject);\n    SP--;\n");
                         } else {
                             b.append("(1), PEEK_OBJ(2));\n    POP_MANY(2);\n");
                         }

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Invoke.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Invoke.java
@@ -206,7 +206,7 @@ public class Invoke extends Instruction {
         
         
         if(opcode != Opcodes.INVOKESTATIC) {
-            b.append(", stack[stackPointer - ");
+            b.append(", SP[-");
             b.append(args.size() + 1);
             b.append("].data.o");
         }
@@ -217,7 +217,7 @@ public class Invoke extends Instruction {
             
             b.append(", ");
             
-            b.append("stack[stackPointer - ");
+            b.append("SP[-");
             b.append(offset);
             b.append("].data.");
             b.append(a);
@@ -233,31 +233,31 @@ public class Invoke extends Instruction {
             b.append(");\n");
             if(opcode != Opcodes.INVOKESTATIC) {
                 if(args.size() > 0) {
-                    b.append("    stackPointer -= ");
+                    b.append("    SP-=");
                     b.append(args.size());
                     b.append(";\n");
                 }
             } else {
                 if(args.size() > 1) {
-                    b.append("    stackPointer -= ");
+                    b.append("    SP-=");
                     b.append(args.size() - 1);
                     b.append(";\n");
                 }
             }
             if(returnVal.equals("JAVA_OBJECT")) {
-                b.append("    stack[stackPointer - 1].data.o = tmpResult; stack[stackPointer - 1].type = CN1_TYPE_OBJECT; }\n");
+                b.append("    SP[-1].data.o = tmpResult; SP[-1].type = CN1_TYPE_OBJECT; }\n");
             } else {
                 if(returnVal.equals("JAVA_INT")) {
-                    b.append("    stack[stackPointer - 1].data.i = tmpResult; stack[stackPointer - 1].type = CN1_TYPE_INT; }\n");
+                    b.append("    SP[-1].data.i = tmpResult; SP[-1].type = CN1_TYPE_INT; }\n");
                 } else {
                     if(returnVal.equals("JAVA_LONG")) {
-                        b.append("    stack[stackPointer - 1].data.l = tmpResult; stack[stackPointer - 1].type = CN1_TYPE_LONG; }\n");
+                        b.append("    SP[-1].data.l = tmpResult; SP[-1].type = CN1_TYPE_LONG; }\n");
                     } else {
                         if(returnVal.equals("JAVA_DOUBLE")) {
-                            b.append("    stack[stackPointer - 1].data.d = tmpResult; stack[stackPointer - 1].type = CN1_TYPE_DOUBLE; }\n");
+                            b.append("    SP[-1].data.d = tmpResult; SP[-1].type = CN1_TYPE_DOUBLE; }\n");
                         } else {
                             if(returnVal.equals("JAVA_FLOAT")) {
-                                b.append("    stack[stackPointer - 1].data.f = tmpResult; stack[stackPointer - 1].type = CN1_TYPE_FLOAT; }\n");
+                                b.append("    SP[-1].data.f = tmpResult; SP[-1].type = CN1_TYPE_FLOAT; }\n");
                             } else {
                                 throw new UnsupportedOperationException("Unknown type: " + returnVal);
                             }
@@ -286,7 +286,7 @@ public class Invoke extends Instruction {
             /*b.append("popMany(threadStateData, ");            
             b.append(val);
             b.append(", stack, &stackPointer); \n"); */
-            b.append("    stackPointer -= ");
+            b.append("    SP-= ");
             b.append(val);
             b.append(";\n");
         } else {

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Jump.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Jump.java
@@ -65,28 +65,28 @@ public class Jump extends Instruction {
                 b.append("if(POP_INT() <= 0) /* IFLE */ ");
                 break;
             case Opcodes.IF_ICMPEQ:
-                b.append("stackPointer -= 2; if(stack[stackPointer].data.i == stack[stackPointer + 1].data.i) /* IF_ICMPEQ */ ");
+                b.append("SP-=2; if((*SP).data.i == SP[1].data.i) /* IF_ICMPEQ */ ");
                 break;
             case Opcodes.IF_ICMPNE:
-                b.append("stackPointer -= 2; if(stack[stackPointer].data.i != stack[stackPointer + 1].data.i) /* IF_ICMPNE */ ");
+                b.append("SP-=2; if((*SP).data.i != SP[1].data.i) /* IF_ICMPNE */ ");
                 break;
             case Opcodes.IF_ICMPLT:
-                b.append("stackPointer -= 2; if(stack[stackPointer].data.i < stack[stackPointer + 1].data.i) /* IF_ICMPLT */ ");
+                b.append("SP-=2; if((*SP).data.i < SP[1].data.i) /* IF_ICMPLT */ ");
                 break;
             case Opcodes.IF_ICMPGE:
-                b.append("stackPointer -= 2; if(stack[stackPointer].data.i >= stack[stackPointer + 1].data.i) /* IF_ICMPGE */ ");
+                b.append("SP-=2; if((*SP).data.i >= SP[1].data.i) /* IF_ICMPGE */ ");
                 break;
             case Opcodes.IF_ICMPGT:
-                b.append("stackPointer -= 2; if(stack[stackPointer].data.i > stack[stackPointer + 1].data.i) /* IF_ICMPGT */ ");
+                b.append("SP-=2; if((*SP).data.i > SP[1].data.i) /* IF_ICMPGT */ ");
                 break;
             case Opcodes.IF_ICMPLE:
-                b.append("stackPointer -= 2; if(stack[stackPointer].data.i <= stack[stackPointer + 1].data.i) /* IF_ICMPLE */ ");
+                b.append("SP-=2; if((*SP).data.i <= SP[1].data.i) /* IF_ICMPLE */ ");
                 break;
             case Opcodes.IF_ACMPEQ:
-                b.append("stackPointer -= 2; if(stack[stackPointer].data.o == stack[stackPointer + 1].data.o) /* IF_ACMPEQ */ ");
+                b.append("SP-=2; if((*SP).data.o == SP[1].data.o) /* IF_ACMPEQ */ ");
                 break;
             case Opcodes.IF_ACMPNE:
-                b.append("stackPointer -= 2; if(stack[stackPointer].data.o != stack[stackPointer + 1].data.o) /* IF_ACMPNE */ ");
+                b.append("SP-=2; if((*SP).data.o != SP[1].data.o) /* IF_ACMPNE */ ");
                 break;
             case Opcodes.GOTO:
                 // this space intentionally left blank

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/MultiArray.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/MultiArray.java
@@ -93,13 +93,13 @@ public class MultiArray extends Instruction {
         }*/
         switch(actualDim) {
             case 2:
-                b.append("    PUSH_OBJ(alloc2DArray(threadStateData, (*pop(stack, &stackPointer)).data.i, ");
+                b.append("    PUSH_OBJ(alloc2DArray(threadStateData, (*(--SP)).data.i, ");
                 switch(dims) {
                     case 1:
                         b.append("-1");
                         break;
                     case 2:
-                        b.append("(*pop(stack, &stackPointer)).data.i");
+                        b.append("(*(--SP)).data.i");
                         break;
                 }
                 b.append(", &class_array2__");

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/SwitchInstruction.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/SwitchInstruction.java
@@ -49,7 +49,7 @@ public class SwitchInstruction extends Instruction {
     
     @Override
     public void appendInstruction(StringBuilder b, List<Instruction> instructions) {
-        b.append("    stackPointer--;\n    switch(stack[stackPointer].data.i) {\n");
+        b.append("    SP--;\n    switch((*SP).data.i) {\n");
         for(int iter = 0 ; iter < keys.length ; iter++) {
             b.append("        case ");
             b.append(keys[iter]);

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/TypeInstruction.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/TypeInstruction.java
@@ -111,22 +111,22 @@ public class TypeInstruction extends Instruction {
                         dim++;
                     }
                     
-                    b.append(" stackPointer--;\n    PUSH_POINTER(allocArray(threadStateData, stack[stackPointer].data.i, &class_array");
+                    b.append(" SP--;\n    PUSH_POINTER(allocArray(threadStateData, (*SP).data.i, &class_array");
                     b.append(dim);
                     b.append("__");
                     b.append(actualType);
                     b.append(", sizeof(JAVA_OBJECT), ");
                     b.append(dim);
-                    b.append("));\n    stack[stackPointer - 1].data.o->__codenameOneParentClsReference = &class_array");
+                    b.append("));\n    SP[-1].data.o->__codenameOneParentClsReference = &class_array");
                     b.append(dim);
                     b.append("__");
                     b.append(actualType);
                     b.append("; /* ANEWARRAY multi */\n");
                     break;
                 }
-                b.append("stackPointer--;\n    PUSH_POINTER(__NEW_ARRAY_");
+                b.append("SP--;\n    PUSH_POINTER(__NEW_ARRAY_");
                 b.append(actualType);
-                b.append("(threadStateData, stack[stackPointer].data.i));\n");
+                b.append("(threadStateData, SP[0].data.i));\n");
                 break;
             case Opcodes.CHECKCAST:
                 b.append("BC_CHECKCAST(");

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/VarOp.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/VarOp.java
@@ -118,10 +118,10 @@ public class VarOp extends Instruction implements AssignableExpression {
         b.append("    ");
         switch(opcode) {
             case Opcodes.ILOAD:
-                b.append("stack[stackPointer].type = CN1_TYPE_INT; /* ILOAD */ \n" +
-                        "    stack[stackPointer].data.i = ilocals_");
+                b.append("(*SP).type = CN1_TYPE_INT; /* ILOAD */ \n" +
+                        "    (*SP).data.i = ilocals_");
                 b.append(var);
-                b.append("_; \n    stackPointer++;\n");
+                b.append("_; \n    SP++;\n");
                 return;
             case Opcodes.LLOAD:
                 b.append("BC_LLOAD(");

--- a/vm/ByteCodeTranslator/src/nativeMethods.m
+++ b/vm/ByteCodeTranslator/src/nativeMethods.m
@@ -1186,12 +1186,12 @@ void initMethodStack(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT __cn1ThisObject, int
     threadStateData->callStackOffset++;
 }
 
-void releaseForReturn(CODENAME_ONE_THREAD_STATE, int cn1LocalsBeginInThread, int stackPointer, int cn1SizeOfLocals, struct elementStruct* stack, struct elementStruct* locals) {
+void releaseForReturn(CODENAME_ONE_THREAD_STATE, int cn1LocalsBeginInThread) {
     threadStateData->threadObjectStackOffset = cn1LocalsBeginInThread;
     threadStateData->callStackOffset--;
 }
 
-void releaseForReturnInException(CODENAME_ONE_THREAD_STATE, int cn1LocalsBeginInThread, int stackPointer, int cn1SizeOfLocals, struct elementStruct* stack, struct elementStruct* locals, int methodBlockOffset) {
+void releaseForReturnInException(CODENAME_ONE_THREAD_STATE, int cn1LocalsBeginInThread, int methodBlockOffset) {
     threadStateData->tryBlockOffset = methodBlockOffset;
     threadStateData->threadObjectStackOffset = cn1LocalsBeginInThread;
     threadStateData->callStackOffset--;


### PR DESCRIPTION
This pull requests greatly simplifies stack operations resulting assembly (e.g, i've seen ALOAD taking 2 ARM ops) via little change in method stack implementation.

Also, this pull request contains _option_ to produce concatenated .m files instead of myriads of little C files thus reducing compile time by more than 60% (on my project). (Reason of inclusion of this feature is that it was already included in my commit while cherrypicking)