### PR TITLE
Move Javadoc build script into .github and add CI workflow

### DIFF
--- a/.github/scripts/build_javadocs.sh
+++ b/.github/scripts/build_javadocs.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+CN1_DIR="$ROOT_DIR/CodenameOne"
+
+JDK_HOME="${JDK_25_HOME:-${JAVA_HOME:-}}"
+if [ -n "$JDK_HOME" ] && [ -x "$JDK_HOME/bin/javadoc" ]; then
+  JAVADOC_CMD="$JDK_HOME/bin/javadoc"
+else
+  JAVADOC_CMD="javadoc"
+fi
+
+rm -rf "$CN1_DIR/dist/javadoc"
+rm -rf "$CN1_DIR/build/tempJavaSources"
+
+mkdir -p "$CN1_DIR/build/tempJavaSources"
+mkdir -p "$CN1_DIR/dist/javadoc"
+
+cp -r "$CN1_DIR/src/"* "$CN1_DIR/build/tempJavaSources/"
+
+cat > "$CN1_DIR/build/tempJavaSources/com/codename1/impl/ImplementationFactory.java" <<'EOF'
+package com.codename1.impl;
+
+public class ImplementationFactory {
+    public static ImplementationFactory getInstance() {
+        return null;
+    }
+
+    public Object createImplementation() {
+        return null;
+    }
+}
+EOF
+
+find "$CN1_DIR/build/tempJavaSources" "$ROOT_DIR/Ports/CLDC11/src" -name "*.java" -not -path "$ROOT_DIR/Ports/CLDC11/src/java/*" \
+  | /usr/bin/xargs "$JAVADOC_CMD" --allow-script-in-comments --release 8 -exclude com.codename1.impl -Xdoclint:none -quiet -protected -d "$CN1_DIR/dist/javadoc" -windowtitle "Codename One API" || true
+
+(
+  cd "$CN1_DIR/dist/javadoc"
+  zip -r "$CN1_DIR/javadocs.zip" .
+)

--- a/.github/workflows/javadocs.yml
+++ b/.github/workflows/javadocs.yml
@@ -1,0 +1,49 @@
+name: Build JavaDocs
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - main
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+jobs:
+  build-javadocs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+
+      - name: Capture Java 25 path
+        run: echo "JDK_25_HOME=$JAVA_HOME" >> "$GITHUB_ENV"
+
+      - name: Build JavaDocs
+        run: ./.github/scripts/build_javadocs.sh
+
+      - name: Verify JavaDocs archive
+        run: test -f CodenameOne/javadocs.zip
+
+      - name: Upload JavaDocs artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: CodenameOne-javadocs
+          path: CodenameOne/javadocs.zip
+
+      - name: Attach JavaDocs to release
+        if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            CodenameOne/javadocs.zip

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -262,34 +262,7 @@ jobs:
 
       - name: Build JavaDocs
         if: matrix.java-version == 8
-        run: |
-          cd CodenameOne
-          mkdir -p build
-          mkdir -p build/tempJavaSources
-          mkdir -p dist
-          mkdir -p dist/javadoc
-          # Skip JavaDocSourceEmbed due to gist access issues in CI
-          cp -r src/* build/tempJavaSources/
-          # Provide a minimal ImplementationFactory stub for Javadoc type resolution on JDK 25.
-          cat > build/tempJavaSources/com/codename1/impl/ImplementationFactory.java <<'EOF'
-          package com.codename1.impl;
-
-          public class ImplementationFactory {
-              public static ImplementationFactory getInstance() {
-                  return null;
-              }
-
-              public Object createImplementation() {
-                  return null;
-              }
-          }
-          EOF
-          # Suppress doclint noise on modern JDKs (e.g., Java 25) while keeping output consistent.
-          # Exclude CLDC11 java.* stubs to avoid module conflicts on modern JDKs.
-          find build/tempJavaSources ../Ports/CLDC11/src -name "*.java" -not -path "../Ports/CLDC11/src/java/*" | /usr/bin/xargs javadoc --allow-script-in-comments --release 8 -exclude com.codename1.impl -Xdoclint:none -quiet -protected -d dist/javadoc -windowtitle "Codename One API" || true
-          cd dist/javadoc
-          zip -r ../../javadocs.zip *
-          cd ..
+        run: ./.github/scripts/build_javadocs.sh
 
       - name: Restore Java 8 after JavaDocs
         if: matrix.java-version == 8

--- a/CodenameOne/build.xml
+++ b/CodenameOne/build.xml
@@ -88,7 +88,7 @@
                 <exclude name="*.java"/>
             </fileset>
         </javadoc -->
-        <exec executable="./build_javadoc.sh" failonerror="false" />
+        <exec executable="../.github/scripts/build_javadocs.sh" failonerror="false" />
         
         <copy todir="${dist.javadoc.dir}">
             <fileset dir="${src.dir}" excludes="${excludes}" includes="${includes}">

--- a/CodenameOne/build_javadoc.sh
+++ b/CodenameOne/build_javadoc.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-rm -Rf dist/javadoc
-rm -Rf build/tempJavaSources
-java -jar ~/dev/java/JavaDocSourceEmbed/target/JavaDocSourceEmbed-1.0-SNAPSHOT.jar src build/tempJavaSources
-
-/usr/bin/find build/tempJavaSources ../Ports/CLDC11/src -name "*.java" | /usr/bin/grep -v /impl/ | /usr/bin/xargs javadoc --allow-script-in-comments -protected -d dist/javadoc -windowtitle "Codename One API"


### PR DESCRIPTION
### Motivation
- Centralize the Javadoc build flow used by CI and releases so the same script is reused in PRs and release pipelines.
- Ensure Javadoc generation follows the CI Java 25 invocation and produces an artifact that can be packaged with releases.
- Replace the old repository-root script with a predictable, CI-friendly script under `.github` so workflows can validate and attach the archive.

### Description
- Add a reusable script ` .github/scripts/build_javadocs.sh` that copies sources, injects a minimal `ImplementationFactory` stub, runs `javadoc` (using `JDK_25_HOME`/`JAVA_HOME` when available), and produces `CodenameOne/javadocs.zip`.
- Add a GitHub Actions workflow ` .github/workflows/javadocs.yml` that runs on `pull_request`, `push` to `main`/`master`, and published `release` events, verifies `CodenameOne/javadocs.zip`, uploads it as an artifact, and attaches it to releases.
- Update the PR workflow in ` .github/workflows/pr.yml` to reuse the shared script for the JavaDocs step.
- Update `CodenameOne/build.xml` to call the new script and remove the deprecated `CodenameOne/build_javadoc.sh` file.

### Testing
- No automated tests were executed locally as part of this change because it only modifies CI/build scripts and workflows.
- A CI workflow `Build JavaDocs` was added that will validate the script when runs occur by checking for `CodenameOne/javadocs.zip` and uploading it as an artifact in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980d27323808331a9ba327f72b38bd3)