### PR TITLE
Issue #3646: Generate Surefire-compatible XML when running tests via Maven

### DIFF
--- a/CodenameOne/src/com/codename1/testing/DeviceRunner.java
+++ b/CodenameOne/src/com/codename1/testing/DeviceRunner.java
@@ -79,9 +79,9 @@ public abstract class DeviceRunner {
         } catch(IOException err) {
             TestReporting.getInstance().logException(err);
         }
-        TestReporting.getInstance().testExecutionFinished();
+        TestReporting.getInstance().testExecutionFinished(getClass().getName());
         if(failedTests > 0) {
-            Log.p("Test execution finished, some failed tests occured. Passed: " + passedTests + " tests. Failed: " + failedTests + " tests.");
+            Log.p("Test execution finished, some failed tests occurred. Passed: " + passedTests + " tests. Failed: " + failedTests + " tests.");
         } else {
             Log.p("All tests passed. Total " + passedTests + " tests passed");
         }
@@ -128,7 +128,7 @@ public abstract class DeviceRunner {
                             TestReporting.getInstance().finishedTestCase(t, false);
                         }
                     }
-                };
+                }
                 RunTestImpl runTest = new RunTestImpl();
                 if (t.shouldExecuteOnEDT() && !CN.isEdt()) {
                     CN.callSeriallyAndWait(runTest);

--- a/CodenameOne/src/com/codename1/testing/DeviceRunner.java
+++ b/CodenameOne/src/com/codename1/testing/DeviceRunner.java
@@ -108,7 +108,7 @@ public abstract class DeviceRunner {
         try {
             final UnitTest t = (UnitTest)Class.forName(testClassName).newInstance();
             try {
-                TestReporting.getInstance().startingTestCase(t);
+                TestReporting.getInstance().startingTestCase(t.getClass().getName());
                 startApplicationInstance();
                 class RunTestImpl implements Runnable {
                     boolean result;
@@ -125,7 +125,7 @@ public abstract class DeviceRunner {
                         } catch (Throwable err) {
                             failedTests++;
                             TestReporting.getInstance().logException(err);
-                            TestReporting.getInstance().finishedTestCase(t, false);
+                            TestReporting.getInstance().finishedTestCase(t.getClass().getName(), false);
                         }
                     }
                 }
@@ -138,11 +138,11 @@ public abstract class DeviceRunner {
                     runTest.run();
                 }
                 stopApplicationInstance();
-                TestReporting.getInstance().finishedTestCase(t, runTest.result);
+                TestReporting.getInstance().finishedTestCase(t.getClass().getName(), runTest.result);
             } catch(Throwable err) {
                 failedTests++;
                 TestReporting.getInstance().logException(err);
-                TestReporting.getInstance().finishedTestCase(t, false);
+                TestReporting.getInstance().finishedTestCase(t.getClass().getName(), false);
             }
         } catch(Throwable t) {
             TestReporting.getInstance().logMessage("Failed to create instance of " + testClassName);

--- a/CodenameOne/src/com/codename1/testing/TestReporting.java
+++ b/CodenameOne/src/com/codename1/testing/TestReporting.java
@@ -66,6 +66,13 @@ public class TestReporting {
     }
 
     /**
+     * @deprecated this method is no longer invoked by the testing framework; please use {@link #startingTestCase(String)}
+     */
+    public void startingTestCase(UnitTest test) {
+        startingTestCase(test.getClass().getName());
+    }
+
+    /**
      * Indicates a message from the current test case
      * @param message the message
      */
@@ -84,7 +91,7 @@ public class TestReporting {
     /**
      * Invoked when a unit test has completed
      *
-     * @param testName
+     * @param testName the name of the test case
      * @param passed   true if the test passed and false otherwise
      */
     public void finishedTestCase(String testName, boolean passed) {
@@ -95,6 +102,13 @@ public class TestReporting {
             Log.p(testName + " failed");
             testsExecuted.put(testName, Boolean.FALSE);
         }
+    }
+
+    /**
+     * @deprecated this method is no longer invoked by the testing framework; please use {@link #finishedTestCase(String, boolean)}
+     */
+    public void finishedTestCase(UnitTest test, boolean passed) {
+        finishedTestCase(test.getClass().getName(), passed);
     }
     
     /**
@@ -114,11 +128,26 @@ public class TestReporting {
             }
         }
     }
+
+    /**
+     * @deprecated this method is no longer invoked by the testing framework; please use {@link #writeReport(String, OutputStream)}
+     */
+    public void writeReport(OutputStream os) throws IOException {
+    }
     
     /**
      * Callback to indicate the test execution has finished allowing
      * for a report to be generated if appropriate
      */
     public void testExecutionFinished(String testSuiteName) {
+        // Call the legacy method in case it has been overridden by a subclass
+        testExecutionFinished();
+    }
+
+    /**
+     * @deprecated this method is no longer invoked by the testing framework; please use {@link #testExecutionFinished(String)}
+     */
+    @SuppressWarnings("DeprecatedIsStillUsed")
+    public void testExecutionFinished() {
     }
 }

--- a/CodenameOne/src/com/codename1/testing/TestReporting.java
+++ b/CodenameOne/src/com/codename1/testing/TestReporting.java
@@ -60,10 +60,9 @@ public class TestReporting {
     
     /**
      * Invoked when a unit test is started
-     * @param test the test case
      */
-    public void startingTestCase(UnitTest test) {
-        Log.p("Starting test case " + test.getClass().getName());
+    public void startingTestCase(String testName) {
+        Log.p("Starting test case " + testName);
     }
 
     /**
@@ -84,16 +83,17 @@ public class TestReporting {
     
     /**
      * Invoked when a unit test has completed
-     * @param test the test case
-     * @param passed true if the test passed and false otherwise
+     *
+     * @param testName
+     * @param passed   true if the test passed and false otherwise
      */
-    public void finishedTestCase(UnitTest test, boolean passed) {
+    public void finishedTestCase(String testName, boolean passed) {
         if(passed) {
-            Log.p(test.getClass().getName() + " passed");
-            testsExecuted.put(test.getClass().getName(), Boolean.TRUE);
+            Log.p(testName + " passed");
+            testsExecuted.put(testName, Boolean.TRUE);
         } else {
-            Log.p(test.getClass().getName() + " failed");
-            testsExecuted.put(test.getClass().getName(), Boolean.FALSE);
+            Log.p(testName + " failed");
+            testsExecuted.put(testName, Boolean.FALSE);
         }
     }
     

--- a/CodenameOne/src/com/codename1/testing/TestReporting.java
+++ b/CodenameOne/src/com/codename1/testing/TestReporting.java
@@ -37,7 +37,7 @@ import java.util.Hashtable;
  */
 public class TestReporting {
     private static TestReporting instance;
-    private Hashtable testsExecuted = new Hashtable();
+    private final Hashtable<String, Boolean> testsExecuted = new Hashtable<String, Boolean>();
     
     
     /**
@@ -99,14 +99,15 @@ public class TestReporting {
     
     /**
      * Writes a test report to the given stream
-     * @param os the destination stream
+     *
+     * @param testSuiteName the name of the test suite
+     * @param os            the destination stream
      */
-    public void writeReport(OutputStream os) throws IOException {
-        Enumeration e = testsExecuted.elements();
+    public void writeReport(String testSuiteName, OutputStream os) throws IOException {
+        Enumeration<String> e = testsExecuted.keys();
         while(e.hasMoreElements()) {
-            String key = (String)e.nextElement();
-            Boolean v = (Boolean)testsExecuted.get(key);
-            if(v.booleanValue()) {
+            String key = e.nextElement();
+            if(testsExecuted.get(key)) {
                 os.write((key + " passed\n").getBytes());
             } else {
                 os.write((key + " failed\n").getBytes());
@@ -118,6 +119,6 @@ public class TestReporting {
      * Callback to indicate the test execution has finished allowing
      * for a report to be generated if appropriate
      */
-    public void testExecutionFinished() {
+    public void testExecutionFinished(String testSuiteName) {
     }
 }

--- a/Ports/JavaSE/src/com/codename1/impl/javase/JUnitXMLReporting.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JUnitXMLReporting.java
@@ -23,7 +23,6 @@
 package com.codename1.impl.javase;
 
 import com.codename1.testing.TestReporting;
-import com.codename1.testing.UnitTest;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -50,10 +49,10 @@ public class JUnitXMLReporting extends TestReporting {
     /**
      * {@inheritDoc}
      */
-    public void startingTestCase(UnitTest test) {
-        testCases += "<testcase classname=\"" + test.getClass().getName() + "\">\n";
+    public void startingTestCase(String testName) {
+        testCases += "<testcase classname=\"" + testName + "\">\n";
         output = "";
-        super.startingTestCase(test);
+        super.startingTestCase(testName);
     }
 
     /**
@@ -81,7 +80,7 @@ public class JUnitXMLReporting extends TestReporting {
     /**
      * {@inheritDoc}
      */
-    public void finishedTestCase(UnitTest test, boolean passed) {
+    public void finishedTestCase(String testName, boolean passed) {
         if(passed) {
             this.passed++;
             testCases += "<system-out>\n" + output + "</system-out>\n"
@@ -91,7 +90,7 @@ public class JUnitXMLReporting extends TestReporting {
             testCases += "<system-out>\n" + output + "</system-out>\n"
                     + "</testcase>";
         }
-        super.finishedTestCase(test, passed);
+        super.finishedTestCase(testName, passed);
     }
     
     /**

--- a/Ports/JavaSE/src/com/codename1/impl/javase/JUnitXMLReporting.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JUnitXMLReporting.java
@@ -20,14 +20,17 @@
  * Please contact Codename One through http://www.codenameone.com/ if you 
  * need additional information or have any questions.
  */
-package com.codename1.testing;
+package com.codename1.impl.javase;
+
+import com.codename1.testing.TestReporting;
+import com.codename1.testing.UnitTest;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.File;
-import java.io.FileOutputStream;
+import java.nio.file.Files;
 
 /**
  * Produces test reporting in the format of JUnit XML for compatibility with
@@ -66,7 +69,7 @@ public class JUnitXMLReporting extends TestReporting {
      */
     public void logException(Throwable err) {
         errors++;
-        testCases += "<error type=\"" + err.getClass().getName() + "\">" + err.toString() + "</error>\n";
+        testCases += "<error type=\"" + err.getClass().getName() + "\">" + err + "</error>\n";
         StringWriter sw = new StringWriter();
         PrintWriter pw = new PrintWriter(sw);
         err.printStackTrace(pw);
@@ -112,19 +115,11 @@ public class JUnitXMLReporting extends TestReporting {
         //noinspection ResultOfMethodCallIgnored
         reportFile.delete();
 
-        OutputStream fos = null;
-        try {
-            fos = new FileOutputStream(reportFile);
+        try (OutputStream fos = Files.newOutputStream(reportFile.toPath())) {
             writeReport(testSuiteName, fos);
         } catch (IOException ex) {
-            System.err.println("Failed to write JUnit XML report: " + ex.toString());
+            System.err.println("Failed to write JUnit XML report: " + ex);
             ex.printStackTrace();
-        } finally {
-            if (fos != null) {
-                try {
-                    fos.close();
-                } catch (IOException ignored) {}
-            }
         }
         super.testExecutionFinished(testSuiteName);
     }

--- a/Ports/JavaSE/src/com/codename1/impl/javase/TestExecuter.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/TestExecuter.java
@@ -64,7 +64,7 @@ public class TestExecuter {
                     Display.getInstance().callSeriallyAndWait(new Runnable() {
                         public void run() {
                             try {
-                                TestReporting.getInstance().startingTestCase(test);
+                                TestReporting.getInstance().startingTestCase(test.getClass().getName());
                                 test.prepare();
                                 TestReporting.getInstance().logMessage("Test prepared for execution on EDT");
                                 failed = !test.runTest();
@@ -73,7 +73,7 @@ public class TestExecuter {
                                 failed = true;
                                 TestReporting.getInstance().logException(err);
                             } finally {
-                                TestReporting.getInstance().finishedTestCase(test, !failed);
+                                TestReporting.getInstance().finishedTestCase(test.getClass().getName(), !failed);
                             }
                         }
                     }, timeout);
@@ -89,7 +89,7 @@ public class TestExecuter {
                     };
                     try {
                         timeoutKiller.schedule(timeoutTask, timeout);
-                        TestReporting.getInstance().startingTestCase(test);
+                        TestReporting.getInstance().startingTestCase(test.getClass().getName());
                         test.prepare();
                         TestReporting.getInstance().logMessage("Test prepared for execution off the EDT");
                         failed = !test.runTest();
@@ -98,7 +98,7 @@ public class TestExecuter {
                         failed = true;
                         TestReporting.getInstance().logException(err);
                     } finally {
-                        TestReporting.getInstance().finishedTestCase(test, !failed);
+                        TestReporting.getInstance().finishedTestCase(test.getClass().getName(), !failed);
                         timeoutTask.cancel();
                     }
                 }

--- a/Ports/JavaSE/src/com/codename1/impl/javase/TestRunner.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/TestRunner.java
@@ -22,7 +22,6 @@
  */
 package com.codename1.impl.javase;
 
-import com.codename1.testing.JUnitXMLReporting;
 import com.codename1.testing.TestReporting;
 import com.codename1.ui.Display;
 

--- a/Ports/JavaSE/src/com/codename1/impl/javase/TestRunner.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/TestRunner.java
@@ -22,13 +22,13 @@
  */
 package com.codename1.impl.javase;
 
-//import com.codename1.impl.javase.fx.JavaFXLoader;
 import com.codename1.testing.JUnitXMLReporting;
 import com.codename1.testing.TestReporting;
+import com.codename1.ui.Display;
+
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.InputStream;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.StringTokenizer;
 import java.util.prefs.Preferences;
@@ -118,6 +118,8 @@ public class TestRunner {
 
                     if(s.equalsIgnoreCase("-junitXML")) {
                         TestReporting.setInstance(new JUnitXMLReporting());
+                        pos++;
+                        continue;
                     }
                     
                     if(s.equalsIgnoreCase("-cleanMode")) {
@@ -178,6 +180,8 @@ public class TestRunner {
             }
             
             System.out.println("Preparing to execute " + tests.length + " tests");
+            // Required to provide implementations of Util for static functions in Log using the current classloader
+            Display.init(new java.awt.Container());
 
             String classPathStr = System.getProperty("java.class.path");
             if (System.getProperty("cn1.class.path") != null) {
@@ -194,11 +198,11 @@ public class TestRunner {
 
             if(cleanMode) {
                 for(String currentTestClass : tests) {
-                    ClassLoader ldr = new ClassPathLoader(files);
-                    Class c = Class.forName("com.codename1.impl.javase.TestExecuter", true, ldr);
+                    ClassLoader ldr = createClassLoader(files);
+                    Class<?> c = Class.forName("com.codename1.impl.javase.TestExecuter", true, ldr);
                     Method m = c.getDeclaredMethod("runTest", String.class, String.class, Boolean.TYPE);
                     Boolean passed = (Boolean)m.invoke(null, mainClass, currentTestClass, quietMode);
-                    if(passed.booleanValue()) {
+                    if(passed) {
                         passedTests++;
                     } else {
                         failedTests++;
@@ -209,12 +213,12 @@ public class TestRunner {
                     }
                 }
             } else {
-                ClassLoader ldr = new ClassPathLoader(files);
-                Class c = Class.forName("com.codename1.impl.javase.TestExecuter", true, ldr);
+                ClassLoader ldr = createClassLoader(files);
+                Class<?> c = Class.forName("com.codename1.impl.javase.TestExecuter", true, ldr);
                 for(String currentTestClass : tests) {
                     Method m = c.getDeclaredMethod("runTest", String.class, String.class, Boolean.TYPE);
                     Boolean passed = (Boolean)m.invoke(null, mainClass, currentTestClass, quietMode);
-                    if(passed.booleanValue()) {
+                    if(passed) {
                         System.out.println(currentTestClass + " passed!");
                         passedTests++;
                     } else {
@@ -226,11 +230,11 @@ public class TestRunner {
                         }
                     }
                 }
-            }      
-            TestReporting.getInstance().testExecutionFinished();
+            }
+            TestReporting.getInstance().testExecutionFinished(mainClass);
             int exitCode = 0;
             if(failedTests > 0) {
-                System.out.println("Test execution finished, some failed tests occured. Passed: " + passedTests + " tests. Failed: " + failedTests + " tests.");
+                System.out.println("Test execution finished, some failed tests occurred. Passed: " + passedTests + " tests. Failed: " + failedTests + " tests.");
                 exitCode = 100;
             } else {
                 System.out.println("All tests passed. Total " + passedTests + " tests passed");
@@ -241,7 +245,12 @@ public class TestRunner {
             System.exit(3);
         }
     }
-    
+
+    private ClassLoader createClassLoader(File[] files) {
+        ClassPathLoader ldr = new ClassPathLoader(files);
+        ldr.addExclude("com.codename1.testing.TestReporting");
+        return ldr;
+    }
     
  
     /**

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/RunTestsMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/RunTestsMojo.java
@@ -233,7 +233,13 @@ public class RunTestsMojo extends AbstractCN1Mojo {
         java.setClassname("com.codename1.impl.javase.TestRunner");
         java.createArg().setValue(properties.getProperty("codename1.packageName")+"."+properties.getProperty("codename1.mainName"));
         //java.createArg().setValue("-quietMode");
+        java.createArg().setValue("-junitXML");
+        File reportsDir = new File(project.getBuild().getDirectory(), "cn1-reports");
+        //noinspection ResultOfMethodCallIgnored
+        reportsDir.mkdirs();
+        java.setDir(reportsDir);
         java.setFork(true);
+        getLog().debug("Executing Test Runner: " + java.getCommandLine());
         int result = java.executeJava();
         if (result != 0) {
             throw new MojoExecutionException("Tests failed");


### PR DESCRIPTION
* Fixed `TestRunner` to correctly support the `-junitXML` parameter
* Implemented generation of XML file with test report on completion of a test suite
* Added a `testName` paramter to `TestReporting.testExecutionFinished` as the existing implementation for the test name was generating an NPE
* Changed `JUnitXMLReporting` to also use the default reporting logic (we can see output in Maven logs as well as in generated XML)
* Improved `TestExecuter` so that test exceptions are logged correctly
* Changed `RunTestMojo` to enable `-junitXML` when calling `TestRunner`, and generate a `"cn1-reports"` directory for the output