### PR TITLE
Replace floating-point Number constructors with valueOf and enforce DM_FP_NUMBER_CTOR

### DIFF
--- a/.github/scripts/generate-quality-report.py
+++ b/.github/scripts/generate-quality-report.py
@@ -797,6 +797,7 @@ def main() -> None:
             "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE",
             "CN_IDIOM_NO_SUPER_CALL",
             "DM_BOOLEAN_CTOR",
+            "DM_FP_NUMBER_CTOR",
             "DM_EXIT",
             "EI_EXPOSE_REP", 
             "EI_EXPOSE_REP2",

--- a/CodenameOne/src/com/codename1/io/JSONParser.java
+++ b/CodenameOne/src/com/codename1/io/JSONParser.java
@@ -838,10 +838,10 @@ public class JSONParser implements JSONParseCallback {
      */
     public void numericToken(double tok) {
         if (isStackHash()) {
-            getStackHash().put(currentKey, new Double(tok));
+            getStackHash().put(currentKey, Double.valueOf(tok));
             currentKey = null;
         } else {
-            getStackVec().add(new Double(tok));
+            getStackVec().add(Double.valueOf(tok));
         }
     }
 

--- a/CodenameOne/src/com/codename1/io/Preferences.java
+++ b/CodenameOne/src/com/codename1/io/Preferences.java
@@ -173,7 +173,7 @@ public class Preferences {
      * @param d    a number
      */
     public static void set(String pref, double d) {
-        set(pref, new Double(d));
+        set(pref, Double.valueOf(d));
     }
 
     /**
@@ -183,7 +183,7 @@ public class Preferences {
      * @param f    a number
      */
     public static void set(String pref, float f) {
-        set(pref, new Float(f));
+        set(pref, Float.valueOf(f));
     }
 
     /**

--- a/CodenameOne/src/com/codename1/javascript/JSObject.java
+++ b/CodenameOne/src/com/codename1/javascript/JSObject.java
@@ -531,7 +531,7 @@ public class JSObject {
      * @param async True if you want this call to be asynchronous.
      */
     public void setInt(String key, int value, boolean async) {
-        set(key, new Double(value), async);
+        set(key, Double.valueOf(value), async);
     }
 
     /**
@@ -552,7 +552,7 @@ public class JSObject {
      * @param async True if you want this call to be asynchronous.
      */
     public void setDouble(String key, double value, boolean async) {
-        set(key, new Double(value), async);
+        set(key, Double.valueOf(value), async);
     }
 
     /**
@@ -615,7 +615,7 @@ public class JSObject {
      * @param async True to make this call asynchronous.
      */
     public void setInt(int index, int value, boolean async) {
-        set(index, new Double(value), async);
+        set(index, Double.valueOf(value), async);
     }
 
     /**
@@ -636,7 +636,7 @@ public class JSObject {
      * @param async True to make this call asynchronous.
      */
     public void setDouble(int index, double value, boolean async) {
-        set(index, new Double(value), async);
+        set(index, Double.valueOf(value), async);
     }
 
     /**

--- a/CodenameOne/src/com/codename1/maps/MapComponent.java
+++ b/CodenameOne/src/com/codename1/maps/MapComponent.java
@@ -1107,11 +1107,11 @@ public class MapComponent extends Container {
     public Object getPropertyValue(String name) {
         if (name.equals("latitude")) {
             Coord c = _map.projection().toWGS84(_center);
-            return new Double(c.getLatitude());
+            return Double.valueOf(c.getLatitude());
         }
         if (name.equals("longitude")) {
             Coord c = _map.projection().toWGS84(_center);
-            return new Double(c.getLongitude());
+            return Double.valueOf(c.getLongitude());
         }
         if (name.equals("zoom")) {
             return Integer.valueOf(getZoomLevel());

--- a/CodenameOne/src/com/codename1/ui/layouts/mig/AC.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/mig/AC.java
@@ -450,7 +450,7 @@ public final class AC {
      * @return <code>this</code> so it is possible to chain calls. E.g. <code>new AxisConstraint().noGrid().gap().fill()</code>.
      */
     public AC grow(float w, int... indexes) {
-        Float gw = new Float(w);
+        Float gw = Float.valueOf(w);
         for (int i = indexes.length - 1; i >= 0; i--) {
             int ix = indexes[i];
             makeSize(ix);
@@ -527,7 +527,7 @@ public final class AC {
      * @since 3.7.2
      */
     public AC shrink(float w, int... indexes) {
-        Float sw = new Float(w);
+        Float sw = Float.valueOf(w);
         for (int i = indexes.length - 1; i >= 0; i--) {
             int ix = indexes[i];
             makeSize(ix);

--- a/CodenameOne/src/com/codename1/ui/layouts/mig/CC.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/mig/CC.java
@@ -333,7 +333,7 @@ public final class CC {
      * @return <code>this</code> so it is possible to chain calls. E.g. <code>new ComponentConstraint().noGrid().gap().fill()</code>.
      */
     public CC shrinkX(float w) {
-        hor.setShrink(new Float(w));
+        hor.setShrink(Float.valueOf(w));
         return this;
     }
 
@@ -560,7 +560,7 @@ public final class CC {
      * @return <code>this</code> so it is possible to chain calls. E.g. <code>new ComponentConstraint().noGrid().gap().fill()</code>.
      */
     public CC shrinkY(float w) {
-        ver.setShrink(new Float(w));
+        ver.setShrink(Float.valueOf(w));
         return this;
     }
 

--- a/CodenameOne/src/com/codename1/ui/layouts/mig/CodenameOneMiGComponentWrapper.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/mig/CodenameOneMiGComponentWrapper.java
@@ -133,7 +133,7 @@ class CodenameOneMiGComponentWrapper implements ComponentWrapper {
 
                 Float s = isHor ? PlatformDefaults.getHorizontalScaleFactor() : PlatformDefaults.getVerticalScaleFactor();
                 if (s == null)
-                    s = new Float(1.0f);
+                    s = Float.valueOf(1.0f);
                 return s * (isHor ? getHorizontalScreenDPI() : getVerticalScreenDPI()) / (float) PlatformDefaults.getDefaultDPI();
 
             default:

--- a/CodenameOne/src/com/codename1/ui/layouts/mig/ConstraintParser.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/mig/ConstraintParser.java
@@ -898,10 +898,10 @@ public final class ConstraintParser {
                     }
 
                     if (part.equals("dock center")) {
-                        cc.getHorizontal().setGrow(new Float(100f));
-                        cc.getVertical().setGrow(new Float(100f));
-                        cc.setPushX(new Float(100f));
-                        cc.setPushY(new Float(100f));
+                        cc.getHorizontal().setGrow(Float.valueOf(100f));
+                        cc.getVertical().setGrow(Float.valueOf(100f));
+                        cc.setPushX(Float.valueOf(100f));
+                        cc.setPushY(Float.valueOf(100f));
                         continue;
                     }
                 }
@@ -1067,7 +1067,7 @@ public final class ConstraintParser {
     }
 
     private static Float parseFloat(String s, Float nullVal) {
-        return s.length() > 0 ? new Float(Float.parseFloat(s)) : nullVal;
+        return s.length() > 0 ? Float.valueOf(Float.parseFloat(s)) : nullVal;
     }
 
     /**

--- a/CodenameOne/src/com/codename1/ui/layouts/mig/ResizeConstraint.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/mig/ResizeConstraint.java
@@ -39,7 +39,7 @@ package com.codename1.ui.layouts.mig;
  * grow compared to other entities.
  */
 final class ResizeConstraint {
-    static final Float WEIGHT_100 = new Float(100);
+    static final Float WEIGHT_100 = Float.valueOf(100);
 
     /**
      * How flexilble the entity should be, relative to other entities, when it comes to growing. <code>null</code> or

--- a/CodenameOne/src/com/codename1/ui/plaf/Style.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/Style.java
@@ -2475,8 +2475,8 @@ public class Style {
      */
     Object[] getBackgroundGradient() {
         if (backgroundGradient == null) {
-            Float c = new Float(0.5f);
-            backgroundGradient = new Object[]{Integer.valueOf(0xffffff), Integer.valueOf(0), c, c, new Float(1)};
+            Float c = Float.valueOf(0.5f);
+            backgroundGradient = new Object[]{Integer.valueOf(0xffffff), Integer.valueOf(0), c, c, Float.valueOf(1)};
         }
         return backgroundGradient;
     }
@@ -2549,7 +2549,7 @@ public class Style {
             return;
         }
         if (((Float) getBackgroundGradient()[2]).floatValue() != backgroundGradientRelativeX) {
-            getBackgroundGradient()[2] = new Float(backgroundGradientRelativeX);
+            getBackgroundGradient()[2] = Float.valueOf(backgroundGradientRelativeX);
             if (!override) {
                 modifiedFlag |= BACKGROUND_GRADIENT_MODIFIED;
             }
@@ -2572,7 +2572,7 @@ public class Style {
             return;
         }
         if (((Float) getBackgroundGradient()[3]).floatValue() != backgroundGradientRelativeY) {
-            getBackgroundGradient()[3] = new Float(backgroundGradientRelativeY);
+            getBackgroundGradient()[3] = Float.valueOf(backgroundGradientRelativeY);
             if (!override) {
                 modifiedFlag |= BACKGROUND_GRADIENT_MODIFIED;
             }
@@ -2596,7 +2596,7 @@ public class Style {
             return;
         }
         if (((Float) getBackgroundGradient()[4]).floatValue() != backgroundGradientRelativeSize) {
-            getBackgroundGradient()[4] = new Float(backgroundGradientRelativeSize);
+            getBackgroundGradient()[4] = Float.valueOf(backgroundGradientRelativeSize);
             if (!override) {
                 modifiedFlag |= BACKGROUND_GRADIENT_MODIFIED;
             }

--- a/CodenameOne/src/com/codename1/ui/plaf/UIManager.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/UIManager.java
@@ -1946,7 +1946,7 @@ public class UIManager {
                     Object[] a = new Object[5];
                     System.arraycopy(backgroundGradient, 0, a, 0, backgroundGradient.length);
                     backgroundGradient = a;
-                    backgroundGradient[4] = new Float(1);
+                    backgroundGradient[4] = Float.valueOf(1);
                 }
                 style.setBackgroundGradient(backgroundGradient);
             }

--- a/CodenameOne/src/com/codename1/ui/spinner/NumericSpinner.java
+++ b/CodenameOne/src/com/codename1/ui/spinner/NumericSpinner.java
@@ -126,7 +126,7 @@ public class NumericSpinner extends BaseSpinner {
     public void setValue(double value) {
         this.value = value;
         if (spin != null) {
-            ((SpinnerNumberModel) spin.getModel()).setValue(new Double(value));
+            ((SpinnerNumberModel) spin.getModel()).setValue(Double.valueOf(value));
         }
     }
 
@@ -177,16 +177,16 @@ public class NumericSpinner extends BaseSpinner {
      */
     public Object getPropertyValue(String name) {
         if (name.equals("min")) {
-            return new Double(min);
+            return Double.valueOf(min);
         }
         if (name.equals("max")) {
-            return new Double(max);
+            return Double.valueOf(max);
         }
         if (name.equals("value")) {
-            return new Double(getValue());
+            return Double.valueOf(getValue());
         }
         if (name.equals("step")) {
-            return new Double(step);
+            return Double.valueOf(step);
         }
         return null;
     }

--- a/CodenameOne/src/com/codename1/ui/spinner/Spinner.java
+++ b/CodenameOne/src/com/codename1/ui/spinner/Spinner.java
@@ -206,7 +206,7 @@ class Spinner extends List {
                 return super.getListCellRendererComponent(list, value, index, isSelected);
             }
         });
-        s.setRenderingPrototype(new Double(max * 10));
+        s.setRenderingPrototype(Double.valueOf(max * 10));
         return s;
     }
 
@@ -531,7 +531,7 @@ class Spinner extends List {
                                 val < ((SpinnerNumberModel) getModel()).getMin()) {
                             return;
                         }
-                        setValue(new Double(val));
+                        setValue(Double.valueOf(val));
                     } else {
                         int val = Integer.parseInt(t);
                         if (val > ((SpinnerNumberModel) getModel()).getMax() ||

--- a/CodenameOne/src/com/codename1/ui/spinner/SpinnerNumberModel.java
+++ b/CodenameOne/src/com/codename1/ui/spinner/SpinnerNumberModel.java
@@ -93,7 +93,7 @@ class SpinnerNumberModel implements ListModel {
 
     Object getValue() {
         if (realValues) {
-            return new Double(currentValue);
+            return Double.valueOf(currentValue);
         }
         return Integer.valueOf((int) currentValue);
     }
@@ -115,7 +115,7 @@ class SpinnerNumberModel implements ListModel {
      */
     public Object getItemAt(int index) {
         if (realValues) {
-            return new Double(min + step * index);
+            return Double.valueOf(min + step * index);
         }
         return Integer.valueOf((int) (min + step * index));
     }

--- a/CodenameOne/src/com/codename1/ui/util/Resources.java
+++ b/CodenameOne/src/com/codename1/ui/util/Resources.java
@@ -1576,8 +1576,8 @@ public class Resources {
                     case 0xF6:
                         // Vertical Linear Gradient
                     case 0xF7:
-                        Float c = new Float(0.5f);
-                        theme.put(key + Style.BACKGROUND_GRADIENT, new Object[]{Integer.valueOf(input.readInt()), Integer.valueOf(input.readInt()), c, c, new Float(1)});
+                        Float c = Float.valueOf(0.5f);
+                        theme.put(key + Style.BACKGROUND_GRADIENT, new Object[]{Integer.valueOf(input.readInt()), Integer.valueOf(input.readInt()), c, c, Float.valueOf(1)});
                         break;
 
                     // Radial Gradient
@@ -1592,9 +1592,9 @@ public class Resources {
                         }
                         theme.put(key + Style.BACKGROUND_GRADIENT, new Object[]{Integer.valueOf(c1),
                                 Integer.valueOf(c2),
-                                new Float(f1),
-                                new Float(f2),
-                                new Float(radialSize)});
+                                Float.valueOf(f1),
+                                Float.valueOf(f2),
+                                Float.valueOf(radialSize)});
                         break;
                     default:
                         break;
@@ -1641,16 +1641,16 @@ public class Resources {
                     theme.put(key, new Object[]{
                             Integer.valueOf(input.readInt()),
                             Integer.valueOf(input.readInt()),
-                            new Float(input.readFloat()),
-                            new Float(input.readFloat())
+                            Float.valueOf(input.readFloat()),
+                            Float.valueOf(input.readFloat())
                     });
                 } else {
                     theme.put(key, new Object[]{
                             Integer.valueOf(input.readInt()),
                             Integer.valueOf(input.readInt()),
-                            new Float(input.readFloat()),
-                            new Float(input.readFloat()),
-                            new Float(input.readFloat())
+                            Float.valueOf(input.readFloat()),
+                            Float.valueOf(input.readFloat()),
+                            Float.valueOf(input.readFloat())
                     });
                 }
                 continue;

--- a/CodenameOne/src/com/codename1/ui/util/UIBuilder.java
+++ b/CodenameOne/src/com/codename1/ui/util/UIBuilder.java
@@ -863,11 +863,11 @@ public class UIBuilder { //implements Externalizable {
         }
 
         if (type == Double.class) {
-            return new Double(in.readDouble());
+            return Double.valueOf(in.readDouble());
         }
 
         if (type == Float.class) {
-            return new Float(in.readFloat());
+            return Float.valueOf(in.readFloat());
         }
 
         if (type == Byte.class) {


### PR DESCRIPTION
### Motivation
- Address SpotBugs warnings about inefficient floating-point Number constructors (use of `new Float(...)` / `new Double(...)`).
- Reduce unnecessary object allocations by using the boxed `valueOf` factory methods.
- Make this class of SpotBugs findings (`DM_FP_NUMBER_CTOR`) a blocking quality gate so regressions are caught in CI.

### Description
- Replaced usages of `new Double(...)` and `new Float(...)` with `Double.valueOf(...)` and `Float.valueOf(...)` across core code paths including JSON parsing, preferences, JS interop, maps, MiG layout, styling, spinner models, resources, and the UI builder.
- Updated the SpotBugs forbidden rules in `.github/scripts/generate-quality-report.py` to include `DM_FP_NUMBER_CTOR` so that occurrences now fail the build.
- Changes span multiple files under `CodenameOne/src/com/codename1/` and the quality-report script to enforce the rule.

### Testing
- No automated unit tests were executed as part of this change.
- CI SpotBugs analysis will now treat `DM_FP_NUMBER_CTOR` findings as failures due to the updated `generate-quality-report.py` enforcement.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695de3f5df5083318ac42c447e8bcf45)