### PR TITLE
Reduce Android emulator AVD disk size to avoid runner disk exhaustion

### DIFF
--- a/.github/workflows/scripts-android.yml
+++ b/.github/workflows/scripts-android.yml
@@ -144,6 +144,7 @@ jobs:
           api-level: 31
           arch: x86_64
           target: google_apis
+          disk-size: 2048M
           script: ./scripts/run-android-instrumentation-tests.sh "${{ steps.build-android-app.outputs.gradle_project_dir }}"
       - name: Upload emulator screenshot
         if: always() && matrix.id == 'default'


### PR DESCRIPTION
### Motivation
- The Android emulator was failing to create the userdata partition on GitHub runners due to insufficient disk space, causing flakiness and aborted instrumentation runs.

### Description
- Set `disk-size: 2048M` for the `reactivecircus/android-emulator-runner@v2` step in `.github/workflows/scripts-android.yml` to reduce the AVD storage requirement.

### Testing
- No automated tests were run because this is a workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69671e5d25488331ba99f972ff089998)