### PR TITLE
Modifications of the AnimationManager to allow parallel animations

### DIFF
--- a/CodenameOne/src/com/codename1/ui/AnimationManager.java
+++ b/CodenameOne/src/com/codename1/ui/AnimationManager.java
@@ -37,71 +37,136 @@ import java.util.ArrayList;
  */
 public final class AnimationManager {
     private final Form parentForm;
-    private ArrayList<ComponentAnimation> anims = new ArrayList<ComponentAnimation>();
-    private ArrayList<Runnable> postAnimations = new ArrayList<Runnable>();
-    
+    private ArrayList<ArrayList<ComponentAnimation>> anims_queues = new ArrayList<ArrayList<ComponentAnimation>>(); //animations queues. Animations of a same queue would be run in serie while queues run in parrallel
+    private ArrayList<ArrayList<Runnable>> postAnimations_queues = new ArrayList<ArrayList<Runnable>>(); //runnables that would run when all animations of a specific queue have finished 
+    private ArrayList<Runnable> postAllAnimations =  new ArrayList<Runnable>(); //runnables that would run when all animations, of all queues, have finished 
+        
     AnimationManager(Form parentForm) {
         this.parentForm = parentForm;
     }
     
     /**
-     * Returns true if an animation is currently in progress
-     * @return true if an animation is currently in progress
+     * Returns true if an animation is currently in progress in a given queue
+     * @param qIndex: the index of the queue
+     * @return true if an animation is currently in progress in this queue
      */
-    public boolean isAnimating() {
-        int size = anims.size();
-        if(size == 0) {
-            return false;
-        }
-        if(size > 1) {
-            return true;
-        }
-        // special case where an animation finished but wasn't removed from the queue just yet...
-        return anims.get(0).isInProgress();
+    public boolean isAnimating(int qIndex) {
+    	if (qIndex >= 0 && qIndex < anims_queues.size()) {
+    		ArrayList<ComponentAnimation> anims = anims_queues.get(qIndex);
+    		if (anims != null) {
+    			int size = anims.size();
+    			if(size == 0) {
+    				return false;
+    			}
+    			if(size > 1) {
+    				return true;
+    			}
+    			// special case where an animation finished but wasn't removed from the queue just yet...
+    			return anims.get(0).isInProgress();
+    		}
+    	}
+    	return false;
     }
     
+    
+    public boolean isAnimating() {
+    	for (int i=0; i<anims_queues.size(); i++) {
+    		if (isAnimating(i)) {
+    			return true;
+    		}
+    	}
+    	return false;
+    }
+    
+    
     void updateAnimations() {
-        if(anims.size() > 0) {
-            ComponentAnimation c = anims.get(0);
-            if(c.isInProgress()) {
-                c.updateAnimationState();
-            } else {
-                c.updateAnimationState();
-                anims.remove(c);
-            }
-        } else {
-            while(postAnimations.size() > 0) {
-                postAnimations.get(0).run();
-                postAnimations.remove(0);
-            }
-        }
+    	boolean animated = false;
+    	for (int i=0; i<anims_queues.size(); i++) {
+    		ArrayList<ComponentAnimation> anims = anims_queues.get(i);
+    		if (anims != null) {
+	    	    if(anims.size() > 0) {
+		            ComponentAnimation c = anims.get(0);
+		            if(c.isInProgress()) {
+		                c.updateAnimationState();
+		            } else {
+		                c.updateAnimationState();
+		                anims.remove(c);
+		            }
+		            animated = true;
+		        } else {  ////execute postAnimations that should be run when this queue has finished animating
+		        	if (i >= 0 && i < postAnimations_queues.size()) { //a queue might not have any associated postAnimations so must ensure that postAnimations_queues.get(i) would not throw an outofbounds exception
+		        		ArrayList<Runnable> postAnimations = postAnimations_queues.get(i);
+		        		if (postAnimations != null) {
+		        			while(postAnimations.size() > 0) {
+		        				postAnimations.get(0).run();
+		        				postAnimations.remove(0);
+		        			}
+		        		}
+		        	}
+		        }
+    		}
+    	}
+    	if (!animated) { //execute postAnimations that should be run when all queues have finished animating
+    		while(postAllAnimations.size() > 0) {
+    			postAllAnimations.get(0).run();
+    			postAllAnimations.remove(0);
+    		}
+    	}
     }
 
     void flush() {
-        while(anims.size() > 0) {
-            anims.get(0).flush();
-            anims.remove(0);
-        }
+    	for (int i=0; i<anims_queues.size(); i++) {
+    		ArrayList<ComponentAnimation> anims = anims_queues.get(i);
+    		if (anims != null) {
+    			while(anims.size() > 0) {
+    				anims.get(0).flush();
+    				anims.remove(0);
+    			}
+    		}
+    	}
     }
     
     /**
-     * Adds the animation to the end to the animation queue
-     * @param an the animation object
+     * Adds the animation to the end of a specific animation queue
+     * Be carefull when using more than one queue in an AnimationManager as these
+     * queue would run their animations in parallel. 
+     * So you must ensure that no animation of one queue can conflict with the animation of another queue
+     * @param an: the animation object
+     * @param qIndex: the index of the queue
      */
-    public void addAnimation(ComponentAnimation an) {
-        anims.add(an);
-        Display.getInstance().notifyDisplay();
+    public void addAnimation(ComponentAnimation an, int qIndex) {
+    	if (qIndex >= 0) {
+    		ArrayList<ComponentAnimation> anims = null;
+    		if (qIndex < anims_queues.size()) {
+    			anims = anims_queues.get(qIndex);
+    			if (anims == null) {
+        			anims = new ArrayList<ComponentAnimation>();
+        			anims_queues.set(qIndex, anims);
+        		}
+    		}
+    		else {
+    			anims = new ArrayList<ComponentAnimation>();
+    			anims_queues.add(qIndex, anims);
+    		}
+    		anims.add(an);
+    		Display.getInstance().notifyDisplay();
+    	}
     }
     
     /**
-     * Adds the animation to the end of the animation queue and blocks the current thread until the animation
+     * Adds the animation to the end of a specific animation queue and blocks the current thread until the animation
      * completes 
-     * @param an the animation to perform 
+     * Be carefull when using more than one queue in an AnimationManager as these
+     * queue would run their animations in parallel. 
+     * So you must ensure that no animation of one queue can conflict with the animation of another queue
+     * @param an: the animation to perform 
+     * @param qIndex: the index of the queue
      */
-    public void addAnimationAndBlock(final ComponentAnimation an) {
+    public void addAnimationAndBlock(final ComponentAnimation an, int qIndex) {
         final Object LOCK = new Object();
         an.setNotifyLock(LOCK);
-        addAnimation(an);
+        addAnimation(an, qIndex);
+        final ArrayList<ComponentAnimation> anims = anims_queues.get(qIndex); //necessarily ok here as addAnimation() would have created the queue if it didn't exist
         Display.getInstance().invokeAndBlock(new Runnable() {
             public void run() {
                 while(an.isInProgress() && anims.contains(an)) {
@@ -113,15 +178,115 @@ public final class AnimationManager {
 
     
     /**
-     * Adds the animation to the end to the animation queue
+     * Adds the animation to the end of a specific animation queue
+     * Be carefull when using more than one queue in an AnimationManager as these
+     * queue would run their animations in parallel. 
+     * So you must ensure that no animation of one queue can conflict with the animation of another queue
+     * @param an: the animation object
+     * @param callback: invoked when the animation completes
+     * @param qIndex: the index of the queue
+     */
+    public void addAnimation(ComponentAnimation an, Runnable callback, int qIndex) {
+        an.setOnCompletion(callback);
+        addAnimation(an, qIndex);
+        Display.getInstance().notifyDisplay();
+    }
+    
+    
+    /**
+     * Adds the animation to the end of the main animation queue
+     * @param an the animation object
+     */
+    public void addAnimation(ComponentAnimation an) {
+    	addAnimation(an, 0);
+    }
+    
+    /**
+     * Adds the animation to the end of the main animation queue and blocks the current thread until the animation
+     * completes 
+     * @param an the animation to perform 
+     */
+    public void addAnimationAndBlock(final ComponentAnimation an) {
+    	addAnimationAndBlock(an, 0);
+    }
+
+    
+    /**
+     * Adds the animation to the end to the main animation queue
      * @param an the animation object
      * @param callback invoked when the animation completes
      */
     public void addAnimation(ComponentAnimation an, Runnable callback) {
-        an.setOnCompletion(callback);
-        addAnimation(an);
-        Display.getInstance().notifyDisplay();
+    	addAnimation(an, callback, 0);
     }
+    
+    
+    /**
+     * Adds an animation that should be run in parallel to others animations
+     * So this animation would be put in a new animation queue
+     * Be carefull when using multiple animation queues. This is your responsability
+     * to ensure that no animation of one queue can conflict with the animation of another queue
+     * @param an the animation object
+     * @return the index of the queue used for this animation
+     */
+    public int addParallelAnimation(ComponentAnimation an) {
+    	int qi = firstEmptyQueue();
+    	addAnimation(an, qi);
+    	return qi;
+    }
+    
+    /**
+     * Adds an animation that should be run in parallel to others animations
+     * and blocks the current thread until the animation completes 
+     * So this animation would be put in a new animation queue
+     * Be carefull when using multiple animation queues. This is your responsability
+     * to ensure that no animation of one queue can conflict with the animation of another queue
+     * @param an the animation to perform 
+     * @return the index of the queue used for this animation
+     */
+    public int addParallelAnimationAndBlock(final ComponentAnimation an) {
+    	int qi = firstEmptyQueue();
+    	addAnimationAndBlock(an, qi);
+    	return qi;
+    }
+
+    
+    /**
+     * Adds an animation that should be run in parallel to others animations
+     * So this animation would be put in a new animation queue
+     * Be carefull when using multiple animation queues. This is your responsability
+     * to ensure that no animation of one queue can conflict with the animation of another queue
+     * @param an the animation object
+     * @param callback invoked when the animation completes
+     * @return the index of the queue used for this animation
+     */
+    public int addParallelAnimation(ComponentAnimation an, Runnable callback) {
+    	int qi = firstEmptyQueue();
+    	addAnimation(an, callback, qi);
+    	return qi;
+    }
+    
+    
+    /**
+     * @return the index of the first empty queue
+     */
+    private int firstEmptyQueue() {
+    	for (int i=0; i<anims_queues.size(); i++) {
+    		ArrayList<ComponentAnimation> aq = anims_queues.get(i);
+    		if (aq == null || aq.isEmpty()) {
+    			//ensure that there is no postAnimation queue pending associated to that queue
+    			ArrayList<Runnable> postAnimations = null;
+    			if (i >= 0 && i < postAnimations_queues.size()) { 
+    				postAnimations = postAnimations_queues.get(i);
+    			}
+    			if (postAnimations == null || postAnimations.isEmpty()) {
+					return i;
+				}
+    		}
+    	}
+    	return anims_queues.size();
+    }
+    
     
     /**
      * Performs a step animation as the user scrolls down/up the page e.g. slowly converting a title UIID from
@@ -169,14 +334,49 @@ public final class AnimationManager {
             }
         });
     }
+       
     
     /**
-     * Invokes the runnable when all animations have completed
-     * @param r the runnable that will be invoked after the animations
+     * Invokes the runnable when all animations of specific queue have completed
+     * @param r: the runnable that will be invoked after the animations of the queue
+     * @param qIndex: the index of the queue 
+     */
+    public void flushAnimation(Runnable r, int qIndex) {
+    	if(isAnimating(qIndex)) { //qIndex necessarily >= 0
+    		ArrayList<Runnable> postAnimations = null;
+    		if (qIndex < postAnimations_queues.size()) {
+    			postAnimations = postAnimations_queues.get(qIndex);
+    			if (postAnimations == null) {
+    				postAnimations = new ArrayList<Runnable>();
+    				postAnimations_queues.set(qIndex, postAnimations);
+    			}
+    		}
+    		else {
+    			postAnimations = new ArrayList<Runnable>();
+    			postAnimations_queues.add(qIndex, postAnimations);
+    		}
+    		postAnimations.add(r);
+    	} else {
+    		r.run();
+    	}
+    }
+    
+    /**
+     * Invokes the runnable when all animations of the main queue (i.e queue with index 0) have completed
+     * @param r the runnable that will be invoked after the animations of the main queue
      */
     public void flushAnimation(Runnable r) {
+    	flushAnimation(r, 0);
+    }
+    
+    
+    /**
+     * Invokes the runnable when all animations (of all queues) have completed
+     * @param r: the runnable that will be invoked after the animations of the queue
+     */
+    public void flushAnimationAll(Runnable r) {
         if(isAnimating()) {
-            postAnimations.add(r);
+        	postAllAnimations.add(r);
         } else {
             r.run();
         }


### PR DESCRIPTION
This PR modify the AnimationManager to allow running some animations in parallel when needed and achieve effects like this:
https://streamable.com/465jv

By default, animations are still run serially in a single queue so this should not break anything

The only thing I couldn't determine is whether you prefer the current flushAnimation(Runnable r) method to map to the flushAnimation(Runnable r) (that would execute the runnable when all animations of queue 0 (= the default queue) have ended) or to flushAnimationAll(Runnable r) (that would execute the runnable when all animations of all parallel queues have ended). 
It do not make any difference with the current CN1 code as CN1 only use serial animations for now (that would all be placed in queue 0) but it might make more sense to rename flushAnimationAll(Runnable r) to flushAnimation(Runnable r) and flushAnimation(Runnable r) ro flushAnimationMainQueue(Runnable r). As you whish ;)