### PR TITLE
Add badges sample unit tests

### DIFF
--- a/maven/core-unittests/src/test/java/com/codename1/samples/BadgesSampleTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/samples/BadgesSampleTest.java
@@ -33,7 +33,7 @@ class BadgesSampleTest extends UITestBase {
 
             assertEquals("1", label.getBadgeText());
             assertEquals(Style.UNIT_TYPE_PIXELS, style.getPaddingUnit()[Component.RIGHT]);
-            assertEquals(CN.convertToPixels(1.5f), style.getPaddingRight());
+            assertEquals(CN.convertToPixels(1.5f), style.getPaddingRight(false));
         } finally {
             harness.cleanup();
         }


### PR DESCRIPTION
## Summary
- add a BadgesSampleTest that recreates the badge demo within the unit test suite
- verify badge padding and message-driven badge updates using UITestBase and TestCodenameOneImplementation

## Testing
- mvn test *(fails: com.codenameone:codenameone-factory:jar:8.0-SNAPSHOT missing)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692fb5828d5c83318b024551b26ad029)