### PR TITLE
Some fixes

### DIFF
--- a/CodenameOne/src/com/codename1/l10n/SimpleDateFormat.java
+++ b/CodenameOne/src/com/codename1/l10n/SimpleDateFormat.java
@@ -32,9 +32,11 @@ import java.util.Vector;
 
 /**
  * A class for parsing and formatting dates with a given pattern, compatible
- * with the Java 6 API.
- *
- * See http://docs.oracle.com/javase/6/docs/api/java/text/DateFormat.html
+ * with the Java 6 API, as in the examples here: https://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html
+ * <br /><br />
+ * To localize the formatted dates, see the discussion
+ * <a href="https://stackoverflow.com/questions/57874534/format-a-localized-date-in-codename-one">Format a localized date
+ * in Codename One</a>. 
  *
  * @author Eric Coolman
  */
@@ -437,15 +439,13 @@ public class SimpleDateFormat extends DateFormat {
         return s;
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see java.text.DateFormat#parse(java.lang.String)
+    /**
+     * Parses text from a string to produce a Date. 
      */
     @Override
     public Date parse(String source) throws ParseException {
         if (pattern == null) {
-            return super.parse(source);
+            throw new ParseException("You must provide a template before calling the SimpleDateFormat.parse(...) method", 0);
         }
         int startIndex = 0;
         // parse based on GMT timezone for handling offsets


### PR DESCRIPTION
Motivation: http://docs.oracle.com/javase/6/docs/api/java/text/DateFormat.html doesn't provide examples of patterns, while https://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html provides examples and explanations that (mostly) apply to this class. I also added a link to the discussion on Stack Overflow.
The Javadoc of the parse() method was wrong because it wasn't a Javadoc (note that it started with /* instead of /**) and so it resulted wrongly as "not implemented" in your official Javadoc (because the Javadoc of the overridden parse() method of the DateFormat class reports that it's not implemented). I fixed it with an actual Javadoc. I also added an exception that is more significant than the exception thrown by the superclass if a template is not provided.