### PR TITLE
Expose system larger-text (Dynamic Type) scale via Display/CodenameOneImplementation

### DIFF
--- a/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
+++ b/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
@@ -8680,6 +8680,28 @@ public abstract class CodenameOneImplementation {
     }
 
     /**
+     * Returns true if the user has selected larger type fonts in the system settings.
+     * Default implementation returns false.
+     *
+     * @return true when the platform indicates a larger text preference.
+     * @since 7.1
+     */
+    public boolean isLargerTextEnabled() {
+        return false;
+    }
+
+    /**
+     * Returns a scale factor representing how much larger system fonts should be.
+     * A value of {@code 1.0} indicates the default system font size.
+     *
+     * @return scale factor for larger system fonts.
+     * @since 7.1
+     */
+    public float getLargerTextScale() {
+        return 1.0f;
+    }
+
+    /**
      * Returns the stack trace from the exception on the given
      * thread. This API isn't supported on all platforms and may
      * return a blank string when unavailable.

--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -749,6 +749,27 @@ public final class Display extends CN1Constants {
     }
 
     /**
+     * Returns true if the user has selected larger type fonts in the system settings.
+     *
+     * @return true when the platform indicates a larger text preference.
+     * @since 7.1
+     */
+    public boolean isLargerTextEnabled() {
+        return impl.isLargerTextEnabled();
+    }
+
+    /**
+     * Returns a scale factor representing how much larger system fonts should be.
+     * A value of {@code 1.0} indicates the default system font size.
+     *
+     * @return scale factor for larger system fonts.
+     * @since 7.1
+     */
+    public float getLargerTextScale() {
+        return impl.getLargerTextScale();
+    }
+
+    /**
      * Checks if async stack traces are enabled.  If enabled, the stack trace
      * at the point of {@link #callSerially(java.lang.Runnable) } calls will
      * be recorded, and logged in the case that there is an uncaught exception.

--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -1267,6 +1267,26 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
         }
     }
 
+    @Override
+    public boolean isLargerTextEnabled() {
+        return getLargerTextScale() > 1.0f;
+    }
+
+    @Override
+    public float getLargerTextScale() {
+        try {
+            Configuration configuration;
+            if (getActivity() != null) {
+                configuration = getActivity().getResources().getConfiguration();
+            } else {
+                configuration = getContext().getResources().getConfiguration();
+            }
+            return configuration.fontScale;
+        } catch (Throwable t) {
+            return 1.0f;
+        }
+    }
+
     
     private boolean hasActionBar() {
         return android.os.Build.VERSION.SDK_INT >= 11;

--- a/Ports/iOSPort/nativeSources/IOSNative.m
+++ b/Ports/iOSPort/nativeSources/IOSNative.m
@@ -4119,6 +4119,29 @@ JAVA_BOOLEAN com_codename1_impl_ios_IOSNative_isDarkModeDetectionSupported___R_b
     }
 }
 
+JAVA_BOOLEAN com_codename1_impl_ios_IOSNative_isLargerTextEnabled___R_boolean(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject) {
+    if (@available(iOS 7.0, *)) {
+        CGFloat baseSize = [UIFont systemFontSize];
+        UIFont *preferred = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+        return preferred.pointSize > (baseSize + 0.5f);
+    } else {
+        return JAVA_FALSE;
+    }
+}
+
+JAVA_FLOAT com_codename1_impl_ios_IOSNative_getLargerTextScale___R_float(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject) {
+    if (@available(iOS 7.0, *)) {
+        CGFloat baseSize = [UIFont systemFontSize];
+        UIFont *preferred = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+        if (baseSize <= 0.0f) {
+            return 1.0f;
+        }
+        return (JAVA_FLOAT)(preferred.pointSize / baseSize);
+    } else {
+        return 1.0f;
+    }
+}
+
 #ifdef INCLUDE_LOCATION_USAGE
 CLLocationManager* com_codename1_impl_ios_IOSNative_createCLLocation = nil;
 #endif

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
@@ -1214,6 +1214,16 @@ public class IOSImplementation extends CodenameOneImplementation {
         }
         return null;
     }
+
+    @Override
+    public boolean isLargerTextEnabled() {
+        return nativeInstance.isLargerTextEnabled();
+    }
+
+    @Override
+    public float getLargerTextScale() {
+        return nativeInstance.getLargerTextScale();
+    }
     
 
     public void flushGraphics() {
@@ -9503,6 +9513,5 @@ public class IOSImplementation extends CodenameOneImplementation {
         IOSNative.announceForAccessibility(text);
     }
 }
-
 
 

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSNative.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSNative.java
@@ -139,6 +139,9 @@ public final class IOSNative {
     native void execute(String url);
 
     native void flashBacklight(int duration);
+    
+    native boolean isLargerTextEnabled();
+    native float getLargerTextScale();
 
     // SJH Nov. 17, 2015 : Removing native isMinimized() method because it conflicted with
     // tracking on the java side.  It caused the app to still be minimized inside start()


### PR DESCRIPTION
### Motivation

- Allow apps to detect when the user enabled larger system text and obtain the platform font scale so UI/layouts can adapt automatically.
- Surface the capability through the same native-extension pattern used elsewhere in the codebase (`CodenameOneImplementation`/`Display`).

### Description

- Added two new APIs to `CodenameOneImplementation`: `isLargerTextEnabled()` and `getLargerTextScale()` with defaults of `false` and `1.0f` respectively, and exposed them on `Display` as `isLargerTextEnabled()` and `getLargerTextScale()`.
- Implemented Android support in `AndroidImplementation` by returning `configuration.fontScale` from `getLargerTextScale()` and defining `isLargerTextEnabled()` as `getLargerTextScale() > 1.0f`.
- Wired iOS native hooks by declaring `isLargerTextEnabled()` and `getLargerTextScale()` in `IOSNative.java`, calling them from `IOSImplementation`, and implementing Objective-C functions in `IOSNative.m` that compare `UIFont` preferred sizes to the base `systemFontSize` to compute a scale and enabled flag.

### Testing

- No automated tests were executed for this change.
- Basic compilation or platform-specific native verification was not performed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962703a40e48331aa06565342362453)