### PR TITLE
[Fix] GridLayout shouldn't ignore the bottom padding

### DIFF
--- a/CodenameOne/src/com/codename1/ui/layouts/GridLayout.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/GridLayout.java
@@ -166,7 +166,7 @@ public class GridLayout extends Layout{
     public void layoutContainer(Container parent) {
         Style s = parent.getStyle();
         int width = parent.getLayoutWidth() - parent.getSideGap() - s.getHorizontalPadding();
-        int height = parent.getLayoutHeight() - parent.getBottomGap() - parent.getStyle().getPaddingTop();
+        int height = parent.getLayoutHeight() - parent.getBottomGap() - s.getVerticalPadding();
         int numOfcomponents = parent.getComponentCount();
 
         autoSizeCols(parent, width);


### PR DESCRIPTION
GridLayout is currently ignoring the bottom padding, with this change it should work as intended