### PR TITLE
Limit core-unittests Checkstyle scope and allow empty {} method/constructor bodies

### DIFF
--- a/maven/core-unittests/checkstyle.xml
+++ b/maven/core-unittests/checkstyle.xml
@@ -16,7 +16,10 @@
             <property name="tabWidth" value="4"/>
         </module>
         <module name="WhitespaceAfter"/>
-        <module name="WhitespaceAround"/>
+        <module name="WhitespaceAround">
+            <property name="allowEmptyMethods" value="true"/>
+            <property name="allowEmptyConstructors" value="true"/>
+        </module>
         <module name="LeftCurly"/>
         <module name="RightCurly"/>
     </module>

--- a/maven/core-unittests/pom.xml
+++ b/maven/core-unittests/pom.xml
@@ -121,7 +121,7 @@
                     <consoleOutput>false</consoleOutput>
                     <failsOnError>false</failsOnError>
                     <linkXRef>false</linkXRef>
-                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                    <includeTestSourceDirectory>false</includeTestSourceDirectory>
                     <outputFile>${project.build.directory}/checkstyle-result.xml</outputFile>
                     <outputFileFormat>xml</outputFileFormat>
                     <sourceDirectories>


### PR DESCRIPTION
### Motivation
- Checkstyle for `maven/core-unittests` was applying to test sources and flagged empty method/constructor bodies written as `{}`, so the configuration should be limited to the CodenameOne source tree and permit empty bodies.

### Description
- Set `<includeTestSourceDirectory>false>` in `maven/core-unittests/pom.xml` so Checkstyle only analyzes the configured `sourceDirectory` (`${src.dir}`) and not test or other module sources.
- Update `maven/core-unittests/checkstyle.xml` to add `allowEmptyMethods=true` and `allowEmptyConstructors=true` to the `WhitespaceAround` module so `{}` bodies are accepted.

### Testing
- No automated tests or CI jobs were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a5feb155883318e8991ef4781b5df)