### PR TITLE
Terminate all redirects in the iOS layer so they can be handled by CN1

### DIFF
--- a/Ports/iOSPort/nativeSources/NetworkConnectionImpl.m
+++ b/Ports/iOSPort/nativeSources/NetworkConnectionImpl.m
@@ -133,6 +133,15 @@ int connections = 0;
 #endif
 }
 
+- (NSURLRequest *)connection:(NSURLConnection *)connection
+             willSendRequest:(NSURLRequest *)_request
+            redirectResponse:(NSHTTPURLResponse *)response {
+    if (response.statusCode >= 300 && response.statusCode < 400) {
+        return nil;
+    }
+    return _request;
+}
+
 extern void connectionComplete(void* peer);
 
 extern void connectionReceivedData(void* peer, NSData* data);


### PR DESCRIPTION
Fixes #2017 

This add a [delegate handler](https://developer.apple.com/reference/foundation/nsurlconnectiondatadelegate/1415830-connection?language=objc) for redirects that will terminate all requests in response to a status code between 300 and 400. This should effectively allow `NetworkManager` to handle redirect logic. 