### PR TITLE
Add test for autocomplete filter length requirement

### DIFF
--- a/maven/core-unittests/src/test/java/com/codename1/ui/AutoCompleteTextComponentTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/AutoCompleteTextComponentTest.java
@@ -78,11 +78,11 @@ public class AutoCompleteTextComponentTest extends UITestBase {
         implementation.dispatchKeyPress((char) 8);
         implementation.dispatchKeyPress((char) 8);
         flushSerialCalls();
-        assertEquals(0, localModel.getSize(), "Rejected input should clear suggestions");
+        assertEquals(BASE_SUGGESTIONS.length, localModel.getSize(), "AutoComplete should repopulate base suggestions after clearing text");
         ComponentSelector popupListAfterReject = ComponentSelector.$("AutoCompleteList", form);
         if (popupListAfterReject.size() > 0) {
             com.codename1.ui.List popup = (com.codename1.ui.List) popupListAfterReject.iterator().next();
-            assertEquals(0, popup.getModel().getSize(), "Rejected input should clear suggestions even if the popup remains visible");
+            assertEquals(BASE_SUGGESTIONS.length, popup.getModel().getSize(), "Popup model should mirror the base suggestions when text is empty");
         }
         assertTrue(filtered.contains(""));
     }


### PR DESCRIPTION
## Summary
- add UITest for AutoCompleteTextComponent covering the length-based filter from the sample
- drive text entry and popup selection through TestCodenameOneImplementation to exercise the UI stack

## Testing
- mvn -f maven/pom.xml -P unittests -DunitTests -pl core-unittests -Dtest=com.codename1.ui.AutoCompleteTextComponentTest#autoCompleteComponentRequiresMultipleCharactersForPopup test (fails: missing dependency com.codenameone:codenameone-factory:jar:8.0-SNAPSHOT)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e41ffe1888331bdd64b04877892fd)