### PR TITLE
Capture Codename One UI screenshot through Android view rendering

### DIFF
--- a/.github/workflows/scripts-android.yml
+++ b/.github/workflows/scripts-android.yml
@@ -23,3 +23,10 @@ jobs:
         run: ./scripts/build-android-port.sh -q -DskipTests
       - name: Build Hello Codename One Android app
         run: ./scripts/build-android-app.sh -q -DskipTests
+      - name: Upload UI test screenshot artifact
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: hello-codenameone-ui-test-screenshot
+          path: ${{ env.CN1_UI_TEST_SCREENSHOT }}
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 **/.idea/*
 **/build/*
 **/dist/*
+build-artifacts/
 *.zip
 CodenameOneDesigner/src/version.properties
 /Ports/iOSPort/build/

--- a/scripts/templates/HelloCodenameOneUiTest.java.tmpl
+++ b/scripts/templates/HelloCodenameOneUiTest.java.tmpl
@@ -1,0 +1,176 @@
+package @PACKAGE@;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.util.DisplayMetrics;
+import android.view.View;
+
+import com.codename1.ui.Display;
+import com.codename1.ui.Form;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 30)
+public class @MAIN_NAME@UiTest {
+
+    @Test
+    public void mainFormScreenshotContainsRenderedContent() throws Exception {
+        ActivityController<@MAIN_NAME@Stub> controller = Robolectric.buildActivity(@MAIN_NAME@Stub.class).setup();
+        try {
+            Form displayed = waitForDisplayedForm(5000L);
+            assertNotNull("Codename One form should be displayed", displayed);
+
+            @MAIN_NAME@Stub activity = controller.get();
+            Bitmap screenshot = captureScreenshot(activity);
+            assertNotNull("Screenshot capture should succeed", screenshot);
+            assertTrue("Screenshot width should be positive", screenshot.getWidth() > 0);
+            assertTrue("Screenshot height should be positive", screenshot.getHeight() > 0);
+            assertTrue("Screenshot should contain rendered content beyond the background", hasRenderableContent(screenshot));
+
+            File screenshotFile = saveScreenshot(screenshot);
+            assertTrue("Screenshot file should exist", screenshotFile.isFile());
+            assertTrue("Screenshot file should not be empty", screenshotFile.length() > 0L);
+        } finally {
+            controller.pause().stop().destroy();
+        }
+    }
+
+    private static Form waitForDisplayedForm(long timeoutMillis) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMillis;
+        final Form[] current = new Form[1];
+        while (System.currentTimeMillis() < deadline) {
+            if (Display.isInitialized()) {
+                Display.getInstance().callSeriallyAndWait(() -> current[0] = Display.getInstance().getCurrent());
+                if (current[0] != null) {
+                    return current[0];
+                }
+            }
+            Thread.sleep(50L);
+        }
+        throw new AssertionError("Timed out waiting for Codename One form to be displayed");
+    }
+
+    private static Bitmap captureScreenshot(@MAIN_NAME@Stub activity) throws InterruptedException {
+        View decorView = waitForDecorViewWithDimensions(activity, 5000L);
+        Bitmap bitmap = Bitmap.createBitmap(decorView.getWidth(), decorView.getHeight(), Bitmap.Config.ARGB_8888);
+        runOnUiThreadAndWait(activity, () -> {
+            Canvas canvas = new Canvas(bitmap);
+            decorView.draw(canvas);
+        });
+        return bitmap;
+    }
+
+    private static boolean hasRenderableContent(Bitmap screenshot) {
+        int width = screenshot.getWidth();
+        int height = screenshot.getHeight();
+        if (width <= 0 || height <= 0) {
+            return false;
+        }
+        int[] pixels = new int[width * height];
+        screenshot.getPixels(pixels, 0, width, 0, 0, width, height);
+        if (pixels.length == 0) {
+            return false;
+        }
+        int background = pixels[0];
+        int contentPixels = 0;
+        for (int argb : pixels) {
+            int alpha = (argb >>> 24) & 0xFF;
+            if (alpha == 0) {
+                continue;
+            }
+            if (argb != background) {
+                contentPixels++;
+                if (contentPixels > width) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static File saveScreenshot(Bitmap screenshot) throws IOException {
+        String directory = System.getenv("CN1_TEST_SCREENSHOT_DIR");
+        File outputDir = (directory != null && !directory.isEmpty()) ? new File(directory) : new File("build/ui-test-screenshots");
+        if (!outputDir.exists() && !outputDir.mkdirs()) {
+            throw new IOException("Failed to create screenshot directory " + outputDir.getAbsolutePath());
+        }
+        File screenshotFile = new File(outputDir, "@MAIN_NAME@-ui-test.png");
+        try (FileOutputStream out = new FileOutputStream(screenshotFile)) {
+            if (!screenshot.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                throw new IOException("Failed to encode screenshot as PNG");
+            }
+        }
+        return screenshotFile;
+    }
+
+    private static View waitForDecorViewWithDimensions(@MAIN_NAME@Stub activity, long timeoutMillis) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMillis;
+        while (System.currentTimeMillis() < deadline) {
+            View decorView = activity.getWindow().getDecorView();
+            if (decorView != null) {
+                ensureViewHasLayout(activity, decorView);
+                if (decorView.getWidth() > 0 && decorView.getHeight() > 0) {
+                    return decorView;
+                }
+            }
+            Thread.sleep(50L);
+        }
+        throw new AssertionError("Timed out waiting for decor view layout");
+    }
+
+    private static void ensureViewHasLayout(@MAIN_NAME@Stub activity, View view) throws InterruptedException {
+        if (view.getWidth() > 0 && view.getHeight() > 0) {
+            return;
+        }
+        runOnUiThreadAndWait(activity, () -> {
+            DisplayMetrics metrics = activity.getResources().getDisplayMetrics();
+            int widthSpec = View.MeasureSpec.makeMeasureSpec(metrics.widthPixels, View.MeasureSpec.EXACTLY);
+            int heightSpec = View.MeasureSpec.makeMeasureSpec(metrics.heightPixels, View.MeasureSpec.EXACTLY);
+            view.measure(widthSpec, heightSpec);
+            view.layout(0, 0, view.getMeasuredWidth(), view.getMeasuredHeight());
+        });
+    }
+
+    private static void runOnUiThreadAndWait(@MAIN_NAME@Stub activity, Runnable runnable) throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        activity.runOnUiThread(() -> {
+            try {
+                runnable.run();
+            } catch (Throwable t) {
+                error.set(t);
+            } finally {
+                latch.countDown();
+            }
+        });
+        if (!latch.await(5, TimeUnit.SECONDS)) {
+            throw new AssertionError("Timed out waiting for UI thread task");
+        }
+        if (error.get() != null) {
+            Throwable thrown = error.get();
+            if (thrown instanceof RuntimeException) {
+                throw (RuntimeException) thrown;
+            }
+            if (thrown instanceof Error) {
+                throw (Error) thrown;
+            }
+            throw new RuntimeException(thrown);
+        }
+    }
+}

--- a/scripts/update_android_ui_test_gradle.py
+++ b/scripts/update_android_ui_test_gradle.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Utility to inject Robolectric UI test settings into an Android Gradle module."""
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+
+def ensure_test_options(content: str) -> str:
+    if "unitTests.includeAndroidResources" in content:
+        return content
+
+    pattern = re.compile(r"(android\s*\{\s*\r?\n)")
+    match = pattern.search(content)
+    if not match:
+        raise SystemExit("Unable to locate android block in Gradle file")
+
+    injection = (
+        "    testOptions {\n"
+        "        unitTests.includeAndroidResources = true\n"
+        "    }\n\n"
+    )
+    start, end = match.span(1)
+    return content[:end] + injection + content[end:]
+
+
+def ensure_dependencies(content: str) -> str:
+    if "org.robolectric:robolectric" in content:
+        return content
+
+    additions = (
+        "    testImplementation 'junit:junit:4.13.2'\n"
+        "    testImplementation 'androidx.test:core:1.5.0'\n"
+        "    testImplementation 'org.robolectric:robolectric:4.11.1'\n"
+        "    androidTestImplementation 'androidx.test.ext:junit:1.1.5'\n"
+        "    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'\n"
+        "    androidTestImplementation 'androidx.test:rules:1.5.0'\n"
+        "    androidTestImplementation 'androidx.test:runner:1.5.2'\n"
+    )
+
+    pattern = re.compile(r"dependencies\s*\{\s*\r?\n", re.MULTILINE)
+    matches = list(pattern.finditer(content))
+    if not matches:
+        raise SystemExit("Unable to locate dependencies block in Gradle file")
+
+    target = matches[-1] if len(matches) == 1 else matches[1]
+    insert_at = target.end()
+    return content[:insert_at] + additions + content[insert_at:]
+
+
+def process_gradle_file(path: pathlib.Path) -> None:
+    content = path.read_text(encoding="utf-8")
+    updated = ensure_test_options(content)
+    updated = ensure_dependencies(updated)
+    if updated != content:
+        path.write_text(updated, encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("gradle_file", type=pathlib.Path, help="Path to module build.gradle file")
+    args = parser.parse_args(argv)
+
+    if not args.gradle_file.is_file():
+        parser.error(f"Gradle file not found: {args.gradle_file}")
+
+    process_gradle_file(args.gradle_file)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- replace the Codename One captureScreen call with native Android decor view rendering to generate the UI test screenshot
- ensure the decor view is measured and laid out before capture and run the draw on the Android UI thread with robust error handling

## Testing
- Not run (requires configured Android SDK workspace)

------
https://chatgpt.com/codex/tasks/task_e_68e2aa8c33048331b04eb6698f35e7d1