### PR TITLE
Add build guide and helper scripts

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,12 +1,18 @@
 name: PR CI
 
-on:   
+on:
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - 'scripts/**'
+      - '**/*.md'
   push:
     branches:
       - master
+    paths-ignore:
+      - 'scripts/**'
+      - '**/*.md'
 
 jobs:
   build-linux-jdk8-fx:

--- a/.github/workflows/scripts-android.yml
+++ b/.github/workflows/scripts-android.yml
@@ -1,0 +1,30 @@
+---
+name: Test Android build scripts
+
+'on':
+  pull_request:
+    paths:
+      - 'scripts/**'
+      - 'BUILDING.md'
+  push:
+    branches:
+      - master
+    paths:
+      - 'scripts/**'
+      - 'BUILDING.md'
+
+jobs:
+  build-android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup workspace
+        run: ./scripts/setup-workspace.sh -q -DskipTests
+      - name: Build Android port
+        run: |
+          source tools/env.sh
+          echo "JAVA_HOME=$JAVA_HOME"
+          java -version
+          echo "JAVA_HOME_17=$JAVA_HOME_17"
+          "$JAVA_HOME_17/bin/java" -version
+          ./scripts/build-android-port.sh -q -DskipTests

--- a/.github/workflows/scripts-ios.yml
+++ b/.github/workflows/scripts-ios.yml
@@ -1,0 +1,28 @@
+---
+name: Test iOS build scripts
+
+'on':
+  pull_request:
+    paths:
+      - 'scripts/**'
+      - 'BUILDING.md'
+  push:
+    branches:
+      - master
+    paths:
+      - 'scripts/**'
+      - 'BUILDING.md'
+
+jobs:
+  build-ios:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup workspace
+        run: ./scripts/setup-workspace.sh -q -DskipTests
+      - name: Build iOS port
+        run: |
+          source tools/env.sh
+          echo "JAVA_HOME=$JAVA_HOME"
+          java -version
+          ./scripts/build-ios-port.sh -q -DskipTests

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,76 @@
+# Building Codename One
+
+This guide provides reproducible steps to build Codename One locally with Maven, including its Android and iOS ports.
+
+## Prerequisites
+
+- **JDK 8**
+- **JDK 17** for building the Android port
+- **Apache Maven 3.6+**
+- macOS with Xcode (required only for the iOS port)
+
+The helper scripts in the `scripts/` directory download these dependencies when they are not already installed. On Apple Silicon
+macOS machines, the scripts download the Intel JDK 8 and run it via Rosetta because an ARM build of JDK 8 is unavailable.
+
+### Installing JDKs on Linux
+
+Download binaries from [Adoptium](https://adoptium.net):
+
+```bash
+# JDK 8 (Linux x64; adjust `_x64_linux_` for your platform)
+curl -L -o temurin8.tar.gz https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u462-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u462b08.tar.gz
+tar xf temurin8.tar.gz
+export JAVA_HOME=$PWD/jdk8u462-b08
+
+# JDK 17 (Linux x64; adjust `_x64_linux_` for your platform)
+curl -L -o temurin17.tar.gz https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.16%2B8/OpenJDK17U-jdk_x64_linux_hotspot_17.0.16_8.tar.gz
+tar xf temurin17.tar.gz
+export JAVA_HOME_17=$PWD/jdk-17.0.16+8
+
+export PATH="$JAVA_HOME/bin:$PATH"
+```
+
+## Preparing the workspace
+
+Clone the repository and run the setup script to download JDK 8 and JDK 17, install Maven, build the core modules, and install the Maven archetypes. This step must be performed before building any ports.
+
+```bash
+git clone https://github.com/codenameone/CodenameOne
+cd CodenameOne
+./scripts/setup-workspace.sh -DskipTests
+source tools/env.sh
+```
+
+The script runs `mvn install` in `maven/`, installs `cn1-maven-archetypes`, and ensures `~/.codenameone/CodeNameOneBuildClient.jar` is installed by invoking the `cn1:install-codenameone` Maven goal. If that goal fails, the script copies the jar from `maven/CodeNameOneBuildClient.jar`. After the script finishes, `tools/env.sh` contains environment variables for the provisioned JDKs and Maven.
+
+## Building the Android port
+
+The Android port uses JDK 17 for compilation while Maven runs with JDK 8. Javadoc generation is skipped to avoid known Maven
+report issues. Run the build script:
+
+```bash
+./scripts/build-android-port.sh -DskipTests
+```
+
+Artifacts are placed in `maven/android/target`.
+
+## Building the iOS port
+
+The iOS port can only be built on macOS with Xcode installed. Run the iOS script:
+
+```bash
+./scripts/build-ios-port.sh -DskipTests
+```
+
+Artifacts are produced in `maven/ios/target`.
+
+## Convenience scripts
+
+- `setup-workspace.sh` – installs Maven, downloads JDK 8 and JDK 17, builds the core modules, installs Maven archetypes, provisions the Codename One build client, and writes `tools/env.sh`.
+- `build-android-port.sh` – builds the Android port using JDK 8 for Maven and JDK 17 for compilation.
+- `build-ios-port.sh` – builds the iOS port on macOS with JDK 8.
+
+## Further reading
+
+- Blog post: <https://www.codenameone.com/blog/building-codename-one-from-source-maven-edition.html>
+- Maven developers guide: <https://shannah.github.io/codenameone-maven-manual/>

--- a/scripts/build-android-port.sh
+++ b/scripts/build-android-port.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Build Codename One Android port using JDK 8 for Maven and JDK 17 for compilation
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+if [ -f "$ROOT/tools/env.sh" ]; then
+  source "$ROOT/tools/env.sh"
+else
+  ./scripts/setup-workspace.sh -q -DskipTests
+  source "$ROOT/tools/env.sh"
+fi
+
+if ! "${JAVA_HOME:-}/bin/java" -version 2>&1 | grep -q '1\.8'; then
+  ./scripts/setup-workspace.sh -q -DskipTests
+  source "$ROOT/tools/env.sh"
+fi
+if ! "${JAVA_HOME:-}/bin/java" -version 2>&1 | grep -q '1\.8'; then
+  echo "Failed to provision JDK 8" >&2
+  exit 1
+fi
+if ! "${JAVA_HOME_17:-}/bin/java" -version 2>&1 | grep -q '17\.0'; then
+  ./scripts/setup-workspace.sh -q -DskipTests
+  source "$ROOT/tools/env.sh"
+fi
+if ! "${JAVA_HOME_17:-}/bin/java" -version 2>&1 | grep -q '17\.0'; then
+  echo "Failed to provision JDK 17" >&2
+  exit 1
+fi
+
+export PATH="$JAVA_HOME/bin:$MAVEN_HOME/bin:$PATH"
+"$JAVA_HOME/bin/java" -version
+"$JAVA_HOME_17/bin/java" -version
+"$MAVEN_HOME/bin/mvn" -version
+
+BUILD_CLIENT="$HOME/.codenameone/CodeNameOneBuildClient.jar"
+if [ ! -f "$BUILD_CLIENT" ]; then
+  if ! "$MAVEN_HOME/bin/mvn" -q -f maven/pom.xml cn1:install-codenameone "$@"; then
+    [ -f maven/CodeNameOneBuildClient.jar ] && cp maven/CodeNameOneBuildClient.jar "$BUILD_CLIENT" || true
+  fi
+fi
+
+"$MAVEN_HOME/bin/mvn" -q -f maven/pom.xml -pl android -am -Dmaven.javadoc.skip=true clean install "$@"

--- a/scripts/build-ios-port.sh
+++ b/scripts/build-ios-port.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Build Codename One iOS port (macOS only)
+set -euo pipefail
+if [[ "$(uname)" != "Darwin" ]]; then
+  echo "The iOS port can only be built on macOS with Xcode installed." >&2
+  exit 1
+fi
+if ! command -v xcodebuild >/dev/null; then
+  echo "Xcode command-line tools not found." >&2
+  exit 1
+fi
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+if [ -f "$ROOT/tools/env.sh" ]; then
+  source "$ROOT/tools/env.sh"
+else
+  ./scripts/setup-workspace.sh -q -DskipTests
+  source "$ROOT/tools/env.sh"
+fi
+if ! "${JAVA_HOME:-}/bin/java" -version 2>&1 | grep -q '1\.8'; then
+  ./scripts/setup-workspace.sh -q -DskipTests
+  source "$ROOT/tools/env.sh"
+fi
+if ! "${JAVA_HOME:-}/bin/java" -version 2>&1 | grep -q '1\.8'; then
+  echo "Failed to provision JDK 8" >&2
+  exit 1
+fi
+export PATH="$JAVA_HOME/bin:$MAVEN_HOME/bin:$PATH"
+"$JAVA_HOME/bin/java" -version
+"$MAVEN_HOME/bin/mvn" -version
+
+BUILD_CLIENT="$HOME/.codenameone/CodeNameOneBuildClient.jar"
+if [ ! -f "$BUILD_CLIENT" ]; then
+  if ! "$MAVEN_HOME/bin/mvn" -q -f maven/pom.xml cn1:install-codenameone "$@"; then
+    [ -f maven/CodeNameOneBuildClient.jar ] && cp maven/CodeNameOneBuildClient.jar "$BUILD_CLIENT" || true
+  fi
+fi
+
+"$MAVEN_HOME/bin/mvn" -q -f maven/pom.xml -pl ios -am clean install "$@"

--- a/scripts/setup-workspace.sh
+++ b/scripts/setup-workspace.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Prepare Codename One workspace by installing Maven, provisioning JDK 8 and JDK 17,
+# building core modules, and installing Maven archetypes.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TOOLS="$ROOT/tools"
+mkdir -p "$TOOLS"
+
+JAVA_HOME="${JAVA_HOME:-}"
+JAVA_HOME_17="${JAVA_HOME_17:-}"
+MAVEN_HOME="${MAVEN_HOME:-}"
+
+os_name=$(uname -s)
+arch_name=$(uname -m)
+case "$os_name" in
+  Linux) os="linux" ;;
+  Darwin) os="mac" ;;
+  *) echo "Unsupported OS: $os_name" >&2; exit 1 ;;
+  esac
+case "$arch_name" in
+  x86_64|amd64) arch="x64" ;;
+  arm64|aarch64) arch="aarch64" ;;
+  *) echo "Unsupported architecture: $arch_name" >&2; exit 1 ;;
+esac
+
+# JDK 8 is not available for Apple Silicon. Use the Intel build when running on macOS ARM.
+jdk8_arch="$arch"
+jdk17_arch="$arch"
+if [ "$os" = "mac" ] && [ "$arch" = "aarch64" ]; then
+  jdk8_arch="x64"
+fi
+
+JDK8_URL="https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u462-b08/OpenJDK8U-jdk_${jdk8_arch}_${os}_hotspot_8u462b08.tar.gz"
+JDK17_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.16%2B8/OpenJDK17U-jdk_${jdk17_arch}_${os}_hotspot_17.0.16_8.tar.gz"
+MAVEN_URL="https://archive.apache.org/dist/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz"
+
+install_jdk() {
+  local url="$1" dest_var="$2"
+  local tmp="$TOOLS/jdk.tgz"
+  echo "Downloading JDK from $url"
+  curl -fL "$url" -o "$tmp"
+  local top
+  top=$(tar -tzf "$tmp" 2>/dev/null | head -1 | cut -d/ -f1 || true)
+  tar -xzf "$tmp" -C "$TOOLS"
+  rm "$tmp"
+  local home="$TOOLS/$top"
+  if [ -d "$home/Contents/Home" ]; then
+    home="$home/Contents/Home"
+  fi
+  eval "$dest_var=\"$home\""
+}
+
+if [ ! -x "${JAVA_HOME:-}/bin/java" ] || ! "${JAVA_HOME:-}/bin/java" -version 2>&1 | grep -q '1\.8'; then
+  echo "Provisioning JDK 8 (this may take a while)..."
+  install_jdk "$JDK8_URL" JAVA_HOME
+fi
+
+if [ ! -x "${JAVA_HOME_17:-}/bin/java" ] || ! "${JAVA_HOME_17:-}/bin/java" -version 2>&1 | grep -q '17\.0'; then
+  echo "Provisioning JDK 17 (this may take a while)..."
+  install_jdk "$JDK17_URL" JAVA_HOME_17
+fi
+
+if ! [ -x "${MAVEN_HOME:-}/bin/mvn" ]; then
+  echo "Downloading Maven from $MAVEN_URL"
+  tmp="$TOOLS/maven.tgz"
+  curl -fL "$MAVEN_URL" -o "$tmp"
+  tar -xzf "$tmp" -C "$TOOLS"
+  rm "$tmp"
+  MAVEN_HOME="$TOOLS/apache-maven-3.9.6"
+fi
+
+cat > "$TOOLS/env.sh" <<ENV
+export JAVA_HOME="$JAVA_HOME"
+export JAVA_HOME_17="$JAVA_HOME_17"
+export MAVEN_HOME="$MAVEN_HOME"
+export PATH="\$JAVA_HOME/bin:\$MAVEN_HOME/bin:\$PATH"
+ENV
+
+source "$TOOLS/env.sh"
+
+"$JAVA_HOME/bin/java" -version
+"$JAVA_HOME_17/bin/java" -version
+"$MAVEN_HOME/bin/mvn" -version
+
+PATH="$JAVA_HOME/bin:$MAVEN_HOME/bin:$PATH"
+("$MAVEN_HOME/bin/mvn" -q -f maven/pom.xml install "$@")
+
+BUILD_CLIENT="$HOME/.codenameone/CodeNameOneBuildClient.jar"
+if [ ! -f "$BUILD_CLIENT" ]; then
+  if ! "$MAVEN_HOME/bin/mvn" -q -f maven/pom.xml cn1:install-codenameone "$@"; then
+    mkdir -p "$(dirname "$BUILD_CLIENT")"
+    cp maven/CodeNameOneBuildClient.jar "$BUILD_CLIENT" || true
+  fi
+fi
+
+if [ ! -d cn1-maven-archetypes ]; then
+  git clone https://github.com/shannah/cn1-maven-archetypes
+fi
+(cd cn1-maven-archetypes && "$MAVEN_HOME/bin/mvn" -q -DskipTests -DskipITs install)


### PR DESCRIPTION
## Summary
- Provide reproducible build instructions in `BUILDING.md` and note Apple Silicon uses Intel JDK 8
- Auto-detect macOS ARM in `setup-workspace.sh` and fetch the x64 JDK 8
- Skip Javadoc generation during Android port builds to avoid MavenReportException errors
- Skip archetype integration tests during workspace setup to prevent Android build failures

## Testing
- `yamllint .github/workflows/scripts-android.yml .github/workflows/scripts-ios.yml`
- `./scripts/setup-workspace.sh -q -DskipTests` *(fails: Unresolveable build extension; Network is unreachable)*
- `source tools/env.sh && ./scripts/build-android-port.sh -q -DskipTests` *(fails: Unresolveable build extension; Network is unreachable)*
- `source tools/env.sh && ./scripts/build-ios-port.sh -q -DskipTests` *(fails: The iOS port can only be built on macOS with Xcode installed.)*

------
https://chatgpt.com/codex/tasks/task_e_68a13836ae20833182c5b0ac5d0482bf