### PR TITLE
Set simulator to always show on top and other simulator improvements

### DIFF
--- a/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
@@ -404,6 +404,7 @@ public class JavaSEPort extends CodenameOneImplementation {
     }
     private static String fontFaceProportional = "SansSerif";
     private static String fontFaceMonospace = "Monospaced";
+    private static boolean alwaysOnTop = false;
     private static boolean useNativeInput = true;
     private static boolean simulateAndroidKeyboard = false;
     private static boolean scrollableSkin = true;
@@ -2712,7 +2713,7 @@ public class JavaSEPort extends CodenameOneImplementation {
                     Motion.setSlowMotion(slowMotionFlag.isSelected());
                 }
             });
-            final JCheckBoxMenuItem permFlag = new JCheckBoxMenuItem("Android 6 permissions", android6PermissionsFlag);
+            final JCheckBoxMenuItem permFlag = new JCheckBoxMenuItem("Android 6 Permissions", android6PermissionsFlag);
             simulatorMenu.add(permFlag);
             permFlag.addActionListener(new ActionListener() {
 
@@ -2752,6 +2753,9 @@ public class JavaSEPort extends CodenameOneImplementation {
                 }
             });
 
+            final JCheckBoxMenuItem alwaysOnTopFlag = new JCheckBoxMenuItem("Always on Top", alwaysOnTop);
+            simulatorMenu.add(alwaysOnTopFlag);
+            
             simulatorMenu.addSeparator();
 
 
@@ -2993,6 +2997,16 @@ public class JavaSEPort extends CodenameOneImplementation {
                 }
             });
             
+            alwaysOnTopFlag.addItemListener(new ItemListener() {
+
+                public void itemStateChanged(ItemEvent ie) {
+                    alwaysOnTop = !alwaysOnTop;
+                    Preferences pref = Preferences.userNodeForPackage(JavaSEPort.class);
+                    pref.putBoolean("AlwaysOnTop", alwaysOnTop);
+                    window.setAlwaysOnTop(alwaysOnTop);
+                }
+            });
+            
             simulateAndroidVKBFlag.addItemListener(new ItemListener() {
 
                 public void itemStateChanged(ItemEvent ie) {
@@ -3055,6 +3069,7 @@ public class JavaSEPort extends CodenameOneImplementation {
             if (skinNames.length() < DEFAULT_SKINS.length()) {
                 skinNames = DEFAULT_SKINS;
             }
+            ButtonGroup skinGroup = new ButtonGroup();
             StringTokenizer tkn = new StringTokenizer(skinNames, ";");
             while (tkn.hasMoreTokens()) {
                 final String current = tkn.nextToken();
@@ -3077,7 +3092,8 @@ public class JavaSEPort extends CodenameOneImplementation {
                         continue;
                     }
                 }
-                JMenuItem i = new JMenuItem(name);
+                String d = System.getProperty("dskin");
+                JRadioButtonMenuItem i = new JRadioButtonMenuItem(name, name.equals(pref.get("skin", d)));
                 i.addActionListener(new ActionListener() {
 
                     public void actionPerformed(ActionEvent ae) {
@@ -3103,6 +3119,7 @@ public class JavaSEPort extends CodenameOneImplementation {
                         }
                     }
                 });
+                skinGroup.add(i);
                 skinMenu.add(i);
             }
         }
@@ -3203,6 +3220,7 @@ public class JavaSEPort extends CodenameOneImplementation {
                         }
 
                         if (data.size() == 0) {
+                            pleaseWait.setVisible(false);
                             JOptionPane.showMessageDialog(frm, "No New Skins to Install");
                             return;
                         }
@@ -3747,6 +3765,10 @@ public class JavaSEPort extends CodenameOneImplementation {
                 canvas.setForcedSize(new java.awt.Dimension((int)(getSkin().getWidth() / retinaScale), (int)(getSkin().getHeight() / retinaScale)));
                 window.setSize(new java.awt.Dimension((int)(getSkin().getWidth() / retinaScale), (int)(getSkin().getHeight() / retinaScale)));
             }
+            
+            alwaysOnTop = pref.getBoolean("AlwaysOnTop", false);
+            window.setAlwaysOnTop(alwaysOnTop);
+            
             window.setVisible(true);
         }
         if (useNativeInput) {


### PR DESCRIPTION
- Useful for while debugging on multiple screens.
- Dispose of "Please wait" Dialog if no new skin to install.
- Change skin list to radio buttons to allow easy identification of
currently used skin.