### PR TITLE
Fix Asciidoc lint issues

### DIFF
--- a/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
+++ b/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
@@ -1125,7 +1125,7 @@ Several rules govern the creation of NativeInterfaces and we only briefly covere
 - `hashCode`, `equals` & `toString` are reserved and won't be mapped to native code
 
 .NativeInterface Supported Types
-[cols="6*",options="header"]
+[cols="5*",options="header"]
 |====
 | Java         | Android   | JavaSE    | Obj-C     | C#
 |byte          | byte      | byte      | char      | sbyte

--- a/docs/developer-guide/Working-With-Javascript.asciidoc
+++ b/docs/developer-guide/Working-With-Javascript.asciidoc
@@ -230,7 +230,7 @@ Display.getInstance().setProperty("javascript.useProxyForSameDomain", "true");
 
 The browser shields some HTTP headers (e.g. "Set-Cookie") from Javascript so that your app cannot access them. Going through the proxy works around this limitation by copying and encoding such headers in a format that the browser will allow, and then decoding them client-side to make them available to your app seamlessly.
 
-===== Using Apache as a Proxy
+==== Using Apache as a Proxy
 
 If you are hosting your application on an Apache 2 web server with mod_proxy installed, and you only need to make CORS requests to a single domain (or a limited set of domains), you can use Apache to serve as your proxy.  One sample configuration (which you would place either in your VirtualHost definition or your .htaccess file is as follows:
 

--- a/docs/developer-guide/developer-guide.asciidoc
+++ b/docs/developer-guide/developer-guide.asciidoc
@@ -99,4 +99,3 @@ include::Working-With-CodenameOne-Sources.asciidoc[]
 
 include::Working-with-UWP.asciidoc[]
 
-include::Travis-CI-Integration.asciidoc[]


### PR DESCRIPTION
## Summary
- correct the NativeInterface type mapping table column configuration
- fix the heading level sequence in the JavaScript guide
- remove the stale Travis CI integration include from the developer guide

## Testing
- not run (asciidoctor not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68faffdc64148331b13b34b0104433e6