### PR TITLE
Fix a NPE

### DIFF
--- a/CodenameOne/src/com/codename1/ui/validation/Validator.java
+++ b/CodenameOne/src/com/codename1/ui/validation/Validator.java
@@ -690,9 +690,11 @@ public class Validator {
             }
         }
         
-        if(validationFailureHighlightMode == HighlightMode.EMBLEM || validationFailureHighlightMode == HighlightMode.UIID_AND_EMBLEM) {
-            if(!(cmp.getComponentForm().getGlassPane() instanceof ComponentListener)) {
-                cmp.getComponentForm().setGlassPane(new ComponentListener(null));
+        if (cmp.getComponentForm() != null) {
+            if(validationFailureHighlightMode == HighlightMode.EMBLEM || validationFailureHighlightMode == HighlightMode.UIID_AND_EMBLEM) {
+                if(!(cmp.getComponentForm().getGlassPane() instanceof ComponentListener)) {
+                    cmp.getComponentForm().setGlassPane(new ComponentListener(null));
+                }
             }
         }
         if(v) {


### PR DESCRIPTION
The use of `cmp.getComponentForm()` assumes that the the component to be validated is already inserted in a Form. This is not necessary true. For example, it may happen that some InputComponents (binded to a Validator) are inserted in a Form with already some data: in this case, the Validator is called before the Form is shown, throwing a NullPointerException. This happens in a particular circumstance in the app I'm developing. This commit fixes this issue.