### PR TITLE
shouldn't be this like this?

### DIFF
--- a/CodenameOne/src/com/codename1/ui/Toolbar.java
+++ b/CodenameOne/src/com/codename1/ui/Toolbar.java
@@ -1170,7 +1170,7 @@ public class Toolbar extends Container {
         checkIfInitialized();
         cmd.putClientProperty("TitleCommand", Boolean.TRUE);
         if(isRTL()) {
-            cmd.putClientProperty("Left", Boolean.TRUE);
+            cmd.putClientProperty("Left", null);
         }
         sideMenu.addCommand(cmd, 0);        
     }


### PR DESCRIPTION
as `getRightBarCommands()` expects null as "Left" property value