### PR TITLE
Add unit test for autocomplete popup form

### DIFF
--- a/maven/core-unittests/src/test/java/com/codename1/testing/TestCodenameOneImplementation.java
+++ b/maven/core-unittests/src/test/java/com/codename1/testing/TestCodenameOneImplementation.java
@@ -1304,6 +1304,17 @@ public class TestCodenameOneImplementation extends CodenameOneImplementation {
         dispatchPointerPressAndRelease(x, y);
     }
 
+    public void tapListRow(com.codename1.ui.List list, int rowIndex) {
+        if (list == null) {
+            return;
+        }
+        int visibleRows = Math.min(Math.max(1, list.getMinElementHeight()), list.getModel().getSize());
+        int rowHeight = list.getHeight() / visibleRows;
+        int x = list.getAbsoluteX() + list.getWidth() / 2;
+        int y = list.getAbsoluteY() + Math.max(0, rowIndex) * rowHeight + rowHeight / 2;
+        dispatchPointerPressAndRelease(x, y);
+    }
+
     private boolean beginAllowingEditDuringKey(int keyCode) {
         TextArea area = getActiveEditingArea();
         if (area == null) {

--- a/maven/core-unittests/src/test/java/com/codename1/ui/AutocompletePopupFormTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/AutocompletePopupFormTest.java
@@ -47,7 +47,7 @@ class AutocompletePopupFormTest extends UITestBase {
         assertEquals(5, suggestionList.getModel().getSize());
         assertEquals(5, suggestionList.getMinElementHeight(), "Minimum elements hint should propagate to list");
 
-        implementation.tapComponent(suggestionList);
+        implementation.tapListRow(suggestionList, 0);
         DisplayTest.flushEdt();
         flushSerialCalls();
         DisplayTest.flushEdt();


### PR DESCRIPTION
## Summary
- add UITestBase-based form test covering autocomplete popup triggered by a button
- verify popup visibility, suggestion list sizing, and selection updates field text

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692d2c474eb883319de7f4f9771ea548)