### PR TITLE
Disable doclint to prevent Javadoc failures

### DIFF
--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -332,6 +332,7 @@
                         <source>1.8</source>
                         <show>protected</show>
                         <failOnError>false</failOnError>
+                        <doclint>none</doclint>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -398,7 +399,11 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.2.0</version>
                 <configuration>
-                    <additionalOptions>--allow-script-in-comments</additionalOptions>
+                    <doclint>none</doclint>
+                    <failOnError>false</failOnError>
+                    <additionalOptions>
+                        <additionalOption>--allow-script-in-comments</additionalOption>
+                    </additionalOptions>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## Summary
- Disable doclint and failure on error for Maven Javadoc plugin so CLDC sources generate documentation without strict checks.

## Testing
- `mvn -q -pl java-runtime -f maven/pom.xml javadoc:javadoc` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b30dd30afc833196997978247e31cd