### PR TITLE
Emit class stubs and headers for default interface methods and add test assertions

### DIFF
--- a/vm/tests/src/test/java/com/codename1/tools/translator/ParserTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/ParserTest.java
@@ -129,6 +129,11 @@ class ParserTest {
         String implCode = impl.generateCCode(classes);
         assertTrue(implCode.contains("&com_example_Greeter_greet___R_java_lang_String"),
                 "Implementing class should point vtable slot to the interface default method implementation");
+        assertTrue(implCode.contains("com_example_GreeterImpl_greet___R_java_lang_String"),
+                "Implementing class should emit a concrete stub for default interface methods");
+        String implHeader = impl.generateCHeader();
+        assertTrue(implHeader.contains("com_example_GreeterImpl_greet___R_java_lang_String"),
+                "Implementing class header should declare the default interface stub");
     }
 
     @Test


### PR DESCRIPTION
### Motivation

- Interface default methods produced concrete implementations in the interface C output but did not always emit corresponding class-level stubs and header declarations for non-interface implementing classes, causing missing-symbol errors at native compile time when code referenced the class-level stub (e.g., for `super` calls).

### Description

- Added `hasMethodInBaseClass`, `appendDefaultInterfaceStubs`, and `appendDefaultInterfaceStubHeaders` to `ByteCodeClass` to walk interface hierarchies and emit class-level stubs and header declarations for concrete default interface methods while skipping abstract/static/private methods.
- Integrated default-interface stub emission into the class C generation and header generation paths by calling the new helpers alongside existing super-stub generation, and changed the logic to only append super stubs when a base class exists.
- The new logic prevents emitting stubs when a base class already supplies the same implementation to avoid accidental overrides.
- Updated `ParserTest.translatesDefaultInterfaceMethodImplementations` to assert that the implementing class C contains the concrete stub symbol and that the implementing class header declares the stub.

### Testing

- Added assertions in `vm/tests/src/test/java/com/codename1/tools/translator/ParserTest.java` to verify the implementing class emits the concrete stub and header declaration for default interface methods, but no automated test suite was executed for this patch.
- No CI or unit test runs were performed as part of this change (tests were updated but not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696be5ecd6a883318f42f3148cecdee8)