### PR TITLE
Improve SpotBugs violation details

### DIFF
--- a/.github/scripts/generate-quality-report.py
+++ b/.github/scripts/generate-quality-report.py
@@ -259,9 +259,9 @@ def parse_spotbugs() -> Tuple[Optional[AnalysisReport], bool, Optional[str]]:
                 severity = "Low"
             severities[severity] += 1
             message = _clean_message(
-                bug.findtext("ShortMessage")
+                bug.attrib.get("message")
                 or bug.findtext("LongMessage")
-                or bug.attrib.get("message")
+                or bug.findtext("ShortMessage")
             )
             bug_type = bug.attrib.get("type")
             source_line = bug.find(".//SourceLine[@primary='true']")
@@ -269,10 +269,14 @@ def parse_spotbugs() -> Tuple[Optional[AnalysisReport], bool, Optional[str]]:
                 source_line = bug.find(".//SourceLine")
             if source_line is not None:
                 source_path = source_line.attrib.get("sourcepath")
-                line = source_line.attrib.get("start") or source_line.attrib.get("end")
+                line = (
+                    bug.attrib.get("lineNumber")
+                    or source_line.attrib.get("start")
+                    or source_line.attrib.get("end")
+                )
             else:
                 source_path = None
-                line = None
+                line = bug.attrib.get("lineNumber")
             path_rel = _relative_path(source_path) if source_path else None
             if path_rel:
                 location = path_rel


### PR DESCRIPTION
### Motivation
- The SpotBugs failure output was showing imprecise or missing information compared to the raw `spotbugs.xml` entries, causing confusing CI failures.
- The goal is to report the same, more accurate message and location details that appear in the XML to make violations actionable.

### Description
- Updated `parse_spotbugs()` in `.github/scripts/generate-quality-report.py` to prefer the `BugInstance` `message` attribute before `LongMessage`/`ShortMessage` when building the finding message.
- Use `BugInstance` `lineNumber` when present and fall back to `SourceLine` `start`/`end` values for more accurate line reporting.
- Preserve the `SourceLine`-derived `sourcepath` for file path resolution while using `lineNumber` as the primary line source when available.

### Testing
- No automated tests were run as part of this change.
- CI will exercise the updated parser and should produce more accurate SpotBugs violation output in the quality report and failure message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69630cb56dac8331a32a6fe7265fb90e)