### PR TITLE
Better RTL support

### DIFF
--- a/CodenameOne/src/com/codename1/ui/Toolbar.java
+++ b/CodenameOne/src/com/codename1/ui/Toolbar.java
@@ -85,7 +85,7 @@ import java.util.Vector;
  * <img src="https://www.codenameone.com/img/developer-guide/components-toolbar-animation-2.png" alt="Toolbar animation stages" />
  * <img src="https://www.codenameone.com/img/developer-guide/components-toolbar-animation-3.png" alt="Toolbar animation stages" />
  *
- * @author Chen
+ * @author Chen, Francesco Galgani
  */
 public class Toolbar extends Container {
 
@@ -344,7 +344,11 @@ public class Toolbar extends Container {
     public void closeLeftSideMenu() {
         if (onTopSideMenu) {
             if (sidemenuDialog != null && sidemenuDialog.isShowing()) {
-                sidemenuDialog.disposeToTheLeft();
+                if (!isRTL()) {
+                    sidemenuDialog.disposeToTheLeft();
+                } else {
+                    sidemenuDialog.disposeToTheRight();
+                }
                 Container cnt = getComponentForm().getFormLayeredPane(Toolbar.class, false);
                 Style s = cnt.getUnselectedStyle();
                 s.setBgTransparency(0);
@@ -361,7 +365,11 @@ public class Toolbar extends Container {
     public void closeRightSideMenu() {
         if (onTopSideMenu) {
             if (rightSidemenuDialog != null && rightSidemenuDialog.isShowing()) {
-                rightSidemenuDialog.disposeToTheRight();
+                if (!isRTL()) {
+                    rightSidemenuDialog.disposeToTheRight();
+                } else {
+                    rightSidemenuDialog.disposeToTheLeft();
+                }
                 Container cnt = getComponentForm().getFormLayeredPane(Toolbar.class, false);
                 Style s = cnt.getUnselectedStyle();
                 s.setBgTransparency(0);
@@ -677,11 +685,7 @@ public class Toolbar extends Container {
      * @return a newly created Command instance
      */
     public Command addCommandToSideMenu(String name, Image icon, final ActionListener ev) {
-        if (!isRTL()) {
-            return addCommandToLeftSideMenu(name, icon, ev);
-        } else {
-            return addCommandToRightSideMenu(name, icon, ev);
-        }
+        return addCommandToLeftSideMenu(name, icon, ev);
     }
 
     /**
@@ -720,11 +724,7 @@ public class Toolbar extends Container {
      * @param cmp c Component to be added to the menu
      */
     public void addComponentToSideMenu(Component cmp) {
-        if (!isRTL()) {
-            addComponentToLeftSideMenu(cmp);
-        } else {
-            addComponentToRightSideMenu(cmp);
-        }
+        addComponentToLeftSideMenu(cmp);
     }
     
     /**
@@ -749,11 +749,7 @@ public class Toolbar extends Container {
      * @param cmd a Command to handle the events
      */
     public void addComponentToSideMenu(Component cmp, Command cmd) {
-        if (!isRTL()) {
-            addComponentToLeftSideMenu(cmp, cmd);
-        } else {
-            addComponentToRightSideMenu(cmp, cmd);
-        }
+        addComponentToLeftSideMenu(cmp, cmd);
     }
 
     /**
@@ -801,11 +797,7 @@ public class Toolbar extends Container {
      * @return a newly created Command instance
      */
     public Command addMaterialCommandToSideMenu(String name, char icon, float size, final ActionListener ev) {
-        if (!isRTL()) {
-            return addMaterialCommandToLeftSideMenu(name, icon, size, ev);
-        } else {
-            return addMaterialCommandToRightSideMenu(name, icon, size, ev);
-        }
+        return addMaterialCommandToLeftSideMenu(name, icon, size, ev);
     }
     
     /**
@@ -819,11 +811,7 @@ public class Toolbar extends Container {
      * @return a newly created Command instance
      */
     public Command addMaterialCommandToSideMenu(String name, char icon, final ActionListener ev) {
-        if (!isRTL()) {
-            return addMaterialCommandToLeftSideMenu(name, icon, ev);
-        } else {
-            return addMaterialCommandToRightSideMenu(name, icon, ev);
-        }
+        return addMaterialCommandToLeftSideMenu(name, icon, ev);
     }
 
     /**
@@ -1000,11 +988,7 @@ public class Toolbar extends Container {
      * @param cmd a Command
      */
     public void addCommandToSideMenu(Command cmd) {
-        if (!isRTL()) {
-            addCommandToLeftSideMenu(cmd);
-        } else {
-            addCommandToRightSideMenu(cmd);
-        }
+        addCommandToLeftSideMenu(cmd);
     }
 
     /**
@@ -1144,7 +1128,7 @@ public class Toolbar extends Container {
                         if (Display.getInstance().getImplementation().isScrollWheeling()) {
                             return;
                         }
-                        if (sidemenuDialog != null) {
+                        if (sidemenuDialog != null && !isRTL()) {
                             if (sidemenuDialog.isShowing()) {
                                 if (evt.getX() > sidemenuDialog.getWidth()) {
                                     parent.putClientProperty("cn1$sidemenuCharged", Boolean.FALSE);
@@ -1172,7 +1156,35 @@ public class Toolbar extends Container {
                                 }
                             }
                         }
-                        if (rightSidemenuDialog != null) {
+                        if (sidemenuDialog != null && isRTL()) {
+                            if (sidemenuDialog.isShowing()) {
+                                if (evt.getX() < Display.getInstance().getDisplayWidth() - sidemenuDialog.getWidth()) {
+                                    parent.putClientProperty("cn1$sidemenuCharged", Boolean.FALSE);
+                                    closeSideMenu();
+                                    evt.consume();
+                                } else {
+                                    if (evt.getX() - Display.getInstance().convertToPixels(8) < Display.getInstance().getDisplayWidth() - sidemenuDialog.getWidth()) {
+                                        parent.putClientProperty("cn1$sidemenuCharged", Boolean.TRUE);
+                                    } else {
+                                        parent.putClientProperty("cn1$sidemenuCharged", Boolean.FALSE);
+                                    }
+                                    if (!isComponentInOnTopRightSidemenu(parent.getComponentAt(evt.getX(), evt.getY()))) {
+                                        evt.consume();
+                                    }
+                                }
+                            } else {
+                                int displayWidth = Display.getInstance().getDisplayWidth();
+                                final int sensitiveSection = displayWidth / getUIManager().getThemeConstant("sideSwipeSensitiveInt", 10);
+                                if (evt.getX() > displayWidth - sensitiveSection) {
+                                    parent.putClientProperty("cn1$sidemenuCharged", Boolean.TRUE);
+                                    evt.consume();
+                                } else {
+                                    parent.putClientProperty("cn1$sidemenuCharged", Boolean.FALSE);
+                                    permanentSideMenuContainer.pointerPressed(evt.getX(), evt.getY());
+                                }
+                            }
+                        }
+                        if (rightSidemenuDialog != null && !isRTL()) {
                             if (rightSidemenuDialog.isShowing()) {
                                 if (evt.getX() < Display.getInstance().getDisplayWidth() - rightSidemenuDialog.getWidth()) {
                                     parent.putClientProperty("cn1$rightSidemenuCharged", Boolean.FALSE);
@@ -1200,6 +1212,34 @@ public class Toolbar extends Container {
                                 }
                             }
                         }
+                        if (rightSidemenuDialog != null && isRTL()) {
+                            if (rightSidemenuDialog.isShowing()) {
+                                if (evt.getX() > rightSidemenuDialog.getWidth()) {
+                                    parent.putClientProperty("cn1$rightSidemenuCharged", Boolean.FALSE);
+                                    closeRightSideMenu();
+                                    evt.consume();
+                                } else {
+                                    if (evt.getX() + Display.getInstance().convertToPixels(8) > rightSidemenuDialog.getWidth()) {
+                                        parent.putClientProperty("cn1$rightSidemenuCharged", Boolean.TRUE);
+                                    } else {
+                                        parent.putClientProperty("cn1$rightSidemenuCharged", Boolean.FALSE);
+                                    }
+                                    if (!isComponentInOnTopSidemenu(parent.getComponentAt(evt.getX(), evt.getY()))) {
+                                        evt.consume();
+                                    }
+                                }
+                            } else {
+                                int displayWidth = Display.getInstance().getDisplayWidth();
+                                final int sensitiveSection = displayWidth / getUIManager().getThemeConstant("sideSwipeSensitiveInt", 10);
+                                if (evt.getX() < sensitiveSection) {
+                                    parent.putClientProperty("cn1$rightSidemenuCharged", Boolean.TRUE);
+                                    evt.consume();
+                                } else {
+                                    parent.putClientProperty("cn1$rightSidemenuCharged", Boolean.FALSE);
+                                    permanentRightSideMenuContainer.pointerPressed(evt.getX(), evt.getY());
+                                }
+                            }
+                        }
                     }
                 });
             }
@@ -1214,27 +1254,29 @@ public class Toolbar extends Container {
                             Boolean b = (Boolean) parent.getClientProperty("cn1$sidemenuCharged");
                             if (b != null && b.booleanValue()) {
                                 parent.putClientProperty("cn1$sidemenuActivated", Boolean.TRUE);
-                                showOnTopSidemenu(evt.getX(), false);
-                                // evt.consume();
+                                if (!isRTL()) {
+                                    showOnTopSidemenu(evt.getX(), false);
+                                } else {
+                                    showOnTopSidemenu(Display.getInstance().getDisplayWidth() - evt.getX(), false);
+                                }
                             } else {
                                 if (sidemenuDialog.isShowing()) {
                                     permanentSideMenuContainer.pointerDragged(evt.getX(), evt.getY());
-                                    // evt.consume();
                                 }
                             }
                         }
                         if (rightSidemenuDialog != null) {
-                            // TO DO
                             Boolean b = (Boolean) parent.getClientProperty("cn1$rightSidemenuCharged");
                             if (b != null && b.booleanValue()) {
                                 parent.putClientProperty("cn1$rightSidemenuActivated", Boolean.TRUE);
-                                // showOnTopRightSidemenu(evt.getX(), false);
-                                showOnTopRightSidemenu(Display.getInstance().getDisplayWidth() - evt.getX(), false);
-                                // evt.consume();
+                                if (!isRTL()) {
+                                    showOnTopRightSidemenu(Display.getInstance().getDisplayWidth() - evt.getX(), false);
+                                } else {
+                                    showOnTopRightSidemenu(evt.getX(), false);
+                                }
                             } else {
                                 if (rightSidemenuDialog.isShowing()) {
                                     permanentRightSideMenuContainer.pointerDragged(evt.getX(), evt.getY());
-                                    // evt.consume();
                                 }
                             }
                         }
@@ -1252,7 +1294,7 @@ public class Toolbar extends Container {
                             Boolean b = (Boolean) parent.getClientProperty("cn1$sidemenuActivated");
                             if (b != null && b.booleanValue()) {
                                 parent.putClientProperty("cn1$sidemenuActivated", null);
-                                if (evt.getX() < parent.getWidth() / 4) {
+                                if ((evt.getX() < parent.getWidth() / 4 && !isRTL()) || (evt.getX() > Display.getInstance().getDisplayWidth() - (parent.getWidth() / 4) && isRTL())) {
                                     closeSideMenu();
                                 } else {
                                     showOnTopSidemenu(-1, true);
@@ -1271,7 +1313,7 @@ public class Toolbar extends Container {
                             Boolean b = (Boolean) parent.getClientProperty("cn1$rightSidemenuActivated");
                             if (b != null && b.booleanValue()) {
                                 parent.putClientProperty("cn1$rightSidemenuActivated", null);
-                                if (evt.getX() > Display.getInstance().getDisplayWidth() - (parent.getWidth() / 4)) {
+                                if ((evt.getX() > Display.getInstance().getDisplayWidth() - (parent.getWidth() / 4) && !isRTL()) || (evt.getX() < parent.getWidth() / 4 && isRTL())) {
                                     closeRightSideMenu();
                                 } else {
                                     showOnTopRightSidemenu(-1, true);
@@ -1444,8 +1486,13 @@ public class Toolbar extends Container {
         if (sidemenuDialog.getClientProperty("cn1$firstShow") == null) {
             sidemenuDialog.setAnimateShow(false);
             sidemenuDialog.setVisible(false);
-            sidemenuDialog.show(0, 0, 0, dw - v);
-            sidemenuDialog.disposeToTheLeft();
+            if (!isRTL()) {
+                sidemenuDialog.show(0, 0, 0, dw - v);
+                sidemenuDialog.disposeToTheLeft();
+            } else {
+                sidemenuDialog.show(0, 0, dw - v, 0);
+                sidemenuDialog.disposeToTheRight();
+            }
             sidemenuDialog.setVisible(true);
             sidemenuDialog.putClientProperty("cn1$firstShow", Boolean.TRUE);
             sidemenuDialog.setAnimateShow(draggedX < 1);
@@ -1453,7 +1500,11 @@ public class Toolbar extends Container {
         sidemenuDialog.setHeight(Display.getInstance().getDisplayHeight());
         sidemenuDialog.setWidth(v);
         if (!fromCurrent) {
-            sidemenuDialog.setX(-v);
+            if (!isRTL()) {
+                sidemenuDialog.setX(-v);
+            } else {
+                sidemenuDialog.setX(Display.getInstance().getDisplayWidth() + v);
+            }
         }
         sidemenuDialog.setRepositionAnimation(false);
         sidemenuDialog.layoutContainer();
@@ -1468,8 +1519,14 @@ public class Toolbar extends Container {
         s.setBgColor(0);
 
         sidemenuDialog.show(0, 0, 0, dw - actualV);
-        if (draggedX > 0) {
-            sidemenuDialog.setX(Math.min(0, draggedX - actualV));
+        if (!isRTL()) {
+            if (draggedX > 0) {
+                sidemenuDialog.setX(Math.min(0, draggedX - actualV));
+            }
+        } else {
+            if (draggedX > 0) {
+                sidemenuDialog.setX(Math.max(dw - draggedX, dw - actualV));
+            }
         }
     }
 
@@ -1522,8 +1579,13 @@ public class Toolbar extends Container {
         if (rightSidemenuDialog.getClientProperty("cn1$firstRightShow") == null) {
             rightSidemenuDialog.setAnimateShow(false);
             rightSidemenuDialog.setVisible(false);
-            rightSidemenuDialog.show(0, 0, dw - v, 0);
-            rightSidemenuDialog.disposeToTheRight();
+            if (!isRTL()) {
+                rightSidemenuDialog.show(0, 0, dw - v, 0);
+                rightSidemenuDialog.disposeToTheRight();
+            } else {
+                rightSidemenuDialog.show(0, 0, 0, dw - v);
+                rightSidemenuDialog.disposeToTheLeft();
+            }
             rightSidemenuDialog.setVisible(true);
             rightSidemenuDialog.putClientProperty("cn1$firstRightShow", Boolean.TRUE);
             rightSidemenuDialog.setAnimateShow(draggedX < 1);
@@ -1531,7 +1593,11 @@ public class Toolbar extends Container {
         rightSidemenuDialog.setHeight(Display.getInstance().getDisplayHeight());
         rightSidemenuDialog.setWidth(v);
         if (!fromCurrent) {
-            rightSidemenuDialog.setX(Display.getInstance().getDisplayWidth() + v);
+            if (!isRTL()) {
+                rightSidemenuDialog.setX(Display.getInstance().getDisplayWidth() + v);
+            } else {
+                rightSidemenuDialog.setX(-v);
+            }
         }
         rightSidemenuDialog.setRepositionAnimation(false);
         rightSidemenuDialog.layoutContainer();
@@ -1544,10 +1610,16 @@ public class Toolbar extends Container {
         Style s = cnt.getUnselectedStyle();
         s.setBgTransparency((int) f);
         s.setBgColor(0);
-        
+
         rightSidemenuDialog.show(0, 0, dw - actualV, 0);
-        if (draggedX > 0) {
-            rightSidemenuDialog.setX(Math.max(dw - draggedX, dw - actualV));
+        if (!isRTL()) {
+            if (draggedX > 0) {
+                rightSidemenuDialog.setX(Math.max(dw - draggedX, dw - actualV));
+            }
+        } else {
+            if (draggedX > 0) {
+                rightSidemenuDialog.setX(Math.min(0, draggedX - actualV));
+            }
         }
     }
 
@@ -1795,18 +1867,10 @@ public class Toolbar extends Container {
      * @param cmd a Command
      */
     public void addCommandToRightBar(Command cmd) {
-        if (isRTL()) {
-            if (cmd.getClientProperty("changedMethod") == null) {
-                cmd.putClientProperty("changedMethod", Boolean.TRUE);
-                addCommandToLeftBar(cmd);
-                return;
-            }
-        }
         checkIfInitialized();
         cmd.putClientProperty("TitleCommand", Boolean.TRUE);
         cmd.putClientProperty("Left", null);
         sideMenu.addCommand(cmd, 0);
-
     }
 
     /**
@@ -1829,18 +1893,10 @@ public class Toolbar extends Container {
      * @param cmd a Command
      */
     public void addCommandToLeftBar(Command cmd) {
-        if (isRTL()) {
-            if (cmd.getClientProperty("changedMethod") == null) {
-                cmd.putClientProperty("changedMethod", Boolean.TRUE);
-                addCommandToRightBar(cmd);
-                return;
-            }
-        }
         checkIfInitialized();
         cmd.putClientProperty("TitleCommand", Boolean.TRUE);
         cmd.putClientProperty("Left", Boolean.TRUE);
         sideMenu.addCommand(cmd, 0);
-
     }
 
     /**


### PR DESCRIPTION
This PR provides a **better RTL support in the Toolbar**, with the following test cases. I attach a zip file with a video for each test: [**tests.zip**](https://github.com/codenameone/CodenameOne/files/2074382/tests.zip)


**LIST OF DONE TESTS**

**TEST1**
Sidemenu _(legacy mode, setOnTopSideMenu(false), old methods signatures)_ + command on right
RTL: NO
Code: https://gist.github.com/jsfan3/cf3b0e75d65dee969d3261ea758bf5a6
Expected behavior:
- the sidemenu is on the left and the command on the right;
- the hamburger icon is on the left;
- the sidemenu can be opened and closed by swiping;
- pressing pointer out of the opened sidemenu closes it.

Result: OK

**TEST2**
Sidemenu _(legacy mode, setOnTopSideMenu(false), old methods signatures)_ + command on right
RTL: YES
Code: https://gist.github.com/jsfan3/680f4e6a61d593cd4a0d0d12e7d0ff5c
Expected behavior:
- the sidemenu is on the right and the command on the left;
- the hamburger icon is on the right;
- the sidemenu can be opened and closed by swiping;
- pressing pointer out of the opened sidemenu closes it.

Result: OK

**TEST3**
Left sidemenu _(onTop mode)_ + command on right
RTL: NO
Code: https://gist.github.com/jsfan3/be97b7e742f6001370947612426928f1
Expected behavior:
- the sidemenu is on the left and the command on the right;
- the hamburger icon is on the left;
- the sidemenu can be opened and closed by swiping;
- pressing pointer out of the opened sidemenu closes it.

Result: OK

**TEST4**
Left sidemenu _(onTop mode)_ + command on right
RTL: YES
Code: https://gist.github.com/jsfan3/f4c9f3043c9b8c389d596b20eddffcc9
Expected behavior:
- the sidemenu is on the right and the command on the left;
- the hamburger icon is on the right;
- the sidemenu can be opened and closed by swiping;
- pressing pointer out of the opened sidemenu closes it.

Result: OK

**TEST5**
Right sidemenu _(onTop mode)_ + command on left
RTL: NO
Code: https://gist.github.com/jsfan3/458653767474882f9866e04b4868e4e2
Expected behavior:
- the sidemenu is on the right and the command on the left;
- the hamburger icon is on the right;
- the sidemenu can be opened and closed by swiping;
- pressing pointer out of the opened sidemenu closes it.

Result: OK

**TEST6**
Right sidemenu _(onTop mode)_ + command on left
RTL: YES
Code: https://gist.github.com/jsfan3/67a640161b88601717ec4b70432245cc
Expected behavior:
- the sidemenu is on the left and the command on the right;
- the hamburger icon is on the left;
- the sidemenu can be opened and closed by swiping;
- pressing pointer out of the opened sidemenu closes it.

Result: OK

**TEST7**
Left and Right sidemenus _(onTop mode)_ + commands on left and on right
RTL: NO
Code: https://gist.github.com/jsfan3/0b6d85d2f885c644adf63747f6567146
Expected behavior:
- the left sidemenu is on the left, the right sidemenu in on the right;
- the left command is on the left, the right command in on the right;
- we have two hamburger icons, on left and on right;
- the sidemenus can be opened and closed by swiping;
- pressing pointer out of the opened sidemenu closes it.

Result: OK

**TEST8**
Left and Right sidemenus _(onTop mode)_ + commands on left and on right
RTL: YES
Code: https://gist.github.com/jsfan3/74f68954955dda0062d02630130e9aef
Result: **FAIL**, at the moment the result is not the expected one.

I repeated some of these tests with a permanent mode sidemenu, and the result is "quite" fine.

However, the next steps are:
- implement working RTL for two side menus (at the moment this test case fails);
- **check all the graphics defects of the Simulator (shown in the videos) on real devices and eventually fix them** (I need your help for this point).