### PR TITLE
UIManager: opt-in larger text scaling for theme fonts

### DIFF
--- a/maven/core-unittests/src/test/java/com/codename1/testing/TestCodenameOneImplementation.java
+++ b/maven/core-unittests/src/test/java/com/codename1/testing/TestCodenameOneImplementation.java
@@ -128,6 +128,8 @@ public class TestCodenameOneImplementation extends CodenameOneImplementation {
     private boolean trueTypeSupported = true;
     private static TestCodenameOneImplementation instance;
     private String executeURL;
+    private boolean largerTextEnabled;
+    private float largerTextScale = 1f;
 
     private boolean autoProcessConnections = true;
     private Map<String, String> properties = new HashMap<>();
@@ -1091,6 +1093,8 @@ public class TestCodenameOneImplementation extends CodenameOneImplementation {
         softkeyCount = 2;
         thirdSoftButton = false;
         mutableImagesFast = true;
+        largerTextEnabled = false;
+        largerTextScale = 1f;
     }
 
     public List<Object> getCleanupCalls() {
@@ -2220,6 +2224,24 @@ public class TestCodenameOneImplementation extends CodenameOneImplementation {
 
     public void setNativeFontSchemeSupported(boolean nativeFontSchemeSupported) {
         this.nativeFontSchemeSupported = nativeFontSchemeSupported;
+    }
+
+    public void setLargerTextEnabled(boolean largerTextEnabled) {
+        this.largerTextEnabled = largerTextEnabled;
+    }
+
+    public void setLargerTextScale(float largerTextScale) {
+        this.largerTextScale = largerTextScale;
+    }
+
+    @Override
+    public boolean isLargerTextEnabled() {
+        return largerTextEnabled;
+    }
+
+    @Override
+    public float getLargerTextScale() {
+        return largerTextScale;
     }
 
     @Override

--- a/maven/core-unittests/src/test/java/com/codename1/ui/plaf/UIManagerLargeTextScaleTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/plaf/UIManagerLargeTextScaleTest.java
@@ -1,0 +1,72 @@
+package com.codename1.ui.plaf;
+
+import com.codename1.junit.UITestBase;
+import com.codename1.testing.TestCodenameOneImplementation;
+import com.codename1.ui.Font;
+import java.util.Hashtable;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class UIManagerLargeTextScaleTest extends UITestBase {
+    @Test
+    public void testLargeTextScaleFlagAppliesToThemeFonts() {
+        TestCodenameOneImplementation impl = implementation;
+        impl.setLargerTextEnabled(true);
+        impl.setLargerTextScale(1.5f);
+
+        UIManager manager = UIManager.getInstance();
+        manager.setUseLargerTextScale(true);
+
+        Font baseFont = Font.createTrueTypeFont(Font.NATIVE_MAIN_REGULAR, Font.NATIVE_MAIN_REGULAR)
+                .derive(20f, Font.STYLE_PLAIN);
+        Hashtable theme = new Hashtable();
+        theme.put("Button.font", baseFont);
+
+        manager.setThemeProps(theme);
+
+        Font scaledFont = manager.getComponentStyle("Button").getFont();
+        assertEquals(30f, scaledFont.getPixelSize(), 0.01f);
+    }
+
+    @Test
+    public void testThemeConstantEnablesLargeTextScaling() {
+        TestCodenameOneImplementation impl = implementation;
+        impl.setLargerTextEnabled(true);
+        impl.setLargerTextScale(1.25f);
+
+        UIManager manager = UIManager.getInstance();
+        manager.setUseLargerTextScale(false);
+
+        Font baseFont = Font.createTrueTypeFont(Font.NATIVE_MAIN_REGULAR, Font.NATIVE_MAIN_REGULAR)
+                .derive(16f, Font.STYLE_PLAIN);
+        Hashtable theme = new Hashtable();
+        theme.put("@useLargerTextScaleBool", "true");
+        theme.put("Label.font", baseFont);
+
+        manager.setThemeProps(theme);
+
+        Font scaledFont = manager.getComponentStyle("Label").getFont();
+        assertEquals(20f, scaledFont.getPixelSize(), 0.01f);
+    }
+
+    @Test
+    public void testLargeTextScaleDisabledByDefault() {
+        TestCodenameOneImplementation impl = implementation;
+        impl.setLargerTextEnabled(true);
+        impl.setLargerTextScale(1.5f);
+
+        UIManager manager = UIManager.getInstance();
+        manager.setUseLargerTextScale(false);
+
+        Font baseFont = Font.createTrueTypeFont(Font.NATIVE_MAIN_REGULAR, Font.NATIVE_MAIN_REGULAR)
+                .derive(12f, Font.STYLE_PLAIN);
+        Hashtable theme = new Hashtable();
+        theme.put("Title.font", baseFont);
+
+        manager.setThemeProps(theme);
+
+        Font scaledFont = manager.getComponentStyle("Title").getFont();
+        assertEquals(12f, scaledFont.getPixelSize(), 0.01f);
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure UIs respect the platform "larger text" accessibility setting by optionally scaling theme fonts using `Display.getLargerTextScale()` when `Display.isLargerTextEnabled()` is true.
- Make this behavior opt-in so existing apps are unaffected by default and can enable scaling via a flag or theme constant.
- Provide deterministic unit tests in `maven/core-unittests` to validate the scaling behavior.

### Description
- Added a `useLargerTextScale` flag with `setUseLargerTextScale`/`isUseLargerTextScale` to `UIManager` and read the `@useLargerTextScaleBool` theme constant when building a theme. (`CodenameOne/src/com/codename1/ui/plaf/UIManager.java`)
- Implemented logic to compute an effective scale (`getEffectiveLargerTextScale`) and to apply scaling to theme font entries and default styles (`applyLargerTextScaleToThemeFonts`, `applyLargerTextScaleToDefaultStyles`) when enabled. (`UIManager.java`)
- Extended the test implementation to simulate platform larger-text behavior by adding `setLargerTextEnabled`, `setLargerTextScale`, and overriding `isLargerTextEnabled`/`getLargerTextScale`, and reset those values in `reset()`. (`maven/core-unittests/src/test/java/com/codename1/testing/TestCodenameOneImplementation.java`)
- Added unit tests `UIManagerLargeTextScaleTest` verifying the flag-based scaling, theme-constant based enabling, and default-off behavior. (`maven/core-unittests/src/test/java/com/codename1/ui/plaf/UIManagerLargeTextScaleTest.java`)

### Testing
- Added automated tests in `maven/core-unittests`: `UIManagerLargeTextScaleTest` which contains three tests covering flag, theme constant, and default-off cases. 
- No automated test execution was performed as part of this change (tests were added but not run in the rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962926446a88331952f984bb92c8be5)