### PR TITLE
Add unit tests for UI plaf borders and style parsing

### DIFF
--- a/maven/core-unittests/src/test/java/com/codename1/ui/plaf/BorderAndPlafTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/plaf/BorderAndPlafTest.java
@@ -165,7 +165,7 @@ class BorderAndPlafTest extends UITestBase {
         assertEquals("native:Other native:Other", mutatedFont.toString());
         assertEquals("native:Other", mutatedFont.getName());
         assertEquals(2, copied.getMargin().getValue(Component.TOP).getValue(), 0.01);
-        assertEquals("1px solid ff0000", copied.getBorder().toString());
+        assertEquals("1.0px solid ff0000", copied.getBorder().toString());
 
         StyleInfo empty = new StyleInfo((String[]) null);
         assertNull(empty.getFont());


### PR DESCRIPTION
## Summary
- add UITestBase-driven coverage for border factories and RoundBorder/RoundRectBorder configuration
- exercise CSSBorder parsing output and StyleParser merging logic, including margin inheritance and bidi alignment handling

## Testing
- mvn -f maven/core-unittests/pom.xml test -DskipITs *(fails: missing com.codenameone:codenameone-factory:jar:8.0-SNAPSHOT dependency in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e07611d9883319a59a09b9038f305)