### PR TITLE
fix: disable play flag when using gradle 8 in android local builds

### DIFF
--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
@@ -1330,7 +1330,8 @@ public class AndroidGradleBuilder extends Executor {
 
 
         // if a flag is declared we don't want the default play flag to be true
-        if(request.getArg("android.playService.plus", null)  != null ||
+        if(useGradle8 ||
+                request.getArg("android.playService.plus", null)  != null ||
                 request.getArg("android.playService.auth", (googleServicesJson.exists()) ? "true":null)  != null ||
                 request.getArg("android.playService.base", null)  != null ||
                 request.getArg("android.playService.identity", null)  != null ||


### PR DESCRIPTION
When using gradle 8, the old play flag, which enables a common base set of play services with an old default play version, does not work. This disables this flag automatically when using gradle 8.