### PR TITLE
Example solution for issue #2012 

### DIFF
--- a/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
+++ b/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
@@ -321,6 +321,21 @@ public abstract class CodenameOneImplementation {
     }
     
     /**
+     * Sets current editingText value and sets it focused.
+     * NB! it not call editString, that is it should be called only internally and
+     * actually the methdo should not be added :)
+     */
+    public void setFocusedEditingText(Component cmp) {
+        editingText = cmp;
+        if (cmp != null) {
+            Form form = cmp.getComponentForm();
+            if (form != null) {
+                form.setFocused(cmp);
+            }
+        }
+    }
+
+    /**
      * Invoked for special cases to stop text editing and clear native editing state
      */
     public void stopTextEditing() {    

--- a/Ports/Android/src/com/codename1/impl/android/InPlaceEditView.java
+++ b/Ports/Android/src/com/codename1/impl/android/InPlaceEditView.java
@@ -735,8 +735,10 @@ public class InPlaceEditView extends FrameLayout{
      *                 a TextAreaData so that the text area properties can be accessed off the EDT safely.
      * @param codenameOneInputType One of the input type constants in com.codename1.ui.TextArea
      * @param initialText The text that appears in the Codename One text are before the call to startEditing
+     * @param isEditedFieldSwitch if true, then special case for async edit mode - the native editing is already active, no need to show
+     *                            native field, just change the connected field
      */
-    private synchronized void startEditing(Activity activity, TextAreaData textArea, String initialText, int codenameOneInputType) {
+    private synchronized void startEditing(Activity activity, TextAreaData textArea, String initialText, int codenameOneInputType, final boolean isEditedFieldSwitch) {
 
         int txty = lastTextAreaY = textArea.getAbsoluteY() + textArea.getScrollY();
         int txtx = lastTextAreaX = textArea.getAbsoluteX() + textArea.getScrollX();
@@ -763,7 +765,11 @@ public class InPlaceEditView extends FrameLayout{
             paddingTop = textArea.paddingTop;
         }
         int id = activity.getResources().getIdentifier("cn1Style", "attr", activity.getApplicationInfo().packageName);
+        if (!isEditedFieldSwitch) {
         mEditText = new EditView(activity, textArea.textArea, this, id);
+        } else {
+            mEditText.switchToTextArea(textArea.textArea);
+        }
     
         if(textArea.getClientProperty("blockCopyPaste") != null || Display.getInstance().getProperty("blockCopyPaste", "false").equals("true")) {
             // The code below is taken from this stackoverflow answer: http://stackoverflow.com/a/22756538/756809
@@ -795,8 +801,17 @@ public class InPlaceEditView extends FrameLayout{
                 });
             }            
         }
-        
+		else if (isEditedFieldSwitch) {
+            //reset copy-paste protection
+            if (android.os.Build.VERSION.SDK_INT < 11) {
+                mEditText.setOnCreateContextMenuListener(null);
+            } else {
+                mEditText.setCustomSelectionActionModeCallback(null);
+            }
+		}
+        if (!isEditedFieldSwitch) {
         mEditText.addTextChangedListener(mEditText.mTextWatcher);
+        }
         mEditText.setBackgroundDrawable(null);
 
         mEditText.setFocusableInTouchMode(true);
@@ -854,7 +869,9 @@ public class InPlaceEditView extends FrameLayout{
         if(textArea.nativeHintBool && textArea.getHint() != null) {
             mEditText.setHint(textArea.getHint());
         }
+        if (!isEditedFieldSwitch) {
         addView(mEditText, mEditLayoutParams);
+        }
         invalidate();
         setVisibility(VISIBLE);
         bringToFront();
@@ -1041,9 +1058,11 @@ public class InPlaceEditView extends FrameLayout{
      * This method will be called by our EditText control when the action
      * key (Enter/Go/Send) on the soft keyboard will be pressed.
      * @param actionCode
+     * @return task to run after call to super.onEditorAction. Returns null if action was consumed (tapped Next in async mode) and super.onEditorAction do not have to be called.
      */
-    void onEditorAction(int actionCode) {
+    Runnable onEditorAction(int actionCode) {
         actionCode = actionCode & 0xf;
+        boolean hasNext = false;
         if (EditorInfo.IME_ACTION_NEXT == actionCode && mEditText != null &&
                 mEditText.mTextArea != null) {
             Component next = mEditText.mTextArea.getNextFocusDown();
@@ -1052,10 +1071,25 @@ public class InPlaceEditView extends FrameLayout{
             }
 
             if (next != null && next instanceof TextArea && ((TextArea)next).isEditable() && ((TextArea)next).isEnabled()) {
+                hasNext = true;
                 nextTextArea = (TextArea) next;
             }
         }
+		if (hasNext && nextTextArea != null && impl.isAsyncEditMode()) {
+			//in async edit mode go right to next field edit to avoid hiding and showing again the native edit text
+            TextArea theNext = nextTextArea;
+			nextTextArea = null;
+            edit(sInstance.impl, theNext, theNext.getConstraint());
+			return null;
+        } else {
+			return new Runnable() {
+
+				@Override
+				public void run() {
         endEditing(REASON_IME_ACTION, false);
+    }
+			};
+		}
     }
 
     private static int trySetEditModeCount=0;
@@ -1242,6 +1276,12 @@ public class InPlaceEditView extends FrameLayout{
                     if (mIsEditing && !isActiveTextEditorHidden() && sInstance != null && sInstance.mEditText != null) {
 
                         if (txt != null) {
+
+                            if (sInstance.mEditText.mTextArea != txt) {
+                                //has changed in between, skip or would change location back to old field
+                                return;
+                            }
+
                             final int txty = lastTextAreaY = txt.getAbsoluteY() + txt.getScrollY();
                             final int txtx = lastTextAreaX = txt.getAbsoluteX() + txt.getScrollX();
                             final int w = lastTextAreaWidth = txt.getWidth();
@@ -1251,6 +1291,11 @@ public class InPlaceEditView extends FrameLayout{
                             sInstance.impl.getActivity().runOnUiThread(new Runnable() {
                                 public void run() {
                                     if (mIsEditing && !isActiveTextEditorHidden() && sInstance != null && sInstance.mEditText != null) {
+
+                                        if (sInstance.mEditText.mTextArea != txt) {
+                                            //has changed in between, skip or would change location back to old field
+                                            return;
+                                        }
 
                                         sInstance.mEditLayoutParams.setMargins(txtx, txty, 0, 0);
                                         sInstance.mEditLayoutParams.width = w;
@@ -1358,10 +1403,19 @@ public class InPlaceEditView extends FrameLayout{
 
         }
 
+		//if true, then in async mode we are currently editing and are switching to another field
+		final boolean isEditedFieldSwitch;
+
         // If we are already editing, we need to finish that up before we proceed to edit the next field.
         synchronized(editingLock) {
             if (mIsEditing) {
 
+                if (impl.isAsyncEditMode()) {
+                    isEditedFieldSwitch = true;
+                    InPlaceEditView.setEditedTextField(textArea);
+                    nextTextArea = null;
+                } else {
+                    isEditedFieldSwitch = false;
 
                 final InPlaceEditView instance = sInstance;
                 if (instance != null && instance.mEditText != null && instance.mEditText.mTextArea == textArea) {
@@ -1389,8 +1443,9 @@ public class InPlaceEditView extends FrameLayout{
 
                 };
                 return;
-
-
+                }
+            } else {
+                isEditedFieldSwitch = false;
             }
             mIsEditing = true;
             isClosing = false;
@@ -1413,6 +1468,7 @@ public class InPlaceEditView extends FrameLayout{
 
             @Override
             public void run() {
+				if (!isEditedFieldSwitch) {
                 releaseEdit();
 
                 if (sInstance == null) {
@@ -1431,7 +1487,8 @@ public class InPlaceEditView extends FrameLayout{
                 }else{
                     trySetEditMode(true);
                 }
-                sInstance.startEditing(impl.getActivity(), textAreaData, initialText, inputType);
+				}
+                sInstance.startEditing(impl.getActivity(), textAreaData, initialText, inputType, isEditedFieldSwitch);
             }
         });
 
@@ -1533,6 +1590,20 @@ public class InPlaceEditView extends FrameLayout{
         onComplete.run();
     }
 
+	public static void setEditedTextField(final TextArea textarea) {
+        Display display = Display.getInstance();
+        Runnable task = new Runnable(){
+            public void run() {
+                Display.getInstance().getImplementation().setFocusedEditingText(textarea);
+            }
+        };
+        if (display.isEdt()) {
+            task.run();
+        } else {
+            display.callSeriallyAndWait(task);
+        }
+    }
+
     private static boolean isScrollableParent(Component c){
         Container p = c.getParent();
         while( p != null){
@@ -1576,13 +1647,21 @@ public class InPlaceEditView extends FrameLayout{
 
         private InPlaceEditView mInPlaceEditView;
         private TextArea mTextArea = null;
-        private TextWatcher mTextWatcher = new TextWatcher() {
+        private ResetableTextWatcher mTextWatcher = new ResetableTextWatcher() {
 
             private boolean started = false;
             private TextChange currChange;
             private int lastInsertStartPos;
             private int lastInsertBeforeCount;
             private int lastInsertAfterCount;
+
+            /**
+             * Reset status after connected textarea change.
+             */
+            @Override
+            public void reset() {
+                started = false;
+            }
 
             @Override
             public void onTextChanged(CharSequence s, int start, int before, int count) {
@@ -1670,11 +1749,24 @@ public class InPlaceEditView extends FrameLayout{
             setBackgroundColor(Color.TRANSPARENT);
         }
 
+		/**
+		 * Connects to other textArea.
+		 */
+		public void switchToTextArea(TextArea other) {
+            if (this.mTextArea != null && this.mTextArea != other) {
+                Display.getInstance().onEditingComplete(this.mTextArea, this.mTextArea.getText());
+            }
+            this.mTextArea = other;
+            mTextWatcher.reset();
+        }
+
         @Override
         public void onEditorAction(int actionCode) {
+			Runnable task = mInPlaceEditView.onEditorAction(actionCode);
+            if (task != null) {
             super.onEditorAction(actionCode);
-
-            mInPlaceEditView.onEditorAction(actionCode);
+                task.run();
+            }
         }
 
         @Override
@@ -1732,4 +1824,9 @@ public class InPlaceEditView extends FrameLayout{
             }
         }
     };
+}
+interface ResetableTextWatcher extends TextWatcher {
+
+    public void reset();
+
 }


### PR DESCRIPTION
Example solution for issue #2012  (https://github.com/codenameone/CodenameOne/issues/2012).

Speed up switching between edited textfields on Android. Implemented and tested only in asyncEditMode. The idea is to avoid removing the native editor component just for switching time, but just native field is connected to another CN1 textfield.

But unfortunately current keyboard code is quite complex and I didn't manage to keep changes small, so probably you can't just take the changes, but at least I have given an example how the issue got improved for my test cases.
