### PR TITLE
Added downloadUrlSafely method and helper code

### DIFF
--- a/CodenameOne/src/com/codename1/io/Util.java
+++ b/CodenameOne/src/com/codename1/io/Util.java
@@ -2087,9 +2087,11 @@ public class Util {
      * download as soon as network conditions allow and in a completely
      * transparent way for the user; note that in the global network error
      * handling, there must be an automatic
-     * <pre>.retry()</pre>, as in the first example below; alternatively, you
-     * can add an exception listener to the returned ConnectionRequest, as in
-     * the second example.</p>
+     * <pre>.retry()</pre>, as in the code example below.</p>
+     * <p>
+     * This method is useful if the server correctly returns Content-Length and
+     * if it supports partial downloads: if not, it works like a normal
+     * download.</p>
      * <p>
      * Pros: always allows you to complete downloads, even if very heavy (e.g.
      * 100MB), even if the connection is unstable (network errors) and even if
@@ -2102,7 +2104,9 @@ public class Util {
      * that slightly slow down the download and cause more traffic than normally
      * needed.</p>
      * <p>
-     * Usage examples:</p>
+     * Usage example:</p>
+     * <script src="https://gist.github.com/jsfan3/554590a12c3102a3d77e17533e7eca98.js"></script>
+     * 
      *
      * @param url
      * @param fileName must be a valid Storage file name or FileSystemStorage
@@ -2112,11 +2116,9 @@ public class Util {
      * monitoring the progress
      * @param filesavedCallback invoked (in EDT) only when the download is
      * finished; if null, no action is taken
-     * @return ConnectionRequest to be used only to add an exception listener
-     * (like in the second code example)
      * @throws IOException
      */
-    public static ConnectionRequest downloadUrlSafely(String url, final String fileName, final OnComplete<Integer> percentageCallback, final OnComplete<String> filesavedCallback) throws IOException {
+    public static void downloadUrlSafely(String url, final String fileName, final OnComplete<Integer> percentageCallback, final OnComplete<String> filesavedCallback) throws IOException {
         // Code discussion here: https://stackoverflow.com/a/62137379/1277576
         String partialDownloadsDir = FileSystemStorage.getInstance().getAppHomePath() + FileSystemStorage.getInstance().getFileSystemSeparator() + "partialDownloads";
         if (!FileSystemStorage.getInstance().isDirectory(partialDownloadsDir)) {
@@ -2214,6 +2216,5 @@ public class Util {
                 }
             }
         });
-        return cr;
     }
 }

--- a/CodenameOne/src/com/codename1/io/Util.java
+++ b/CodenameOne/src/com/codename1/io/Util.java
@@ -112,7 +112,7 @@ public class Util {
 
 
     /**
-     * Copy the input stream into the fileName stream, closes both streams when finishing or in
+     * Copy the input stream into the output stream, closes both streams when finishing or in
  a case of an exception
      * 
      * @param i source
@@ -123,7 +123,7 @@ public class Util {
     }
 
     /**
-     * Copy the input stream into the fileName stream, without closing the streams when done
+     * Copy the input stream into the output stream, without closing the streams when done
      *
      * @param i source
      * @param o destination
@@ -134,7 +134,7 @@ public class Util {
     }
     
     /**
-     * Copy the input stream into the fileName stream, without closing the streams when done
+     * Copy the input stream into the output stream, without closing the streams when done
      *
      * @param i source
      * @param o destination
@@ -156,7 +156,7 @@ public class Util {
     }
     
     /**
-     * Copy the input stream into the fileName stream, closes both streams when finishing or in
+     * Copy the input stream into the output stream, closes both streams when finishing or in
  a case of an exception
      *
      * @param i source
@@ -276,7 +276,7 @@ public class Util {
      * <script src="https://gist.github.com/codenameone/858d8634e3cf1a82a1eb.js"></script>
      *
      * @param o the object to write which can be null
-     * @param out the destination fileName stream
+     * @param out the destination output stream
      * @throws IOException thrown by the stream
      */
     public static void writeObject(Object o, DataOutputStream out) throws IOException {
@@ -1066,7 +1066,7 @@ public class Util {
      * Writes a string with a null flag, this allows a String which may be null
      *
      * @param s the string to write
-     * @param d the destination fileName stream
+     * @param d the destination output stream
      * @throws java.io.IOException
      */
     public static void writeUTF(String s, DataOutputStream d) throws IOException {

--- a/CodenameOne/src/com/codename1/io/Util.java
+++ b/CodenameOne/src/com/codename1/io/Util.java
@@ -113,7 +113,7 @@ public class Util {
 
     /**
      * Copy the input stream into the output stream, closes both streams when finishing or in
- a case of an exception
+     * a case of an exception
      * 
      * @param i source
      * @param o destination
@@ -157,7 +157,7 @@ public class Util {
     
     /**
      * Copy the input stream into the output stream, closes both streams when finishing or in
- a case of an exception
+     * a case of an exception
      *
      * @param i source
      * @param o destination

--- a/CodenameOne/src/com/codename1/util/Wrapper.java
+++ b/CodenameOne/src/com/codename1/util/Wrapper.java
@@ -1,0 +1,23 @@
+package com.codename1.util;
+
+/**
+ * Generic object wrapper, as workaround for the issue "Local variables
+ * referenced from a lambda expression must be final or effectively final".
+ */
+public class Wrapper<T> {
+    
+    private T object;
+    
+    public Wrapper(T obj) {
+        this.object = obj;
+    }
+
+    public T get() {
+        return object;
+    }
+    
+    public void set(T obj) {
+        this.object = obj;
+    }
+    
+}


### PR DESCRIPTION
After the discussion on Stack Overflow https://stackoverflow.com/a/62137379, I made many changes to the code to make it suitable to be integrated into Codename One. I also followed your suggestions.

Specifically:

1. The target file can be in both the Storage and FileSystemStorage, this difference is automatically managed.

2. Use a separate thread for merging files.

3. Callbacks are still executed in the EDT.

4. Use a unique string in the name of partial downloads to reduce problems with concurrent downloads.

5. Save partial downloads in a special folder in the FileSystemStorage to keep them more orderly.

6. Verified that the size of the output file is requested to the server only once.

7. Fixed an important error in the measurement of the downloaded data, which caused download corruption. Now the downloads are intact and even faster.

8. Added full code usage example.