### PR TITLE
Update Component.java

### DIFF
--- a/CodenameOne/src/com/codename1/ui/Component.java
+++ b/CodenameOne/src/com/codename1/ui/Component.java
@@ -987,8 +987,8 @@ public class Component implements Animation, StyleListener, Editable {
         
         int w = getWidth();
         int h = getHeight();
-        int x = getAbsoluteX();
-        int y = getAbsoluteY();
+        int x = getAbsoluteX() + scrollX;
+        int y = getAbsoluteY() + scrollY;
         if (init) {
             r.setBounds(x, y, w, h);
             if (w <= 0 || h <= 0) {


### PR DESCRIPTION
We initialize the X and Y variables with getAbsoluteY( ) and getAbsoluteX( ) methods. so no mether how much we scroll the page the difference between the Y of the Component and the Y of the container will always be the same.

So if we change the initialization to be:

int x = getAbsoluteX() + scrollX;
int y = getAbsoluteY() + scrollY;

It will fix the problem.