### PR TITLE
Added flag to allow clearing textfield without toggling keyboard on Android

### DIFF
--- a/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
+++ b/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
@@ -344,6 +344,14 @@ public abstract class CodenameOneImplementation {
      */
     public void stopTextEditing() {    
     }
+	
+	
+    /**
+     * Invoked for special cases to stop text editing and clear native editing state
+     * Used specifically to prevent hiding keyboard on Android
+     */
+    public void stopTextEditing(boolean hideKeyboard) {    
+    }
 
     
     /**

--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -1805,6 +1805,18 @@ public final class Display extends CN1Constants {
             }
         }
     }
+    
+    /**
+     * Allows us to stop editString on the given text component without hiding the keyboard
+     * Only use on Android
+     * @param cmp the text field/text area component
+     * @param hideKeyboard hide/keep keyboard on
+     */
+    public void stopEditing(Component cmp, boolean hideKeyboard) {
+        if(isTextEditing(cmp)) {
+            impl.stopTextEditing(hideKeyboard);
+        }
+    }
 
     boolean isTextEditing(Component c) {
         if (c instanceof Form && c == getCurrent()) {

--- a/CodenameOne/src/com/codename1/ui/TextField.java
+++ b/CodenameOne/src/com/codename1/ui/TextField.java
@@ -863,6 +863,25 @@ public class TextField extends TextArea {
     }   
     
     /**
+     * Clears the text from the TextField with the option of not toggling keyboard (iOS, And)
+     */
+    public void clear(boolean hideKeyboard){
+        if(hideKeyboard) {
+            clear();
+        } else {
+            if(Display.getInstance().getPlatformName().equals("ios")) {
+                setText("");
+            } else if (Display.getInstance().getPlatformName().equals("and")) {
+                Display.getInstance().stopEditing(this, hideKeyboard);
+                setText("");
+                Display.getInstance().setProperty("android.keepEditorOpenWhenClearing", "true");
+                this.startEditingAsync();
+            }
+            requestFocus();
+        }
+    }
+    
+    /**
      * Invoked on a long click by the user
      */
     private void longClick(int keyCode) {

--- a/CodenameOne/src/com/codename1/ui/TextField.java
+++ b/CodenameOne/src/com/codename1/ui/TextField.java
@@ -866,7 +866,7 @@ public class TextField extends TextArea {
      * Clears the text from the TextField with the option of not toggling keyboard (iOS, And)
      */
     public void clear(boolean toggleKeyboard){
-        if(hideKeyboard) {
+        if(toggleKeyboard) {
             clear();
         } else {
             if(Display.getInstance().getPlatformName().equals("ios")) {

--- a/CodenameOne/src/com/codename1/ui/TextField.java
+++ b/CodenameOne/src/com/codename1/ui/TextField.java
@@ -866,7 +866,7 @@ public class TextField extends TextArea {
      * Clears the text from the TextField with the option of not toggling keyboard (iOS, And)
      */
     public void clear(boolean toggleKeyboard){
-        if(toggleKeyboard) {
+        if(toggleKeyboard || com.codename1.ui.CN.isSimulator()) {
             clear();
         } else {
             if(Display.getInstance().getPlatformName().equals("ios")) {

--- a/CodenameOne/src/com/codename1/ui/TextField.java
+++ b/CodenameOne/src/com/codename1/ui/TextField.java
@@ -865,19 +865,21 @@ public class TextField extends TextArea {
     /**
      * Clears the text from the TextField with the option of not toggling keyboard (iOS, And)
      */
-    public void clear(boolean hideKeyboard){
+    public void clear(boolean toggleKeyboard){
         if(hideKeyboard) {
             clear();
         } else {
             if(Display.getInstance().getPlatformName().equals("ios")) {
                 setText("");
+                requestFocus();
             } else if (Display.getInstance().getPlatformName().equals("and")) {
-                Display.getInstance().stopEditing(this, hideKeyboard);
+                Display.getInstance().stopEditing(this, toggleKeyboard);
                 setText("");
                 Display.getInstance().setProperty("android.keepEditorOpenWhenClearing", "true");
                 this.startEditingAsync();
-            }
-            requestFocus();
+                requestFocus();
+            }else
+                clear();
         }
     }
     

--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -1464,6 +1464,11 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
     public boolean isNativeEditorVisible(Component c) {
         return super.isNativeEditorVisible(c) && !InPlaceEditView.isActiveTextEditorHidden();
     }
+    
+    @Override
+    public void stopTextEditing(boolean hideKeyboard) {
+        stopEditing(!hideKeyboard);
+    }
 
     public static void stopEditing() {
         stopEditing(false);

--- a/Ports/Android/src/com/codename1/impl/android/InPlaceEditView.java
+++ b/Ports/Android/src/com/codename1/impl/android/InPlaceEditView.java
@@ -1709,7 +1709,21 @@ public class InPlaceEditView extends FrameLayout{
             @Override
             public void run() {
 		if (!isEditedFieldSwitch) {
-                    releaseEdit();
+                    //https://github.com/codenameone/CodenameOne/issues/3311
+                    //https://github.com/codenameone/CodenameOne/issues/3316
+                    //https://github.com/codenameone/CodenameOne/issues/3317
+                    //When clearing a textfield, the keyboard re-loads. It goes down, and it comes back up.
+                    //This may be ok for most applications, but it isn't for a host of others (chat send buttons clear textfield but need the user to stay focused on the textfield, not have to see how it goes down and up)
+                    //To clear a textfield without moving the keyboard, the following steps must be followed:
+                    //1. call com.codename1.impl.android.AndroidImplementation.stopEditing(); natively instead of textField.stopEditing(); this will reset the textfield's internal logic but not hide the keyboard
+                    //2. call textField.setText(""). This will erase the text
+                    //3. call Display.getInstance().setProperty("android.keepEditorOpenWhenClearing", "true"); This will prepare the next startEditingAsync to not re-load the keyboard (done in releaseEdit() below)
+		    //4. call textField.startEditingAsync();
+                    if("false".equals(Display.getInstance().getProperty("android.keepEditorOpenWhenClearing", "false"))) {
+                        releaseEdit();
+                    } else {
+                        Display.getInstance().setProperty("android.keepEditorOpenWhenClearing", "false");
+                    }
 
                     if (sInstance == null) {
                         sInstance = new InPlaceEditView(impl);


### PR DESCRIPTION
I know this is very specific to Android, but that's because:
1. Android is the only platform where the keyboard can't currently be kept open while clearing text. On iOS, it's as simple as `setText("")`
2. Android's `InPlaceEditView` static method `public static void stopEdit()`, which stops editing without closing the keyboard, isn't exposed in the interface implementation so calling it from `Display` (to avoid having to call it natively) isn't currently possible

Feel free to create a wrapper to call the 4 points in the comments (and then remove the comments). I tried doing this but then as I went along I felt very confident that you would object to my implementation, so it's best CN1 does this

For now, can we please have this merged so I can call this from my side? It will fix a big source of pain