### PR TITLE
Android: Check that String property is defined before reading it's value

### DIFF
--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -2380,9 +2380,10 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
         //these keys/values are from the Application Resources (strings values)
         try {
             int id = getContext().getResources().getIdentifier(key, "string", getContext().getApplicationInfo().packageName);
-            String val = getContext().getResources().getString(id);
-            return val;
-
+            if (id != 0) {
+                String val = getContext().getResources().getString(id);
+                return val;
+            }
         } catch (Exception e) {
         }
         return System.getProperty(key, super.getProperty(key, defaultValue));


### PR DESCRIPTION
Added check for not 0 to avoid this warning when reading undefined property on Android:

    W/ResourceType: No package identifier when getting value for resource number 0x00000000