### PR TITLE
fix: add new line after facebook proguard rules in android builds

### DIFF
--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
@@ -1033,7 +1033,7 @@ public class AndroidGradleBuilder extends Executor {
                     + "-keepattributes Signature\n"
                     + "-dontwarn bolts.**\n"
                     + "-dontnote android.support.**\n"
-                    + "-dontnote androidx.**";
+                    + "-dontnote androidx.**\n";
 
 
             facebookActivityMetaData = " <meta-data android:name=\"com.facebook.sdk.ApplicationId\" android:value=\"@string/facebook_app_id\"/>\n";


### PR DESCRIPTION
If facebook is used and also google play, then the proguard rules may be corrupted because of the missing new line after the facebook rules.