### PR TITLE
[Android] Add solution to IMEI for tablet

### DIFF
--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -2359,7 +2359,7 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
                 if (tm!=null && tm.getDeviceId() != null)
                     imei = tm.getDeviceId(); // for phones or 3g tablets
                 else
-                    imei = Secure.getString(getApplicationContext().getContentResolver(), Secure.ANDROID_ID); 
+                    imei = Secure.getString(getContext().getContentResolver(), Secure.ANDROID_ID); 
                 return imei;
             }
             if ("MSISDN".equals(key)) {

--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -2355,7 +2355,12 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
                     return "";
                 }
                 TelephonyManager tm = (TelephonyManager) getContext().getSystemService(Context.TELEPHONY_SERVICE);
-                return tm.getDeviceId();
+                String imei = null;
+                if (tm!=null && tm.getDeviceId() != null)
+                    imei = tm.getDeviceId(); // for phones or 3g tablets
+                else
+                    imei = Secure.getString(getApplicationContext().getContentResolver(), Secure.ANDROID_ID); 
+                return imei;
             }
             if ("MSISDN".equals(key)) {
                 if(!checkForPermission(Manifest.permission.READ_PHONE_STATE, "This is required to get the device ID")){


### PR DESCRIPTION
On Android, for non data devices :
`TelephonyManager.getDeviceId()` should return null value.

In this case, we could use `Secure.ANDROID_ID` (which can change if user reset the device).

NB : this fix has not been tested.