### PR TITLE
Added "see also" link in the javadoc

### DIFF
--- a/CodenameOne/src/com/codename1/io/Externalizable.java
+++ b/CodenameOne/src/com/codename1/io/Externalizable.java
@@ -56,6 +56,7 @@ import java.io.IOException;
  *
  * <p><strong>WARNING:</strong> The externalization process caches objects so the app will seem to work and only fail on restart!</p>
  * 
+ * @see <a href="https://sjhannah.com/blog/2013/02/08/object-persistence-in-codename-one/">Object Persistence in Codename One</a>
  * @author Shai Almog
  */
 public interface Externalizable {


### PR DESCRIPTION
I added a link to a blog article of Steve that clarify the externalizable interface in a way deeper than the Javadoc.