### PR TITLE
Ensure Sheets render above native peers by enabling lightweight mode and adding blocker

### DIFF
--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/BrowserComponentScreenshotTest.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/BrowserComponentScreenshotTest.java
@@ -58,13 +58,16 @@ public class BrowserComponentScreenshotTest extends BaseTest {
             return;
         }
 
-        if (!sheetShown) {
-            sheetShown = true;
-            Sheet sheet = new Sheet(null, "Browser Sheet");
-            sheet.show();
-        }
-        UITimer.timer(2000, false, form, readyRunnable);
+        Runnable run = readyRunnable;
         readyRunnable = null;
+        UITimer.timer(300, false, form, () -> {
+            if (!sheetShown) {
+                sheetShown = true;
+                Sheet sheet = new Sheet(null, "Browser Sheet");
+                sheet.show(0);
+            }
+            UITimer.timer(700, false, form, run);
+        });
     }
 
     private static String buildHtml() {


### PR DESCRIPTION
### Motivation
- Fix an iOS rendering bug where a `Sheet` could appear behind native peers (e.g. `BrowserComponent`) by making the form render in lightweight mode while the sheet is visible.
- Prevent native peers from receiving pointer events and visually overlapping the sheet by inserting a full-screen blocker into the sheet layer when peers are present.
- Keep existing sheet animation/layout behavior while isolating sheet content into a dedicated sheet layer so replacement/animation works reliably.

### Description
- Enable lightweight rendering on the current `Form` when showing a sheet if `Form.activePeerCount > 0` by calling `f.setLightweightMode(true)` before showing and restoring it after the sheet is hidden.
- Create and use a dedicated sheet layer retrieved via the new `getSheetLayer(Container)` helper that stores the layer in a client property `cn1$sheetLayer` and centralizes layout/animation work.
- Add `ensureSheetBlocker(Container, Container)` which manages a `SheetBlocker` component stored under client property `cn1$sheetBlocker` to block pointer events and cover the display when native peers exist, and remove it when no peers are active.
- Add inner class `SheetBlocker` that grabs pointer events and reports full-screen preferred size via `calcPreferredSize()`; switch container layout to `LayeredLayout` and update add/replace/animate calls to operate on the sheet layer.
- Update imports to include `Dimension` and modify `BrowserComponentScreenshotTest` to show a `Sheet` during the test to exercise the native-peer/sheet interaction scenario.

### Testing
- No automated tests were executed for this change.
- The `BrowserComponentScreenshotTest` was adjusted to present a `Sheet` to reproduce the issue, but the test was not run in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69877ecbbd048331b55ac367958aa0a6)