### PR TITLE
Use TestLogger in AsyncResourceSampleTest

### DIFF
--- a/maven/core-unittests/src/test/java/com/codename1/samples/AsyncResourceSampleTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/samples/AsyncResourceSampleTest.java
@@ -1,6 +1,7 @@
 package com.codename1.samples;
 
 import com.codename1.junit.FormTest;
+import com.codename1.junit.TestLogger;
 import com.codename1.junit.UITestBase;
 import com.codename1.media.Media;
 import com.codename1.ui.Button;
@@ -40,23 +41,30 @@ class AsyncResourceSampleTest extends UITestBase {
 
     @FormTest
     void playAsyncHandlesErrors() {
-        AsyncResource<Media> asyncMedia = new AsyncResource<Media>();
-        implementation.setMediaAsync(ERROR_URI, asyncMedia);
+        TestLogger.install();
+        try {
+            AsyncResource<Media> asyncMedia = new AsyncResource<Media>();
+            implementation.setMediaAsync(ERROR_URI, asyncMedia);
 
-        AsyncResourceSample sample = new AsyncResourceSample();
-        sample.start();
+            AsyncResourceSample sample = new AsyncResourceSample();
+            sample.start();
 
-        Button errorButton = findButton(Display.getInstance().getCurrent(), "Play Async (Not Found)");
-        assertNotNull(errorButton);
+            Button errorButton = findButton(Display.getInstance().getCurrent(), "Play Async (Not Found)");
+            assertNotNull(errorButton);
 
-        errorButton.released();
-        assertFalse(errorButton.isEnabled());
+            errorButton.released();
+            assertFalse(errorButton.isEnabled());
 
-        RuntimeException failure = new RuntimeException("Resource missing");
-        implementation.failMediaAsync(ERROR_URI, failure);
-        flushSerialCalls();
+            RuntimeException failure = new RuntimeException("Resource missing");
+            implementation.failMediaAsync(ERROR_URI, failure);
+            flushSerialCalls();
 
-        assertTrue(errorButton.isEnabled());
+            assertTrue(errorButton.isEnabled());
+            assertEquals(1, TestLogger.getThrowables().size());
+            assertSame(failure, TestLogger.getThrowables().get(0));
+        } finally {
+            TestLogger.remove();
+        }
     }
 
     private Button findButton(Form form, String text) {


### PR DESCRIPTION
## Summary
- install TestLogger in AsyncResourceSampleTest to swallow expected logging from the error path
- verify the expected throwable is captured while ensuring the logger is restored after the test

## Testing
- mvn -f maven/pom.xml -pl core-unittests -Dtest=AsyncResourceSampleTest test *(fails: module core-unittests not found in the reactor of maven/pom.xml)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925cd693a908331ae16785a35f9cadc)