### PR TITLE
Clean some unused variables in the Style constructor

### DIFF
--- a/CodenameOne/src/com/codename1/ui/plaf/Style.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/Style.java
@@ -527,14 +527,11 @@ public class Style {
      * 
      * @param fgColor foreground color
      * @param bgColor background color
-     * @param fgSelectionColor foreground selection color
-     * @param bgSelectionColor background selection color
      * @param f font
      * @param transparency transparency value
      * @param im background image
-     * @param scaledImage whether the image should be scaled or tiled
      */
-    private Style(int fgColor, int bgColor, int fgSelectionColor, int bgSelectionColor, Font f, byte transparency, Image im, boolean scaledImage) {
+    private Style(int fgColor, int bgColor, Font f, byte transparency, Image im) {
         this();
         this.fgColor = fgColor;
         this.bgColor = bgColor;

--- a/CodenameOne/src/com/codename1/ui/plaf/Style.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/Style.java
@@ -485,8 +485,8 @@ public class Style {
      * @param style the style to copy
      */
     public Style(Style style) {
-        this(style.getFgColor(), style.getBgColor(), 0, 0, style.getFont(), style.getBgTransparency(),
-                style.getBgImage(), true);
+        this(style.getFgColor(), style.getBgColor(), style.getFont(), style.getBgTransparency(),
+                style.getBgImage());
         setPadding(style.padding[Component.TOP],
                 style.padding[Component.BOTTOM],
                 style.padding[Component.LEFT],


### PR DESCRIPTION
Greetings,

There is no use for `fgSelectionColor`, `bgSelectionColor`, `scaledImage` so i cleaned them up ..
`fgSelectionColor`, `bgSelectionColor `there was no use for them that i could tell.
`scaledImage `could be used to determine scaled or tiled but tiled images have more than one type so it's kinda better to use [this constructor](https://github.com/codenameone/CodenameOne/blob/master/CodenameOne/src/com/codename1/ui/plaf/Style.java#L561) 