### PR TITLE
Generate complete clean-target headers and drop test patches

### DIFF
--- a/vm/ByteCodeTranslator/src/cn1_globals.h
+++ b/vm/ByteCodeTranslator/src/cn1_globals.h
@@ -1029,6 +1029,7 @@ extern void initMethodStack(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT __cn1ThisObje
 
 
 #if defined(__APPLE__) && defined(__OBJC__)
+@class NSString;
 extern JAVA_OBJECT fromNSString(CODENAME_ONE_THREAD_STATE, NSString* str);
 extern NSString* toNSString(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT o);
 #else

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
@@ -1103,10 +1103,6 @@ public class BytecodeMethod implements SignatureSet {
             returnType.appendCMethodExt(bld);
         }
         
-        if(!forceVirtual && !virtualMethodsInvoked.contains(bld.toString())) {
-            return;
-        }
-                
         // generate the function pointer declaration
         appendCMethodPrefix("\ntypedef ", ")", b, "(*functionPtr_", cls);
         b.append(";\n");
@@ -1155,9 +1151,6 @@ public class BytecodeMethod implements SignatureSet {
         if(!returnType.isVoid()) {
             bld.append("_R");
             returnType.appendCMethodExt(bld);
-        }
-        if(!forceVirtual && !virtualMethodsInvoked.contains(bld.toString())) {
-            return;
         }
         appendCMethodPrefix(b, "virtual_", cls);
         b.append(";\n");

--- a/vm/tests/src/test/java/com/codename1/tools/translator/BytecodeInstructionIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/BytecodeInstructionIntegrationTest.java
@@ -111,7 +111,6 @@ class BytecodeInstructionIntegrationTest {
         assertTrue(Files.exists(cmakeLists), "Translator should emit a CMake project for the optimized sample");
 
         Path srcRoot = distDir.resolve("CustomBytecodeApp-src");
-        CleanTargetIntegrationTest.patchCn1Globals(srcRoot);
 
         Path generatedSource = findGeneratedSource(srcRoot);
         String generatedCode = new String(Files.readAllBytes(generatedSource), StandardCharsets.UTF_8);
@@ -262,7 +261,6 @@ class BytecodeInstructionIntegrationTest {
         assertTrue(Files.exists(cmakeLists), "Translator should emit a CMake project for Invoke/Ldc sample");
 
         Path srcRoot = distDir.resolve("InvokeLdcLocalVars-src");
-        CleanTargetIntegrationTest.patchCn1Globals(srcRoot);
 
         Path generatedSource = findGeneratedSource(srcRoot, "InvokeLdcLocalVarsApp");
         String generatedCode = new String(Files.readAllBytes(generatedSource), StandardCharsets.UTF_8);

--- a/vm/tests/src/test/java/com/codename1/tools/translator/CleanTargetIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/CleanTargetIntegrationTest.java
@@ -79,7 +79,6 @@ class CleanTargetIntegrationTest {
         assertTrue(Files.exists(cmakeLists), "Translator should emit a CMake project");
 
         Path srcRoot = distDir.resolve("HelloCleanApp-src");
-        patchCn1Globals(srcRoot);
 
         replaceLibraryWithExecutableTarget(cmakeLists, srcRoot.getFileName().toString());
 
@@ -180,20 +179,6 @@ class CleanTargetIntegrationTest {
         assertEquals(0, exit, "Command failed: " + String.join(" ", command) + "\nOutput:\n" + output);
         return output;
     }
-
-    static void patchCn1Globals(Path srcRoot) throws IOException {
-        Path cn1Globals = srcRoot.resolve("cn1_globals.h");
-        String content = new String(Files.readAllBytes(cn1Globals), StandardCharsets.UTF_8);
-        if (!content.contains("@class NSString;")) {
-            content = content.replace("#ifdef __OBJC__\n", "#ifdef __OBJC__\n@class NSString;\n");
-            Files.write(cn1Globals, content.getBytes(StandardCharsets.UTF_8));
-        }
-        if (!content.contains("#include <string.h>")) {
-            content = content.replace("#include <stdlib.h>\n", "#include <stdlib.h>\n#include <string.h>\n#include <math.h>\n#include <limits.h>\n");
-            Files.write(cn1Globals, content.getBytes(StandardCharsets.UTF_8));
-        }
-    }
-
 
     static String helloWorldSource() {
         return "public class HelloWorld {\n" +

--- a/vm/tests/src/test/java/com/codename1/tools/translator/CompilerHelper.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/CompilerHelper.java
@@ -230,8 +230,6 @@ public class CompilerHelper {
             CleanTargetIntegrationTest.runTranslator(classesDir, outputDir, "ExecutorApp");
 
             java.nio.file.Path distDir = outputDir.resolve("dist");
-            java.nio.file.Path srcRoot = distDir.resolve("ExecutorApp-src");
-            CleanTargetIntegrationTest.patchCn1Globals(srcRoot);
 
             CleanTargetIntegrationTest.replaceLibraryWithExecutableTarget(outputDir.resolve("dist").resolve("CMakeLists.txt"), "ExecutorApp-src");
 

--- a/vm/tests/src/test/java/com/codename1/tools/translator/FileClassIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/FileClassIntegrationTest.java
@@ -70,8 +70,6 @@ public class FileClassIntegrationTest {
         assertTrue(Files.exists(cmakeLists), "Translator should emit a CMake project");
 
         Path srcRoot = distDir.resolve("FileTestApp-src");
-        CleanTargetIntegrationTest.patchCn1Globals(srcRoot);
-
         replaceLibraryWithExecutableTarget(cmakeLists, srcRoot.getFileName().toString());
 
         Path buildDir = distDir.resolve("build");

--- a/vm/tests/src/test/java/com/codename1/tools/translator/LambdaIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/LambdaIntegrationTest.java
@@ -118,7 +118,6 @@ class LambdaIntegrationTest {
         assertTrue(Files.exists(cmakeLists), "Translator should emit a CMake project");
 
         Path srcRoot = distDir.resolve("LambdaApp-src");
-        CleanTargetIntegrationTest.patchCn1Globals(srcRoot);
 
         CleanTargetIntegrationTest.replaceLibraryWithExecutableTarget(cmakeLists, srcRoot.getFileName().toString());
 

--- a/vm/tests/src/test/java/com/codename1/tools/translator/LockIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/LockIntegrationTest.java
@@ -75,9 +75,6 @@ class LockIntegrationTest {
         Path cmakeLists = distDir.resolve("CMakeLists.txt");
         assertTrue(Files.exists(cmakeLists));
 
-        Path srcRoot = distDir.resolve("LockTestApp-src");
-        CleanTargetIntegrationTest.patchCn1Globals(srcRoot);
-
         Path buildDir = distDir.resolve("build");
         Files.createDirectories(buildDir);
 

--- a/vm/tests/src/test/java/com/codename1/tools/translator/ReadWriteLockIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/ReadWriteLockIntegrationTest.java
@@ -75,10 +75,6 @@ class ReadWriteLockIntegrationTest {
         Path cmakeLists = distDir.resolve("CMakeLists.txt");
         assertTrue(Files.exists(cmakeLists));
 
-        Path srcRoot = distDir.resolve("ReadWriteLockTestApp-src");
-        CleanTargetIntegrationTest.patchCn1Globals(srcRoot);
-        ensureReentrantReadWriteLockHeader(srcRoot);
-
         Path buildDir = distDir.resolve("build");
         Files.createDirectories(buildDir);
 
@@ -191,18 +187,4 @@ class ReadWriteLockIntegrationTest {
     }
 
 
-    private void ensureReentrantReadWriteLockHeader(Path srcRoot) throws java.io.IOException {
-        Path header = srcRoot.resolve("java_util_concurrent_locks_ReentrantReadWriteLock.h");
-        if (!Files.exists(header)) {
-            return;
-        }
-        String content = new String(Files.readAllBytes(header), StandardCharsets.UTF_8);
-        if (content.contains("virtual_java_util_concurrent_locks_ReentrantReadWriteLock_readLock")) {
-            return;
-        }
-        String additions = "JAVA_OBJECT virtual_java_util_concurrent_locks_ReentrantReadWriteLock_readLock___R_java_util_concurrent_locks_ReentrantReadWriteLock_ReadLock(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT __cn1ThisObject);\n" +
-                "JAVA_OBJECT virtual_java_util_concurrent_locks_ReentrantReadWriteLock_writeLock___R_java_util_concurrent_locks_ReentrantReadWriteLock_WriteLock(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT __cn1ThisObject);\n";
-        content = content.replace("#endif\n", additions + "#endif\n");
-        Files.write(header, content.getBytes(StandardCharsets.UTF_8));
-    }
 }

--- a/vm/tests/src/test/java/com/codename1/tools/translator/StampedLockIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/StampedLockIntegrationTest.java
@@ -75,9 +75,6 @@ class StampedLockIntegrationTest {
         Path cmakeLists = distDir.resolve("CMakeLists.txt");
         assertTrue(Files.exists(cmakeLists));
 
-        Path srcRoot = distDir.resolve("StampedLockTestApp-src");
-        CleanTargetIntegrationTest.patchCn1Globals(srcRoot);
-
         Path buildDir = distDir.resolve("build");
         Files.createDirectories(buildDir);
 


### PR DESCRIPTION
### Motivation
- Ensure the Bytecode translator emits self-contained, correct C/Obj-C headers so generated projects build without test-time header fixes. 
- Prevent tests from mutating generated translator output at runtime, which masked generator bugs and caused flaky behavior. 

### Description
- Add an Objective-C forward declaration for `NSString` to `cn1_globals.h` so generated headers are self-contained for Obj-C builds (`vm/ByteCodeTranslator/src/cn1_globals.h`).
- Unconditionally emit virtual method function-pointer typedefs, wrappers and header declarations from the translator by removing the `virtualMethodsInvoked` guard in `appendVirtualMethodC`/`appendVirtualMethodHeader` (`vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java`).
- Remove test-time patching helpers and calls that modified generated headers (remove `patchCn1Globals` and `ensureReentrantReadWriteLockHeader` usages), and update integration tests to build the generated source as-is (`vm/tests/src/test/java/com/codename1/tools/translator/*`).
- Update `CompilerHelper` and several integration tests to stop calling the removed patch routines so tests no longer alter translator output (`vm/tests/.../CompilerHelper.java`, `BytecodeInstructionIntegrationTest.java`, `CleanTargetIntegrationTest.java`, `FileClassIntegrationTest.java`, `LambdaIntegrationTest.java`, `LockIntegrationTest.java`, `ReadWriteLockIntegrationTest.java`, `StampedLockIntegrationTest.java`).

### Testing
- No automated tests were executed as part of this change (no CI/test run was requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984e0897030833184ba28351a5432d3)