### PR TITLE
escape from getSomeData if there will never be data

### DIFF
--- a/CodenameOne/src/com/codename1/io/Socket.java
+++ b/CodenameOne/src/com/codename1/io/Socket.java
@@ -221,7 +221,8 @@ public class Socket {
           		// end has closed the socket, resulting in eof, but the local end hasn't
           		// closed it yet.
           		if(buffer==null) { return(false); }
-        		if( !closed
+        		if( (buffer.length==0)
+        			&& !closed
         			&& Util.getImplementation().isSocketConnected(impl))
          		{	// wait a while if there's still hope
         			try {


### PR DESCRIPTION
If the remote end closed the inputstream while the local thread is
in getSomeData, the local end hasn't been closed, and the thread
hangs forever.