### PR TITLE
Added ability to create strikethrough horizontal and vertical borders

### DIFF
--- a/CodenameOne/src/com/codename1/ui/plaf/Border.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/Border.java
@@ -68,6 +68,8 @@ public class Border {
     private static final int TYPE_OUTSET = 18;
     private static final int TYPE_IMAGE_SCALED = 19;
     private static final int TYPE_UNDERLINE = 21;
+    private static final int TYPE_STRIKETHROUGH_H = 22;
+    private static final int TYPE_STRIKETHROUGH_V = 23;
 
     // variables are package protected for the benefit of the resource editor!
     int type;
@@ -529,6 +531,72 @@ public class Border {
     public static Border createUnderlineBorder(float thickness, int color) {
         Border b = new Border();
         b.type = TYPE_UNDERLINE;
+        b.themeColors = false;
+        b.thickness = thickness;
+        b.millimeters = true;
+        b.colorA = color;
+        return b;
+    }
+    
+    /**
+     * Creates a strike through border that uses the color of the component foreground for drawing
+     * 
+     * @param thickness thickness of the border in pixels
+     * @param horizontal specify if horizontal or vertical
+     * @return new border instance
+     */
+    public static Border createStrikeThroughBorder(int thickness, boolean horizontal) {
+        Border b = new Border();
+        b.type = horizontal ? TYPE_STRIKETHROUGH_H : TYPE_STRIKETHROUGH_V;
+        b.themeColors = true;
+        b.thickness = thickness;
+        return b;
+    }
+
+    /**
+     * Creates a strike through border that uses the color of the component foreground for drawing
+     * 
+     * @param thickness thickness of the border in millimeters
+     * @param horizontal specify if horizontal or vertical
+     * @return new border instance
+     */
+    public static Border createStrikeThroughBorder(float thickness, boolean horizontal) {
+        Border b = new Border();
+        b.type = horizontal ? TYPE_STRIKETHROUGH_H : TYPE_STRIKETHROUGH_V;
+        b.themeColors = true;
+        b.thickness = thickness;
+        b.millimeters = true;
+        return b;
+    }
+    
+    /**
+     * Creates a strike through border that uses the given color
+     * 
+     * @param thickness thickness of the border in pixels
+     * @param color the color
+     * @param horizontal specify if horizontal or vertical
+     * @return new border instance
+     */
+    public static Border createStrikeThroughBorder(int thickness, int color, boolean horizontal) {
+        Border b = new Border();
+        b.type = horizontal ? TYPE_STRIKETHROUGH_H : TYPE_STRIKETHROUGH_V;
+        b.themeColors = false;
+        b.thickness = thickness;
+        b.colorA = color;
+        return b;
+    }
+
+    /**
+     * Creates a strike through border that uses the given color
+     * 
+     * @param thickness thickness of the border in millimeters
+     * @param color the color
+     * @param horizontal specify if horizontal or vertical
+     * @return new border instance
+     */
+    public static Border createStrikeThroughBorder(float thickness, int color, boolean horizontal) {
+        Border b = new Border();
+        b.type = horizontal ? TYPE_STRIKETHROUGH_H : TYPE_STRIKETHROUGH_V;
         b.themeColors = false;
         b.thickness = thickness;
         b.millimeters = true;
@@ -1727,6 +1795,12 @@ public class Border {
                 break;
             case TYPE_UNDERLINE:
                 g.fillRect(x, y + height - ac - 1, width, ac);
+                break;
+            case TYPE_STRIKETHROUGH_H:
+                g.fillRect(x, (y + height - ac - 1) / 2, width, ac);
+                break;
+            case TYPE_STRIKETHROUGH_V:
+                g.fillRect((x + width - ac - 1) / 2, y, ac, height);
                 break;
             case TYPE_BEVEL_LOWERED: 
                 if(themeColors) {

--- a/CodenameOne/src/com/codename1/ui/plaf/StyleParser.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/StyleParser.java
@@ -680,7 +680,7 @@ public class StyleParser {
                     return (int)Style.TEXT_DECORATION_STRIKETHRU;
                 }
                 
-                if ("underine".equalsIgnoreCase(val)) {
+                if ("underline".equalsIgnoreCase(val)) {
                     return (int)Style.TEXT_DECORATION_UNDERLINE;
                 }
                 
@@ -1354,6 +1354,10 @@ public class StyleParser {
                 out.setType("dotted");
             } else if ("underline".equals(type)) {
                 out.setType("underline");
+            } else if ("strikeThroughH".equals(type)) {
+                out.setType("strikeThroughH");
+            } else if ("strikeThroughH".equals(type)) {
+                out.setType("strikeThroughV");
             }
             return out;
         }
@@ -1431,17 +1435,17 @@ public class StyleParser {
         private String spliceInsets;
         
         /**
-         * The thickness for line/dashed/dotted/underline border
+         * The thickness for line/dashed/dotted/underline/strike-through border
          */
         private Float width;
         
         /**
-         * The unit for line/dashed/dotted/underline border
+         * The unit for line/dashed/dotted/underline/strike-through border
          */
         private byte widthUnit;
         
         /**
-         * The color for a line/dashed/dotted/underline border.
+         * The color for a line/dashed/dotted/underline/strike-through border.
          */
         private Integer color;
 
@@ -1460,7 +1464,7 @@ public class StyleParser {
                     sb.append(img).append(" ");
                 }
                 return sb.toString().trim();
-            } else if ("line".equals(getType()) || "dashed".equals(getType()) || "dotted".equals(getType()) || "underline".equals(getType())) {
+            } else if ("line".equals(getType()) || "dashed".equals(getType()) || "dotted".equals(getType()) || "underline".equals(getType()) || "strikeThroughH".equals(getType()) || "strikeThroughV".equals(getType())) {
                 int color = getColor() == null ? 0 : getColor();
                 
                 return widthString()+" "+lineTypeString()+" "+Integer.toHexString(color);
@@ -1603,6 +1607,20 @@ public class StyleParser {
                     return Border.createUnderlineBorder(getWidth().intValue(), getColor());
                 }
             }
+            if ("strikeThroughH".equals(getType())) {
+                if (this.getWidthUnit() == Style.UNIT_TYPE_DIPS) {
+                    return Border.createStrikeThroughBorder(Display.getInstance().convertToPixels(getWidth()), getColor(), true);
+                } else {
+                    return Border.createStrikeThroughBorder(getWidth().intValue(), getColor(), true);
+                }
+            }
+            if ("strikeThroughV".equals(getType())) {
+                if (this.getWidthUnit() == Style.UNIT_TYPE_DIPS) {
+                    return Border.createStrikeThroughBorder(Display.getInstance().convertToPixels(getWidth()), getColor(), false);
+                } else {
+                    return Border.createStrikeThroughBorder(getWidth().intValue(), getColor(), false);
+                }
+            }
             if ("image".equals(getType())) {
                 int ilen = getImages().length;
                 if (ilen == 9) {
@@ -1704,7 +1722,7 @@ public class StyleParser {
         }
 
         /**
-         * The border type.  E.g. line, dashed, dotted, underline, image, horizontalImage, verticalImage, splicedImage.
+         * The border type.  E.g. line, dashed, dotted, underline, strikeThroughH, strikeThroughV, image, horizontalImage, verticalImage, splicedImage.
          * @return the type
          */
         public String getType() {
@@ -1713,7 +1731,7 @@ public class StyleParser {
 
         /**
          * Sets the border type.
-         * @param type the type to set. E.g. line, dashed, dotted, underline, image, horizontalImage, verticalImage, splicedImage.
+         * @param type the type to set. E.g. line, dashed, dotted, underline, strikeThroughH, strikeThroughV, image, horizontalImage, verticalImage, splicedImage.
          */
         public void setType(String type) {
             this.type = type;
@@ -1812,7 +1830,7 @@ public class StyleParser {
         }
 
         /**
-         * For a line/dashed/dotted/underline/round border, the thickness value.
+         * For a line/dashed/dotted/underline/strike-through/round border, the thickness value.
          * @return the width
          * @see #getWidthUnit() 
          */
@@ -1823,14 +1841,14 @@ public class StyleParser {
         /**
          * Gets the border thickness as a scalar value.  This is effectively the same
          * value as returned by {@link #getWidth() } and {@link #getWidthUnit() }
-         * @return The thickness of the border.  Used with line, dashed, dotted, underline, and round borders.
+         * @return The thickness of the border.  Used with line, dashed, dotted, underline, strike-through, and round borders.
          */
         public ScalarValue getThickness() {
             return new ScalarValue(width, widthUnit);
         }
         
         /**
-         * For line/dashed/dotted/underline border.  The thickness in pixels.
+         * For line/dashed/dotted/underline/strike-through border.  The thickness in pixels.
          * @return The thickness in pixels of the border line.
          * @asee #getWidth()
          */
@@ -1846,7 +1864,7 @@ public class StyleParser {
         }
 
         /**
-         * For a line/dashed/dotted/underline/round border, gets the thickness value.
+         * For a line/dashed/dotted/underline/strike-through/round border, gets the thickness value.
          * @param width the width to set
          * @see #setWidthUnit(byte) 
          */
@@ -1855,7 +1873,7 @@ public class StyleParser {
         }
 
         /**
-         * For a line/dashed/dotted/underline/round border, gets the unit of the thickness value.
+         * For a line/dashed/dotted/underline/strike-through/round border, gets the unit of the thickness value.
          * @return the widthUnit
          * @see #getWidth() 
          */
@@ -1864,7 +1882,7 @@ public class StyleParser {
         }
 
         /**
-         * For a line/dashed/dotted/underline/round border, sets the unit of the thickness value.
+         * For a line/dashed/dotted/underline/strike-through/round border, sets the unit of the thickness value.
          * 
          * @param widthUnit the widthUnit to set
          * @see #setWidth(java.lang.Float) 
@@ -1874,7 +1892,7 @@ public class StyleParser {
         }
 
         /**
-         * For a line/dashed/dotted/underline/round border, sets the color.  For round border
+         * For a line/dashed/dotted/underline/strike-through/round border, sets the color.  For round border
          * this gets the fill color.  For line border variants, it gets the stroke color.
          * @return the color
          * 
@@ -1884,7 +1902,7 @@ public class StyleParser {
         }
 
         /**
-         * For a line/dashed/dotted/underline/round border, gets the color.  For
+         * For a line/dashed/dotted/underline/strike-through/round border, gets the color.  For
          * round border, this sets the fill color.  For line border variants, it sets the stroke color.
          * @param color the color to set
          */

--- a/CodenameOne/src/com/codename1/ui/util/Resources.java
+++ b/CodenameOne/src/com/codename1/ui/util/Resources.java
@@ -132,6 +132,8 @@ public class Resources {
     static final int BORDER_TYPE_IMAGE_SCALED = 19;
     static final int BORDER_TYPE_IMAGE_ROUND = 20;
     static final int BORDER_TYPE_UNDERLINE = 21;
+    static final int BORDER_TYPE_STRIKETHROUGH_H = 22;
+    static final int BORDER_TYPE_STRIKETHROUGH_V = 23;
 
     // for use by the resource editor
     private static Class classLoader = Resources.class;
@@ -1520,14 +1522,44 @@ public class Resources {
                 // use theme colors?
                 if(input.readBoolean()) {
                     if(input.readBoolean()) {
-                        return Border.createUndelineBorder(input.readFloat());
+                        return Border.createUnderlineBorder(input.readFloat());
                     }
-                    return Border.createUndelineBorder((int)input.readFloat());
+                    return Border.createUnderlineBorder((int)input.readFloat());
                 } else {
                     if(input.readBoolean()) {
                         return Border.createUnderlineBorder(input.readFloat(), input.readInt());
                     }
                     return Border.createUnderlineBorder((int)input.readFloat(), input.readInt());
+                }
+
+            // Strike through horizontal border
+            case 0xff15:
+                // use theme colors?
+                if(input.readBoolean()) {
+                    if(input.readBoolean()) {
+                        return Border.createStrikeThroughBorder(input.readFloat(), true);
+                    }
+                    return Border.createStrikeThroughBorder((int)input.readFloat(), true);
+                } else {
+                    if(input.readBoolean()) {
+                        return Border.createStrikeThroughBorder(input.readFloat(), input.readInt(), true);
+                    }
+                    return Border.createStrikeThroughBorder((int)input.readFloat(), input.readInt(), true);
+                }
+
+            // Strike through vertical border
+            case 0xff16:
+                // use theme colors?
+                if(input.readBoolean()) {
+                    if(input.readBoolean()) {
+                        return Border.createStrikeThroughBorder(input.readFloat(), false);
+                    }
+                    return Border.createStrikeThroughBorder((int)input.readFloat(), false);
+                } else {
+                    if(input.readBoolean()) {
+                        return Border.createStrikeThroughBorder(input.readFloat(), input.readInt(), false);
+                    }
+                    return Border.createStrikeThroughBorder((int)input.readFloat(), input.readInt(), false);
                 }
 
             // Rounded border

--- a/CodenameOneDesigner/src/com/codename1/designer/BorderEditor.java
+++ b/CodenameOneDesigner/src/com/codename1/designer/BorderEditor.java
@@ -492,7 +492,7 @@ public class BorderEditor extends javax.swing.JPanel {
         jPanel6.setName("jPanel6"); // NOI18N
         jPanel6.setLayout(new java.awt.BorderLayout());
 
-        borderType.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "[Null]", "[Empty]", "Bevel", "Etched", "Line", "Underline", "Rounded (Deprecated)", "Image", "Horizontal Image", "Vertical Image", "Round (circle or square whose corners are completely round)", "Rounded Rectangle" }));
+        borderType.setModel(new javax.swing.DefaultComboBoxModel(new String[] { "[Null]", "[Empty]", "Bevel", "Etched", "Line", "Underline", "Strike Through Horizontal", "Strike Through Vertical", "Rounded (Deprecated)", "Image", "Horizontal Image", "Vertical Image", "Round (circle or square whose corners are completely round)", "Rounded Rectangle" }));
         borderType.setName("borderType"); // NOI18N
         borderType.addActionListener(formListener);
         jPanel6.add(borderType, java.awt.BorderLayout.CENTER);

--- a/CodenameOneDesigner/src/com/codename1/designer/BorderEditor.java
+++ b/CodenameOneDesigner/src/com/codename1/designer/BorderEditor.java
@@ -29,14 +29,12 @@ import com.codename1.ui.Button;
 import com.codename1.ui.Image;
 import com.codename1.ui.plaf.Border;
 import com.codename1.ui.plaf.Accessor;
-import com.codename1.designer.ResourceEditorView;
 import com.codename1.ui.Display;
 import com.codename1.ui.plaf.RoundBorder;
 import com.codename1.ui.plaf.RoundRectBorder;
 import com.codename1.ui.util.EditableResources;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.swing.JButton;
@@ -218,35 +216,43 @@ public class BorderEditor extends javax.swing.JPanel {
                         case Accessor.TYPE_EMPTY:
                             borderType.setSelectedIndex(1);
                             break;
+                        case Accessor.TYPE_BEVEL_LOWERED:
+                            borderType.setSelectedIndex(2);
+                            fourColorBorder = true;
+                            break;
+                        case Accessor.TYPE_ETCHED_LOWERED:
+                            borderType.setSelectedIndex(3);
+                            break;
                         case Accessor.TYPE_LINE:
                             borderType.setSelectedIndex(4);
                             break;
                         case Accessor.TYPE_UNDERLINE:
                             borderType.setSelectedIndex(5);
                             break;
+                        case Accessor.TYPE_STRIKETHROUGH_H:
+                            borderType.setSelectedIndex(6);
+                            break;
+                        case Accessor.TYPE_STRIKETHROUGH_V:
+                            borderType.setSelectedIndex(7);
+                            break;
                         case Accessor.TYPE_ROUNDED:
                         case Accessor.TYPE_ROUNDED_PRESSED:
-                            borderType.setSelectedIndex(6);
+                            borderType.setSelectedIndex(8);
+                            break;
+                        case Accessor.TYPE_IMAGE:
+                            borderType.setSelectedIndex(9);
+                            break;
+                        case Accessor.TYPE_IMAGE_HORIZONTAL:
+                            borderType.setSelectedIndex(10);
+                            break;
+                        case Accessor.TYPE_IMAGE_VERTICAL:
+                            borderType.setSelectedIndex(11);
                             break;
                         case Accessor.TYPE_ETCHED_RAISED:
                             raisedBorder.setSelected(true);
-                        case Accessor.TYPE_ETCHED_LOWERED:
-                            borderType.setSelectedIndex(3);
                             break;
                         case Accessor.TYPE_BEVEL_RAISED:
                             raisedBorder.setSelected(true);
-                        case Accessor.TYPE_BEVEL_LOWERED:
-                            borderType.setSelectedIndex(2);
-                            fourColorBorder = true;
-                            break;
-                        case Accessor.TYPE_IMAGE:
-                            borderType.setSelectedIndex(7);
-                            break;
-                        case Accessor.TYPE_IMAGE_HORIZONTAL:
-                            borderType.setSelectedIndex(8);
-                            break;
-                        case Accessor.TYPE_IMAGE_VERTICAL:
-                            borderType.setSelectedIndex(9);
                             break;
                     }
                 }
@@ -1444,7 +1450,81 @@ private void borderTypeActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FI
                             }
                         }
                         break;
-                    case 7: {
+                    case 4:
+                        // line border
+                        if(thicknessMillimeters.isSelected()) {
+                            if(themeColors.isSelected()) {
+                                currentBorder = Border.createLineBorder(((Number)thickness.getValue()).floatValue());
+                            } else {
+                                currentBorder = Border.createLineBorder(((Number)thickness.getValue()).floatValue(), getColor(lineColor));
+                            }
+                        } else {
+                            if(themeColors.isSelected()) {
+                                currentBorder = Border.createLineBorder(((Number)thickness.getValue()).intValue());
+                            } else {
+                                currentBorder = Border.createLineBorder(((Number)thickness.getValue()).intValue(), getColor(lineColor));
+                            }
+                        }
+                        break;
+                    case 5:
+                        // underline border
+                        if(thicknessMillimeters.isSelected()) {
+                            if(themeColors.isSelected()) {
+                                currentBorder = Border.createUnderlineBorder(((Number)thickness.getValue()).floatValue());
+                            } else {
+                                currentBorder = Border.createUnderlineBorder(((Number)thickness.getValue()).floatValue(), getColor(lineColor));
+                            }
+                        } else {
+                            if(themeColors.isSelected()) {
+                                currentBorder = Border.createUnderlineBorder(((Number)thickness.getValue()).intValue());
+                            } else {
+                                currentBorder = Border.createUnderlineBorder(((Number)thickness.getValue()).intValue(), getColor(lineColor));
+                            }
+                        }
+                        break;
+                    case 6:
+                        // strike through horizontal border
+                        if(thicknessMillimeters.isSelected()) {
+                            if(themeColors.isSelected()) {
+                                currentBorder = Border.createStrikeThroughBorder(((Number)thickness.getValue()).floatValue(), true);
+                            } else {
+                                currentBorder = Border.createStrikeThroughBorder(((Number)thickness.getValue()).floatValue(), getColor(lineColor), true);
+                            }
+                        } else {
+                            if(themeColors.isSelected()) {
+                                currentBorder = Border.createStrikeThroughBorder(((Number)thickness.getValue()).intValue(), true);
+                            } else {
+                                currentBorder = Border.createStrikeThroughBorder(((Number)thickness.getValue()).intValue(), getColor(lineColor), true);
+                            }
+                        }
+                        break;
+                    case 7:
+                        // strike through vertical border
+                        if(thicknessMillimeters.isSelected()) {
+                            if(themeColors.isSelected()) {
+                                currentBorder = Border.createStrikeThroughBorder(((Number)thickness.getValue()).floatValue(), false);
+                            } else {
+                                currentBorder = Border.createStrikeThroughBorder(((Number)thickness.getValue()).floatValue(), getColor(lineColor), false);
+                            }
+                        } else {
+                            if(themeColors.isSelected()) {
+                                currentBorder = Border.createStrikeThroughBorder(((Number)thickness.getValue()).intValue(), false);
+                            } else {
+                                currentBorder = Border.createStrikeThroughBorder(((Number)thickness.getValue()).intValue(), getColor(lineColor), false);
+                            }
+                        }
+                        break;
+                    case 8:
+                        // rounded border
+                        if(themeColors.isSelected()) {
+                            currentBorder = Border.createRoundBorder(((Number)arcWidth.getValue()).intValue(), 
+                                ((Number)arcHeight.getValue()).intValue());
+                        } else {
+                            currentBorder = Border.createRoundBorder(((Number)arcWidth.getValue()).intValue(), 
+                                ((Number)arcHeight.getValue()).intValue(), getColor(lineColor));
+                        }
+                        break;
+                    case 9: {
                         // this is a theme with no images
                         if(borderType.getItemCount() < 8) {
                             break;
@@ -1469,7 +1549,7 @@ private void borderTypeActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FI
                         }
                         break;
                     }
-                    case 8: {
+                    case 10: {
                         Image c = getButtonImageBorderIcon(this.center);
 
                         currentBorder = Border.createHorizonalImageBorder(
@@ -1478,7 +1558,7 @@ private void borderTypeActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FI
                             c);
                         break;
                     }
-                    case 9: {
+                    case 11: {
                         Image c = getButtonImageBorderIcon(this.center);
 
                         currentBorder = Border.createVerticalImageBorder(
@@ -1487,48 +1567,6 @@ private void borderTypeActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FI
                             c);
                         break;
                     }
-                    case 4:
-                        // line border
-                        if(thicknessMillimeters.isSelected()) {
-                            if(themeColors.isSelected()) {
-                                currentBorder = Border.createLineBorder(((Number)thickness.getValue()).floatValue());
-                            } else {
-                                currentBorder = Border.createLineBorder(((Number)thickness.getValue()).floatValue(), getColor(lineColor));
-                            }
-                        } else {
-                            if(themeColors.isSelected()) {
-                                currentBorder = Border.createLineBorder(((Number)thickness.getValue()).intValue());
-                            } else {
-                                currentBorder = Border.createLineBorder(((Number)thickness.getValue()).intValue(), getColor(lineColor));
-                            }
-                        }
-                        break;
-                    case 5:
-                        // underline border
-                        if(thicknessMillimeters.isSelected()) {
-                            if(themeColors.isSelected()) {
-                                currentBorder = Border.createUndelineBorder(((Number)thickness.getValue()).floatValue());
-                            } else {
-                                currentBorder = Border.createUnderlineBorder(((Number)thickness.getValue()).floatValue(), getColor(lineColor));
-                            }
-                        } else {
-                            if(themeColors.isSelected()) {
-                                currentBorder = Border.createUndelineBorder(((Number)thickness.getValue()).intValue());
-                            } else {
-                                currentBorder = Border.createUnderlineBorder(((Number)thickness.getValue()).intValue(), getColor(lineColor));
-                            }
-                        }
-                        break;
-                    case 6:
-                        // rounded border
-                        if(themeColors.isSelected()) {
-                            currentBorder = Border.createRoundBorder(((Number)arcWidth.getValue()).intValue(), 
-                                ((Number)arcHeight.getValue()).intValue());
-                        } else {
-                            currentBorder = Border.createRoundBorder(((Number)arcWidth.getValue()).intValue(), 
-                                ((Number)arcHeight.getValue()).intValue(), getColor(lineColor));
-                        }
-                        break;
                 }
             }
         }

--- a/CodenameOneDesigner/src/com/codename1/tools/resourcebuilder/ThemeTask.java
+++ b/CodenameOneDesigner/src/com/codename1/tools/resourcebuilder/ThemeTask.java
@@ -173,6 +173,30 @@ public class ThemeTask extends ResourceTask implements ThemeTaskConstants {
                 } else {
                     return Border.createLineBorder(thinkness, Integer.valueOf(tokenizer.nextToken(), 16));
                 }
+            case TYPE_UNDERLINE:
+                // use theme colors?
+                int thicknessU = Integer.parseInt(tokenizer.nextToken());
+                if(!tokenizer.hasMoreTokens()) {
+                    return Border.createUnderlineBorder(thicknessU);
+                } else {
+                    return Border.createLineBorder(thicknessU, Integer.valueOf(tokenizer.nextToken(), 16));
+                }
+            case TYPE_STRIKETHROUGH_H:
+                // use theme colors?
+                int thicknessH = Integer.parseInt(tokenizer.nextToken());
+                if(!tokenizer.hasMoreTokens()) {
+                    return Border.createStrikeThroughBorder(thicknessH, true);
+                } else {
+                    return Border.createStrikeThroughBorder(thicknessH, Integer.valueOf(tokenizer.nextToken(), 16), true);
+                }
+            case TYPE_STRIKETHROUGH_V:
+                // use theme colors?
+                int thicknessV = Integer.parseInt(tokenizer.nextToken());
+                if(!tokenizer.hasMoreTokens()) {
+                    return Border.createStrikeThroughBorder(thicknessV, false);
+                } else {
+                    return Border.createStrikeThroughBorder(thicknessV, Integer.valueOf(tokenizer.nextToken(), 16), false);
+                }
             case TYPE_ROUNDED:
                 // use theme colors?
                 int arcWidth = Integer.parseInt(tokenizer.nextToken());

--- a/CodenameOneDesigner/src/com/codename1/tools/resourcebuilder/ThemeTaskConstants.java
+++ b/CodenameOneDesigner/src/com/codename1/tools/resourcebuilder/ThemeTaskConstants.java
@@ -32,6 +32,9 @@ package com.codename1.tools.resourcebuilder;
 public interface ThemeTaskConstants {
     public static final int TYPE_EMPTY = 0;
     public static final int TYPE_LINE = 1;
+    public static final int TYPE_UNDERLINE = 9;
+    public static final int TYPE_STRIKETHROUGH_H = 10;
+    public static final int TYPE_STRIKETHROUGH_V = 11;
     public static final int TYPE_ROUNDED = 2;
     public static final int TYPE_ETCHED_LOWERED = 4;
     public static final int TYPE_ETCHED_RAISED = 5;

--- a/CodenameOneDesigner/src/com/codename1/ui/plaf/Accessor.java
+++ b/CodenameOneDesigner/src/com/codename1/ui/plaf/Accessor.java
@@ -37,6 +37,8 @@ public class Accessor {
     public static final int TYPE_EMPTY = 0;
     public static final int TYPE_LINE = 1;
     public static final int TYPE_UNDERLINE = 21;
+    public static final int TYPE_STRIKETHROUGH_H = 22;
+    public static final int TYPE_STRIKETHROUGH_V = 23;
     public static final int TYPE_ROUNDED = 2;
     public static final int TYPE_ROUNDED_PRESSED = 3;
     public static final int TYPE_ETCHED_LOWERED = 4;
@@ -81,6 +83,10 @@ public class Accessor {
                 return "Line";
             case TYPE_UNDERLINE:
                 return "Underline";
+            case TYPE_STRIKETHROUGH_H:
+                return "Strike Through Horizontal";
+            case TYPE_STRIKETHROUGH_V:
+                return "Strike Through Vertical";
             case TYPE_ROUNDED:
             case TYPE_ROUNDED_PRESSED:
                 return "Rounded";

--- a/CodenameOneDesigner/src/com/codename1/ui/util/EditableResources.java
+++ b/CodenameOneDesigner/src/com/codename1/ui/util/EditableResources.java
@@ -637,9 +637,27 @@ public class EditableResources extends Resources implements TreeModel {
 
                                         if("underline".equals(b.getType())) {
                                             if(b.getColor() == null) {
-                                                theme.put(b.getKey(), Border.createUndelineBorder(b.getThickness().intValue()));
+                                                theme.put(b.getKey(), Border.createUnderlineBorder(b.getThickness().intValue()));
                                             } else {
                                                 theme.put(b.getKey(), Border.createUnderlineBorder(b.getThickness().intValue(), b.getColor().intValue()));
+                                            }
+                                            continue;
+                                        }
+
+                                        if("strikeThroughH".equals(b.getType())) {
+                                            if(b.getColor() == null) {
+                                                theme.put(b.getKey(), Border.createStrikeThroughBorder(b.getThickness().intValue(), true));
+                                            } else {
+                                                theme.put(b.getKey(), Border.createStrikeThroughBorder(b.getThickness().intValue(), b.getColor().intValue(), true));
+                                            }
+                                            continue;
+                                        }
+
+                                        if("strikeThroughV".equals(b.getType())) {
+                                            if(b.getColor() == null) {
+                                                theme.put(b.getKey(), Border.createStrikeThroughBorder(b.getThickness().intValue(), false));
+                                            } else {
+                                                theme.put(b.getKey(), Border.createStrikeThroughBorder(b.getThickness().intValue(), b.getColor().intValue(), false));
                                             }
                                             continue;
                                         }
@@ -1149,6 +1167,32 @@ public class EditableResources extends Resources implements TreeModel {
                                                     "\" thickness=\"" + Accessor.getThickness(border) + "\" />\n");
                                         } else {
                                             bw.write("        <border key=\"" + key + "\" type=\"underline\"  millimeters=\"" + 
+                                                    Accessor.isMillimeters(border) +"\" thickness=\"" + 
+                                                    Accessor.getThickness(border) + "\" color=\""
+                                                    + Accessor.getColorA(border) + "\" />\n");
+                                        }
+                                        continue;
+                                    case BORDER_TYPE_STRIKETHROUGH_H:
+                                        // use theme colors?
+                                        if(Accessor.isThemeColors(border)) {
+                                            bw.write("        <border key=\"" + key + "\" type=\"strikeThroughH\" millimeters=\"" + 
+                                                    Accessor.isMillimeters(border) +
+                                                    "\" thickness=\"" + Accessor.getThickness(border) + "\" />\n");
+                                        } else {
+                                            bw.write("        <border key=\"" + key + "\" type=\"strikeThroughH\"  millimeters=\"" + 
+                                                    Accessor.isMillimeters(border) +"\" thickness=\"" + 
+                                                    Accessor.getThickness(border) + "\" color=\""
+                                                    + Accessor.getColorA(border) + "\" />\n");
+                                        }
+                                        continue;
+                                    case BORDER_TYPE_STRIKETHROUGH_V:
+                                        // use theme colors?
+                                        if(Accessor.isThemeColors(border)) {
+                                            bw.write("        <border key=\"" + key + "\" type=\"strikeThroughV\" millimeters=\"" + 
+                                                    Accessor.isMillimeters(border) +
+                                                    "\" thickness=\"" + Accessor.getThickness(border) + "\" />\n");
+                                        } else {
+                                            bw.write("        <border key=\"" + key + "\" type=\"strikeThroughV\"  millimeters=\"" + 
                                                     Accessor.isMillimeters(border) +"\" thickness=\"" + 
                                                     Accessor.getThickness(border) + "\" color=\""
                                                     + Accessor.getColorA(border) + "\" />\n");
@@ -2121,6 +2165,36 @@ public class EditableResources extends Resources implements TreeModel {
                 return;
             case BORDER_TYPE_UNDERLINE:
                 output.writeShort(0xff14);
+
+                // use theme colors?
+                if(Accessor.isThemeColors(border)) {
+                    output.writeBoolean(true);
+                    output.writeBoolean(Accessor.isMillimeters(border));
+                    output.writeFloat(Accessor.getThickness(border));
+                } else {
+                    output.writeBoolean(false);
+                    output.writeBoolean(Accessor.isMillimeters(border));
+                    output.writeFloat(Accessor.getThickness(border));
+                    output.writeInt(Accessor.getColorA(border));
+                }
+                return;
+            case BORDER_TYPE_STRIKETHROUGH_H:
+                output.writeShort(0xff15);
+
+                // use theme colors?
+                if(Accessor.isThemeColors(border)) {
+                    output.writeBoolean(true);
+                    output.writeBoolean(Accessor.isMillimeters(border));
+                    output.writeFloat(Accessor.getThickness(border));
+                } else {
+                    output.writeBoolean(false);
+                    output.writeBoolean(Accessor.isMillimeters(border));
+                    output.writeFloat(Accessor.getThickness(border));
+                    output.writeInt(Accessor.getColorA(border));
+                }
+                return;
+            case BORDER_TYPE_STRIKETHROUGH_V:
+                output.writeShort(0xff16);
 
                 // use theme colors?
                 if(Accessor.isThemeColors(border)) {


### PR DESCRIPTION
I rearranged the switch cases incrementally to make them clearer before adding the strike through codes.

I couldn't include **Strike Through Horizontal** and **Strike Through Vertical** to `initComponents()` method because the code is not-editable. @codenameone, please add this for me before merging.

I had to touch `ThemeTask.java` because Underline code was not implemented and I needed to add Strike Through codes too.

Please review thoroughly before merging. I don't want to break anything.