### PR TITLE
Respect interface hierarchy for default methods in vtable generation

### DIFF
--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeClass.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeClass.java
@@ -426,6 +426,20 @@ public class ByteCodeClass {
         }
         return false;
     }
+
+    private boolean isInterfaceInHierarchy(String className) {
+        if (clsName.equals(className)) {
+            return true;
+        }
+        if (baseInterfacesObject != null) {
+            for (ByteCodeClass bc : baseInterfacesObject) {
+                if (bc.isInterfaceInHierarchy(className)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
     
     public static void addArrayType(String type, int dimenstions) {
         String arr = dimenstions + "_" + type;
@@ -1614,7 +1628,7 @@ public class ByteCodeClass {
                         bm.setForceVirtual(true);
                     }
                 } else {
-                    if(replace) {
+                    if(replace || (isInterface && isInterfaceInHierarchy(virtualMethods.get(offset).getClsName()))) {
                         virtualMethods.set(offset, bm);
                         if(isInterface) {
                             bm.setForceVirtual(true);


### PR DESCRIPTION
### Motivation

- The existing default-method support did not account for interface hierarchies, so a subinterface default method that calls `super` would not correctly replace the base interface entry in the virtual method table. 
- This could lead to incorrect generated C code where implementing classes point vtable slots at the base interface default instead of the overriding subinterface default. 

### Description

- Add a helper `isInterfaceInHierarchy` to detect when a class name appears in an interface's inheritance chain. 
- Modify `fillVirtualMethodTable` to allow an interface method to replace a base-interface entry when the current class is an interface and the existing entry belongs to an interface in its hierarchy. 
- Add a regression test `translatesDefaultInterfaceMethodOverridesWithSuperCalls` in `ParserTest` which generates a base interface, derived interface that invokes `super`, and an implementation, and asserts both the derived method calls the base default and that the implementation points its vtable to the derived default. 

### Testing

- Executed `mvn -Dtest=ParserTest test` in `vm/tests` to exercise the updated `ParserTest` including `translatesDefaultInterfaceMethodOverridesWithSuperCalls`. 
- The Maven run failed due to an unresolved dependency `com.codename1.parparvm:ByteCodeTranslator:jar:1.0-SNAPSHOT`, so the test suite could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964606034108331b94219d2b7404e3f)