### PR TITLE
fix: ios sockets segfault on connect timeout

### DIFF
--- a/Ports/iOSPort/nativeSources/SocketImpl.m
+++ b/Ports/iOSPort/nativeSources/SocketImpl.m
@@ -46,19 +46,23 @@ static void _resume() {
          });
         
     }
-    [inputStream open];
-    [outputStream open];
-    while ([outputStream streamStatus] == NSStreamStatusOpening) {
+    if (inputStream != nil) {
+        [inputStream open];
+    }
+    if (outputStream != nil) {
+        [outputStream open];
+    }
+    while (outputStream != nil && [outputStream streamStatus] == NSStreamStatusOpening) {
         _yield();
         usleep(100000);
         _resume();
     }
-    while ([inputStream streamStatus] == NSStreamStatusOpening) {
+    while (inputStream != nil && [inputStream streamStatus] == NSStreamStatusOpening) {
         _yield();
         usleep(100000);
         _resume();
     }
-    if ([self isInputShutdown] || [self isOutputShutdown]) {
+    if (outputStream == nil || inputStream == nil || [self isInputShutdown] || [self isOutputShutdown]) {
         connected = NO;
     } else {
         connected = YES;


### PR DESCRIPTION
Untested.  

I believe this fixes a segfault that occurs if an iOS socket times out on connection.

The problem is that on timeout, it "disconnects" which sets the inputStream and outputStream to null, but on the thread that calls connect(), it is blocking on the `[inputStream open]` call until this disconnect happens.  The disconnect removes the logjam, so that it proceeds to the next line, where it tries to call `[outputStream]` open, but by this time `outputStream` was set to nil by the disconnect.

This fix just guards against calling methods on a nil reference.