### PR TITLE
Scroll to the dragged component - not, as before, to absolute

### DIFF
--- a/CodenameOne/src/com/codename1/ui/Component.java
+++ b/CodenameOne/src/com/codename1/ui/Component.java
@@ -3395,7 +3395,7 @@ public class Component implements Animation, StyleListener {
             }
             if(dropTargetComponent != null) {
                 p.repaint(x, y, getWidth(), getHeight());
-                getParent().scrollRectToVisible(x, y, getWidth(), getHeight(), getParent());
+                getParent().scrollRectToVisible(getX(), getY(), getWidth(), getHeight(), getParent());
                 if(dropListener != null) {
                     ActionEvent ev = new ActionEvent(this, ActionEvent.Type.PointerDrag, dropTargetComponent, x, y);
                     dropListener.fireActionEvent(ev);


### PR DESCRIPTION
The method `com.codename1.ui.Component.dragFinishedImpl(int, int)` used to scroll to a absolute position which caused scrollable drop targets to scroll erroneously - see #1994.

This change makes it scrolling to the dragged component. What I do not know is whether this scrolling makes sense at all. But with this change it seems to work. 