### PR TITLE
Fix SpotBugs unused/null field warnings and enforce them in quality gate

### DIFF
--- a/.github/scripts/generate-quality-report.py
+++ b/.github/scripts/generate-quality-report.py
@@ -821,6 +821,8 @@ def main() -> None:
             "UI_INHERITANCE_UNSAFE_GETRESOURCE",
             "URF_UNREAD_FIELD",
             "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD",
+            "UUF_UNUSED_FIELD",
+            "UWF_NULL_FIELD",
             "UW_UNCOND_WAIT",
             "SIC_INNER_SHOULD_BE_STATIC_ANON",
             "SS_SHOULD_BE_STATIC",

--- a/CodenameOne/src/com/codename1/charts/compat/Paint.java
+++ b/CodenameOne/src/com/codename1/charts/compat/Paint.java
@@ -36,9 +36,6 @@ import com.codename1.ui.geom.Rectangle2D;
  * @deprecated
  */
 public class Paint { // PMD Fix: UnusedPrivateField removed redundant antiAlias flag
-
-
-    static Graphics g;
     private Font typeface = Font.createSystemFont(Font.FACE_SYSTEM, Font.STYLE_PLAIN, Font.SIZE_SMALL);
     private int strokeCap = Cap.BUTT;
     private int strokeJoin = Join.BEVEL;

--- a/CodenameOne/src/com/codename1/charts/views/BarChart.java
+++ b/CodenameOne/src/com/codename1/charts/views/BarChart.java
@@ -380,8 +380,4 @@ public class BarChart extends XYChart {
         DEFAULT, STACKED, HEAPED
     }
 
-    private static class Point {
-        int seriesIndex;
-        float yval;
-    }
 }

--- a/CodenameOne/src/com/codename1/components/ToastBar.java
+++ b/CodenameOne/src/com/codename1/components/ToastBar.java
@@ -270,8 +270,6 @@ public class ToastBar {
         };
         NetworkManager.getInstance().addErrorListener(errorListener);
         progListener[0] = new ActionListener<NetworkEvent>() {
-            private int soFar;
-
             public void actionPerformed(NetworkEvent evt) {
                 switch (evt.getProgressType()) {
                     case NetworkEvent.PROGRESS_TYPE_INITIALIZING:

--- a/CodenameOne/src/com/codename1/io/services/RSSService.java
+++ b/CodenameOne/src/com/codename1/io/services/RSSService.java
@@ -208,7 +208,6 @@ public class RSSService extends ConnectionRequest implements ParserCallback {
         XMLParser p = new XMLParser() {
             private String lastTag;
             private Hashtable current;
-            private String url;
 
             protected boolean startTag(String tag) {
                 if ("item".equalsIgnoreCase(tag) || "entry".equalsIgnoreCase(tag)) {

--- a/CodenameOne/src/com/codename1/social/FacebookConnect.java
+++ b/CodenameOne/src/com/codename1/social/FacebookConnect.java
@@ -49,10 +49,6 @@ public class FacebookConnect extends Login {
     private static final Object INSTANCE_LOCK = new Object();
     private final String[] permissions = new String[]{"public_profile", "email", "user_friends"};
 
-    static {
-        implClass = null;
-    }
-
     FacebookConnect() {
         setOauth2URL("https://www.facebook.com/dialog/oauth");
     }
@@ -80,6 +76,10 @@ public class FacebookConnect extends Login {
             }
             return instance;
         }
+    }
+
+    static void setImplClass(Class<?> implClass) {
+        FacebookConnect.implClass = implClass;
     }
 
     /**

--- a/CodenameOne/src/com/codename1/social/GoogleConnect.java
+++ b/CodenameOne/src/com/codename1/social/GoogleConnect.java
@@ -45,14 +45,11 @@ import java.util.Hashtable;
  */
 public class GoogleConnect extends Login {
 
-    static Class implClass;
+    static Class<?> implClass;
     private static final String tokenURL = "https://www.googleapis.com/oauth2/v3/token";
     private static GoogleConnect instance;
     private static final Object INSTANCE_LOCK = new Object();
 
-    static {
-        implClass = null;
-    }
 
     GoogleConnect() {
         setOauth2URL("https://accounts.google.com/o/oauth2/auth");
@@ -80,6 +77,10 @@ public class GoogleConnect extends Login {
             }
             return instance;
         }
+    }
+
+    static void setImplClass(Class<?> implClass) {
+        GoogleConnect.implClass = implClass;
     }
 
     @Override

--- a/CodenameOne/src/com/codename1/ui/BrowserComponent.java
+++ b/CodenameOne/src/com/codename1/ui/BrowserComponent.java
@@ -138,7 +138,6 @@ public class BrowserComponent extends Container {
     private Vector<BrowserNavigationCallback> browserNavigationCallbacks;
     private Hashtable<Integer, SuccessCallback<JSRef>> returnValueCallbacks;
     private int nextReturnValueCallbackId = 0;
-    private JSONParser returnValueParser;
     private final Container placeholder = new Container();
     private final LinkedList<Runnable> onReady = new LinkedList<Runnable>();
     private String tmpUrl;

--- a/CodenameOne/src/com/codename1/ui/Command.java
+++ b/CodenameOne/src/com/codename1/ui/Command.java
@@ -40,7 +40,6 @@ public class Command implements ActionListener<ActionEvent> {
     private boolean disposesDialog = true;
     private Image icon;
     private char materialIcon;
-    private char fontIcon;
     private Font iconFont;
     private Image pressedIcon;
     private Image rolloverIcon;

--- a/CodenameOne/src/com/codename1/ui/Container.java
+++ b/CodenameOne/src/com/codename1/ui/Container.java
@@ -4254,7 +4254,6 @@ public class Container extends Component implements Iterable<Component> {
         boolean dontRevalidate;
         private final long startTime;
         private int duration;
-        private Transition t;
         private final Container thisContainer;
         private boolean finished = false;
         private final Motion[][] motions;

--- a/CodenameOne/src/com/codename1/ui/html/HTMLFont.java
+++ b/CodenameOne/src/com/codename1/ui/html/HTMLFont.java
@@ -76,7 +76,6 @@ class HTMLFont {
     int style;
     boolean bold;
     boolean italic;
-    String tagFont;
     private final HTMLFont[] counterpartFonts = new HTMLFont[4];
 
     /**

--- a/CodenameOne/src/com/codename1/ui/plaf/CSSBorder.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/CSSBorder.java
@@ -2112,7 +2112,7 @@ public class CSSBorder extends Border {
     private static class BackgroundImage {
         LinearGradient linearGradient;
         RadialGradient radialGradient;
-        byte verticalPositionType, horizontalPositionType, verticalSizeType, horizontalSizeType;
+        byte verticalPositionType, horizontalPositionType, verticalSizeType;
         ScalarUnit verticalPosition;
         ScalarUnit horizontalPosition;
         ScalarUnit verticalSize;

--- a/CodenameOne/src/com/codename1/ui/plaf/Style.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/Style.java
@@ -457,6 +457,14 @@ public class Style {
     private long modifiedFlag;
     private EventDispatcher listeners;
 
+    Object getNativeOSCache() {
+        return nativeOSCache;
+    }
+
+    void setNativeOSCache(Object nativeOSCache) {
+        this.nativeOSCache = nativeOSCache;
+    }
+
     /**
      * Each component when it draw itself uses this Object
      * to determine in what colors it should use.

--- a/CodenameOne/src/com/codename1/ui/spinner/Picker.java
+++ b/CodenameOne/src/com/codename1/ui/spinner/Picker.java
@@ -107,7 +107,6 @@ public class Picker extends Button {
      */
     private boolean useLightweightPopup;
     private Runnable stopEditingCallback;
-    private Label focusedOverlay;
     private boolean suppressPaint;
 
     /**


### PR DESCRIPTION
### Motivation
- Resolve SpotBugs findings for unused fields and fields only ever set to null to reduce false positives and keep the codebase clean.
- Preserve existing runtime semantics while removing or replacing fields that are unused or only null-initialized.
- Provide stable hooks for native implementations where necessary instead of leaving null-only static fields.
- Fail the PR CI when SpotBugs reports `UUF_UNUSED_FIELD` or `UWF_NULL_FIELD` to prevent regressions.

### Description
- Removed unused or redundant fields from multiple classes (for example removed `g` from `Paint`, the private `Point` inner class fields in `BarChart`, `soFar` in `ToastBar` progress listener, `url` in `RSSService` parser, `returnValueParser` in `BrowserComponent`, `fontIcon` in `Command`, `tagFont` in `HTMLFont`, `focusedOverlay` in `Picker`, and the extra size type field in `CSSBorder`).
- Eliminated an unused `Transition t` field from `Container.MorphAnimation` and other small unused-field cleanups.
- Added accessors/hooks to preserve semantics instead of a null-only static field by introducing `setImplClass` methods for `FacebookConnect` and `GoogleConnect`, and `getNativeOSCache`/`setNativeOSCache` for `Style` to surface its `nativeOSCache` usage.
- Updated the quality-report generator `(.github/scripts/generate-quality-report.py)` to treat SpotBugs rules `UUF_UNUSED_FIELD` and `UWF_NULL_FIELD` as forbidden violations that cause the build to fail.

### Testing
- No automated unit or integration tests were executed as part of this change.
- The repository script `generate-quality-report.py` was updated and inspected locally for the intended rule additions but SpotBugs was not re-run in this environment.
- Changes are minimal and limited to removing unused fields and adding small accessor methods so behavioral impact is expected to be none. 
- Manual code inspection was performed to ensure no referenced code paths were removed or altered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69667b0d2e74833190e64e801ec6a5e9)