### PR TITLE
Improve replaceAll and replaceFirst from StringUtil.

### DIFF
--- a/CodenameOne/src/com/codename1/util/StringUtil.java
+++ b/CodenameOne/src/com/codename1/util/StringUtil.java
@@ -44,58 +44,44 @@ public class StringUtil {
     }
 
     /**
-     * This method replaces all occurrences of the pattern with the 
+     * This method replaces all occurrences of the target with the
      * replacement String
      * 
      * @param source the String source
-     * @param pattern String to replace in the source
+     * @param target String to replace in the source
      * @param replace replacement String
      * @return string with replaced elements
      */
-    public static String replaceAll(String source, String pattern, String replace) {
-        StringBuilder sb = new StringBuilder();
-        int idx = 0;
-        String workingSource = source;
-        idx = workingSource.indexOf(pattern);
-        if(idx == -1){
+    public static String replaceAll(String source, String target, String replacement) {
+        int index = source.indexOf(target);
+        if (index == -1)
             return source;
+        final StringBuilder result = new StringBuilder(source.length() + replacement.length());
+        result.append(source, 0, index);
+        while (true) {
+            result.append(replacement);
+            final int start = index + target.length();
+            index = source.indexOf(target, start);
+            if (index < 0)
+                return result.append(source, start, source.length()).toString();
+            result.append(source, start, index);
         }
-        
-        while (idx != -1) {
-            sb.append(workingSource.substring(0, idx));
-            sb.append(replace);
-            workingSource = workingSource.substring(idx + pattern.length());
-            idx = workingSource.indexOf(pattern);            
-        }
-        sb.append(workingSource);
-
-        return sb.toString();
     }
 
     /**
-     * This method replaces the first occurrence of the pattern with the 
+     * This method replaces the first occurrence of the target with the
      * replacement String
      * 
      * @param source the String source
-     * @param pattern String to replace in the source
+     * @param target String to replace in the source
      * @param replace replacement String
      * @return string with replaced elements
      */
-    public static String replaceFirst(String source, String pattern, String replace) {
-        StringBuilder sb = new StringBuilder();
-        int idx = 0;
-        String workingSource = source;
-        idx = workingSource.indexOf(pattern);
-        if(idx == -1){
+    public static String replaceFirst(String source, String target, String replacement) {
+        final int index = source.indexOf(target);
+        if (index == -1)
             return source;
-        }
-        
-        sb.append(workingSource.substring(0, idx));
-        sb.append(replace);
-        workingSource = workingSource.substring(idx + pattern.length());
-        sb.append(workingSource);
-
-        return sb.toString();
+        return source.substring(0, index) + replacement + source.substring(index + target.length());
     }
     
     /**

--- a/tests/core/test/com/codename1/util/StringUtilReplaceTests.java
+++ b/tests/core/test/com/codename1/util/StringUtilReplaceTests.java
@@ -1,0 +1,28 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.codename1.util;
+
+import com.codename1.testing.AbstractTest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class StringUtilReplaceTests extends AbstractTest {
+    @Override
+    public boolean runTest() throws Exception {
+        check("aabaa", "aa", "a", "abaa", "aba");
+        check("aa", "a", "aaa", "aaaa", "aaaaaa");
+        check("", "a", "aaa", "", "");
+        check("aaba", "a", "a", "aaba", "aaba");
+        check("aabaab", "ab", "ba", "abaaab", "abaaba");
+        return true;
+    }
+
+    private void check(String source, String target, String replacement, String expectedFirst, String expectedAll) {
+        assertEqual(expectedFirst, StringUtil.replaceFirst(source, target, replacement));
+        assertEqual(expectedAll, StringUtil.replaceAll(source, target, replacement));
+    }
+}


### PR DESCRIPTION
- Rename `pattern` to `target` in order to avoid confusion with regex and to conform with standard `String.replace`.
- Avoid needless `StringBuilder` allocation.
- Avoid `String#substring`, which is no more `O(1)`.
- Add tests.