### PR TITLE
Feature/3868 wkwebview inspectable

### DIFF
--- a/CodenameOne/src/com/codename1/ui/BrowserComponent.java
+++ b/CodenameOne/src/com/codename1/ui/BrowserComponent.java
@@ -2140,8 +2140,10 @@ public class BrowserComponent extends Container {
     public void setDebugMode(boolean mode) {
         if(mode) {
             putClientProperty("BrowserComponent.firebug", Boolean.TRUE);
+            putClientProperty("BrowserComponent.ios.debug", Boolean.TRUE);
         } else {
             putClientProperty("BrowserComponent.firebug", null);
+            putClientProperty("BrowserComponent.ios.debug", null);
         }
     }
 

--- a/Ports/iOSPort/nativeSources/IOSNative.m
+++ b/Ports/iOSPort/nativeSources/IOSNative.m
@@ -427,6 +427,21 @@ void releaseCN1(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT o){
     com_codename1_impl_ios_IOSImplementation_release___java_lang_Object(CN1_THREAD_STATE_PASS_ARG o);
 }
 
+JAVA_OBJECT getClientProperty(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT o, NSString* key){
+    return com_codename1_ui_Component_getClientProperty___java_lang_String_R_java_lang_Object(
+        CN1_THREAD_STATE_PASS_ARG o,
+        fromNSString(CN1_THREAD_STATE_PASS_ARG key)
+    );
+}
+
+BOOL getBooleanClientProperty(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT o, NSString* key){
+    JAVA_OBJECT val = getClientProperty(CN1_THREAD_STATE_PASS_ARG o, key);
+    if(val == JAVA_NULL){
+        return NO;
+    }
+    return val == get_static_java_lang_Boolean_TRUE(threadStateData);
+}
+
 #ifndef NEW_CODENAME_ONE_VM
 NSString* toNSString(JAVA_OBJECT str) {
     if(str == JAVA_NULL) {
@@ -2489,6 +2504,10 @@ JAVA_LONG com_codename1_impl_ios_IOSNative_createWKBrowserComponent___java_lang_
             com_codename1_impl_ios_IOSNative_createWKBrowserComponent.backgroundColor = [UIColor clearColor];
             com_codename1_impl_ios_IOSNative_createWKBrowserComponent.opaque = NO;
             com_codename1_impl_ios_IOSNative_createWKBrowserComponent.autoresizesSubviews = YES;
+
+            if (getBooleanClientProperty(CN1_THREAD_GET_STATE_PASS_ARG obj, @"BrowserComponent.ios.debug")) {}
+                com_codename1_impl_ios_IOSNative_createWKBrowserComponent.inspectable = YES;
+            }
             
             com_codename1_impl_ios_IOSNative_createWKBrowserComponent.navigationDelegate = del;
             com_codename1_impl_ios_IOSNative_createWKBrowserComponent.autoresizingMask=(UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth);

--- a/Ports/iOSPort/nativeSources/IOSNative.m
+++ b/Ports/iOSPort/nativeSources/IOSNative.m
@@ -2505,7 +2505,7 @@ JAVA_LONG com_codename1_impl_ios_IOSNative_createWKBrowserComponent___java_lang_
             com_codename1_impl_ios_IOSNative_createWKBrowserComponent.opaque = NO;
             com_codename1_impl_ios_IOSNative_createWKBrowserComponent.autoresizesSubviews = YES;
 
-            if (getBooleanClientProperty(CN1_THREAD_GET_STATE_PASS_ARG obj, @"BrowserComponent.ios.debug")) {}
+            if (getBooleanClientProperty(CN1_THREAD_GET_STATE_PASS_ARG obj, @"BrowserComponent.ios.debug")) {
                 com_codename1_impl_ios_IOSNative_createWKBrowserComponent.inspectable = YES;
             }
             


### PR DESCRIPTION
Adds support for making iOS webview debuggable in safari.   https://github.com/codenameone/CodenameOne/issues/3868

Use the `setDebug(true)` method on the webview.

```java
package ca.weblite.jcbtest;

import static com.codename1.ui.CN.*;
import com.codename1.system.Lifecycle;
import com.codename1.ui.*;
import com.codename1.ui.layouts.*;
import com.codename1.io.*;
import com.codename1.ui.plaf.*;
import com.codename1.ui.util.Resources;

/**
 * This file was generated by <a href="https://www.codenameone.com/">Codename One</a> for the purpose
 * of building native mobile applications using Java.
 */
public class JSCallbackTest extends Lifecycle {
    @Override
    public void runApp() {
        Form hi = new Form("Browser", new BorderLayout());
        BrowserComponent browser = new BrowserComponent();
        browser.setDebugMode(true);
        browser.setURL("https://www.codenameone.com/");
        browser.addWebEventListener(BrowserComponent.onLoad, evt -> {
            browser.addJSCallback("window.myCallback = function(args) {callback.onSuccess(args)};"
                    , (args) -> {
                System.out.println("Hello: " + args);
            });
        });
        hi.add(BorderLayout.CENTER, browser);
        Button btn = new Button("Hello");
        btn.addActionListener(e -> {
            browser.execute("myCallback('Hello from Java')");
        });
        hi.add(BorderLayout.SOUTH, btn);
        hi.show();
    }
}
```