### PR TITLE
Fix SpotBugs indexOf handling and enforce RV rule

### DIFF
--- a/.github/scripts/generate-quality-report.py
+++ b/.github/scripts/generate-quality-report.py
@@ -811,7 +811,8 @@ def main() -> None:
             "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD",
             "UW_UNCOND_WAIT",
             "SIC_INNER_SHOULD_BE_STATIC_ANON",
-            "SS_SHOULD_BE_STATIC"
+            "SS_SHOULD_BE_STATIC",
+            "RV_CHECK_FOR_POSITIVE_INDEXOF",
         }
 
         def _is_exempt(f: Finding) -> bool:

--- a/CodenameOne/src/com/codename1/facebook/FacebookRESTService.java
+++ b/CodenameOne/src/com/codename1/facebook/FacebookRESTService.java
@@ -89,9 +89,10 @@ class FacebookRESTService extends ConnectionRequest implements JSONParseCallback
     }
 
     protected void setQuery(String query) {
-        if (query.indexOf("?") > 0) {
-            String search = query.substring(query.indexOf("?") + 1);
-            query = query.substring(0, query.indexOf("?"));
+        int queryParamsIndex = query.indexOf("?");
+        if (queryParamsIndex >= 0) {
+            String search = query.substring(queryParamsIndex + 1);
+            query = query.substring(0, queryParamsIndex);
             java.util.List<String> parts = StringUtil.tokenize(search, "&");
             for (String part : parts) {
                 java.util.List<String> kv = StringUtil.tokenize(part, "=");
@@ -153,7 +154,8 @@ class FacebookRESTService extends ConnectionRequest implements JSONParseCallback
                 }
             };
             stack.addElement(node);
-            if (connectionType.length() > 0 || getUrl().indexOf("search") > 0) {
+            String currentUrl = getUrl();
+            if (connectionType.length() > 0 || currentUrl.indexOf("search") >= 0) {
                 return;
             }
         } else {

--- a/CodenameOne/src/com/codename1/io/Oauth2.java
+++ b/CodenameOne/src/com/codename1/io/Oauth2.java
@@ -610,10 +610,16 @@ public class Oauth2 {
                 boolean success = url.indexOf("#") > -1;
                 if (success) {
                     String accessToken = url.substring(url.indexOf("#") + 1);
-                    if (accessToken.indexOf("&") > 0) {
-                        token = accessToken.substring(accessToken.indexOf("=") + 1, accessToken.indexOf("&"));
+                    int ampIndex = accessToken.indexOf("&");
+                    int equalsIndex = accessToken.indexOf("=");
+                    if (equalsIndex >= 0) {
+                        if (ampIndex >= 0 && ampIndex > equalsIndex) {
+                            token = accessToken.substring(equalsIndex + 1, ampIndex);
+                        } else {
+                            token = accessToken.substring(equalsIndex + 1);
+                        }
                     } else {
-                        token = accessToken.substring(accessToken.indexOf("=") + 1);
+                        token = accessToken;
                     }
                     if (login != null) {
                         login.dispose();
@@ -645,7 +651,8 @@ public class Oauth2 {
         String[] params = Util.split(url, "&");
         int plen = params.length;
         for (int i = 0; i < plen; i++) {
-            if (params[i].indexOf("=") > 0) {
+            int equalsIndex = params[i].indexOf("=");
+            if (equalsIndex >= 0) {
                 String[] keyVal = Util.split(params[i], "=");
                 retVal.put(keyVal[0], keyVal[1]);
             }

--- a/CodenameOne/src/com/codename1/properties/UiBinding.java
+++ b/CodenameOne/src/com/codename1/properties/UiBinding.java
@@ -480,7 +480,7 @@ public class UiBinding {
             }
             if (source instanceof String) {
                 String s = ((String) source).toLowerCase();
-                return s.indexOf("true") > 0 || s.indexOf("yes") > 0 || s.indexOf("1") > 0;
+                return s.contains("true") || s.contains("yes") || s.contains("1");
             }
             return Util.toIntValue(source) > 0;
         }

--- a/CodenameOne/src/com/codename1/ui/plaf/CSSBorder.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/CSSBorder.java
@@ -1762,7 +1762,7 @@ public class CSSBorder extends Border {
         private final ScalarUnit bottomRightY;
 
         BorderRadius(String value) {
-            if (value.indexOf("/") > 0) {
+            if (value.contains("/")) {
                 String[] parts = Util.split(value, "/");
                 String[] hVals = Util.split(parts[0].trim(), " ");
                 String[] vVals = Util.split(parts[1].trim(), " ");


### PR DESCRIPTION
## Summary
- update indexOf handling to avoid missing matches at position zero in FacebookRESTService, Oauth2, UiBinding, and CSSBorder
- add RV_CHECK_FOR_POSITIVE_INDEXOF to the forbidden SpotBugs rules in the quality report script

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d413f6e408331ab300a59c2d18f1e)