### PR TITLE
Update InPlaceEditView.java for Enter Key issue 3850

### DIFF
--- a/Ports/Android/src/com/codename1/impl/android/InPlaceEditView.java
+++ b/Ports/Android/src/com/codename1/impl/android/InPlaceEditView.java
@@ -2160,6 +2160,10 @@ public class InPlaceEditView extends FrameLayout{
                 case KeyEvent.KEYCODE_MENU:
                     endEditing(InPlaceEditView.REASON_SYSTEM_KEY, false, true, 0);
                     break;
+		case KeyEvent.KEYCODE_ENTER:
+                    if (mEditText.mTextArea != null && mEditText.mTextArea.isSingleLineTextArea())
+                        onEditorAction(EditorInfo.IME_ACTION_DONE);
+                    break;
                 case KeyEvent.KEYCODE_ESCAPE:
                     endEditing(InPlaceEditView.REASON_IME_ACTION, false, true, EditorInfo.IME_ACTION_DONE, keyCode);
                     break;


### PR DESCRIPTION
I am referring to issue #3850 , when the Enter key is pressed the TextField loses focus, now I have added this condition to the code that if it is a multi-line TextArea then when the Enter key is pressed it wraps maintaining the focus on the TextField instead if it is a single line TextField it enters the onEditorAction()