### PR TITLE
150725_1114_AM real fix gap safe area android side 15 and others versions

### DIFF
--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -1299,13 +1299,19 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
         return isImmersive(getActivity().getWindow());
     }
     public static boolean isImmersive(Window window) {
-        if (Build.VERSION.SDK_INT >= 35) {
-            // Android 15+ is always immersive (overlay mode by default)
-            return true;
+        if (Build.VERSION.SDK_INT >= 30) {
+            try {
+                // Android 11+ supports decorFitsSystemWindows
+                Method m = Window.class.getMethod("getDecorFitsSystemWindows");
+                Boolean result = (Boolean) m.invoke(window);
+                return result != null && !result;  // Immersive = decorFitsSystemWindows == false
+            } catch (Throwable t) {
+                // Fallback: allow developer override
+                return "true".equals(Display.getInstance().getProperty("android.forceImmersive", "false"));
+            }
         }
-        // On Android 34 and below, we can't detect decorFitsSystemWindows
-        // reliably at runtime. So the app must make the decision explicitly.
-        return false;
+        // For Android < 11, use only developer override
+        return "true".equals(Display.getInstance().getProperty("android.forceImmersive", "false"));
     }
     public static Rect getSystemBarInsets(final View rootView) {
         final Rect result = new Rect(0, 0, 0, 0);

--- a/Ports/Android/src/com/codename1/impl/android/CodenameOneView.java
+++ b/Ports/Android/src/com/codename1/impl/android/CodenameOneView.java
@@ -164,9 +164,9 @@ public class CodenameOneView {
 
     private void updateSafeArea() {
         final Activity activity = CodenameOneView.this.implementation.getActivity();
-
         final Rect rect = this.safeArea;
         final View rootView = activity.getWindow().getDecorView();
+
         if (Build.VERSION.SDK_INT >= VERSION_CODE_P) {
             try {
                 Method getRootWindowInsetsMethod = View.class.getMethod("getRootWindowInsets");
@@ -176,6 +176,8 @@ public class CodenameOneView {
                     Method getDisplayCutoutMethod = windowInsetsClass.getMethod("getDisplayCutout");
                     Object cutout = getDisplayCutoutMethod.invoke(insets);
 
+                    int left = 0, top = 0, right = 0, bottom = 0;
+
                     if (cutout != null) {
                         Class<?> displayCutoutClass = Class.forName("android.view.DisplayCutout");
                         Method getSafeInsetLeft = displayCutoutClass.getMethod("getSafeInsetLeft");
@@ -183,91 +185,82 @@ public class CodenameOneView {
                         Method getSafeInsetRight = displayCutoutClass.getMethod("getSafeInsetRight");
                         Method getSafeInsetBottom = displayCutoutClass.getMethod("getSafeInsetBottom");
 
-                        int left = ((Integer) getSafeInsetLeft.invoke(cutout)).intValue();
-                        int top = ((Integer) getSafeInsetTop.invoke(cutout)).intValue();
-                        int right = ((Integer) getSafeInsetRight.invoke(cutout)).intValue();
-                        int bottom = ((Integer) getSafeInsetBottom.invoke(cutout)).intValue();
-                        boolean imeVisible = false;
-                        try {
-                            Method isVisibleMethod = insets.getClass().getMethod("isVisible", int.class);
-                            Class<?> typeClass = Class.forName("android.view.WindowInsets$Type");
-                            int imeType = ((Integer) typeClass.getMethod("ime").invoke(null)).intValue();
-                            imeVisible = (Boolean) isVisibleMethod.invoke(insets, imeType);
-                        } catch (Throwable t) {
-                            // Fallback or log
-                        }
+                        left = ((Integer) getSafeInsetLeft.invoke(cutout)).intValue();
+                        top = ((Integer) getSafeInsetTop.invoke(cutout)).intValue();
+                        right = ((Integer) getSafeInsetRight.invoke(cutout)).intValue();
+                        bottom = ((Integer) getSafeInsetBottom.invoke(cutout)).intValue();
+                    }
 
-                        Rect systemBarInsets = AndroidImplementation.getSystemBarInsets(rootView);
-                        top = Math.max(systemBarInsets.top, top);
-                        if (imeVisible) {
-                            // Avoid double-counting the bottom gesture bar
-                            bottom = Math.max(bottom, 0);
-                        } else {
-                            bottom = Math.max(systemBarInsets.bottom, bottom);
-                        }
-                        left = Math.max(systemBarInsets.left, left);
-                        right = Math.max(systemBarInsets.right, right);
+                    boolean imeVisible = false;
+                    try {
+                        Method isVisibleMethod = insets.getClass().getMethod("isVisible", int.class);
+                        Class<?> typeClass = Class.forName("android.view.WindowInsets$Type");
+                        int imeType = ((Integer) typeClass.getMethod("ime").invoke(null)).intValue();
+                        imeVisible = (Boolean) isVisibleMethod.invoke(insets, imeType);
+                    } catch (Throwable t) {
+                        // IME visibility check not available or failed
+                    }
 
-                        if (!AndroidImplementation.isImmersive()) {
-                            top -= systemBarInsets.top;
-                            if (!imeVisible) {
-                                bottom -= systemBarInsets.bottom;
+                    boolean immersive = AndroidImplementation.isImmersive(activity.getWindow());
+                    Rect systemBarInsets = AndroidImplementation.getSystemBarInsets(rootView);
+
+                    if (cutout == null) {
+                        top = systemBarInsets.top;
+                        bottom = imeVisible ? 0 : systemBarInsets.bottom;
+                        left = systemBarInsets.left;
+                        right = systemBarInsets.right;
+                    } else {
+                        top = Math.max(top, systemBarInsets.top);
+                        if (!imeVisible) {
+                            bottom = Math.max(bottom, systemBarInsets.bottom);
+                        }
+                        left = Math.max(left, systemBarInsets.left);
+                        right = Math.max(right, systemBarInsets.right);
+                    }
+
+                    if (!immersive) {
+                        top = Math.max(0, top - systemBarInsets.top);
+                        if (!imeVisible) {
+                            bottom = Math.max(0, bottom - systemBarInsets.bottom);
+                        }
+                        left = Math.max(0, left - systemBarInsets.left);
+                        right = Math.max(0, right - systemBarInsets.right);
+                    }
+
+                    boolean isChanged = rect.left != left || rect.top != top || rect.right != right || rect.bottom != bottom;
+
+                    rect.left = left;
+                    rect.top = top;
+                    rect.right = right;
+                    rect.bottom = bottom;
+
+                    if (isChanged) {
+                        Display.getInstance().callSerially(new Runnable() {
+                            public void run() {
+                                AndroidImplementation.getInstance().revalidate();
                             }
-                            left -= systemBarInsets.left;
-                            right -= systemBarInsets.right;
-                        }
-
-                        // Only apply if at least one is non-zero
-                        if (left != 0 || top != 0 || right != 0 || bottom != 0) {
-                            boolean isChanged = rect.left != left
-                                    || rect.right != right
-                                    || rect.top != top
-                                    || rect.bottom != bottom;
-                            rect.left = left;
-                            rect.top = top;
-                            rect.right = right;
-                            rect.bottom = bottom;
-
-                            if (isChanged) {
-                                Display.getInstance().callSerially(new Runnable() {
-                                    public void run() {
-                                        AndroidImplementation.getInstance().revalidate();
-                                    }
-                                });
-                            }
-                        }
+                        });
                     }
                 }
             } catch (Exception e) {
-                rect.top = 0;
-                rect.left = 0;
-                rect.right = 0;
-                rect.bottom = 0;
+                rect.set(0, 0, 0, 0);
             }
-
         } else if (Build.VERSION.SDK_INT >= VERSION_CODE_M) {
             rootView.post(new Runnable() {
                 public void run() {
                     WindowInsets insets = rootView.getRootWindowInsets();
                     if (insets != null) {
                         rect.top = insets.getSystemWindowInsetTop();
-                        rect.left = insets.getSystemWindowInsetLeft();;
+                        rect.left = insets.getSystemWindowInsetLeft();
                         rect.right = insets.getSystemWindowInsetRight();
                         rect.bottom = insets.getSystemWindowInsetBottom();
                     } else {
-                        rect.top = 0;
-                        rect.left = 0;
-                        rect.right = 0;
-                        rect.bottom = 0;
+                        rect.set(0, 0, 0, 0);
                     }
                 }
             });
         } else {
-            // For pre-Marshmallow (API < 23), assume full screen
-            rect.top = 0;
-            rect.left = 0;
-            rect.right = 0;
-            rect.bottom = 0;
+            rect.set(0, 0, 0, 0);
         }
     }
 


### PR DESCRIPTION
🐞 **Bug Summary**
In Android 11+ (including Android 15), when setDecorFitsSystemWindows(true) is active (the default), the system already applies padding for system bars (status bar, navigation bar, gesture area).

The original updateSafeArea() logic manually adds those same systemBarInsets again, resulting in double padding on the top and bottom of the screen — even when the keyboard is not visible.

This caused unwanted blank space above and below the Form content on Android 13–15.

✅ **Fix Summary**
The fix improves AndroidImplementation.isImmersive(Window) to check the actual runtime state of decorFitsSystemWindows.
Then, in updateSafeArea():

Insets are only added when Android is not already applying them (i.e. in immersive/overlay mode).

If the system already applied them, the manual padding is subtracted.

This prevents double insets and ensures consistent layout across Android versions.


✅ **Why this improvement is necessary and compatible with Android 15 and below**

📌 **Problem**
In Android 11 (API 30) and above, the method Window.setDecorFitsSystemWindows(false) allows apps to take full control of layout insets. **When this flag is set to false, Android no longer automatically applies padding for system bars (status bar, navigation bar, gesture area, etc.).**

Codename One's original implementation of isImmersive() assumed that:

Immersive mode (i.e., manual inset handling) is only enabled on Android 15+, and

Lower versions do not support this and thus always apply insets automatically.

**This logic fails in cases where:**

The developer sets setDecorFitsSystemWindows(false) manually on Android 11–14.

The framework applies system insets and the app adds them again, **causing duplicated margins or padding.** like this https://github.com/codenameone/CodenameOne/pull/3911#issuecomment-3070835117 and this **https://github.com/codenameone/CodenameOne/issues/3916#issuecomment-3067296508**

✅ **What this improvement does**
The new implementation of AndroidImplementation.isImmersive(Window window):

Uses reflection to check window.getDecorFitsSystemWindows() at runtime (API 30+).

If getDecorFitsSystemWindows() returns false, it means manual inset compensation is required.

If reflection is not available or fails (e.g., on older devices), the app can explicitly override immersive mode using a system property:

**Display.getInstance().setProperty("android.forceImmersive", "true");**
This logic is now used inside CodenameOneView.updateSafeArea() to **avoid double-applying system insets.**

🧩 **Compatibility**
✅ Android 15+ (API 35+): Still works as before, since these versions default to overlay behavior.

✅ Android 11–14 (API 30–34): Now correctly respects the developer’s use of setDecorFitsSystemWindows(false).

✅ Android 10 and below (API < 30): Safe fallback using the property override.

✅ No changes needed in user code unless they explicitly want to force immersive mode on old versions.

✅ **Result**
This change ensures that the safe area insets are:

Only applied **when needed** (i.e., when Android isn’t doing it already).

Prevents layout **bugs caused by double-padding.**

**Keeps Codename One apps visually consistent across Android versions.**



