### PR TITLE
FIX for invalid JSON produced by PropertyIndex.toJSONList()

### DIFF
--- a/CodenameOne/src/com/codename1/properties/PropertyIndex.java
+++ b/CodenameOne/src/com/codename1/properties/PropertyIndex.java
@@ -457,21 +457,22 @@ public class PropertyIndex implements Iterable<PropertyBase> {
 
     /**
      * Creates a JSON string, containing the list of property business objects
+     *
      * @param objs a list of business objects
      * @return the JSON string
      */
     public static String toJSONList(List<? extends PropertyBusinessObject> objs) {
         StringBuilder b = new StringBuilder("[");
-        b.append("[");
         boolean first = true;
-        for(PropertyBusinessObject pb : objs) {
-            if(first) {
+        for (PropertyBusinessObject pb : objs) {
+            if (first) {
                 first = false;
             } else {
                 b.append(",\n");
             }
             b.append(pb.getPropertyIndex().toJSON());
         }
+        b.append("]");
         return b.toString();
     }
 


### PR DESCRIPTION
The JSON produced by PropertyIndex.toJSONList() are invalid and cannot be processed by a Spring Boot controller.

Example of invalid produced JSON:
```
[[{
  "text_IT": "Maschile",
  "text_EN": "Male",
  "position": 0,
  "keyword": "male"
},
{
  "text_IT": "Femminile",
  "text_EN": "Female",
  "position": 1,
  "keyword": "female"
}
```
This commit fixed the issue, producing JSONs that validate on a JSON validator and that can be processed by Spring Boot controllers.