### PR TITLE
Ensure core unit tests reset mocked state between runs

### DIFF
--- a/maven/core-unittests/src/test/java/com/codename1/io/MultipartRequestTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/io/MultipartRequestTest.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -13,6 +14,11 @@ class MultipartRequestTest {
     @BeforeEach
     void resetImplementation() {
         TestImplementationProvider.installImplementation(true);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TestImplementationProvider.resetImplementation();
     }
 
     @Test

--- a/maven/core-unittests/src/test/java/com/codename1/io/NetworkManagerTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/io/NetworkManagerTest.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Field;
 import java.util.Enumeration;
 import java.util.Vector;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -26,6 +27,17 @@ class NetworkManagerTest {
         manager = NetworkManager.getInstance();
         resetManagerState();
         bootstrapDisplayThread();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        Field edtField = Display.class.getDeclaredField("edt");
+        edtField.setAccessible(true);
+        edtField.set(Display.getInstance(), null);
+        Field runningField = Display.class.getDeclaredField("codenameOneRunning");
+        runningField.setAccessible(true);
+        runningField.set(Display.getInstance(), Boolean.FALSE);
+        TestImplementationProvider.resetImplementation();
     }
 
     @Test

--- a/maven/core-unittests/src/test/java/com/codename1/io/PreferencesTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/io/PreferencesTest.java
@@ -1,6 +1,5 @@
 package com.codename1.io;
 
-import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -13,14 +12,14 @@ import static org.junit.jupiter.api.Assertions.*;
 class PreferencesTest {
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
+        TestImplementationProvider.resetImplementation();
         TestImplementationProvider.installImplementation(true);
-        resetPreferencesState();
     }
 
     @AfterEach
-    void tearDown() throws Exception {
-        resetPreferencesState();
+    void tearDown() {
+        TestImplementationProvider.resetImplementation();
     }
 
     @Test
@@ -99,20 +98,4 @@ class PreferencesTest {
         assertEquals("original", Preferences.get("shared", ""));
     }
 
-    @SuppressWarnings("unchecked")
-    private void resetPreferencesState() throws Exception {
-        Field pField = Preferences.class.getDeclaredField("p");
-        pField.setAccessible(true);
-        pField.set(null, null);
-
-        Field listenerField = Preferences.class.getDeclaredField("listenerMap");
-        listenerField.setAccessible(true);
-        ((Map) listenerField.get(null)).clear();
-
-        Field locationField = Preferences.class.getDeclaredField("preferencesLocation");
-        locationField.setAccessible(true);
-        locationField.set(null, "CN1Preferences");
-
-        Storage.setStorageInstance(null);
-    }
 }

--- a/maven/core-unittests/src/test/java/com/codename1/io/SocketTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/io/SocketTest.java
@@ -2,6 +2,7 @@ package com.codename1.io;
 
 import com.codename1.impl.CodenameOneImplementation;
 import com.codename1.ui.Display;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,6 +33,11 @@ class SocketTest {
     void setUp() {
         implementation = TestImplementationProvider.installImplementation(true);
         Display.getInstance();
+    }
+
+    @AfterEach
+    void tearDown() {
+        TestImplementationProvider.resetImplementation();
     }
 
     @Test

--- a/maven/core-unittests/src/test/java/com/codename1/io/StorageTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/io/StorageTest.java
@@ -1,6 +1,7 @@
 package com.codename1.io;
 
 import com.codename1.impl.CodenameOneImplementation;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -23,6 +24,11 @@ class StorageTest {
         storage.clearStorage();
         storage.clearCache();
         storage.setNormalizeNames(true);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TestImplementationProvider.resetImplementation();
     }
 
     @Test

--- a/maven/core-unittests/src/test/java/com/codename1/io/TestImplementationProvider.java
+++ b/maven/core-unittests/src/test/java/com/codename1/io/TestImplementationProvider.java
@@ -1,11 +1,15 @@
 package com.codename1.io;
 
 import com.codename1.impl.CodenameOneImplementation;
+import com.codename1.io.Preferences;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.util.Hashtable;
 import java.util.Map;
+import java.util.Vector;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -22,6 +26,9 @@ import static org.mockito.Mockito.when;
 public final class TestImplementationProvider {
     private TestImplementationProvider() {
     }
+
+    private static final String DEFAULT_AUTO_DETECT_URL = NetworkManager.getAutoDetectURL();
+    private static final String DEFAULT_PREFERENCES_LOCATION = Preferences.getPreferencesLocation();
 
     public static CodenameOneImplementation installImplementation(boolean timeoutSupported) {
         Storage.setStorageInstance(null);
@@ -101,5 +108,83 @@ public final class TestImplementationProvider {
 
         Util.setImplementation(impl);
         return impl;
+    }
+
+    public static void resetImplementation() {
+        Util.setImplementation(null);
+        Storage.setStorageInstance(null);
+        resetNetworkManager();
+        resetPreferences();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void resetNetworkManager() {
+        NetworkManager manager = NetworkManager.getInstance();
+        try {
+            Field runningField = NetworkManager.class.getDeclaredField("running");
+            runningField.setAccessible(true);
+            runningField.setBoolean(manager, false);
+
+            Field threadCountField = NetworkManager.class.getDeclaredField("threadCount");
+            threadCountField.setAccessible(true);
+            threadCountField.setInt(manager, 1);
+
+            Field networkThreadsField = NetworkManager.class.getDeclaredField("networkThreads");
+            networkThreadsField.setAccessible(true);
+            networkThreadsField.set(manager, null);
+
+            Field errorField = NetworkManager.class.getDeclaredField("errorListeners");
+            errorField.setAccessible(true);
+            errorField.set(manager, null);
+
+            Field progressField = NetworkManager.class.getDeclaredField("progressListeners");
+            progressField.setAccessible(true);
+            progressField.set(manager, null);
+
+            Field pendingField = NetworkManager.class.getDeclaredField("pending");
+            pendingField.setAccessible(true);
+            ((Vector) pendingField.get(manager)).clear();
+
+            Field threadAssignmentsField = NetworkManager.class.getDeclaredField("threadAssignements");
+            threadAssignmentsField.setAccessible(true);
+            ((Hashtable) threadAssignmentsField.get(manager)).clear();
+
+            Field userHeadersField = NetworkManager.class.getDeclaredField("userHeaders");
+            userHeadersField.setAccessible(true);
+            userHeadersField.set(manager, null);
+
+            Field timeoutField = NetworkManager.class.getDeclaredField("timeout");
+            timeoutField.setAccessible(true);
+            timeoutField.setInt(manager, 300000);
+
+            Field autoDetectedField = NetworkManager.class.getDeclaredField("autoDetected");
+            autoDetectedField.setAccessible(true);
+            autoDetectedField.setBoolean(manager, false);
+
+            Field nextConnectionIdField = NetworkManager.class.getDeclaredField("nextConnectionId");
+            nextConnectionIdField.setAccessible(true);
+            nextConnectionIdField.setInt(manager, 1);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Unable to reset NetworkManager state", e);
+        }
+
+        NetworkManager.setAutoDetectURL(DEFAULT_AUTO_DETECT_URL);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void resetPreferences() {
+        try {
+            Field pField = Preferences.class.getDeclaredField("p");
+            pField.setAccessible(true);
+            pField.set(null, null);
+
+            Field listenerField = Preferences.class.getDeclaredField("listenerMap");
+            listenerField.setAccessible(true);
+            ((Map<?, ?>) listenerField.get(null)).clear();
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Unable to reset Preferences state", e);
+        }
+
+        Preferences.setPreferencesLocation(DEFAULT_PREFERENCES_LOCATION);
     }
 }

--- a/maven/core-unittests/src/test/java/com/codename1/io/URLTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/io/URLTest.java
@@ -1,6 +1,7 @@
 package com.codename1.io;
 
 import com.codename1.impl.CodenameOneImplementation;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -63,6 +64,11 @@ class URLTest {
         } catch (IOException e) {
             throw new AssertionError(e);
         }
+    }
+
+    @AfterEach
+    void tearDown() {
+        TestImplementationProvider.resetImplementation();
     }
 
     @Test

--- a/maven/core-unittests/src/test/java/com/codename1/io/UtilTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/io/UtilTest.java
@@ -1,6 +1,7 @@
 package com.codename1.io;
 
 import com.codename1.impl.CodenameOneImplementation;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -25,6 +26,11 @@ class UtilTest {
     @BeforeEach
     void setUp() {
         implementation = TestImplementationProvider.installImplementation(true);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TestImplementationProvider.resetImplementation();
     }
 
     @Test

--- a/maven/core-unittests/src/test/java/com/codename1/io/rest/RequestBuilderTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/io/rest/RequestBuilderTest.java
@@ -11,6 +11,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -20,6 +21,11 @@ class RequestBuilderTest {
     @BeforeEach
     void setUp() {
         TestImplementationProvider.installImplementation(true);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TestImplementationProvider.resetImplementation();
     }
 
     @Test

--- a/maven/core-unittests/src/test/java/com/codename1/properties/PropertiesPackageTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/properties/PropertiesPackageTest.java
@@ -1,7 +1,6 @@
 package com.codename1.properties;
 
 import com.codename1.io.Preferences;
-import com.codename1.io.Storage;
 import com.codename1.io.TestImplementationProvider;
 import com.codename1.xml.Element;
 import org.junit.jupiter.api.AfterEach;
@@ -20,10 +19,9 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class PropertiesPackageTest {
 
-    private String originalPreferencesLocation;
-
     @BeforeEach
     void setup() throws Exception {
+        TestImplementationProvider.resetImplementation();
         TestImplementationProvider.installImplementation(true);
         resetPreferencesState();
         resetMetadata();
@@ -35,11 +33,7 @@ class PropertiesPackageTest {
     void tearDown() throws Exception {
         PropertyBase.bindGlobalGetListener(null);
         PropertyBase.bindGlobalSetListener(null);
-        resetPreferencesState();
-        if (originalPreferencesLocation != null) {
-            Preferences.setPreferencesLocation(originalPreferencesLocation);
-        }
-        Storage.setStorageInstance(null);
+        TestImplementationProvider.resetImplementation();
         resetMetadata();
     }
 
@@ -246,14 +240,8 @@ class PropertiesPackageTest {
         assertEquals(7, Preferences.get("prefs.total", 0));
     }
 
-    private void resetPreferencesState() throws Exception {
-        FieldAccessor.resetStaticField(Preferences.class, "p", null);
-        FieldAccessor.resetStaticMap(Preferences.class, "listenerMap");
-        if (originalPreferencesLocation == null) {
-            originalPreferencesLocation = Preferences.getPreferencesLocation();
-        }
+    private void resetPreferencesState() {
         Preferences.setPreferencesLocation("PropertiesTest-" + System.nanoTime());
-        Storage.setStorageInstance(null);
     }
 
     private void resetMetadata() throws Exception {
@@ -262,12 +250,6 @@ class PropertiesPackageTest {
 
     private static class FieldAccessor {
         private FieldAccessor() {
-        }
-
-        static void resetStaticField(Class<?> type, String name, Object value) throws Exception {
-            java.lang.reflect.Field field = type.getDeclaredField(name);
-            field.setAccessible(true);
-            field.set(null, value);
         }
 
         @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary
- add `TestImplementationProvider.resetImplementation()` to tear down mocked storage, network manager, and preferences state between tests
- hook the new reset helper into IO and properties unit tests so each case restores a clean environment

## Testing
- `mvn -q test` *(fails: missing com.codenameone:codenameone-factory:jar:8.0-SNAPSHOT dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68fb5be05c4c8331b6179af1f972c73b