### PR TITLE
Fixed error in boolean returned value

### DIFF
--- a/CodenameOne/src/com/codename1/io/File.java
+++ b/CodenameOne/src/com/codename1/io/File.java
@@ -234,7 +234,7 @@ public class File {
      */
     public boolean delete() {
         FileSystemStorage.getInstance().delete(path);
-        return FileSystemStorage.getInstance().exists(path);
+        return !FileSystemStorage.getInstance().exists(path);
     }
     
     /**


### PR DESCRIPTION
The value returned by `delete()` must be `true` if the file does not exist, but in the current implementation it is the opposite. This fix allows the current implementation to be corrected.