### PR TITLE
Add build guide and helper scripts

### DIFF
--- a/.github/workflows/scripts-android.yml
+++ b/.github/workflows/scripts-android.yml
@@ -1,0 +1,20 @@
+---
+name: Test Android build scripts
+
+'on':
+  push:
+    paths:
+      - 'scripts/**'
+  pull_request:
+    paths:
+      - 'scripts/**'
+
+jobs:
+  build-android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Android port
+        run: |
+          ./scripts/setup-workspace.sh -q -DskipTests
+          ./scripts/build-android-port.sh -q -DskipTests

--- a/.github/workflows/scripts-ios.yml
+++ b/.github/workflows/scripts-ios.yml
@@ -1,0 +1,20 @@
+---
+name: Test iOS build scripts
+
+'on':
+  push:
+    paths:
+      - 'scripts/**'
+  pull_request:
+    paths:
+      - 'scripts/**'
+
+jobs:
+  build-ios:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build iOS port
+        run: |
+          ./scripts/setup-workspace.sh -q -DskipTests
+          ./scripts/build-ios-port.sh -q -DskipTests

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,78 @@
+# Building Codename One
+
+This guide describes how to build Codename One and its Android and iOS ports locally using Maven. It includes reproducible steps for setting up the workspace and compiling each port.
+
+## Prerequisites
+
+- **JDK 11** for building the main project and the iOS port.
+- **JDK 17** for building the Android port.
+- **Apache Maven 3.6+**.
+
+The `setup-workspace.sh` script downloads these dependencies automatically when they are not already installed.
+
+### Installing JDKs on Linux
+
+Download binaries from [Adoptium](https://adoptium.net):
+
+```bash
+# JDK 11 (Linux x64; adjust `_x64_linux_` for your OS and architecture)
+curl -L -o temurin11.tar.gz https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.28%2B6/OpenJDK11U-jdk_x64_linux_hotspot_11.0.28_6.tar.gz
+tar xf temurin11.tar.gz
+export JAVA_HOME=$PWD/jdk-11*
+
+# JDK 17 (Linux x64; adjust `_x64_linux_` for your OS and architecture)
+curl -L -o temurin17.tar.gz https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.16%2B8/OpenJDK17U-jdk_x64_linux_hotspot_17.0.16_8.tar.gz
+tar xf temurin17.tar.gz
+export JAVA_HOME_17=$PWD/jdk-17*
+
+export PATH="$JAVA_HOME/bin:$PATH"
+```
+
+The Android port uses JDK 17 while Maven runs with JDK 11. The helper scripts download both JDKs and set `JAVA_HOME` and `JAVA_HOME_17`.
+
+## Preparing the workspace
+
+Clone the repository and run the setup script to install Maven, download JDK 11 and JDK 17, build the core modules, and install the Maven archetypes. This step must be performed before building any ports.
+
+```bash
+git clone https://github.com/codenameone/CodenameOne
+cd CodenameOne
+./scripts/setup-workspace.sh -DskipTests
+```
+
+The script runs `mvn install` in `maven/`, installs `cn1-maven-archetypes`, and ensures `~/.codenameone/CodeNameOneBuildClient.jar` is installed by invoking the `cn1:install-codenameone` Maven goal. If that goal fails, the script copies the jar from `maven/CodeNameOneBuildClient.jar`.
+
+## Building the Android port
+
+Run the Android build script. It requires `JAVA_HOME` pointing to JDK 11 and `JAVA_HOME_17` pointing to JDK 17. If these variables are unset, the script will look for the JDKs under `tools/` as provisioned by `setup-workspace.sh`:
+
+```bash
+./scripts/build-android-port.sh -DskipTests
+```
+
+The resulting artifacts are placed in `maven/android/target`.
+
+## Building the iOS port
+
+The iOS port can only be built on macOS with Xcode installed. The build script expects `JAVA_HOME` to point to JDK 11 and will search `tools/` if it is not set:
+
+```bash
+./scripts/build-ios-port.sh -DskipTests
+```
+
+The build output is in `maven/ios/target`.
+
+## Convenience scripts
+
+The `scripts` directory contains helper scripts:
+
+- `setup-workspace.sh` – installs Maven, downloads JDK 11 and JDK 17, builds the core modules, installs Maven archetypes, and provisions the Codename One build client.
+- `build-android-port.sh` – builds the Android port using JDK 11 for Maven and JDK 17 for compilation.
+- `build-ios-port.sh` – builds the iOS port on macOS with JDK 11.
+
+These scripts accept additional Maven arguments, which are passed through to the underlying `mvn` commands.
+
+## Further reading
+
+- Blog post: *Building Codename One from source, Maven edition* – https://www.codenameone.com/blog/building-codename-one-from-source-maven-edition.html
+- Maven developers guide – https://shannah.github.io/codenameone-maven-manual/

--- a/scripts/build-android-port.sh
+++ b/scripts/build-android-port.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Build Codename One Android port
+set -e
+
+DIR="$(cd "$(dirname "$0")" && pwd)/.."
+cd "$DIR"
+
+# Locate JDK 11
+if [ -z "$JAVA_HOME" ] || ! "$JAVA_HOME/bin/java" -version 2>&1 | head -n1 | grep -q "11"; then
+  JAVA_HOME=$(ls -d "$DIR"/tools/jdk-11* 2>/dev/null | head -n1)
+fi
+if [ -z "$JAVA_HOME" ] || ! "$JAVA_HOME/bin/java" -version 2>&1 | head -n1 | grep -q "11"; then
+  echo "JAVA_HOME must point to JDK 11." >&2
+  exit 1
+fi
+
+# Locate JDK 17
+if [ -z "$JAVA_HOME_17" ] || ! "$JAVA_HOME_17/bin/java" -version 2>&1 | head -n1 | grep -q "17"; then
+  JAVA_HOME_17=$(ls -d "$DIR"/tools/jdk-17* 2>/dev/null | head -n1)
+fi
+if [ -z "$JAVA_HOME_17" ] || ! "$JAVA_HOME_17/bin/java" -version 2>&1 | head -n1 | grep -q "17"; then
+  echo "JAVA_HOME_17 must point to JDK 17." >&2
+  exit 1
+fi
+
+export PATH="$JAVA_HOME/bin:$PATH"
+
+BUILD_CLIENT="$HOME/.codenameone/CodeNameOneBuildClient.jar"
+if [ ! -f "$BUILD_CLIENT" ]; then
+  if ! mvn -f maven/pom.xml cn1:install-codenameone "$@"; then
+    if [ -f maven/CodeNameOneBuildClient.jar ]; then
+      mkdir -p "$(dirname "$BUILD_CLIENT")"
+      cp maven/CodeNameOneBuildClient.jar "$BUILD_CLIENT"
+    else
+      echo "maven/CodeNameOneBuildClient.jar not found." >&2
+    fi
+  fi
+fi
+
+mvn -f maven/pom.xml -pl android -am clean install "$@"

--- a/scripts/build-ios-port.sh
+++ b/scripts/build-ios-port.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Build Codename One iOS port
+# Requires macOS with Xcode installed
+set -e
+
+if [[ "$(uname)" != "Darwin" ]]; then
+  echo "The iOS port can only be built on macOS." >&2
+  exit 1
+fi
+if ! command -v xcodebuild >/dev/null; then
+  echo "Xcode command-line tools not found." >&2
+  exit 1
+fi
+
+DIR="$(cd "$(dirname "$0")" && pwd)/.."
+cd "$DIR"
+
+# Locate JDK 11
+if [ -z "$JAVA_HOME" ]; then
+  JAVA_HOME=$(ls -d "$DIR"/tools/jdk-11* 2>/dev/null | head -n1)
+fi
+if [ -z "$JAVA_HOME" ] || ! "$JAVA_HOME/bin/java" -version 2>&1 | head -n1 | grep -q "11"; then
+  echo "JAVA_HOME must point to JDK 11." >&2
+  exit 1
+fi
+
+export PATH="$JAVA_HOME/bin:$PATH"
+
+BUILD_CLIENT="$HOME/.codenameone/CodeNameOneBuildClient.jar"
+if [ ! -f "$BUILD_CLIENT" ]; then
+  if ! mvn -f maven/pom.xml cn1:install-codenameone "$@"; then
+    if [ -f maven/CodeNameOneBuildClient.jar ]; then
+      mkdir -p "$(dirname "$BUILD_CLIENT")"
+      cp maven/CodeNameOneBuildClient.jar "$BUILD_CLIENT"
+    else
+      echo "maven/CodeNameOneBuildClient.jar not found." >&2
+    fi
+  fi
+fi
+
+mvn -f maven/pom.xml -pl ios -am clean install "$@"

--- a/scripts/setup-workspace.sh
+++ b/scripts/setup-workspace.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Prepare Codename One workspace by installing Maven, provisioning JDK 11 and JDK 17,
+# building core modules, and installing Maven archetypes
+set -e
+DIR="$(cd "$(dirname "$0")" && pwd)/.."
+cd "$DIR"
+
+TOOLS_DIR="$DIR/tools"
+mkdir -p "$TOOLS_DIR"
+
+ensure_jdk() {
+  local envvar="$1" version="$2" url="$3"
+  local current="${!envvar}"
+  if [ -z "$current" ] || ! "$current/bin/java" -version 2>&1 | head -n1 | grep -q "$version"; then
+    local existing=$(ls -d "$TOOLS_DIR"/jdk-$version* 2>/dev/null | head -n1)
+    if [ -z "$existing" ]; then
+      echo "Downloading JDK $version (this may take a while)..."
+      local archive="$TOOLS_DIR/jdk$version.tar.gz"
+      curl -L -o "$archive" "$url"
+      tar -xzf "$archive" -C "$TOOLS_DIR"
+      rm "$archive"
+      existing=$(ls -d "$TOOLS_DIR"/jdk-$version* | head -n1)
+    fi
+    export "$envvar"="$existing"
+  fi
+}
+
+ensure_maven() {
+  if ! command -v mvn >/dev/null; then
+    local version="3.9.6"
+    local archive="$TOOLS_DIR/apache-maven-$version-bin.tar.gz"
+    echo "Downloading Maven $version..."
+    curl -L -o "$archive" "https://archive.apache.org/dist/maven/maven-3/$version/binaries/apache-maven-$version-bin.tar.gz"
+    tar -xzf "$archive" -C "$TOOLS_DIR"
+    rm "$archive"
+    MAVEN_HOME="$TOOLS_DIR/apache-maven-$version"
+    export PATH="$MAVEN_HOME/bin:$PATH"
+  fi
+}
+
+detect_platform() {
+  case "$(uname -s)" in
+    Linux) platform="linux" ;;
+    Darwin) platform="mac" ;;
+    *) echo "Unsupported OS: $(uname -s)" >&2; exit 1 ;;
+  esac
+
+  case "$(uname -m)" in
+    x86_64|amd64) arch="x64" ;;
+    arm64|aarch64) arch="aarch64" ;;
+    *) echo "Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+  esac
+}
+
+detect_platform
+
+JDK11_URL="https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.28%2B6/"\
+"OpenJDK11U-jdk_${arch}_${platform}_hotspot_11.0.28_6.tar.gz"
+JDK17_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.16%2B8/"\
+"OpenJDK17U-jdk_${arch}_${platform}_hotspot_17.0.16_8.tar.gz"
+
+ensure_jdk JAVA_HOME 11 "$JDK11_URL"
+ensure_jdk JAVA_HOME_17 17 "$JDK17_URL"
+
+ensure_maven
+
+export PATH="$JAVA_HOME/bin:$PATH"
+
+mvn -f maven/pom.xml install "$@"
+
+BUILD_CLIENT="$HOME/.codenameone/CodeNameOneBuildClient.jar"
+if [ ! -f "$BUILD_CLIENT" ]; then
+  echo "Installing Codename One build client..."
+  if ! mvn -f maven/pom.xml cn1:install-codenameone "$@"; then
+    echo "Falling back to manual copy of build client jar." >&2
+    if [ -f maven/CodeNameOneBuildClient.jar ]; then
+      mkdir -p "$(dirname "$BUILD_CLIENT")"
+      cp maven/CodeNameOneBuildClient.jar "$BUILD_CLIENT"
+    else
+      echo "maven/CodeNameOneBuildClient.jar not found." >&2
+    fi
+  fi
+fi
+
+if [ ! -d cn1-maven-archetypes ]; then
+  git clone https://github.com/shannah/cn1-maven-archetypes
+fi
+(
+  cd cn1-maven-archetypes
+  mvn install "$@"
+)


### PR DESCRIPTION
## Summary
- Document unified setup script that installs Maven and downloads JDK 11 and JDK 17 before building core modules
- Simplify Android and iOS build scripts to reuse provisioned JDKs and drop redundant bootstrap helper
- Expand build guide to reflect new prerequisites and helper scripts
- Add CI workflows that build Android and iOS ports when scripts change, relying on the scripts themselves to provision JDKs

## Testing
- `yamllint .github/workflows/scripts-android.yml .github/workflows/scripts-ios.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a13836ae20833182c5b0ac5d0482bf