### PR TITLE
fix: [3914] Fix safe area insets on android 34

### DIFF
--- a/Ports/Android/src/com/codename1/impl/android/CodenameOneView.java
+++ b/Ports/Android/src/com/codename1/impl/android/CodenameOneView.java
@@ -164,6 +164,7 @@ public class CodenameOneView {
 
     private void updateSafeArea() {
         final Activity activity = CodenameOneView.this.implementation.getActivity();
+
         final Rect rect = this.safeArea;
         final View rootView = activity.getWindow().getDecorView();
         if (Build.VERSION.SDK_INT >= VERSION_CODE_P) {
@@ -182,10 +183,23 @@ public class CodenameOneView {
                         Method getSafeInsetRight = displayCutoutClass.getMethod("getSafeInsetRight");
                         Method getSafeInsetBottom = displayCutoutClass.getMethod("getSafeInsetBottom");
 
-                        rect.left = ((Integer) getSafeInsetLeft.invoke(cutout)).intValue();
-                        rect.top = ((Integer) getSafeInsetTop.invoke(cutout)).intValue();
-                        rect.right = ((Integer) getSafeInsetRight.invoke(cutout)).intValue();
-                        rect.bottom = ((Integer) getSafeInsetBottom.invoke(cutout)).intValue();
+                        int left = ((Integer) getSafeInsetLeft.invoke(cutout)).intValue();
+                        int top = ((Integer) getSafeInsetTop.invoke(cutout)).intValue();
+                        int right = ((Integer) getSafeInsetRight.invoke(cutout)).intValue();
+                        int bottom = ((Integer) getSafeInsetBottom.invoke(cutout)).intValue();
+                        if (!AndroidImplementation.isImmersive()) {
+                            Rect systemBarInsets = AndroidImplementation.getSystemBarInsets(rootView);
+                            top -= systemBarInsets.top;
+                            bottom -= systemBarInsets.bottom;
+                        }
+
+                        // Only apply if at least one is non-zero
+                        if (left != 0 || top != 0 || right != 0 || bottom != 0) {
+                            rect.left = left;
+                            rect.top = top;
+                            rect.right = right;
+                            rect.bottom = bottom;
+                        }
                     }
                 }
             } catch (Exception e) {

--- a/Ports/Android/src/com/codename1/impl/android/InPlaceEditView.java
+++ b/Ports/Android/src/com/codename1/impl/android/InPlaceEditView.java
@@ -1398,51 +1398,7 @@ public class InPlaceEditView extends FrameLayout{
     }
 
     private static boolean isImmersive(Window window) {
-        View decor = window.getDecorView();
-
-        // ---------- Modern branch : API 30+ ----------
-        if (Build.VERSION.SDK_INT >= 30) {
-            try {
-                // WindowInsets insets = decor.getRootWindowInsets();
-                Object insets = View.class
-                        .getMethod("getRootWindowInsets")
-                        .invoke(decor);
-                if (insets == null) return false;
-
-                // int mask = WindowInsets.Type.systemBars();
-                Class<?> typeCls =
-                        Class.forName("android.view.WindowInsets$Type");
-                int systemBars = (Integer) typeCls
-                        .getMethod("systemBars")
-                        .invoke(null);
-
-                // boolean barsVisible = insets.isVisible(mask);
-                boolean barsVisible = (Boolean) insets.getClass()
-                        .getMethod("isVisible", int.class)
-                        .invoke(insets, systemBars);
-
-                /* --------------------------------------------------
-                 * Edge-to-edge is guaranteed on API 35+ anyway, and
-                 * `getDecorFitsSystemWindows()` no longer exists on
-                 * API 36.  We treat everything >=30 as edge-to-edge
-                 * (decorFits = false) and only look at bar visibility
-                 * to decide if we’re *immersive*.
-                 * -------------------------------------------------- */
-                return !barsVisible;    // immersive ⇢ bars are hidden
-            } catch (Throwable ignore) {
-                System.out.println("Error: " + ignore);
-            }
-        }
-
-        // ---------- Legacy branch : API 19-29 ----------
-        int f = decor.getSystemUiVisibility();
-        boolean immersiveBits =
-                (f & View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY) != 0 ||
-                        (f & View.SYSTEM_UI_FLAG_IMMERSIVE)        != 0;
-        boolean barsHidden =
-                (f & View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) != 0 &&
-                        (f & View.SYSTEM_UI_FLAG_FULLSCREEN)      != 0;
-        return immersiveBits && barsHidden;
+        return AndroidImplementation.isImmersive(window);
     }
 
     private static void applyImeInsetPaddingReflection(View rootView) {


### PR DESCRIPTION
This fixes both safe area insets and form bottom padding editing on android 34. By trial and error, I found that, with respect to immersive mode, android 34 behaves like android 33 and earlier unless we explicitly enable it by calling WindowCompat.setDecorFitsSystemWindows(window, false), which we don't do.  And it is not possible to detect whether this has been called. This patch adjusts immersive heuristics to check for API 35+ instead of 34+ when determining if we are drawing edge to edge on the screen.

This impacts the safe area insets implementation as well as form bottom padding editing.

As part of this, I have re-enabled the android.useSafeAreaInsets display property by default so taht we use safe area insets by default.  This can be opted out.

The reason is that on API 35+ it needs this setting to work properly.