### PR TITLE
Suppress existing PMD CompareObjectsWithEquals violations and enforce rule in quality gate

### DIFF
--- a/.github/scripts/generate-quality-report.py
+++ b/.github/scripts/generate-quality-report.py
@@ -899,6 +899,7 @@ def main() -> None:
     if pmd:
         forbidden_pmd_rules = {
             "ClassWithOnlyPrivateConstructorsShouldBeFinal",
+            "CompareObjectsWithEquals",
             "FormalParameterNamingConventions",
             "LiteralsFirstInComparisons",
             "LocalVariableNamingConventions",

--- a/CodenameOne/src/com/codename1/analytics/AnalyticsService.java
+++ b/CodenameOne/src/com/codename1/analytics/AnalyticsService.java
@@ -255,7 +255,7 @@ public class AnalyticsService {
             ActionListener onComplete = new ActionListener() {
                 @Override
                 public void actionPerformed(ActionEvent evt) {
-                    if (req == lastRequest) {
+                    if (req == lastRequest) { //NOPMD CompareObjectsWithEquals
                         lastRequest = null;
                     }
                 }
@@ -294,7 +294,7 @@ public class AnalyticsService {
             ActionListener onComplete = new ActionListener() {
                 @Override
                 public void actionPerformed(ActionEvent evt) {
-                    if (r == lastRequest) {
+                    if (r == lastRequest) { //NOPMD CompareObjectsWithEquals
                         lastRequest = null;
                     }
                 }

--- a/CodenameOne/src/com/codename1/compat/java/util/Objects.java
+++ b/CodenameOne/src/com/codename1/compat/java/util/Objects.java
@@ -45,7 +45,7 @@ public final class Objects {
      * @return
      */
     public static boolean equals(Object a, Object b) {
-        if (a == b) {
+        if (a == b) { //NOPMD CompareObjectsWithEquals
             return true;
         }
         return a != null && a.equals(b);
@@ -89,7 +89,7 @@ public final class Objects {
     }
 
     public static boolean deepEquals(Object a, Object b) {
-        if (a == b) {
+        if (a == b) { //NOPMD CompareObjectsWithEquals
             return true;
         }
         if (a == null) {

--- a/CodenameOne/src/com/codename1/components/Accordion.java
+++ b/CodenameOne/src/com/codename1/components/Accordion.java
@@ -445,7 +445,7 @@ public class Accordion extends Container {
                     if (autoClose) {
                         for (int i = 0; i < Accordion.this.getComponentCount(); i++) {
                             AccordionContent c = (AccordionContent) Accordion.this.getComponentAt(i);
-                            if (c != AccordionContent.this && !c.isClosed()) {
+                            if (c != AccordionContent.this && !c.isClosed()) { //NOPMD CompareObjectsWithEquals
                                 c.openClose(true);
                             }
                         }

--- a/CodenameOne/src/com/codename1/components/ButtonList.java
+++ b/CodenameOne/src/com/codename1/components/ButtonList.java
@@ -163,7 +163,7 @@ public abstract class ButtonList extends Container implements DataChangedListene
     }
 
     public final void setModel(ListModel model) {
-        if (model != this.model) {
+        if (model != this.model) { //NOPMD CompareObjectsWithEquals
             if (this.model != null) {
                 this.model.removeDataChangedListener(this);
                 this.model.removeSelectionListener(this);
@@ -210,7 +210,7 @@ public abstract class ButtonList extends Container implements DataChangedListene
      */
     @Override
     public void setLayout(Layout layout) {
-        if (layout != this.getLayout()) {
+        if (layout != this.getLayout()) { //NOPMD CompareObjectsWithEquals
             super.setLayout(layout);
             refresh();
         }

--- a/CodenameOne/src/com/codename1/components/FloatingActionButton.java
+++ b/CodenameOne/src/com/codename1/components/FloatingActionButton.java
@@ -300,7 +300,7 @@ public class FloatingActionButton extends Button {
         flow.setValign(valign);
 
         Form f = cnt.getComponentForm();
-        if (f != null && (f.getContentPane() == cnt || f == cnt)) {
+        if (f != null && (f.getContentPane() == cnt || f == cnt)) { //NOPMD CompareObjectsWithEquals
             // special case for content pane installs the button directly on the content pane
             Container layers = f.getLayeredPane(getClass(), true);
             layers.setSafeArea(true);

--- a/CodenameOne/src/com/codename1/components/FloatingHint.java
+++ b/CodenameOne/src/com/codename1/components/FloatingHint.java
@@ -128,7 +128,7 @@ public class FloatingHint extends Container {
     }
 
     private boolean isInitializedImpl() {
-        return isInitialized() && getComponentForm() == Display.getInstance().getCurrent();
+        return isInitialized() && getComponentForm() == Display.getInstance().getCurrent(); //NOPMD CompareObjectsWithEquals
     }
 
     private void focusLostImpl() {

--- a/CodenameOne/src/com/codename1/components/ImageViewer.java
+++ b/CodenameOne/src/com/codename1/components/ImageViewer.java
@@ -785,7 +785,7 @@ public class ImageViewer extends Component {
      * @param image the image to set
      */
     public final void setImage(Image image) {
-        if (this.image != image) {
+        if (this.image != image) { //NOPMD CompareObjectsWithEquals
             panPositionX = 0.5f;
             panPositionY = 0.5f;
             zoom = MIN_ZOOM;
@@ -1151,10 +1151,10 @@ public class ImageViewer extends Component {
                         setImage(replaceImage);
                         Image left = getImageLeft();
                         Image right = getImageRight();
-                        if (left != replaceImage) {
+                        if (left != replaceImage) { //NOPMD CompareObjectsWithEquals
                             left.unlock();
                         }
-                        if (right != replaceImage) {
+                        if (right != replaceImage) { //NOPMD CompareObjectsWithEquals
                             right.unlock();
                         }
                         selectLock = true;

--- a/CodenameOne/src/com/codename1/components/InfiniteProgress.java
+++ b/CodenameOne/src/com/codename1/components/InfiniteProgress.java
@@ -234,7 +234,7 @@ public class InfiniteProgress extends Component {
      * @since 7.0
      */
     public boolean animate(boolean force) {
-        if (!force && (!isVisible() || Display.getInstance().getCurrent() != this.getComponentForm())) { // PMD Fix: CollapsibleIfStatements merged visibility checks
+        if (!force && (!isVisible() || Display.getInstance().getCurrent() != this.getComponentForm())) { // PMD Fix: CollapsibleIfStatements merged visibility checks //NOPMD CompareObjectsWithEquals
             return false;
         }
         // reduce repaint thrushing of the UI from the infinite progress
@@ -299,7 +299,7 @@ public class InfiniteProgress extends Component {
      */
     @Override
     public void paint(Graphics g) {
-        if (this.getComponentForm() != null && Display.getInstance().getCurrent() != this.getComponentForm()) {
+        if (this.getComponentForm() != null && Display.getInstance().getCurrent() != this.getComponentForm()) { //NOPMD CompareObjectsWithEquals
             return;
         }
         super.paint(g);

--- a/CodenameOne/src/com/codename1/components/MultiButton.java
+++ b/CodenameOne/src/com/codename1/components/MultiButton.java
@@ -128,7 +128,7 @@ public class MultiButton extends Container implements ActionSource, SelectableIc
      * @return
      */
     public boolean isLinesTogetherMode() {
-        return firstRow.getParent() == secondRow.getParent();
+        return firstRow.getParent() == secondRow.getParent(); //NOPMD CompareObjectsWithEquals
     }
 
     /**

--- a/CodenameOne/src/com/codename1/components/Progress.java
+++ b/CodenameOne/src/com/codename1/components/Progress.java
@@ -139,7 +139,7 @@ public class Progress extends Dialog implements ActionListener<NetworkEvent> {
      */
     @Override
     public void actionPerformed(NetworkEvent ev) {
-        if (ev.getConnectionRequest() == request) {
+        if (ev.getConnectionRequest() == request) { //NOPMD CompareObjectsWithEquals
             if (disposeOnCompletion && ev.getProgressType() == NetworkEvent.PROGRESS_TYPE_COMPLETED) {
                 dispose();
                 return;

--- a/CodenameOne/src/com/codename1/components/RSSReader.java
+++ b/CodenameOne/src/com/codename1/components/RSSReader.java
@@ -548,7 +548,7 @@ public class RSSReader extends List {
                 for (int iter = 0; iter < existingData.size(); iter++) {
                     Hashtable h = (Hashtable) existingData.elementAt(iter);
                     Object icn = h.get("icon");
-                    if (icn != null && icn == iconPlaceholder) {
+                    if (icn != null && icn == iconPlaceholder) { //NOPMD CompareObjectsWithEquals
                         downloadImage(h, iter);
                     }
                 }

--- a/CodenameOne/src/com/codename1/components/SignatureComponent.java
+++ b/CodenameOne/src/com/codename1/components/SignatureComponent.java
@@ -289,7 +289,7 @@ public class SignatureComponent extends Container implements ActionSource<Action
      * @param img The image to set as the signature image.
      */
     public void setSignatureImage(Image img) {
-        if (img != signatureImage) {
+        if (img != signatureImage) { //NOPMD CompareObjectsWithEquals
             signatureImage = img;
             lead.setText("");
             if (img != null) {

--- a/CodenameOne/src/com/codename1/components/SpanButton.java
+++ b/CodenameOne/src/com/codename1/components/SpanButton.java
@@ -186,7 +186,7 @@ public class SpanButton extends Container implements ActionSource<ActionEvent>, 
 
     @Override
     protected void initLaf(UIManager uim) {
-        if (uim == getUIManager() && isInitialized()) {
+        if (uim == getUIManager() && isInitialized()) { //NOPMD CompareObjectsWithEquals
             return;
         }
         super.initLaf(uim);

--- a/CodenameOne/src/com/codename1/components/SpanLabel.java
+++ b/CodenameOne/src/com/codename1/components/SpanLabel.java
@@ -125,7 +125,7 @@ public class SpanLabel extends Container implements IconHolder, TextHolder {
 
     @Override
     protected void initLaf(UIManager uim) {
-        if (uim == getUIManager() && isInitialized()) {
+        if (uim == getUIManager() && isInitialized()) { //NOPMD CompareObjectsWithEquals
             return;
         }
         super.initLaf(uim);
@@ -326,7 +326,7 @@ public class SpanLabel extends Container implements IconHolder, TextHolder {
      * @return -1 for unaligned otherwise one of Component.LEFT/RIGHT/CENTER
      */
     public int getTextBlockAlign() {
-        if (text.getParent() == this) {
+        if (text.getParent() == this) { //NOPMD CompareObjectsWithEquals
             return -1;
         }
         return ((FlowLayout) text.getParent().getLayout()).getAlign();
@@ -348,7 +348,7 @@ public class SpanLabel extends Container implements IconHolder, TextHolder {
                 wrapText(align);
                 return;
             default:
-                if (text.getParent() != this) {
+                if (text.getParent() != this) { //NOPMD CompareObjectsWithEquals
                     removeComponent(text.getParent());
                     text.getParent().removeAll();
                     addComponent(BorderLayout.CENTER, BoxLayout.encloseYCenter(text));
@@ -358,7 +358,7 @@ public class SpanLabel extends Container implements IconHolder, TextHolder {
 
     private void wrapText(int alignment) {
         Container parent = text.getParent();
-        if (parent == this) {
+        if (parent == this) { //NOPMD CompareObjectsWithEquals
             parent.removeComponent(text);
             parent = new Container(new FlowLayout(alignment, CENTER));
             parent.getAllStyles().stripMarginAndPadding();

--- a/CodenameOne/src/com/codename1/components/SpanMultiButton.java
+++ b/CodenameOne/src/com/codename1/components/SpanMultiButton.java
@@ -156,7 +156,7 @@ public class SpanMultiButton extends Container implements ActionSource, Selectab
      * @return
      */
     public boolean isLinesTogetherMode() {
-        return firstRow.getParent() == secondRow.getParent();
+        return firstRow.getParent() == secondRow.getParent(); //NOPMD CompareObjectsWithEquals
     }
 
     /**

--- a/CodenameOne/src/com/codename1/components/ToastBar.java
+++ b/CodenameOne/src/com/codename1/components/ToastBar.java
@@ -683,7 +683,7 @@ public final class ToastBar {
 
         } else {
             Form f = c.getComponentForm();
-            if (Display.getInstance().getCurrent() == f && !f.getMenuBar().isMenuShowing()) {
+            if (Display.getInstance().getCurrent() == f && !f.getMenuBar().isMenuShowing()) { //NOPMD CompareObjectsWithEquals
                 if (this.position == Component.BOTTOM) {
                     c.setY(c.getY() + c.getHeight());
                 }

--- a/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
+++ b/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
@@ -693,7 +693,7 @@ public abstract class CodenameOneImplementation {
      * @return whether a component is being edited
      */
     public boolean isEditingText(Component c) {
-        return editingText == c;
+        return editingText == c; //NOPMD CompareObjectsWithEquals
     }
 
     /**
@@ -951,7 +951,7 @@ public abstract class CodenameOneImplementation {
     public void cancelRepaint(Animation cmp) {
         synchronized (displayLock) {
             for (int iter = 0; iter < paintQueueFill; iter++) {
-                if (paintQueue[iter] == cmp) {
+                if (paintQueue[iter] == cmp) { //NOPMD CompareObjectsWithEquals
                     paintQueue[iter] = null;
                     return;
                 }
@@ -969,14 +969,14 @@ public abstract class CodenameOneImplementation {
         synchronized (displayLock) {
             for (int iter = 0; iter < paintQueueFill; iter++) {
                 Animation ani = paintQueue[iter];
-                if (ani == cmp) {
+                if (ani == cmp) { //NOPMD CompareObjectsWithEquals
                     return;
                 }
                 //no need to paint a Component if one of its parent is already in the queue
                 if (ani instanceof Container && cmp instanceof Component) {
                     Component parent = ((Component) cmp).getParent();
                     while (parent != null) {
-                        if (parent == ani) {
+                        if (parent == ani) { //NOPMD CompareObjectsWithEquals
                             return;
                         }
                         parent = parent.getParent();

--- a/CodenameOne/src/com/codename1/io/BufferedInputStream.java
+++ b/CodenameOne/src/com/codename1/io/BufferedInputStream.java
@@ -261,7 +261,7 @@ public class BufferedInputStream extends InputStream {
                 }
                 byte[] nbuf = new byte[nsz];
                 System.arraycopy(buffer, 0, nbuf, 0, pos);
-                if (buffer != buf) {
+                if (buffer != buf) { //NOPMD CompareObjectsWithEquals
                     throw new IOException("Stream closed");
                 }
                 buf = nbuf;

--- a/CodenameOne/src/com/codename1/io/ConnectionRequest.java
+++ b/CodenameOne/src/com/codename1/io/ConnectionRequest.java
@@ -2323,7 +2323,7 @@ public class ConnectionRequest implements IOProgressListener {
             ConnectionRequest r = (ConnectionRequest) o;
 
             // interned string comparison
-            if (r.url == url) {
+            if (r.url == url) { //NOPMD CompareObjectsWithEquals
                 if (requestArguments != null) {
                     if (r.requestArguments != null && requestArguments.size() == r.requestArguments.size()) {
                         Iterator entries = requestArguments.entrySet().iterator();

--- a/CodenameOne/src/com/codename1/io/NetworkManager.java
+++ b/CodenameOne/src/com/codename1/io/NetworkManager.java
@@ -403,7 +403,7 @@ public final class NetworkManager {
                     }
                     return;
                 }
-                if (e.getConnectionRequest() == request) {
+                if (e.getConnectionRequest() == request) { //NOPMD CompareObjectsWithEquals
                     if (e.getProgressType() == NetworkEvent.PROGRESS_TYPE_COMPLETED) {
                         if (request.retrying) {
                             request.retrying = false;
@@ -466,7 +466,7 @@ public final class NetworkManager {
                     removeErrorListener(this);
                     return;
                 }
-                if (e.getConnectionRequest() == request) {
+                if (e.getConnectionRequest() == request) { //NOPMD CompareObjectsWithEquals
                     if (e.getProgressType() == NetworkEvent.PROGRESS_TYPE_COMPLETED) {
                         if (request.retrying) {
                             request.retrying = false;
@@ -835,7 +835,7 @@ public final class NetworkManager {
                 if (networkThreads == null) {
                     return false;
                 }
-                if (threadOffset != null && networkThreads[threadOffset.intValue()] != this) {
+                if (threadOffset != null && networkThreads[threadOffset.intValue()] != this) { //NOPMD CompareObjectsWithEquals
                     synchronized (LOCK) {
                         if (pending.size() > 0) {
                             pending.insertElementAt(currentRequest, 1);

--- a/CodenameOne/src/com/codename1/io/Oauth2.java
+++ b/CodenameOne/src/com/codename1/io/Oauth2.java
@@ -498,7 +498,7 @@ public class Oauth2 {
 
     private void handleURL(String url, WebBrowser web, final ActionListener<ActionEvent> al, final Form frm, final Form backToForm, final Dialog progress) {
         if ((url.startsWith(redirectURI))) {
-            if (progress != null && Display.getInstance().getCurrent() == progress) {
+            if (progress != null && Display.getInstance().getCurrent() == progress) { //NOPMD CompareObjectsWithEquals
                 progress.dispose();
             }
 
@@ -643,7 +643,7 @@ public class Oauth2 {
                 }
             }
         } else {
-            if (frm != null && Display.getInstance().getCurrent() != frm) {
+            if (frm != null && Display.getInstance().getCurrent() != frm) { //NOPMD CompareObjectsWithEquals
                 progress.dispose();
                 frm.show();
             }
@@ -724,7 +724,7 @@ public class Oauth2 {
 
         @Override
         public void actionPerformed(ActionEvent ev) {
-            if (Display.getInstance().getCurrent() == progress) {
+            if (Display.getInstance().getCurrent() == progress) { //NOPMD CompareObjectsWithEquals
                 progress.dispose();
             }
             old.showBack();

--- a/CodenameOne/src/com/codename1/io/Preferences.java
+++ b/CodenameOne/src/com/codename1/io/Preferences.java
@@ -440,7 +440,7 @@ public class Preferences {
      */
     private static void fireChange(final String pref, final Object priorValue, final Object value) {
         //noinspection EqualsReplaceableByObjectsCall,ObjectEquality
-        boolean valueChanged = (priorValue != value) && ((priorValue == null) || !priorValue.equals(value));
+        boolean valueChanged = (priorValue != value) && ((priorValue == null) || !priorValue.equals(value)); //NOPMD CompareObjectsWithEquals
         if (valueChanged) {
             ArrayList<PreferenceListener> listenerList = listenerMap.get(pref);
             if (listenerList != null) {

--- a/CodenameOne/src/com/codename1/io/Util.java
+++ b/CodenameOne/src/com/codename1/io/Util.java
@@ -892,7 +892,7 @@ public class Util {
         // hence this method simulates the proper behavior
         if (!charArrayBugTested) {
             charArrayBugTested = true;
-            if (s.toCharArray() == s.toCharArray()) {
+            if (s.toCharArray() == s.toCharArray()) { //NOPMD CompareObjectsWithEquals
                 charArrayBug = true;
             }
         }
@@ -1377,7 +1377,7 @@ public class Util {
     public static int indexOf(Object[] arr, Object value) {
         int l = arr.length;
         for (int iter = 0; iter < l; iter++) {
-            if (arr[iter] == value) {
+            if (arr[iter] == value) { //NOPMD CompareObjectsWithEquals
                 return iter;
             }
         }
@@ -2377,7 +2377,7 @@ public class Util {
         NetworkManager.getInstance().addProgressListener(new ActionListener<NetworkEvent>() {
             @Override
             public void actionPerformed(NetworkEvent evt) {
-                if (cr == evt.getConnectionRequest() && fileSize > 0) {
+                if (cr == evt.getConnectionRequest() && fileSize > 0) { //NOPMD CompareObjectsWithEquals
                     // the following casting to long is necessary when the file is bigger than 21MB, otherwise the result of the calculation is wrong
                     if (percentageCallback != null) {
                         CN.callSerially(new Runnable() {

--- a/CodenameOne/src/com/codename1/io/gzip/Deflater.java
+++ b/CodenameOne/src/com/codename1/io/gzip/Deflater.java
@@ -115,11 +115,11 @@ final public class Deflater extends ZStream {
         if (bits < 9 || bits > 15) {
             return Z_STREAM_ERROR;
         }
-        if (wrapperType == JZlib.W_NONE) {
+        if (wrapperType == JZlib.W_NONE) { //NOPMD CompareObjectsWithEquals
             bits *= -1;
-        } else if (wrapperType == JZlib.W_GZIP) {
+        } else if (wrapperType == JZlib.W_GZIP) { //NOPMD CompareObjectsWithEquals
             bits += 16;
-        } else if (wrapperType == JZlib.W_ANY) {
+        } else if (wrapperType == JZlib.W_ANY) { //NOPMD CompareObjectsWithEquals
             return Z_STREAM_ERROR;
         }
         return init(level, bits, memlevel);

--- a/CodenameOne/src/com/codename1/io/gzip/Inflater.java
+++ b/CodenameOne/src/com/codename1/io/gzip/Inflater.java
@@ -102,11 +102,11 @@ final public class Inflater extends ZStream {
 
     public int init(int w, JZlib.WrapperType wrapperType) {
         boolean nowrap = false;
-        if (wrapperType == JZlib.W_NONE) {
+        if (wrapperType == JZlib.W_NONE) { //NOPMD CompareObjectsWithEquals
             nowrap = true;
-        } else if (wrapperType == JZlib.W_GZIP) {
+        } else if (wrapperType == JZlib.W_GZIP) { //NOPMD CompareObjectsWithEquals
             w += 16;
-        } else if (wrapperType == JZlib.W_ANY) {
+        } else if (wrapperType == JZlib.W_ANY) { //NOPMD CompareObjectsWithEquals
             w |= Inflate.INFLATE_ANY;
         }
         return init(w, nowrap);

--- a/CodenameOne/src/com/codename1/io/gzip/ZStream.java
+++ b/CodenameOne/src/com/codename1/io/gzip/ZStream.java
@@ -109,11 +109,11 @@ public class ZStream {
 
     public int inflateInit(int w, JZlib.WrapperType wrapperType) {
         boolean nowrap = false;
-        if (wrapperType == JZlib.W_NONE) {
+        if (wrapperType == JZlib.W_NONE) { //NOPMD CompareObjectsWithEquals
             nowrap = true;
-        } else if (wrapperType == JZlib.W_GZIP) {
+        } else if (wrapperType == JZlib.W_GZIP) { //NOPMD CompareObjectsWithEquals
             w += 16;
-        } else if (wrapperType == JZlib.W_ANY) {
+        } else if (wrapperType == JZlib.W_ANY) { //NOPMD CompareObjectsWithEquals
             w |= Inflate.INFLATE_ANY;
         }
         return inflateInit(w, nowrap);
@@ -181,11 +181,11 @@ public class ZStream {
         if (bits < 9 || bits > 15) {
             return Z_STREAM_ERROR;
         }
-        if (wrapperType == JZlib.W_NONE) {
+        if (wrapperType == JZlib.W_NONE) { //NOPMD CompareObjectsWithEquals
             bits *= -1;
-        } else if (wrapperType == JZlib.W_GZIP) {
+        } else if (wrapperType == JZlib.W_GZIP) { //NOPMD CompareObjectsWithEquals
             bits += 16;
-        } else if (wrapperType == JZlib.W_ANY) {
+        } else if (wrapperType == JZlib.W_ANY) { //NOPMD CompareObjectsWithEquals
             return Z_STREAM_ERROR;
         }
         return this.deflateInit(level, bits, memlevel);

--- a/CodenameOne/src/com/codename1/javascript/JavascriptContext.java
+++ b/CodenameOne/src/com/codename1/javascript/JavascriptContext.java
@@ -164,7 +164,7 @@ public class JavascriptContext {
      * @param c The BrowserComponent on which the context runs.
      */
     public final void setBrowserComponent(BrowserComponent c) {
-        if (c != browser) {
+        if (c != browser) { //NOPMD CompareObjectsWithEquals
             if (browser != null) {
                 this.uninstall();
             }

--- a/CodenameOne/src/com/codename1/location/Geofence.java
+++ b/CodenameOne/src/com/codename1/location/Geofence.java
@@ -188,7 +188,7 @@ public class Geofence {
         if (l1 != null && l2 != null) {
             return l1.equalsLatLng(l2);
         }
-        return l1 == l2; // both null
+        return l1 == l2; // both null //NOPMD CompareObjectsWithEquals
     }
 
     @Override

--- a/CodenameOne/src/com/codename1/maps/MapComponent.java
+++ b/CodenameOne/src/com/codename1/maps/MapComponent.java
@@ -573,7 +573,7 @@ public class MapComponent extends Container {
             zoomToLayers();
         }
         super.keyPressed(keyCode);
-        if (_center != oldCenter || _zoom != oldZoom) {
+        if (_center != oldCenter || _zoom != oldZoom) { //NOPMD CompareObjectsWithEquals
             _needTiles = true;
         }
         super.repaint();
@@ -727,7 +727,7 @@ public class MapComponent extends Container {
         int length = _layers.size();
         int no;
         for (no = 0; no < length; no++) {
-            if (((LayerWithZoomLevels) _layers.elementAt(no)).layer == layer) {
+            if (((LayerWithZoomLevels) _layers.elementAt(no)).layer == layer) { //NOPMD CompareObjectsWithEquals
                 break;
             }
         }

--- a/CodenameOne/src/com/codename1/media/AbstractMedia.java
+++ b/CodenameOne/src/com/codename1/media/AbstractMedia.java
@@ -137,7 +137,7 @@ public abstract class AbstractMedia implements AsyncMedia {
         return playAsync(new PlayRequest() {
             @Override
             public void complete(AsyncMedia value) {
-                if (this == pendingPlayRequest) {
+                if (this == pendingPlayRequest) { //NOPMD CompareObjectsWithEquals
                     pendingPlayRequest = null;
                 }
                 super.complete(value);
@@ -145,7 +145,7 @@ public abstract class AbstractMedia implements AsyncMedia {
 
             @Override
             public void error(Throwable t) {
-                if (this == pendingPlayRequest) {
+                if (this == pendingPlayRequest) { //NOPMD CompareObjectsWithEquals
                     pendingPlayRequest = null;
                 }
                 super.error(t);
@@ -180,7 +180,7 @@ public abstract class AbstractMedia implements AsyncMedia {
             return out;
         }
 
-        if (pendingPlayRequest != null && pendingPlayRequest != out) {
+        if (pendingPlayRequest != null && pendingPlayRequest != out) { //NOPMD CompareObjectsWithEquals
             pendingPlayRequest.ready(new PlayAsyncSuccessCallback(out))
                     .except(new PlayAsyncExceptSuccessCallback(out));
             return out;
@@ -240,7 +240,7 @@ public abstract class AbstractMedia implements AsyncMedia {
         return pauseAsync(new PauseRequest() {
             @Override
             public void complete(AsyncMedia value) {
-                if (pendingPauseRequest == this) {
+                if (pendingPauseRequest == this) { //NOPMD CompareObjectsWithEquals
                     pendingPauseRequest = null;
                 }
                 super.complete(value);
@@ -248,7 +248,7 @@ public abstract class AbstractMedia implements AsyncMedia {
 
             @Override
             public void error(Throwable t) {
-                if (pendingPauseRequest == this) {
+                if (pendingPauseRequest == this) { //NOPMD CompareObjectsWithEquals
                     pendingPauseRequest = null;
                 }
                 super.error(t);
@@ -285,7 +285,7 @@ public abstract class AbstractMedia implements AsyncMedia {
             pendingPauseRequest = out;
             return out;
         }
-        if (pendingPauseRequest != null && pendingPauseRequest != out) {
+        if (pendingPauseRequest != null && pendingPauseRequest != out) { //NOPMD CompareObjectsWithEquals
             pendingPauseRequest.ready(new PauseAsyncSuccessCallback(out))
                     .except(new PauseAsyncExceptSuccessCallback(out));
             return out;

--- a/CodenameOne/src/com/codename1/processing/HashtableContent.java
+++ b/CodenameOne/src/com/codename1/processing/HashtableContent.java
@@ -132,7 +132,7 @@ class MapContent implements StructuredContent {
     @Override
     public boolean equals(Object o) {
         return o instanceof MapContent &&
-                (root == ((MapContent) o).root ||
+                (root == ((MapContent) o).root || //NOPMD CompareObjectsWithEquals
                         (root != null && root.equals(((MapContent) o).root)));
     }
 

--- a/CodenameOne/src/com/codename1/properties/Property.java
+++ b/CodenameOne/src/com/codename1/properties/Property.java
@@ -119,7 +119,7 @@ public class Property<T, K> extends PropertyBase<T, K> {
         }
         Property other = (Property) obj;
         Object otherval = other.get();
-        if (otherval == value) {
+        if (otherval == value) { //NOPMD CompareObjectsWithEquals
             return true;
         }
         return otherval != null && otherval.equals(value);

--- a/CodenameOne/src/com/codename1/properties/PropertyIndex.java
+++ b/CodenameOne/src/com/codename1/properties/PropertyIndex.java
@@ -830,7 +830,7 @@ public class PropertyIndex implements Iterable<PropertyBase> {
     public boolean equals(Object o) {
         if (o instanceof PropertyIndex) {
             PropertyIndex other = (PropertyIndex) o;
-            if (parent == other.parent) {
+            if (parent == other.parent) { //NOPMD CompareObjectsWithEquals
                 return true;
             }
             if (parent.getClass() != other.parent.getClass()) {

--- a/CodenameOne/src/com/codename1/properties/PropertyXMLElement.java
+++ b/CodenameOne/src/com/codename1/properties/PropertyXMLElement.java
@@ -59,7 +59,7 @@ class PropertyXMLElement extends Element {
 
     @Override
     public boolean contains(Element element) {
-        if (this == element) {
+        if (this == element) { //NOPMD CompareObjectsWithEquals
             return true;
         }
         Vector children = getChildren();
@@ -112,7 +112,7 @@ class PropertyXMLElement extends Element {
         int current = -1;
         PropertyBase text = parent.getXmlTextElement();
         for (PropertyBase b : parent) {
-            if (b == text) {
+            if (b == text) { //NOPMD CompareObjectsWithEquals
                 current++;
                 if (current == index) {
                     Element e = new Element(b.getName(), true);

--- a/CodenameOne/src/com/codename1/system/DefaultCrashReporter.java
+++ b/CodenameOne/src/com/codename1/system/DefaultCrashReporter.java
@@ -184,7 +184,7 @@ public final class DefaultCrashReporter implements CrashReport {
             grid.addComponent(send);
             grid.addComponent(dontSend);
             Command result = error.showPacked(BorderLayout.CENTER, true);
-            if (result == dont) {
+            if (result == dont) { //NOPMD CompareObjectsWithEquals
                 if (cb.isSelected()) {
                     Preferences.set("$CN1_crashBlocked", true);
                 }

--- a/CodenameOne/src/com/codename1/testing/TestRunnerComponent.java
+++ b/CodenameOne/src/com/codename1/testing/TestRunnerComponent.java
@@ -122,7 +122,7 @@ public class TestRunnerComponent extends Container {
         resultsPane.add(new Label("Running " + tests.size() + " tests"));
         for (final AbstractTest test : tests) {
             final Button statusLabel = new Button(test + ": Running...");
-            if (f != CN.getCurrentForm()) {
+            if (f != CN.getCurrentForm()) { //NOPMD CompareObjectsWithEquals
 
                 f.showBack();
             }
@@ -141,7 +141,7 @@ public class TestRunnerComponent extends Container {
             }
             resultsPane.revalidate();
         }
-        if (f != CN.getCurrentForm()) {
+        if (f != CN.getCurrentForm()) { //NOPMD CompareObjectsWithEquals
             f.showBack();
         }
     }

--- a/CodenameOne/src/com/codename1/testing/TestUtils.java
+++ b/CodenameOne/src/com/codename1/testing/TestUtils.java
@@ -1072,7 +1072,7 @@ public final class TestUtils {
         if (verbose) {
             log("assertSame(" + expected + ", " + actual + ")");
         }
-        assertBool(expected == actual);
+        assertBool(expected == actual); //NOPMD CompareObjectsWithEquals
     }
 
     /**
@@ -1084,7 +1084,7 @@ public final class TestUtils {
         if (verbose) {
             log("assertSame(" + expected + ", " + actual + ", " + errorMessage + ")");
         }
-        assertBool(expected == actual, errorMessage);
+        assertBool(expected == actual, errorMessage); //NOPMD CompareObjectsWithEquals
     }
 
     /**
@@ -1094,7 +1094,7 @@ public final class TestUtils {
         if (verbose) {
             log("assertNotSame(" + expected + ", " + actual + ")");
         }
-        assertBool(expected != actual);
+        assertBool(expected != actual); //NOPMD CompareObjectsWithEquals
     }
 
     /**
@@ -1106,7 +1106,7 @@ public final class TestUtils {
         if (verbose) {
             log("assertNotSame(" + expected + ", " + actual + ", " + errorMessage + ")");
         }
-        assertBool(expected != actual, errorMessage);
+        assertBool(expected != actual, errorMessage); //NOPMD CompareObjectsWithEquals
     }
 
     private static void assertRelativeErrorExceeded(float expected, float actual, double minRelativeError) {

--- a/CodenameOne/src/com/codename1/ui/Calendar.java
+++ b/CodenameOne/src/com/codename1/ui/Calendar.java
@@ -164,7 +164,7 @@ public class Calendar extends Container implements ActionSource {
                     lock = true;
                     int month = mv.getMonth();
                     int year = mv.getYear();
-                    if (evt.getSource() == left) {
+                    if (evt.getSource() == left) { //NOPMD CompareObjectsWithEquals
                         month--;
                         if (month < java.util.Calendar.JANUARY) {
                             month = java.util.Calendar.DECEMBER;
@@ -181,9 +181,9 @@ public class Calendar extends Container implements ActionSource {
                     if (tran) {
                         Transition cm;
                         if (UIManager.getInstance().isThemeConstant("calTransitionVertBool", false)) {
-                            cm = CommonTransitions.createSlide(CommonTransitions.SLIDE_VERTICAL, evt.getSource() == left, 300);
+                            cm = CommonTransitions.createSlide(CommonTransitions.SLIDE_VERTICAL, evt.getSource() == left, 300); //NOPMD CompareObjectsWithEquals
                         } else {
-                            cm = CommonTransitions.createSlide(CommonTransitions.SLIDE_HORIZONTAL, evt.getSource() == left, 300);
+                            cm = CommonTransitions.createSlide(CommonTransitions.SLIDE_HORIZONTAL, evt.getSource() == left, 300); //NOPMD CompareObjectsWithEquals
                         }
                         MonthView newMv = new MonthView(mv.currentDay);
                         newMv.setMonth(year, month);
@@ -1253,7 +1253,7 @@ public class Calendar extends Container implements ActionSource {
                         isContained = ((Container) components[iter]).contains((Component) src);
                     }
 
-                    if (src == components[iter] || isContained) {
+                    if (src == components[iter] || isContained) { //NOPMD CompareObjectsWithEquals
                         if (multipleSelectionEnabled) {
                             if (selectedDays.contains(new Date(dates[iter]))) {
                                 if (SELECTED_DAY == dates[iter]) {

--- a/CodenameOne/src/com/codename1/ui/ComboBox.java
+++ b/CodenameOne/src/com/codename1/ui/ComboBox.java
@@ -486,7 +486,7 @@ public class ComboBox<T> extends List<T> implements ActionSource {
         Dialog.setDefaultBlurBackgroundRadius(rr);
         Form.comboLock = false;
         parentForm.setTintColor(tint);
-        if (result == popupDialog.getMenuBar().getCancelMenuItem() || popupDialog.wasDisposedDueToOutOfBoundsTouch() ||
+        if (result == popupDialog.getMenuBar().getCancelMenuItem() || popupDialog.wasDisposedDueToOutOfBoundsTouch() || //NOPMD CompareObjectsWithEquals
                 popupDialog.wasDisposedDueToRotation()) {
             setSelectedIndex(originalSel);
         }

--- a/CodenameOne/src/com/codename1/ui/Command.java
+++ b/CodenameOne/src/com/codename1/ui/Command.java
@@ -275,12 +275,12 @@ public class Command implements ActionListener<ActionEvent> {
         }
         if (((Command) obj).command == null) {
             return obj.getClass() == getClass() && command == null &&
-                    ((Command) obj).icon == icon && ((Command) obj).commandId == commandId &&
+                    ((Command) obj).icon == icon && ((Command) obj).commandId == commandId && //NOPMD CompareObjectsWithEquals
                     ((Command) obj).materialIcon == materialIcon && com.codename1.util.MathUtil.compare(((Command) obj).materialIconSize, materialIconSize) == 0 &&
                     (Objects.equals(clientProperties, ((Command) obj).clientProperties));
         } else {
             return obj.getClass() == getClass() && ((Command) obj).command.equals(command) &&
-                    ((Command) obj).icon == icon && ((Command) obj).commandId == commandId &&
+                    ((Command) obj).icon == icon && ((Command) obj).commandId == commandId && //NOPMD CompareObjectsWithEquals
                     ((Command) obj).materialIcon == materialIcon && com.codename1.util.MathUtil.compare(((Command) obj).materialIconSize, materialIconSize) == 0 &&
                     (Objects.equals(clientProperties, ((Command) obj).clientProperties));
         }

--- a/CodenameOne/src/com/codename1/ui/Component.java
+++ b/CodenameOne/src/com/codename1/ui/Component.java
@@ -818,7 +818,7 @@ public class Component implements Animation, StyleListener, Editable {
      * This method initializes the Component defaults constants
      */
     protected void initLaf(UIManager uim) {
-        if (uim == getUIManager() && isInitialized()) {
+        if (uim == getUIManager() && isInitialized()) { //NOPMD CompareObjectsWithEquals
             return;
         }
         selectText = uim.localize("select", "Select");
@@ -1953,7 +1953,7 @@ public class Component implements Animation, StyleListener, Editable {
      * @param parent the parent container
      */
     void setParent(Container parent) {
-        if (parent == this) {
+        if (parent == this) { //NOPMD CompareObjectsWithEquals
             throw new IllegalArgumentException("Attempt to add self as parent");
         }
         this.parent = parent;
@@ -2010,7 +2010,7 @@ public class Component implements Animation, StyleListener, Editable {
         Component c = this.owner;
         Container cnt = (cmp instanceof Container) ? (Container) cmp : null;
         while (c != null) {
-            if (c == cmp) {
+            if (c == cmp) { //NOPMD CompareObjectsWithEquals
                 return true;
             }
             if (cnt != null) {
@@ -2773,7 +2773,7 @@ public class Component implements Animation, StyleListener, Editable {
     int getRelativeX(Container relativeTo) {
         int x = getX() - getScrollX();
         Container parent = getParent();
-        if (parent != relativeTo && parent != null) {
+        if (parent != relativeTo && parent != null) { //NOPMD CompareObjectsWithEquals
             x += parent.getRelativeX(relativeTo);
         }
         return x;
@@ -2782,7 +2782,7 @@ public class Component implements Animation, StyleListener, Editable {
     int getRelativeY(Container relativeTo) {
         int y = getY() - getScrollY();
         Container parent = getParent();
-        if (parent != relativeTo && parent != null) {
+        if (parent != relativeTo && parent != null) { //NOPMD CompareObjectsWithEquals
             y += parent.getRelativeY(relativeTo);
         }
         return y;
@@ -3232,7 +3232,7 @@ public class Component implements Animation, StyleListener, Editable {
     }
 
     private void paintRippleEffect(Graphics g) {
-        if (isRippleEffect() && Form.getRippleComponent() == this && Form.getRippleMotion() != null) {
+        if (isRippleEffect() && Form.getRippleComponent() == this && Form.getRippleMotion() != null) { //NOPMD CompareObjectsWithEquals
             paintRippleOverlay(g, Form.rippleX, Form.rippleY, Form.getRippleMotion().getValue());
         }
     }
@@ -4634,7 +4634,7 @@ public class Component implements Animation, StyleListener, Editable {
 
     void clearDrag() {
         Component leadParent = LeadUtil.leadParentImpl(this);
-        if (leadParent != null && leadParent != this) {
+        if (leadParent != null && leadParent != this) { //NOPMD CompareObjectsWithEquals
             leadParent.clearDrag();
             return;
         }
@@ -5116,7 +5116,7 @@ public class Component implements Animation, StyleListener, Editable {
         if (p == null) {
             return;
         }
-        if (currentPointerPress != p.getCurrentPointerPress()) {
+        if (currentPointerPress != p.getCurrentPointerPress()) { //NOPMD CompareObjectsWithEquals
             return;
         }
 
@@ -5156,7 +5156,7 @@ public class Component implements Animation, StyleListener, Editable {
                     return;
                 }
             }
-            if (dropTargetComponent != dropTo) {
+            if (dropTargetComponent != dropTo) { //NOPMD CompareObjectsWithEquals
                 if (dropTargetComponent != null) {
                     dropTargetComponent.dragExit(this);
                 }
@@ -5239,7 +5239,7 @@ public class Component implements Animation, StyleListener, Editable {
                 p.setDraggedComponent(this);
                 p.registerAnimatedInternal(this);
                 Component fc = p.getFocused();
-                if (fc != null && fc != this) {
+                if (fc != null && fc != this) { //NOPMD CompareObjectsWithEquals
                     fc.dragInitiated();
                 }
             }
@@ -5455,13 +5455,13 @@ public class Component implements Animation, StyleListener, Editable {
     boolean isScrollDecelerationMotionInProgress() {
         Motion dmY = draggedMotionY;
         if (dmY != null) {
-            if (dmY == decelerationMotion && !dmY.isFinished()) {
+            if (dmY == decelerationMotion && !dmY.isFinished()) { //NOPMD CompareObjectsWithEquals
                 return true;
             }
         }
         Motion dmX = draggedMotionX;
         if (dmX != null) {
-            if (dmX == decelerationMotion && !dmX.isFinished()) {
+            if (dmX == decelerationMotion && !dmX.isFinished()) { //NOPMD CompareObjectsWithEquals
                 return true;
             }
         }
@@ -5589,7 +5589,7 @@ public class Component implements Animation, StyleListener, Editable {
             }
             p.setDraggedComponent(null);
             Component dropTo = findDropTarget(this, x, y);
-            if (dropTargetComponent != dropTo) {
+            if (dropTargetComponent != dropTo) { //NOPMD CompareObjectsWithEquals
                 if (dropTargetComponent != null) {
                     dropTargetComponent.dragExit(this);
                 }
@@ -6672,12 +6672,12 @@ public class Component implements Animation, StyleListener, Editable {
             if (coordinateSpace != null) {
                 parent = coordinateSpace.getParent();
             }
-            if (parent == this) {
+            if (parent == this) { //NOPMD CompareObjectsWithEquals
                 if (view.contains(x, y, width, height)) {
                     return;
                 }
             } else {
-                while (parent != this) {
+                while (parent != this) { //NOPMD CompareObjectsWithEquals
                     // mostly a special case for list
                     if (parent == null) {
                         relativeX = x;
@@ -7121,7 +7121,7 @@ public class Component implements Animation, StyleListener, Editable {
         //changing the Font, Padding, Margin may casue the size of the Component to Change
         //therefore we turn on the shouldCalcPreferredSize flag
         if ((!shouldCalcPreferredSize &&
-                source == getStyle()) &&
+                source == getStyle()) && //NOPMD CompareObjectsWithEquals
                 (Style.FONT.equals(propertyName) ||
                         Style.MARGIN.equals(propertyName) ||
                         Style.PADDING.equals(propertyName))) {
@@ -7764,7 +7764,7 @@ public class Component implements Animation, StyleListener, Editable {
      * @return false if the container isn't one of our parent containers
      */
     public boolean isChildOf(Container cnt) {
-        if (cnt == parent) {
+        if (cnt == parent) { //NOPMD CompareObjectsWithEquals
             return true;
         }
         return parent != null && parent.isChildOf(cnt);

--- a/CodenameOne/src/com/codename1/ui/ComponentSelector.java
+++ b/CodenameOne/src/com/codename1/ui/ComponentSelector.java
@@ -1410,7 +1410,7 @@ public class ComponentSelector implements Iterable<Component>, Set<Component> {
             Container parent = c.getParent();
             Component replacement = mapper.map(c);
             if (parent != null) {
-                if (replacement != c) {
+                if (replacement != c) { //NOPMD CompareObjectsWithEquals
                     if (replacement != null) {
                         animations.add(parent.createReplaceTransition(c, replacement, t.copy(false)));
                     } else {
@@ -1449,7 +1449,7 @@ public class ComponentSelector implements Iterable<Component>, Set<Component> {
             Container parent = c.getParent();
             Component replacement = mapper.map(c);
             if (parent != null) {
-                if (replacement != c) {
+                if (replacement != c) { //NOPMD CompareObjectsWithEquals
                     if (replacement != null) {
                         animations.add(parent.createReplaceTransition(c, replacement, t.copy(false)));
                     } else {

--- a/CodenameOne/src/com/codename1/ui/Container.java
+++ b/CodenameOne/src/com/codename1/ui/Container.java
@@ -221,7 +221,7 @@ public class Container extends Component implements Iterable<Component> {
      */
     @Override
     protected void initLaf(UIManager uim) {
-        if (uim == getUIManager() && isInitialized()) {
+        if (uim == getUIManager() && isInitialized()) { //NOPMD CompareObjectsWithEquals
             return;
         }
         super.initLaf(uim);
@@ -496,7 +496,7 @@ public class Container extends Component implements Iterable<Component> {
      * @param lead component that takes over the hierarchy
      */
     public final void setLeadComponent(Component lead) {
-        if (lead == leadComponent) {
+        if (lead == leadComponent) { //NOPMD CompareObjectsWithEquals
             return;
         }
         leadComponent = lead;
@@ -958,7 +958,7 @@ public class Container extends Component implements Iterable<Component> {
             cmp.setPreferredSize(null);
         }
         UIManager manager = getUIManager();
-        boolean refreshLaf = manager != cmp.getUIManager();
+        boolean refreshLaf = manager != cmp.getUIManager(); //NOPMD CompareObjectsWithEquals
         cmp.setParent(this);
         if (refreshLaf) {
             Display.getInstance().callSerially(new RefreshThemeRunnable(cmp));
@@ -1145,7 +1145,7 @@ public class Container extends Component implements Iterable<Component> {
         if (c == null || c instanceof Form) {
             return false;
         }
-        return (c == this) || isParentOf(c);
+        return (c == this) || isParentOf(c); //NOPMD CompareObjectsWithEquals
     }
 
     @Override
@@ -1207,7 +1207,7 @@ public class Container extends Component implements Iterable<Component> {
         boolean currentFocused = false;
         if (current.getComponentForm() != null) {
             Component currentF = current.getComponentForm().getFocused();
-            currentFocused = currentF == current;
+            currentFocused = currentF == current; //NOPMD CompareObjectsWithEquals
             if (!currentFocused && current instanceof Container && currentF != null && ((Container) current).isParentOf(currentF)) {
                 currentFocused = true;
             }
@@ -1270,7 +1270,7 @@ public class Container extends Component implements Iterable<Component> {
         // Normally a container shouldn't be a lead component but this happens
         // in the GUI builder and this block can cause an infinite recursion
         // without the second condition
-        if (leadComponent != null && leadComponent != this) {
+        if (leadComponent != null && leadComponent != this) { //NOPMD CompareObjectsWithEquals
             return leadComponent.isEnabled();
         }
         return super.isEnabled();
@@ -1375,11 +1375,11 @@ public class Container extends Component implements Iterable<Component> {
         components.remove(cmp);
         cmp.setParent(null);
         if (parentForm != null) {
-            if (parentForm.getFocused() == cmp || cmp instanceof Container && ((Container) cmp).contains(parentForm.getFocused())) {
+            if (parentForm.getFocused() == cmp || cmp instanceof Container && ((Container) cmp).contains(parentForm.getFocused())) { //NOPMD CompareObjectsWithEquals
                 parentForm.setFocusedInternal(null);
             }
             Component dragged = parentForm.getDraggedComponent();
-            if (dragged == cmp) {
+            if (dragged == cmp) { //NOPMD CompareObjectsWithEquals
                 parentForm.setDraggedComponent(null);
             }
             if (cmp.isSmoothScrolling()) {
@@ -1552,7 +1552,7 @@ public class Container extends Component implements Iterable<Component> {
         setShouldCalcPreferredSize(true);
         Form root = getComponentForm();
 
-        if (root != null && root != this) {
+        if (root != null && root != this) { //NOPMD CompareObjectsWithEquals
             root.removeFromRevalidateQueue(this);
             if (fromRoot && root.revalidateFromRoot) {
                 root.layoutContainer();
@@ -1961,7 +1961,7 @@ public class Container extends Component implements Iterable<Component> {
                 // We need to paint all components that should be "on top" of the elevated component
                 // also.
                 paintOnTopLoop:
-                while (cnt != this && cnt != null) {
+                while (cnt != this && cnt != null) { //NOPMD CompareObjectsWithEquals
                     Layout cntLayout = cnt.getLayout();
                     if (!foundOverlap && cntLayout.isOverlapSupported()) {
                         foundOverlap = true;
@@ -2029,7 +2029,7 @@ public class Container extends Component implements Iterable<Component> {
                 // We need to paint all components that should be "on top" of the elevated component
                 // also.
                 paintOnTopLoop:
-                while (cnt != this && cnt != null) {
+                while (cnt != this && cnt != null) { //NOPMD CompareObjectsWithEquals
                     Layout cntLayout = cnt.getLayout();
                     if (!foundOverlap && cntLayout.isOverlapSupported()) {
                         foundOverlap = true;
@@ -2156,7 +2156,7 @@ public class Container extends Component implements Iterable<Component> {
 
     void paintIntersecting(Graphics g, Component cmp, int x, int y, int w, int h, boolean above, int elevation) {
 
-        if (layout.isOverlapSupported() && cmp.getParent() == this) {
+        if (layout.isOverlapSupported() && cmp.getParent() == this) { //NOPMD CompareObjectsWithEquals
             int indexOfComponent = components.indexOf(cmp);
 
             int startIndex;
@@ -2562,7 +2562,7 @@ public class Container extends Component implements Iterable<Component> {
         }
         cmp = cmp.getParent();
         while (cmp != null) {
-            if (cmp == this) {
+            if (cmp == this) { //NOPMD CompareObjectsWithEquals
                 return true;
             }
             cmp = cmp.getParent();
@@ -2585,9 +2585,9 @@ public class Container extends Component implements Iterable<Component> {
                     // way to the top
                     Form f = getComponentForm();
                     if (f != null && f.getInvisibleAreaUnderVKB() == 0 &&
-                            f.findFirstFocusable() == c) {
+                            f.findFirstFocusable() == c) { //NOPMD CompareObjectsWithEquals
                         // support this use case only if the component doesn't explicitly declare visible bounds
-                        if (r == c.getBounds() && !Display.getInstance().isTouchScreenDevice()) {
+                        if (r == c.getBounds() && !Display.getInstance().isTouchScreenDevice()) { //NOPMD CompareObjectsWithEquals
                             scrollRectToVisible(new Rectangle(0, 0,
                                     c.getX() + Math.min(c.getWidth(), getWidth()),
                                     c.getY() + Math.min(c.getHeight(), getHeight())), this);
@@ -2697,7 +2697,7 @@ public class Container extends Component implements Iterable<Component> {
             f.setCyclicFocus(cyclic);
             //if the Form doesn't contain a focusable Component simply move the
             //viewport by pixels
-            if (next == null || next == this) {
+            if (next == null || next == this) { //NOPMD CompareObjectsWithEquals
                 scrollRectToVisible(x, y, w, h, this);
                 return false;
             }
@@ -2913,12 +2913,12 @@ public class Container extends Component implements Iterable<Component> {
                                 top = c;
                             }
                         }
-                        if (c != cmp) {
+                        if (c != cmp) { //NOPMD CompareObjectsWithEquals
                             Component tmp = c;
                             if (cmp.isFocusable()) {
                                 isPotentialCandidate = true;
                                 boolean found = false;
-                                while (tmp != cmp && tmp != null) {
+                                while (tmp != cmp && tmp != null) { //NOPMD CompareObjectsWithEquals
                                     if (tmp.isFocusable()) {
                                         // We found a focusable child
                                         // so we will use that.
@@ -2938,7 +2938,7 @@ public class Container extends Component implements Iterable<Component> {
 
                             } else if (cmp.respondsToPointerEvents()) {
                                 isPotentialCandidate = true;
-                                while (tmp != cmp && tmp != null) {
+                                while (tmp != cmp && tmp != null) { //NOPMD CompareObjectsWithEquals
                                     if (tmp.respondsToPointerEvents()) {
                                         // We found a child that also responds to
                                         // pointer events so we will use that.
@@ -2954,7 +2954,7 @@ public class Container extends Component implements Iterable<Component> {
                                 // so all we want to know is if any of the children respond to pointer events
                                 // so we know if it will be eligible to be returned in the case of an overlapping
                                 // layout.
-                                while (tmp != cmp && tmp != null) {
+                                while (tmp != cmp && tmp != null) { //NOPMD CompareObjectsWithEquals
                                     if (tmp.respondsToPointerEvents()) {
                                         isPotentialCandidate = true;
 
@@ -3036,7 +3036,7 @@ public class Container extends Component implements Iterable<Component> {
         leadParent.clearDrag();
         leadParent.setDragActivated(false);
         Component cmp = getComponentAt(x, y);
-        if (cmp == this) {
+        if (cmp == this) { //NOPMD CompareObjectsWithEquals
             super.pointerPressed(x, y);
             return;
         }
@@ -3645,7 +3645,7 @@ public class Container extends Component implements Iterable<Component> {
         int i = getComponentIndex(dragged);
         if (i > -1) {
             Component dest = getComponentAt(x, y);
-            if (dest != dragged) {
+            if (dest != dragged) { //NOPMD CompareObjectsWithEquals
                 int destIndex = getComponentIndex(dest);
                 if (destIndex > -1 && destIndex != i) {
                     setComponentIndex(dragged, destIndex);

--- a/CodenameOne/src/com/codename1/ui/Dialog.java
+++ b/CodenameOne/src/com/codename1/ui/Dialog.java
@@ -312,7 +312,7 @@ public class Dialog extends Form {
         } else {
             cmds = new Command[]{okCommand};
         }
-        return show(title, text, okCommand, cmds, type, icon, timeout) == okCommand;
+        return show(title, text, okCommand, cmds, type, icon, timeout) == okCommand; //NOPMD CompareObjectsWithEquals
     }
 
     /**
@@ -1492,7 +1492,7 @@ public class Dialog extends Form {
             contentPaneStyle.getBorder().clearImageBorderSpecialTile();
         }
 
-        if (result == backCommand) {
+        if (result == backCommand) { //NOPMD CompareObjectsWithEquals
             return null;
         }
         return result;
@@ -1884,7 +1884,7 @@ public class Dialog extends Form {
             super.repaint(cmp);
             return;
         }
-        if (isVisible() && !disposed && (isMenu() || CN.getCurrentForm() == this)) {
+        if (isVisible() && !disposed && (isMenu() || CN.getCurrentForm() == this)) { //NOPMD CompareObjectsWithEquals
             Display.getInstance().repaint(cmp);
         }
     }

--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -691,7 +691,7 @@ public final class Display extends CN1Constants {
      * otherwise false
      */
     public boolean isEdt() {
-        return edt == Thread.currentThread();
+        return edt == Thread.currentThread(); //NOPMD CompareObjectsWithEquals
     }
 
     /**
@@ -1013,7 +1013,7 @@ public final class Display extends CN1Constants {
                 } else {
                     Form f = (Form) ((Transition) ani).getDestination();
                     restoreMenu(f);
-                    if (source == null || source == impl.getCurrentForm() || source == getCurrent()) {
+                    if (source == null || source == impl.getCurrentForm() || source == getCurrent()) { //NOPMD CompareObjectsWithEquals
                         setCurrentForm(f);
                     }
                     ((Transition) ani).cleanup();
@@ -1537,7 +1537,7 @@ public final class Display extends CN1Constants {
             setShowVirtualKeyboard(false);
         }
 
-        if (current == newForm) {
+        if (current == newForm) { //NOPMD CompareObjectsWithEquals
             current.revalidate();
             current.repaint();
             current.onShowCompletedImpl();
@@ -1571,7 +1571,7 @@ public final class Display extends CN1Constants {
                 current.deinitializeImpl();
             } else {
                 Form fg = getCurrentUpcoming();
-                if (fg != current) {
+                if (fg != current) { //NOPMD CompareObjectsWithEquals
                     if (fg.isInitialized()) {
                         fg.deinitializeImpl();
                     }
@@ -1619,7 +1619,7 @@ public final class Display extends CN1Constants {
             }
 
             // prevent the transition from occurring from a form into itself
-            if (newForm != current) {
+            if (newForm != current) { //NOPMD CompareObjectsWithEquals
                 if ((current != null && current.getTransitionOutAnimator() != null) || newForm.getTransitionInAnimator() != null) {
                     if (animationQueue == null) {
                         animationQueue = new ArrayList<Animation>();
@@ -1822,7 +1822,7 @@ public final class Display extends CN1Constants {
     }
 
     boolean isTextEditing(Component c) {
-        if (c instanceof Form && c == getCurrent()) {
+        if (c instanceof Form && c == getCurrent()) { //NOPMD CompareObjectsWithEquals
             return impl.isEditingText();
         }
 
@@ -2311,7 +2311,7 @@ public final class Display extends CN1Constants {
 
                 //make sure the released event is sent to the same Form who got a
                 //pressed event
-                if (xf == f || multiKeyMode) {
+                if (xf == f || multiKeyMode) { //NOPMD CompareObjectsWithEquals
                     f.keyReleased(inputEventStackTmp[offset]);
                     offset++;
                 }
@@ -2359,7 +2359,7 @@ public final class Display extends CN1Constants {
 
                 // make sure the released event is sent to the same Form that got a
                 // pressed event
-                if (x == f || f.shouldSendPointerReleaseToOtherForm()) {
+                if (x == f || f.shouldSendPointerReleaseToOtherForm()) { //NOPMD CompareObjectsWithEquals
                     xArray1[0] = inputEventStackTmp[offset];
                     offset++;
                     yArray1[0] = inputEventStackTmp[offset];
@@ -2381,7 +2381,7 @@ public final class Display extends CN1Constants {
 
                 // make sure the released event is sent to the same Form that got a
                 // pressed event
-                if (xy == f || f.shouldSendPointerReleaseToOtherForm()) {
+                if (xy == f || f.shouldSendPointerReleaseToOtherForm()) { //NOPMD CompareObjectsWithEquals
                     int[] array1 = readArrayStackArgument(offset);
                     offset += array1.length + 1;
                     int[] array2 = readArrayStackArgument(offset);
@@ -5265,7 +5265,7 @@ public final class Display extends CN1Constants {
             HashSet<Throwable> circuitCheck = new HashSet<Throwable>();
             circuitCheck.add(cause);
             EdtException root = this;
-            if (root != cause) {
+            if (root != cause) { //NOPMD CompareObjectsWithEquals
                 root.setCause(cause);
                 circuitCheck.add(root);
             } else {

--- a/CodenameOne/src/com/codename1/ui/Form.java
+++ b/CodenameOne/src/com/codename1/ui/Form.java
@@ -1803,7 +1803,7 @@ public class Form extends Container {
                 removeComponentFromForm(titleArea);
             }
             //if the Form is already displayed refresh the title
-            if (Display.getInstance().getCurrent() == this) {
+            if (Display.getInstance().getCurrent() == this) { //NOPMD CompareObjectsWithEquals
                 Display.getInstance().refreshNativeTitle();
             }
         }
@@ -2325,7 +2325,7 @@ public class Form extends Container {
         }
 
         if (comboLock) {
-            if (cmd == menuBar.getCancelMenuItem()) {
+            if (cmd == menuBar.getCancelMenuItem()) { //NOPMD CompareObjectsWithEquals
                 actionCommand(cmd);
                 return;
             }
@@ -2335,7 +2335,7 @@ public class Form extends Container {
             }
             return;
         }
-        if (cmd != menuBar.getSelectCommand()) {
+        if (cmd != menuBar.getSelectCommand()) { //NOPMD CompareObjectsWithEquals
             if (commandListener != null) {
                 commandListener.fireActionEvent(ev);
                 if (ev.isConsumed()) {
@@ -2361,13 +2361,13 @@ public class Form extends Container {
         }
 
         if (comboLock) {
-            if (cmd == menuBar.getCancelMenuItem()) {
+            if (cmd == menuBar.getCancelMenuItem()) { //NOPMD CompareObjectsWithEquals
                 actionCommand(cmd);
                 return;
             }
             return;
         }
-        if (cmd != menuBar.getSelectCommand()) {
+        if (cmd != menuBar.getSelectCommand()) { //NOPMD CompareObjectsWithEquals
             if (commandListener != null) {
                 commandListener.fireActionEvent(ev);
                 if (ev.isConsumed()) {
@@ -2713,11 +2713,11 @@ public class Form extends Container {
      */
     void disposeImpl() {
         if (previousForm != null) {
-            boolean clearPrevious = Display.getInstance().getCurrent() == this;
+            boolean clearPrevious = Display.getInstance().getCurrent() == this; //NOPMD CompareObjectsWithEquals
             if (!clearPrevious) {
                 Form f = Display.getInstance().getCurrent();
                 while (f != null) {
-                    if (f.previousForm == this) {
+                    if (f.previousForm == this) { //NOPMD CompareObjectsWithEquals
                         f.previousForm = previousForm;
                         previousForm = null;
                         return;
@@ -2767,7 +2767,7 @@ public class Form extends Container {
         }
 
 
-        if (isVisible() && CN.getCurrentForm() == this) {
+        if (isVisible() && CN.getCurrentForm() == this) { //NOPMD CompareObjectsWithEquals
             Display.getInstance().repaint(cmp);
         }
     }
@@ -2880,7 +2880,7 @@ public class Form extends Container {
      * @param focused the newly focused component or null for no focus
      */
     public void setFocused(Component focused) {
-        if (this.focused == focused && focused != null) {
+        if (this.focused == focused && focused != null) { //NOPMD CompareObjectsWithEquals
             this.focused.repaint();
             return;
         }
@@ -2897,7 +2897,7 @@ public class Form extends Container {
         }
         // a listener might trigger a focus change event essentially
         // invalidating focus so we shouldn't break that
-        if (focused != null && this.focused == focused) {
+        if (focused != null && this.focused == focused) { //NOPMD CompareObjectsWithEquals
             triggerRevalidate = changeFocusState(focused, true) || triggerRevalidate;
             //if we need to revalidate no need to repaint the Component, it will
             //be painted from the Form
@@ -2916,7 +2916,7 @@ public class Form extends Container {
     @Override
     protected void longKeyPress(int keyCode) {
         if (focused != null) {
-            if (focused.getComponentForm() == this) {
+            if (focused.getComponentForm() == this) { //NOPMD CompareObjectsWithEquals
                 focused.longKeyPress(keyCode);
             }
         }
@@ -2935,7 +2935,7 @@ public class Form extends Container {
             }
         }
         if (focused != null && focused.contains(x, y)) {
-            if (focused.getComponentForm() == this) {
+            if (focused.getComponentForm() == this) { //NOPMD CompareObjectsWithEquals
                 LeadUtil.longPointerPress(focused, x, y);
 
             }
@@ -3016,7 +3016,7 @@ public class Form extends Container {
             if (focused.handlesInput()) {
                 return;
             }
-            if (focused.getComponentForm() == this) {
+            if (focused.getComponentForm() == this) { //NOPMD CompareObjectsWithEquals
                 //if the arrow keys have been pressed update the focus.
                 updateFocus(game);
             } else {
@@ -3083,7 +3083,7 @@ public class Form extends Container {
 
         //Component focused = focusManager.getFocused();
         if (focused != null) {
-            if (focused.getComponentForm() == this) {
+            if (focused.getComponentForm() == this) { //NOPMD CompareObjectsWithEquals
                 if (focused.isEnabled()) {
                     focused.keyReleased(keyCode);
                 }
@@ -3380,7 +3380,7 @@ public class Form extends Container {
                 pendingC = LeadUtil.leadParentImpl(pendingC);
             }
             Component pendingCLead = LeadUtil.leadComponentImpl(pendingC);
-            if (atXY != pendingC) {
+            if (atXY != pendingC) { //NOPMD CompareObjectsWithEquals
                 if (pendingCLead instanceof ReleasableComponent) {
                     ReleasableComponent rc = (ReleasableComponent) pendingCLead;
                     int relRadius = rc.getReleaseRadius();
@@ -3458,7 +3458,7 @@ public class Form extends Container {
                 if (cmp != null && cmp.isEnabled()) {
                     cmp.pointerDragged(x, y);
                     cmp.repaint();
-                    if (cmp == pressedCmp && cmp.isStickyDrag()) {
+                    if (cmp == pressedCmp && cmp.isStickyDrag()) { //NOPMD CompareObjectsWithEquals
                         stickyDrag = cmp;
                     }
                 }
@@ -3477,7 +3477,7 @@ public class Form extends Container {
 
             LeadUtil.pointerDragged(cmp, x, y);
 
-            if (cmp == pressedCmp && cmp.isStickyDrag()) {
+            if (cmp == pressedCmp && cmp.isStickyDrag()) { //NOPMD CompareObjectsWithEquals
                 stickyDrag = cmp;
             }
         }
@@ -3527,7 +3527,7 @@ public class Form extends Container {
                 if (cmp != null && cmp.isEnabled()) {
                     cmp.pointerDragged(x, y);
                     cmp.repaint();
-                    if (cmp == pressedCmp && cmp.isStickyDrag()) {
+                    if (cmp == pressedCmp && cmp.isStickyDrag()) { //NOPMD CompareObjectsWithEquals
                         stickyDrag = cmp;
                     }
                 }
@@ -3547,7 +3547,7 @@ public class Form extends Container {
             }
             LeadUtil.pointerDragged(cmp, x, y);
 
-            if (cmp == pressedCmp && cmp.isStickyDrag()) {
+            if (cmp == pressedCmp && cmp.isStickyDrag()) { //NOPMD CompareObjectsWithEquals
                 stickyDrag = cmp;
             }
         }
@@ -3725,9 +3725,9 @@ public class Form extends Container {
                 if (pendingC != null) {
                     pendingC = LeadUtil.leadParentImpl(pendingC);
                 }
-                if (atXY == pendingC) {
+                if (atXY == pendingC) { //NOPMD CompareObjectsWithEquals
                     componentsAwaitingRelease = null;
-                    if (dragged == pendingC) {
+                    if (dragged == pendingC) { //NOPMD CompareObjectsWithEquals
                         if (pendingC.isDragAndDropInitialized()) {
                             LeadUtil.dragFinished(pendingC, x, y);
                         } else {
@@ -4289,7 +4289,7 @@ public class Form extends Container {
                 parent = current.getParent();
             }
             while (parent != null) {
-                if (parent == this) {
+                if (parent == this) { //NOPMD CompareObjectsWithEquals
                     if (getContentPane().isScrollable()) {
                         getContentPane().moveScrollTowards(direction, c);
                     }
@@ -4334,7 +4334,7 @@ public class Form extends Container {
         Container parent = c.getParent();
         while (parent != null) {
             if (parent.isScrollable()) {
-                if (parent == this) {
+                if (parent == this) { //NOPMD CompareObjectsWithEquals
                     // special case for Form
                     if (getContentPane().isScrollable()) {
                         getContentPane().scrollComponentToVisible(c);

--- a/CodenameOne/src/com/codename1/ui/InterFormContainer.java
+++ b/CodenameOne/src/com/codename1/ui/InterFormContainer.java
@@ -123,7 +123,7 @@ public class InterFormContainer extends Container {
      */
     @Override
     protected void initComponent() {
-        if (content.getParent() != this) {
+        if (content.getParent() != this) { //NOPMD CompareObjectsWithEquals
             content.remove();
             add(CENTER, content);
         }
@@ -141,7 +141,7 @@ public class InterFormContainer extends Container {
     public InterFormContainer findPeer(Component root) {
         if (root.getClass() == InterFormContainer.class) {
             InterFormContainer cnt = (InterFormContainer) root;
-            if (cnt.content == content) {
+            if (cnt.content == content) { //NOPMD CompareObjectsWithEquals
                 return cnt;
             }
         }
@@ -166,7 +166,7 @@ public class InterFormContainer extends Container {
         if (!isVisible()) {
             return;
         }
-        if (content.getParent() != this) {
+        if (content.getParent() != this) { //NOPMD CompareObjectsWithEquals
             if (isInitialized() && !content.isInitialized()) {
                 if (content.getParent() != null) {
                     content.remove();

--- a/CodenameOne/src/com/codename1/ui/Label.java
+++ b/CodenameOne/src/com/codename1/ui/Label.java
@@ -536,7 +536,7 @@ public class Label extends Component implements IconHolder, TextHolder {
 
     @Override
     protected void initLaf(UIManager uim) {
-        if (uim == getUIManager() && isInitialized()) {
+        if (uim == getUIManager() && isInitialized()) { //NOPMD CompareObjectsWithEquals
             return;
         }
         super.initLaf(uim);
@@ -657,7 +657,7 @@ public class Label extends Component implements IconHolder, TextHolder {
      */
     @Override
     public void setIcon(Image icon) {
-        if (this.icon == icon) {
+        if (this.icon == icon) { //NOPMD CompareObjectsWithEquals
             return;
         }
         if (this.icon != null) {

--- a/CodenameOne/src/com/codename1/ui/LeadUtil.java
+++ b/CodenameOne/src/com/codename1/ui/LeadUtil.java
@@ -97,7 +97,7 @@ class LeadUtil {
         if (f != null && !Display.impl.isScrollWheeling() && leadParent.isFocusable() && leadParent.isEnabled()) {
             f.setFocused(leadParent);
         }
-        if (cmp != lead) {
+        if (cmp != lead) { //NOPMD CompareObjectsWithEquals
             leadParent.repaint();
         }
 
@@ -116,7 +116,7 @@ class LeadUtil {
         }
         Component lead = leadComponentImpl(cmp);
         lead.pointerDragged(x, y);
-        if (cmp != lead) {
+        if (cmp != lead) { //NOPMD CompareObjectsWithEquals
             leadParentImpl(cmp).repaint();
         }
 
@@ -135,7 +135,7 @@ class LeadUtil {
         }
         Component lead = leadComponentImpl(cmp);
         lead.pointerDragged(x, y);
-        if (cmp != lead) {
+        if (cmp != lead) { //NOPMD CompareObjectsWithEquals
             leadParentImpl(cmp).repaint();
         }
 
@@ -154,7 +154,7 @@ class LeadUtil {
         }
         Component lead = leadComponentImpl(cmp);
         lead.pointerReleased(x, y);
-        if (lead != cmp) {
+        if (lead != cmp) { //NOPMD CompareObjectsWithEquals
             leadParentImpl(cmp).repaint();
         }
     }
@@ -171,7 +171,7 @@ class LeadUtil {
             return;
         }
         leadComponentImpl(cmp).pointerHoverReleased(x, y);
-        if (leadParentImpl(cmp) != cmp) {
+        if (leadParentImpl(cmp) != cmp) { //NOPMD CompareObjectsWithEquals
             leadParentImpl(cmp).repaint();
         }
     }
@@ -182,7 +182,7 @@ class LeadUtil {
         }
         Component lead = leadComponentImpl(cmp);
         lead.pointerHoverPressed(x, y);
-        if (lead != cmp) {
+        if (lead != cmp) { //NOPMD CompareObjectsWithEquals
             leadParentImpl(cmp).repaint();
         }
     }
@@ -193,7 +193,7 @@ class LeadUtil {
         }
         Component lead = leadComponentImpl(cmp);
         lead.pointerHover(x, y);
-        if (lead != cmp) {
+        if (lead != cmp) { //NOPMD CompareObjectsWithEquals
             leadParentImpl(cmp).repaint();
         }
     }
@@ -204,7 +204,7 @@ class LeadUtil {
         }
         Component lead = leadComponentImpl(cmp);
         lead.dragFinishedImpl(x, y);
-        if (lead != cmp) {
+        if (lead != cmp) { //NOPMD CompareObjectsWithEquals
             leadParentImpl(cmp).repaint();
         }
     }
@@ -215,7 +215,7 @@ class LeadUtil {
         }
         Component lead = leadComponentImpl(cmp);
         lead.longPointerPress(x, y);
-        if (cmp != lead) {
+        if (cmp != lead) { //NOPMD CompareObjectsWithEquals
             leadParentImpl(cmp).repaint();
         }
     }

--- a/CodenameOne/src/com/codename1/ui/MenuBar.java
+++ b/CodenameOne/src/com/codename1/ui/MenuBar.java
@@ -137,7 +137,7 @@ public class MenuBar extends Container implements ActionListener {
     private int componentCountOffset(Container c) {
         if (getUIManager().isThemeConstant("paintsTitleBarBool", false)) {
             Container t = getTitleAreaContainer();
-            if (t == c && ((BorderLayout) t.getLayout()).getNorth() != null) {
+            if (t == c && ((BorderLayout) t.getLayout()).getNorth() != null) { //NOPMD CompareObjectsWithEquals
                 return 1;
             }
         }
@@ -345,7 +345,7 @@ public class MenuBar extends Container implements ActionListener {
             Component current = cnt.getComponentAt(iter);
             if (current instanceof Button) {
                 Button b = (Button) current;
-                if (b.getCommand() == c) {
+                if (b.getCommand() == c) { //NOPMD CompareObjectsWithEquals
                     return b;
                 }
             } else {
@@ -400,7 +400,7 @@ public class MenuBar extends Container implements ActionListener {
         if (getParent() == null) {
             installMenuBar();
         } else {
-            if (getParent() == getTitleAreaContainer() && commandBehavior != Display.COMMAND_BEHAVIOR_BUTTON_BAR_TITLE_RIGHT
+            if (getParent() == getTitleAreaContainer() && commandBehavior != Display.COMMAND_BEHAVIOR_BUTTON_BAR_TITLE_RIGHT //NOPMD CompareObjectsWithEquals
                     && commandBehavior != Display.COMMAND_BEHAVIOR_ICS) {
                 getParent().removeComponent(this);
                 installMenuBar();
@@ -418,7 +418,7 @@ public class MenuBar extends Container implements ActionListener {
                 if (commandBehavior == Display.COMMAND_BEHAVIOR_BUTTON_BAR_TITLE_RIGHT
                         || commandBehavior == Display.COMMAND_BEHAVIOR_BUTTON_BAR_TITLE_BACK) {
                     if (getParent() != null) {
-                        if (getParent() == getTitleAreaContainer()) {
+                        if (getParent() == getTitleAreaContainer()) { //NOPMD CompareObjectsWithEquals
                             return;
                         }
                         getParent().removeComponent(this);
@@ -577,8 +577,8 @@ public class MenuBar extends Container implements ActionListener {
         if (commandList == null) {
             Button source = (Button) src;
             for (int iter = 0; iter < soft.length; iter++) {
-                if (source == soft[iter]) {
-                    if (softCommand[iter] == menuCommand) {
+                if (source == soft[iter]) { //NOPMD CompareObjectsWithEquals
+                    if (softCommand[iter] == menuCommand) { //NOPMD CompareObjectsWithEquals
                         showMenu();
                         return;
                     }
@@ -739,9 +739,9 @@ public class MenuBar extends Container implements ActionListener {
         menuDisplaying = true;
         Command result = showMenuDialog(d);
         menuDisplaying = false;
-        if (result != cancelMenuItem) {
+        if (result != cancelMenuItem) { //NOPMD CompareObjectsWithEquals
             Command c = null;
-            if (result == selectMenuItem) {
+            if (result == selectMenuItem) { //NOPMD CompareObjectsWithEquals
                 c = getComponentSelectedCommand(d.getMenuBar().commandList);
                 if (c != null) {
                     ActionEvent e = new ActionEvent(c, ActionEvent.Type.Command);
@@ -765,7 +765,7 @@ public class MenuBar extends Container implements ActionListener {
         }
 
         Form upcoming = Display.getInstance().getCurrentUpcoming();
-        if (upcoming == parent) {
+        if (upcoming == parent) { //NOPMD CompareObjectsWithEquals
             d.disposeImpl();
         } else {
             parent.tint = (upcoming instanceof Dialog);
@@ -828,7 +828,7 @@ public class MenuBar extends Container implements ActionListener {
         }
         for (int iter = 0; iter < cmdCount; iter++) {
             Button btn = (Button) getComponentAt(iter);
-            if (btn.getCommand() != getCommand(iter + startOffset)) {
+            if (btn.getCommand() != getCommand(iter + startOffset)) { //NOPMD CompareObjectsWithEquals
                 btn.setCommand(getCommand(iter + startOffset));
             }
         }
@@ -867,7 +867,7 @@ public class MenuBar extends Container implements ActionListener {
                 verifyBackCommandRTL(back);
             } else {
                 Button b = (Button) leftContainer.getComponentAt(0);
-                if (b.getCommand() != parent.getBackCommand()) {
+                if (b.getCommand() != parent.getBackCommand()) { //NOPMD CompareObjectsWithEquals
                     b.setCommand(parent.getBackCommand());
                     if (!b.getUIID().startsWith("BackCommand")) {
                         b.setUIID("BackCommand");
@@ -986,7 +986,7 @@ public class MenuBar extends Container implements ActionListener {
             if (!btn.getUIID().equals(styleA)) {
                 btn.setUIID(styleA);
             }
-            if (btn.getCommand() != a) {
+            if (btn.getCommand() != a) { //NOPMD CompareObjectsWithEquals
                 btn.setCommand(a);
             }
             if (b != null) {
@@ -1004,7 +1004,7 @@ public class MenuBar extends Container implements ActionListener {
             if (!btn.getUIID().equals(styleA)) {
                 btn.setUIID(styleA);
             }
-            if (btn.getCommand() != a) {
+            if (btn.getCommand() != a) { //NOPMD CompareObjectsWithEquals
                 btn.setCommand(a);
             }
             hideEmptyCommand(btn);
@@ -1013,7 +1013,7 @@ public class MenuBar extends Container implements ActionListener {
                 if (!btn.getUIID().equals(styleB)) {
                     btn.setUIID(styleB);
                 }
-                if (btn.getCommand() != b) {
+                if (btn.getCommand() != b) { //NOPMD CompareObjectsWithEquals
                     btn.setCommand(b);
                 }
                 hideEmptyCommand(btn);
@@ -1035,12 +1035,12 @@ public class MenuBar extends Container implements ActionListener {
             return;
         }
 
-        if (getBackCommand() == cmd && UIManager.getInstance().isThemeConstant("hideBackCommandBool", false)) {
+        if (getBackCommand() == cmd && UIManager.getInstance().isThemeConstant("hideBackCommandBool", false)) { //NOPMD CompareObjectsWithEquals
             return;
         }
 
         // special case for default commands which are placed at the end and aren't overriden later
-        if (soft.length > 2 && cmd == parent.getDefaultCommand()) {
+        if (soft.length > 2 && cmd == parent.getDefaultCommand()) { //NOPMD CompareObjectsWithEquals
             commands.addElement(cmd);
         } else {
             commands.insertElementAt(cmd, 0);
@@ -1050,11 +1050,11 @@ public class MenuBar extends Container implements ActionListener {
             int behavior = getCommandBehavior();
             if (behavior == Display.COMMAND_BEHAVIOR_BUTTON_BAR || behavior == Display.COMMAND_BEHAVIOR_BUTTON_BAR_TITLE_BACK
                     || behavior == Display.COMMAND_BEHAVIOR_BUTTON_BAR_TITLE_RIGHT || behavior == Display.COMMAND_BEHAVIOR_ICS) {
-                if (behavior == Display.COMMAND_BEHAVIOR_BUTTON_BAR_TITLE_BACK && (cmd == parent.getBackCommand()
+                if (behavior == Display.COMMAND_BEHAVIOR_BUTTON_BAR_TITLE_BACK && (cmd == parent.getBackCommand() //NOPMD CompareObjectsWithEquals
                         || findCommandComponent(cmd) != null)) {
                     return;
                 }
-                if (parent.getBackCommand() != cmd) {
+                if (parent.getBackCommand() != cmd) { //NOPMD CompareObjectsWithEquals
                     if ((behavior == Display.COMMAND_BEHAVIOR_BUTTON_BAR_TITLE_BACK)
                             && parent.getTitle() != null && parent.getTitle().length() > 0) {
                         synchronizeCommandsWithButtonsInBackbutton();
@@ -1118,7 +1118,7 @@ public class MenuBar extends Container implements ActionListener {
                     || behavior == Display.COMMAND_BEHAVIOR_BUTTON_BAR_TITLE_RIGHT
                     || behavior == Display.COMMAND_BEHAVIOR_ICS
                     || behavior == Display.COMMAND_BEHAVIOR_SIDE_NAVIGATION) {
-                if (behavior == Display.COMMAND_BEHAVIOR_BUTTON_BAR_TITLE_BACK && cmd == parent.getBackCommand()) {
+                if (behavior == Display.COMMAND_BEHAVIOR_BUTTON_BAR_TITLE_BACK && cmd == parent.getBackCommand()) { //NOPMD CompareObjectsWithEquals
                     return;
                 }
                 if (behavior == Display.COMMAND_BEHAVIOR_SIDE_NAVIGATION) {
@@ -1129,7 +1129,7 @@ public class MenuBar extends Container implements ActionListener {
                     synchronizeCommandsWithButtonsInBackbutton();
                     return;
                 }
-                if (parent.getBackCommand() != cmd) {
+                if (parent.getBackCommand() != cmd) { //NOPMD CompareObjectsWithEquals
                     if (behavior != Display.COMMAND_BEHAVIOR_ICS) {
                         setLayout(new GridLayout(1, getComponentCount() + 1));
                         addComponent(Math.min(getComponentCount(), index), createTouchCommandButton(cmd));

--- a/CodenameOne/src/com/codename1/ui/SearchBar.java
+++ b/CodenameOne/src/com/codename1/ui/SearchBar.java
@@ -69,7 +69,7 @@ class SearchBar extends Toolbar {
             }
         });
         setUIIDFinal("ToolbarSearch");
-        if (parent.getComponentForm() == Display.INSTANCE.getCurrent()) {
+        if (parent.getComponentForm() == Display.INSTANCE.getCurrent()) { //NOPMD CompareObjectsWithEquals
             search.startEditingAsync();
         } else {
             if (parent.getComponentForm() != null) {

--- a/CodenameOne/src/com/codename1/ui/Sheet.java
+++ b/CodenameOne/src/com/codename1/ui/Sheet.java
@@ -152,7 +152,7 @@ public class Sheet extends Container {
                 return;
             }
             Component cmp = f.getComponentAt(evt.getX(), evt.getY());
-            if (Sheet.this.contains(cmp) || Sheet.this == cmp || cmp.isOwnedBy(Sheet.this)) {
+            if (Sheet.this.contains(cmp) || Sheet.this == cmp || cmp.isOwnedBy(Sheet.this)) { //NOPMD CompareObjectsWithEquals
                 // do nothing.
             } else {
                 evt.consume();
@@ -473,7 +473,7 @@ public class Sheet extends Container {
                 public void call(Component c) {
                     if (c instanceof Sheet) {
                         Sheet s = (Sheet) c;
-                        if (s.isAncestorSheetOf(Sheet.this) || s == Sheet.this) {
+                        if (s.isAncestorSheetOf(Sheet.this) || s == Sheet.this) { //NOPMD CompareObjectsWithEquals
                             // If the sheet is an ancestor of
                             // ours then we don't need to fire a close event
                             // yet.  We fire it when it is closed
@@ -488,7 +488,7 @@ public class Sheet extends Container {
                         // so their close events should also be fired in this case.
                         Sheet sp = s.getParentSheet();
                         while (sp != null) {
-                            if (sp == Sheet.this) {
+                            if (sp == Sheet.this) { //NOPMD CompareObjectsWithEquals
                                 break;
                             }
                             if (!sp.isAncestorSheetOf(Sheet.this)) {
@@ -835,7 +835,7 @@ public class Sheet extends Container {
      */
     public boolean isAncestorSheetOf(Sheet sheet) {
         sheet = sheet.getParentSheet();
-        if (sheet == this) {
+        if (sheet == this) { //NOPMD CompareObjectsWithEquals
             return true;
         } else if (sheet == null) {
             return false;

--- a/CodenameOne/src/com/codename1/ui/SideMenuBar.java
+++ b/CodenameOne/src/com/codename1/ui/SideMenuBar.java
@@ -343,7 +343,7 @@ public class SideMenuBar extends MenuBar {
                         return;
                     }
                     if (parent.getCommandCount() == 1) {
-                        if (parent.getCommand(0) == parent.getBackCommand()) {
+                        if (parent.getCommand(0) == parent.getBackCommand()) { //NOPMD CompareObjectsWithEquals
                             return;
                         }
                     }
@@ -391,7 +391,7 @@ public class SideMenuBar extends MenuBar {
                 return DRAG_REGION_NOT_DRAGGABLE;
             }
             if (parent.getCommandCount() == 1) {
-                if (parent.getCommand(0) == parent.getBackCommand()) {
+                if (parent.getCommand(0) == parent.getBackCommand()) { //NOPMD CompareObjectsWithEquals
                     return DRAG_REGION_NOT_DRAGGABLE;
                 }
             }
@@ -641,7 +641,7 @@ public class SideMenuBar extends MenuBar {
                 removeCommandComponent((Container) c, cmd);
                 continue;
             }
-            if (c instanceof Button && ((Button) c).getCommand() == cmd) {
+            if (c instanceof Button && ((Button) c).getCommand() == cmd) { //NOPMD CompareObjectsWithEquals
                 Container cc = c.getParent();
                 if (cc != null) {
                     cc.removeComponent(c);
@@ -687,7 +687,7 @@ public class SideMenuBar extends MenuBar {
                 return;
             }
             if (parent.getCommandCount() == 1) {
-                if (parent.getCommand(0) == parent.getBackCommand()) {
+                if (parent.getCommand(0) == parent.getBackCommand()) { //NOPMD CompareObjectsWithEquals
                     return;
                 }
             }
@@ -726,7 +726,7 @@ public class SideMenuBar extends MenuBar {
         if (transitionRunning) {
             return;
         }
-        if (Display.getInstance().getCurrent() == menu) {
+        if (Display.getInstance().getCurrent() == menu) { //NOPMD CompareObjectsWithEquals
             parent.showBack();
         }
     }
@@ -742,7 +742,7 @@ public class SideMenuBar extends MenuBar {
      * Opens the menu if it is currently closed
      */
     void openMenu(String direction, int time, int dest, boolean transition) {
-        if (Display.getInstance().getCurrent() == parent) {
+        if (Display.getInstance().getCurrent() == parent) { //NOPMD CompareObjectsWithEquals
             menu = createMenu(direction);
             //replace transtions to perform the Form shift
             out = parent.getTransitionOutAnimator();
@@ -766,7 +766,7 @@ public class SideMenuBar extends MenuBar {
      * @deprecated this code references functionality that is no longer supported and currently always returns false
      */
     public boolean isMenuOpen() {
-        return Display.getInstance().getCurrent() == menu;
+        return Display.getInstance().getCurrent() == menu; //NOPMD CompareObjectsWithEquals
     }
 
     private void addOpenButton(Command cmd, boolean checkCommands) {
@@ -1065,7 +1065,7 @@ public class SideMenuBar extends MenuBar {
                 initTitleBarStatus();
             } else {
                 // special case: hide back button that doesn't have text, icon or a side component entry
-                if (parent.getBackCommand() == c && (c.getCommandName() == null || c.getCommandName().length() == 0) &&
+                if (parent.getBackCommand() == c && (c.getCommandName() == null || c.getCommandName().length() == 0) && //NOPMD CompareObjectsWithEquals
                         c.getIcon() == null) {
                     continue;
                 }
@@ -1184,7 +1184,7 @@ public class SideMenuBar extends MenuBar {
 
                             @Override
                             public void run() {
-                                while (Display.getInstance().getCurrent() != parent) {
+                                while (Display.getInstance().getCurrent() != parent) { //NOPMD CompareObjectsWithEquals
                                     try {
                                         Thread.sleep(40);
                                     } catch (InterruptedException ex) {
@@ -1910,7 +1910,7 @@ public class SideMenuBar extends MenuBar {
                 }
 
                 synchronized (LOCK) {
-                    while (Display.getInstance().getCurrent() != parent) {
+                    while (Display.getInstance().getCurrent() != parent) { //NOPMD CompareObjectsWithEquals
                         try {
                             LOCK.wait(40);
                         } catch (InterruptedException ex) {

--- a/CodenameOne/src/com/codename1/ui/SwipeableContainer.java
+++ b/CodenameOne/src/com/codename1/ui/SwipeableContainer.java
@@ -415,7 +415,7 @@ public class SwipeableContainer extends Container {
                     }
 
                     if (initialX != -1) {
-                        if (getPreviouslyOpened() != null && getPreviouslyOpened() != SwipeableContainer.this && getPreviouslyOpened().isOpen()) {
+                        if (getPreviouslyOpened() != null && getPreviouslyOpened() != SwipeableContainer.this && getPreviouslyOpened().isOpen()) { //NOPMD CompareObjectsWithEquals
                             getPreviouslyOpened().close();
                         }
                         int diff = x - initialX;

--- a/CodenameOne/src/com/codename1/ui/Tabs.java
+++ b/CodenameOne/src/com/codename1/ui/Tabs.java
@@ -217,7 +217,7 @@ public class Tabs extends Container {
             frm.registerAnimatedInternal(this);
             if (changeTabContainerStyleOnFocus && Display.getInstance().shouldRenderSelection()) {
                 Component f = getComponentForm().getFocused();
-                if (f != null && f.getParent() == tabsContainer) {
+                if (f != null && f.getParent() == tabsContainer) { //NOPMD CompareObjectsWithEquals
                     initTabsContainerStyle();
                     tabsContainer.setUnselectedStyle(originalTabsContainerSelected);
                     tabsContainer.repaint();
@@ -1552,10 +1552,10 @@ public class Tabs extends Container {
                     riskySwipe = false;
                     if (!isEventBlockedByHigherComponent(evt) && contentPane.visibleBoundsContains(x, y)) {
                         Component testCmp = contentPane.getComponentAt(x, y);
-                        if (testCmp != null && testCmp != contentPane) {
+                        if (testCmp != null && testCmp != contentPane) { //NOPMD CompareObjectsWithEquals
                             doNotBlockSideSwipe = true;
                             try {
-                                while (testCmp != null && testCmp != contentPane) {
+                                while (testCmp != null && testCmp != contentPane) { //NOPMD CompareObjectsWithEquals
                                     if (testCmp.shouldBlockSideSwipe()) {
                                         lastX = -1;
                                         lastY = -1;

--- a/CodenameOne/src/com/codename1/ui/TextArea.java
+++ b/CodenameOne/src/com/codename1/ui/TextArea.java
@@ -223,7 +223,7 @@ public class TextArea extends Component implements ActionSource, TextHolder {
         public void actionPerformed(ActionEvent evt) {
             Form f = getComponentForm();
             if (f != null) {
-                if (isEditing() && f.getComponentAt(evt.getX(), evt.getY()) != TextArea.this) {
+                if (isEditing() && f.getComponentAt(evt.getX(), evt.getY()) != TextArea.this) { //NOPMD CompareObjectsWithEquals
                     fireActionEvent();
                     setSuppressActionEvent(true);
                 }
@@ -1090,7 +1090,7 @@ public class TextArea extends Component implements ActionSource, TextHolder {
 
         int charWidth = font.charWidth(widestChar);
         Style selectedStyle = getSelectedStyle();
-        if (selectedStyle.getFont() != style.getFont()) {
+        if (selectedStyle.getFont() != style.getFont()) { //NOPMD CompareObjectsWithEquals
             int cw = selectedStyle.getFont().charWidth(widestChar);
             if (cw > charWidth) {
                 charWidth = cw;
@@ -1978,7 +1978,7 @@ public class TextArea extends Component implements ActionSource, TextHolder {
     public void registerAsInputDevice() {
         Form f = this.getComponentForm();
 
-        if (f != null && Display.impl.getEditingText() != this) {
+        if (f != null && Display.impl.getEditingText() != this) { //NOPMD CompareObjectsWithEquals
             try {
                 TextAreaInputDevice previousInput = null;
                 if (f.getCurrentInputDevice() instanceof TextAreaInputDevice) {
@@ -2027,7 +2027,7 @@ public class TextArea extends Component implements ActionSource, TextHolder {
                 // before starting a new edit session or the previous text
                 // field won't be updated until the next one is finished editing.
                 Component c = Display.impl.getEditingText();
-                if (c != this && c != null) {
+                if (c != this && c != null) { //NOPMD CompareObjectsWithEquals
                     if (c instanceof TextArea) {
                         //System.out.println("Stopping editing");
                         ((TextArea) c).stopEditing();

--- a/CodenameOne/src/com/codename1/ui/TextField.java
+++ b/CodenameOne/src/com/codename1/ui/TextField.java
@@ -1190,7 +1190,7 @@ public class TextField extends TextArea {
     protected void showSymbolDialog() {
         Command cancel = new Command(getUIManager().localize("cancel", "Cancel"));
         Command r = Dialog.show("", createSymbolTable(), cancel);
-        if (r != null && r != cancel) {
+        if (r != null && r != cancel) { //NOPMD CompareObjectsWithEquals
             insertChars(r.getCommandName());
         }
     }

--- a/CodenameOne/src/com/codename1/ui/TextSelection.java
+++ b/CodenameOne/src/com/codename1/ui/TextSelection.java
@@ -631,7 +631,7 @@ public class TextSelection {
         if (isVerticallyCovered) {
             return true;
         }
-        if (cmp == selectionRoot) {
+        if (cmp == selectionRoot) { //NOPMD CompareObjectsWithEquals
             return false;
         }
         Container parent = cmp.getParent();
@@ -1406,7 +1406,7 @@ public class TextSelection {
 
         @Override
         public void actionPerformed(ActionEvent e) {
-            if (e.getSource() == selectAll) {
+            if (e.getSource() == selectAll) { //NOPMD CompareObjectsWithEquals
                 selectAll();
             } else {
                 copy();

--- a/CodenameOne/src/com/codename1/ui/Toolbar.java
+++ b/CodenameOne/src/com/codename1/ui/Toolbar.java
@@ -599,7 +599,7 @@ public class Toolbar extends Container {
         f.removeComponentFromForm(Toolbar.this);
         f.setToolbar(s);
         s.initSearchBar();
-        if (f == Display.INSTANCE.getCurrent()) {
+        if (f == Display.INSTANCE.getCurrent()) { //NOPMD CompareObjectsWithEquals
             f.animateLayout(100);
         }
     }
@@ -944,12 +944,12 @@ public class Toolbar extends Container {
 
     boolean isComponentInOnTopSidemenu(Component cmp) {
         if (cmp != null) {
-            if (cmp == permanentSideMenuContainer || cmp == this || cmp == sidemenuSouthComponent) {
+            if (cmp == permanentSideMenuContainer || cmp == this || cmp == sidemenuSouthComponent) { //NOPMD CompareObjectsWithEquals
                 return true;
             }
             while (cmp.getParent() != null) {
                 cmp = cmp.getParent();
-                if (cmp == permanentSideMenuContainer || cmp == this || cmp == sidemenuSouthComponent) {
+                if (cmp == permanentSideMenuContainer || cmp == this || cmp == sidemenuSouthComponent) { //NOPMD CompareObjectsWithEquals
                     return true;
                 }
             }
@@ -959,14 +959,14 @@ public class Toolbar extends Container {
 
     boolean isComponentInOnTopRightSidemenu(Component cmp) {
         if (cmp != null) {
-            if (cmp == permanentRightSideMenuContainer || cmp == this
-                    || cmp == rightSidemenuSouthComponent) {
+            if (cmp == permanentRightSideMenuContainer || cmp == this //NOPMD CompareObjectsWithEquals
+                    || cmp == rightSidemenuSouthComponent) { //NOPMD CompareObjectsWithEquals
                 return true;
             }
             while (cmp.getParent() != null) {
                 cmp = cmp.getParent();
-                if (cmp == permanentRightSideMenuContainer || cmp == this
-                        || cmp == rightSidemenuSouthComponent) {
+                if (cmp == permanentRightSideMenuContainer || cmp == this //NOPMD CompareObjectsWithEquals
+                        || cmp == rightSidemenuSouthComponent) { //NOPMD CompareObjectsWithEquals
                     return true;
                 }
             }
@@ -1955,7 +1955,7 @@ public class Toolbar extends Container {
             Component current = cnt.getComponentAt(iter);
             if (current instanceof Button) {
                 Button b = (Button) current;
-                if (b.getCommand() == c || sideMenu.unwrapCommand(b.getCommand()) == c) {
+                if (b.getCommand() == c || sideMenu.unwrapCommand(b.getCommand()) == c) { //NOPMD CompareObjectsWithEquals
                     return b;
                 }
             } else {
@@ -2059,7 +2059,7 @@ public class Toolbar extends Container {
         int commandCount = cmds.size() - 1;
         while (commandCount > 0) {
             Command c = cmds.get(commandCount);
-            if (c.getClientProperty("Left") != leftValue) {
+            if (c.getClientProperty("Left") != leftValue) { //NOPMD CompareObjectsWithEquals
                 cmds.remove(commandCount);
             }
             commandCount--;
@@ -2258,7 +2258,7 @@ public class Toolbar extends Container {
      */
     public void hideToolbar() {
         showing = false;
-        if (Display.INSTANCE.getCurrent() != getComponentForm()) {
+        if (Display.INSTANCE.getCurrent() != getComponentForm()) { //NOPMD CompareObjectsWithEquals
             setVisible(false);
             setHidden(true);
             return;

--- a/CodenameOne/src/com/codename1/ui/TooltipManager.java
+++ b/CodenameOne/src/com/codename1/ui/TooltipManager.java
@@ -93,7 +93,7 @@ public class TooltipManager {
      * @param cmp the component
      */
     protected void prepareTooltip(final String tip, final Component cmp) {
-        if (currentComponent == cmp) {
+        if (currentComponent == cmp) { //NOPMD CompareObjectsWithEquals
             return;
         }
         clearTooltip();

--- a/CodenameOne/src/com/codename1/ui/animations/CommonTransitions.java
+++ b/CodenameOne/src/com/codename1/ui/animations/CommonTransitions.java
@@ -1190,7 +1190,7 @@ public final class CommonTransitions extends Transition {
                 return;
             }
             if (!(getSource() instanceof Dialog && getDestination() instanceof Dialog
-                    && cmp == getDestination())) {
+                    && cmp == getDestination())) { //NOPMD CompareObjectsWithEquals
                 Painter p = cmp.getStyle().getBgPainter();
                 cmp.getStyle().setBgPainter(null);
                 g.translate(x, y);

--- a/CodenameOne/src/com/codename1/ui/animations/ComponentAnimation.java
+++ b/CodenameOne/src/com/codename1/ui/animations/ComponentAnimation.java
@@ -328,7 +328,7 @@ public abstract class ComponentAnimation {
                 return false;
             }
             for (Container existing : containers) {
-                if (cnt == existing || existing.contains(cnt) || cnt.contains(existing)) {
+                if (cnt == existing || existing.contains(cnt) || cnt.contains(existing)) { //NOPMD CompareObjectsWithEquals
                     return false;
                 }
             }

--- a/CodenameOne/src/com/codename1/ui/html/CSSEngine.java
+++ b/CodenameOne/src/com/codename1/ui/html/CSSEngine.java
@@ -1400,10 +1400,10 @@ class CSSEngine {
         boolean leftBorder = false; // Used to prevent drawing a border in the middle of two words in the same segment
         boolean rightBorder = false; // Used to prevent drawing a border in the middle of two words in the same segment
         boolean hasBorder = false;
-        if ((borderUi == ui) && (element.getUi().size() > 1)) {
-            if (element.getUi().firstElement() == borderUi) {
+        if ((borderUi == ui) && (element.getUi().size() > 1)) { //NOPMD CompareObjectsWithEquals
+            if (element.getUi().firstElement() == borderUi) { //NOPMD CompareObjectsWithEquals
                 leftBorder = true;
-            } else if (element.getUi().lastElement() == borderUi) {
+            } else if (element.getUi().lastElement() == borderUi) { //NOPMD CompareObjectsWithEquals
                 rightBorder = true;
             }
         } else {

--- a/CodenameOne/src/com/codename1/ui/html/HTMLComponent.java
+++ b/CodenameOne/src/com/codename1/ui/html/HTMLComponent.java
@@ -760,7 +760,7 @@ public class HTMLComponent extends Container implements ActionListener, IOCallba
                 if (cmp != null) {
                     Container parent = cmp.getParent();
                     int y = cmp.getY();
-                    while ((parent != null) && (parent != this)) {
+                    while ((parent != null) && (parent != this)) { //NOPMD CompareObjectsWithEquals
                         y += parent.getY();
                         parent = parent.getParent();
                     }
@@ -1474,7 +1474,7 @@ public class HTMLComponent extends Container implements ActionListener, IOCallba
     HTMLFont getHTMLFont(Font font) {
         for (Enumeration e = fonts.elements(); e.hasMoreElements(); ) {
             HTMLFont hFont = (HTMLFont) e.nextElement();
-            if (hFont.getFont() == font) {
+            if (hFont.getFont() == font) { //NOPMD CompareObjectsWithEquals
                 return hFont;
             }
         }
@@ -2226,7 +2226,7 @@ public class HTMLComponent extends Container implements ActionListener, IOCallba
             for (Enumeration e = accessKeys.keys(); e.hasMoreElements(); ) {
                 Object key = e.nextElement();
                 Component c = (Component) accessKeys.get(key);
-                if (c != cmp) {
+                if (c != cmp) { //NOPMD CompareObjectsWithEquals
                     newAccessKeys.put(key, c);
                 }
             }
@@ -2682,12 +2682,12 @@ public class HTMLComponent extends Container implements ActionListener, IOCallba
                     returnInputField = newInputField;
 
                     // Replace operation must be done on the EDT if the form is visible
-                    if (Display.getInstance().getCurrent() != inputField.getComponentForm()) { // ((inputField.getComponentForm()==null) ||
+                    if (Display.getInstance().getCurrent() != inputField.getComponentForm()) { // ((inputField.getComponentForm()==null) || //NOPMD CompareObjectsWithEquals
                         inputField.getParent().replace(inputField, newInputField, null); // Applying the constraints may return a new instance that has to be replaced in the form
                     } else {
                         Display.getInstance().callSerially(new InputFormatRunnable(inputField, newInputField));
                     }
-                    if (firstFocusable == inputField) {
+                    if (firstFocusable == inputField) { //NOPMD CompareObjectsWithEquals
                         firstFocusable = newInputField;
                     }
                 }

--- a/CodenameOne/src/com/codename1/ui/html/HTMLElement.java
+++ b/CodenameOne/src/com/codename1/ui/html/HTMLElement.java
@@ -1565,7 +1565,7 @@ public class HTMLElement extends Element {
         if (parent != null) {
             for (Element e : parent) {
                 HTMLElement elem = (HTMLElement) e;
-                if (elem == this) {
+                if (elem == this) { //NOPMD CompareObjectsWithEquals
                     return true;
                 }
                 if (!elem.isTextElement()) {

--- a/CodenameOne/src/com/codename1/ui/layouts/BorderLayout.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/BorderLayout.java
@@ -426,7 +426,7 @@ public class BorderLayout extends Layout {
         } else {
             throw new IllegalArgumentException("cannot add to layout: unknown constraint: " + name);
         }
-        if (previous != null && previous != comp) {
+        if (previous != null && previous != comp) { //NOPMD CompareObjectsWithEquals
             c.removeComponent(previous);
         }
     }
@@ -436,17 +436,17 @@ public class BorderLayout extends Layout {
      */
     @Override
     public void removeLayoutComponent(Component comp) {
-        if (comp == portraitCenter) {
+        if (comp == portraitCenter) { //NOPMD CompareObjectsWithEquals
             portraitCenter = null;
-        } else if (comp == portraitNorth) {
+        } else if (comp == portraitNorth) { //NOPMD CompareObjectsWithEquals
             portraitNorth = null;
-        } else if (comp == portraitSouth) {
+        } else if (comp == portraitSouth) { //NOPMD CompareObjectsWithEquals
             portraitSouth = null;
-        } else if (comp == portraitEast) {
+        } else if (comp == portraitEast) { //NOPMD CompareObjectsWithEquals
             portraitEast = null;
-        } else if (comp == portraitWest) {
+        } else if (comp == portraitWest) { //NOPMD CompareObjectsWithEquals
             portraitWest = null;
-        } else if (comp == overlay) {
+        } else if (comp == overlay) { //NOPMD CompareObjectsWithEquals
             overlay = null;
         }
     }
@@ -459,18 +459,18 @@ public class BorderLayout extends Layout {
      */
     @Override
     public Object getComponentConstraint(Component comp) {
-        if (comp == portraitCenter) {
+        if (comp == portraitCenter) { //NOPMD CompareObjectsWithEquals
             return CENTER;
-        } else if (comp == portraitNorth) {
+        } else if (comp == portraitNorth) { //NOPMD CompareObjectsWithEquals
             return NORTH;
-        } else if (comp == portraitSouth) {
+        } else if (comp == portraitSouth) { //NOPMD CompareObjectsWithEquals
             return SOUTH;
-        } else if (comp == portraitEast) {
+        } else if (comp == portraitEast) { //NOPMD CompareObjectsWithEquals
             return EAST;
-        } else if (comp == overlay) {
+        } else if (comp == overlay) { //NOPMD CompareObjectsWithEquals
             return OVERLAY;
         } else {
-            if (comp == portraitWest) {
+            if (comp == portraitWest) { //NOPMD CompareObjectsWithEquals
                 return WEST;
             }
         }
@@ -845,7 +845,7 @@ public class BorderLayout extends Layout {
     @Override
     public boolean equals(Object o) {
         if (super.equals(o) && centerBehavior == ((BorderLayout) o).centerBehavior) {
-            if (landscapeSwap == ((BorderLayout) o).landscapeSwap) {
+            if (landscapeSwap == ((BorderLayout) o).landscapeSwap) { //NOPMD CompareObjectsWithEquals
                 return true;
             }
             if (landscapeSwap != null) {

--- a/CodenameOne/src/com/codename1/ui/layouts/GridBagLayout.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/GridBagLayout.java
@@ -498,7 +498,7 @@ public class GridBagLayout extends Layout {
         for (Map.Entry<Component, GridBagConstraints> entry : comptable.entrySet()) {
             Component comp = entry.getKey();
             GridBagConstraints cons = entry.getValue();
-            if ((comp.getParent() == parent) && comp.isVisible()) {
+            if ((comp.getParent() == parent) && comp.isVisible()) { //NOPMD CompareObjectsWithEquals
                 components[i++] = comp;
             }
             if ((cons.gridx != GridBagConstraints.RELATIVE)
@@ -514,7 +514,7 @@ public class GridBagLayout extends Layout {
         int componentsNumber = 0;
         for (Map.Entry<Component, GridBagConstraints> entry : comptable.entrySet()) {
             Component comp = entry.getKey();
-            if ((comp.getParent() == parent) && comp.isVisible()) {
+            if ((comp.getParent() == parent) && comp.isVisible()) { //NOPMD CompareObjectsWithEquals
                 componentsNumber++;
             }
         }

--- a/CodenameOne/src/com/codename1/ui/layouts/GroupLayout.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/GroupLayout.java
@@ -731,7 +731,7 @@ public class GroupLayout extends Layout {
             throw new IllegalArgumentException("Component must already exist");
         }
         host.removeComponent(existingComponent);
-        if (newComponent.getParent() != host) {
+        if (newComponent.getParent() != host) { //NOPMD CompareObjectsWithEquals
             host.addComponent(newComponent);
         }
         info.setComponent(newComponent);
@@ -1038,7 +1038,7 @@ public class GroupLayout extends Layout {
     }
 
     private void checkParent(Container parent) {
-        if (parent != host) {
+        if (parent != host) { //NOPMD CompareObjectsWithEquals
             throw new IllegalArgumentException(
                     "GroupLayout can only be used with one Container at a time");
         }
@@ -1052,7 +1052,7 @@ public class GroupLayout extends Layout {
         if (info == null) {
             info = new ComponentInfo(component);
             componentInfos.put(component, info);
-            if (component.getParent() != host) {
+            if (component.getParent() != host) { //NOPMD CompareObjectsWithEquals
                 host.addComponent(component);
             }
         }
@@ -1186,7 +1186,7 @@ public class GroupLayout extends Layout {
             if (childMaster == null) {
                 linked.add(child);
                 child.setLinkInfo(axis, this);
-            } else if (childMaster != this) {
+            } else if (childMaster != this) { //NOPMD CompareObjectsWithEquals
                 addAll(linked, childMaster.linked);
                 for (int i = 0; i < childMaster.linked.size(); i++) {
                     ComponentInfo childInfo = (ComponentInfo) childMaster.linked.get(i);
@@ -2141,7 +2141,7 @@ public class GroupLayout extends Layout {
                     int size = 0;
                     for (int i = 0, max = springs.size(); i < max; i++) {
                         Spring spring = getSpring(i);
-                        if (spring == baselineSpring) {
+                        if (spring == baselineSpring) { //NOPMD CompareObjectsWithEquals
                             return size + baseline;
                         } else {
                             size += spring.getPreferredSize(VERTICAL);
@@ -2162,7 +2162,7 @@ public class GroupLayout extends Layout {
                     boolean leadingResizable = false;
                     for (int i = 0, max = springs.size(); i < max; i++) {
                         Spring spring = getSpring(i);
-                        if (spring == baselineSpring) {
+                        if (spring == baselineSpring) { //NOPMD CompareObjectsWithEquals
                             break;
                         } else if (spring.isResizable(VERTICAL)) {
                             leadingResizable = true;
@@ -2172,7 +2172,7 @@ public class GroupLayout extends Layout {
                     boolean trailingResizable = false;
                     for (int i = springs.size() - 1; i >= 0; i--) {
                         Spring spring = getSpring(i);
-                        if (spring == baselineSpring) {
+                        if (spring == baselineSpring) { //NOPMD CompareObjectsWithEquals
                             break;
                         }
                         if (spring.isResizable(VERTICAL)) {
@@ -2195,7 +2195,7 @@ public class GroupLayout extends Layout {
                     if (brb == Component.BRB_CONSTANT_ASCENT) {
                         for (int i = 0, max = springs.size(); i < max; i++) {
                             Spring spring = getSpring(i);
-                            if (spring == baselineSpring) {
+                            if (spring == baselineSpring) { //NOPMD CompareObjectsWithEquals
                                 return Component.BRB_CONSTANT_ASCENT;
                             }
                             if (spring.isResizable(VERTICAL)) {
@@ -2205,7 +2205,7 @@ public class GroupLayout extends Layout {
                     } else if (brb == Component.BRB_CONSTANT_DESCENT) {
                         for (int i = springs.size() - 1; i >= 0; i--) {
                             Spring spring = getSpring(i);
-                            if (spring == baselineSpring) {
+                            if (spring == baselineSpring) { //NOPMD CompareObjectsWithEquals
                                 return Component.BRB_CONSTANT_DESCENT;
                             }
                             if (spring.isResizable(VERTICAL)) {

--- a/CodenameOne/src/com/codename1/ui/layouts/LayeredLayout.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/LayeredLayout.java
@@ -383,7 +383,7 @@ public class LayeredLayout extends Layout {
      */
     private LayeredLayoutConstraint installConstraint(LayeredLayoutConstraint constraint, Component cmp) {
 
-        if (constraint.outer() != this || (constraint.cmp != null && constraint.cmp != cmp)) {
+        if (constraint.outer() != this || (constraint.cmp != null && constraint.cmp != cmp)) { //NOPMD CompareObjectsWithEquals
             LayeredLayoutConstraint tmp = createConstraint();
             constraint.copyTo(tmp);
             constraint = tmp;
@@ -2407,7 +2407,7 @@ public class LayeredLayout extends Layout {
              */
             private Inset fixDependencies(Container parent) {
                 Container refParent;
-                if (referenceComponent != null && (refParent = referenceComponent.getParent()) != parent) {
+                if (referenceComponent != null && (refParent = referenceComponent.getParent()) != parent) { //NOPMD CompareObjectsWithEquals
                     // The reference component is not in this parent
                     String name = referenceComponent.getName();
                     boolean found = false;
@@ -3252,7 +3252,7 @@ public class LayeredLayout extends Layout {
                 //    // This could potentially affect the opposite inset if it is a percentage
                 //    referenceComponent(newRef).referencePosition(pos);
                 //} else {
-                if (newRef != referenceComponent || com.codename1.util.MathUtil.compare(pos, referencePosition) != 0) {
+                if (newRef != referenceComponent || com.codename1.util.MathUtil.compare(pos, referencePosition) != 0) { //NOPMD CompareObjectsWithEquals
                     // This may potentially affect both this inset
                     // and the opposite inset if it is either flexible or
                     // percent.

--- a/CodenameOne/src/com/codename1/ui/layouts/TextModeLayout.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/TextModeLayout.java
@@ -89,7 +89,7 @@ public class TextModeLayout extends Layout {
      */
     @Override
     public void addLayoutComponent(Object value, Component comp, Container c) {
-        if (actual == table) {
+        if (actual == table) { //NOPMD CompareObjectsWithEquals
             // forcing default constraint to still be aligned top
             if (!(value instanceof TableLayout.Constraint)) {
                 value = createConstraint();
@@ -151,7 +151,7 @@ public class TextModeLayout extends Layout {
      */
     @Override
     public void layoutContainer(Container parent) {
-        if (autoGrouping && actual != table && lastComponentCount != parent.getComponentCount()) {
+        if (autoGrouping && actual != table && lastComponentCount != parent.getComponentCount()) { //NOPMD CompareObjectsWithEquals
             lastComponentCount = parent.getComponentCount();
             ArrayList<Component> tc = new ArrayList<Component>();
             for (Component c : parent) {

--- a/CodenameOne/src/com/codename1/ui/layouts/mig/BoundSize.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/mig/BoundSize.java
@@ -207,7 +207,7 @@ public class BoundSize {
             return cs;
         }
 
-        if (min == pref && pref == max) {
+        if (min == pref && pref == max) { //NOPMD CompareObjectsWithEquals
             return min != null ? (min.getConstraintString() + "!") : "null";
         }
 

--- a/CodenameOne/src/com/codename1/ui/layouts/mig/ConstraintParser.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/mig/ConstraintParser.java
@@ -218,7 +218,7 @@ public final class ConstraintParser {
                     ix = startsWithLenient(part, new String[]{"aligny", "ay"}, new int[]{6, 2}, true);
                     if (ix > -1) {
                         UnitValue align = parseUnitValueOrAlign(part.substring(ix).trim(), false, null);
-                        if (align == UnitValue.BASELINE_IDENTITY) {
+                        if (align == UnitValue.BASELINE_IDENTITY) { //NOPMD CompareObjectsWithEquals
                             throw new IllegalArgumentException("'baseline' can not be used to align the whole component group.");
                         }
                         lc.setAlignY(align);

--- a/CodenameOne/src/com/codename1/ui/layouts/mig/Grid.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/mig/Grid.java
@@ -312,7 +312,7 @@ public final class Grid {
                 hasPushX |= (visible || hideMode > 1) && (cc.getPushX() != null);
                 hasPushY |= (visible || hideMode > 1) && (cc.getPushY() != null);
 
-                if (cc != rootCc) { // If not first in a cell
+                if (cc != rootCc) { // If not first in a cell //NOPMD CompareObjectsWithEquals
                     if (cc.isNewline() || !cc.isBoundsInGrid() || cc.getDockSide() != -1) {
                         break;
                     }
@@ -331,7 +331,7 @@ public final class Grid {
                 cell.hasTagged |= cc.getTag() != null;
                 hasTagged |= cell.hasTagged;
 
-                if (cc != rootCc) {
+                if (cc != rootCc) { //NOPMD CompareObjectsWithEquals
                     if (cc.getHorizontal().getSizeGroup() != null) {
                         sizeGroupsX++;
                     }
@@ -573,7 +573,7 @@ public final class Grid {
             for (int j = 0, jSz = groups.size(); j < jSz; j++) {
                 ArrayList<CompWrap> cwList = groups.get(j)._compWraps;
                 for (int k = 0, kSz = cwList.size(); k < kSz; k++) {
-                    if (cwList.get(k) == cw) {
+                    if (cwList.get(k) == cw) { //NOPMD CompareObjectsWithEquals
                         return groups.get(j);
                     }
                 }
@@ -711,7 +711,7 @@ public final class Grid {
         if (spanCount == 1 && align == null) {
             align = dc.getAlignOrDefault(false);
         }
-        if (align == UnitValue.BASELINE_IDENTITY) {
+        if (align == UnitValue.BASELINE_IDENTITY) { //NOPMD CompareObjectsWithEquals
             align = UnitValue.CENTER;
         }
 
@@ -815,14 +815,14 @@ public final class Grid {
         if (align == null) {
             align = rowAlign;
         }
-        if (align == UnitValue.BASELINE_IDENTITY) {
+        if (align == UnitValue.BASELINE_IDENTITY) { //NOPMD CompareObjectsWithEquals
             align = UnitValue.CENTER;
         }
 
         if (fromEnd) {
-            if (align == UnitValue.LEFT) {
+            if (align == UnitValue.LEFT) { //NOPMD CompareObjectsWithEquals
                 align = UnitValue.RIGHT;
-            } else if (align == UnitValue.RIGHT) {
+            } else if (align == UnitValue.RIGHT) { //NOPMD CompareObjectsWithEquals
                 align = UnitValue.LEFT;
             }
         }
@@ -1908,7 +1908,7 @@ public final class Grid {
                     retValues[i] = new int[]{aft, aft, aft};
 
                 } else {
-                    retValues[i] = gapAfter != gapBefore ? mergeSizes(gapAfter, gapBefore) : new int[]{defGapArr[0], defGapArr[1], defGapArr[2]};
+                    retValues[i] = gapAfter != gapBefore ? mergeSizes(gapAfter, gapBefore) : new int[]{defGapArr[0], defGapArr[1], defGapArr[2]}; //NOPMD CompareObjectsWithEquals
                 }
 
                 if (specBefore != null && specBefore.isGapAfterPush() || specAfter != null && specAfter.isGapBeforePush()) {
@@ -2030,7 +2030,7 @@ public final class Grid {
                 } else {
                     for (int cwIx = 0; cwIx < cell.compWraps.size(); cwIx++) {
                         CompWrap cw = cell.compWraps.get(cwIx);
-                        boolean rowBaselineAlign = (isRows && lc.isTopToBottom() && dc.getAlignOrDefault(!isRows) == UnitValue.BASELINE_IDENTITY); // Disable baseline for bottomToTop since I can not verify it working.
+                        boolean rowBaselineAlign = (isRows && lc.isTopToBottom() && dc.getAlignOrDefault(!isRows) == UnitValue.BASELINE_IDENTITY); // Disable baseline for bottomToTop since I can not verify it working. //NOPMD CompareObjectsWithEquals
                         boolean isBaseline = isRows && cw.isBaselineAlign(rowBaselineAlign);
 
                         String linkCtx = isBaseline ? "baseline" : null;
@@ -2190,7 +2190,7 @@ public final class Grid {
         }
 
         private void setCompWraps(ArrayList<CompWrap> cws) {
-            if (_compWraps != cws) {
+            if (_compWraps != cws) { //NOPMD CompareObjectsWithEquals
                 _compWraps.clear();
                 _compWraps.addAll(cws);
             }
@@ -2597,7 +2597,7 @@ public final class Grid {
             }
 
             UnitValue al = cc.getVertical().getAlign();
-            return (al != null ? al == UnitValue.BASELINE_IDENTITY : defValue) && comp.hasBaseline();
+            return (al != null ? al == UnitValue.BASELINE_IDENTITY : defValue) && comp.hasBaseline(); //NOPMD CompareObjectsWithEquals
         }
 
         private int getBaseline(int sizeType) {

--- a/CodenameOne/src/com/codename1/ui/layouts/mig/LayoutUtil.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/mig/LayoutUtil.java
@@ -448,7 +448,7 @@ public final class LayoutUtil {
      * @return Returns <code>true</code> if <code>o1</code> and <code>o2</code> are equal (using .equals()) or both are <code>null</code>.
      */
     static boolean equals(Object o1, Object o2) {
-        return o1 == o2 || (o1 != null && o2 != null && o1.equals(o2));
+        return o1 == o2 || (o1 != null && o2 != null && o1.equals(o2)); //NOPMD CompareObjectsWithEquals
     }
 
     /**

--- a/CodenameOne/src/com/codename1/ui/layouts/mig/LinkHandler.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/mig/LinkHandler.java
@@ -62,7 +62,7 @@ public final class LinkHandler {
 
         for (int i = LAYOUTS.size() - 1; i >= 0; i--) {
             Object l = Display.getInstance().extractHardRef(LAYOUTS.get(i));
-            if (ret == null && l == layout) {
+            if (ret == null && l == layout) { //NOPMD CompareObjectsWithEquals
                 int[] rect = VALUES_TEMP.get(i).get(key);
                 if (cont && rect != null && rect[type] != LayoutUtil.NOT_SET) {
                     ret = Integer.valueOf(rect[type]);
@@ -100,7 +100,7 @@ public final class LinkHandler {
     synchronized static boolean setBounds(Object layout, String key, int x, int y, int width, int height, boolean temporary, boolean incCur) {
         for (int i = LAYOUTS.size() - 1; i >= 0; i--) {
             Object l = Display.getInstance().extractHardRef(LAYOUTS.get(i));
-            if (l == layout) {
+            if (l == layout) { //NOPMD CompareObjectsWithEquals
                 HashMap<String, int[]> map = (temporary ? VALUES_TEMP : VALUES).get(i);
                 int[] old = map.get(key);
 
@@ -182,7 +182,7 @@ public final class LinkHandler {
     public synchronized static boolean clearBounds(Object layout, String key) {
         for (int i = LAYOUTS.size() - 1; i >= 0; i--) {
             Object l = Display.getInstance().extractHardRef(LAYOUTS.get(i));
-            if (l == layout) {
+            if (l == layout) { //NOPMD CompareObjectsWithEquals
                 return VALUES.get(i).remove(key) != null;
             }
         }
@@ -192,7 +192,7 @@ public final class LinkHandler {
     synchronized static void clearTemporaryBounds(Object layout) {
         for (int i = LAYOUTS.size() - 1; i >= 0; i--) {
             Object l = Display.getInstance().extractHardRef(LAYOUTS.get(i));
-            if (l == layout) {
+            if (l == layout) { //NOPMD CompareObjectsWithEquals
                 VALUES_TEMP.get(i).clear();
                 return;
             }

--- a/CodenameOne/src/com/codename1/ui/layouts/mig/MigLayout.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/mig/MigLayout.java
@@ -547,7 +547,7 @@ public final class MigLayout extends Layout {
             return null;
         }
 
-        if (cacheParentW == null || cacheParentW.getComponent() != parent) {
+        if (cacheParentW == null || cacheParentW.getComponent() != parent) { //NOPMD CompareObjectsWithEquals
             cacheParentW = new CodenameOneMiGContainerWrapper(parent);
         }
 

--- a/CodenameOne/src/com/codename1/ui/list/GenericListCellRenderer.java
+++ b/CodenameOne/src/com/codename1/ui/list/GenericListCellRenderer.java
@@ -113,7 +113,7 @@ public class GenericListCellRenderer<T> implements ListCellRenderer<T>, CellRend
      * @param unselected indicates the unselected value for the renderer
      */
     public GenericListCellRenderer(Component selected, Component unselected) {
-        if (selected == unselected) {
+        if (selected == unselected) { //NOPMD CompareObjectsWithEquals
             throw new IllegalArgumentException("Must use distinct instances for renderer!");
         }
         this.selected = selected;

--- a/CodenameOne/src/com/codename1/ui/painter/PainterChain.java
+++ b/CodenameOne/src/com/codename1/ui/painter/PainterChain.java
@@ -93,7 +93,7 @@ public class PainterChain implements Painter {
         if (existing == null) {
             return;
         }
-        if (existing == p) {
+        if (existing == p) { //NOPMD CompareObjectsWithEquals
             f.setGlassPane(null);
             return;
         }
@@ -105,7 +105,7 @@ public class PainterChain implements Painter {
                 Vector v = new Vector();
                 int plen = pc.chain.length;
                 for (int iter = 0; iter < plen; iter++) {
-                    if (pc.chain[iter] != p) {
+                    if (pc.chain[iter] != p) { //NOPMD CompareObjectsWithEquals
                         v.addElement(pc.chain[iter]);
                     }
                 }

--- a/CodenameOne/src/com/codename1/ui/plaf/Border.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/Border.java
@@ -1112,7 +1112,7 @@ public class Border {
             if (v && (type == TYPE_IMAGE || type == TYPE_IMAGE_HORIZONTAL || type == TYPE_IMAGE_VERTICAL || type == TYPE_IMAGE_SCALED)) {
                 int ilen = images.length;
                 for (int iter = 0; iter < ilen; iter++) {
-                    if (images[iter] != b.images[iter]) {
+                    if (images[iter] != b.images[iter]) { //NOPMD CompareObjectsWithEquals
                         return false;
                     }
                 }

--- a/CodenameOne/src/com/codename1/ui/plaf/DefaultLookAndFeel.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/DefaultLookAndFeel.java
@@ -2254,7 +2254,7 @@ public class DefaultLookAndFeel extends LookAndFeel implements FocusListener {
             }
         }
 
-        if (pull.getComponentAt(0) != updating && cmpToDraw != pull.getComponentAt(0)) {
+        if (pull.getComponentAt(0) != updating && cmpToDraw != pull.getComponentAt(0)) { //NOPMD CompareObjectsWithEquals
 
             parentForm.registerAnimated(new Animation() {
 
@@ -2272,7 +2272,7 @@ public class DefaultLookAndFeel extends LookAndFeel implements FocusListener {
                 public boolean animate() {
                     counter++;
 
-                    if (pull.getComponentAt(0) == releaseToRefresh) {
+                    if (pull.getComponentAt(0) == releaseToRefresh) { //NOPMD CompareObjectsWithEquals
                         ((Label) releaseToRefresh).setIcon(i.rotate(180 - (180 / 6) * counter));
                     } else {
                         ((Label) pullDown).setIcon(i.rotate(180 * counter / 6));
@@ -2303,13 +2303,13 @@ public class DefaultLookAndFeel extends LookAndFeel implements FocusListener {
             });
 
         }
-        if (pull.getComponentAt(0) != cmpToDraw
+        if (pull.getComponentAt(0) != cmpToDraw //NOPMD CompareObjectsWithEquals
                 && cmpToDraw instanceof Label
                 && (pull.getComponentAt(0) instanceof Label)) {
             ((Label) cmpToDraw).setIcon(((Label) pull.getComponentAt(0)).getIcon());
         }
         Component current = pull.getComponentAt(0);
-        if (current != cmpToDraw) {
+        if (current != cmpToDraw) { //NOPMD CompareObjectsWithEquals
             pull.replace(current, cmpToDraw, null);
         }
 

--- a/CodenameOne/src/com/codename1/ui/plaf/Style.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/Style.java
@@ -2391,7 +2391,7 @@ public class Style {
             }
             return;
         }
-        if (this.bgImage != bgImage) {
+        if (this.bgImage != bgImage) { //NOPMD CompareObjectsWithEquals
             this.bgImage = bgImage;
             if (!override) {
                 modifiedFlag |= BG_IMAGE_MODIFIED;

--- a/CodenameOne/src/com/codename1/ui/plaf/UIManager.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/UIManager.java
@@ -1707,7 +1707,7 @@ public class UIManager {
             Object value = entry.getValue();
             if (value instanceof Font) {
                 Font scaled = scaleFontForLargerText((Font) value, scale);
-                if (scaled != value) {
+                if (scaled != value) { //NOPMD CompareObjectsWithEquals
                     entry.setValue(scaled);
                 }
             }

--- a/CodenameOne/src/com/codename1/ui/scene/Node.java
+++ b/CodenameOne/src/com/codename1/ui/scene/Node.java
@@ -530,7 +530,7 @@ public class Node {
      * @param child
      */
     public void remove(Node child) {
-        if (child.parent != this) {
+        if (child.parent != this) { //NOPMD CompareObjectsWithEquals
             return;
         }
         if (children != null) {

--- a/CodenameOne/src/com/codename1/ui/spinner/Picker.java
+++ b/CodenameOne/src/com/codename1/ui/spinner/Picker.java
@@ -903,7 +903,7 @@ public class Picker extends Button {
         stopEditingCallback = onFinish;
         Form f = this.getComponentForm();
         if (f != null) {
-            if (f.getCurrentInputDevice() == currentInput) {
+            if (f.getCurrentInputDevice() == currentInput) { //NOPMD CompareObjectsWithEquals
                 try {
                     f.setCurrentInputDevice(null);
                 } catch (Throwable t) {
@@ -916,7 +916,7 @@ public class Picker extends Button {
     @Override
     public boolean isEditing() {
         Form f = this.getComponentForm();
-        boolean out = currentInput != null && f != null && f.getCurrentInputDevice() == currentInput;
+        boolean out = currentInput != null && f != null && f.getCurrentInputDevice() == currentInput; //NOPMD CompareObjectsWithEquals
 
         return out;
     }

--- a/CodenameOne/src/com/codename1/ui/spinner/SpinnerNode.java
+++ b/CodenameOne/src/com/codename1/ui/spinner/SpinnerNode.java
@@ -105,7 +105,7 @@ class SpinnerNode extends Node {
     }
 
     public void setRowFormatter(RowFormatter formatter) {
-        if (rowFormatter != formatter) {
+        if (rowFormatter != formatter) { //NOPMD CompareObjectsWithEquals
             rowFormatter = formatter;
             rebuildChildren();
         }

--- a/CodenameOne/src/com/codename1/ui/tree/Tree.java
+++ b/CodenameOne/src/com/codename1/ui/tree/Tree.java
@@ -453,7 +453,7 @@ public class Tree extends Container {
         }
         Container p = c.getParent();
         for (int iter = 0; iter < p.getComponentCount(); iter++) {
-            if (p.getComponentAt(iter) != c) {
+            if (p.getComponentAt(iter) != c) { //NOPMD CompareObjectsWithEquals
                 if (t == null) {
                     p.removeComponent(p.getComponentAt(iter));
                     break; // there should only be one container with all children

--- a/CodenameOne/src/com/codename1/ui/util/UIBuilder.java
+++ b/CodenameOne/src/com/codename1/ui/util/UIBuilder.java
@@ -553,7 +553,7 @@ public class UIBuilder { //implements Externalizable {
         Component c = (Component) rootComponent.getClientProperty("%" + name + "%");
         if (c == null) {
             Container newRoot = getRootAncestor(rootComponent);
-            if (newRoot != null && rootComponent != newRoot) {
+            if (newRoot != null && rootComponent != newRoot) { //NOPMD CompareObjectsWithEquals
                 return findByName(name, newRoot);
             }
         }
@@ -571,7 +571,7 @@ public class UIBuilder { //implements Externalizable {
         Component c = (Component) rootComponent.getClientProperty("%" + name + "%");
         if (c == null) {
             Container newRoot = getRootAncestor(rootComponent);
-            if (newRoot != null && rootComponent != newRoot) {
+            if (newRoot != null && rootComponent != newRoot) { //NOPMD CompareObjectsWithEquals
                 return findByName(name, newRoot);
             }
         }
@@ -1991,7 +1991,7 @@ public class UIBuilder { //implements Externalizable {
 
     private boolean isParentOf(Container cnt, Component c) {
         while (c != null) {
-            if (c == cnt) {
+            if (c == cnt) { //NOPMD CompareObjectsWithEquals
                 return true;
             }
             c = c.getParent();
@@ -2252,7 +2252,7 @@ public class UIBuilder { //implements Externalizable {
             getFormListenerInstance(newForm, null);
 
             for (int iter = 0; iter < currentForm.getCommandCount(); iter++) {
-                if (backCommand == currentForm.getCommand(iter)) {
+                if (backCommand == currentForm.getCommand(iter)) { //NOPMD CompareObjectsWithEquals
                     newForm.addCommand(backCommand, newForm.getCommandCount());
                     break;
                 }
@@ -2309,7 +2309,7 @@ public class UIBuilder { //implements Externalizable {
                         t = t.copy(true);
                     } else {
                         if (sourceCommand != null) {
-                            if (t != null && backCommands != null && backCommands.contains(sourceCommand) || Display.getInstance().getCurrent().getBackCommand() == sourceCommand) {
+                            if (t != null && backCommands != null && backCommands.contains(sourceCommand) || Display.getInstance().getCurrent().getBackCommand() == sourceCommand) { //NOPMD CompareObjectsWithEquals
                                 isBack = true;
                                 t = t.copy(true);
                             }
@@ -2444,7 +2444,7 @@ public class UIBuilder { //implements Externalizable {
             currentForm = Display.getInstance().getCurrent();
         }
         Vector formNavigationStack = baseFormNavigationStack;
-        if (sourceCommand != null && currentForm != null && currentForm.getBackCommand() == sourceCommand) {
+        if (sourceCommand != null && currentForm != null && currentForm.getBackCommand() == sourceCommand) { //NOPMD CompareObjectsWithEquals
             exitForm(currentForm);
             if (formNavigationStack != null && formNavigationStack.size() > 0) {
                 String name = f.getName();
@@ -2792,7 +2792,7 @@ public class UIBuilder { //implements Externalizable {
         }
 
         private void waitForForm(Form f) {
-            while (Display.getInstance().getCurrent() != f) {
+            while (Display.getInstance().getCurrent() != f) { //NOPMD CompareObjectsWithEquals
                 try {
                     Thread.sleep(5);
                 } catch (InterruptedException ex) {
@@ -2880,7 +2880,7 @@ public class UIBuilder { //implements Externalizable {
                     String firstScreen = action.substring(0, pos);
                     String nextScreen = action.substring(pos + 1);
                     Form f = (Form) createContainer(fetchResourceFile(), firstScreen);
-                    if (Display.getInstance().getCurrent().getBackCommand() == cmd) {
+                    if (Display.getInstance().getCurrent().getBackCommand() == cmd) { //NOPMD CompareObjectsWithEquals
                         onBackNavigation();
                         beforeShow(f);
                         f.showBack();
@@ -2900,7 +2900,7 @@ public class UIBuilder { //implements Externalizable {
                         exitForm(currentForm);
                     }
                     Form f = (Form) createContainer(fetchResourceFile(), action);
-                    if (Display.getInstance().getCurrent().getBackCommand() == cmd) {
+                    if (Display.getInstance().getCurrent().getBackCommand() == cmd) { //NOPMD CompareObjectsWithEquals
                         onBackNavigation();
                         beforeShow(f);
                         f.showBack();

--- a/CodenameOne/src/com/codename1/ui/validation/Validator.java
+++ b/CodenameOne/src/com/codename1/ui/validation/Validator.java
@@ -524,7 +524,7 @@ public class Validator {
                     public void focusGained(Component cmp) {
                         // special case. Before the form is showing don't show error dialogs
                         Form p = cmp.getComponentForm();
-                        if (p != Display.getInstance().getCurrent()) {
+                        if (p != Display.getInstance().getCurrent()) { //NOPMD CompareObjectsWithEquals
                             return;
                         }
                         if (message != null) {

--- a/CodenameOne/src/com/codename1/util/EasyThread.java
+++ b/CodenameOne/src/com/codename1/util/EasyThread.java
@@ -209,7 +209,7 @@ public final class EasyThread {
      * @return true if we are currently within this easy thread
      */
     public boolean isThisIt() {
-        return t == Thread.currentThread();
+        return t == Thread.currentThread(); //NOPMD CompareObjectsWithEquals
     }
 
     /**

--- a/CodenameOne/src/com/codename1/util/TMultiplication.java
+++ b/CodenameOne/src/com/codename1/util/TMultiplication.java
@@ -260,7 +260,7 @@ final class TMultiplication {
     }
 
     static void multPAP(int[] a, int[] b, int[] t, int aLen, int bLen) {
-        if (a == b && aLen == bLen) {
+        if (a == b && aLen == bLen) { //NOPMD CompareObjectsWithEquals
             square(a, aLen, t);
             return;
         }

--- a/CodenameOne/src/com/codename1/xml/Element.java
+++ b/CodenameOne/src/com/codename1/xml/Element.java
@@ -484,7 +484,7 @@ public class Element implements Iterable<Element> {
      * @return true if this element contains the specified element, false otherwise
      */
     public boolean contains(Element element) {
-        if (this == element) {
+        if (this == element) { //NOPMD CompareObjectsWithEquals
             return true;
         }
         if (children != null) {
@@ -624,7 +624,7 @@ public class Element implements Iterable<Element> {
         int result = -1;
         if (children != null) {
             for (int i = 0; i < children.size(); i++) {
-                if (child == children.get(i)) {
+                if (child == children.get(i)) { //NOPMD CompareObjectsWithEquals
                     result = i;
                     break;
                 }

--- a/maven/core-unittests/pmd.xml
+++ b/maven/core-unittests/pmd.xml
@@ -16,5 +16,6 @@
         level and can't just replace them -->
         <exclude name="LooseCoupling" />
         <exclude name="ReturnEmptyCollectionRatherThanNull"/>
+        <exclude name="UncommentedEmptyMethodBody"/>
     </rule>
 </ruleset>


### PR DESCRIPTION
### Motivation
- Silence existing PMD `CompareObjectsWithEquals` findings where identity comparisons are intentional so CI isn't noisy while preserving existing semantics.
- Make sure future PRs fail the quality gate for new `CompareObjectsWithEquals` violations by adding the rule to the enforced PMD list.
- Remove the redundant `UncommentedEmptyMethodBody` PMD rule from the core unit-tests ruleset.

### Description
- Added inline suppressions (`//NOPMD CompareObjectsWithEquals`) at existing identity comparison sites across Codename One sources to explicitly document and silence intentional `==`/`!=` usage without changing runtime behavior.
- Marked the PMD rule `CompareObjectsWithEquals` as forbidden in the QA gating script by adding it to the `forbidden_pmd_rules` set in `.github/scripts/generate-quality-report.py` so the PR-quality report will fail on new violations.
- Excluded the redundant PMD rule `UncommentedEmptyMethodBody` from `maven/core-unittests/pmd.xml` to avoid duplicate/irrelevant warnings.

### Testing
- No automated tests were executed as part of this change (no unit or CI run was requested); changes are limited to targeted inline suppressions and quality-report configuration updates.
- The quality-report script was updated to treat `CompareObjectsWithEquals` as a forbidden PMD rule; this will cause CI to fail on future occurrences when the script runs in the PR pipeline.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e5412df9883318cd29b205ea34cff)