### PR TITLE
Fixcookie

### DIFF
--- a/CodenameOne/src/com/codename1/io/Socket.java
+++ b/CodenameOne/src/com/codename1/io/Socket.java
@@ -216,9 +216,12 @@ public class Socket {
           			}
           		buffer = Util.getImplementation().readFromSocketStream(impl);
           		bufferOffset = 0;
-          		
-        		if(((buffer==null) || (buffer.length==0))
-        			&& !closed
+          		// the contract of readFromSocket is to get data for sure. If it returns 
+          		// null, there will never be data.  The case of interest is when the remote
+          		// end has closed the socket, resulting in eof, but the local end hasn't
+          		// closed it yet.
+          		if(buffer==null) { return(false); }
+        		if( !closed
         			&& Util.getImplementation().isSocketConnected(impl))
          		{	// wait a while if there's still hope
         			try {

--- a/CodenameOne/src/com/codename1/io/Socket.java
+++ b/CodenameOne/src/com/codename1/io/Socket.java
@@ -221,7 +221,8 @@ public class Socket {
           		// end has closed the socket, resulting in eof, but the local end hasn't
           		// closed it yet.
           		if(buffer==null) { return(false); }
-        		if( !closed
+        		if( (buffer.length==0)
+        			&& !closed
         			&& Util.getImplementation().isSocketConnected(impl))
          		{	// wait a while if there's still hope
         			try {

--- a/CodenameOne/src/com/codename1/io/Util.java
+++ b/CodenameOne/src/com/codename1/io/Util.java
@@ -702,7 +702,7 @@ public class Util {
         } catch (InstantiationException ex1) {
             Log.e(ex1);
             throw new IOException(ex1.getClass().getName() + ": " + ex1.getMessage());
-        } catch (IllegalAccessException ex1) {
+        } catch (IllegalAccessError|IllegalAccessException ex1) {
             Log.e(ex1);
             throw new IOException(ex1.getClass().getName() + ": " + ex1.getMessage());
         } 


### PR DESCRIPTION
Encountering this when doing a http request.  Result is that the request hangs forever because the
error bypasses the catch somewhere above it.   In this case, the class being instantiated is Codename1.io.Cookie, and perhaps the underlying cause is some fallout from project jigsaw.

In any case, the catch clause didn't expect java.lang.IllegalAccessError.

I suggest this might be fixed less conservatively, but making the catch clause Throwable
rather than an explicit list of expected errors.

Launcher start Fri Nov 23 11:22:53 PST 2018
java.lang.IllegalAccessError: class sun.reflect.GeneratedConstructorAccessor8 cannot access its superclass sun.reflect.ConstructorAccessorImpl
	at sun.misc.Unsafe.defineClass(Native Method)
	at sun.reflect.ClassDefiner.defineClass(ClassDefiner.java:63)
	at sun.reflect.MethodAccessorGenerator$1.run(MethodAccessorGenerator.java:399)
	at sun.reflect.MethodAccessorGenerator$1.run(MethodAccessorGenerator.java:394)
	at java.security.AccessController.doPrivileged(Native Method)
	at sun.reflect.MethodAccessorGenerator.generate(MethodAccessorGenerator.java:393)
	at sun.reflect.MethodAccessorGenerator.generateConstructor(MethodAccessorGenerator.java:92)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:55)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:422)
	at java.lang.Class.newInstance(Class.java:442)
	at com.codename1.io.Util.readObject(Util.java:690)
	at com.codename1.io.Util.readObject(Util.java:660)
	at com.codename1.io.Util.readObject(Util.java:660)
	at com.codename1.io.Storage.readObject(Storage.java:261)
	at com.codename1.impl.CodenameOneImplementation.getCookiesForURL(CodenameOneImplementation.java:4411)
	at com.codename1.io.ConnectionRequest.performOperation(ConnectionRequest.java:633)
	at com.codename1.io.NetworkManager$NetworkThread.run(NetworkManager.java:282)
	at com.codename1.impl.CodenameOneThread.run(CodenameOneThread.java:176)
