### PR TITLE
fix for background color regression in RoundRectBorder

### DIFF
--- a/CodenameOne/src/com/codename1/ui/plaf/RoundRectBorder.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/RoundRectBorder.java
@@ -327,6 +327,7 @@ public class RoundRectBorder extends Border {
                 byte bgt = c.getStyle().getBgTransparency();
                 if(bgt != 0) {
                     tg.setAlpha(bgt &0xff);
+                    tg.setColor(s.getBgColor());
                     tg.fillShape(gp);
                 }
                 if(this.stroke != null && strokeOpacity > 0 && strokeThickness > 0) {


### PR DESCRIPTION
since last friday the background color of the component is ignored when a RoundRectBorder is set. 

````java
        Form helloWorld = new Form(BorderLayout.center());
        Button roundedRect = new Button("Hello");
        Style allStyles = roundedRect.getAllStyles();
	allStyles.setBgColor(0xFFFF00);
        allStyles.setBgTransparency(0xFF);
        allStyles.setBorder(RoundRectBorder.create().cornerRadius(1.5f));
        helloWorld.add(BorderLayout.CENTER, roundedRect);
        helloWorld.show();
````