### PR TITLE
Scrolling improvements

### DIFF
--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -4245,15 +4245,21 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
                                     if (AndroidImplementation.this.myView == null) {
                                         return false;
                                     }
-                                    if (me.isFromSource(InputDevice.SOURCE_CLASS_POINTER)) {
-                                        switch (me.getAction()) {
-                                            case MotionEvent.ACTION_SCROLL:
-                                                int currentX = (int) me.getX();
-                                                int scrollDistance = (int) me.getAxisValue(MotionEvent.AXIS_VSCROLL);
-                                                int scrollToLocation = (int) (scrollDistance * 5d);
-                                                myView.getAndroidView().scrollTo(currentX, scrollToLocation);
-                                                return true;
+                                    if (me.isFromSource(InputDevice.SOURCE_CLASS_POINTER) &&
+                                            me.getAction() == MotionEvent.ACTION_SCROLL) {
+                                        double currentX = me.getX();
+                                        double currentY = me.getY();
+                                        int maxHeight = myView.getViewHeight();
+                                        double scrollOffSet = me.getAxisValue(MotionEvent.AXIS_VSCROLL);
+                                        int scrollToLocation = (int) (scrollOffSet * 5d + currentY);
+                                        // determine the location that the view should scroll to
+                                        // the 5d is a scroll speed factor
+                                        if (scrollToLocation <= 0) {
+                                            scrollToLocation = 0;
+                                        } else if (scrollToLocation >= maxHeight) {
+                                            scrollToLocation = maxHeight;
                                         }
+                                        myView.getAndroidView().scrollTo((int) currentX, scrollToLocation);
                                     }
                                     return false;
                                 }

--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -4235,6 +4235,29 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
                                     return myView.getAndroidView().onTouchEvent(me);
                                 }
                             });
+                            /**
+                             * Mouse Event Listener used to handle mouse wheel events
+                             * The mouse wheel can be used to scroll the page up or down
+                             */
+                            layoutWrapper.setOnGenericMotionListener(new View.OnGenericMotionListener() {
+                                @Override
+                                public boolean onGenericMotion(View view, MotionEvent me) {
+                                    if (AndroidImplementation.this.myView == null) {
+                                        return false;
+                                    }
+                                    if (me.isFromSource(InputDevice.SOURCE_CLASS_POINTER)) {
+                                        switch (me.getAction()) {
+                                            case MotionEvent.ACTION_SCROLL:
+                                                int currentX = (int) me.getX();
+                                                int scrollDistance = (int) me.getAxisValue(MotionEvent.AXIS_VSCROLL);
+                                                int scrollToLocation = (int) (scrollDistance * 5d);
+                                                myView.getAndroidView().scrollTo(currentX, scrollToLocation);
+                                                return true;
+                                        }
+                                    }
+                                    return false;
+                                }
+                            });
                         }
                         if(AndroidImplementation.this.relativeLayout != null){
                             // not sure why this happens but we got an exception where add view was called with

--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -4260,6 +4260,7 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
                                             scrollToLocation = maxHeight;
                                         }
                                         myView.getAndroidView().scrollTo((int) currentX, scrollToLocation);
+                                        return true;
                                     }
                                     return false;
                                 }


### PR DESCRIPTION
Fix #3657 
- Use setOnGenericMotionListener to handle scrolling event
- The logic is detecting input from source ***InputDevice.SOURCE_CLASS_POINTER*** and verify if this event is a motion event with a type of ***MotionEvent.ACTION_SCROLL***
- Get current pointers' X axis and Y axis value
- Using ***event.getAxisValue(MotionEvent.AXIS_VSCROLL)*** to get the moving direction indicator (this can get a value between -1 and 1)
- Use the current Y axis value to calculate the location that the scene should be scrolled to
- Keep the same X axis value and utilize ***scrollTo()*** method to scroll the scene
- Add constrains to verify the desired scrolling location is not off the screen. 