### PR TITLE
TextField.NON_PREDICTIVE

### DIFF
--- a/CodenameOne/src/com/codename1/ui/TextComponentPassword.java
+++ b/CodenameOne/src/com/codename1/ui/TextComponentPassword.java
@@ -48,7 +48,7 @@ public class TextComponentPassword extends TextComponent {
             @Override
             public void actionPerformed(ActionEvent e) {
                 if (field.getConstraint() == TextArea.PASSWORD) {
-                    field.setConstraint(TextField.ANY);
+                    field.setConstraint(TextField.NON_PREDICTIVE);
                     showPassword.setIcon(mask);
                 } else {
                     field.setConstraint(TextField.PASSWORD);


### PR DESCRIPTION
Because it's a password, it should be better TextField.NON_PREDICTIVE than TextField.ANY