### PR TITLE
Disable specific SpotBugs detectors reporting false positives

### DIFF
--- a/maven/core-unittests/pom.xml
+++ b/maven/core-unittests/pom.xml
@@ -63,6 +63,7 @@
                     <failOnError>false</failOnError>
                     <xmlOutput>true</xmlOutput>
                     <xmlOutputDirectory>${project.build.directory}</xmlOutputDirectory>
+                    <excludeFilterFile>${project.basedir}/spotbugs-exclude.xml</excludeFilterFile>
                 </configuration>
                 <executions>
                     <execution>

--- a/maven/core-unittests/spotbugs-exclude.xml
+++ b/maven/core-unittests/spotbugs-exclude.xml
@@ -1,0 +1,11 @@
+<FindBugsFilter>
+    <Match>
+        <Bug pattern="ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD"/>
+    </Match>
+    <Match>
+        <Bug pattern="DM_GC"/>
+    </Match>
+    <Match>
+        <Bug pattern="CN_IMPLEMENTS_CLONE_BUT_NOT_CLONEABLE"/>
+    </Match>
+</FindBugsFilter>


### PR DESCRIPTION
## Summary
- add a SpotBugs exclude filter for detectors that report frequent false positives
- configure the SpotBugs Maven plugin to use the new exclude filter

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f25c1c4f8883319436048bb5dddf39