### PR TITLE
Add plugin.xml referencing codenameone-icon.png for IntelliJ plugin ( fixes #3166)

### DIFF
--- a/maven/codenameone-maven-plugin/src/main/resources/META-INF/plugin.xml
+++ b/maven/codenameone-maven-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,0 +1,8 @@
+<idea-plugin>
+    <id>com.codename1.maven.codenameone</id>
+    <name>Codename One Maven Plugin</name>
+    <description>Codename One plugin for IntelliJ IDEA</description>
+    <version>1.0.0</version>
+    <vendor>Codename One</vendor>
+    <icon>com/codename1/maven/codenameone-icon.png</icon>
+</idea-plugin>


### PR DESCRIPTION
This PR adds the missing plugin.xml file and references the plugin icon for the Codename One Maven Plugin (IntelliJ plugin), resolving issue #3166 
