### PR TITLE
Run Java SE device-runner tests in PR CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -302,7 +302,7 @@ jobs:
 
     - name: Run Java SE device-runner tests
       env:
-        ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
+        ARTIFACTS_DIR: ${{ github.workspace }}/artifacts/desktop-device-runner
       run: ./scripts/run-javase-device-tests.sh
 
     - name: Upload Java SE device-runner artifacts


### PR DESCRIPTION
## Summary
- add a reusable script to run the device-runner app against the Java SE port and decode screenshots
- update the PR CI workflow to execute the Java SE device-runner tests and upload the screenshots as artifacts

## Testing
- bash -n scripts/run-javase-device-tests.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d524950dc8331a260be833576b79b)