### PR TITLE
Added right sidemenu

### DIFF
--- a/CodenameOne/src/com/codename1/ui/Toolbar.java
+++ b/CodenameOne/src/com/codename1/ui/Toolbar.java
@@ -33,6 +33,7 @@ import com.codename1.ui.events.ActionListener;
 import com.codename1.ui.events.ScrollListener;
 import com.codename1.ui.layouts.BorderLayout;
 import com.codename1.ui.layouts.BoxLayout;
+import com.codename1.ui.layouts.FlowLayout;
 import com.codename1.ui.layouts.Layout;
 import com.codename1.ui.list.DefaultListCellRenderer;
 import com.codename1.ui.plaf.LookAndFeel;
@@ -42,46 +43,54 @@ import java.util.ArrayList;
 import java.util.Vector;
 
 /**
- * <p>Toolbar replaces the default title area with a powerful abstraction that allows functionality ranging
- * from side menus (hamburger) to title animations and any arbitrary component type. Toolbar allows
- * customizing the Form title with different commands on the title area, within the side menu or the overflow menu.</p>
- * 
  * <p>
- * The Toolbar allows placing components in one of 4 positions as illustrated by the sample below:
+ * Toolbar replaces the default title area with a powerful abstraction that
+ * allows functionality ranging from side menus (hamburger) to title animations
+ * and any arbitrary component type. Toolbar allows customizing the Form title
+ * with different commands on the title area, within the side menu or the
+ * overflow menu.</p>
+ *
+ * <p>
+ * The Toolbar allows placing components in one of 4 positions as illustrated by
+ * the sample below:
  * </p>
  * <script src="https://gist.github.com/codenameone/e72cfa6aedd7fcd1af72.js"></script>
  * <img src="https://www.codenameone.com/img/developer-guide/components-toolbar.png" alt="Simple usage of Toolbar" />
- *  
+ *
  * <p>
- * {@code Toolbar} supports a search mode that implicitly replaces the title with a search field/magnifying glass
- * effect. The code below demonstrates searching thru the contacts using this API:
+ * {@code Toolbar} supports a search mode that implicitly replaces the title
+ * with a search field/magnifying glass effect. The code below demonstrates
+ * searching thru the contacts using this API:
  * </p>
  * <script src="https://gist.github.com/codenameone/cd227aaca486889f7c940e2e97985426.js"></script>
  * <img src="https://www.codenameone.com/img/developer-guide/toolbar-search-mode.jpg" alt="Dynamic search mode in the Toolbar" />
- * 
+ *
  * <p>
- * The following code also demonstrates search with a more custom UX where the title
- * area was replaced dynamically. This code predated the builtin search support above. 
- * Notice that the {@code TextField} and its hint are styled to look like the title.
+ * The following code also demonstrates search with a more custom UX where the
+ * title area was replaced dynamically. This code predated the builtin search
+ * support above. Notice that the {@code TextField} and its hint are styled to
+ * look like the title.
  * </p>
  * <script src="https://gist.github.com/codenameone/dce6598a226aaf9a3157.js"></script>
  * <img src="https://www.codenameone.com/img/developer-guide/components-toolbar-search.png" alt="Dynamic TextField search using the Toolbar" />
- * 
+ *
  * <p>
- * This sample code show off title animations that allow a title to change (and potentially shrink) as the user scrolls
- * down the UI.  The 3 frames below show a step by step process in the change.
+ * This sample code show off title animations that allow a title to change (and
+ * potentially shrink) as the user scrolls down the UI. The 3 frames below show
+ * a step by step process in the change.
  * </p>
  * <script src="https://gist.github.com/codenameone/085e3a8fa1c36829d812.js"></script>
  * <img src="https://www.codenameone.com/img/developer-guide/components-toolbar-animation-1.png" alt="Toolbar animation stages" />
  * <img src="https://www.codenameone.com/img/developer-guide/components-toolbar-animation-2.png" alt="Toolbar animation stages" />
  * <img src="https://www.codenameone.com/img/developer-guide/components-toolbar-animation-3.png" alt="Toolbar animation stages" />
- * 
+ *
  * @author Chen
  */
 public class Toolbar extends Container {
 
     /**
      * Indicates whether the toolbar should be properly centered by default
+     *
      * @return the centeredDefault
      */
     public static boolean isCenteredDefault() {
@@ -90,6 +99,7 @@ public class Toolbar extends Container {
 
     /**
      * Indicates whether the toolbar should be properly centered by default
+     *
      * @param aCenteredDefault the centeredDefault to set
      */
     public static void setCenteredDefault(boolean aCenteredDefault) {
@@ -98,6 +108,7 @@ public class Toolbar extends Container {
 
     /**
      * Indicates if the side menu is in "on-top" mode
+     *
      * @return the onTopSideMenu
      */
     public static boolean isOnTopSideMenu() {
@@ -106,6 +117,7 @@ public class Toolbar extends Container {
 
     /**
      * Sets the side menu to "on-top" mode
+     *
      * @param aOnTopSideMenu the onTopSideMenu to set
      */
     public static void setOnTopSideMenu(boolean aOnTopSideMenu) {
@@ -137,22 +149,24 @@ public class Toolbar extends Container {
     private boolean showing;
 
     private boolean layered = false;
-    
+
     private boolean initialized = false;
-    
+
     private static boolean permanentSideMenu;
-    
+
     /**
      * Sets the side menu to "on-top" mode
      */
     private static boolean onTopSideMenu = true;
-    
+
     private InteractionDialog sidemenuDialog;
-    
+    private InteractionDialog rightSidemenuDialog;
+
     private Container permanentSideMenuContainer;
+    private Container permanentRightSideMenuContainer;
 
     private static boolean globalToolbar;
-    
+
     /**
      * Indicates whether the toolbar should be properly centered by default
      */
@@ -161,60 +175,66 @@ public class Toolbar extends Container {
     private Command searchCommand;
 
     /**
-     * Component placed on the bottom (south) portion of the permanent/on-top side menu. 
+     * Component placed on the bottom (south) portion of the permanent/on-top
+     * side menu.
      */
     private Component sidemenuSouthComponent;
-    
+    private Component rightSidemenuSouthComponent;
+
     /**
      * Empty Constructor
      */
     public Toolbar() {
         setLayout(new BorderLayout());
-        if(UIManager.getInstance().isThemeConstant("landscapeTitleUiidBool", false)) {
+        if (UIManager.getInstance().isThemeConstant("landscapeTitleUiidBool", false)) {
             setUIID("Toolbar", "ToolbarLandscape");
         } else {
             setUIID("Toolbar");
         }
         sideMenu = new ToolbarSideMenu();
-        if(centeredDefault && 
-                UIManager.getInstance().getComponentStyle("Title").getAlignment() == CENTER) {
+        if (centeredDefault
+                && UIManager.getInstance().getComponentStyle("Title").getAlignment() == CENTER) {
             setTitleCentered(true);
         }
     }
-    
+
     /**
-     * Enables/disables the Toolbar for all the forms in the application. This flag can be flipped via the 
-     * theme constant {@code globalToobarBool}. Notice that the name of this method might imply that
-     * one toolbar instance will be used for all forms which isn't the case, separate instances will be used for each form
-     * 
+     * Enables/disables the Toolbar for all the forms in the application. This
+     * flag can be flipped via the theme constant {@code globalToobarBool}.
+     * Notice that the name of this method might imply that one toolbar instance
+     * will be used for all forms which isn't the case, separate instances will
+     * be used for each form
+     *
      * @param gt true to enable the toolbar globally
      */
     public static void setGlobalToolbar(boolean gt) {
         globalToolbar = gt;
     }
-    
+
     /**
-     * Enables/disables the Toolbar for all the forms in the application. This flag can be flipped via the 
-     * theme constant {@code globalToobarBool}. Notice that the name of this method might imply that
-     * one toolbar instance will be used for all forms which isn't the case, separate instances will be used for each form
-     * 
-     * @return  true if the toolbar API is turned on by default
+     * Enables/disables the Toolbar for all the forms in the application. This
+     * flag can be flipped via the theme constant {@code globalToobarBool}.
+     * Notice that the name of this method might imply that one toolbar instance
+     * will be used for all forms which isn't the case, separate instances will
+     * be used for each form
+     *
+     * @return true if the toolbar API is turned on by default
      */
     public static boolean isGlobalToolbar() {
         return globalToolbar;
     }
-    
+
     /**
-     * This constructor places the Toolbar on a different layer on top of the 
+     * This constructor places the Toolbar on a different layer on top of the
      * Content Pane.
-     * 
+     *
      * @param layered if true places the Toolbar on top of the Content Pane
      */
     public Toolbar(boolean layered) {
         this();
         this.layered = layered;
     }
-    
+
     /**
      * Sets the title of the Toolbar.
      *
@@ -237,30 +257,33 @@ public class Toolbar extends Container {
     }
 
     /**
-     * Makes the title align to the center accurately by doing it at the layout level which also takes into 
-     * account right/left commands
+     * Makes the title align to the center accurately by doing it at the layout
+     * level which also takes into account right/left commands
+     *
      * @param cent whether the title should be centered
      */
     public void setTitleCentered(boolean cent) {
-        if(cent) {
-            ((BorderLayout)getLayout()).setCenterBehavior(BorderLayout.CENTER_BEHAVIOR_CENTER_ABSOLUTE);
+        if (cent) {
+            ((BorderLayout) getLayout()).setCenterBehavior(BorderLayout.CENTER_BEHAVIOR_CENTER_ABSOLUTE);
         } else {
-            ((BorderLayout)getLayout()).setCenterBehavior(BorderLayout.CENTER_BEHAVIOR_SCALE);
+            ((BorderLayout) getLayout()).setCenterBehavior(BorderLayout.CENTER_BEHAVIOR_SCALE);
         }
-    } 
-    
-    /**
-     * Returns true if the title is centered via the layout
-     * @return true if the title is centered
-     */
-    public boolean isTitleCentered() {
-        return ((BorderLayout)getLayout()).getCenterBehavior() == BorderLayout.CENTER_BEHAVIOR_CENTER_ABSOLUTE;
     }
 
     /**
-     * Creates a static side menu that doesn't fold instead of the standard sidemenu.
-     * This is common for tablet UI's where folding the side menu doesn't make as much sense.
-     * 
+     * Returns true if the title is centered via the layout
+     *
+     * @return true if the title is centered
+     */
+    public boolean isTitleCentered() {
+        return ((BorderLayout) getLayout()).getCenterBehavior() == BorderLayout.CENTER_BEHAVIOR_CENTER_ABSOLUTE;
+    }
+
+    /**
+     * Creates a static side menu that doesn't fold instead of the standard
+     * sidemenu. This is common for tablet UI's where folding the side menu
+     * doesn't make as much sense.
+     *
      * @param p true to have a permanent side menu
      */
     public static void setPermanentSideMenu(boolean p) {
@@ -269,9 +292,10 @@ public class Toolbar extends Container {
     }
 
     /**
-     * Creates a static side menu that doesn't fold instead of the standard sidemenu.
-     * This is common for tablet UI's where folding the side menu doesn't make as much sense.
-     * 
+     * Creates a static side menu that doesn't fold instead of the standard
+     * sidemenu. This is common for tablet UI's where folding the side menu
+     * doesn't make as much sense.
+     *
      * @return true if we will use a permanent sidemenu
      */
     public static boolean isPermanentSideMenu() {
@@ -279,56 +303,83 @@ public class Toolbar extends Container {
     }
 
     /**
-     * This is a convenience method to open the side menu bar. It's useful for cases where we want to place the 
-     * menu button in a "creative way" in which case we can bind the side menu to this
+     * This is a convenience method to open the left side menu bar. It's useful
+     * for cases where we want to place the menu button in a "creative way" in
+     * which case we can bind the side menu to this
      */
     public void openSideMenu() {
-        if(onTopSideMenu) {
+        if (onTopSideMenu) {
             showOnTopSidemenu(-1, false);
         } else {
-            ((SideMenuBar)getMenuBar()).openMenu(null);
+            ((SideMenuBar) getMenuBar()).openMenu(null);
         }
     }
-    
+
     /**
-     * Closes the current side menu
+     * This is a convenience method to open the right side menu bar. It's useful
+     * for cases where we want to place the menu button in a "creative way" in
+     * which case we can bind the side menu to this
+     */
+    public void openRightSideMenu() {
+        if (onTopSideMenu) {
+            showOnTopRightSidemenu(-1, false);
+        }
+    }
+
+    /**
+     * Closes the current left side menu
      */
     public void closeSideMenu() {
-        if(onTopSideMenu) {
-            if(sidemenuDialog != null && sidemenuDialog.isShowing()) {
+        if (onTopSideMenu) {
+            if (sidemenuDialog != null && sidemenuDialog.isShowing()) {
                 sidemenuDialog.disposeToTheLeft();
                 Container cnt = getComponentForm().getFormLayeredPane(Toolbar.class, false);
                 Style s = cnt.getUnselectedStyle();
                 s.setBgTransparency(0);
                 cnt.remove();
-            } 
+            }
         } else {
             SideMenuBar.closeCurrentMenu();
         }
     }
-    
+
+    /**
+     * Closes the current right side menu
+     */
+    public void closeRightSideMenu() {
+        if (onTopSideMenu) {
+            if (rightSidemenuDialog != null && rightSidemenuDialog.isShowing()) {
+                rightSidemenuDialog.disposeToTheRight();
+                Container cnt = getComponentForm().getFormLayeredPane(Toolbar.class, false);
+                Style s = cnt.getUnselectedStyle();
+                s.setBgTransparency(0);
+                cnt.remove();
+            }
+        }
+    }
+
     /**
      * Sets the Toolbar title component. This method allow placing any component
      * in the Toolbar center instead of the regular Label. Can be used to place
-     * a TextField to preform search operations
+     * a TextField to perform search operations
      *
      * @param titleCmp Component to place in the Toolbar center.
      */
     public void setTitleComponent(Component titleCmp) {
         checkIfInitialized();
-        if(titleComponent != null) {
+        if (titleComponent != null) {
             titleComponent.remove();
         }
         titleComponent = titleCmp;
         addComponent(BorderLayout.CENTER, titleComponent);
     }
-    
+
     /**
      * Returns the Toolbar title Component.
-     * 
+     *
      * @return the Toolbar title component
-     */ 
-    public Component getTitleComponent(){
+     */
+    public Component getTitleComponent() {
         return titleComponent;
     }
 
@@ -345,121 +396,122 @@ public class Toolbar extends Container {
         addCommandToOverflowMenu(cmd);
         return cmd;
     }
-    
+
     /**
-     * The behavior of the back command  in the title
+     * The behavior of the back command in the title
      */
     public static enum BackCommandPolicy {
         /**
-         * Show the back command always within the title bar on the left hand side
+         * Show the back command always within the title bar on the left hand
+         * side
          */
         ALWAYS,
-        
         /**
          * Show the back command always but shows it with the UIID standard UIID
          */
         AS_REGULAR_COMMAND,
-
         /**
-         * Show the back command always as a back arrow image from the material design style
+         * Show the back command always as a back arrow image from the material
+         * design style
          */
         AS_ARROW,
-
         /**
-         * Shows the back command only if the {@code backUsesTitleBool} theme constant is defined to true which
-         * is the case for iOS themes
+         * Shows the back command only if the {@code backUsesTitleBool} theme
+         * constant is defined to true which is the case for iOS themes
          */
         ONLY_WHEN_USES_TITLE,
-        
         /**
-         * Shows the back command only if the {@code backUsesTitleBool} theme constant is defined to true 
-         * on other platforms uses the left arrow material icon
+         * Shows the back command only if the {@code backUsesTitleBool} theme
+         * constant is defined to true on other platforms uses the left arrow
+         * material icon
          */
         WHEN_USES_TITLE_OTHERWISE_ARROW,
-        
         /**
-         * Never show the command in the title area and only set the back command to the toolbar
+         * Never show the command in the title area and only set the back
+         * command to the toolbar
          */
         NEVER
     }
-    
+
     /**
-     * Sets the back command in the title bar to an arrow type and maps the back command hardware key
-     * if applicable. This is functionally identical to {@code setBackCommand(title, Toolbar.BackCommandPolicy.AS_ARROW, listener); }
-     * 
+     * Sets the back command in the title bar to an arrow type and maps the back
+     * command hardware key if applicable. This is functionally identical to {@code setBackCommand(title, Toolbar.BackCommandPolicy.AS_ARROW, listener);
+     * }
+     *
      * @param title command title
      * @param listener action event for the back command
-     * @return  the created command
+     * @return the created command
      */
     public Command setBackCommand(String title, ActionListener<ActionEvent> listener) {
-        Command cmd  = Command.create(title, null, listener);
+        Command cmd = Command.create(title, null, listener);
         setBackCommand(cmd, BackCommandPolicy.AS_ARROW);
         return cmd;
     }
-    
+
     /**
-     * Sets the back command in the title bar to an arrow type and maps the back command hardware key
-     * if applicable. This is functionally identical to {@code setBackCommand(cmd, Toolbar.BackCommandPolicy.AS_ARROW); }
-     * 
-     * @param cmd the command 
+     * Sets the back command in the title bar to an arrow type and maps the back
+     * command hardware key if applicable. This is functionally identical to {@code setBackCommand(cmd, Toolbar.BackCommandPolicy.AS_ARROW);
+     * }
+     *
+     * @param cmd the command
      */
     public void setBackCommand(Command cmd) {
         setBackCommand(cmd, BackCommandPolicy.AS_ARROW);
     }
-    
+
     /**
-     * Sets the back command in the title bar and in the form, back command behaves based on the given
-     * policy type
-     * 
+     * Sets the back command in the title bar and in the form, back command
+     * behaves based on the given policy type
+     *
      * @param title command title
      * @param policy the behavior of the back command in the title
      * @param listener action event for the back command
-     * @return  the created command
+     * @return the created command
      */
     public Command setBackCommand(String title, BackCommandPolicy policy, ActionListener<ActionEvent> listener) {
-        Command cmd  = Command.create(title, null, listener);
+        Command cmd = Command.create(title, null, listener);
         setBackCommand(cmd, policy);
         return cmd;
     }
 
     /**
-     * Sets the back command in the title bar and in the form, back command behaves based on the given
-     * policy type
-     * 
-     * @param cmd the command 
+     * Sets the back command in the title bar and in the form, back command
+     * behaves based on the given policy type
+     *
+     * @param cmd the command
      * @param policy the behavior of the back command in the title
      * @param iconSize the size of the back command icon in millimeters
      */
     public void setBackCommand(Command cmd, BackCommandPolicy policy, float iconSize) {
-        if(iconSize < 0) {
+        if (iconSize < 0) {
             iconSize = 3;
         }
         getComponentForm().setBackCommand(cmd);
-        switch(policy) {
+        switch (policy) {
             case ALWAYS:
-                if(UIManager.getInstance().isThemeConstant("landscapeTitleUiidBool", false)) {
+                if (UIManager.getInstance().isThemeConstant("landscapeTitleUiidBool", false)) {
                     cmd.putClientProperty("luiid", "BackCommandLandscape");
                 }
                 cmd.putClientProperty("uiid", "BackCommand");
                 addCommandToLeftBar(cmd);
                 break;
             case WHEN_USES_TITLE_OTHERWISE_ARROW:
-                if(UIManager.getInstance().isThemeConstant("landscapeTitleUiidBool", false)) {
+                if (UIManager.getInstance().isThemeConstant("landscapeTitleUiidBool", false)) {
                     cmd.putClientProperty("luiid", "BackCommandLandscape");
                 }
                 cmd.putClientProperty("uiid", "BackCommand");
-                if(getUIManager().isThemeConstant("backUsesTitleBool", false)) {
-                    if(getUIManager().isThemeConstant("iosStyleBackArrowBool", false)) {
+                if (getUIManager().isThemeConstant("backUsesTitleBool", false)) {
+                    if (getUIManager().isThemeConstant("iosStyleBackArrowBool", false)) {
                         cmd.setIconGapMM(0.5f);
                         cmd.setMaterialIcon(FontImage.MATERIAL_KEYBOARD_ARROW_LEFT);
-                    } 
+                    }
                     addCommandToLeftBar(cmd);
                     break;
-                } 
-                // we now internally fallback to as arrow...
+                }
+            // we now internally fallback to as arrow...
             case AS_ARROW:
                 cmd.setCommandName("");
-                if(!isRTL()) {
+                if (!isRTL()) {
                     cmd.setMaterialIcon(FontImage.MATERIAL_ARROW_BACK);
                 } else {
                     cmd.setMaterialIcon(FontImage.MATERIAL_ARROW_FORWARD);
@@ -471,15 +523,15 @@ public class Toolbar extends Container {
                 addCommandToLeftBar(cmd);
                 break;
             case ONLY_WHEN_USES_TITLE:
-                if(getUIManager().isThemeConstant("backUsesTitleBool", false)) {
-                    if(UIManager.getInstance().isThemeConstant("landscapeTitleUiidBool", false)) {
+                if (getUIManager().isThemeConstant("backUsesTitleBool", false)) {
+                    if (UIManager.getInstance().isThemeConstant("landscapeTitleUiidBool", false)) {
                         cmd.putClientProperty("luiid", "BackCommandLandscape");
                     }
                     cmd.putClientProperty("uiid", "BackCommand");
-                    if(getUIManager().isThemeConstant("iosStyleBackArrowBool", false)) {
+                    if (getUIManager().isThemeConstant("iosStyleBackArrowBool", false)) {
                         cmd.setIconGapMM(0.5f);
                         cmd.setMaterialIcon(FontImage.MATERIAL_KEYBOARD_ARROW_LEFT);
-                    } 
+                    }
                     addCommandToLeftBar(cmd);
                 }
                 break;
@@ -487,12 +539,12 @@ public class Toolbar extends Container {
                 break;
         }
     }
-    
+
     /**
-     * Sets the back command in the title bar and in the form, back command behaves based on the given
-     * policy type
-     * 
-     * @param cmd the command 
+     * Sets the back command in the title bar and in the form, back command
+     * behaves based on the given policy type
+     *
+     * @param cmd the command
      * @param policy the behavior of the back command in the title
      */
     public void setBackCommand(Command cmd, BackCommandPolicy policy) {
@@ -500,73 +552,84 @@ public class Toolbar extends Container {
     }
 
     /**
-     * <p>This method add a search Command on the right bar of the {@code Toolbar}.
-     * When the search Command is invoked the current {@code Toolbar} is replaced with 
-     * a search {@code Toolbar} to perform a search on the Current Form.</p>
-     * <p>The callback ActionListener gets the search string and it's up to developer 
-     * to do the actual filtering on the Form.</>
-     * <p>It is possible to customize the default look of the search {@code Toolbar} with the following 
-     * uiid's: {@code ToolbarSearch}, {@code TextFieldSearch} &amp; {@code TextHintSearch}.</>
+     * <p>
+     * This method add a search Command on the right bar of the {@code Toolbar}.
+     * When the search Command is invoked the current {@code Toolbar} is
+     * replaced with a search {@code Toolbar} to perform a search on the Current
+     * Form.</p>
+     * <p>
+     * The callback ActionListener gets the search string and it's up to
+     * developer to do the actual filtering on the Form.</>
+     * <p>
+     * It is possible to customize the default look of the search
+     * {@code Toolbar} with the following uiid's: {@code ToolbarSearch},
+     * {@code TextFieldSearch} &amp; {@code TextHintSearch}.</>
      * <script src="https://gist.github.com/codenameone/cd227aaca486889f7c940e2e97985426.js"></script>
      * <img src="https://www.codenameone.com/img/developer-guide/toolbar-search-mode.jpg" alt="Dynamic search mode in the Toolbar" />
-     * 
+     *
      * @param callback gets the search string callbacks
-     * @param iconSize indicates the size of the icons used in the search/back in millimeters
-     */ 
-    public void addSearchCommand(final ActionListener callback, final float iconSize){
-        searchCommand = new Command(""){
+     * @param iconSize indicates the size of the icons used in the search/back
+     * in millimeters
+     */
+    public void addSearchCommand(final ActionListener callback, final float iconSize) {
+        searchCommand = new Command("") {
 
             @Override
             public void actionPerformed(ActionEvent evt) {
-                SearchBar s = new SearchBar(Toolbar.this, iconSize){
+                SearchBar s = new SearchBar(Toolbar.this, iconSize) {
 
                     @Override
                     public void onSearch(String text) {
                         callback.actionPerformed(new ActionEvent(text));
                     }
-                
+
                 };
-                Form f = (Form)Toolbar.this.getComponentForm();
+                Form f = (Form) Toolbar.this.getComponentForm();
                 setHidden(true);
                 f.removeComponentFromForm(Toolbar.this);
                 f.setToolbar(s);
                 s.initSearchBar();
                 f.animateLayout(100);
             }
-        
+
         };
         searchCommand.setMaterialIcon(FontImage.MATERIAL_SEARCH);
         searchCommand.setMaterialIconSize(iconSize);
         addCommandToRightBar(searchCommand);
-    }    
-    
+    }
+
     /**
      * Removes a previously installed search command
      */
     public void removeSearchCommand() {
-        if(searchCommand != null) {
+        if (searchCommand != null) {
             sideMenu.removeCommand(searchCommand);
             searchCommand = null;
         }
     }
-    
+
     /**
-     * <p>This method add a search Command on the right bar of the {@code Toolbar}.
-     * When the search Command is invoked the current {@code Toolbar} is replaced with 
-     * a search {@code Toolbar} to perform a search on the Current Form.</p>
-     * <p>The callback ActionListener gets the search string and it's up to developer 
-     * to do the actual filtering on the Form.</>
-     * <p>It is possible to customize the default look of the search {@code Toolbar} with the following 
-     * uiid's: {@code ToolbarSearch}, {@code TextFieldSearch} &amp; {@code TextHintSearch}.</>
+     * <p>
+     * This method add a search Command on the right bar of the {@code Toolbar}.
+     * When the search Command is invoked the current {@code Toolbar} is
+     * replaced with a search {@code Toolbar} to perform a search on the Current
+     * Form.</p>
+     * <p>
+     * The callback ActionListener gets the search string and it's up to
+     * developer to do the actual filtering on the Form.</>
+     * <p>
+     * It is possible to customize the default look of the search
+     * {@code Toolbar} with the following uiid's: {@code ToolbarSearch},
+     * {@code TextFieldSearch} &amp; {@code TextHintSearch}.</>
      * <script src="https://gist.github.com/codenameone/cd227aaca486889f7c940e2e97985426.js"></script>
      * <img src="https://www.codenameone.com/img/developer-guide/toolbar-search-mode.jpg" alt="Dynamic search mode in the Toolbar" />
-     * 
+     *
      * @param callback gets the search string callbacks
-     */ 
-    public void addSearchCommand(final ActionListener callback){
+     */
+    public void addSearchCommand(final ActionListener callback) {
         addSearchCommand(callback, -1);
     }
-    
+
     /**
      * Adds a Command to the overflow menu
      *
@@ -580,10 +643,12 @@ public class Toolbar extends Container {
         overflowCommands.add(cmd);
         sideMenu.installRightCommands();
     }
-    
+
     /**
-     * Returns the commands within the overflow menu which can be useful for things like unit testing. Notice
-     * that you should not mutate the commands or the iteratable set in any way!
+     * Returns the commands within the overflow menu which can be useful for
+     * things like unit testing. Notice that you should not mutate the commands
+     * or the iteratable set in any way!
+     *
      * @return the commands in the overflow menu
      */
     public Iterable<Command> getOverflowCommands() {
@@ -591,7 +656,7 @@ public class Toolbar extends Container {
     }
 
     /**
-     * Adds a Command to the side navigation menu
+     * Adds a Command to the left side navigation menu
      *
      * @param name the name/title of the command
      * @param icon the icon for the command
@@ -603,10 +668,25 @@ public class Toolbar extends Container {
         addCommandToSideMenu(cmd);
         return cmd;
     }
-    
+
     /**
-     * Adds a Command to the side navigation menu with a material design icon reference
-     * {@link com.codename1.ui.FontImage}.
+     * Adds a Command to the right side navigation menu (it requires a permanent
+     * sidemenu or an onTop mode sidemenu, otherwise it does nothing)
+     *
+     * @param name the name/title of the command
+     * @param icon the icon for the command
+     * @param ev the even handler
+     * @return a newly created Command instance
+     */
+    public Command addCommandToRightSideMenu(String name, Image icon, final ActionListener ev) {
+        Command cmd = Command.create(name, icon, ev);
+        addCommandToRightSideMenu(cmd);
+        return cmd;
+    }
+
+    /**
+     * Adds a Command to the left side navigation menu with a material design
+     * icon reference {@link com.codename1.ui.FontImage}.
      *
      * @param name the name/title of the command
      * @param icon the icon for the command
@@ -621,8 +701,25 @@ public class Toolbar extends Container {
     }
 
     /**
-     * Adds a Command to the side navigation menu with a material design icon reference
-     * {@link com.codename1.ui.FontImage}.
+     * Adds a Command to the right side navigation menu with a material design
+     * icon reference {@link com.codename1.ui.FontImage} (it requires a
+     * permanent sidemenu or an onTop mode sidemenu, otherwise it does nothing).
+     *
+     * @param name the name/title of the command
+     * @param icon the icon for the command
+     * @param ev the even handler
+     * @return a newly created Command instance
+     */
+    public Command addMaterialCommandToRightSideMenu(String name, char icon, final ActionListener ev) {
+        Command cmd = Command.create(name, null, ev);
+        setCommandMaterialIcon(cmd, icon, "SideCommand");
+        addCommandToRightSideMenu(cmd);
+        return cmd;
+    }
+
+    /**
+     * Adds a Command to the left side navigation menu with a material design
+     * icon reference {@link com.codename1.ui.FontImage}.
      *
      * @param name the name/title of the command
      * @param icon the icon for the command
@@ -636,10 +733,28 @@ public class Toolbar extends Container {
         addCommandToSideMenu(cmd);
         return cmd;
     }
-    
+
     /**
-     * Adds a Command to the TitleArea on the right side with a material design icon reference
-     * {@link com.codename1.ui.FontImage}.
+     * Adds a Command to the right side navigation menu with a material design
+     * icon reference {@link com.codename1.ui.FontImage} (it requires a
+     * permanent sidemenu or an onTop mode sidemenu, otherwise it does nothing).
+     *
+     * @param name the name/title of the command
+     * @param icon the icon for the command
+     * @param size size in millimeters for the icon
+     * @param ev the even handler
+     * @return a newly created Command instance
+     */
+    public Command addMaterialCommandToRightSideMenu(String name, char icon, float size, final ActionListener ev) {
+        Command cmd = Command.create(name, null, ev);
+        setCommandMaterialIcon(cmd, icon, size, "SideCommand");
+        addCommandToRightSideMenu(cmd);
+        return cmd;
+    }
+
+    /**
+     * Adds a Command to the TitleArea on the right side with a material design
+     * icon reference {@link com.codename1.ui.FontImage}.
      *
      * @param name the name/title of the command
      * @param icon the icon for the command
@@ -651,11 +766,11 @@ public class Toolbar extends Container {
         setCommandMaterialIcon(cmd, icon, "TitleCommand");
         addCommandToRightBar(cmd);
         return cmd;
-    }    
+    }
 
     /**
-     * Adds a Command to the TitleArea on the right side with a material design icon reference
-     * {@link com.codename1.ui.FontImage}.
+     * Adds a Command to the TitleArea on the right side with a material design
+     * icon reference {@link com.codename1.ui.FontImage}.
      *
      * @param name the name/title of the command
      * @param icon the icon for the command
@@ -668,20 +783,20 @@ public class Toolbar extends Container {
         setCommandMaterialIcon(cmd, icon, size, "TitleCommand");
         addCommandToRightBar(cmd);
         return cmd;
-    }    
-    
+    }
+
     private void setCommandMaterialIcon(Command cmd, char icon, String defaultUIID) {
         cmd.setMaterialIcon(icon);
     }
-    
+
     private void setCommandMaterialIcon(Command cmd, char icon, float size, String defaultUIID) {
         cmd.setMaterialIcon(icon);
         cmd.setMaterialIconSize(size);
     }
-    
+
     /**
-     * Adds a Command to the TitleArea on the left side with a material design icon reference
-     * {@link com.codename1.ui.FontImage}.
+     * Adds a Command to the TitleArea on the left side with a material design
+     * icon reference {@link com.codename1.ui.FontImage}.
      *
      * @param name the name/title of the command
      * @param icon the icon for the command
@@ -693,11 +808,11 @@ public class Toolbar extends Container {
         setCommandMaterialIcon(cmd, icon, "TitleCommand");
         addCommandToLeftBar(cmd);
         return cmd;
-    }    
+    }
 
     /**
-     * Adds a Command to the TitleArea on the left side with a material design icon reference
-     * {@link com.codename1.ui.FontImage}.
+     * Adds a Command to the TitleArea on the left side with a material design
+     * icon reference {@link com.codename1.ui.FontImage}.
      *
      * @param name the name/title of the command
      * @param icon the icon for the command
@@ -710,7 +825,7 @@ public class Toolbar extends Container {
         setCommandMaterialIcon(cmd, icon, size, "TitleCommand");
         addCommandToLeftBar(cmd);
         return cmd;
-    }    
+    }
 
     /**
      * Adds a Command to the overflow menu with a material design icon reference
@@ -744,75 +859,139 @@ public class Toolbar extends Container {
         addCommandToOverflowMenu(cmd);
         return cmd;
     }
-    
+
     boolean isComponentInOnTopSidemenu(Component cmp) {
-        if(cmp != null) {
-            while(cmp.getParent() != null) {
+        if (cmp != null) {
+            while (cmp.getParent() != null) {
                 cmp = cmp.getParent();
-                if(cmp == permanentSideMenuContainer || cmp == this) {
+                if (cmp == permanentSideMenuContainer || cmp == this) {
                     return true;
                 }
             }
         }
         return false;
     }
-    
+
+    boolean isComponentInOnTopRightSidemenu(Component cmp) {
+        if (cmp != null) {
+            while (cmp.getParent() != null) {
+                cmp = cmp.getParent();
+                if (cmp == permanentRightSideMenuContainer || cmp == this) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     /**
-     * Adds a Command to the side navigation menu
+     * Adds a Command to the left side navigation menu
      *
      * @param cmd a Command
      */
     public void addCommandToSideMenu(Command cmd) {
         checkIfInitialized();
-        if(permanentSideMenu) {
+        if (permanentSideMenu) {
             constructPermanentSideMenu();
 
             Button b = new Button(cmd);
             b.setEndsWith3Points(false);
-            Integer gap = (Integer)cmd.getClientProperty("iconGap");
-            if(gap != null) {
+            Integer gap = (Integer) cmd.getClientProperty("iconGap");
+            if (gap != null) {
                 b.setGap(gap.intValue());
             }
             b.setTextPosition(Label.RIGHT);
-            String uiid = (String)cmd.getClientProperty("uiid");
-            if(uiid != null) {
-                String luiid = (String)cmd.getClientProperty("luiid");
+            String uiid = (String) cmd.getClientProperty("uiid");
+            if (uiid != null) {
+                String luiid = (String) cmd.getClientProperty("luiid");
                 b.setUIID(uiid, luiid);
             } else {
                 b.setUIID("SideCommand");
             }
-            addComponentToSideMenu(permanentSideMenuContainer, b); 
+            addComponentToSideMenu(permanentSideMenuContainer, b);
         } else {
-            if(onTopSideMenu) {
+            if (onTopSideMenu) {
                 constructOnTopSideMenu();
 
                 Button b = new Button(sideMenu.wrapCommand(cmd));
                 b.setEndsWith3Points(false);
-                Integer gap = (Integer)cmd.getClientProperty("iconGap");
-                if(gap != null) {
+                Integer gap = (Integer) cmd.getClientProperty("iconGap");
+                if (gap != null) {
                     b.setGap(gap.intValue());
                 }
                 b.setTextPosition(Label.RIGHT);
-                String uiid = (String)cmd.getClientProperty("uiid");
-                if(uiid != null) {
-                    String luiid = (String)cmd.getClientProperty("luiid");
+                String uiid = (String) cmd.getClientProperty("uiid");
+                if (uiid != null) {
+                    String luiid = (String) cmd.getClientProperty("luiid");
                     b.setUIID(uiid, luiid);
                 } else {
                     b.setUIID("SideCommand");
                 }
-                addComponentToSideMenu(permanentSideMenuContainer, b); 
+                addComponentToSideMenu(permanentSideMenuContainer, b);
             } else {
                 sideMenu.addCommand(cmd);
                 sideMenu.installMenuBar();
             }
         }
     }
-    
+
+    /**
+     * Adds a Command to the right side navigation menu (it requires a permanent
+     * sidemenu or an onTop mode sidemenu, otherwise it does nothing).
+     *
+     * @param cmd a Command
+     */
+    public void addCommandToRightSideMenu(Command cmd) {
+        checkIfInitialized();
+        if (permanentSideMenu) {
+            constructPermanentRightSideMenu();
+
+            Button b = new Button(cmd);
+            b.setEndsWith3Points(false);
+            Integer gap = (Integer) cmd.getClientProperty("iconGap");
+            if (gap != null) {
+                b.setGap(gap.intValue());
+            }
+            b.setTextPosition(Label.LEFT);
+            String uiid = (String) cmd.getClientProperty("uiid");
+            if (uiid != null) {
+                String luiid = (String) cmd.getClientProperty("luiid");
+                b.setUIID(uiid, luiid);
+            } else {
+                b.setUIID("SideCommand");
+            }
+            addComponentToRightSideMenu(permanentRightSideMenuContainer, FlowLayout.encloseRight(b));
+        } else {
+            if (onTopSideMenu) {
+                constructOnTopRightSideMenu();
+
+                Button b = new Button(sideMenu.wrapCommand(cmd));
+                b.setEndsWith3Points(false);
+                Integer gap = (Integer) cmd.getClientProperty("iconGap");
+                if (gap != null) {
+                    b.setGap(gap.intValue());
+                }
+                b.setTextPosition(Label.LEFT);
+                String uiid = (String) cmd.getClientProperty("uiid");
+                if (uiid != null) {
+                    String luiid = (String) cmd.getClientProperty("luiid");
+                    b.setUIID(uiid, luiid);
+                } else {
+                    b.setUIID("SideCommand");
+                }
+                b.getAllStyles().setAlignment(Font.RIGHT);
+                addComponentToRightSideMenu(permanentRightSideMenuContainer, b);
+            } else {
+                // not implemented
+            }
+        }
+    }
+
     private void constructPermanentSideMenu() {
-        if(permanentSideMenuContainer == null) {
+        if (permanentSideMenuContainer == null) {
             permanentSideMenuContainer = constructSideNavigationComponent();
             Form parent = getComponentForm();
-            if(sidemenuSouthComponent != null) {
+            if (sidemenuSouthComponent != null) {
                 Container c = BorderLayout.center(permanentSideMenuContainer);
                 c.add(BorderLayout.SOUTH, sidemenuSouthComponent);
                 parent.addComponentToForm(BorderLayout.WEST, c);
@@ -822,35 +1001,49 @@ public class Toolbar extends Container {
         }
     }
 
+    private void constructPermanentRightSideMenu() {
+        if (permanentRightSideMenuContainer == null) {
+            permanentRightSideMenuContainer = constructSideNavigationComponent();
+            Form parent = getComponentForm();
+            if (rightSidemenuSouthComponent != null) {
+                Container c = BorderLayout.center(permanentRightSideMenuContainer);
+                c.add(BorderLayout.SOUTH, rightSidemenuSouthComponent);
+                parent.addComponentToForm(BorderLayout.EAST, c);
+            } else {
+                parent.addComponentToForm(BorderLayout.EAST, permanentRightSideMenuContainer);
+            }
+        }
+    }
+
     private void constructOnTopSideMenu() {
-        if(sidemenuDialog == null) {
+        if (sidemenuDialog == null) {
             permanentSideMenuContainer = constructSideNavigationComponent();
-            
+
             final Form parent = getComponentForm();
             parent.addPointerPressedListener(new ActionListener() {
                 public void actionPerformed(ActionEvent evt) {
                     if (Display.getInstance().getImplementation().isScrollWheeling()) {
                         return;
                     }
-                    if(sidemenuDialog.isShowing()) {
-                        if(evt.getX() > sidemenuDialog.getWidth()) {
+                    if (sidemenuDialog.isShowing()) {
+                        if (evt.getX() > sidemenuDialog.getWidth()) {
                             parent.putClientProperty("cn1$sidemenuCharged", Boolean.FALSE);
                             closeSideMenu();
                             evt.consume();
                         } else {
-                            if(evt.getX() + Display.getInstance().convertToPixels(8) > sidemenuDialog.getWidth()) {
+                            if (evt.getX() + Display.getInstance().convertToPixels(8) > sidemenuDialog.getWidth()) {
                                 parent.putClientProperty("cn1$sidemenuCharged", Boolean.TRUE);
                             } else {
                                 parent.putClientProperty("cn1$sidemenuCharged", Boolean.FALSE);
                             }
-                            if(!isComponentInOnTopSidemenu(parent.getComponentAt(evt.getX(), evt.getY()))) {
+                            if (!isComponentInOnTopSidemenu(parent.getComponentAt(evt.getX(), evt.getY()))) {
                                 evt.consume();
                             }
                         }
                     } else {
                         int displayWidth = Display.getInstance().getDisplayWidth();
                         final int sensitiveSection = displayWidth / getUIManager().getThemeConstant("sideSwipeSensitiveInt", 10);
-                        if(evt.getX() < sensitiveSection) {
+                        if (evt.getX() < sensitiveSection) {
                             parent.putClientProperty("cn1$sidemenuCharged", Boolean.TRUE);
                             evt.consume();
                         } else {
@@ -865,16 +1058,16 @@ public class Toolbar extends Container {
                     if (Display.getInstance().getImplementation().isScrollWheeling()) {
                         return;
                     }
-                    Boolean b = (Boolean)parent.getClientProperty("cn1$sidemenuCharged");
-                    if(b != null && b.booleanValue()) {
+                    Boolean b = (Boolean) parent.getClientProperty("cn1$sidemenuCharged");
+                    if (b != null && b.booleanValue()) {
                         parent.putClientProperty("cn1$sidemenuActivated", Boolean.TRUE);
                         showOnTopSidemenu(evt.getX(), false);
                         evt.consume();
                     } else {
-                        if(sidemenuDialog.isShowing()) {
+                        if (sidemenuDialog.isShowing()) {
                             permanentSideMenuContainer.pointerDragged(evt.getX(), evt.getY());
-                            evt.consume();                        
-                        }                        
+                            evt.consume();
+                        }
                     }
                 }
             });
@@ -883,18 +1076,18 @@ public class Toolbar extends Container {
                     if (Display.getInstance().getImplementation().isScrollWheeling()) {
                         return;
                     }
-                    Boolean b = (Boolean)parent.getClientProperty("cn1$sidemenuActivated");
-                    if(b != null && b.booleanValue()) {
+                    Boolean b = (Boolean) parent.getClientProperty("cn1$sidemenuActivated");
+                    if (b != null && b.booleanValue()) {
                         parent.putClientProperty("cn1$sidemenuActivated", null);
-                        if(evt.getX() < parent.getWidth() / 4) {
+                        if (evt.getX() < parent.getWidth() / 4) {
                             closeSideMenu();
                         } else {
                             showOnTopSidemenu(-1, true);
                         }
                         evt.consume();
                     } else {
-                        if(sidemenuDialog.isShowing()) {
-                            if(!isComponentInOnTopSidemenu(parent.getComponentAt(evt.getX(), evt.getY()))) {
+                        if (sidemenuDialog.isShowing()) {
+                            if (!isComponentInOnTopSidemenu(parent.getComponentAt(evt.getX(), evt.getY()))) {
                                 evt.consume();
                             }
                             permanentSideMenuContainer.pointerReleased(evt.getX(), evt.getY());
@@ -902,30 +1095,30 @@ public class Toolbar extends Container {
                     }
                 }
             });
-            
+
             sidemenuDialog = new InteractionDialog(new BorderLayout());
-            
+
             sidemenuDialog.setFormMode(true);
             sidemenuDialog.setUIID("Container");
             sidemenuDialog.setDialogUIID("Container");
             sidemenuDialog.getTitleComponent().remove();
             sidemenuDialog.add(BorderLayout.CENTER, permanentSideMenuContainer);
-            if(sidemenuSouthComponent != null) {
+            if (sidemenuSouthComponent != null) {
                 sidemenuDialog.add(BorderLayout.SOUTH, sidemenuSouthComponent);
             }
             float size = 4.5f;
             try {
                 size = Float.parseFloat(getUIManager().getThemeConstant("menuImageSize", "4.5"));
-            } catch(Throwable t) {
+            } catch (Throwable t) {
                 Log.e(t);
             }
-            
+
             if (!parent.getUIManager().isThemeConstant("hideLeftSideMenuBool", false)) {
                 Image i = (Image) parent.getUIManager().getThemeImageConstant("sideMenuImage");
-                if(i != null) {
+                if (i != null) {
                     Command cmd = addCommandToLeftBar("", i, new ActionListener() {
                         public void actionPerformed(ActionEvent evt) {
-                            if(sidemenuDialog.isShowing()) {
+                            if (sidemenuDialog.isShowing()) {
                                 closeSideMenu();
                                 return;
                             }
@@ -939,7 +1132,7 @@ public class Toolbar extends Container {
                 } else {
                     addMaterialCommandToLeftBar("", FontImage.MATERIAL_MENU, size, new ActionListener() {
                         public void actionPerformed(ActionEvent evt) {
-                            if(sidemenuDialog.isShowing()) {
+                            if (sidemenuDialog.isShowing()) {
                                 closeSideMenu();
                                 return;
                             }
@@ -950,21 +1143,152 @@ public class Toolbar extends Container {
             }
         }
     }
-    
+
+    private void constructOnTopRightSideMenu() {
+        if (rightSidemenuDialog == null) {
+            permanentRightSideMenuContainer = constructSideNavigationComponent();
+
+            final Form parent = getComponentForm();
+            parent.addPointerPressedListener(new ActionListener() {
+                public void actionPerformed(ActionEvent evt) {
+                    if (Display.getInstance().getImplementation().isScrollWheeling()) {
+                        return;
+                    }
+                    if (rightSidemenuDialog.isShowing()) {
+                        if (evt.getX() < Display.getInstance().getDisplayWidth() - rightSidemenuDialog.getWidth()) {
+                            parent.putClientProperty("cn1$rightSidemenuCharged", Boolean.FALSE);
+                            closeRightSideMenu();
+                            evt.consume();
+                        } else {
+                            if (evt.getX() - Display.getInstance().convertToPixels(8) < Display.getInstance().getDisplayWidth() - rightSidemenuDialog.getWidth()) {
+                                parent.putClientProperty("cn1$rightSidemenuCharged", Boolean.TRUE);
+                            } else {
+                                parent.putClientProperty("cn1$rightSidemenuCharged", Boolean.FALSE);
+                            }
+                            if (!isComponentInOnTopRightSidemenu(parent.getComponentAt(evt.getX(), evt.getY()))) {
+                                evt.consume();
+                            }
+                        }
+                    } else {
+                        int displayWidth = Display.getInstance().getDisplayWidth();
+                        final int sensitiveSection = displayWidth / getUIManager().getThemeConstant("sideSwipeSensitiveInt", 10);
+                        if (evt.getX() > displayWidth - sensitiveSection) {
+                            parent.putClientProperty("cn1$rightSidemenuCharged", Boolean.TRUE);
+                            evt.consume();
+                        } else {
+                            parent.putClientProperty("cn1$rightSidemenuCharged", Boolean.FALSE);
+                            permanentRightSideMenuContainer.pointerPressed(evt.getX(), evt.getY());
+                        }
+                    }
+                }
+            });
+            /* COMMENTED BECAUSE IT WORKS CORRECTLY ONLY FOR THE LEFT SIDEMENU
+            parent.addPointerDraggedListener(new ActionListener() {
+                public void actionPerformed(ActionEvent evt) {
+                    if (Display.getInstance().getImplementation().isScrollWheeling()) {
+                        return;
+                    }
+                    Boolean b = (Boolean) parent.getClientProperty("cn1$rightSidemenuCharged");
+                    if (b != null && b.booleanValue()) {
+                        parent.putClientProperty("cn1$rightSidemenuCharged", Boolean.TRUE);
+                        showOnTopRightSidemenu(evt.getX(), false);
+                        evt.consume();
+                    } else {
+                        if (rightSidemenuDialog.isShowing()) {
+                            permanentRightSideMenuContainer.pointerDragged(evt.getX(), evt.getY());
+                            evt.consume();
+                        }
+                    }
+                }
+            });
+            */
+            parent.addPointerReleasedListener(new ActionListener() {
+                public void actionPerformed(ActionEvent evt) {
+                    if (Display.getInstance().getImplementation().isScrollWheeling()) {
+                        return;
+                    }
+                    Boolean b = (Boolean) parent.getClientProperty("cn1$rightSidemenuActivated");
+                    if (b != null && b.booleanValue()) {
+                        parent.putClientProperty("cn1$rightSidemenuActivated", null);
+                        if (evt.getX() > Display.getInstance().getDisplayWidth() - (parent.getWidth() / 4)) {
+                            closeRightSideMenu();
+                        } else {
+                            showOnTopRightSidemenu(-1, true);
+                        }
+                        evt.consume();
+                    } else {
+                        if (rightSidemenuDialog.isShowing()) {
+                            if (!isComponentInOnTopRightSidemenu(parent.getComponentAt(evt.getX(), evt.getY()))) {
+                                evt.consume();
+                            }
+                            permanentRightSideMenuContainer.pointerReleased(evt.getX(), evt.getY());
+                        }
+                    }
+                }
+            });
+
+            rightSidemenuDialog = new InteractionDialog(new BorderLayout());
+
+            rightSidemenuDialog.setFormMode(true);
+            rightSidemenuDialog.setUIID("Container");
+            rightSidemenuDialog.setDialogUIID("Container");
+            rightSidemenuDialog.getTitleComponent().remove();
+            rightSidemenuDialog.add(BorderLayout.CENTER, permanentRightSideMenuContainer);
+            if (rightSidemenuSouthComponent != null) {
+                rightSidemenuDialog.add(BorderLayout.SOUTH, rightSidemenuSouthComponent);
+            }
+            float size = 4.5f;
+            try {
+                size = Float.parseFloat(getUIManager().getThemeConstant("menuImageSize", "4.5"));
+            } catch (Throwable t) {
+                Log.e(t);
+            }
+
+            if (!parent.getUIManager().isThemeConstant("hideRightSideMenuBool", false)) {
+                Image i = (Image) parent.getUIManager().getThemeImageConstant("sideMenuImage");
+                if (i != null) {
+                    Command cmd = addCommandToRightBar("", i, new ActionListener() {
+                        public void actionPerformed(ActionEvent evt) {
+                            if (rightSidemenuDialog.isShowing()) {
+                                closeRightSideMenu();
+                                return;
+                            }
+                            showOnTopRightSidemenu(-1, false);
+                        }
+                    });
+                    Image p = (Image) parent.getUIManager().getThemeImageConstant("sideMenuPressImage");
+                    if (p != null) {
+                        findCommandComponent(cmd).setPressedIcon(p);
+                    }
+                } else {
+                    addMaterialCommandToRightBar("", FontImage.MATERIAL_MENU, size, new ActionListener() {
+                        public void actionPerformed(ActionEvent evt) {
+                            if (rightSidemenuDialog.isShowing()) {
+                                closeRightSideMenu();
+                                return;
+                            }
+                            showOnTopRightSidemenu(-1, false);
+                        }
+                    });
+                }
+            }
+        }
+    }
+
     void showOnTopSidemenu(int draggedX, boolean fromCurrent) {
         int v = 0;
         int dw = Display.getInstance().getDisplayWidth();
         if (Display.getInstance().isPortrait()) {
             if (Display.getInstance().isTablet()) {
                 v = getUIManager().getThemeConstant("sideMenuSizeTabPortraitInt", -1);
-                if(v < 0) {
+                if (v < 0) {
                     v = dw * 2 / 3;
                 } else {
                     v = dw * (100 - v) / 100;
                 }
             } else {
                 v = getUIManager().getThemeConstant("sideMenuSizePortraitInt", -1);
-                if(v < 0) {
+                if (v < 0) {
                     v = dw - Display.getInstance().convertToPixels(10);
                 } else {
                     v = dw * (100 - v) / 100;
@@ -973,31 +1297,31 @@ public class Toolbar extends Container {
         } else {
             if (Display.getInstance().isTablet()) {
                 v = getUIManager().getThemeConstant("sideMenuSizeTabLandscapeInt", -1);
-                if(v < 0) {
+                if (v < 0) {
                     v = dw * 3 / 4;
                 } else {
                     v = dw * (100 - v) / 100;
                 }
             } else {
                 v = getUIManager().getThemeConstant("sideMenuSizeLandscapeInt", -1);
-                if(v < 0) {
+                if (v < 0) {
                     v = dw * 4 / 10;
                 } else {
-                    v = dw * (100 - v) / 100;                        
+                    v = dw * (100 - v) / 100;
                 }
             }
         }
         int actualV = v;
-        if(draggedX > 0) {
+        if (draggedX > 0) {
             v = Math.min(v, draggedX);
             sidemenuDialog.setAnimateShow(false);
             sidemenuDialog.dispose();
-        }  else {
+        } else {
             sidemenuDialog.setAnimateShow(true);
         }
-        
+
         // workaround for layout issue on first show
-        if(sidemenuDialog.getClientProperty("cn1$firstShow") == null) {
+        if (sidemenuDialog.getClientProperty("cn1$firstShow") == null) {
             sidemenuDialog.setAnimateShow(false);
             sidemenuDialog.setVisible(false);
             sidemenuDialog.show(0, 0, 0, dw - v);
@@ -1008,7 +1332,7 @@ public class Toolbar extends Container {
         }
         sidemenuDialog.setHeight(Display.getInstance().getDisplayHeight());
         sidemenuDialog.setWidth(v);
-        if(!fromCurrent) {
+        if (!fromCurrent) {
             sidemenuDialog.setX(-v);
         }
         sidemenuDialog.setRepositionAnimation(false);
@@ -1016,36 +1340,117 @@ public class Toolbar extends Container {
         if (!getUIManager().isThemeConstant("sideMenuTensileDragBool", true)) {
             sidemenuDialog.getContentPane().setTensileDragEnabled(false);
         }
-        
-        float f = ((float)v) / ((float)dw) * 80.0f;
+
+        float f = ((float) v) / ((float) dw) * 80.0f;
         Container cnt = getComponentForm().getFormLayeredPane(Toolbar.class, false);
         Style s = cnt.getUnselectedStyle();
-        s.setBgTransparency((int)f);
+        s.setBgTransparency((int) f);
         s.setBgColor(0);
-        
+
         sidemenuDialog.show(0, 0, 0, dw - actualV);
-        if(draggedX > 0) {
+        if (draggedX > 0) {
             sidemenuDialog.setX(Math.min(0, draggedX - actualV));
         }
     }
+
+    void showOnTopRightSidemenu(int draggedX, boolean fromCurrent) {
+        int v = 0;
+        int dw = Display.getInstance().getDisplayWidth();
+        if (Display.getInstance().isPortrait()) {
+            if (Display.getInstance().isTablet()) {
+                v = getUIManager().getThemeConstant("sideMenuSizeTabPortraitInt", -1);
+                if (v < 0) {
+                    v = dw * 2 / 3;
+                } else {
+                    v = dw * (100 - v) / 100;
+                }
+            } else {
+                v = getUIManager().getThemeConstant("sideMenuSizePortraitInt", -1);
+                if (v < 0) {
+                    v = dw - Display.getInstance().convertToPixels(10);
+                } else {
+                    v = dw * (100 - v) / 100;
+                }
+            }
+        } else {
+            if (Display.getInstance().isTablet()) {
+                v = getUIManager().getThemeConstant("sideMenuSizeTabLandscapeInt", -1);
+                if (v < 0) {
+                    v = dw * 3 / 4;
+                } else {
+                    v = dw * (100 - v) / 100;
+                }
+            } else {
+                v = getUIManager().getThemeConstant("sideMenuSizeLandscapeInt", -1);
+                if (v < 0) {
+                    v = dw * 4 / 10;
+                } else {
+                    v = dw * (100 - v) / 100;
+                }
+            }
+        }
+        int actualV = v;
+        if (draggedX > 0) {
+            v = Math.min(v, draggedX);
+            rightSidemenuDialog.setAnimateShow(false);
+            rightSidemenuDialog.dispose();
+        } else {
+            rightSidemenuDialog.setAnimateShow(true);
+        }
+
+        // workaround for layout issue on first show
+        if (rightSidemenuDialog.getClientProperty("cn1$firstRightShow") == null) {
+            rightSidemenuDialog.setAnimateShow(false);
+            rightSidemenuDialog.setVisible(false);
+            rightSidemenuDialog.show(0, 0, dw - v, 0);
+            rightSidemenuDialog.disposeToTheRight();
+            rightSidemenuDialog.setVisible(true);
+            rightSidemenuDialog.putClientProperty("cn1$firstRightShow", Boolean.TRUE);
+            rightSidemenuDialog.setAnimateShow(draggedX < 1);
+        }
+        rightSidemenuDialog.setHeight(Display.getInstance().getDisplayHeight());
+        rightSidemenuDialog.setWidth(v);
+        if (!fromCurrent) {
+            rightSidemenuDialog.setX(Display.getInstance().getDisplayWidth() + v);
+        }
+        rightSidemenuDialog.setRepositionAnimation(false);
+        rightSidemenuDialog.layoutContainer();
+        if (!getUIManager().isThemeConstant("sideMenuTensileDragBool", true)) {
+            rightSidemenuDialog.getContentPane().setTensileDragEnabled(false);
+        }
+
+        float f = ((float) v) / ((float) dw) * 80.0f;
+        Container cnt = getComponentForm().getFormLayeredPane(Toolbar.class, false);
+        Style s = cnt.getUnselectedStyle();
+        s.setBgTransparency((int) f);
+        s.setBgColor(0);
         
+        rightSidemenuDialog.show(0, 0, dw - actualV, 0);
+        if (draggedX > 0) {
+            rightSidemenuDialog.setX(Math.min(0, draggedX - actualV));
+        }
+    }
+
     /**
-     * Places a component in the south portion (bottom) of the side menu. Notice this only works with on-top 
-     * side menu and the permanent side menu. Setting this value to null will remove the existing component. Only
-     * one component can be placed in the south but it can be a container that includes many components
-     * @param sidemenuSouthComponent the new component to place in the south or null to remove the current
-     * component
+     * Places a component in the south portion (bottom) of the left side menu.
+     * Notice this only works with on-top side menu and the permanent side menu.
+     * Setting this value to null will remove the existing component. Only one
+     * component can be placed in the south but it can be a container that
+     * includes many components
+     *
+     * @param sidemenuSouthComponent the new component to place in the south or
+     * null to remove the current component
      */
     public void setComponentToSideMenuSouth(Component sidemenuSouthComponent) {
-        if(this.sidemenuSouthComponent != null) {
+        if (this.sidemenuSouthComponent != null) {
             sidemenuSouthComponent.remove();
         }
         this.sidemenuSouthComponent = sidemenuSouthComponent;
-        if(this.sidemenuSouthComponent != null) {
-            if(sidemenuDialog != null) {
+        if (this.sidemenuSouthComponent != null) {
+            if (sidemenuDialog != null) {
                 sidemenuDialog.add(BorderLayout.SOUTH, sidemenuSouthComponent);
             } else {
-                if(permanentSideMenu && permanentSideMenuContainer != null) {
+                if (permanentSideMenu && permanentSideMenuContainer != null) {
                     Form parent = getComponentForm();
                     parent.removeComponentFromForm(permanentSideMenuContainer);
                     Container c = BorderLayout.center(permanentSideMenuContainer);
@@ -1055,7 +1460,37 @@ public class Toolbar extends Container {
             }
         }
     }
-    
+
+    /**
+     * Places a component in the south portion (bottom) of the right side menu.
+     * Notice this only works with on-top side menu and the permanent side menu.
+     * Setting this value to null will remove the existing component. Only one
+     * component can be placed in the south but it can be a container that
+     * includes many components
+     *
+     * @param sidemenuSouthComponent the new component to place in the south or
+     * null to remove the current component
+     */
+    public void setComponentToRightSideMenuSouth(Component sidemenuSouthComponent) {
+        if (this.rightSidemenuSouthComponent != null) {
+            rightSidemenuSouthComponent.remove();
+        }
+        this.rightSidemenuSouthComponent = sidemenuSouthComponent;
+        if (this.rightSidemenuSouthComponent != null) {
+            if (rightSidemenuDialog != null) {
+                rightSidemenuDialog.add(BorderLayout.SOUTH, sidemenuSouthComponent);
+            } else {
+                if (permanentSideMenu && permanentSideMenuContainer != null) {
+                    Form parent = getComponentForm();
+                    parent.removeComponentFromForm(permanentRightSideMenuContainer);
+                    Container c = BorderLayout.center(permanentRightSideMenuContainer);
+                    c.add(BorderLayout.SOUTH, sidemenuSouthComponent);
+                    parent.addComponentToForm(BorderLayout.EAST, c);
+                }
+            }
+        }
+    }
+
     /**
      * Adds a Component to the side navigation menu. The Component is added to
      * the navigation menu and the command gets the events once the Component is
@@ -1066,7 +1501,7 @@ public class Toolbar extends Container {
      */
     public void addComponentToSideMenu(Component cmp, Command cmd) {
         checkIfInitialized();
-        if(permanentSideMenu) {
+        if (permanentSideMenu) {
             constructPermanentSideMenu();
             Container cnt = new Container(new BorderLayout());
             cnt.addComponent(BorderLayout.CENTER, cmp);
@@ -1075,7 +1510,7 @@ public class Toolbar extends Container {
             cnt.setLeadComponent(btn);
             addComponentToSideMenu(permanentSideMenuContainer, cnt);
         } else {
-            if(onTopSideMenu) {
+            if (onTopSideMenu) {
                 constructOnTopSideMenu();
                 Container cnt = new Container(new BorderLayout());
                 cnt.addComponent(BorderLayout.CENTER, cmp);
@@ -1093,17 +1528,51 @@ public class Toolbar extends Container {
     }
 
     /**
-     * Adds a Component to the side navigation menu.
+     * Adds a Component to the right side navigation menu (it requires a
+     * permanent sidemenu or an onTop sidemenu, otherwise it does nothing). The
+     * Component is added to the navigation menu and the command gets the events
+     * once the Component is being pressed.
+     *
+     * @param cmp c Component to be added to the menu
+     * @param cmd a Command to handle the events
+     */
+    public void addComponentToRightSideMenu(Component cmp, Command cmd) {
+        checkIfInitialized();
+        if (permanentSideMenu) {
+            constructPermanentRightSideMenu();
+            Container cnt = new Container(new BorderLayout());
+            cnt.addComponent(BorderLayout.CENTER, cmp);
+            Button btn = new Button(cmd);
+            btn.setParent(cnt);
+            cnt.setLeadComponent(btn);
+            addComponentToRightSideMenu(permanentRightSideMenuContainer, cnt);
+        } else {
+            if (onTopSideMenu) {
+                constructOnTopRightSideMenu();
+                Container cnt = new Container(new BorderLayout());
+                cnt.addComponent(BorderLayout.CENTER, cmp);
+                Button btn = new Button(cmd);
+                btn.setParent(cnt);
+                cnt.setLeadComponent(btn);
+                addComponentToRightSideMenu(permanentRightSideMenuContainer, cnt);
+            } else {
+                // not implemented
+            }
+        }
+    }
+
+    /**
+     * Adds a Component to the left side navigation menu.
      *
      * @param cmp c Component to be added to the menu
      */
     public void addComponentToSideMenu(Component cmp) {
         checkIfInitialized();
-        if(permanentSideMenu) {
+        if (permanentSideMenu) {
             constructPermanentSideMenu();
             addComponentToSideMenu(permanentSideMenuContainer, cmp);
         } else {
-            if(onTopSideMenu) {
+            if (onTopSideMenu) {
                 constructOnTopSideMenu();
                 addComponentToSideMenu(permanentSideMenuContainer, cmp);
             } else {
@@ -1117,26 +1586,48 @@ public class Toolbar extends Container {
     }
 
     /**
+     * Adds a Component to the right side navigation menu (it requires a
+     * permanent sidemenu or an onTop sidemenu, otherwise it does nothing).
+     *
+     * @param cmp c Component to be added to the menu
+     */
+    public void addComponentToRightSideMenu(Component cmp) {
+        checkIfInitialized();
+        if (permanentSideMenu) {
+            constructPermanentRightSideMenu();
+            addComponentToRightSideMenu(permanentRightSideMenuContainer, cmp);
+        } else {
+            if (onTopSideMenu) {
+                constructOnTopRightSideMenu();
+                addComponentToRightSideMenu(permanentRightSideMenuContainer, cmp);
+            } else {
+                // not implemented
+            }
+        }
+    }
+
+    /**
      * Find the command component instance if such an instance exists
+     *
      * @param c the command instance
      * @return the button instance
      */
     public Button findCommandComponent(Command c) {
-        if(permanentSideMenu || onTopSideMenu) {
+        if (permanentSideMenu || onTopSideMenu) {
             if (permanentSideMenuContainer != null) {
                 Button b = findCommandComponent(c, permanentSideMenuContainer);
-                if(b != null) {
+                if (b != null) {
                     return b;
                 }
             }
         }
         Button b = sideMenu.findCommandComponent(c);
-        if(b != null) {
+        if (b != null) {
             return b;
         }
         return findCommandComponent(c, this);
     }
-    
+
     private Button findCommandComponent(Command c, Container cnt) {
         int count = cnt.getComponentCount();
         for (int iter = 0; iter < count; iter++) {
@@ -1149,7 +1640,7 @@ public class Toolbar extends Container {
             } else {
                 if (current instanceof Container) {
                     Button b = findCommandComponent(c, (Container) current);
-                    if(b != null) {
+                    if (b != null) {
                         return b;
                     }
                 }
@@ -1157,7 +1648,7 @@ public class Toolbar extends Container {
         }
         return null;
     }
-    
+
     /**
      * Adds a Command to the TitleArea on the right side.
      *
@@ -1171,7 +1662,7 @@ public class Toolbar extends Container {
         addCommandToRightBar(cmd);
         return cmd;
     }
-    
+
     /**
      * Adds a Command to the TitleArea on the right side.
      *
@@ -1180,12 +1671,12 @@ public class Toolbar extends Container {
     public void addCommandToRightBar(Command cmd) {
         checkIfInitialized();
         cmd.putClientProperty("TitleCommand", Boolean.TRUE);
-        if(isRTL()) {
+        if (isRTL()) {
             cmd.putClientProperty("Left", null);
         }
-        sideMenu.addCommand(cmd, 0);        
+        sideMenu.addCommand(cmd, 0);
     }
-    
+
     /**
      * Adds a Command to the TitleArea on the left side.
      *
@@ -1208,15 +1699,17 @@ public class Toolbar extends Container {
     public void addCommandToLeftBar(Command cmd) {
         checkIfInitialized();
         cmd.putClientProperty("TitleCommand", Boolean.TRUE);
-        if(!isRTL()) {
+        if (!isRTL()) {
             cmd.putClientProperty("Left", Boolean.TRUE);
         }
         sideMenu.addCommand(cmd, 0);
     }
-    
+
     /**
-     * Returns the commands within the right bar section which can be useful for things like unit testing. Notice
-     * that you should not mutate the commands or the iteratable set in any way!
+     * Returns the commands within the right bar section which can be useful for
+     * things like unit testing. Notice that you should not mutate the commands
+     * or the iteratable set in any way!
+     *
      * @return the commands in the overflow menu
      */
     public Iterable<Command> getRightBarCommands() {
@@ -1224,8 +1717,10 @@ public class Toolbar extends Container {
     }
 
     /**
-     * Returns the commands within the left bar section which can be useful for things like unit testing. Notice
-     * that you should not mutate the commands or the iteratable set in any way!
+     * Returns the commands within the left bar section which can be useful for
+     * things like unit testing. Notice that you should not mutate the commands
+     * or the iteratable set in any way!
+     *
      * @return the commands in the overflow menu
      */
     public Iterable<Command> getLeftBarCommands() {
@@ -1236,9 +1731,9 @@ public class Toolbar extends Container {
         ArrayList<Command> cmds = new ArrayList<Command>();
         findAllCommands(this, cmds);
         int commandCount = cmds.size() - 1;
-        while(commandCount > 0) {
+        while (commandCount > 0) {
             Command c = cmds.get(commandCount);
-            if(c.getClientProperty("Left") != leftValue) {
+            if (c.getClientProperty("Left") != leftValue) {
                 cmds.remove(commandCount);
             }
             commandCount--;
@@ -1247,20 +1742,20 @@ public class Toolbar extends Container {
     }
 
     private void findAllCommands(Container cnt, ArrayList<Command> cmds) {
-        for(Component c : cnt) {
-            if(c instanceof Container) {
-                findAllCommands((Container)c, cmds);
+        for (Component c : cnt) {
+            if (c instanceof Container) {
+                findAllCommands((Container) c, cmds);
                 continue;
             }
-            if(c instanceof Button) {
-                Command b = ((Button)c).getCommand();
-                if(b != null) {
+            if (c instanceof Button) {
+                Command b = ((Button) c).getCommand();
+                if (b != null) {
                     cmds.add(b);
                 }
             }
         }
     }
-    
+
     /**
      * Returns the associated SideMenuBar object of this Toolbar.
      *
@@ -1301,8 +1796,8 @@ public class Toolbar extends Container {
         LookAndFeel lf = manager.getLookAndFeel();
         if (lf.getDefaultMenuTransitionIn() != null || lf.getDefaultMenuTransitionOut() != null) {
             transitionIn = lf.getDefaultMenuTransitionIn();
-            if(transitionIn instanceof BubbleTransition){
-                ((BubbleTransition)transitionIn).setComponentName("OverflowButton");
+            if (transitionIn instanceof BubbleTransition) {
+                ((BubbleTransition) transitionIn).setComponentName("OverflowButton");
             }
             transitionOut = lf.getDefaultMenuTransitionOut();
         } else {
@@ -1311,8 +1806,8 @@ public class Toolbar extends Container {
         }
         menu.setTransitionInAnimator(transitionIn);
         menu.setTransitionOutAnimator(transitionOut);
-        
-        if(isRTL()){
+
+        if (isRTL()) {
             marginRight = marginLeft;
             marginLeft = 0;
         }
@@ -1325,10 +1820,10 @@ public class Toolbar extends Container {
         if (statusBar != null) {
             topPadding = statusBar.getAbsoluteY() + statusBar.getHeight();
         }
-        if(showBelowTitle){
+        if (showBelowTitle) {
             topPadding = th;
         }
-        
+
         Command r = menu.show(topPadding, Math.max(topPadding, height - topPadding), marginLeft, marginRight, true);
         parent.setTintColor(tint);
         return r;
@@ -1350,7 +1845,7 @@ public class Toolbar extends Container {
         c.setUIID("CommandFocus");
         l.setFixedSelection(List.FIXED_NONE_CYCLIC);
         l.setScrollVisible(false);
-        ((DefaultListCellRenderer)l.getRenderer()).setShowNumbers(false);
+        ((DefaultListCellRenderer) l.getRenderer()).setShowNumbers(false);
         return l;
     }
 
@@ -1360,7 +1855,7 @@ public class Toolbar extends Container {
      */
     protected void initTitleBarStatus() {
         Form f = getComponentForm();
-        if(f != null && !f.shouldPaintStatusBar()) {
+        if (f != null && !f.shouldPaintStatusBar()) {
             return;
         }
         if (getUIManager().isThemeConstant("paintsTitleBarBool", false)) {
@@ -1379,7 +1874,7 @@ public class Toolbar extends Container {
                     + "Form#setToolBar(Toolbar toolbar) before calling this method");
         }
     }
-    
+
     /**
      * Sets the Toolbar to scroll off the screen upon content scroll. This
      * feature can only work if the Form contentPane is scrollableY
@@ -1398,10 +1893,10 @@ public class Toolbar extends Container {
      * Hide the Toolbar if it is currently showing
      */
     public void hideToolbar() {
-        showing = false;       
+        showing = false;
         if (actualPaneInitialH == 0) {
             Form f = getComponentForm();
-            if(f != null){
+            if (f != null) {
                 initVars(f.getActualPane());
             }
         }
@@ -1426,7 +1921,7 @@ public class Toolbar extends Container {
             final Container actualPane = f.getActualPane();
             int val = hideShowMotion.getValue();
             setY(val);
-            if(!layered){
+            if (!layered) {
                 actualPane.setY(actualPaneInitialY + val);
                 if (showing) {
                     actualPane.setHeight(actualPaneInitialH + getHeight() - val);
@@ -1471,7 +1966,7 @@ public class Toolbar extends Container {
                         toolbarNewY = Math.min(toolbarNewY, initialY);
                         if (toolbarNewY != getY()) {
                             setY(toolbarNewY);
-                            if(!layered){
+                            if (!layered) {
                                 actualPane.setY(actualPaneInitialY + toolbarNewY);
                                 actualPane.setHeight(actualPaneInitialH + getHeight() - toolbarNewY);
                                 actualPane.doLayout();
@@ -1504,7 +1999,7 @@ public class Toolbar extends Container {
         }
 
     }
-    
+
     /**
      * Creates the side navigation component with the Commands.
      *
@@ -1514,7 +2009,7 @@ public class Toolbar extends Container {
     protected Container createSideNavigationComponent(Vector commands, String placement) {
         return sideMenu.createSideNavigationPanel(commands, placement);
     }
-    
+
     /**
      * Creates an empty side navigation panel.
      */
@@ -1535,58 +2030,89 @@ public class Toolbar extends Container {
     }
 
     /**
-     * Returns the commands within the side menu which can be useful for things like unit testing. Notice
-     * that you should not mutate the commands or the iteratable set in any way!
-     * @return the commands in the overflow menu
+     * This method responsible to add a Component to the right side navigation
+     * panel.
+     *
+     * @param menu the Menu Container that was created in the
+     * constructSideNavigationComponent() method
+     *
+     * @param cmp the Component to add to the side menu
+     */
+    protected void addComponentToRightSideMenu(Container menu, Component cmp) {
+        sideMenu.addComponentToSideMenuImpl(menu, cmp);
+    }
+
+    /**
+     * Returns the commands within the left side menu which can be useful for
+     * things like unit testing. Notice that you should not mutate the commands
+     * or the iteratable set in any way!
+     *
+     * @return the commands in the left side menu
      */
     public Iterable<Command> getSideMenuCommands() {
         ArrayList<Command> cmds = new ArrayList<Command>();
-        if(permanentSideMenu || onTopSideMenu) {
-            if(permanentSideMenuContainer != null) {
+        if (permanentSideMenu || onTopSideMenu) {
+            if (permanentSideMenuContainer != null) {
                 findAllCommands(permanentSideMenuContainer, cmds);
             }
             return cmds;
         }
         Form f = getComponentForm();
         int commands = f.getCommandCount();
-        for(int iter = 0 ; iter < commands ; iter++) {
+        for (int iter = 0; iter < commands; iter++) {
             cmds.add(f.getCommand(iter));
         }
         return cmds;
     }
 
     /**
-     * Removes the given overflow menu command, notice that this has no effect on the menu that is currently
-     * showing (if it is currently showing) only on the upcoming iterations.
+     * Returns the commands within the right side menu which can be useful for
+     * things like unit testing. Notice that you should not mutate the commands
+     * or the iteratable set in any way!
+     *
+     * @return the commands in the right side menu
+     */
+    public Iterable<Command> getRightSideMenuCommands() {
+        ArrayList<Command> cmds = new ArrayList<Command>();
+        if (permanentSideMenu || onTopSideMenu) {
+            if (permanentRightSideMenuContainer != null) {
+                findAllCommands(permanentRightSideMenuContainer, cmds);
+            }
+        }
+        return cmds;
+    }
+
+    /**
+     * Removes the given overflow menu command, notice that this has no effect
+     * on the menu that is currently showing (if it is currently showing) only
+     * on the upcoming iterations.
+     *
      * @param cmd the command to remove from the overflow
      */
     public void removeOverflowCommand(Command cmd) {
         overflowCommands.remove(cmd);
     }
 
-    
-
     class ToolbarSideMenu extends SideMenuBar {
 
         @Override
         protected void removeCommand(Command cmd) {
             super.removeCommand(cmd);
-            if(onTopSideMenu || permanentSideMenu) {
+            if (onTopSideMenu || permanentSideMenu) {
                 Button b = Toolbar.this.findCommandComponent(cmd);
-                if(b != null) {
+                if (b != null) {
                     b.remove();
                 }
             }
         }
 
-        
         @Override
         protected Container createSideNavigationComponent(Vector commands, String placement) {
             return Toolbar.this.createSideNavigationComponent(commands, placement);
         }
-        
+
         @Override
-        protected Container constructSideNavigationComponent(){
+        protected Container constructSideNavigationComponent() {
             return Toolbar.this.constructSideNavigationComponent();
         }
 
@@ -1594,7 +2120,7 @@ public class Toolbar extends Container {
         protected void addComponentToSideMenu(Container menu, Component cmp) {
             Toolbar.this.addComponentToSideMenu(menu, cmp);
         }
-        
+
         @Override
         protected Container getTitleAreaContainer() {
             return Toolbar.this;
@@ -1610,17 +2136,17 @@ public class Toolbar extends Container {
             Component ta = parent.getTitleArea();
             parent.removeComponentFromForm(ta);
             super.initMenuBar(parent);
-            if(layered){
+            if (layered) {
                 Container layeredPane = parent.getLayeredPane();
                 Container p = layeredPane.getParent();
                 Container top = new Container(new BorderLayout());
                 top.addComponent(BorderLayout.NORTH, Toolbar.this);
                 p.addComponent(top);
-            
-            }else{
+
+            } else {
                 parent.addComponentToForm(BorderLayout.NORTH, Toolbar.this);
             }
-            
+
             initialized = true;
             setTitle(parent.getTitle());
             parent.revalidate();
@@ -1651,11 +2177,11 @@ public class Toolbar extends Container {
             if (overflowCommands != null && overflowCommands.size() > 0) {
                 UIManager uim = UIManager.getInstance();
                 Image i = (Image) uim.getThemeImageConstant("menuImage");
-                if (i == null) { 
+                if (i == null) {
                     float size = 4.5f;
                     try {
                         size = Float.parseFloat(uim.getThemeConstant("overflowImageSize", "4.5"));
-                    } catch(Throwable t) {
+                    } catch (Throwable t) {
                         Log.e(t);
                     }
                     i = FontImage.createMaterial(FontImage.MATERIAL_MORE_VERT, UIManager.getInstance().getComponentStyle("TitleCommand"), size);
@@ -1725,7 +2251,7 @@ public class Toolbar extends Container {
         public int getCommandBehavior() {
             return Display.COMMAND_BEHAVIOR_ICS;
         }
-        
+
         @Override
         void synchronizeCommandsWithButtonsInBackbutton() {
             boolean hasSideCommands = false;

--- a/CodenameOne/src/com/codename1/ui/Toolbar.java
+++ b/CodenameOne/src/com/codename1/ui/Toolbar.java
@@ -325,11 +325,19 @@ public class Toolbar extends Container {
             showOnTopRightSidemenu(-1, false);
         }
     }
-
+    
     /**
-     * Closes the current left side menu
+     * Closes the current side menu
      */
     public void closeSideMenu() {
+        closeLeftSideMenu();
+        closeRightSideMenu();
+    }
+
+    /**
+     * Closes the left side menu
+     */
+    public void closeLeftSideMenu() {
         if (onTopSideMenu) {
             if (sidemenuDialog != null && sidemenuDialog.isShowing()) {
                 sidemenuDialog.disposeToTheLeft();
@@ -344,7 +352,7 @@ public class Toolbar extends Container {
     }
 
     /**
-     * Closes the current right side menu
+     * Closes the right side menu
      */
     public void closeRightSideMenu() {
         if (onTopSideMenu) {


### PR DESCRIPTION
I did the best I could to implement a right sidemenu, as in RFE https://github.com/codenameone/CodenameOne/issues/2257 and as suggested by Shai in Stack Overflow: https://stackoverflow.com/a/50653946/2670744

I use the "format" option of Netbeans when I write code to keep it well formatted, that's why there are a lot of unnecessary changes in the `Toolbar.java`, I'm so sorry about that.

I added several methods to support the right sidemenu, such as: `addCommandToRightSideMenu, addComponentToRightSideMenu, addMaterialCommandToRightSideMenu, closeRightSideMenu, openRightSideMenu, isComponentOnTopRightSideMenu, setComponentToRightSideMenuSouth, constructOnTopRightSideMenu, constructPermamentRightSideMenu, getRightSideMenuCommands, etc.`. In this video you can see an example with the Simulator, in which I added a left sidemenu (without hamburger menu) and a right sidemenu (with the hamburger menu):
https://www.informatica-libera.net/rightSidemenu.mp4

I used as much as possible the same logic used in the left side menu bar to create a similar right side menu bar: the code is as much as possible similar.

However, in this implementation there are some limits / bugs that can require your attention:
1. The right sidemenu can be used only as a permanent sidemenu or as an onTop sidemenu, otherwise the methods that I added do nothing.
2. I didn't implemented the swipe to open and close the right sidemenu: more precisely, in the method `constructOnTopRightSideMenu` I commented the `parent.addPointerDraggedListener(new ActionListener() {...}` because the PointerDraggedListener seems to detect only the drag from the left edge to the center, and not from the right edge to the center. I'm also not sure how to manage two PointerDraggedListeners (for the left sidemenu and for the right sidemenu) and how to detect which should be used.
3. When the user taps a Command in the left sidemenu, that sidemenu closes automatically; when the user taps a Command in the right sidemenu, that sidemenu doesn't close automatically: the only way to close is to tap outside the sidemenu.
4. There is an odd graphic defect in the Simulator, as you can see in the video, because the sentence `Contact Us (RIGHT)` is shown as `Contact Us (R  HT)` (without two chars): I cannot try my code in real devices because it cannot compile on your build servers with my new methods (for example, I get: `Exception: java.lang.NoSuchMethodError - com.codename1.ui.Toolbar.addComponentToRightSideMenu`).

The code that I used to test the right sidemenu + the left sidemenu in the same Form (as in the video) is the following:

```
public void start() {
        if(current != null){
            current.show();
            return;
        }
        Form hi = new Form("Hi World", BoxLayout.y());
        hi.add(new Label("Hi World"));
        
        // Test the right sidemenu 
        Toolbar.setOnTopSideMenu(true);
        Toolbar tb = hi.getToolbar();
        Image icon = FontImage.createMaterial(FontImage.MATERIAL_BOOKMARK_BORDER, "SidemenuTagline", 10);
        Button button = new Button(icon, "Label");
        Container topBar = BorderLayout.east(button);
        topBar.add(BorderLayout.SOUTH, FlowLayout.encloseRight(new Label("Help Desk (RIGHT)", "SidemenuTagline")));
        topBar.setUIID("SideCommand");
        tb.addComponentToRightSideMenu(topBar);
        tb.addMaterialCommandToRightSideMenu("Contact Us (RIGHT)", FontImage.MATERIAL_LIVE_HELP, e -> {
            Log.p("Contact Us (RIGHT) tapped");
        });
        
        // Test the left sidemenu (with @hideLeftSideMenuBool=true)
        Image iconLeft = FontImage.createMaterial(FontImage.MATERIAL_BOOKMARK_BORDER, "SidemenuTagline", 10);
        Button buttonLeft = new Button(iconLeft, "Label");
        Container topBarLeft = BorderLayout.west(buttonLeft);
        topBarLeft.add(BorderLayout.SOUTH, new Label("Help Desk (LEFT)", "SidemenuTagline"));
        topBarLeft.setUIID("SideCommand");
        tb.addComponentToSideMenu(topBarLeft);
        tb.addMaterialCommandToSideMenu("Contact Us (LEFT)", FontImage.MATERIAL_LIVE_HELP, e -> {
            Log.p("Contact Us (LEFT) tapped");
        });
        
        
        hi.show();
    }
```

This is my `res/theme.xml`:
```
<?xml version="1.0" encoding="UTF-8"?>

<resource majorVersion="1" minorVersion="9" useXmlUI="false">
    <theme name="Theme">
        <val key="@hideLeftSideMenuBool" value="true" />
        <val key="@includeNativeBool" value="true" />
        <val key="SideCommand.bgColor" value="9966" />
        <border key="SideCommand.border" type="empty" />
        <val key="SideCommand.fgColor" value="ffffff" />
        <font key="SideCommand.font" type="ttf" face="0" style="0" size="0" name="native:MainLight" family="native:MainLight" sizeSettings="3" actualSize="3.5" />
        <val key="SideCommand.margin" value="0.0,1.0,0.0,0.0" />
        <val key="SideCommand.padUnit" value="2,2,2,2" />
        <val key="SideCommand.padding" value="3.0,3.0,3.0,3.0" />
        <val key="SideCommand.press#bgColor" value="6666" />
        <val key="SideCommand.press#derive" value="SideCommand" />
        <val key="SideCommand.sel#bgColor" value="6666" />
        <val key="SideCommand.sel#derive" value="SideCommand" />
        <val key="SideCommand.transparency" value="255" />
        <val key="SideNavigationPanel.bgColor" value="ffffff" />
        <val key="SideNavigationPanel.transparency" value="255" />
        <val key="SidemenuTagline.bgColor" value="9966" />
        <border key="SidemenuTagline.border" type="empty" />
        <val key="SidemenuTagline.fgColor" value="ffffff" />
        <font key="SidemenuTagline.font" type="ttf" face="0" style="0" size="0" name="native:ItalicLight" family="native:ItalicLight" sizeSettings="3" actualSize="3.0" />
    </theme>
</resource>
```

Of course, before merging this code is better to discuss about it :)
