### PR TITLE
Suppress checkstyle for gzip sources

### DIFF
--- a/maven/core-unittests/checkstyle.xml
+++ b/maven/core-unittests/checkstyle.xml
@@ -2,6 +2,10 @@
 <!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
         "https://checkstyle.org/dtds/configuration_1_3.dtd">
 <module name="Checker">
+    <module name="SuppressionSingleFilter">
+        <property name="checks" value=".*"/>
+        <property name="files" value=".*[\\\\/]com[\\\\/]codename1[\\\\/]io[\\\\/]gzip[\\\\/].*"/>
+    </module>
     <module name="FileTabCharacter">
         <property name="eachLine" value="true"/>
     </module>


### PR DESCRIPTION
### Motivation
- Disable Checkstyle for the third-party-like gzip implementation under `CodenameOne/src/com/codename1/io/gzip` so the core unit test Checkstyle run does not report issues for those files.

### Description
- Add a `SuppressionSingleFilter` to `maven/core-unittests/checkstyle.xml` that matches all checks (`.*`) for files under `com/codename1/io/gzip` using a path regex.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ac656e7008331bd38a06f09970484)