### PR TITLE
Add unit tests for transition animations

### DIFF
--- a/maven/core-unittests/src/test/java/com/codename1/ui/animations/CommonTransitionsTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/animations/CommonTransitionsTest.java
@@ -1,0 +1,201 @@
+package com.codename1.ui.animations;
+
+import com.codename1.test.UITestBase;
+import com.codename1.ui.Image;
+import com.codename1.util.LazyValue;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link CommonTransitions}.
+ */
+public class CommonTransitionsTest extends UITestBase {
+    private boolean originalDefaultLinearMotion;
+
+    @BeforeEach
+    public void captureDefaultLinearMotion() {
+        originalDefaultLinearMotion = CommonTransitions.isDefaultLinearMotion();
+    }
+
+    @AfterEach
+    public void restoreDefaultLinearMotion() {
+        CommonTransitions.setDefaultLinearMotion(originalDefaultLinearMotion);
+    }
+
+    @Test
+    public void testCreateSlideHorizontal() {
+        CommonTransitions transition = CommonTransitions.createSlide(CommonTransitions.SLIDE_HORIZONTAL, true, 300);
+        assertTrue(transition.isHorizontalSlide());
+        assertFalse(transition.isVerticalSlide());
+        assertTrue(transition.isForwardSlide());
+        assertEquals(300, transition.getTransitionSpeed());
+    }
+
+    @Test
+    public void testCreateSlideVerticalCopyReverse() {
+        CommonTransitions transition = CommonTransitions.createSlide(CommonTransitions.SLIDE_VERTICAL, false, 400);
+        assertTrue(transition.isVerticalSlide());
+        assertFalse(transition.isHorizontalSlide());
+        assertFalse(transition.isForwardSlide());
+
+        CommonTransitions reversed = (CommonTransitions) transition.copy(true);
+        assertNotSame(transition, reversed);
+        assertTrue(reversed.isVerticalSlide());
+        assertTrue(reversed.isForwardSlide());
+        assertEquals(transition.getTransitionSpeed(), reversed.getTransitionSpeed());
+    }
+
+    @Test
+    public void testCreateCoverAndUncoverCopies() {
+        CommonTransitions cover = CommonTransitions.createCover(CommonTransitions.SLIDE_HORIZONTAL, true, 200);
+        assertTrue(cover.isHorizontalCover());
+        CommonTransitions coverCopy = (CommonTransitions) cover.copy(false);
+        assertNotSame(cover, coverCopy);
+        assertTrue(coverCopy.isHorizontalCover());
+        assertEquals(cover.getTransitionSpeed(), coverCopy.getTransitionSpeed());
+
+        CommonTransitions uncover = CommonTransitions.createUncover(CommonTransitions.SLIDE_VERTICAL, false, 220);
+        CommonTransitions reverseUncover = (CommonTransitions) uncover.copy(true);
+        assertTrue(reverseUncover.isForwardSlide());
+        assertEquals(CommonTransitions.SLIDE_VERTICAL, getPrivateInt(reverseUncover, "slideType"));
+    }
+
+    @Test
+    public void testFadeAndTimelineCopies() throws Exception {
+        CommonTransitions fade = CommonTransitions.createFade(250);
+        CommonTransitions fadeCopy = (CommonTransitions) fade.copy(false);
+        assertNotSame(fade, fadeCopy);
+        assertEquals(250, fadeCopy.getTransitionSpeed());
+
+        Image timeline = Image.createImage(10, 10);
+        CommonTransitions timelineTransition = CommonTransitions.createTimeline(timeline);
+        CommonTransitions timelineCopy = (CommonTransitions) timelineTransition.copy(false);
+        assertNotSame(timelineTransition, timelineCopy);
+
+        Field timelineField = CommonTransitions.class.getDeclaredField("timeline");
+        timelineField.setAccessible(true);
+        assertSame(timeline, timelineField.get(timelineCopy));
+    }
+
+    @Test
+    public void testDialogPulsateAndEmptyCopy() {
+        CommonTransitions empty = CommonTransitions.createEmpty();
+        CommonTransitions emptyCopy = (CommonTransitions) empty.copy(false);
+        assertNotSame(empty, emptyCopy);
+
+        CommonTransitions pulsate = CommonTransitions.createDialogPulsate();
+        CommonTransitions pulsateCopy = (CommonTransitions) pulsate.copy(false);
+        assertNotSame(pulsate, pulsateCopy);
+    }
+
+    @Test
+    public void testSlideFadeTitleCopyReverse() {
+        CommonTransitions transition = CommonTransitions.createSlideFadeTitle(true, 180);
+        assertTrue(transition.isForwardSlide());
+
+        CommonTransitions reversed = (CommonTransitions) transition.copy(true);
+        assertNotSame(transition, reversed);
+        assertFalse(reversed.isForwardSlide());
+        assertEquals(transition.getTransitionSpeed(), reversed.getTransitionSpeed());
+    }
+
+    @Test
+    public void testDefaultLinearMotionPropagation() {
+        CommonTransitions.setDefaultLinearMotion(true);
+        CommonTransitions linearTransition = CommonTransitions.createSlide(CommonTransitions.SLIDE_HORIZONTAL, true, 120);
+        assertTrue(linearTransition.isLinearMotion());
+
+        CommonTransitions.setDefaultLinearMotion(false);
+        CommonTransitions easedTransition = CommonTransitions.createSlide(CommonTransitions.SLIDE_HORIZONTAL, true, 120);
+        assertFalse(easedTransition.isLinearMotion());
+
+        linearTransition.setLinearMotion(false);
+        assertFalse(linearTransition.isLinearMotion());
+    }
+
+    @Test
+    public void testManualMotionUsage() throws Exception {
+        CommonTransitions transition = CommonTransitions.createSlide(CommonTransitions.SLIDE_HORIZONTAL, true, 100);
+        Motion manualMotion = Motion.createLinearMotion(0, 10, 10);
+        manualMotion.start();
+        manualMotion.setCurrentMotionTime(20);
+        transition.setMotion(manualMotion);
+
+        assertTrue(transition.animate());
+
+        Field firstFinishedField = CommonTransitions.class.getDeclaredField("firstFinished");
+        firstFinishedField.setAccessible(true);
+        assertTrue(firstFinishedField.getBoolean(transition));
+
+        Field positionField = CommonTransitions.class.getDeclaredField("position");
+        positionField.setAccessible(true);
+        assertEquals(manualMotion.getValue(), positionField.getInt(transition));
+
+        assertFalse(transition.animate());
+    }
+
+    @Test
+    public void testLazyMotionFactory() throws Exception {
+        CommonTransitions transition = CommonTransitions.createSlide(CommonTransitions.SLIDE_HORIZONTAL, true, 100);
+        final int expectedStart = 5;
+        final int expectedDest = 15;
+        final int expectedSpeed = 25;
+        transition.setMotion(new LazyValue<Motion>() {
+            public Motion get(Object... args) {
+                assertEquals(expectedStart, ((Integer) args[0]).intValue());
+                assertEquals(expectedDest, ((Integer) args[1]).intValue());
+                assertEquals(expectedSpeed, ((Integer) args[2]).intValue());
+                Motion m = Motion.createLinearMotion(expectedStart, expectedDest, expectedSpeed);
+                m.start();
+                return m;
+            }
+        });
+
+        Method createMotion = CommonTransitions.class.getDeclaredMethod("createMotion", int.class, int.class, int.class);
+        createMotion.setAccessible(true);
+        Motion produced = (Motion) createMotion.invoke(transition, expectedStart, expectedDest, expectedSpeed);
+        assertNotNull(produced);
+        assertEquals(expectedStart, produced.getSourceValue());
+        assertEquals(expectedDest, produced.getDestinationValue());
+    }
+
+    @Test
+    public void testManualMotionDirectInstance() throws Exception {
+        CommonTransitions transition = CommonTransitions.createSlide(CommonTransitions.SLIDE_HORIZONTAL, true, 100);
+        Motion manual = Motion.createLinearMotion(3, 9, 30);
+        transition.setMotion(manual);
+
+        Method createMotion = CommonTransitions.class.getDeclaredMethod("createMotion", int.class, int.class, int.class);
+        createMotion.setAccessible(true);
+        Motion produced = (Motion) createMotion.invoke(transition, 1, 2, 3);
+        assertSame(manual, produced);
+    }
+
+    @Test
+    public void testCreateFastSlideUsesMutableImageHint() {
+        when(implementation.areMutableImagesFast()).thenReturn(false);
+        CommonTransitions slow = CommonTransitions.createFastSlide(CommonTransitions.SLIDE_HORIZONTAL, true, 90);
+        assertTrue(slow.isHorizontalSlide());
+
+        when(implementation.areMutableImagesFast()).thenReturn(true);
+        CommonTransitions fast = CommonTransitions.createFastSlide(CommonTransitions.SLIDE_HORIZONTAL, true, 90);
+        assertTrue(fast.isHorizontalSlide());
+    }
+
+    private int getPrivateInt(CommonTransitions transition, String fieldName) {
+        try {
+            Field f = CommonTransitions.class.getDeclaredField(fieldName);
+            f.setAccessible(true);
+            return f.getInt(transition);
+        } catch (Exception ex) {
+            throw new AssertionError(ex);
+        }
+    }
+}

--- a/maven/core-unittests/src/test/java/com/codename1/ui/animations/FlipTransitionTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/animations/FlipTransitionTest.java
@@ -1,0 +1,148 @@
+package com.codename1.ui.animations;
+
+import com.codename1.test.UITestBase;
+import com.codename1.ui.Form;
+import com.codename1.ui.Label;
+import com.codename1.ui.geom.Dimension;
+import com.codename1.ui.layouts.LayeredLayout;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link FlipTransition}.
+ */
+public class FlipTransitionTest extends UITestBase {
+
+    @Test
+    public void testDefaultConfiguration() {
+        FlipTransition transition = new FlipTransition();
+        assertEquals(200, transition.getDuration());
+        assertEquals(-1, transition.getBgColor());
+    }
+
+    @Test
+    public void testCustomConfiguration() {
+        FlipTransition transition = new FlipTransition(0x123456, 450);
+        assertEquals(450, transition.getDuration());
+        assertEquals(0x123456, transition.getBgColor());
+
+        transition.setDuration(300);
+        transition.setBgColor(0x654321);
+        assertEquals(300, transition.getDuration());
+        assertEquals(0x654321, transition.getBgColor());
+    }
+
+    @Test
+    public void testCopyProducesNewInstance() {
+        FlipTransition transition = new FlipTransition(0x111111, 350);
+        FlipTransition copy = (FlipTransition) transition.copy(false);
+        assertNotSame(transition, copy);
+        assertEquals(transition.getDuration(), copy.getDuration());
+        assertEquals(transition.getBgColor(), copy.getBgColor());
+    }
+
+    @Test
+    public void testInitTransitionPreparesBuffers() throws Exception {
+        FlipTransition transition = new FlipTransition(0, 10);
+        Form source = createForm("source");
+        Form destination = createForm("destination");
+        transition.init(source, destination);
+        transition.initTransition();
+
+        Field sourceBufferField = FlipTransition.class.getDeclaredField("sourceBuffer");
+        sourceBufferField.setAccessible(true);
+        assertNotNull(sourceBufferField.get(transition));
+
+        Field destBufferField = FlipTransition.class.getDeclaredField("destBuffer");
+        destBufferField.setAccessible(true);
+        assertNotNull(destBufferField.get(transition));
+
+        Field motionField = FlipTransition.class.getDeclaredField("motion");
+        motionField.setAccessible(true);
+        Motion motion = (Motion) motionField.get(transition);
+        assertNotNull(motion);
+
+        Field stateField = FlipTransition.class.getDeclaredField("transitionState");
+        stateField.setAccessible(true);
+        int state = stateField.getInt(transition);
+        assertEquals(getStaticIntField("STATE_MOVE_AWAY"), state);
+    }
+
+    @Test
+    public void testAnimateProgressesStates() throws Exception {
+        FlipTransition transition = new FlipTransition(0, 5);
+        Form source = createForm("source");
+        Form destination = createForm("destination");
+        transition.init(source, destination);
+        transition.initTransition();
+
+        Field motionField = FlipTransition.class.getDeclaredField("motion");
+        motionField.setAccessible(true);
+        Field stateField = FlipTransition.class.getDeclaredField("transitionState");
+        stateField.setAccessible(true);
+
+        Motion motion = (Motion) motionField.get(transition);
+        motion.setCurrentMotionTime(transition.getDuration() + 1);
+        assertTrue(transition.animate());
+        assertEquals(getStaticIntField("STATE_FLIP"), stateField.getInt(transition));
+
+        motion = (Motion) motionField.get(transition);
+        motion.setCurrentMotionTime(transition.getDuration() + 1);
+        assertTrue(transition.animate());
+        assertEquals(getStaticIntField("STATE_MOVE_CLOSER"), stateField.getInt(transition));
+
+        motion = (Motion) motionField.get(transition);
+        motion.setCurrentMotionTime(transition.getDuration() + 1);
+        assertFalse(transition.animate());
+    }
+
+    @Test
+    public void testCleanupReleasesBuffers() throws Exception {
+        FlipTransition transition = new FlipTransition();
+        Form source = createForm("source");
+        Form destination = createForm("destination");
+        transition.init(source, destination);
+        transition.initTransition();
+
+        transition.cleanup();
+
+        Field sourceBufferField = FlipTransition.class.getDeclaredField("sourceBuffer");
+        sourceBufferField.setAccessible(true);
+        assertNull(sourceBufferField.get(transition));
+
+        Field destBufferField = FlipTransition.class.getDeclaredField("destBuffer");
+        destBufferField.setAccessible(true);
+        assertNull(destBufferField.get(transition));
+    }
+
+    private Form createForm(String name) {
+        Form form = new Form();
+        form.setName(name);
+        form.setWidth(240);
+        form.setHeight(320);
+        form.getContentPane().setWidth(240);
+        form.getContentPane().setHeight(320);
+        form.getContentPane().setLayout(new LayeredLayout());
+
+        Label label = new Label(name);
+        label.setName(name + "Label");
+        label.setPreferredSize(new Dimension(80, 40));
+        label.setWidth(80);
+        label.setHeight(40);
+        label.setX(20);
+        label.setY(30);
+        form.add(label);
+        form.layoutContainer();
+        form.getContentPane().layoutContainer();
+        return form;
+    }
+
+    private int getStaticIntField(String name) throws Exception {
+        Field field = FlipTransition.class.getDeclaredField(name);
+        field.setAccessible(true);
+        return field.getInt(null);
+    }
+}

--- a/maven/core-unittests/src/test/java/com/codename1/ui/animations/MorphTransitionTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/animations/MorphTransitionTest.java
@@ -1,0 +1,190 @@
+package com.codename1.ui.animations;
+
+import com.codename1.test.UITestBase;
+import com.codename1.ui.Component;
+import com.codename1.ui.Container;
+import com.codename1.ui.Form;
+import com.codename1.ui.Label;
+import com.codename1.ui.layouts.LayeredLayout;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link MorphTransition}.
+ */
+public class MorphTransitionTest extends UITestBase {
+
+    @Test
+    public void testMorphMappingAndCopy() throws Exception {
+        MorphTransition transition = MorphTransition.create(300)
+                .morph("a")
+                .morph("b", "c");
+
+        Field fromToField = MorphTransition.class.getDeclaredField("fromTo");
+        fromToField.setAccessible(true);
+        Map<?, ?> mapping = (Map<?, ?>) fromToField.get(transition);
+        assertEquals("a", mapping.get("a"));
+        assertEquals("c", mapping.get("b"));
+
+        MorphTransition reversed = (MorphTransition) transition.copy(true);
+        Map<?, ?> reversedMap = (Map<?, ?>) fromToField.get(reversed);
+        assertEquals("b", reversedMap.get("c"));
+        assertEquals("a", reversedMap.get("a"));
+    }
+
+    @Test
+    public void testInitTransitionSetsUpComponents() throws Exception {
+        Form source = createFormWithComponent("sourceForm", "shared", 10, 20, 40, 30);
+        Form destination = createFormWithComponent("destinationForm", "shared", 120, 150, 80, 60);
+
+        MorphTransition transition = MorphTransition.create(200).morph("shared");
+        transition.init(source, destination);
+        transition.initTransition();
+
+        Field componentsField = MorphTransition.class.getDeclaredField("fromToComponents");
+        componentsField.setAccessible(true);
+        Object[] ccArray = (Object[]) componentsField.get(transition);
+        assertNotNull(ccArray);
+        assertTrue(ccArray.length > 0);
+        assertNotNull(ccArray[0]);
+
+        Field motionField = MorphTransition.class.getDeclaredField("animationMotion");
+        motionField.setAccessible(true);
+        Motion animationMotion = (Motion) motionField.get(transition);
+        assertNotNull(animationMotion);
+
+        Field finishedField = MorphTransition.class.getDeclaredField("finished");
+        finishedField.setAccessible(true);
+        assertFalse(finishedField.getBoolean(transition));
+
+        Object cc = ccArray[0];
+        Class<?> ccClass = cc.getClass();
+        Field xMotionField = ccClass.getDeclaredField("xMotion");
+        xMotionField.setAccessible(true);
+        Motion xMotion = (Motion) xMotionField.get(cc);
+        xMotion.setCurrentMotionTime(transitionTime(animationMotion, 100));
+
+        Field yMotionField = ccClass.getDeclaredField("yMotion");
+        yMotionField.setAccessible(true);
+        Motion yMotion = (Motion) yMotionField.get(cc);
+        yMotion.setCurrentMotionTime(transitionTime(animationMotion, 100));
+
+        Field wMotionField = ccClass.getDeclaredField("wMotion");
+        wMotionField.setAccessible(true);
+        Motion wMotion = (Motion) wMotionField.get(cc);
+        wMotion.setCurrentMotionTime(transitionTime(animationMotion, 100));
+
+        Field hMotionField = ccClass.getDeclaredField("hMotion");
+        hMotionField.setAccessible(true);
+        Motion hMotion = (Motion) hMotionField.get(cc);
+        hMotion.setCurrentMotionTime(transitionTime(animationMotion, 100));
+
+        assertTrue(transition.animate());
+
+        Label sourceLabel = findLabel(source, "shared");
+        Label destLabel = findLabel(destination, "shared");
+        assertEquals(xMotion.getValue(), sourceLabel.getX());
+        assertEquals(yMotion.getValue(), sourceLabel.getY());
+        assertEquals(wMotion.getValue(), sourceLabel.getWidth());
+        assertEquals(hMotion.getValue(), sourceLabel.getHeight());
+        assertEquals(sourceLabel.getX(), destLabel.getX());
+        assertEquals(sourceLabel.getY(), destLabel.getY());
+    }
+
+    @Test
+    public void testAnimateCompletionRestoresComponents() throws Exception {
+        Form source = createFormWithComponent("sourceForm", "alpha", 5, 15, 50, 35);
+        Form destination = createFormWithComponent("destinationForm", "alpha", 100, 120, 90, 70);
+
+        Container sourceParent = source.getContentPane();
+        Container destinationParent = destination.getContentPane();
+        Label sourceLabel = findLabel(source, "alpha");
+        Label destinationLabel = findLabel(destination, "alpha");
+
+        MorphTransition transition = MorphTransition.create(150).morph("alpha");
+        transition.init(source, destination);
+        transition.initTransition();
+
+        Field motionField = MorphTransition.class.getDeclaredField("animationMotion");
+        motionField.setAccessible(true);
+        Motion animationMotion = (Motion) motionField.get(transition);
+        animationMotion.setCurrentMotionTime(transitionTime(animationMotion, 1000));
+        assertTrue(transition.animate());
+
+        Field componentsField = MorphTransition.class.getDeclaredField("fromToComponents");
+        componentsField.setAccessible(true);
+        assertNull(componentsField.get(transition));
+
+        Field finishedField = MorphTransition.class.getDeclaredField("finished");
+        finishedField.setAccessible(true);
+        assertTrue(finishedField.getBoolean(transition));
+
+        assertSame(sourceParent, sourceLabel.getParent());
+        assertSame(destinationParent, destinationLabel.getParent());
+        assertFalse(transition.animate());
+    }
+
+    private int transitionTime(Motion motion, int offset) {
+        return motion.getDuration() + offset;
+    }
+
+    private Form createFormWithComponent(String formName, String componentName, int x, int y, int w, int h) {
+        Form form = new Form(new LayeredLayout());
+        form.setName(formName);
+        form.setWidth(240);
+        form.setHeight(320);
+        form.getContentPane().setWidth(240);
+        form.getContentPane().setHeight(320);
+        form.getContentPane().setLayout(new LayeredLayout());
+
+        Label label = new Label(componentName);
+        label.setName(componentName);
+        label.setWidth(w);
+        label.setHeight(h);
+        label.setPreferredSize(new com.codename1.ui.geom.Dimension(w, h));
+        label.setX(x);
+        label.setY(y);
+        form.add(label);
+        form.layoutContainer();
+        form.getContentPane().layoutContainer();
+        return form;
+    }
+
+    private Label findLabel(Container root, String name) {
+        Label label = findLabelRecursive(root, name);
+        if (label != null) {
+            return label;
+        }
+        if (root instanceof Form) {
+            Form form = (Form) root;
+            label = findLabelRecursive(form.getLayeredPane(), name);
+            if (label != null) {
+                return label;
+            }
+        }
+        throw new IllegalStateException("Label not found: " + name);
+    }
+
+    private Label findLabelRecursive(Container container, String name) {
+        if (container == null) {
+            return null;
+        }
+        for (int i = 0; i < container.getComponentCount(); i++) {
+            Component cmp = container.getComponentAt(i);
+            if (cmp instanceof Label && name.equals(cmp.getName())) {
+                return (Label) cmp;
+            }
+            if (cmp instanceof Container) {
+                Label nested = findLabelRecursive((Container) cmp, name);
+                if (nested != null) {
+                    return nested;
+                }
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- add a CommonTransitions test suite covering creation helpers, motion customization, and copying behavior
- add FlipTransition tests validating configuration, state transitions, cleanup, and buffer preparation
- add MorphTransition tests covering morph mapping, initialization workflow, and animation completion restoration

## Testing
- `mvn -f maven/core-unittests/pom.xml -Dtest=CommonTransitionsTest,FlipTransitionTest,MorphTransitionTest test -DunitTests=true -Djacoco.skip=true`


------
https://chatgpt.com/codex/tasks/task_e_68f836fd520483318ac9c92e0ada301d