### PR TITLE
Move jailbreak check to hellocodenameone startup

### DIFF
--- a/scripts/hellocodenameone/common/src/main/kotlin/com/codenameone/examples/hellocodenameone/HelloCodenameOne.kt
+++ b/scripts/hellocodenameone/common/src/main/kotlin/com/codenameone/examples/hellocodenameone/HelloCodenameOne.kt
@@ -2,6 +2,7 @@ package com.codenameone.examples.hellocodenameone
 
 import com.codename1.system.Lifecycle
 import com.codename1.testing.TestReporting
+import com.codename1.ui.Display
 import com.codenameone.examples.hellocodenameone.tests.Cn1ssDeviceRunner
 import com.codenameone.examples.hellocodenameone.tests.Cn1ssDeviceRunnerReporter
 import com.codenameone.examples.hellocodenameone.tests.KotlinUiTest
@@ -9,6 +10,9 @@ import com.codenameone.examples.hellocodenameone.tests.KotlinUiTest
 open class HelloCodenameOne : Lifecycle() {
     override fun init(context: Any?) {
         super.init(context)
+        check(!Display.getInstance().isJailbrokenDevice()) {
+            "Jailbroken device detected by Display.isJailbrokenDevice()."
+        }
         Cn1ssDeviceRunner.addTest(KotlinUiTest())
         TestReporting.setInstance(Cn1ssDeviceRunnerReporter())
     }


### PR DESCRIPTION
### Motivation
- Ensure the app fails fast on compromised devices by performing jailbreak detection during app initialization.
- Consolidate jailbreak detection logic into runtime startup instead of a standalone test to catch issues earlier.
- Improve iOS native detection to catch modern dynamic-library injection and common bypass libraries.

### Description
- Enhanced `Ports/iOSPort/nativeSources/CN1JailbreakDetector.m` to import `<unistd.h>` and `<stdlib.h>`, check `getenv("DYLD_INSERT_LIBRARIES")`, scan loaded images via `_dyld_image_count()`/`_dyld_get_image_name()` for known bypass libraries, and exit when detected. 
- Updated restricted path checks and write-test behavior in `CN1JailbreakDetector.m` by moving `MobileSubstrate` entry, adding `"/private/var/lib/apt/"`, using `BOOL wroteFile = [@"Test" writeToFile:...]` and removing the test file on success. 
- Kept additional runtime checks (`fork()` and process tracing via `sysctl`) to detect abnormal behavior and exit when bypass indications are found. 
- Removed the standalone `JailbreakDetectionTest.java` and added a startup assertion in `scripts/hellocodenameone/common/src/main/kotlin/com/codenameone/examples/hellocodenameone/HelloCodenameOne.kt` that calls `Display.getInstance().isJailbrokenDevice()` and uses `check(!...)` to fail initialization if the device is jailbroken.

### Testing
- No automated tests were executed for these changes.
- The previous standalone test `JailbreakDetectionTest.java` was deleted and not run as part of CI.
- No native compilation or runtime verification was performed automatically for the iOS detector changes.
- The startup assertion was added to application initialization but was not executed in an automated test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964c56486e083319471b5895ba504a0)