### PR TITLE
Feature to allow null-valued properties in output from parseJSON(Reader i)

### DIFF
--- a/CodenameOne/src/com/codename1/io/JSONParser.java
+++ b/CodenameOne/src/com/codename1/io/JSONParser.java
@@ -76,6 +76,22 @@ public class JSONParser implements JSONParseCallback {
         useLongsDefault = aUseLongsDefault;
     }
 
+    /**
+     * Indicates that the parser will include null values in the parsed output
+     * @return the includeNullsDefault
+     */
+    public static boolean isIncludeNulls() {
+        return includeNullsDefault;
+    }
+
+    /**
+     * Indicates that the parser will include null values in the parsed output
+     * @param aIncludeNullsDefault the includeNullsDefault to set
+     */
+    public static void setIncludeNulls(boolean aIncludeNullsDefault) {
+        includeNullsDefault = aIncludeNullsDefault;
+    }
+
     static class ReaderClass {
         char[] buffer;
         int buffOffset;
@@ -102,6 +118,7 @@ public class JSONParser implements JSONParseCallback {
     }
 
     private static boolean useLongsDefault;
+    private static boolean includeNullsDefault;
     private boolean modern;
     private Map<String, Object> state;
     private java.util.List<Object> parseStack;
@@ -528,7 +545,7 @@ public class JSONParser implements JSONParseCallback {
             if (currentKey == null) {
                 currentKey = tok;
             } else {
-                if (tok != null) {
+                if (tok != null || isIncludeNulls()) {
                     getStackHash().put(currentKey, tok);
                 }
                 currentKey = null;


### PR DESCRIPTION
This change applies to the parseJSON(Reader i) method for the JSONParser class.  As currently implemented, the Map returned by that method does not include properties from the incoming JSON stream whose values are null.  They just do not exist in the output Map.

This request implements two new methods:
public static boolean isIncludeNulls() {}
public static void setIncludeNulls(boolean aIncludeNullsDefault) {}

If set to true, properties whose values are null will be included in the Map returned by parseJSON(Reader i).