### PR TITLE
Fix SpotBugs warnings and tighten quality gates

### DIFF
--- a/.github/scripts/generate-quality-report.py
+++ b/.github/scripts/generate-quality-report.py
@@ -763,6 +763,7 @@ def main() -> None:
     if spotbugs:
         forbidden_rules = {
             "NP_ALWAYS_NULL",
+            "NP_NULL_PARAM_DEREF",
             "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
             "RCN_REDUNDANT_NULLCHECK_OF_NULL_VALUE",
             "UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR",
@@ -772,6 +773,7 @@ def main() -> None:
             "IA_AMBIGUOUS_INVOCATION_OF_INHERITED_OR_OUTER_METHOD",
             "LI_LAZY_INIT_STATIC",
             "RpC_REPEATED_CONDITIONAL_TEST",
+            "NS_NON_SHORT_CIRCUIT",
             "ES_COMPARING_PARAMETER_STRING_WITH_EQ",
             "FE_FLOATING_POINT_EQUALITY",
             "FE_TEST_IF_EQUAL_TO_NOT_A_NUMBER",
@@ -787,7 +789,9 @@ def main() -> None:
             "EQ_DOESNT_OVERRIDE_EQUALS",
             "CO_COMPARETO_INCORRECT_FLOATING",
             "DL_SYNCHRONIZATION_ON_SHARED_CONSTANT",
+            "SSD_DO_NOT_USE_INSTANCE_LOCK_ON_SHARED_STATIC_DATA",
             "DLS_DEAD_LOCAL_STORE",
+            "DLS_DEAD_LOCAL_STORE_OF_NULL",
             "DM_NUMBER_CTOR",
             "DMI_INVOKING_TOSTRING_ON_ARRAY",
             "EC_NULL_ARG",
@@ -819,6 +823,7 @@ def main() -> None:
             "NO_NOTIFY_NOT_NOTIFYALL",
             "NP_LOAD_OF_KNOWN_NULL_VALUE",
             "NP_BOOLEAN_RETURN_NULL",
+            "RC_REF_COMPARISON_BAD_PRACTICE_BOOLEAN",
             "REFLC_REFLECTION_MAY_INCREASE_ACCESSIBILITY_OF_CLASS",
             "REC_CATCH_EXCEPTION",
             "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",

--- a/CodenameOne/src/com/codename1/facebook/FacebookRESTService.java
+++ b/CodenameOne/src/com/codename1/facebook/FacebookRESTService.java
@@ -239,8 +239,11 @@ class FacebookRESTService extends ConnectionRequest implements JSONParseCallback
     }
 
     public void keyValue(String key, String value) {
+        if (key == null) {
+            return;
+        }
         //make sure value is not null to prevent NPE
-        if (key != null && value == null) {
+        if (value == null) {
             value = "";
         }
         getCurrent().put(key, value);

--- a/CodenameOne/src/com/codename1/io/gzip/DeflaterOutputStream.java
+++ b/CodenameOne/src/com/codename1/io/gzip/DeflaterOutputStream.java
@@ -84,7 +84,7 @@ public class DeflaterOutputStream extends FilterOutputStream {
     public void write(byte[] b, int off, int len) throws IOException {
         if (deflater.finished()) {
             throw new IOException("finished");
-        } else if (off < 0 | len < 0 | off + len > b.length) {
+        } else if (off < 0 || len < 0 || off + len > b.length) {
             throw new IndexOutOfBoundsException();
         } else if (len == 0) {
         } else {

--- a/CodenameOne/src/com/codename1/location/LocationManager.java
+++ b/CodenameOne/src/com/codename1/location/LocationManager.java
@@ -52,6 +52,7 @@ public abstract class LocationManager {
     public static final int OUT_OF_SERVICE = 1;
     public static final int TEMPORARILY_UNAVAILABLE = 2;
     private static LocationListener listener;
+    private static final Object LISTENER_LOCK = new Object();
     private LocationRequest request;
     private static Class backgroundlistener;
     private int status = TEMPORARILY_UNAVAILABLE;
@@ -198,7 +199,7 @@ public abstract class LocationManager {
      *          from getting updates
      */
     public void setLocationListener(final LocationListener l) {
-        synchronized (this) {
+        synchronized (LISTENER_LOCK) {
             if (listener != null) {
                 clearListener();
                 request = null;
@@ -243,7 +244,7 @@ public abstract class LocationManager {
      *                         try to create an instance and invoke the locationUpdated method
      */
     public void setBackgroundLocationListener(Class locationListener) {
-        synchronized (this) {
+        synchronized (LISTENER_LOCK) {
             if (backgroundlistener != null) {
                 clearBackgroundListener();
             }

--- a/CodenameOne/src/com/codename1/properties/InstantUI.java
+++ b/CodenameOne/src/com/codename1/properties/InstantUI.java
@@ -81,7 +81,7 @@ public class InstantUI {
      * @return true if the property was excluded from the GUI
      */
     public boolean isExcludedProperty(PropertyBase exclude) {
-        return exclude.getClientProperty("cn1$excludeFromUI") == Boolean.TRUE;
+        return Boolean.TRUE.equals(exclude.getClientProperty("cn1$excludeFromUI"));
     }
 
     /**

--- a/CodenameOne/src/com/codename1/ui/BrowserComponent.java
+++ b/CodenameOne/src/com/codename1/ui/BrowserComponent.java
@@ -1601,7 +1601,7 @@ public class BrowserComponent extends Container {
      * @return true if debug mode was activated
      */
     public boolean isDebugMode() {
-        return getClientProperty("BrowserComponent.firebug") == Boolean.TRUE;
+        return Boolean.TRUE.equals(getClientProperty("BrowserComponent.firebug"));
     }
 
     /**

--- a/CodenameOne/src/com/codename1/ui/html/HTMLComponent.java
+++ b/CodenameOne/src/com/codename1/ui/html/HTMLComponent.java
@@ -463,13 +463,13 @@ public class HTMLComponent extends Container implements ActionListener, IOCallba
      * @param font    The actual Codename One font object
      */
     public static void addFont(String fontKey, Font font) {
-        if (fontKey != null) {
-            fontKey = fontKey.toLowerCase();
-        } else {
+        if (fontKey == null) {
             if (font.getCharset() != null) {
                 throw new IllegalArgumentException("Font key must be non-null for bitmap fonts");
             }
+            throw new IllegalArgumentException("Font key must be non-null");
         }
+        fontKey = fontKey.toLowerCase();
         fonts.put(fontKey, new HTMLFont(fontKey, font));
     }
 

--- a/CodenameOne/src/com/codename1/ui/plaf/UIManager.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/UIManager.java
@@ -1901,7 +1901,6 @@ public class UIManager {
                     style = new Style(getComponentStyle(baseStyle));
                 }
             } else {
-                baseStyle = null;
                 if (selected) {
                     style = new Style(defaultSelectedStyle);
                 } else {

--- a/CodenameOne/src/com/codename1/util/TBigInteger.java
+++ b/CodenameOne/src/com/codename1/util/TBigInteger.java
@@ -1240,7 +1240,7 @@ class TBigInteger {
         }
         TBigInteger base = this;
 
-        if (m.isOne() | (exponent.sign > 0 & base.sign == 0)) {
+        if (m.isOne() || (exponent.sign > 0 && base.sign == 0)) {
             return TBigInteger.ZERO;
         }
         if (exponent.sign == 0) {


### PR DESCRIPTION
### Motivation
- Silence several SpotBugs findings (null param deref, non-short-circuit logic, Boolean reference comparisons, instance locking on shared static data, dead local store) while keeping existing behavior intact. 
- Make the CI quality gate stricter by failing the build on the identified SpotBugs rules so regressions are caught early.

### Description
- Guard `FacebookRESTService.keyValue` against a `null` key and normalize `null` values to an empty string before calling `put` (`keyValue`).
- Validate `fontKey` in `HTMLComponent.addFont` by throwing `IllegalArgumentException` for `null` keys and perform `toLowerCase()` before inserting into `fonts`.
- Replace non-short-circuit bitwise checks with logical short-circuit operators in `DeflaterOutputStream.write` (use `||`) and `TBigInteger.modPow` (use `||` / `&&`) to avoid evaluation surprises.
- Replace Boolean reference comparisons with `Boolean.TRUE.equals(...)` in `InstantUI.isExcludedProperty` and `BrowserComponent.isDebugMode` to avoid reference-comparison pitfalls.
- Introduce a dedicated static lock `LISTENER_LOCK` and synchronize on it in `LocationManager.setLocationListener` and `setBackgroundLocationListener` to avoid using instance-level locks when modifying static listener fields.
- Remove a dead local store assignment to `baseStyle` in `UIManager.createStyle` to eliminate a dead-store warning.
- Extend the SpotBugs quality gate in `.github/scripts/generate-quality-report.py` to treat the rules `NP_NULL_PARAM_DEREF`, `NS_NON_SHORT_CIRCUIT`, `SSD_DO_NOT_USE_INSTANCE_LOCK_ON_SHARED_STATIC_DATA`, `DLS_DEAD_LOCAL_STORE_OF_NULL`, and `RC_REF_COMPARISON_BAD_PRACTICE_BOOLEAN` as build-breaking violations.

### Testing
- No automated tests were executed as part of this change (no `mvn` or unit test runs were performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967e141b9788331b0466b82e746432d)