### PR TITLE
Fix useless object warnings and tighten quality gate

### DIFF
--- a/.github/scripts/generate-quality-report.py
+++ b/.github/scripts/generate-quality-report.py
@@ -772,6 +772,7 @@ def main() -> None:
             "FE_TEST_IF_EQUAL_TO_NOT_A_NUMBER",
             "SA_FIELD_SELF_ASSIGNMENT",
             "UC_USELESS_CONDITION",
+            "UC_USELESS_OBJECT",
             "EC_UNRELATED_TYPES",
             "EQ_ALWAYS_FALSE",
             "SBSC_USE_STRINGBUFFER_CONCATENATION",

--- a/CodenameOne/src/com/codename1/charts/views/DoughnutChart.java
+++ b/CodenameOne/src/com/codename1/charts/views/DoughnutChart.java
@@ -103,10 +103,8 @@ public class DoughnutChart extends RoundChart {
         for (int category = 0; category < cLength; category++) {
             int sLength = mDataset.getItemCount(category);
             double total = 0;
-            String[] titles = new String[sLength];
             for (int i = 0; i < sLength; i++) {
                 total += mDataset.getValues(category)[i];
-                titles[i] = mDataset.getTitles(category)[i];
             }
             float currentAngle = mRenderer.getStartAngle();
             Rectangle2D oval = PkgUtils.makeRect(mCenterX - radius, mCenterY - radius, mCenterX + radius, mCenterY

--- a/CodenameOne/src/com/codename1/payment/Purchase.java
+++ b/CodenameOne/src/com/codename1/payment/Purchase.java
@@ -586,8 +586,6 @@ public abstract class Purchase {
             callback.onSucess(true);
             return;
         }
-        List<Receipt> oldData = new ArrayList<Receipt>();
-        oldData.addAll(getReceipts());
 
         SuccessCallback<Receipt[]> onSuccess = new SuccessCallback<Receipt[]>() {
 

--- a/CodenameOne/src/com/codename1/properties/SQLMap.java
+++ b/CodenameOne/src/com/codename1/properties/SQLMap.java
@@ -783,8 +783,6 @@ public class SQLMap {
         }
 
         public java.util.List<PropertyBusinessObject> build(PropertyBusinessObject obj, int maxElements, int page) throws IOException, InstantiationException {
-            ArrayList<Object> params = new ArrayList<Object>();
-
             SelectBuilder root = this;
             while (root.parent.property != null) {
                 root = root.parent;
@@ -816,7 +814,7 @@ public class SQLMap {
                 }
             }
 
-            return selectImpl(obj, createStatement.toString(), obj.getClass(), params.toArray(),
+            return selectImpl(obj, createStatement.toString(), obj.getClass(), paramList.toArray(),
                     null, false, maxElements, page);
         }
 

--- a/CodenameOne/src/com/codename1/ui/BrowserComponent.java
+++ b/CodenameOne/src/com/codename1/ui/BrowserComponent.java
@@ -2172,7 +2172,7 @@ public class BrowserComponent extends Container {
                 i++;
             }
             js.append("callback.onSuccess(undefined)");
-            execute(timeout, js.toString(), callback);
+            execute(timeout, js.toString(), params, callback);
         }
 
         /**
@@ -2201,7 +2201,7 @@ public class BrowserComponent extends Container {
                 i++;
             }
             js.append("callback.onSuccess(undefined)");
-            executeAndWait(timeout, js.toString());
+            executeAndWait(timeout, js.toString(), params);
         }
 
         /**

--- a/CodenameOne/src/com/codename1/ui/ComponentSelector.java
+++ b/CodenameOne/src/com/codename1/ui/ComponentSelector.java
@@ -1281,11 +1281,9 @@ public class ComponentSelector implements Iterable<Component>, Set<Component> {
      * @return Self for chaining.
      */
     public ComponentSelector slideDownAndWait(final int duration) {
-        final ArrayList<Component> animatedComponents = new ArrayList<Component>();
         for (Component c : this) {
             c.setHeight(0);
             c.setVisible(true);
-            animatedComponents.add(c);
         }
         getParent().animateLayoutAndWait(duration);
 


### PR DESCRIPTION
## Summary
- remove unused temporary collections and arrays flagged by SpotBugs
- pass parameter arrays to BrowserComponent property setters to avoid unused allocations
- add UC_USELESS_OBJECT to the forbidden SpotBugs rules enforced by the quality report

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d363691688331a7a093a1f8074878)