### PR TITLE
Restore developer guide metadata attributes

### DIFF
--- a/.github/workflows/developer-guide-docs.yml
+++ b/.github/workflows/developer-guide-docs.yml
@@ -21,6 +21,24 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Update publication metadata for release
+        if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          REV_DATE="$(date -u +%Y-%m-%d)"
+          VERSION="${RELEASE_TAG:-}"
+          if [ -z "$VERSION" ] && [ -n "${GITHUB_REF_NAME:-}" ]; then
+            VERSION="$GITHUB_REF_NAME"
+          fi
+          VERSION="${VERSION#v}"
+          if [ -z "$VERSION" ]; then
+            VERSION="UNKNOWN"
+          fi
+          sed -i -E "s/^:revdate: .*/:revdate: ${REV_DATE}/" docs/developer-guide/developer-guide.asciidoc
+          sed -i -E "s/^:revnumber: .*/:revnumber: ${VERSION}/" docs/developer-guide/developer-guide.asciidoc
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/docs/developer-guide/developer-guide.asciidoc
+++ b/docs/developer-guide/developer-guide.asciidoc
@@ -18,18 +18,27 @@
 :uuid: 92CA37B2-EB2B-4B8F-AC7C-1ED13683F7FB
 :front-cover-image: image:img/cover.png[Front Cover,1000,1600]
 :lang: en-US
-//:revdate: 2018-07-22
+:revdate: 2025-10-20
+:revnumber: DEV-SNAPSHOT
 :doctitle: Codename One Developer Guide
-:author: Shai Almog, Steve Hannah and Chen Fishbein
-:producer: Codename One Academy
+:author: Codename One Documentation Team; Shai Almog; Steve Hannah; Chen Fishbein
 :description: Build native mobile apps in Java
 :keywords: java, android, ios, iphone, mobile development
 :copyright: Codename One, all rights reserved
 :publication-type: book
+:producer: Codename One Ltd.
+:partnums:
+
+= {doctitle}
+{author}
+
+toc::[]
 
 include::About-This-Guide.asciidoc[]
 
-include::index.asciidoc[]
+= Part I. Foundations
+
+include::Index.asciidoc[]
 
 include::basics.asciidoc[]
 
@@ -39,15 +48,17 @@ include::Advanced-Theming.asciidoc[]
 
 include::css.asciidoc[]
 
+= Part II. User Interface and Experience
+
 include::The-Components-Of-Codename-One.asciidoc[]
 
 include::Animations.asciidoc[]
 
 include::The-EDT---Event-Dispatch-Thread.asciidoc[]
 
-include::Monetization.asciidoc[]
-
 include::graphics.asciidoc[]
+
+= Part III. Application Services
 
 include::Events.asciidoc[]
 
@@ -59,7 +70,13 @@ include::Miscellaneous-Features.asciidoc[]
 
 include::performance.asciidoc[]
 
+include::Monetization.asciidoc[]
+
+= Part IV. Platform and Deployment
+
 include::Advanced-Topics-Under-The-Hood.asciidoc[]
+
+include::security.asciidoc[]
 
 include::signing.asciidoc[]
 
@@ -67,12 +84,14 @@ include::Working-With-iOS.asciidoc[]
 
 include::Working-With-Javascript.asciidoc[]
 
-include::Working-with-UWP.asciidoc[]
-
 include::Working-with-Mac-OS-X.asciidoc[]
 
-include::security.asciidoc[]
-
-include::Travis-CI-Integration.asciidoc[]
+= Part V. Contributing and Appendices
 
 include::Working-With-CodenameOne-Sources.asciidoc[]
+
+= Historical Reference
+
+include::Working-with-UWP.asciidoc[]
+
+include::Travis-CI-Integration.asciidoc[]


### PR DESCRIPTION
## Summary
- restore the developer guide's doctitle and author Asciidoctor attributes alongside the manual heading so the publication pipeline retains required metadata

## Testing
- not run (asciidoctor command not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f678b223b88331953a91e8ba189c51