### PR TITLE
Ability to get the textarea used in SpanLabel and SpanButton

### DIFF
--- a/CodenameOne/src/com/codename1/components/SpanButton.java
+++ b/CodenameOne/src/com/codename1/components/SpanButton.java
@@ -89,6 +89,14 @@ public class SpanButton extends Container {
     }
 
     /**
+     * Returns the TextArea holding the actual text
+     * @return the component
+     */
+    public TextArea getTextComponent() {
+        return text;
+    }
+    
+    /**
      * Sets the UIID for the actual text
      *
      * @param uiid the uiid

--- a/CodenameOne/src/com/codename1/components/SpanLabel.java
+++ b/CodenameOne/src/com/codename1/components/SpanLabel.java
@@ -79,6 +79,14 @@ public class SpanLabel extends Container {
     }
     
     /**
+     * Returns the TextArea holding the actual text
+     * @return the component
+     */
+    public TextArea getTextComponent() {
+        return text;
+    }
+    
+    /**
      * Sets the UIID for the actual text
      * @param uiid the uiid
      */


### PR DESCRIPTION
Rather than having this:

        new Helper(span.getComponentAt(1)).textWhite().textCenter().ma0().pa2();

I could have below which is guaranteed to return the right component:

        new Helper(span.getTextComponent).textWhite().textCenter().ma0().pa2();