### PR TITLE
Exclude SE_COMPARATOR_SHOULD_BE_SERIALIZABLE SpotBugs check

### DIFF
--- a/maven/core-unittests/spotbugs-exclude.xml
+++ b/maven/core-unittests/spotbugs-exclude.xml
@@ -3,6 +3,9 @@
     <Match>
         <Bug pattern="SE_NO_SERIALVERSIONID"/>
     </Match>
+    <Match>
+        <Bug pattern="SE_COMPARATOR_SHOULD_BE_SERIALIZABLE"/>
+    </Match>
 
     <!-- We don't support clone() -->
     <Match>


### PR DESCRIPTION
## Summary
- exclude SE_COMPARATOR_SHOULD_BE_SERIALIZABLE from SpotBugs filter because Codename One does not support serialization

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d417ca9fc8331ad25d84ba2530488)