### PR TITLE
Resolve invokespecial owners for interface default methods

### DIFF
--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeClass.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeClass.java
@@ -289,6 +289,44 @@ public class ByteCodeClass {
         return false;
     }
 
+    public ByteCodeClass findMethodOwner(String name, String desc) {
+        return findMethodOwner(name, desc, new HashSet<ByteCodeClass>());
+    }
+
+    private ByteCodeClass findMethodOwner(String name, String desc, Set<ByteCodeClass> visited) {
+        if (!visited.add(this)) {
+            return null;
+        }
+        BytecodeMethod declaredMethod = findDeclaredMethod(name, desc);
+        if (declaredMethod != null && !declaredMethod.isAbstract()) {
+            return this;
+        }
+        if (baseClassObject != null) {
+            ByteCodeClass owner = baseClassObject.findMethodOwner(name, desc, visited);
+            if (owner != null) {
+                return owner;
+            }
+        }
+        if (baseInterfacesObject != null) {
+            for (ByteCodeClass iface : baseInterfacesObject) {
+                ByteCodeClass owner = iface.findMethodOwner(name, desc, visited);
+                if (owner != null) {
+                    return owner;
+                }
+            }
+        }
+        return null;
+    }
+
+    private BytecodeMethod findDeclaredMethod(String name, String desc) {
+        for (BytecodeMethod meth : methods) {
+            if (meth.getMethodName().equals(name) && desc.equals(meth.getSignature())) {
+                return meth;
+            }
+        }
+        return null;
+    }
+
     public void unmark() {
         marked = false;
     }

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/Util.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/Util.java
@@ -123,6 +123,21 @@ public class Util {
         return arguments;
     }
 
+    public static String resolveInvokeSpecialOwner(String owner, String name, String desc) {
+        if (owner == null) {
+            return owner;
+        }
+        ByteCodeClass bc = Parser.getClassObject(owner.replace('/', '_').replace('$', '_'));
+        if (bc == null) {
+            return owner;
+        }
+        ByteCodeClass resolvedOwner = bc.findMethodOwner(name, desc);
+        if (resolvedOwner == null) {
+            return owner;
+        }
+        return resolvedOwner.getOriginalClassName();
+    }
+
     public static char[] getStackInputTypes(Instruction instr) {
         char[] out = instr.getStackInputTypes();
         if (out != null) {

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/CustomInvoke.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/CustomInvoke.java
@@ -157,6 +157,9 @@ public class CustomInvoke extends Instruction {
             }
             return true;
         }
+        if (origOpcode == Opcodes.INVOKESPECIAL && !name.equals("<init>") && !name.equals("<clinit>")) {
+            owner = Util.resolveInvokeSpecialOwner(owner, name, desc);
+        }
         
         StringBuilder bld = new StringBuilder();
         boolean isVirtualCall = false;
@@ -273,6 +276,9 @@ public class CustomInvoke extends Instruction {
                 b.append("    POP_MANY_AND_PUSH_OBJ(cloneArray(PEEK_OBJ(1)), 1);\n");
             }
             return;
+        }
+        if (origOpcode == Opcodes.INVOKESPECIAL && !name.equals("<init>") && !name.equals("<clinit>")) {
+            owner = Util.resolveInvokeSpecialOwner(owner, name, desc);
         }
         
         StringBuilder bld = new StringBuilder();

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Invoke.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Invoke.java
@@ -140,6 +140,9 @@ public class Invoke extends Instruction {
             b.append("    POP_MANY_AND_PUSH_OBJ(cloneArray(PEEK_OBJ(1)), 1);\n");
             return;
         }
+        if (opcode == Opcodes.INVOKESPECIAL && !name.equals("<init>") && !name.equals("<clinit>")) {
+            owner = Util.resolveInvokeSpecialOwner(owner, name, desc);
+        }
         
         StringBuilder bld = new StringBuilder();
         boolean isVirtualCall = false;


### PR DESCRIPTION
### Motivation
- Fix incorrect `invokespecial` target selection that caused generated C calls to reference the wrong declaring class for inherited default/interface methods (e.g. `super.drawNumber` resolving to the wrong parent). 

### Description
- Add `ByteCodeClass.findMethodOwner(name, desc)` to search the class, its superclass chain and interfaces for the first non-abstract declaring owner and avoid cycles via a visited set. 
- Add `Util.resolveInvokeSpecialOwner(owner, name, desc)` helper to map the original owner to the resolved declaring class name. 
- Use the new helper in both normal and custom invocation code paths by remapping `owner` when emitting `INVOKESPECIAL` (excluding `<init>` and `<clinit>`), so super calls target the real concrete implementation. 
- Add a small `findDeclaredMethod` helper to locate a declared method on a class.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e3befc30c8331acb04dee99a6ade8)