### PR TITLE
Fix and Improve TableLayout

### DIFF
--- a/CodenameOne/src/com/codename1/ui/AutoCompleteTextField.java
+++ b/CodenameOne/src/com/codename1/ui/AutoCompleteTextField.java
@@ -183,7 +183,7 @@ public class AutoCompleteTextField extends TextField {
         Form f = getComponentForm();
         boolean v = filter.getSize() > 0 && getText().length() >= minimumLength;
         if(v != popup.isVisible()) {
-            popup.getComponentAt(0).setScrollY(0);
+            if(popup.getComponentCount() > 0) {popup.getComponentAt(0).setScrollY(0);}
             popup.setVisible(v);
             popup.setEnabled(v);
             f.repaint();


### PR DESCRIPTION
Fix issue with TableLayout that did not shrink when not scrollable horizontally and not enough space
+ Add the possibility to auto-grow any column or row (with a '-2' width or height constraint value on any number of rows/columns
+ Add the possibility to choose whether to shrink (Expected behaviour of the original TableLayout code) or truncate (Actual behaviour of the original TableLayout code) the table when not enough space
+ remove the unnecessary storage of some arrays at the TableLayout object level