### PR TITLE
Fix virtual invoke tracking in bytecode translator

### DIFF
--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/CustomInvoke.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/CustomInvoke.java
@@ -159,6 +159,7 @@ public class CustomInvoke extends Instruction {
         }
         
         StringBuilder bld = new StringBuilder();
+        boolean isVirtualCall = false;
         if(origOpcode == Opcodes.INVOKEINTERFACE || origOpcode == Opcodes.INVOKEVIRTUAL) {
             b.append("    ");
             
@@ -179,6 +180,7 @@ public class CustomInvoke extends Instruction {
             }
             if (isVirtual) {
                 bld.append("virtual_");
+                isVirtualCall = true;
             }
         } else {
             b.append("    ");
@@ -207,6 +209,9 @@ public class CustomInvoke extends Instruction {
         bld.append("__");
         ArrayList<String> args = new ArrayList<String>();
         String returnVal = BytecodeMethod.appendMethodSignatureSuffixFromDesc(desc, bld, args);
+        if (isVirtualCall) {
+            BytecodeMethod.addVirtualMethodsInvoked(bld.substring("virtual_".length()));
+        }
         int numLiteralArgs = this.getNumLiteralArgs();
         if (numLiteralArgs > 0) {
             b.append("/* CustomInvoke */");

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Invoke.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Invoke.java
@@ -142,9 +142,10 @@ public class Invoke extends Instruction {
         }
         
         StringBuilder bld = new StringBuilder();
+        boolean isVirtualCall = false;
         if(opcode == Opcodes.INVOKEINTERFACE || opcode == Opcodes.INVOKEVIRTUAL) {
             b.append("    ");
-            
+
             // Well, it is actually legal to call private methods with invoke virtual, and kotlin
             // generates such calls.  But ParparVM strips out these virtual method definitions
             // so we need to check if the method is private, and remove the virtual invocation 
@@ -162,6 +163,7 @@ public class Invoke extends Instruction {
             }
             if (isVirtual) {
                 bld.append("virtual_");
+                isVirtualCall = true;
             }
         } else {
             b.append("    ");
@@ -195,6 +197,9 @@ public class Invoke extends Instruction {
         bld.append("__");
         ArrayList<String> args = new ArrayList<String>();
         String returnVal = BytecodeMethod.appendMethodSignatureSuffixFromDesc(desc, bld, args);
+        if (isVirtualCall) {
+            BytecodeMethod.addVirtualMethodsInvoked(bld.substring("virtual_".length()));
+        }
         boolean noPop = false;
         if(returnVal == null) {
             b.append(bld);


### PR DESCRIPTION
## Summary
- ensure virtual invocations in Invoke and CustomInvoke mark their targets as used
- prevent missing virtual stubs that lead to undefined function calls in generated code

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942d09258c48331aea514f2db226545)