### PR TITLE
feat: new android.extendAppCompatActivity build hint

### DIFF
--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -2723,6 +2723,9 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
         @Override
         public void run() {
             activity.invalidateOptionsMenu();
+            if (activity.getActionBar() == null) {
+                return;
+            }
             if (show) {
                 activity.getActionBar().show();
             } else {

--- a/Ports/Android/src/com/codename1/impl/android/CodenameOneActivity.java
+++ b/Ports/Android/src/com/codename1/impl/android/CodenameOneActivity.java
@@ -155,7 +155,9 @@ public class CodenameOneActivity extends Activity {
 
         if (android.os.Build.VERSION.SDK_INT >= 11) {
             getWindow().requestFeature(Window.FEATURE_ACTION_BAR);
-            getActionBar().hide();
+            if (getActionBar() != null) {
+                getActionBar().hide();
+            }
         }
 
         try {


### PR DESCRIPTION
This build hint, when set true, will cause the CodenameOneActivity class to extend AppCompatActivity instead of Activity.

Why?

Because some newer APIs require AppCompatActivity.  Eg. The new photopicker https://github.com/codenameone/CodenameOne/issues/3727