### PR TITLE
fix: android builder firebase proguard keep rules

### DIFF
--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
@@ -3167,11 +3167,8 @@ public class AndroidGradleBuilder extends Executor {
 
         String keepOverride = request.getArg("android.proguardKeepOverride", "Exceptions, InnerClasses, Signature, Deprecated, SourceFile, LineNumberTable, *Annotation*, EnclosingMethod");
 
-        String keepFirebase = "";
-        if (newFirebaseMessaging) {
-            keepFirebase = "-keep class com.google.android.gms.** { *; }\n\n" +
-                    "-keep class com.google.firebase.** { *; }\n\n";
-        }
+        String keepFirebase = "-keep class com.google.android.gms.** { *; }\n\n" +
+                "-keep class com.google.firebase.** { *; }\n\n";
         // workaround broken optimizer in proguard
         String proguardConfigOverride = "-dontusemixedcaseclassnames\n"
                 + "-dontskipnonpubliclibraryclasses\n"


### PR DESCRIPTION
Backporting rules that were already applied when newFirebaseMessaging was on, but they are needed in all cases.