### PR TITLE
RFE: Display.invokeWithoutBlockingWithResultSync

### DIFF
--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -1345,6 +1345,29 @@ public final class Display extends CN1Constants {
     }
     
     /**
+     * Invokes a RunnableWithResultSync with blocking disabled.  If any attempt is made to block
+     * (i.e. call {@link #invokeAndBlock(java.lang.Runnable) } from inside this Runnable,
+     * it will result in a {@link BlockingDisallowedException} being thrown.
+     * @param r RunnableWithResultSync to be run immediately.
+     * @throws BlockingDisallowedException If {@link #invokeAndBlock(java.lang.Runnable) } is attempted
+     * anywhere in the Runnable.
+     * 
+     * @since 7.0
+     */
+    public static <T> T invokeWithoutBlockingWithResultSync(RunnableWithResultSync<T> r) {
+        if (disableInvokeAndBlock || !isEdt()) {
+            return r.run();
+        } else {
+            disableInvokeAndBlock = true;
+            try {
+                return r.run();
+            } finally {
+                disableInvokeAndBlock = false;
+            }
+        }
+    }
+    
+    /**
      * Invokes runnable and blocks the current thread, if the current thread is the
      * EDT it will still be blocked in a way that doesn't break event dispatch .
      * <b>Important:</b> calling this method spawns a new thread that shouldn't access the UI!<br />

--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -54,6 +54,7 @@ import com.codename1.ui.plaf.UIManager;
 import com.codename1.ui.util.EventDispatcher;
 import com.codename1.ui.util.ImageIO;
 import com.codename1.util.AsyncResource;
+import com.codename1.util.RunnableWithResultSync;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;

--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -1355,7 +1355,7 @@ public final class Display extends CN1Constants {
      * 
      * @since 7.0
      */
-    public static <T> T invokeWithoutBlockingWithResultSync(RunnableWithResultSync<T> r) {
+    public <T> T invokeWithoutBlockingWithResultSync(RunnableWithResultSync<T> r) {
         if (disableInvokeAndBlock || !isEdt()) {
             return r.run();
         } else {


### PR DESCRIPTION
This morning I was reading again the blog post https://www.codenameone.com/blog/invoke-without-blocking.html to add `CN.invokeWithoutBlocking` to my code. It's very interesting, but I'm not sure if it's applicable to the critical code of my app, because that code has to return an object. That's why I'm adding the method `invokeWithoutBlockingWithResultSync`.