### PR TITLE
Exclude ReturnEmptyCollectionRatherThanNull from core-unittests PMD rules

### DIFF
--- a/maven/core-unittests/pmd.xml
+++ b/maven/core-unittests/pmd.xml
@@ -6,5 +6,6 @@
     <description>PMD rules for core unit tests.</description>
     <rule ref="rulesets/java/quickstart.xml">
         <exclude name="UselessParentheses"/>
+        <exclude name="ReturnEmptyCollectionRatherThanNull"/>
     </rule>
 </ruleset>


### PR DESCRIPTION
### Motivation
- Exclude the `ReturnEmptyCollectionRatherThanNull` PMD rule for the core unit tests to avoid spurious findings from test code.

### Description
- Add an `<exclude name="ReturnEmptyCollectionRatherThanNull"/>` entry to `maven/core-unittests/pmd.xml` alongside the existing `UselessParentheses` exclusion.

### Testing
- No automated tests were run because this is a configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696be80959bc8331b30c4d3cb0bcddb4)