### PR TITLE
Fix NativeFont equals/hashCode and add DrawString font-hash consistency test

### DIFF
--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
@@ -5525,14 +5525,37 @@ public class IOSImplementation extends CodenameOneImplementation {
         }
         
         public boolean equals(Object o) {
-            NativeFont f = (NativeFont)o;
-            if(name != null) {
-                return f.name != null && f.name.equals(name) && f.weight == weight && f.height == height;
+            if (this == o) {
+                return true;
             }
-            return f.name == null && f.style == style && f.face == face && f.size == size;
+            if (!(o instanceof NativeFont)) {
+                return false;
+            }
+            NativeFont f = (NativeFont)o;
+            if (name != null || f.name != null) {
+                return name != null && name.equals(f.name) && f.weight == weight && f.height == height;
+            }
+            if (weight != 0 || height != 0 || f.weight != 0 || f.height != 0) {
+                return f.style == style && f.face == face && f.weight == weight && f.height == height;
+            }
+            return f.style == style && f.face == face && f.size == size;
         }
         
         public int hashCode() {
+            int result;
+            if (name != null) {
+                result = name.hashCode();
+                result = 31 * result + weight;
+                result = 31 * result + Float.floatToIntBits(height);
+                return result;
+            }
+            if (weight != 0 || height != 0) {
+                result = style;
+                result = 31 * result + face;
+                result = 31 * result + weight;
+                result = 31 * result + Float.floatToIntBits(height);
+                return result;
+            }
             return style | face | size;
         }
 
@@ -9513,5 +9536,4 @@ public class IOSImplementation extends CodenameOneImplementation {
         IOSNative.announceForAccessibility(text);
     }
 }
-
 

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/graphics/DrawString.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/graphics/DrawString.java
@@ -4,8 +4,15 @@ import com.codename1.ui.Font;
 import com.codename1.ui.Graphics;
 import com.codename1.ui.geom.Rectangle;
 import com.codenameone.examples.hellocodenameone.tests.AbstractGraphicsScreenshotTest;
+import java.util.Hashtable;
 
 public class DrawString extends AbstractGraphicsScreenshotTest {
+    @Override
+    public boolean runTest() {
+        verifyFontHashing();
+        return super.runTest();
+    }
+
     @Override
     protected void drawContent(Graphics g, Rectangle bounds) {
         g.setColor(0);
@@ -33,5 +40,28 @@ public class DrawString extends AbstractGraphicsScreenshotTest {
     @Override
     protected String screenshotName() {
         return "graphics-draw-string";
+    }
+
+    private void verifyFontHashing() {
+        if (!Font.isNativeFontSchemeSupported()) {
+            return;
+        }
+        Font base = Font.createTrueTypeFont("native:MainRegular", 4);
+        if (base == null) {
+            return;
+        }
+        float derivedSize = base.getHeight() + 1;
+        Font derived = base.derive(derivedSize, Font.STYLE_PLAIN);
+        Hashtable<Font, String> cache = new Hashtable<Font, String>();
+        cache.put(base, "base");
+        cache.put(derived, "derived");
+        Font baseCopy = Font.createTrueTypeFont("native:MainRegular", 4);
+        assertTrue(base.equals(baseCopy), "Expected native font instances to be equal.");
+        assertTrue("base".equals(cache.get(baseCopy)),
+                "Expected native font hash/equals to match Hashtable lookup.");
+        Font derivedCopy = baseCopy.derive(derivedSize, Font.STYLE_PLAIN);
+        assertTrue(derived.equals(derivedCopy), "Expected derived native font instances to be equal.");
+        assertTrue("derived".equals(cache.get(derivedCopy)),
+                "Expected derived font hash/equals to match Hashtable lookup.");
     }
 }


### PR DESCRIPTION
### Motivation
- Fix inconsistent `NativeFont` equality/hashing on iOS to avoid cache/key mismatches when fonts are named (TTF/native) or derived.
- Ensure `NativeFont` instances behave consistently between JVM and iOS port implementations when used as map keys.
- Add a lightweight runtime check in the example test suite to detect regressions in font hash/equals behavior during example/test runs.

### Description
- Updated `NativeFont.equals(Object)` in `Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java` to perform identity and `instanceof` checks and to correctly handle name-based and derived fonts.
- Reworked `NativeFont.hashCode()` to produce stable hashes for name-based fonts and derived fonts using `31` multipliers and `Float.floatToIntBits(height)`, while preserving the prior fallback for plain system fonts.
- Added a `verifyFontHashing()` preflight and call in `scripts/hellocodenameone/common/src/main/java/com/codenameone/examples.hellocodenameone/tests/graphics/DrawString.java` which uses a `Hashtable<Font,String>` and `assertTrue` checks to validate equality and hashtable lookups for base and derived native fonts.

### Testing
- No automated unit tests were executed as part of this change.
- A runtime assertion check was added to `DrawString` that will exercise the font hashing logic when the hellocodenameone example/test harness is run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964648f1dc48331af33282f537e92e3)