### PR TITLE
fix: slf4j conflicts

### DIFF
--- a/Ports/JavaSE/build.xml
+++ b/Ports/JavaSE/build.xml
@@ -158,7 +158,7 @@
         <copy file="../../../codenameone-skins/iphone5_os7.skin" tofile="src/iphone5.skin" />
         <copy file="../../../codenameone-skins/xoom.skin" todir="src" / -->
         <copydir src="${project.CodenameOne}/build/classes" dest="build/classes" />
-        <unjar src="../../../cn1-binaries/javase/sqlite-jdbc-3.46.0.1.jar" dest="build/classes" />
+        <unjar src="../../../cn1-binaries/javase/sqlite-jdbc-3.46.1.0.jar" dest="build/classes" />
         <unjar src="../../../cn1-binaries/javase/Filters.jar" dest="build/classes" /> 
     </target>    
 

--- a/Ports/JavaSE/nbproject/project.properties
+++ b/Ports/JavaSE/nbproject/project.properties
@@ -35,13 +35,13 @@ file.reference.Filters.jar=../../../cn1-binaries/javase/Filters.jar
 file.reference.jcef.jar=../../../cn1-binaries/javase/jcef.jar
 file.reference.jmf-2.1.1e.jar=../../../cn1-binaries/javase/jmf-2.1.1e.jar
 file.reference.jfxrt.jar=../../../cn1-binaries/jfxrt.jar
-file.reference.sqlite-jdbc-3.46.0.1.jar=../../../cn1-binaries/javase/sqlite-jdbc-3.46.0.1.jar
+file.reference.sqlite-jdbc-3.46.1.0.jar=../../../cn1-binaries/javase/sqlite-jdbc-3.46.1.0.jar
 includes=**
 jar.compress=false
 javafx.path=../../../cn1-binaries/javafx/lib
 javac.classpath=\
     ${reference.CodenameOne.jar}:\
-    ${file.reference.sqlite-jdbc-3.46.0.1.jar}:\
+    ${file.reference.sqlite-jdbc-3.46.1.0.jar}:\
     ${file.reference.Filters.jar}:\
     ${file.reference.jcef.jar}:\
     ${file.reference.jmf-2.1.1e.jar}:\

--- a/maven/javase/pom.xml
+++ b/maven/javase/pom.xml
@@ -19,9 +19,8 @@
 
         </dependency>
         <dependency>
-            <groupId>org.xerial</groupId>
+            <groupId>com.codenameone</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>3.46.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.jhlabs</groupId>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -67,6 +67,7 @@
         <module>java-runtime</module>
         <module>core</module>
         <module>factory</module>
+        <module>sqlite-jdbc</module>
         <module>javase</module>
         <module>javase-svg</module>
         <module>android</module>
@@ -92,6 +93,11 @@
             <dependency>
                 <groupId>com.codenameone</groupId>
                 <artifactId>codenameone-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.codenameone</groupId>
+                <artifactId>sqlite-jdbc</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/maven/sqlite-jdbc/README.adoc
+++ b/maven/sqlite-jdbc/README.adoc
@@ -1,0 +1,6 @@
+= sqlite-jdbc Shaded Jar
+
+This is a shaded jar that includes the sqlite-jdbc jar with the slf4j-api jar shaded into it at a different package,
+so as not to conflict with other libraries that might include slf4j.
+
+We needed to add this when we upgraded to version 3.46.1.0 of the sqlite-jdbc library, because it adds a dependency on slf4j-api.

--- a/maven/sqlite-jdbc/dependency-reduced-pom.xml
+++ b/maven/sqlite-jdbc/dependency-reduced-pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <parent>
+    <artifactId>codenameone</artifactId>
+    <groupId>com.codenameone</groupId>
+    <version>8.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>sqlite-jdbc</artifactId>
+  <version>8.0-SNAPSHOT</version>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.3.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <relocations>
+                <relocation>
+                  <pattern>org.slf4j</pattern>
+                  <shadedPattern>com.codename1.compat.sqlite.slf4j</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/maven/sqlite-jdbc/pom.xml
+++ b/maven/sqlite-jdbc/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>sqlite-jdbc</artifactId>
+    <version>8.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <parent>
+        <groupId>com.codenameone</groupId>
+        <artifactId>codenameone</artifactId>
+        <version>8.0-SNAPSHOT</version>
+    </parent>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.slf4j</pattern>
+                                    <shadedPattern>com.codename1.compat.sqlite.slf4j</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.46.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.36</version>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
created shaded jar for sqlite-jdbc library that shades the slf4j dependency at a namespace that should not conflict.