### PR TITLE
Add JVM bytecode tests for ParparVM

### DIFF
--- a/.github/workflows/parparvm-tests.yml
+++ b/.github/workflows/parparvm-tests.yml
@@ -1,0 +1,34 @@
+name: ParparVM Java Tests
+
+on:
+  pull_request:
+    paths:
+      - 'vm/**'
+      - '!vm/**/README.md'
+      - '!vm/**/readme.md'
+      - '!vm/**/docs/**'
+  push:
+    branches: [ master, main ]
+    paths:
+      - 'vm/**'
+      - '!vm/**/README.md'
+      - '!vm/**/readme.md'
+      - '!vm/**/docs/**'
+
+jobs:
+  vm-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+          cache: 'maven'
+
+      - name: Run ParparVM JVM tests
+        working-directory: vm/tests
+        run: mvn -B test

--- a/vm/tests/pom.xml
+++ b/vm/tests/pom.xml
@@ -1,0 +1,69 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.codename1.parparvm</groupId>
+    <artifactId>parparvm-tests</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>ParparVM Java Tests</name>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <junit.jupiter.version>5.10.2</junit.jupiter.version>
+        <asm.version>5.0.3</asm.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+            <version>${asm.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-commons</artifactId>
+            <version>${asm.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>add-bytecodetranslator-sources</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>../ByteCodeTranslator/src</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/vm/tests/src/test/java/com/codename1/tools/translator/ParserTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/ParserTest.java
@@ -1,0 +1,288 @@
+package com.codename1.tools.translator;
+
+import com.codename1.tools.translator.bytecodes.Instruction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ParserTest {
+
+    @BeforeEach
+    void cleanParser() {
+        Parser.cleanup();
+    }
+
+    @Test
+    void parsesBasicClassWithFieldsAndMethodBodies() throws Exception {
+        Path classFile = createSampleClass();
+
+        Parser.parse(classFile.toFile());
+
+        ByteCodeClass cls = Parser.getClassObject("com_example_Sample");
+        assertNotNull(cls, "Class should be parsed");
+        assertEquals("java/lang/Object", cls.getBaseClass());
+        assertFalse(cls.isIsInterface());
+        assertFalse(cls.isIsAbstract());
+
+        ByteCodeField greeting = findField(cls, "GREETING");
+        assertTrue(greeting.isStaticField());
+        assertEquals("hi", greeting.getValue());
+
+        ByteCodeField names = findField(cls, "names");
+        assertTrue(names.isObjectType(), "Generics-based list field should be an object type");
+        assertTrue(names.getDependentClasses().contains("java_util_List"));
+
+        BytecodeMethod sum = findMethod(cls, "sum");
+        assertFalse(sum.isStatic());
+        List<Instruction> instructions = getInstructions(sum);
+        List<Integer> opcodes = instructions.stream()
+                .map(Instruction::getOpcode)
+                .collect(Collectors.toList());
+        assertTrue(opcodes.contains(Opcodes.IADD), "Method should include an integer add operation");
+        assertEquals(Opcodes.IRETURN, opcodes.get(opcodes.size() - 1));
+    }
+
+    @Test
+    void parsesInterfacesAsAbstractContracts() throws Exception {
+        Path classFile = createTaskInterface();
+
+        Parser.parse(classFile.toFile());
+
+        ByteCodeClass cls = Parser.getClassObject("com_example_Task");
+        assertNotNull(cls);
+        assertTrue(cls.isIsInterface());
+        assertTrue(cls.isIsAbstract());
+
+        BytecodeMethod method = findMethod(cls, "runTask");
+        assertTrue(method.canBeVirtual());
+    }
+
+    @Test
+    void parsesEnumMetadataAndBaseType() throws Exception {
+        Path classFile = createPriorityEnum();
+
+        Parser.parse(classFile.toFile());
+
+        ByteCodeClass cls = Parser.getClassObject("com_example_Priority");
+        assertNotNull(cls);
+        assertEquals("java/lang/Enum", cls.getBaseClass());
+        assertTrue(readPrivateBoolean(cls, "isEnum"));
+    }
+
+    @Test
+    void parsesAnnotationsWithCorrectFlags() throws Exception {
+        Path classFile = createAnnotation();
+
+        Parser.parse(classFile.toFile());
+
+        ByteCodeClass cls = Parser.getClassObject("com_example_TestAnnotation");
+        assertNotNull(cls);
+        assertTrue(cls.isIsInterface(), "Annotations should be treated as interfaces");
+        assertTrue(readPrivateBoolean(cls, "isAnnotation"));
+        assertFalse(readPrivateBoolean(cls, "isSynthetic"));
+    }
+
+    private ByteCodeField findField(ByteCodeClass cls, String name) {
+        return cls.getFields()
+                .stream()
+                .filter(f -> f.getFieldName().equals(name))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Field not found: " + name));
+    }
+
+    private BytecodeMethod findMethod(ByteCodeClass cls, String name) {
+        return cls.getMethods()
+                .stream()
+                .filter(m -> m.getMethodName().equals(name))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Method not found: " + name));
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Instruction> getInstructions(BytecodeMethod method) throws Exception {
+        Field instructionsField = BytecodeMethod.class.getDeclaredField("instructions");
+        instructionsField.setAccessible(true);
+        return (List<Instruction>) instructionsField.get(method);
+    }
+
+    private boolean readPrivateBoolean(Object target, String fieldName) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field.getBoolean(target);
+    }
+
+    private Path createSampleClass() throws Exception {
+        return writeClass("com/example/Sample", cw -> {
+            cw.visit(Opcodes.V1_5, Opcodes.ACC_PUBLIC | Opcodes.ACC_SUPER, "com/example/Sample", null, "java/lang/Object", null);
+            cw.visitField(Opcodes.ACC_PRIVATE, "counter", "I", null, null).visitEnd();
+            cw.visitField(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL, "GREETING", "Ljava/lang/String;", null, "hi").visitEnd();
+            cw.visitField(Opcodes.ACC_PUBLIC, "names", "Ljava/util/List;", "Ljava/util/List<Ljava/lang/String;>;", null).visitEnd();
+
+            MethodVisitor init = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "()V", null, null);
+            init.visitCode();
+            init.visitVarInsn(Opcodes.ALOAD, 0);
+            init.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+            init.visitInsn(Opcodes.RETURN);
+            init.visitMaxs(1, 1);
+            init.visitEnd();
+
+            MethodVisitor sum = cw.visitMethod(Opcodes.ACC_PUBLIC, "sum", "(II)I", null, null);
+            sum.visitCode();
+            sum.visitVarInsn(Opcodes.ILOAD, 1);
+            sum.visitVarInsn(Opcodes.ILOAD, 2);
+            sum.visitInsn(Opcodes.IADD);
+            sum.visitInsn(Opcodes.IRETURN);
+            sum.visitMaxs(2, 3);
+            sum.visitEnd();
+
+            cw.visitEnd();
+        });
+    }
+
+    private Path createTaskInterface() throws Exception {
+        return writeClass("com/example/Task", cw -> {
+            cw.visit(
+                    Opcodes.V1_5,
+                    Opcodes.ACC_PUBLIC | Opcodes.ACC_ABSTRACT | Opcodes.ACC_INTERFACE,
+                    "com/example/Task",
+                    null,
+                    "java/lang/Object",
+                    null
+            );
+            cw.visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_ABSTRACT, "runTask", "()V", null, null).visitEnd();
+            cw.visitEnd();
+        });
+    }
+
+    private Path createPriorityEnum() throws Exception {
+        return writeClass("com/example/Priority", cw -> {
+            cw.visit(
+                    Opcodes.V1_5,
+                    Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL | Opcodes.ACC_SUPER | Opcodes.ACC_ENUM,
+                    "com/example/Priority",
+                    null,
+                    "java/lang/Enum",
+                    null
+            );
+            cw.visitField(enumFieldFlags(), "LOW", "Lcom/example/Priority;", null, null).visitEnd();
+            cw.visitField(enumFieldFlags(), "HIGH", "Lcom/example/Priority;", null, null).visitEnd();
+            cw.visitField(Opcodes.ACC_PRIVATE | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL | Opcodes.ACC_SYNTHETIC, "$VALUES", "[Lcom/example/Priority;", null, null).visitEnd();
+
+            MethodVisitor ctor = cw.visitMethod(Opcodes.ACC_PRIVATE, "<init>", "(Ljava/lang/String;I)V", null, null);
+            ctor.visitCode();
+            ctor.visitVarInsn(Opcodes.ALOAD, 0);
+            ctor.visitVarInsn(Opcodes.ALOAD, 1);
+            ctor.visitVarInsn(Opcodes.ILOAD, 2);
+            ctor.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Enum", "<init>", "(Ljava/lang/String;I)V", false);
+            ctor.visitInsn(Opcodes.RETURN);
+            ctor.visitMaxs(3, 3);
+            ctor.visitEnd();
+
+            MethodVisitor codeMethod = cw.visitMethod(Opcodes.ACC_PUBLIC, "code", "()I", null, null);
+            codeMethod.visitCode();
+            codeMethod.visitVarInsn(Opcodes.ALOAD, 0);
+            codeMethod.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "java/lang/Enum", "ordinal", "()I", false);
+            codeMethod.visitInsn(Opcodes.IRETURN);
+            codeMethod.visitMaxs(1, 1);
+            codeMethod.visitEnd();
+
+            MethodVisitor values = cw.visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC, "values", "()[Lcom/example/Priority;", null, null);
+            values.visitCode();
+            values.visitFieldInsn(Opcodes.GETSTATIC, "com/example/Priority", "$VALUES", "[Lcom/example/Priority;");
+            values.visitMethodInsn(Opcodes.INVOKEVIRTUAL, "[Lcom/example/Priority;", "clone", "()Ljava/lang/Object;", false);
+            values.visitTypeInsn(Opcodes.CHECKCAST, "[Lcom/example/Priority;");
+            values.visitInsn(Opcodes.ARETURN);
+            values.visitMaxs(1, 0);
+            values.visitEnd();
+
+            MethodVisitor valueOf = cw.visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC, "valueOf", "(Ljava/lang/String;)Lcom/example/Priority;", null, null);
+            valueOf.visitCode();
+            valueOf.visitLdcInsn(Type.getType("Lcom/example/Priority;"));
+            valueOf.visitVarInsn(Opcodes.ALOAD, 0);
+            valueOf.visitMethodInsn(Opcodes.INVOKESTATIC, "java/lang/Enum", "valueOf", "(Ljava/lang/Class;Ljava/lang/String;)Ljava/lang/Enum;", false);
+            valueOf.visitTypeInsn(Opcodes.CHECKCAST, "com/example/Priority");
+            valueOf.visitInsn(Opcodes.ARETURN);
+            valueOf.visitMaxs(2, 1);
+            valueOf.visitEnd();
+
+            MethodVisitor clinit = cw.visitMethod(Opcodes.ACC_STATIC, "<clinit>", "()V", null, null);
+            clinit.visitCode();
+            clinit.visitTypeInsn(Opcodes.NEW, "com/example/Priority");
+            clinit.visitInsn(Opcodes.DUP);
+            clinit.visitLdcInsn("LOW");
+            clinit.visitInsn(Opcodes.ICONST_0);
+            clinit.visitMethodInsn(Opcodes.INVOKESPECIAL, "com/example/Priority", "<init>", "(Ljava/lang/String;I)V", false);
+            clinit.visitFieldInsn(Opcodes.PUTSTATIC, "com/example/Priority", "LOW", "Lcom/example/Priority;");
+
+            clinit.visitTypeInsn(Opcodes.NEW, "com/example/Priority");
+            clinit.visitInsn(Opcodes.DUP);
+            clinit.visitLdcInsn("HIGH");
+            clinit.visitInsn(Opcodes.ICONST_1);
+            clinit.visitMethodInsn(Opcodes.INVOKESPECIAL, "com/example/Priority", "<init>", "(Ljava/lang/String;I)V", false);
+            clinit.visitFieldInsn(Opcodes.PUTSTATIC, "com/example/Priority", "HIGH", "Lcom/example/Priority;");
+
+            clinit.visitInsn(Opcodes.ICONST_2);
+            clinit.visitTypeInsn(Opcodes.ANEWARRAY, "com/example/Priority");
+            clinit.visitInsn(Opcodes.DUP);
+            clinit.visitInsn(Opcodes.ICONST_0);
+            clinit.visitFieldInsn(Opcodes.GETSTATIC, "com/example/Priority", "LOW", "Lcom/example/Priority;");
+            clinit.visitInsn(Opcodes.AASTORE);
+            clinit.visitInsn(Opcodes.DUP);
+            clinit.visitInsn(Opcodes.ICONST_1);
+            clinit.visitFieldInsn(Opcodes.GETSTATIC, "com/example/Priority", "HIGH", "Lcom/example/Priority;");
+            clinit.visitInsn(Opcodes.AASTORE);
+            clinit.visitFieldInsn(Opcodes.PUTSTATIC, "com/example/Priority", "$VALUES", "[Lcom/example/Priority;");
+            clinit.visitInsn(Opcodes.RETURN);
+            clinit.visitMaxs(5, 0);
+            clinit.visitEnd();
+
+            cw.visitEnd();
+        });
+    }
+
+    private Path createAnnotation() throws Exception {
+        return writeClass("com/example/TestAnnotation", cw -> {
+            cw.visit(
+                    Opcodes.V1_5,
+                    Opcodes.ACC_PUBLIC | Opcodes.ACC_ABSTRACT | Opcodes.ACC_INTERFACE | Opcodes.ACC_ANNOTATION,
+                    "com/example/TestAnnotation",
+                    null,
+                    "java/lang/Object",
+                    new String[]{"java/lang/annotation/Annotation"}
+            );
+            cw.visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_ABSTRACT, "value", "()Ljava/lang/String;", null, null).visitEnd();
+            cw.visitEnd();
+        });
+    }
+
+    private int enumFieldFlags() {
+        return Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_FINAL | Opcodes.ACC_ENUM;
+    }
+
+    private Path writeClass(String internalName, ClassEmitter emitter) throws Exception {
+        ClassWriter cw = new ClassWriter(0);
+        emitter.accept(cw);
+        Path outputDir = Files.createTempDirectory("parparvm-classes");
+        Path classFile = outputDir.resolve(internalName + ".class");
+        Files.createDirectories(classFile.getParent());
+        Files.write(classFile, cw.toByteArray());
+        return classFile;
+    }
+
+    @FunctionalInterface
+    private interface ClassEmitter {
+        void accept(ClassWriter classWriter) throws Exception;
+    }
+}


### PR DESCRIPTION
## Summary
- add a Maven-based ParparVM JVM test project under `vm/tests`
- generate Java 5 bytecode with ASM to verify Parser handling of classes, interfaces, enums, and annotations
- add a CI workflow to run the new tests for ParparVM changes while ignoring documentation-only updates

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 PATH="$JAVA_HOME/bin:$PATH" mvn -B test` (from `vm/tests`)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939b75f93208331b2b7a4f3eeb57385)