### PR TITLE
Mark utility classes final to satisfy PMD and enforce PMD gate

### DIFF
--- a/.github/scripts/generate-quality-report.py
+++ b/.github/scripts/generate-quality-report.py
@@ -895,6 +895,18 @@ def main() -> None:
                 print(f"  - {v.rule}: {v.location} - {v.message}")
             exit(1)
 
+    pmd = parse_pmd()
+    if pmd:
+        forbidden_pmd_rules = {
+            "ClassWithOnlyPrivateConstructorsShouldBeFinal",
+        }
+        violations = [f for f in pmd.findings if f.rule in forbidden_pmd_rules]
+        if violations:
+            print("\n❌ Build failed due to forbidden PMD violations:")
+            for v in violations:
+                print(f"  - {v.rule}: {v.location} - {v.message}")
+            exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/CodenameOne/src/com/codename1/charts/util/MathHelper.java
+++ b/CodenameOne/src/com/codename1/charts/util/MathHelper.java
@@ -26,7 +26,7 @@ import java.util.List;
 /**
  * Utility class for math operations.
  */
-public class MathHelper {
+public final class MathHelper {
     /** A value that is used a null value. */
     public static final double NULL_VALUE = -Double.MAX_VALUE + 1;
     /**

--- a/CodenameOne/src/com/codename1/components/ClearableTextField.java
+++ b/CodenameOne/src/com/codename1/components/ClearableTextField.java
@@ -39,7 +39,7 @@ import com.codename1.ui.plaf.Style;
  *
  * @author Shai Almog
  */
-public class ClearableTextField extends Container {
+public final class ClearableTextField extends Container {
     private ClearableTextField() {
         super(new BorderLayout());
     }

--- a/CodenameOne/src/com/codename1/components/FileEncodedImage.java
+++ b/CodenameOne/src/com/codename1/components/FileEncodedImage.java
@@ -41,7 +41,7 @@ import java.io.OutputStream;
  *
  * @author Shai Almog
  */
-public class FileEncodedImage extends EncodedImage {
+public final class FileEncodedImage extends EncodedImage {
     private final String fileName;
     private final boolean keep;
     private byte[] data;

--- a/CodenameOne/src/com/codename1/components/FileEncodedImageAsync.java
+++ b/CodenameOne/src/com/codename1/components/FileEncodedImageAsync.java
@@ -41,7 +41,7 @@ import java.io.InputStream;
  *
  * @author Shai Almog
  */
-public class FileEncodedImageAsync extends EncodedImage {
+public final class FileEncodedImageAsync extends EncodedImage {
     private static final Object LOCK = new Object();
     private final String fileName;
     private boolean changePending;

--- a/CodenameOne/src/com/codename1/components/InfiniteScrollAdapter.java
+++ b/CodenameOne/src/com/codename1/components/InfiniteScrollAdapter.java
@@ -49,7 +49,7 @@ import com.codename1.ui.layouts.FlowLayout;
  *
  * @author Shai Almog
  */
-public class InfiniteScrollAdapter {
+public final class InfiniteScrollAdapter {
     private Container infiniteContainer;
     private Runnable fetchMore;
     private final Component ip;

--- a/CodenameOne/src/com/codename1/components/ReplaceableImage.java
+++ b/CodenameOne/src/com/codename1/components/ReplaceableImage.java
@@ -32,7 +32,7 @@ import com.codename1.ui.EncodedImage;
  *
  * @author Shai Almog
  */
-public class ReplaceableImage extends EncodedImage {
+public final class ReplaceableImage extends EncodedImage {
     private boolean replaced;
     private byte[] data;
     private final boolean opaque;

--- a/CodenameOne/src/com/codename1/components/StorageImage.java
+++ b/CodenameOne/src/com/codename1/components/StorageImage.java
@@ -36,7 +36,7 @@ import java.io.InputStream;
  *
  * @author Shai Almog
  */
-public class StorageImage extends EncodedImage {
+public final class StorageImage extends EncodedImage {
     private final String fileName;
     private final boolean keep;
     private byte[] data;

--- a/CodenameOne/src/com/codename1/components/StorageImageAsync.java
+++ b/CodenameOne/src/com/codename1/components/StorageImageAsync.java
@@ -34,7 +34,7 @@ import com.codename1.ui.Image;
  *
  * @author Shai Almog
  */
-public class StorageImageAsync extends EncodedImage {
+public final class StorageImageAsync extends EncodedImage {
     private static final Object LOCK = new Object();
     private final String fileName;
     private boolean changePending;

--- a/CodenameOne/src/com/codename1/components/ToastBar.java
+++ b/CodenameOne/src/com/codename1/components/ToastBar.java
@@ -82,7 +82,7 @@ import static com.codename1.ui.ComponentSelector.$;
  *
  * @author shannah
  */
-public class ToastBar {
+public final class ToastBar {
 
     /**
      * The default timeout for info/error messages

--- a/CodenameOne/src/com/codename1/facebook/FaceBookAccess.java
+++ b/CodenameOne/src/com/codename1/facebook/FaceBookAccess.java
@@ -53,7 +53,7 @@ import java.util.Vector;
  *
  * @author Chen Fishbein
  */
-public class FaceBookAccess {
+public final class FaceBookAccess {
 
     private static final String TEMP_STORAGE = "FaceBookAccesstmp";
     private static String clientId = "132970916828080";

--- a/CodenameOne/src/com/codename1/io/FileSystemStorage.java
+++ b/CodenameOne/src/com/codename1/io/FileSystemStorage.java
@@ -47,7 +47,7 @@ import java.util.TimerTask;
  *
  * @author Shai Almog
  */
-public class FileSystemStorage {
+public final class FileSystemStorage {
     /**
      * Represents the type for the get root type method, this type generally represents the main
      * phone memory

--- a/CodenameOne/src/com/codename1/io/NetworkManager.java
+++ b/CodenameOne/src/com/codename1/io/NetworkManager.java
@@ -55,7 +55,7 @@ import java.util.Vector;
  *
  * @author Shai Almog
  */
-public class NetworkManager {
+public final class NetworkManager {
     /**
      * Indicates an unknown access point type
      */

--- a/CodenameOne/src/com/codename1/io/Socket.java
+++ b/CodenameOne/src/com/codename1/io/Socket.java
@@ -35,7 +35,7 @@ import java.io.OutputStream;
  *
  * @author Shai Almog
  */
-public class Socket {
+public final class Socket {
     private Socket() {
     }
 

--- a/CodenameOne/src/com/codename1/io/services/CachedDataService.java
+++ b/CodenameOne/src/com/codename1/io/services/CachedDataService.java
@@ -38,7 +38,7 @@ import java.io.InputStream;
  *
  * @author Shai Almog
  */
-public class CachedDataService extends ConnectionRequest {
+public final class CachedDataService extends ConnectionRequest {
     private final CachedData data = new CachedData();
     private boolean responseProcessed;
 

--- a/CodenameOne/src/com/codename1/location/GeofenceManager.java
+++ b/CodenameOne/src/com/codename1/location/GeofenceManager.java
@@ -82,7 +82,7 @@ import java.util.Map;
  *
  * @author shannah
  */
-public class GeofenceManager implements Iterable<Geofence> {
+public final class GeofenceManager implements Iterable<Geofence> {
     //private GeoStreamerAsyncDataSource dataSource;
     private static final String STORAGE_KEY = "$AsyncGeoStreamer.geofences$";
     private static final String ACTIVE_FENCES_KEY = "$AsyncGeoStreamer.activegeofences$";

--- a/CodenameOne/src/com/codename1/processing/PrettyPrinter.java
+++ b/CodenameOne/src/com/codename1/processing/PrettyPrinter.java
@@ -52,7 +52,7 @@ import java.util.Map;
  *
  * @author Eric Coolman (2012-03 - derivative work from original Sun source).
  */
-class PrettyPrinter {
+final class PrettyPrinter {
     Map<?, ?> myHashMap;
 
     private PrettyPrinter(Map<?, ?> h) {

--- a/CodenameOne/src/com/codename1/processing/Result.java
+++ b/CodenameOne/src/com/codename1/processing/Result.java
@@ -92,7 +92,7 @@ import java.util.Vector;
  *
  * @author Eric Coolman (2012-03 - derivative work from original Sun source).
  */
-public class Result {
+public final class Result {
 
     public static final String JSON = "json";
     public static final String XML = "xml";

--- a/CodenameOne/src/com/codename1/properties/PreferencesObject.java
+++ b/CodenameOne/src/com/codename1/properties/PreferencesObject.java
@@ -32,7 +32,7 @@ import com.codename1.io.Preferences;
  *
  * @author Shai Almog
  */
-public class PreferencesObject {
+public final class PreferencesObject {
     private PropertyBusinessObject bo;
     private String prefix;
     private boolean bound;

--- a/CodenameOne/src/com/codename1/properties/SQLMap.java
+++ b/CodenameOne/src/com/codename1/properties/SQLMap.java
@@ -42,7 +42,7 @@ import java.util.List;
  *
  * @author Shai Almog
  */
-public class SQLMap {
+public final class SQLMap {
     private boolean verbose = true;
     private Database db;
 

--- a/CodenameOne/src/com/codename1/push/PushContent.java
+++ b/CodenameOne/src/com/codename1/push/PushContent.java
@@ -30,7 +30,7 @@ import com.codename1.ui.Display;
  *
  * @author Steve Hannah
  */
-public class PushContent {
+public final class PushContent {
     private static final String PROP_PREFIX = "com.codename1.push.prop.";
 
     private final String title;

--- a/CodenameOne/src/com/codename1/system/DefaultCrashReporter.java
+++ b/CodenameOne/src/com/codename1/system/DefaultCrashReporter.java
@@ -43,7 +43,7 @@ import java.util.TimerTask;
  *
  * @author Shai Almog
  */
-public class DefaultCrashReporter implements CrashReport {
+public final class DefaultCrashReporter implements CrashReport {
     private static String errorText = "The application encountered an error, do you wish to report it?";
     private static String sendButtonText = "Send";
     private static String dontSendButtonText = "Don't Send";

--- a/CodenameOne/src/com/codename1/system/NativeLookup.java
+++ b/CodenameOne/src/com/codename1/system/NativeLookup.java
@@ -38,7 +38,7 @@ import java.util.HashMap;
  *
  * @author Shai Almog
  */
-public class NativeLookup {
+public final class NativeLookup {
     /**
      * Indicates whether stack traces should be printed when lookup fails
      */

--- a/CodenameOne/src/com/codename1/testing/TestUtils.java
+++ b/CodenameOne/src/com/codename1/testing/TestUtils.java
@@ -49,7 +49,7 @@ import java.util.ArrayList;
  *
  * @author Shai Almog
  */
-public class TestUtils {
+public final class TestUtils {
     private static boolean verbose;
 
     private TestUtils() {

--- a/CodenameOne/src/com/codename1/ui/FontImage.java
+++ b/CodenameOne/src/com/codename1/ui/FontImage.java
@@ -74,7 +74,7 @@ import com.codename1.ui.util.ImageIO;
  *
  * @author Shai Almog
  */
-public class FontImage extends Image {
+public final class FontImage extends Image {
     /**
      * Material design icon font character code see
      * https://www.material.io/resources/icons/ for full list

--- a/CodenameOne/src/com/codename1/ui/UIFragment.java
+++ b/CodenameOne/src/com/codename1/ui/UIFragment.java
@@ -181,7 +181,7 @@ import static com.codename1.ui.ComponentSelector.$;
  * @author shannah
  * @since 7.0
  */
-public class UIFragment {
+public final class UIFragment {
 
 
     // The root element of this template

--- a/CodenameOne/src/com/codename1/ui/URLImage.java
+++ b/CodenameOne/src/com/codename1/ui/URLImage.java
@@ -70,7 +70,7 @@ import java.util.Map;
  *
  * @author Shai Almog
  */
-public class URLImage extends EncodedImage {
+public final class URLImage extends EncodedImage {
 
     /**
      * Flag used by {@link #createCachedImage(java.lang.String, java.lang.String, com.codename1.ui.Image, int) }.

--- a/CodenameOne/src/com/codename1/ui/animations/MorphTransition.java
+++ b/CodenameOne/src/com/codename1/ui/animations/MorphTransition.java
@@ -40,7 +40,7 @@ import java.util.Map;
  *
  * @author Shai Almog
  */
-public class MorphTransition extends Transition {
+public final class MorphTransition extends Transition {
     private int duration;
     private final HashMap<String, String> fromTo = new HashMap<String, String>();
     private CC[] fromToComponents;

--- a/CodenameOne/src/com/codename1/ui/html/HTMLInputFormat.java
+++ b/CodenameOne/src/com/codename1/ui/html/HTMLInputFormat.java
@@ -37,7 +37,7 @@ import java.util.Vector;
  *
  * @author Ofir Leitner
  */
-class HTMLInputFormat {
+final class HTMLInputFormat {
 
     /**
      * The allowed literals in an input format defintion

--- a/CodenameOne/src/com/codename1/ui/html/HTMLUtils.java
+++ b/CodenameOne/src/com/codename1/ui/html/HTMLUtils.java
@@ -31,7 +31,7 @@ import java.util.Hashtable;
  * @author Ofir Leitner
  * @deprecated the HTML package is no longer used or maintained and may be removed in a future revision
  */
-public class HTMLUtils {
+public final class HTMLUtils {
 
     /**
      * The char entities strings supported in XML. When a char entity is found these will be compared against first.

--- a/CodenameOne/src/com/codename1/ui/plaf/RoundBorder.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/RoundBorder.java
@@ -45,7 +45,7 @@ import com.codename1.ui.geom.Rectangle;
  *
  * @author Shai Almog
  */
-public class RoundBorder extends Border {
+public final class RoundBorder extends Border {
     private static final String CACHE_KEY = "cn1$$-rbcache";
     // these allow us to have more than one border per component in cache which is important for selected/unselected/pressed values
     private static int instanceCounter;

--- a/CodenameOne/src/com/codename1/ui/plaf/RoundRectBorder.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/RoundRectBorder.java
@@ -48,7 +48,7 @@ import com.codename1.ui.geom.Rectangle;
  *
  * @author Shai Almog
  */
-public class RoundRectBorder extends Border {
+public final class RoundRectBorder extends Border {
     private static final String CACHE_KEY = "cn1$$-rrbcache";
     // these allow us to have more than one border per component in cache which is important for selected/unselected/pressed values
     private static int instanceCounter;

--- a/CodenameOne/src/com/codename1/ui/spinner/DateTimeRenderer.java
+++ b/CodenameOne/src/com/codename1/ui/spinner/DateTimeRenderer.java
@@ -38,7 +38,7 @@ import java.util.Map;
  * @author Shai Almog
  * @deprecated use Picker instead
  */
-class DateTimeRenderer extends SpinnerRenderer<Object> {
+final class DateTimeRenderer extends SpinnerRenderer<Object> {
     static final String[] MONTHS = {
             "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
     };

--- a/CodenameOne/src/com/codename1/ui/util/Effects.java
+++ b/CodenameOne/src/com/codename1/ui/util/Effects.java
@@ -36,7 +36,7 @@ import com.codename1.ui.animations.Motion;
  *
  * @author Shai Almog
  */
-public class Effects {
+public final class Effects {
     private Effects() {
     }
 

--- a/CodenameOne/src/com/codename1/util/CallbackDispatcher.java
+++ b/CodenameOne/src/com/codename1/util/CallbackDispatcher.java
@@ -29,7 +29,7 @@ import com.codename1.ui.Display;
  *
  * @author shannah
  */
-public class CallbackDispatcher<T> implements Runnable {
+public final class CallbackDispatcher<T> implements Runnable {
     private SuccessCallback<T> success;
     private FailureCallback<T> failure;
     private T arg;

--- a/CodenameOne/src/com/codename1/util/EasyThread.java
+++ b/CodenameOne/src/com/codename1/util/EasyThread.java
@@ -35,7 +35,7 @@ import java.util.List;
  *
  * @author Shai Almog
  */
-public class EasyThread {
+public final class EasyThread {
     private static final List<ErrorListener> globalErrorListenenrs = new ArrayList<ErrorListener>();
     private final Object LOCK = new Object();
     private List<ErrorListener> errorListenenrs;

--- a/CodenameOne/src/com/codename1/util/TBitLevel.java
+++ b/CodenameOne/src/com/codename1/util/TBitLevel.java
@@ -33,7 +33,7 @@ package com.codename1.util;
  * All operations are provided in immutable way, and some in both mutable and
  * immutable.
  */
-class TBitLevel {
+final class TBitLevel {
 
     /**
      * Just to denote that this class can't be instantiated.

--- a/CodenameOne/src/com/codename1/util/TConversion.java
+++ b/CodenameOne/src/com/codename1/util/TConversion.java
@@ -21,7 +21,7 @@ package com.codename1.util;
  * Static library that provides {@link TBigInteger} base conversion from/to any
  * integer represented in an {@link java.lang.String} Object.
  */
-class TConversion {
+final class TConversion {
 
     /**
      * Holds the maximal exponent for each radix, so that radix<sup>digitFitInInt[radix]</sup>

--- a/CodenameOne/src/com/codename1/util/TElementary.java
+++ b/CodenameOne/src/com/codename1/util/TElementary.java
@@ -28,7 +28,7 @@ package com.codename1.util;
  * In addition to this, some <i><b>Inplace</b></i> (mutable) methods are
  * provided.
  */
-class TElementary {
+final class TElementary {
 
     /**
      * Just to denote that this class can't be instantiated

--- a/CodenameOne/src/com/codename1/util/TLogical.java
+++ b/CodenameOne/src/com/codename1/util/TLogical.java
@@ -28,7 +28,7 @@ package com.codename1.util;
  * <li>xor</li>
  * </ul>
  */
-class TLogical {
+final class TLogical {
 
     /**
      * Just to denote that this class can't be instantiated.

--- a/CodenameOne/src/com/codename1/util/TMultiplication.java
+++ b/CodenameOne/src/com/codename1/util/TMultiplication.java
@@ -20,7 +20,7 @@ package com.codename1.util;
 /**
  * Static library that provides all multiplication of {@link TBigInteger} methods.
  */
-class TMultiplication {
+final class TMultiplication {
 
     /**
      * Break point in digits (number of {@code int} elements)

--- a/CodenameOne/src/com/codename1/util/TPrimality.java
+++ b/CodenameOne/src/com/codename1/util/TPrimality.java
@@ -23,7 +23,7 @@ import java.util.Random;
 /**
  * Provides primality probabilistic methods.
  */
-class TPrimality {
+final class TPrimality {
 
     /**
      * All prime numbers with bit length lesser than 10 bits.


### PR DESCRIPTION
### Motivation
- Resolve PMD warnings for `ClassWithOnlyPrivateConstructorsShouldBeFinal` by making utility-style classes final across the codebase.
- Prevent regressions by failing CI when this specific PMD rule appears in future quality reports.

### Description
- Marked many classes that only have private constructors as `final` (multiple files under `CodenameOne/src/...`) so they no longer trigger the PMD rule.
- Updated the quality report script ` .github/scripts/generate-quality-report.py` to parse PMD results and treat violations of `ClassWithOnlyPrivateConstructorsShouldBeFinal` as a forbidden rule that fails the build.
- The PMD rule name enforced is `ClassWithOnlyPrivateConstructorsShouldBeFinal` and violations are printed with rule/location/message when detected.

### Testing
- No automated tests were executed as part of this change (no `mvn` or unit test run was performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696934a648b08331998afb4b6be6b186)