### PR TITLE
Fixed problem in 3 Layouts where Dimension reused between calls to getPreferredSize and getScrollSize

### DIFF
--- a/CodenameOne/src/com/codename1/components/SpanButton.java
+++ b/CodenameOne/src/com/codename1/components/SpanButton.java
@@ -234,6 +234,8 @@ public class SpanButton extends Container {
      */
     public void setCommand(Command cmd) {
         actualButton.setCommand(cmd);
+        actualButton.setText(""); //remove any text set by cmd for the actualButton since text from Command should only be shown for the TextArea
+        setText(cmd.getCommandName()); //use the text of the Command (since Button is hidden)
     }
 
     /**

--- a/CodenameOne/src/com/codename1/components/SpanButton.java
+++ b/CodenameOne/src/com/codename1/components/SpanButton.java
@@ -233,8 +233,6 @@ public class SpanButton extends Container {
      * @param cmd the command
      */
     public void setCommand(Command cmd) {
-        actualButton.setCommand(cmd);
-        actualButton.setText(""); //remove any text set by cmd for the actualButton since text from Command should only be shown for the TextArea
         setText(cmd.getCommandName()); //use the text of the Command (since Button is hidden)
     }
 

--- a/CodenameOne/src/com/codename1/components/SpanButton.java
+++ b/CodenameOne/src/com/codename1/components/SpanButton.java
@@ -233,7 +233,7 @@ public class SpanButton extends Container {
      * @param cmd the command
      */
     public void setCommand(Command cmd) {
-        setText(cmd.getCommandName()); //use the text of the Command (since Button is hidden)
+        actualButton.setCommand(cmd);
     }
 
     /**

--- a/CodenameOne/src/com/codename1/ui/layouts/BorderLayout.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/BorderLayout.java
@@ -453,12 +453,13 @@ public class BorderLayout extends Layout {
         c.setHeight(Math.min(targetHeight, c.getPreferredH())); //verify I want to use tge prefered size
     }
 
-    private Dimension dim = new Dimension(0, 0);
+//    private Dimension dim = new Dimension(0, 0); //moved into getPreferredSize, otherwise the same dim instance can be used both as preferredSize and scrollSize which creates side effects when preferredSize is forced to (0,0) in setHidden(true)
     
     /**
      * {@inheritDoc}
      */
     public Dimension getPreferredSize(Container parent) {
+        Dimension dim = new Dimension(0, 0);
         dim.setWidth(0);
         dim.setHeight(0);
         Component east = getEast();

--- a/CodenameOne/src/com/codename1/ui/layouts/BoxLayout.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/BoxLayout.java
@@ -203,7 +203,7 @@ public class BoxLayout extends Layout{
         }
     }
     
-    private Dimension dim = new Dimension(0, 0);
+//    private Dimension dim = new Dimension(0, 0); //moved into getPreferredSize, otherwise the same dim instance can be used both as preferredSize and scrollSize which creates side effects when preferredSize is forced to (0,0) in setHidden(true)
 
     /**
      * {@inheritDoc}
@@ -228,6 +228,7 @@ public class BoxLayout extends Layout{
             }
         }
         Style s = parent.getStyle();
+        Dimension dim = new Dimension(0, 0);
         dim.setWidth(width + s.getHorizontalPadding());
         dim.setHeight(height + s.getVerticalPadding());
         return dim;

--- a/CodenameOne/src/com/codename1/ui/layouts/FlowLayout.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/FlowLayout.java
@@ -290,7 +290,7 @@ public class FlowLayout extends Layout{
         }
     }
 
-    private Dimension dim = new Dimension(0, 0);
+//    private Dimension dim = new Dimension(0, 0);//moved into getPreferredSize, otherwise the same dim instance can be used both as preferredSize and scrollSize which creates side effects when preferredSize is forced to (0,0) in setHidden(true)
 
     /**
      * {@inheritDoc}
@@ -322,6 +322,7 @@ public class FlowLayout extends Layout{
 
         width = Math.max(w, width);
 
+        Dimension dim = new Dimension(0, 0);
         dim.setWidth(width + parent.getStyle().getPaddingLeftNoRTL()+ parent.getStyle().getPaddingRightNoRTL());
         dim.setHeight(height + parent.getStyle().getPaddingTop()+ parent.getStyle().getPaddingBottom());
         return dim;


### PR DESCRIPTION
Border, Box and Flow layouts (contrary to all other layouts) reuse the same Dimension for calls to getPreferredSize and getScrollSize. This creates an issue since the same dim instance gets used both as preferredSize and scrollSize which creates side effects when preferredSize is forced to (0,0) in setHidden(true). (Took me several days to debug why a hidden container with BoxLayout kept becoming visible after being set hidden)

(Sorry for the Commit history, still struggling with using Git correctly)