### PR TITLE
Fix bug whith animation callbacks multiple executions in ComponentAnimation

### DIFF
--- a/CodenameOne/src/com/codename1/ui/animations/ComponentAnimation.java
+++ b/CodenameOne/src/com/codename1/ui/animations/ComponentAnimation.java
@@ -35,6 +35,7 @@ public abstract class ComponentAnimation {
     private Runnable onCompletion;
     private int step = -1;
     private ArrayList<Runnable> post;
+    private boolean completed = false;
 
     /**
      * Invokes the runnable just as the animation finishes thus allowing cleanup of the UI for the upcoming 
@@ -94,19 +95,25 @@ public abstract class ComponentAnimation {
     public final void updateAnimationState() {
         updateState();
         if(!isInProgress()) {
-            if(notifyLock != null) {
-                synchronized(notifyLock) {
-                    notifyLock.notify();
-                }
-            }
-            if(onCompletion != null) {
-                onCompletion.run();
-            }
-            if(post != null) {
-                for(Runnable p : post) {
-                    p.run();
-                }
-            }
+        	if (!completed) {
+        		completed = true;
+        		if(notifyLock != null) {
+        			synchronized(notifyLock) {
+        				notifyLock.notify();
+        			}
+        		}
+        		if(onCompletion != null) {
+        			onCompletion.run();
+        		}
+        		if(post != null) {
+        			for(Runnable p : post) {
+        				p.run();
+        			}
+        		}
+        	}
+        }
+        else { //ensure completed would be set to false if animation has been restarted
+        	 completed = false; 
         }
     }
     


### PR DESCRIPTION
I have a component with some associated animations that are executed this way:
```
getAnimationManager().addAnimation(anim, new Runnable() {
   	public void run() {
              ...
             System.out.println("Executed animation callback runnable");
        }
}

...

ComponentAnimation c = anims.get(0);
            if(c.isInProgress()) {
                c.updateAnimationState();
            } else {
                c.updateAnimationState();
                anims.remove(c);
            }
```

and I endup having my animation callback runnable to be executed twice. The reason is that, when you test `isInProgress()`, the animation can still be in progress, but, by the time your code execution reach the second `isInProgress()` test inside the `updateAnimationState()` method, your animation can just have ended. So you endup with executing your animation callback runnable without knowing it. Indeed, with the current `ComponentAnimation` implementation, if your animation ended, you will execute the animation callbacks every time you call `updateAnimationState()`, even if they already have been previously executed.
This PR fix this bug by unsuring that `ComponentAnimation` callbacks will only be executed once when the animation ended.   
