### PR TITLE
Improvements to the toolbar

### DIFF
--- a/CodenameOne/src/com/codename1/ui/SideMenuBar.java
+++ b/CodenameOne/src/com/codename1/ui/SideMenuBar.java
@@ -1002,6 +1002,14 @@ public class SideMenuBar extends MenuBar {
         return menu;
     }
     
+    Container constructRightSideNavigationPanel(){
+        Container menu = new Container(new BoxLayout(BoxLayout.Y_AXIS));
+        menu.setUIID("RightSideNavigationPanel");
+        menu.setScrollableY(true);
+        menu.setScrollVisible(getUIManager().isThemeConstant("rightSideMenuScrollVisibleBool", false));
+        return menu;
+    }
+    
     Container createSideNavigationPanel(Vector commands, String placement) {
         Container menu = constructSideNavigationComponent();
         if (getUIManager().isThemeConstant("paintsTitleBarBool", false)) {

--- a/CodenameOne/src/com/codename1/ui/Toolbar.java
+++ b/CodenameOne/src/com/codename1/ui/Toolbar.java
@@ -165,6 +165,7 @@ public class Toolbar extends Container {
     private boolean isPointerReleasedListenerAdded = false;
     private boolean isPointerPressedListenerAdded = false;
     private boolean isPointerDraggedListenerAdded = false;
+    private boolean rightSideMenuCmdsAlignedToLeft = false;
 
     private Container permanentSideMenuContainer;
     private Container permanentRightSideMenuContainer;
@@ -780,7 +781,7 @@ public class Toolbar extends Container {
      */
     public Command addMaterialCommandToRightSideMenu(String name, char icon, final ActionListener ev) {
         Command cmd = Command.create(name, null, ev);
-        setCommandMaterialIcon(cmd, icon, "SideCommand");
+        setCommandMaterialIcon(cmd, icon, "RightSideCommand");
         addCommandToRightSideMenu(cmd);
         return cmd;
     }
@@ -844,7 +845,7 @@ public class Toolbar extends Container {
      */
     public Command addMaterialCommandToRightSideMenu(String name, char icon, float size, final ActionListener ev) {
         Command cmd = Command.create(name, null, ev);
-        setCommandMaterialIcon(cmd, icon, size, "SideCommand");
+        setCommandMaterialIcon(cmd, icon, size, "RightSideCommand");
         addCommandToRightSideMenu(cmd);
         return cmd;
     }
@@ -1010,7 +1011,7 @@ public class Toolbar extends Container {
         addCommandToSideMenu(cmd, false);
     }
     
-    private void addCommandToSideMenu(Command cmd, boolean isLeft) {
+    private void addCommandToSideMenu(Command cmd, boolean isLeft) {        
         checkIfInitialized();
         if (permanentSideMenu) {
             if (isLeft) {
@@ -1025,7 +1026,7 @@ public class Toolbar extends Container {
             if (gap != null) {
                 b.setGap(gap.intValue());
             }
-            if (isLeft) {
+            if (isLeft || rightSideMenuCmdsAlignedToLeft) {
                 b.setTextPosition(Label.RIGHT);
             } else {
                 b.setTextPosition(Label.LEFT);
@@ -1035,12 +1036,19 @@ public class Toolbar extends Container {
                 String luiid = (String) cmd.getClientProperty("luiid");
                 b.setUIID(uiid, luiid);
             } else {
-                b.setUIID("SideCommand");
+                if (isLeft) {
+                    b.setUIID("SideCommand");
+                } else {
+                    b.setUIID("RightSideCommand");
+                }
             }
             if (isLeft) {
                 addComponentToLeftSideMenu(permanentSideMenuContainer, b);
             } else {
-                addComponentToRightSideMenu(permanentRightSideMenuContainer, FlowLayout.encloseRight(b));
+                if (!rightSideMenuCmdsAlignedToLeft) {
+                    b.getAllStyles().setAlignment(Font.RIGHT);
+                }
+                addComponentToRightSideMenu(permanentRightSideMenuContainer, b);
             }
         } else {
             if (onTopSideMenu) {
@@ -1056,7 +1064,7 @@ public class Toolbar extends Container {
                 if (gap != null) {
                     b.setGap(gap.intValue());
                 }
-                if (isLeft) {
+                if (isLeft || rightSideMenuCmdsAlignedToLeft) {
                     b.setTextPosition(Label.RIGHT);
                 } else {
                     b.setTextPosition(Label.LEFT);
@@ -1066,12 +1074,18 @@ public class Toolbar extends Container {
                     String luiid = (String) cmd.getClientProperty("luiid");
                     b.setUIID(uiid, luiid);
                 } else {
-                    b.setUIID("SideCommand");
+                    if (isLeft) {
+                        b.setUIID("SideCommand");
+                    } else {
+                        b.setUIID("RightSideCommand");
+                    }
                 }
                 if (isLeft) {
-                    addComponentToSideMenu(permanentSideMenuContainer, b);
+                    addComponentToLeftSideMenu(permanentSideMenuContainer, b);
                 } else {
-                    b.getAllStyles().setAlignment(Font.RIGHT);
+                    if (!rightSideMenuCmdsAlignedToLeft) {
+                        b.getAllStyles().setAlignment(Font.RIGHT);
+                    }
                     addComponentToRightSideMenu(permanentRightSideMenuContainer, b);
                 }
             } else {
@@ -1101,7 +1115,7 @@ public class Toolbar extends Container {
 
     private void constructPermanentRightSideMenu() {
         if (permanentRightSideMenuContainer == null) {
-            permanentRightSideMenuContainer = constructSideNavigationComponent();
+            permanentRightSideMenuContainer = constructRightSideNavigationComponent();
             Form parent = getComponentForm();
             if (rightSidemenuSouthComponent != null) {
                 Container c = BorderLayout.center(permanentRightSideMenuContainer);
@@ -1114,11 +1128,12 @@ public class Toolbar extends Container {
     }
 
     private void constructOnTopSideMenu(boolean isLeft) {
+        
         if ((isLeft && sidemenuDialog == null) || (!isLeft && rightSidemenuDialog == null)) {
             if (isLeft) {
                 permanentSideMenuContainer = constructSideNavigationComponent();
             } else {
-                permanentRightSideMenuContainer = constructSideNavigationComponent();
+                permanentRightSideMenuContainer = constructRightSideNavigationComponent();
             }
 
             final Form parent = getComponentForm();
@@ -2234,10 +2249,17 @@ public class Toolbar extends Container {
     }
 
     /**
-     * Creates an empty side navigation panel.
+     * Creates an empty left side navigation panel.
      */
     protected Container constructSideNavigationComponent() {
         return sideMenu.constructSideNavigationPanel();
+    }
+    
+    /**
+     * Creates an empty right side navigation panel.
+     */
+    protected Container constructRightSideNavigationComponent() {
+        return sideMenu.constructRightSideNavigationPanel();
     }
 
     /**
@@ -2537,5 +2559,23 @@ public class Toolbar extends Container {
         }
 
     }
+
+    /**
+     * Normally on a right side menu the alignment should be "mirrored" in
+     * comparision with the left side menu, also for non-RTL languages: this
+     * method allows to change this default behaviour for non-RTL languages,
+     * forcing the alignment of the Commands of the right side menu to left.
+     * Note that for RTL languages this method does nothing. This method should
+     * be called before adding commands to the right side menu.
+     *
+     * @param toLeft false is the default, true changes the alignment.
+     */
+    public void setRightSideMenuCmdsAlignedToLeft(boolean toLeft) {
+        if (!isRTL()) {
+            rightSideMenuCmdsAlignedToLeft = toLeft;
+        }
+    }
+    
+    
 
 }


### PR DESCRIPTION
**Improvements**:
1. Fixed a weird layout issue with permanent right side menu
2. Added the method setRightSideMenuCmdsAlignedToLeft(boolean toLeft), see my last comment to: https://github.com/codenameone/CodenameOne/pull/2440
3. Added constructRightSideNavigationPanel() in SideMenuBar.java, with the new UIID "RightSideNavigationPanel" and the new theme constant "rightSideMenuScrollVisibleBool"
4. Added the new UIID "RightSideCommand" in addMaterialCommandToRightSideMenu (however it's not used, probably there is an old method signature for compatibility) and in addCommandToSideMenu(Command cmd, boolean isLeft) (here it's used)

**Problems not solved**:
1. The container of the **permanent** right side menu (UIID RightSideNavigationPanel) is not scrollable even if it's setted scrollable in the code. @codenameone: is it a bug of the simulator?
2. The commands in the **permanent** right side menu (UIID RightSideCommand) cannot be pressed, even if they have an ActionListener in the code. @codenameone: is it a bug of the simulator?
_(Note: the previous two bugs are not present in the onTop right side menu)._
3. RTL cannot be used with both the left and right side menu bars: the result is weird.  @codenameone: when you will have time, can you try to find a solution? I wasn't able to fix it.

**TEST1**
Right sidemenu (onTop mode) + command on left
RTL: NO
**setRightSideMenuCmdsAlignedToLeft: NO** (default)
Code: https://gist.github.com/jsfan3/9c57c1f52960dbf45e8e4dcd46e16f1c
Expected behavior:
- the sidemenu is on the right and the command on the left;
- the hamburger icon is on the right;
- the sidemenu can be opened and closed by swiping;
- pressing pointer out of the opened sidemenu closes it.
- **the layout is mirrored in comparison with the left side menu (default)**
Result: OK

**TEST2**
Right sidemenu (onTop mode) + command on left
RTL: NO
**setRightSideMenuCmdsAlignedToLeft: YES**
Code: https://gist.github.com/jsfan3/bd6cabf9b387c5ffb12344df1ac574f6
Expected behavior:
- the sidemenu is on the right and the command on the left;
- the hamburger icon is on the right;
- the sidemenu can be opened and closed by swiping;
- pressing pointer out of the opened sidemenu closes it.
- **the layout is on the left (like the left side menu)**
Result: OK

**TEST3**
Repeated TEST1 AND TEST2 with RTL. In these cases, setRightSideMenuCmdsAlignedToLeft(true) is ignored, as expected.

See the attached videos to see the difference between test 1 and 2:
[**Video.zip**](https://github.com/codenameone/CodenameOne/files/2077090/Video.zip)


I've done other tests like in the previous PR. I also checked that the hideRightSideMenuBool and hideLeftSideMenuBool theme constants work correctly.
