### PR TITLE
Feature/ios local build improvements

### DIFF
--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
@@ -1154,9 +1154,15 @@ public class IPhoneBuilder extends Executor {
                 }
             }
         }
-
+        String javacPath = System.getProperty("java.home") + "/../bin/javac";
+        if (!new File(javacPath).exists()) {
+            javacPath = System.getProperty("java.home") + "/bin/javac";
+        }
+        if (!new File(javacPath).exists()) {
+            javacPath = "javac";
+        }
         try {
-            if (!execWithFiles(stubSource, stubSource, ".java", "javac", "-source", "1.6", "-target", "1.6", "-classpath",
+            if (!execWithFiles(stubSource, stubSource, ".java", javacPath, "-source", "1.6", "-target", "1.6", "-classpath",
                     classesDir.getAbsolutePath(),
                     "-d", classesDir.getAbsolutePath())) {
                 return false;

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
@@ -59,6 +59,7 @@ public class IPhoneBuilder extends Executor {
     private File tmpFile;
     private File icon57;
     private File icon512;
+    private static final String DEFAULT_MIN_DEPLOYMENT_VERSION = "12.0";
 
     // StringBuilder used for constructing ruby script with xcodeproj
     // which adds localized strings files to the project.
@@ -209,6 +210,7 @@ public class IPhoneBuilder extends Executor {
 
     @Override
     public boolean build(File sourceZip, BuildRequest request) throws BuildException {
+        addMinDeploymentTarget(DEFAULT_MIN_DEPLOYMENT_VERSION);
         defaultEnvironment.put("LANG", "en_US.UTF-8");
         tmpFile = tmpDir = getBuildDirectory();
         useMetal = "true".equals(request.getArg("ios.metal", "false"));


### PR DESCRIPTION
1. Bumped minimum deployment target to 12.0 so that xcode builds (in xcode 15) work out of the box.
2. Use the javac from the current java home jdk so that it will use the correct version.  iOS local builds need JDK 8 (not 11 or anything else) so that it can generate 1.6 source level.