### PR TITLE
Add IntelliJ-style Checkstyle config for core-unittests

### DIFF
--- a/maven/core-unittests/checkstyle.xml
+++ b/maven/core-unittests/checkstyle.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<module name="Checker">
+    <module name="FileTabCharacter">
+        <property name="eachLine" value="true"/>
+    </module>
+    <module name="NewlineAtEndOfFile"/>
+
+    <module name="TreeWalker">
+        <module name="Indentation">
+            <property name="basicOffset" value="4"/>
+            <property name="braceAdjustment" value="0"/>
+            <property name="caseIndent" value="4"/>
+            <property name="lineWrappingIndentation" value="8"/>
+            <property name="tabWidth" value="4"/>
+        </module>
+        <module name="WhitespaceAfter"/>
+        <module name="WhitespaceAround"/>
+        <module name="LeftCurly"/>
+        <module name="RightCurly"/>
+    </module>
+</module>

--- a/maven/core-unittests/pom.xml
+++ b/maven/core-unittests/pom.xml
@@ -116,7 +116,7 @@
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <version>3.3.0</version>
                 <configuration>
-                    <configLocation>google_checks.xml</configLocation>
+                    <configLocation>${project.basedir}/checkstyle.xml</configLocation>
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <consoleOutput>false</consoleOutput>
                     <failsOnError>false</failsOnError>


### PR DESCRIPTION
### Motivation
- Ensure the core unit tests module runs Checkstyle with IntelliJ/IDEA defaults (4-space indentation and related whitespace/brace rules) so CI aligns with the project's preferred formatting.

### Description
- Add a project-local Checkstyle configuration at `maven/core-unittests/checkstyle.xml` and update `maven/core-unittests/pom.xml` to point the `maven-checkstyle-plugin` `configLocation` to `${project.basedir}/checkstyle.xml`.

### Testing
- No automated tests were run as part of this change (Checkstyle will be evaluated by the existing CI `verify` phase when the pipeline runs).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a5baebda8833186d5568c3de25774)