### PR TITLE
Stabilize CachedDataServiceTest by disabling auto processing

### DIFF
--- a/maven/core-unittests/src/test/java/com/codename1/io/services/CachedDataServiceTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/io/services/CachedDataServiceTest.java
@@ -27,46 +27,52 @@ class CachedDataServiceTest extends UITestBase {
         data.setEtag("etag-1");
 
         implementation.clearQueuedRequests();
+        boolean previousAutoProcessConnections = implementation.isAutoProcessConnections();
+        implementation.setAutoProcessConnections(false);
 
         final boolean[] callbackInvoked = new boolean[1];
-        CachedDataService.updateData(data, new ActionListener() {
-            public void actionPerformed(ActionEvent evt) {
-                callbackInvoked[0] = true;
-                NetworkEvent ne = (NetworkEvent) evt;
-                CachedData updated = (CachedData) ne.getMetaData();
-                data.setModified(updated.getModified());
-                data.setEtag(updated.getEtag());
-                data.setData(updated.getData());
-                data.setFetching(false);
-            }
-        });
-        assertTrue(data.isFetching());
+        try {
+            CachedDataService.updateData(data, new ActionListener() {
+                public void actionPerformed(ActionEvent evt) {
+                    callbackInvoked[0] = true;
+                    NetworkEvent ne = (NetworkEvent) evt;
+                    CachedData updated = (CachedData) ne.getMetaData();
+                    data.setModified(updated.getModified());
+                    data.setEtag(updated.getEtag());
+                    data.setData(updated.getData());
+                    data.setFetching(false);
+                }
+            });
+            assertTrue(data.isFetching());
 
-        List<ConnectionRequest> requests = implementation.getQueuedRequests();
-        assertEquals(1, requests.size());
-        CachedDataService request = (CachedDataService) requests.get(0);
-        assertEquals("http://example.com/data", request.getUrl());
-        assertFalse(request.isPost());
+            List<ConnectionRequest> requests = implementation.getQueuedRequests();
+            assertEquals(1, requests.size());
+            CachedDataService request = (CachedDataService) requests.get(0);
+            assertEquals("http://example.com/data", request.getUrl());
+            assertFalse(request.isPost());
 
-        TestCodenameOneImplementation.TestConnection connection = implementation.createConnection(request.getUrl());
-        connection.setHeader("Last-Modified", "Sun, 02 Jan 2000 00:00:00 GMT");
-        connection.setHeader("ETag", "etag-2");
+            TestCodenameOneImplementation.TestConnection connection = implementation.createConnection(request.getUrl());
+            connection.setHeader("Last-Modified", "Sun, 02 Jan 2000 00:00:00 GMT");
+            connection.setHeader("ETag", "etag-2");
 
-        request.readHeaders(connection);
+            request.readHeaders(connection);
 
-        byte[] payload = "fresh".getBytes();
-        connection.setInputData(payload);
-        connection.setContentLength(payload.length);
+            byte[] payload = "fresh".getBytes();
+            connection.setInputData(payload);
+            connection.setContentLength(payload.length);
 
-        request.readResponse(new ByteArrayInputStream(payload));
-        assertTrue(callbackInvoked[0]);
-        assertEquals("Sun, 02 Jan 2000 00:00:00 GMT", data.getModified());
-        assertEquals("etag-2", data.getEtag());
-        assertArrayEquals(payload, data.getData());
-        assertFalse(data.isFetching());
+            request.readResponse(new ByteArrayInputStream(payload));
+            assertTrue(callbackInvoked[0]);
+            assertEquals("Sun, 02 Jan 2000 00:00:00 GMT", data.getModified());
+            assertEquals("etag-2", data.getEtag());
+            assertArrayEquals(payload, data.getData());
+            assertFalse(data.isFetching());
 
-        data.setFetching(true);
-        request.handleErrorResponseCode(304, "Not Modified");
-        assertTrue(data.isFetching());
+            data.setFetching(true);
+            request.handleErrorResponseCode(304, "Not Modified");
+            assertTrue(data.isFetching());
+        } finally {
+            implementation.setAutoProcessConnections(previousAutoProcessConnections);
+        }
     }
 }

--- a/maven/core-unittests/src/test/java/com/codename1/testing/TestCodenameOneImplementation.java
+++ b/maven/core-unittests/src/test/java/com/codename1/testing/TestCodenameOneImplementation.java
@@ -124,6 +124,8 @@ public class TestCodenameOneImplementation extends CodenameOneImplementation {
     private Media mediaRecorder;
     private boolean trueTypeSupported = true;
     private static TestCodenameOneImplementation instance;
+
+    private boolean autoProcessConnections = true;
     private Map<String, String> properties = new HashMap<>();
     private boolean blockCopyAndPaste;
     private PeerComponent browserComponent;
@@ -2342,7 +2344,17 @@ public class TestCodenameOneImplementation extends CodenameOneImplementation {
         if (r != null) {
             queuedRequests.add(r);
         }
-        super.addConnectionToQueue(r);
+        if (autoProcessConnections) {
+            super.addConnectionToQueue(r);
+        }
+    }
+
+    public boolean isAutoProcessConnections() {
+        return autoProcessConnections;
+    }
+
+    public void setAutoProcessConnections(boolean autoProcessConnections) {
+        this.autoProcessConnections = autoProcessConnections;
     }
 
     public void clearQueuedRequests() {


### PR DESCRIPTION
## Summary
- add a test-implementation flag to prevent auto-processing queued connections
- wrap CachedDataServiceTest in manual processing to avoid races with network threads

## Testing
- mvn -Dtest=CachedDataServiceTest test (fails: missing com.codenameone:codenameone-factory dependency)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d235331b883319bf9a8cfabf0375a)