### PR TITLE
Harden barebone checks and enforce explicit atomics for volatile fields

### DIFF
--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeClass.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeClass.java
@@ -713,7 +713,11 @@ public class ByteCodeClass {
                     b.append(clsName);
                     b.append("_");
                     b.append(bf.getFieldName());
-                    b.append(" = 0;\n");
+                    if (bf.isVolatile()) {
+                        b.append(" = ATOMIC_VAR_INIT(0);\n");
+                    } else {
+                        b.append(" = 0;\n");
+                    }
 
                     // static getter
                     b.append(bf.getCDefinition());
@@ -724,11 +728,11 @@ public class ByteCodeClass {
                     b.append("(CODENAME_ONE_THREAD_STATE) {\n    __STATIC_INITIALIZER_");
                     b.append(bf.getClsName());
                     if (bf.isVolatile()) {
-                        b.append("(threadStateData);\n     return atomic_load(&STATIC_FIELD_");
+                        b.append("(threadStateData);\n     return atomic_load_explicit(&STATIC_FIELD_");
                         b.append(bf.getClsName());
                         b.append("_");
                         b.append(bf.getFieldName());
-                        b.append(");\n}\n\n");
+                        b.append(", memory_order_acquire);\n}\n\n");
                     } else {
                         b.append("(threadStateData);\n     return STATIC_FIELD_");
                         b.append(bf.getClsName());
@@ -747,11 +751,11 @@ public class ByteCodeClass {
                     b.append(" __cn1StaticVal) {\n    __STATIC_INITIALIZER_");
                     b.append(bf.getClsName());
                     if (bf.isVolatile()) {
-                        b.append("(threadStateData);\n    atomic_store(&STATIC_FIELD_");
+                        b.append("(threadStateData);\n    atomic_store_explicit(&STATIC_FIELD_");
                         b.append(bf.getClsName());
                         b.append("_");
                         b.append(bf.getFieldName());
-                        b.append(", __cn1StaticVal);");
+                        b.append(", __cn1StaticVal, memory_order_release);");
                     } else {
                         b.append("(threadStateData);\n    STATIC_FIELD_");
                         b.append(bf.getClsName());
@@ -793,13 +797,13 @@ public class ByteCodeClass {
             b.append(fld.getFieldName());
             b.append("(JAVA_OBJECT __cn1T) {\n ").append(nullCheck).append("    ");
             if (fld.isVolatile()) {
-                b.append("return atomic_load(&((struct obj__");
+                b.append("return atomic_load_explicit(&((struct obj__");
                 b.append(clsName);
                 b.append("*)__cn1T)->");
                 b.append(fld.getClsName());
                 b.append("_");
                 b.append(fld.getFieldName());
-                b.append(");\n}\n\n");
+                b.append(", memory_order_acquire);\n}\n\n");
             } else {
                 b.append("return ((struct obj__");
                 b.append(clsName);
@@ -822,13 +826,13 @@ public class ByteCodeClass {
                 b.append(" __cn1Val, JAVA_OBJECT __cn1T) {\n  ").append(nullCheck).append("  ");
             }
             if (fld.isVolatile()) {
-                b.append("atomic_store(&((struct obj__");
+                b.append("atomic_store_explicit(&((struct obj__");
                 b.append(clsName);
                 b.append("*)__cn1T)->");
                 b.append(fld.getClsName());
                 b.append("_");
                 b.append(fld.getFieldName());
-                b.append(", __cn1Val);\n}\n\n");
+                b.append(", __cn1Val, memory_order_release);\n}\n\n");
             } else {
                 b.append("((struct obj__");
                 b.append(clsName);
@@ -871,11 +875,11 @@ public class ByteCodeClass {
             if(!fld.isStaticField() && fld.isObjectType() && fld.getClsName().equals(clsName)) {
                 b.append("    gcMarkObject(threadStateData, ");
                 if (fld.isVolatile()) {
-                    b.append("atomic_load(&objInstance->");
+                    b.append("atomic_load_explicit(&objInstance->");
                     b.append(fld.getClsName());
                     b.append("_");
                     b.append(fld.getFieldName());
-                    b.append(")");
+                    b.append(", memory_order_acquire)");
                 } else {
                     b.append("objInstance->");
                     b.append(fld.getClsName());
@@ -1920,11 +1924,11 @@ public class ByteCodeClass {
             if(bf.isStaticField() && bf.isObjectType() && !bf.shouldRemoveFromHeapCollection()) {
                 b.append("    gcMarkObject(threadStateData, ");
                 if (bf.isVolatile()) {
-                    b.append("atomic_load(&STATIC_FIELD_");
+                    b.append("atomic_load_explicit(&STATIC_FIELD_");
                     b.append(clsName);
                     b.append("_");
                     b.append(bf.getFieldName());
-                    b.append(")");
+                    b.append(", memory_order_acquire)");
                 } else {
                     b.append("STATIC_FIELD_");
                     b.append(clsName);

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
@@ -139,6 +139,17 @@ public class BytecodeMethod implements SignatureSet {
         if(maxLocals > argSlots) {
             return false;
         }
+        int maxLocalIndexUsed = -1;
+        for (Instruction i : instructions) {
+            if (i instanceof VarOp) {
+                maxLocalIndexUsed = Math.max(maxLocalIndexUsed, ((VarOp)i).getIndex());
+            } else if (i instanceof IInc) {
+                maxLocalIndexUsed = Math.max(maxLocalIndexUsed, ((IInc)i).getVar());
+            }
+        }
+        if (maxLocalIndexUsed >= argSlots) {
+            return false;
+        }
         for(Instruction i : instructions) {
             if(i instanceof LabelInstruction || i instanceof LineNumber || i instanceof IInc ||
                     i instanceof Jump || i instanceof CustomJump || i instanceof LocalVariable) {
@@ -191,12 +202,8 @@ public class BytecodeMethod implements SignatureSet {
                     case Opcodes.LMUL:
                     case Opcodes.FMUL:
                     case Opcodes.DMUL:
-                    case Opcodes.IDIV:
-                    case Opcodes.LDIV:
                     case Opcodes.FDIV:
                     case Opcodes.DDIV:
-                    case Opcodes.IREM:
-                    case Opcodes.LREM:
                     case Opcodes.FREM:
                     case Opcodes.DREM:
                     case Opcodes.INEG:

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/IInc.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/IInc.java
@@ -39,6 +39,10 @@ public class IInc extends Instruction {
         this.num = num;
     }
 
+    public int getVar() {
+        return var;
+    }
+
     @Override
     public void appendInstruction(StringBuilder b) {
         if(getMethod() != null && getMethod().isBarebone()) {


### PR DESCRIPTION
### Motivation

- Prevent incorrect "barebone" method classification when methods use local slots beyond argument slots or modify locals via `IINC` which wasn't accounted for. 
- Avoid silently allowing opcodes that can implicitly throw (divide/remainder) in methods considered `barebone`.
- Ensure volatile field code generation uses explicit atomic initialization and explicit acquire/release memory ordering to avoid undefined ordering and initialization issues.

### Description

- Added `getVar()` to `IInc` so the local index used by `IINC` is visible to analysis (`vm/.../bytecodes/IInc.java`).
- Tightened `BytecodeMethod.checkBarebone()` to scan `instructions` for maximum local index used by `VarOp` and `IInc` and reject `barebone` if that index is >= argument slots (`vm/.../BytecodeMethod.java`).
- Removed implicit divide/remainder opcodes from the allowed `barebone` instruction set to avoid methods that could throw implicitly from being marked `barebone` (`vm/.../BytecodeMethod.java`).
- Modified volatile field codegen to use `ATOMIC_VAR_INIT(0)` for static volatile initialization and to call `atomic_load_explicit(..., memory_order_acquire)` / `atomic_store_explicit(..., memory_order_release)` for static and instance volatile accesses, including GC mark paths and static field marking (`vm/.../ByteCodeClass.java`).

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c442d9a1c8331a6d5505249533ede)