### PR TITLE
Document larger text accessibility APIs

### DIFF
--- a/docs/developer-guide/Advanced-Theming.asciidoc
+++ b/docs/developer-guide/Advanced-Theming.asciidoc
@@ -193,6 +193,9 @@ SoftKey, Touch, Bar, Title, Right, Native
 |textUiid
 |Overrides the text component UIID for `SpanLabel`, `SpanButton`, `MultiButton`, and `SpanMultiButton` instances when provided as a theme constant.
 
+|useLargerTextScaleBool
+|When `true`, UIManager applies the larger text accessibility scale from `Display.getLargerTextScale()` when `Display.isLargerTextEnabled()` is enabled.
+
 |dialogTransitionOutImage
 |Default transition https://www.codenameone.com/javadoc/com/codename1/ui/Image.html[Image] for dialog, causes a https://www.codenameone.com/javadoc/com/codename1/ui/animations/Timeline.html[Timeline] transition effect
 

--- a/docs/developer-guide/Miscellaneous-Features.asciidoc
+++ b/docs/developer-guide/Miscellaneous-Features.asciidoc
@@ -96,6 +96,32 @@ Display.getInstance().sendMessage(new String[] {"someone@gmail.com"}, "Subject o
 
 NOTE: Some features such as attachments etc. don't work correctly in the simulator but should work on iOS/Android
 
+=== Larger Text Accessibility
+
+Codename One can adapt to the operating system’s larger text accessibility setting. The https://www.codenameone.com/javadoc/com/codename1/ui/Display.html[Display] APIs expose two signals: `isLargerTextEnabled()` indicates whether the user has enabled larger text, and `getLargerTextScale()` returns the scale factor that should be applied to fonts.
+
+If you want the theme system to automatically scale its fonts when larger text is enabled, enable the https://www.codenameone.com/javadoc/com/codename1/ui/plaf/UIManager.html[UIManager] setting:
+
+[source,java]
+----
+UIManager.getInstance().setUseLargerTextScale(true);
+----
+
+You can also enable this behavior in the theme by setting the `useLargerTextScaleBool` theme constant to `true`.
+
+If you need to apply the scale manually for custom fonts or layout calculations, read the values directly:
+
+[source,java]
+----
+Display display = Display.getInstance();
+if (display.isLargerTextEnabled()) {
+    float scale = display.getLargerTextScale();
+    Font base = UIManager.getInstance().getLookAndFeel().getDefaultStyle().getFont();
+    Font scaled = base.derive(base.getHeight() * scale, base.getStyle());
+    someComponent.getUnselectedStyle().setFont(scaled);
+}
+----
+
 === Contacts API
 
 The contacts API provides us with the means to query the phone’s address book, delete elements from it and create new entries into it. To get the platform specific list of contacts you can use


### PR DESCRIPTION
### Motivation

- Document how Codename One responds to the OS larger-text accessibility setting and how to consume that information in apps.
- Explain how the theme system can automatically apply the larger-text scale so developers can enable it without manual font adjustments.
- Surface the `useLargerTextScaleBool` theme constant so designers can enable the behavior from the Designer or theme file.

### Description

- Added a new `Larger Text Accessibility` section to `docs/developer-guide/Miscellaneous-Features.asciidoc` explaining `Display.isLargerTextEnabled()` and `Display.getLargerTextScale()` with a usage example.
- Documented how to enable automatic scaling via `UIManager.getInstance().setUseLargerTextScale(true)` and the theme constant `useLargerTextScaleBool`.
- Added a `useLargerTextScaleBool` entry to the theme constants table in `docs/developer-guide/Advanced-Theming.asciidoc`.

### Testing

- No automated tests were run because this is a documentation-only change.
- No code behavior was modified, so unit test suites were not invoked as part of this update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69629bb0fa34833199eda643f646802c)