### PR TITLE
Adjust Android emulator runner settings to reduce boot flakiness

### DIFF
--- a/.github/workflows/scripts-android.yml
+++ b/.github/workflows/scripts-android.yml
@@ -145,6 +145,10 @@ jobs:
           arch: x86_64
           target: google_apis
           disk-size: 2048M
+          force-avd-creation: true
+          emulator-boot-timeout: 1200
+          emulator-port: 5554
+          disable-linux-hw-accel: true
           script: ./scripts/run-android-instrumentation-tests.sh "${{ steps.build-android-app.outputs.gradle_project_dir }}"
       - name: Upload emulator screenshot
         if: always() && matrix.id == 'default'


### PR DESCRIPTION
### Motivation
- The Android emulator in CI was frequently failing with `adb: device 'emulator-5554' not found` and `Timeout waiting for emulator to boot`, so the workflow was updated to make runner behavior more explicit and resilient.

### Description
- Added explicit emulator runner options in `.github/workflows/scripts-android.yml`: `force-avd-creation: true`, `emulator-boot-timeout: 1200`, `emulator-port: 5554`, and `disable-linux-hw-accel: true` to reduce flakiness. 
- Kept the existing `disk-size: 2048M` setting and left the instrumentation script invocation unchanged at `./scripts/run-android-instrumentation-tests.sh`.

### Testing
- No automated tests were run because this is a workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967bf852f388331be5f8e9f84e1257a)