### PR TITLE
Document chart usage in Javadoc and developer guide

### DIFF
--- a/CodenameOne/src/com/codename1/charts/views/BarChart.java
+++ b/CodenameOne/src/com/codename1/charts/views/BarChart.java
@@ -32,7 +32,27 @@ import java.util.List;
 
 
 /**
- * The bar chart rendering class.
+ * Renders a bar chart based on an {@link XYMultipleSeriesDataset}.
+ * <p>
+ * Create an instance together with a matching {@link XYMultipleSeriesRenderer}
+ * and wrap it in a {@link com.codename1.charts.ChartComponent} to display it in
+ * the UI. A minimal setup looks like this:
+ *
+ * <pre>
+ * XYMultipleSeriesDataset dataset = new XYMultipleSeriesDataset();
+ * dataset.addSeries(mySeries);
+ *
+ * XYMultipleSeriesRenderer renderer = new XYMultipleSeriesRenderer();
+ * renderer.addSeriesRenderer(new XYSeriesRenderer());
+ *
+ * BarChart chart = new BarChart(dataset, renderer, BarChart.Type.DEFAULT);
+ * Form form = new Form(new BorderLayout());
+ * form.add(BorderLayout.CENTER, new ChartComponent(chart));
+ * form.show();
+ * </pre>
+ *
+ * The {@link Type} supplied to the constructor controls whether the bars are
+ * rendered in their default style, stacked or heaped.
  */
 public class BarChart extends XYChart {
     /** The constant to identify this chart type. */

--- a/CodenameOne/src/com/codename1/charts/views/BubbleChart.java
+++ b/CodenameOne/src/com/codename1/charts/views/BubbleChart.java
@@ -28,7 +28,14 @@ import java.util.List;
 
 
 /**
- * The bubble chart rendering class.
+ * Displays series of {@link XYValueSeries} entries as proportional bubbles on
+ * top of an {@link XYChart} plot.
+ * <p>
+ * Combine the chart with an {@link XYMultipleSeriesDataset} that contains one
+ * or more {@link XYValueSeries} instances and supply an
+ * {@link XYMultipleSeriesRenderer}. The resulting {@code BubbleChart} can be
+ * wrapped in a {@link com.codename1.charts.ChartComponent} to embed it inside a
+ * Codename One UI.
  */
 public class BubbleChart extends XYChart {
     /** The constant to identify this chart type. */

--- a/CodenameOne/src/com/codename1/charts/views/CombinedXYChart.java
+++ b/CodenameOne/src/com/codename1/charts/views/CombinedXYChart.java
@@ -29,7 +29,15 @@ import java.util.List;
 
 
 /**
- * The combined XY chart rendering class.
+ * Aggregates multiple {@link XYChart} implementations into a single plot so
+ * different series can be visualised using different renderers (for example a
+ * line overlaid on top of a bar chart).
+ * <p>
+ * Provide the constructor with an {@link XYMultipleSeriesDataset}, a matching
+ * {@link XYMultipleSeriesRenderer} and an array of
+ * {@link XYCombinedChartDef} instances that describe which inner chart type
+ * should render each data series. The combined chart can then be wrapped in a
+ * {@link com.codename1.charts.ChartComponent} for display.
  */
 public class CombinedXYChart extends XYChart {
 

--- a/CodenameOne/src/com/codename1/charts/views/CubicLineChart.java
+++ b/CodenameOne/src/com/codename1/charts/views/CubicLineChart.java
@@ -28,7 +28,13 @@ import java.util.List;
 
 
 /**
- * The interpolated (cubic) line chart rendering class.
+ * Draws smooth curves through XY series values using cubic interpolation.
+ * <p>
+ * Use this chart when you want to emphasise the trend between points rather
+ * than the raw straight-line segments of {@link LineChart}. Supply the
+ * {@link XYMultipleSeriesDataset} and {@link XYMultipleSeriesRenderer} as usual
+ * and pass an optional smoothness factor to control how tightly the curve
+ * follows the provided data points.
  */
 public class CubicLineChart extends LineChart {
     /** The chart type. */

--- a/CodenameOne/src/com/codename1/charts/views/DialChart.java
+++ b/CodenameOne/src/com/codename1/charts/views/DialChart.java
@@ -27,7 +27,12 @@ import com.codename1.ui.Component;
 
 
 /**
- * The dial chart rendering class.
+ * Presents values from a {@link CategorySeries} as gauges on a dial.
+ * <p>
+ * Configure the dial appearance via a {@link DialRenderer} and supply both the
+ * dataset and renderer to the constructor. Dial charts are typically wrapped in
+ * a {@link com.codename1.charts.ChartComponent} so they can be placed inside
+ * regular Codename One layouts.
  */
 public class DialChart extends RoundChart {
     /** The radius of the needle. */

--- a/CodenameOne/src/com/codename1/charts/views/DoughnutChart.java
+++ b/CodenameOne/src/com/codename1/charts/views/DoughnutChart.java
@@ -29,7 +29,13 @@ import java.util.List;
 
 
 /**
- * The doughnut chart rendering class.
+ * Visualises a {@link MultipleCategorySeries} as concentric rings that share a
+ * common centre (also known as a doughnut chart).
+ * <p>
+ * Each category in the dataset is drawn as a separate ring, making it suitable
+ * for representing hierarchical proportions. Construct the chart with the
+ * dataset and a {@link DefaultRenderer} and wrap it in a
+ * {@link com.codename1.charts.ChartComponent} to place it on screen.
  */
 public class DoughnutChart extends RoundChart {
     /** The series dataset. */

--- a/CodenameOne/src/com/codename1/charts/views/LineChart.java
+++ b/CodenameOne/src/com/codename1/charts/views/LineChart.java
@@ -29,7 +29,12 @@ import java.util.List;
 
 
 /**
- * The line chart rendering class.
+ * Plots series of X/Y points using straight line segments.
+ * <p>
+ * Supply the chart with an {@link XYMultipleSeriesDataset} and configure its
+ * appearance via an {@link XYMultipleSeriesRenderer}. The chart is commonly
+ * wrapped in a {@link com.codename1.charts.ChartComponent} before being added
+ * to a Codename One form.
  */
 public class LineChart extends XYChart {
     /** The constant to identify this chart type. */

--- a/CodenameOne/src/com/codename1/charts/views/PieChart.java
+++ b/CodenameOne/src/com/codename1/charts/views/PieChart.java
@@ -33,7 +33,11 @@ import java.util.List;
 
 
 /**
- * The pie chart rendering class.
+ * Shows each value from a {@link CategorySeries} as a slice of a circle.
+ * <p>
+ * Combine this chart with a {@link DefaultRenderer} to control colours, labels
+ * and gradients. The resulting {@code PieChart} can be embedded in a form via a
+ * {@link com.codename1.charts.ChartComponent}.
  */
 public class PieChart extends RoundChart {
     /** Handles returning values when tapping on PieChart. */

--- a/CodenameOne/src/com/codename1/charts/views/RadarChart.java
+++ b/CodenameOne/src/com/codename1/charts/views/RadarChart.java
@@ -28,7 +28,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * The radar chart rendering class.
+ * Draws multi-dimensional data as a web chart (also known as a radar or spider
+ * chart).
+ * <p>
+ * The chart consumes an {@link AreaSeries} where each category represents an
+ * axis radiating from the centre. Configure colours and labelling through a
+ * {@link DefaultRenderer} and wrap the instance in a
+ * {@link com.codename1.charts.ChartComponent} to present it inside your UI.
  */
 public class RadarChart extends RoundChart {
 

--- a/CodenameOne/src/com/codename1/charts/views/RangeBarChart.java
+++ b/CodenameOne/src/com/codename1/charts/views/RangeBarChart.java
@@ -27,7 +27,13 @@ import java.util.List;
 
 
 /**
- * The range bar chart rendering class.
+ * Extends {@link BarChart} to support values that represent ranges rather than
+ * single points. Each bar is drawn from the lower value to the upper value in
+ * the dataset.
+ * <p>
+ * Use this chart with an {@link XYMultipleSeriesDataset} containing
+ * {@link XYSeries} instances where consecutive entries form the minimum/maximum
+ * pair for a category.
  */
 public class RangeBarChart extends BarChart {
     /** The chart type. */

--- a/CodenameOne/src/com/codename1/charts/views/RoundChart.java
+++ b/CodenameOne/src/com/codename1/charts/views/RoundChart.java
@@ -25,7 +25,13 @@ import com.codename1.charts.renderers.SimpleSeriesRenderer;
 import com.codename1.ui.Component;
 
 /**
- * An abstract class to be extended by round like chart rendering classes.
+ * Base class for charts that render circular data representations such as pie
+ * charts, doughnut charts or gauges.
+ * <p>
+ * Subclasses operate on {@link CategorySeries} data and share common
+ * functionality for drawing the chart title, legend entries and handling
+ * layout. Developers typically work with concrete subclasses such as
+ * {@link PieChart} or {@link DoughnutChart} directly.
  */
 public abstract class RoundChart extends AbstractChart {
     /** The legend shape width. */

--- a/CodenameOne/src/com/codename1/charts/views/ScatterChart.java
+++ b/CodenameOne/src/com/codename1/charts/views/ScatterChart.java
@@ -27,7 +27,12 @@ import java.util.List;
 
 
 /**
- * The scatter chart rendering class.
+ * Renders discrete X/Y points without connecting lines.
+ * <p>
+ * Configure the marker style through {@link XYSeriesRenderer#setPointStyle} and
+ * related options on the {@link XYMultipleSeriesRenderer}. As with other
+ * charts, wrap the instance in a {@link com.codename1.charts.ChartComponent} to
+ * place it on a form.
  */
 public class ScatterChart extends XYChart {
     /** The constant to identify this chart type. */

--- a/CodenameOne/src/com/codename1/charts/views/TimeChart.java
+++ b/CodenameOne/src/com/codename1/charts/views/TimeChart.java
@@ -32,7 +32,12 @@ import java.util.TimeZone;
 
 
 /**
- * The time chart rendering class.
+ * Specialised {@link LineChart} that formats the X axis as dates or times.
+ * <p>
+ * Populate the chart with an {@link XYMultipleSeriesDataset} where X values are
+ * expressed as milliseconds since the epoch. Configure the desired date format
+ * using {@link #setDateFormat(String)} or let the chart choose an appropriate
+ * format automatically.
  */
 public class TimeChart extends LineChart {
     /**

--- a/docs/developer-guide/graphics.asciidoc
+++ b/docs/developer-guide/graphics.asciidoc
@@ -1377,3 +1377,94 @@ private Map<String, Object> createListEntry(String name, String date, String cov
 
 .A URL image fetched dynamically into the list model
 image::img/developer-guide/graphics-urlimage-multilist.png[A URL image fetched dynamically into the list model,scaledwidth=20%]
+
+=== Charts
+
+Codename One includes a charting toolkit in the `com.codename1.charts` package
+that is designed to integrate with regular UI layouts. Charts are drawn by
+creating an appropriate dataset and renderer pair, instantiating the matching
+chart view class, and wrapping it in a
+https://www.codenameone.com/javadoc/com/codename1/charts/ChartComponent.html[`ChartComponent`]
+so it can be added to a form.
+
+[source,java]
+----
+XYSeriesRenderer seriesRenderer = new XYSeriesRenderer();
+seriesRenderer.setColor(0xff0000);
+
+XYMultipleSeriesRenderer renderer = new XYMultipleSeriesRenderer();
+renderer.addSeriesRenderer(seriesRenderer);
+
+XYSeries series = new XYSeries("Sales");
+series.add(1, 42);
+series.add(2, 57);
+
+XYMultipleSeriesDataset dataset = new XYMultipleSeriesDataset();
+dataset.addSeries(series);
+
+BarChart chart = new BarChart(dataset, renderer, BarChart.Type.DEFAULT);
+Form form = new Form(new BorderLayout());
+form.add(BorderLayout.CENTER, new ChartComponent(chart));
+form.show();
+----
+
+The following classes are available for different kinds of visualisations:
+
+[cols="1,1,2", options="header"]
+|===
+| Chart class
+| Dataset & renderer
+| Notes
+
+| https://www.codenameone.com/javadoc/com/codename1/charts/views/BarChart.html[`BarChart`]
+| `XYMultipleSeriesDataset` / `XYMultipleSeriesRenderer`
+| Draws categorical data as vertical bars. The `Type` constructor parameter controls default, stacked, or heaped bars.
+
+| https://www.codenameone.com/javadoc/com/codename1/charts/views/BubbleChart.html[`BubbleChart`]
+| `XYMultipleSeriesDataset` containing `XYValueSeries` / `XYMultipleSeriesRenderer`
+| Represents each data point as a circle whose size is proportional to a third value.
+
+| https://www.codenameone.com/javadoc/com/codename1/charts/views/CombinedXYChart.html[`CombinedXYChart`]
+| `XYMultipleSeriesDataset` / `XYMultipleSeriesRenderer`
+| Combines several XY chart types in a single plot using `XYCombinedChartDef` to map series to chart implementations.
+
+| https://www.codenameone.com/javadoc/com/codename1/charts/views/CubicLineChart.html[`CubicLineChart`]
+| `XYMultipleSeriesDataset` / `XYMultipleSeriesRenderer`
+| Smooths line series with cubic interpolation. Pass a smoothness factor to the constructor to control the curve.
+
+| https://www.codenameone.com/javadoc/com/codename1/charts/views/DialChart.html[`DialChart`]
+| `CategorySeries` / `DialRenderer`
+| Renders one or more gauges on a dial, making it useful for KPI dashboards.
+
+| https://www.codenameone.com/javadoc/com/codename1/charts/views/DoughnutChart.html[`DoughnutChart`]
+| `MultipleCategorySeries` / `DefaultRenderer`
+| Shows hierarchical proportions as concentric rings around a common centre.
+
+| https://www.codenameone.com/javadoc/com/codename1/charts/views/LineChart.html[`LineChart`]
+| `XYMultipleSeriesDataset` / `XYMultipleSeriesRenderer`
+| Connects series of points using straight line segments. Supports optional fill areas and point markers.
+
+| https://www.codenameone.com/javadoc/com/codename1/charts/views/PieChart.html[`PieChart`]
+| `CategorySeries` / `DefaultRenderer`
+| Splits a circle into slices that are proportional to each category value.
+
+| https://www.codenameone.com/javadoc/com/codename1/charts/views/RadarChart.html[`RadarChart`]
+| `AreaSeries` / `DefaultRenderer`
+| Draws a spider/web chart that compares multiple categories across the same set of axes.
+
+| https://www.codenameone.com/javadoc/com/codename1/charts/views/RangeBarChart.html[`RangeBarChart`]
+| `XYMultipleSeriesDataset` / `XYMultipleSeriesRenderer`
+| Variation of `BarChart` that uses paired min/max values to render ranges.
+
+| https://www.codenameone.com/javadoc/com/codename1/charts/views/RoundChart.html[`RoundChart`]
+| `CategorySeries` / `DefaultRenderer`
+| Abstract base class for circular charts. Use subclasses such as `PieChart`, `DoughnutChart`, or `DialChart` directly.
+
+| https://www.codenameone.com/javadoc/com/codename1/charts/views/ScatterChart.html[`ScatterChart`]
+| `XYMultipleSeriesDataset` / `XYMultipleSeriesRenderer`
+| Plots unconnected X/Y points with configurable marker shapes.
+
+| https://www.codenameone.com/javadoc/com/codename1/charts/views/TimeChart.html[`TimeChart`]
+| `XYMultipleSeriesDataset` / `XYMultipleSeriesRenderer`
+| Extends `LineChart` with date-aware labelling on the X axis for time series data.
+|===


### PR DESCRIPTION
## Summary
- add usage-focused Javadoc to chart view classes describing their datasets, renderers, and embedding
- extend the developer guide with an overview of the charting toolkit and reference table for available chart types

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f90d6e0bac833184432148b82757dc