### PR TITLE
Fix SpotBugs naming convention violations

### DIFF
--- a/.github/scripts/generate-quality-report.py
+++ b/.github/scripts/generate-quality-report.py
@@ -811,6 +811,8 @@ def main() -> None:
             "EQ_COMPARETO_USE_OBJECT_EQUALS",
             "MS_EXPOSE_REP",
             "NM_CONFUSING",
+            "NM_FIELD_NAMING_CONVENTION",
+            "NM_METHOD_NAMING_CONVENTION",
             "NO_NOTIFY_NOT_NOTIFYALL",
             "NP_LOAD_OF_KNOWN_NULL_VALUE",
             "NP_BOOLEAN_RETURN_NULL",

--- a/CodenameOne/src/com/codename1/analytics/AnalyticsService.java
+++ b/CodenameOne/src/com/codename1/analytics/AnalyticsService.java
@@ -167,7 +167,7 @@ public class AnalyticsService {
      */
     public static void sendCrashReport(Throwable t, String message, boolean fatal) {
         // https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#exception
-        ConnectionRequest req = GetGARequest();
+        ConnectionRequest req = getGaRequest();
         req.addArgument("t", "exception");
         System.out.println(message);
         req.addArgument("exd", message.substring(0, Math.min(message.length(), 150) - 1));
@@ -180,7 +180,7 @@ public class AnalyticsService {
         NetworkManager.getInstance().addToQueue(req);
     }
 
-    private static ConnectionRequest GetGARequest() {
+    private static ConnectionRequest getGaRequest() {
         ConnectionRequest req = new ConnectionRequest();
         req.setUrl("https://www.google-analytics.com/collect");
         req.setPost(true);
@@ -246,7 +246,7 @@ public class AnalyticsService {
         }
         if (appsMode) {
             // https://developers.google.com/analytics/devguides/collection/protocol/v1/devguide#apptracking
-            final ConnectionRequest req = GetGARequest();
+            final ConnectionRequest req = getGaRequest();
             req.addArgument("t", "appview");
             req.addArgument("an", Display.getInstance().getProperty("AppName", "Codename One App"));
             String version = Display.getInstance().getProperty("AppVersion", "1.0");

--- a/CodenameOne/src/com/codename1/charts/util/ColorUtil.java
+++ b/CodenameOne/src/com/codename1/charts/util/ColorUtil.java
@@ -129,7 +129,7 @@ public class ColorUtil {
             this.green = (argb >>> 8) & 0xff;
             this.blue = (argb & 0xff);
 
-            this.argb = ToARGB(this);
+            this.argb = toArgb(this);
         }
 
 
@@ -144,10 +144,10 @@ public class ColorUtil {
             this.green = (g & 0xff);
             this.blue = (b & 0xff);
 
-            this.argb = ToARGB(this);
+            this.argb = toArgb(this);
         }
 
-        private static int ToARGB(IColor c) { // PMD Fix: UnnecessaryModifier removed redundant final
+        private static int toArgb(IColor c) { // PMD Fix: UnnecessaryModifier removed redundant final
             return ((c.alpha << 24) |
                     (c.red << 16) |
                     (c.green << 8) |

--- a/CodenameOne/src/com/codename1/ui/geom/GeneralPath.java
+++ b/CodenameOne/src/com/codename1/ui/geom/GeneralPath.java
@@ -2984,7 +2984,7 @@ public final class GeneralPath implements Shape {
         public static class QuadCurve {
 
             double ax, ay, bx, by;
-            double Ax, Ay, Bx, By;
+            double axCoeff, ayCoeff, bxCoeff, byCoeff;
 
             public QuadCurve(double x1, double y1, double cx, double cy, double x2, double y2) {
                 ax = x2 - x1;
@@ -2992,11 +2992,11 @@ public final class GeneralPath implements Shape {
                 bx = cx - x1;
                 by = cy - y1;
 
-                Bx = bx + bx;   // Bx = 2.0 * bx
-                Ax = ax - Bx;   // Ax = ax - 2.0 * bx
+                bxCoeff = bx + bx;   // Bx = 2.0 * bx
+                axCoeff = ax - bxCoeff;   // Ax = ax - 2.0 * bx
 
-                By = by + by;   // By = 2.0 * by
-                Ay = ay - By;   // Ay = ay - 2.0 * by
+                byCoeff = by + by;   // By = 2.0 * by
+                ayCoeff = ay - byCoeff;   // Ay = ay - 2.0 * by
             }
 
             int cross(double[] res, int rc, double py1, double py2) {
@@ -3024,10 +3024,10 @@ public final class GeneralPath implements Shape {
                         continue;
                     }
                     // CURVE-INSIDE
-                    double ry = t * (t * Ay + By);
+                    double ry = t * (t * ayCoeff + byCoeff);
                     // ry = t * t * Ay + t * By
                     if (ry > py2) {
-                        double rxt = t * Ax + bx;
+                        double rxt = t * axCoeff + bx;
                         // rxt = 2.0 * t * Ax + Bx = 2.0 * t * Ax + 2.0 * bx
                         if (rxt > -DELTA && rxt < DELTA) {
                             continue;
@@ -3040,17 +3040,17 @@ public final class GeneralPath implements Shape {
             }
 
             int solvePoint(double[] res, double px) {
-                double[] eqn = {-px, Bx, Ax};
+                double[] eqn = {-px, bxCoeff, axCoeff};
                 return solveQuad(eqn, res);
             }
 
             int solveExtrem(double[] res) {
                 int rc = 0;
-                if (!isZero(Ax)) {
-                    res[rc++] = -Bx / (Ax + Ax);
+                if (!isZero(axCoeff)) {
+                    res[rc++] = -bxCoeff / (axCoeff + axCoeff);
                 }
-                if (!isZero(Ay)) {
-                    res[rc++] = -By / (Ay + Ay);
+                if (!isZero(ayCoeff)) {
+                    res[rc++] = -byCoeff / (ayCoeff + ayCoeff);
                 }
                 return rc;
             }
@@ -3059,11 +3059,11 @@ public final class GeneralPath implements Shape {
                 for (int i = 0; i < rc; i++) {
                     double t = res[i];
                     if (t > -DELTA && t < 1 + DELTA) {
-                        double rx = t * (t * Ax + Bx);
+                        double rx = t * (t * axCoeff + bxCoeff);
                         if (minX <= rx && rx <= maxX) {
                             bound[bc++] = t;
                             bound[bc++] = rx;
-                            bound[bc++] = t * (t * Ay + By);
+                            bound[bc++] = t * (t * ayCoeff + byCoeff);
                             bound[bc++] = id;
                             if (changeId) {
                                 id++;
@@ -3082,8 +3082,8 @@ public final class GeneralPath implements Shape {
         public static class CubicCurve {
 
             double ax, ay, bx, by, cx, cy;
-            double Ax, Ay, Bx, By, Cx, Cy;
-            double Ax3, Bx2;
+            double axCoeff, ayCoeff, bxCoeff, byCoeff, cxCoeff, cyCoeff;
+            double axCoeff3, bxCoeff2;
 
             public CubicCurve(double x1, double y1, double cx1, double cy1, double cx2, double cy2, double x2, double y2) {
                 ax = x2 - x1;
@@ -3093,16 +3093,16 @@ public final class GeneralPath implements Shape {
                 cx = cx2 - x1;
                 cy = cy2 - y1;
 
-                Cx = bx + bx + bx;           // Cx = 3.0 * bx
-                Bx = cx + cx + cx - Cx - Cx; // Bx = 3.0 * cx - 6.0 * bx
-                Ax = ax - Bx - Cx;           // Ax = ax - 3.0 * cx + 3.0 * bx
+                cxCoeff = bx + bx + bx;           // Cx = 3.0 * bx
+                bxCoeff = cx + cx + cx - cxCoeff - cxCoeff; // Bx = 3.0 * cx - 6.0 * bx
+                axCoeff = ax - bxCoeff - cxCoeff;           // Ax = ax - 3.0 * cx + 3.0 * bx
 
-                Cy = by + by + by;           // Cy = 3.0 * by
-                By = cy + cy + cy - Cy - Cy; // By = 3.0 * cy - 6.0 * by
-                Ay = ay - By - Cy;           // Ay = ay - 3.0 * cy + 3.0 * by
+                cyCoeff = by + by + by;           // Cy = 3.0 * by
+                byCoeff = cy + cy + cy - cyCoeff - cyCoeff; // By = 3.0 * cy - 6.0 * by
+                ayCoeff = ay - byCoeff - cyCoeff;           // Ay = ay - 3.0 * cy + 3.0 * by
 
-                Ax3 = Ax + Ax + Ax;
-                Bx2 = Bx + Bx;
+                axCoeff3 = axCoeff + axCoeff + axCoeff;
+                bxCoeff2 = bxCoeff + bxCoeff;
             }
 
             int cross(double[] res, int rc, double py1, double py2) {
@@ -3129,13 +3129,13 @@ public final class GeneralPath implements Shape {
                         continue;
                     }
                     // CURVE-INSIDE
-                    double ry = t * (t * (t * Ay + By) + Cy);
+                    double ry = t * (t * (t * ayCoeff + byCoeff) + cyCoeff);
                     // ry = t * t * t * Ay + t * t * By + t * Cy
                     if (ry > py2) {
-                        double rxt = t * (t * Ax3 + Bx2) + Cx;
+                        double rxt = t * (t * axCoeff3 + bxCoeff2) + cxCoeff;
                         // rxt = 3.0 * t * t * Ax + 2.0 * t * Bx + Cx
                         if (rxt > -DELTA && rxt < DELTA) {
-                            rxt = t * (Ax3 + Ax3) + Bx2;
+                            rxt = t * (axCoeff3 + axCoeff3) + bxCoeff2;
                             // rxt = 6.0 * t * Ax + 2.0 * Bx
                             if (rxt < -DELTA || rxt > DELTA) {
                                 // Inflection point
@@ -3151,17 +3151,17 @@ public final class GeneralPath implements Shape {
             }
 
             int solvePoint(double[] res, double px) {
-                double[] eqn = {-px, Cx, Bx, Ax};
+                double[] eqn = {-px, cxCoeff, bxCoeff, axCoeff};
                 return solveCubic(eqn, res);
             }
 
             int solveExtremX(double[] res) {
-                double[] eqn = {Cx, Bx2, Ax3};
+                double[] eqn = {cxCoeff, bxCoeff2, axCoeff3};
                 return solveQuad(eqn, res);
             }
 
             int solveExtremY(double[] res) {
-                double[] eqn = {Cy, By + By, Ay + Ay + Ay};
+                double[] eqn = {cyCoeff, byCoeff + byCoeff, ayCoeff + ayCoeff + ayCoeff};
                 return solveQuad(eqn, res);
             }
 
@@ -3169,11 +3169,11 @@ public final class GeneralPath implements Shape {
                 for (int i = 0; i < rc; i++) {
                     double t = res[i];
                     if (t > -DELTA && t < 1 + DELTA) {
-                        double rx = t * (t * (t * Ax + Bx) + Cx);
+                        double rx = t * (t * (t * axCoeff + bxCoeff) + cxCoeff);
                         if (minX <= rx && rx <= maxX) {
                             bound[bc++] = t;
                             bound[bc++] = rx;
-                            bound[bc++] = t * (t * (t * Ay + By) + Cy);
+                            bound[bc++] = t * (t * (t * ayCoeff + byCoeff) + cyCoeff);
                             bound[bc++] = id;
                             if (changeId) {
                                 id++;

--- a/CodenameOne/src/com/codename1/ui/layouts/GridBagLayout.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/GridBagLayout.java
@@ -230,7 +230,7 @@ public class GridBagLayout extends Layout {
         }
     }*/
 
-    protected void ArrangeGrid(Container parent) {
+    protected void arrangeGrid(Container parent) {
         ParentInfo info = lastParentInfo = getParentInfo(parent);
         if (getComponentsNumber(parent) == 0) {
             return;
@@ -253,14 +253,6 @@ public class GridBagLayout extends Layout {
         return cons;
     }
 
-    protected void adjustForGravity(GridBagConstraints constraints, Rectangle r) {
-        AdjustForGravity(constraints, r);
-    }
-
-    protected void arrangeGrid(Container parent) {
-        ArrangeGrid(parent);
-    }
-
     /*protected GridBagLayoutInfo getLayoutInfo(Container parent, int sizeflag) {
         return GetLayoutInfo(parent, sizeflag);
     }
@@ -274,7 +266,7 @@ public class GridBagLayout extends Layout {
         }
     }*/
 
-    protected void AdjustForGravity(GridBagConstraints constraints, Rectangle r) {
+    protected void adjustForGravity(GridBagConstraints constraints, Rectangle r) {
         /*try {
             //                ((GridBagConstraints) constraints).verify();
         } catch (IllegalArgumentException e) {


### PR DESCRIPTION
### Motivation
- Eliminate SpotBugs NM_FIELD_NAMING_CONVENTION and NM_METHOD_NAMING_CONVENTION findings reported for internal fields and helper methods. 
- Keep code behavior and public API semantics unchanged while addressing naming warnings. 
- Ensure the CI quality report treats naming-convention violations as build failures so regressions are caught early. 

### Description
- Renamed internal coefficient fields in `GeneralPath` curve helpers to lower-case identifiers (e.g. in `QuadCurve` and `CubicCurve`: `Ax/Ay/Bx/By/Cx/Cy/Ax3/Bx2` -> `axCoeff/ayCoeff/bxCoeff/byCoeff/cxCoeff/cyCoeff/axCoeff3/bxCoeff2`) and updated all usages accordingly. 
- Standardized helper/method names to lower-case: `AnalyticsService.GetGARequest()` -> `AnalyticsService.getGaRequest()` and `ColorUtil.ToARGB(...)` -> `ColorUtil.toArgb(...)`. 
- Fixed `GridBagLayout` naming by replacing `ArrangeGrid`/`AdjustForGravity` usages with `arrangeGrid`/`adjustForGravity` and removed accidental self-referencing stubs introduced during renames. 
- Updated the quality-gate script ` .github/scripts/generate-quality-report.py` to treat `NM_FIELD_NAMING_CONVENTION` and `NM_METHOD_NAMING_CONVENTION` as forbidden SpotBugs rules so they fail the build. 

### Testing
- No automated tests were executed as part of this change. 
- Changes are limited to identifier renames and internal call sites to preserve original semantics. 
- The CI quality gate will now fail on the two SpotBugs naming rules added to the forbidden list. 
- Manual compilation / CI run is recommended to validate SpotBugs/PMD/Checkstyle results in the updated pipeline.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965b14a64e08331bf243846198783d1)