### PR TITLE
Issue3371 string buffer

### DIFF
--- a/vm/JavaAPI/src/java/lang/StringBuffer.java
+++ b/vm/JavaAPI/src/java/lang/StringBuffer.java
@@ -357,7 +357,7 @@ public final class StringBuffer implements CharSequence, Appendable {
     }
 
     public CharSequence subSequence(int start, int end) {
-        return new StringBuffer(toString().substring(start, end));
+        return internal.substring(start, end);
     }
 
 

--- a/vm/JavaAPI/src/java/lang/StringBuilder.java
+++ b/vm/JavaAPI/src/java/lang/StringBuilder.java
@@ -74,6 +74,20 @@ public final class StringBuilder implements CharSequence, Appendable {
 
     public StringBuilder(CharSequence str){
         this(str.toString());
+    }
+
+    /*
+     * Allocates new array with characters from 'data', starting at 'offset', and with length charCount.
+     * Pretty much the same implementation as String(char[] data, int offset, int charCount) in ./String.java
+     * throws failedBundsCheck() if the new string tries to take characters outside the range of 'data'
+     */
+    private StringBuilder(char[] data, int offset, int charCount) {
+        if((offset | charCount) < 0 || charCount > data.length - offset) {
+            throw failedBoundsCheck(data.length, offset, charCount);
+        }
+        this.value = new char[charCount];
+        this.count = charCount;
+        System.arraycopy(data, offset, value, 0, charCount);
     }    
     
     private void enlargeBuffer(int min) {
@@ -617,6 +631,10 @@ public final class StringBuilder implements CharSequence, Appendable {
 
     @Override
     public CharSequence subSequence(int start, int end) {
-        return toString().substring(start, end);
+        return substring(start,end);
+    }
+
+    public StringBuilder subString(int start, int end) {
+        return new StringBuilder(value, start, end-start);
     }
 }

--- a/vm/JavaAPI/src/java/lang/StringBuilder.java
+++ b/vm/JavaAPI/src/java/lang/StringBuilder.java
@@ -76,6 +76,10 @@ public final class StringBuilder implements CharSequence, Appendable {
         this(str.toString());
     }
 
+    private StringIndexOutOfBoundsException failedBoundsCheck(int arrayLength, int offset, int count) {
+	    throw new StringIndexOutOfBoundsException(count);
+    }
+
     /*
      * Allocates new array with characters from 'data', starting at 'offset', and with length charCount.
      * Pretty much the same implementation as String(char[] data, int offset, int charCount) in ./String.java
@@ -634,7 +638,7 @@ public final class StringBuilder implements CharSequence, Appendable {
         return substring(start,end);
     }
 
-    public StringBuilder subString(int start, int end) {
+    public StringBuilder substring(int start, int end) {
         return new StringBuilder(value, start, end-start);
     }
 }


### PR DESCRIPTION
Hi, this is my first time submitting an OSS contribution. This was very fun, I learnt a lot of things. I think I might eventually be able to make a good contribution out of addressing this issue (#3371). Specifically, I noticed that there are still some functions to implement in both StringBuilder and StringBuffer. This PR is really a first attempt at contributing to CodeNameOne. I look forward to receiving feedback, and from the get go, I appreciate your consideration. I know I ended up writing a pretty long narrative 📖😄. 

I'll be more than happy to add more commits to this PR. There are still questions of backwards compatibility, testing, and documentation to address. There is no realistic expectation that this PR will be accepted right now as is, but I am willing to make it a good contribution.  

Thank you, 
Octavio

### Highlights

Implemented substring(int start, int end) in java.lang.StringBuilder:
- Very similar to java.lang.String substring(int start, int end);
- avoids having to create a new string by using a new Constructor instead;
- New constructor is private so that from the outside StringBuilder is still the same as [specified](https://docs.oracle.com/javase/7/docs/api/java/lang/StringBuilder.html) by Oracle;
- ! StringBuilder could can now throw a "new" type of error;
- ! returns StringBuilder object.

Modified subSequence(int start, int end) in java.lang.StringBuffer:
- does a substring() call on its own StringBuilder object, therefore;
- ! returns a StringBuilder object.

### Narrative
In issue #3371, a more efficient version of java.lang.StringBuffer's subSequence() is requested. Since StringBuffer is based on manipulating a StringBuilder object, I decided it was best to modify subSequence() in java.lang.StringBuilder. When it came to modifying java.lang.StringBuilder's subSequence(), I decided to follow what is seen in java.lang.String:  java.lang.String's subSequence() makes a call to a new method, substring(int start, int end). To implement java.lang.StringBuilder's substring(int start, int end), I created a new constructor in java.lang.StringBuilder. The new constructor is private, so that it is not seen outside java.lang.StringBuilder, ensuring it is still congruent with Oracle's class specification, which only lists four constructors. This new Constructor makes a call to System.arraycopy(...) to copy the characters from the original StringBuilder object to a new StringBuilder object.
I believe this is more memory efficient than the old method since: (1) java.lang.StringBuilder's toString() is not called, so no new String object is created; and (2) java.lang.String's substring(int start, int end) is not called, so no second new String object is created. Also, all calls are to functions inside the same file.
(!) As a consequence of the new Constructor, java.lang.StringBuilder subSequence(...) and substring(...) now always return a StringBuilder object: this might come with backward compatibility issues. A solution might be adding a .toString() call after the substring(...) call on internal. Then subSequence(...) will return a java.lang.String object as it used to while substring(...) will return a StringBuilder. Old programs will still receive a String from java.lang.StringBuilder subSequence(...), while new programs can use the new substring(...) knowing they will get a java.lang.StringBuilder object.
(!) substring(...) in java.lang.StringBuilder now throws a StringIndexOutOfBoundsException; in the past the call to java.lang.Substring meant that java.lang.StringBuilder would throw a ArrayIndexOutOfBoundsException, should the indeces be out of bounds. In another problem with backwards compatibility, callers expecting to catch specifically a ArrayIndexOutOfBoundsException will fail to catch the StringIndexOutOfBoundsException. The solution may therefore be to just throw a ArrayIndexOutOfBoundsException instead.
Finally, subSequence(int start, int end) in java.lang.StringBuffer just calls java.lang.StringBuilder's substring(...) on its 'internal' object. This is more memory efficient because: (1) java.lang.StringBuffer's toString() is not called, which would in turn be a call to java.lang.StringBuilder's toString() which would generate a new String Object; and (2), java.lang.String's substring(...) is not called on the otherwise newly created java.lang.String object to create another String Object!
(!) Again, this may cause backwards compatibility issues since subSequence used to return a java.lang.String object.

**As per issue #3371, java.lang.StringBuffer's subSequence(int start, int end) should now be more efficient, ready to be used in an implementation in this same class of substring(int start, int end).**

### Testing
I was able to compile my changes using ant -f build.xml from within the JavaAPI directory. Also running mvn install from within the source finished successfully.
**I need help applying these library changes to a local CodeNameOne project for testing purposes**. So far, I have been able to download and run a sample project from source ( by following [these](https://www.codenameone.com/blog/building-codename-one-from-source-maven-edition.html)). But when I try to use my new substring method in the sample project, /build.sh and mvn install will fail.

 ### Documentation Changes
Again, it is not clear to me how to update the JavaDocs from source. I know they are generated upon building, but I haven't really found a way to modify them. If you could point me in the direction of the JavaDocs, I will make sure to update them along with the modifications to the JavaAPI herein.