### PR TITLE
Add HelloCodenameOne regression coverage for storage/properties

### DIFF
--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/Cn1ssDeviceRunner.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/Cn1ssDeviceRunner.java
@@ -72,6 +72,7 @@ public final class Cn1ssDeviceRunner extends DeviceRunner {
             new InPlaceEditViewTest(),
             new BytecodeTranslatorRegressionTest(),
             new BackgroundThreadUiAccessTest(),
+            new StorageAndPropertiesRegressionTest(),
             new AccessibilityTest()));
 
     public static void addTest(BaseTest test) {

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/StorageAndPropertiesRegressionTest.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/StorageAndPropertiesRegressionTest.java
@@ -1,0 +1,61 @@
+package com.codenameone.examples.hellocodenameone.tests;
+
+import com.codename1.io.Storage;
+import com.codename1.ui.Display;
+import com.codename1.io.Properties;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Hashtable;
+
+public class StorageAndPropertiesRegressionTest extends BaseTest {
+    private static final String STORE_KEY_ROLL_CALL_USER = "roll-call-user";
+
+    @Override
+    public boolean shouldTakeScreenshot() {
+        return false;
+    }
+
+    @Override
+    public boolean runTest() throws Exception {
+        try {
+            verifyPropertiesLoad();
+            verifyStorageReadWrite();
+        } catch (Exception exception) {
+            fail("Storage/properties regression test failed: " + exception);
+            return true;
+        }
+        done();
+        return true;
+    }
+
+    private void verifyPropertiesLoad() throws IOException {
+        Properties props = new Properties();
+        try (InputStream stream = Display.getInstance().getResourceAsStream(
+                StorageAndPropertiesRegressionTest.class, "/app-resources.properties")) {
+            if (stream == null) {
+                throw new IOException("app-resources.properties not found on classpath.");
+            }
+            props.load(stream);
+        }
+        String version = props.getProperty("app.version");
+        if (version == null || version.length() == 0) {
+            throw new IOException("app.version missing from app-resources.properties.");
+        }
+    }
+
+    private void verifyStorageReadWrite() throws IOException {
+        Storage storage = Storage.getInstance();
+        Object store = storage.readObject(STORE_KEY_ROLL_CALL_USER);
+        if (store == null) {
+            Hashtable<String, String> newStore = new Hashtable<>();
+            newStore.put("status", "created");
+            storage.writeObject(STORE_KEY_ROLL_CALL_USER, newStore);
+            storage.flushStorageCache();
+            store = storage.readObject(STORE_KEY_ROLL_CALL_USER);
+        }
+        if (!(store instanceof Hashtable)) {
+            throw new IOException("Storage read returned unexpected type: " + store);
+        }
+    }
+}

--- a/scripts/hellocodenameone/common/src/main/resources/app-resources.properties
+++ b/scripts/hellocodenameone/common/src/main/resources/app-resources.properties
@@ -1,0 +1,1 @@
+app.version=1.0.0


### PR DESCRIPTION
### Motivation
- Reproduce a reported crash path related to loading a root-level properties file via `Display.getResourceAsStream` / `Properties` and to using `Storage.getInstance()` for read/write/flush. 
- Provide a minimal in-app reproduction inside the HelloCodenameOne test suite to help diagnose iOS/storage/properties regressions.

### Description
- Add `StorageAndPropertiesRegressionTest` in `scripts/hellocodenameone/common/src/main/java/.../tests` which loads `/app-resources.properties` via `Display.getResourceAsStream`, reads `app.version` from `Properties`, and exercises `Storage.readObject`/`writeObject`/`flushStorageCache`.
- Add sample resource `scripts/hellocodenameone/common/src/main/resources/app-resources.properties` containing `app.version=1.0.0` used by the test.
- Register the new test in the device runner by adding `new StorageAndPropertiesRegressionTest()` to `Cn1ssDeviceRunner` so it runs with the existing HelloCodenameOne suite.

### Testing
- No automated tests were run as part of this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cdf68e2ac8331b7bb4d7dfacb5fd7)