### PR TITLE
Add VPN API smoke and unit tests; Test implementation support

### DIFF
--- a/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
+++ b/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
@@ -6281,6 +6281,31 @@ public abstract class CodenameOneImplementation {
     public void setCurrentAccessPoint(String id) {
     }
 
+    /// Indicates whether this platform can attempt to detect active VPN usage.
+    ///
+    /// The default implementation returns `false`. Platforms that provide a
+    /// best-effort VPN heuristic should override this method and `#isVPNActive()`.
+    ///
+    /// #### Returns
+    ///
+    /// `true` if VPN detection is implemented on this platform.
+    public boolean isVPNDetectionSupported() {
+        return false;
+    }
+
+    /// Best-effort check for whether a VPN appears to be active.
+    ///
+    /// This API is intentionally heuristic and should **not** be used as a
+    /// security boundary. False positives and false negatives are both possible,
+    /// and some VPN products may avoid detection completely.
+    ///
+    /// #### Returns
+    ///
+    /// `true` if the platform believes a VPN may be active.
+    public boolean isVPNActive() {
+        return false;
+    }
+
     /// For some reason the standard code for writing UTF8 output in a server request
     /// doesn't work as expected on SE/CDC stacks.
     ///

--- a/CodenameOne/src/com/codename1/io/NetworkManager.java
+++ b/CodenameOne/src/com/codename1/io/NetworkManager.java
@@ -823,6 +823,28 @@ public final class NetworkManager {
         Util.getImplementation().setCurrentAccessPoint(id);
     }
 
+    /// Indicates whether the current platform supports best-effort VPN detection.
+    ///
+    /// #### Returns
+    ///
+    /// `true` if `#isVPNActive()` is implemented on this platform.
+    public boolean isVPNDetectionSupported() {
+        return Util.getImplementation().isVPNDetectionSupported();
+    }
+
+    /// Best-effort check for whether a VPN appears to be active.
+    ///
+    /// This value should be treated as advisory only. Platform APIs and
+    /// interface-name heuristics can miss some VPN configurations and may also
+    /// report non-VPN tunnels as VPNs.
+    ///
+    /// #### Returns
+    ///
+    /// `true` if a VPN appears to be active on the current connection.
+    public boolean isVPNActive() {
+        return Util.getImplementation().isVPNActive();
+    }
+
     class NetworkThread implements Runnable {
         boolean stopped = false;
         private ConnectionRequest currentRequest;

--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -9606,6 +9606,46 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
         return apName;
     }
 
+    @Override
+    public boolean isVPNDetectionSupported() {
+        return true;
+    }
+
+    @Override
+    public boolean isVPNActive() {
+        try {
+            ConnectivityManager cm = (ConnectivityManager) getContext().getSystemService(Context.CONNECTIVITY_SERVICE);
+            if (cm != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                android.net.Network network = cm.getActiveNetwork();
+                if (network != null) {
+                    android.net.NetworkCapabilities capabilities = cm.getNetworkCapabilities(network);
+                    if (capabilities != null && capabilities.hasTransport(android.net.NetworkCapabilities.TRANSPORT_VPN)) {
+                        return true;
+                    }
+                }
+            }
+
+            Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+            while (interfaces != null && interfaces.hasMoreElements()) {
+                NetworkInterface current = interfaces.nextElement();
+                if (!current.isUp() || current.isLoopback()) {
+                    continue;
+                }
+                String name = current.getName();
+                if (name == null) {
+                    continue;
+                }
+                name = name.toLowerCase(Locale.US);
+                if (name.startsWith("tun") || name.startsWith("ppp") || name.startsWith("tap") || name.startsWith("ipsec")) {
+                    return true;
+                }
+            }
+        } catch (Throwable t) {
+            Log.d("Codename One", "VPN detection failed", t);
+        }
+        return false;
+    }
+
     /**
      * @inheritDoc
      */

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
@@ -1223,6 +1223,16 @@ public class IOSImplementation extends CodenameOneImplementation {
     }
 
     @Override
+    public boolean isVPNDetectionSupported() {
+        return true;
+    }
+
+    @Override
+    public boolean isVPNActive() {
+        return nativeInstance.isVPNActive();
+    }
+
+    @Override
     public boolean isLargerTextEnabled() {
         return nativeInstance.isLargerTextEnabled();
     }

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSNative.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSNative.java
@@ -290,7 +290,8 @@ public final class IOSNative {
 
     native boolean isDarkMode();
     native boolean isDarkModeDetectionSupported();
-    
+    native boolean isVPNActive();
+
     native int fileCountInDir(String dir);
     native void listFilesInDir(String dir, String[] files);
     native void createDirectory(String dir);

--- a/docs/developer-guide/io.asciidoc
+++ b/docs/developer-guide/io.asciidoc
@@ -459,6 +459,31 @@ There is one exception to this rule which is the `postResponse()` method designe
 
 IMPORTANT: Never change the UI from a `ConnectionRequest` callback. You can either use a listener on the `ConnectionRequest`, use `postResponse()` (which is the only exception to this rule) or wrap your UI code with `callSerially`.
 
+==== VPN Detection (Best Effort)
+
+`NetworkManager` includes two APIs for querying VPN state:
+
+[source,java]
+----
+NetworkManager nm = NetworkManager.getInstance();
+if (nm.isVPNDetectionSupported()) {
+    boolean vpnActive = nm.isVPNActive();
+}
+----
+
+IMPORTANT: This is a heuristic signal, not a security control.
+
+Both Android and iOS implementations rely on platform networking metadata and
+interface-name patterns (e.g. `tun`, `ppp`, `utun`, `ipsec`). This means the
+result can be wrong in either direction:
+
+* False negatives: Some VPNs may hide or avoid these patterns.
+* False positives: Other virtual/tunnel interfaces may look like VPNs.
+
+Use this API only for UX or diagnostics (e.g. warnings, telemetry, or logging),
+not for access control or fraud prevention by itself.
+
+
 ==== Arguments, Headers & Methods
 
 HTTP/S is a complex protocol that expects complex encoded data for its requests. Codename One tries to simplify and abstract most of these complexities behind common sense API's while still providing the full low level access you would expect from such an API.

--- a/maven/core-unittests/src/test/java/com/codename1/io/NetworkManagerTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/io/NetworkManagerTest.java
@@ -160,6 +160,17 @@ class NetworkManagerTest extends com.codename1.junit.UITestBase {
     }
 
     @Test
+    void vpnDelegatesToImplementation() {
+        implementation.setVPNState(true, true);
+        assertTrue(manager.isVPNDetectionSupported());
+        assertTrue(manager.isVPNActive());
+
+        implementation.setVPNState(false, false);
+        assertFalse(manager.isVPNDetectionSupported());
+        assertFalse(manager.isVPNActive());
+    }
+
+    @Test
     void apDelegatesToImplementation() {
         implementation.setAccessPoints(new String[]{"wifi"},
                 Collections.singletonMap("wifi", NetworkManager.ACCESS_POINT_TYPE_WLAN),

--- a/maven/core-unittests/src/test/java/com/codename1/testing/TestCodenameOneImplementation.java
+++ b/maven/core-unittests/src/test/java/com/codename1/testing/TestCodenameOneImplementation.java
@@ -115,6 +115,8 @@ public class TestCodenameOneImplementation extends CodenameOneImplementation {
     private final Map<String, Integer> accessPointTypes = new HashMap<>();
     private final Map<String, String> accessPointNames = new HashMap<>();
     private String currentAccessPoint;
+    private boolean vpnDetectionSupported;
+    private boolean vpnActive;
     private LocationManager locationManager;
     private L10NManager localizationManager;
     private ImageIO imageIO;
@@ -1059,6 +1061,8 @@ public class TestCodenameOneImplementation extends CodenameOneImplementation {
         accessPointTypes.clear();
         accessPointNames.clear();
         currentAccessPoint = null;
+        vpnDetectionSupported = false;
+        vpnActive = false;
         startRemoteControlInvocations = 0;
         stopRemoteControlInvocations = 0;
         nativeTitle = false;
@@ -1144,6 +1148,12 @@ public class TestCodenameOneImplementation extends CodenameOneImplementation {
         if (names != null) {
             this.accessPointNames.putAll(names);
         }
+    }
+
+
+    public void setVPNState(boolean detectionSupported, boolean active) {
+        this.vpnDetectionSupported = detectionSupported;
+        this.vpnActive = active;
     }
 
     @Override
@@ -2721,6 +2731,16 @@ public class TestCodenameOneImplementation extends CodenameOneImplementation {
     @Override
     public int convertToPixels(int dipCount, boolean horizontal) {
         return dipCount;
+    }
+
+    @Override
+    public boolean isVPNDetectionSupported() {
+        return vpnDetectionSupported;
+    }
+
+    @Override
+    public boolean isVPNActive() {
+        return vpnActive;
     }
 
     @Override

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/Cn1ssDeviceRunner.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/Cn1ssDeviceRunner.java
@@ -73,6 +73,7 @@ public final class Cn1ssDeviceRunner extends DeviceRunner {
             new InPlaceEditViewTest(),
             new BytecodeTranslatorRegressionTest(),
             new BackgroundThreadUiAccessTest(),
+            new VPNDetectionAPITest(),
             new AccessibilityTest()));
 
     public static void addTest(BaseTest test) {

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/VPNDetectionAPITest.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/VPNDetectionAPITest.java
@@ -1,0 +1,23 @@
+package com.codenameone.examples.hellocodenameone.tests;
+
+import com.codename1.io.NetworkManager;
+
+public class VPNDetectionAPITest extends BaseTest {
+    @Override
+    public boolean runTest() {
+        try {
+            NetworkManager manager = NetworkManager.getInstance();
+            manager.isVPNDetectionSupported();
+            manager.isVPNActive();
+            done();
+        } catch (Throwable t) {
+            fail("VPN detection API invocation failed: " + t);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean shouldTakeScreenshot() {
+        return false;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide runtime and unit test coverage for the new best-effort VPN detection APIs so API invocations are safe and behavior can be tested deterministically. 
- Make the test implementation controllable so unit tests can assert `NetworkManager` delegation without relying on platform networking.

### Description
- Added a Hello app smoke test `VPNDetectionAPITest` that calls `NetworkManager.getInstance().isVPNDetectionSupported()` and `NetworkManager.getInstance().isVPNActive()` and registered it in `Cn1ssDeviceRunner`.
- Added a core unit test `vpnDelegatesToImplementation()` in `maven/core-unittests/src/test/java/com/codename1/io/NetworkManagerTest.java` that verifies `NetworkManager` delegates the VPN APIs to the implementation.
- Extended `TestCodenameOneImplementation` with `vpnDetectionSupported` and `vpnActive` fields, a `setVPNState(boolean, boolean)` helper, and overrides for `isVPNDetectionSupported()` and `isVPNActive()` to allow deterministic testing.
- Kept the platform wiring and documentation in place (Android/iOS heuristics and `docs/developer-guide/io.asciidoc` updates) so the APIs are implemented and documented across ports.

### Testing
- Ran core unit tests with `cd maven && mvn -pl core-unittests -am -DunitTests=true -Dmaven.javadoc.skip=true -DfailIfNoTests=false -Dtest=NetworkManagerTest test`, and the suite passed including the new `vpnDelegatesToImplementation` test.
- Attempted to run the HelloCodenameOne module with `cd scripts/hellocodenameone/common && mvn test -DskipTests=false`, but it failed in this environment due to an unresolved `com.codenameone:codenameone-maven-plugin:8.0-SNAPSHOT` artifact (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a9d4c0040833193007f05824b0cb0)