### PR TITLE
Modify a component index without removing and re-adding

### DIFF
--- a/CodenameOne/src/com/codename1/ui/Container.java
+++ b/CodenameOne/src/com/codename1/ui/Container.java
@@ -920,6 +920,18 @@ public class Container extends Component implements Iterable<Component>{
     public void removeComponent(Component cmp) {
         removeComponentImpl(cmp);
     }
+    
+    /**
+     * changes the component index of a child component
+     * @param cmp The component to be moved
+     * @param location The new component index
+     */
+    public void moveComponent(Component cmp, int location) {
+    	if (location < components.size()) {
+        	components.remove(cmp);
+        	components.add(location, cmp);
+    	}
+    }
 
     void removeComponentImpl(final Component cmp) {
         AnimationManager a = getAnimationManager();
@@ -2368,13 +2380,7 @@ public class Container extends Component implements Iterable<Component>{
             if(dest != dragged) {
                 int destIndex = getComponentIndex(dest);
                 if(destIndex > -1 && destIndex != i) {
-                    removeComponent(dragged);
-                    Object con = getLayout().getComponentConstraint(dragged);
-                    if(con != null) {
-                        addComponent(destIndex, con, dragged);
-                    } else {
-                        addComponent(destIndex, dragged);
-                    }
+                	moveComponent(dragged,destIndex);
                 }
             }
             animateLayout(400);


### PR DESCRIPTION
#Also see #1992

This is about beeing able to change a component index within `com.codename1.ui.Container.components` whilst not removing it from animations and drag-and-drop.  

This also allows continuous drag-and-drop - like so:

	@Override
	public void pointerDragged(int x, int y) {
		super.pointerDragged(x, y);
		if (isDragActivated() && !getAnimationManager().isAnimating()) {
			PackageAccess.flush(getAnimationManager());
			getParent().drop(this, x, getDraggedy());
		}
	}

To make continuous drag-and-drop real smooth #1993 needs to be addressed, too. That is what the workaround `PackageAccess.flush(getAnimationManager());` ìs for.

	package com.codename1.ui;
	
	public class PackageAccess {
		public static void flush(AnimationManager aAnimationManager) {
			aAnimationManager.flush();
		}
	}
