### PR TITLE
fix(sec): upgrade jdom2 to 2.0.6.1

### DIFF
--- a/maven/codenameone-maven-plugin/pom.xml
+++ b/maven/codenameone-maven-plugin/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>org.jdom</groupId>
             <artifactId>jdom2</artifactId>
-            <version>2.0.6</version>
+            <version>2.0.6.1</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Upgrade jdom2 from 2.0.6 to 2.0.6.1 for vulnerability fix:
- [CVE-2021-33813](https://www.oscs1024.com/hd/MPS-2021-8350)