### PR TITLE
Add extensive tests for Purchase and processing utilities

### DIFF
--- a/maven/core-unittests/src/test/java/com/codename1/payment/PurchaseTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/payment/PurchaseTest.java
@@ -9,7 +9,6 @@ import com.codename1.util.SuccessCallback;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -196,14 +195,18 @@ public class PurchaseTest {
     }
 
     @Test
-    public void testGetReceiptsThrowsWhenStoredDataHasUnexpectedType() {
+    public void testGetReceiptsReturnsEmptyListWhenStoredDataHasUnexpectedType() {
         Storage.getInstance().writeObject(receiptsKey, "bad-data");
+        Storage.getInstance().clearCache();
 
-        assertThrows(ClassCastException.class, new Executable() {
-            public void execute() throws Throwable {
-                purchase.getReceipts();
-            }
-        });
+        List<Receipt> receipts = purchase.getReceipts();
+        assertNotNull(receipts, "Receipts list should be initialized");
+        assertTrue(receipts.isEmpty(), "Unexpected types should produce an empty cache");
+
+        List<Receipt> secondCall = purchase.getReceipts();
+        assertSame(receipts, secondCall, "Receipts cache should be reused after invalid data");
+        assertEquals("bad-data", Storage.getInstance().readObject(receiptsKey),
+                "Storage contents should remain untouched when data cannot be cast");
     }
 
     @Test

--- a/maven/core-unittests/src/test/java/com/codename1/processing/ProcessingPackageTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/processing/ProcessingPackageTest.java
@@ -103,8 +103,8 @@ public class ProcessingPackageTest {
 
         result.mapNamespaceAlias("http://example.com/schema", "alias");
         assertEquals("Namespace", result.getAsString("/root/alias:entry"));
-        assertEquals("External", result.getAsString("/root/alias:entry/@value"));
-        assertEquals("X", result.getAsString("/root/alias:entry/@alias:code"));
+        assertEquals("External", result.getAsString("/root/alias:entry[0]/@value"));
+        assertEquals("X", result.getAsString("/root/alias:entry[0]/@ex:code"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add unit tests around Purchase covering receipt persistence, subscription logic, and synchronization flows
- add processing package tests that exercise Result extraction, tokenization, and evaluator factory dispatch

## Testing
- mvn -f maven/core-unittests/pom.xml test *(fails: missing dependency com.codenameone:codenameone-factory:jar:8.0-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68f66399efe88331ae7f93c50f7d252e