### PR TITLE
Refactor Android permission prompt callback API

### DIFF
--- a/Ports/Android/src/com/codename1/impl/android/AndroidNativeUtil.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidNativeUtil.java
@@ -198,6 +198,16 @@ public class AndroidNativeUtil {
     public static interface BitmapViewRenderer {
         public Bitmap renderViewOnBitmap(View v, int w, int h);
     }
+
+    /**
+     * Sets a callback used to customize permission rationale dialogs.
+     * Passing {@code null} restores the default Codename One Dialog behavior.
+     *
+     * @param callback callback implementation or {@code null}
+     */
+    public static void setPermissionPromptCallback(final PermissionPromptCallback callback) {
+        AndroidImplementation.setPermissionPromptCallback(callback);
+    }
     
     /**
      * Check for a dangerous permission, if the permission is already granted return true, 

--- a/Ports/Android/src/com/codename1/impl/android/PermissionPromptCallback.java
+++ b/Ports/Android/src/com/codename1/impl/android/PermissionPromptCallback.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.impl.android;
+
+/**
+ * Callback used to customize Android permission rationale dialogs.
+ */
+public interface PermissionPromptCallback {
+    /**
+     * Shows a permission prompt that has positive and negative actions.
+     *
+     * @param permission Android permission name
+     * @param title prompt title
+     * @param body prompt body text
+     * @param positiveButtonText positive button text
+     * @param negativeButtonText negative button text
+     * @return true to perform the positive action, false for the negative action
+     */
+    public boolean showPermissionPrompt(String permission, String title, String body, String positiveButtonText, String negativeButtonText);
+
+    /**
+     * Shows an informational permission message with only one action button.
+     *
+     * @param permission Android permission name
+     * @param title dialog title
+     * @param body dialog body
+     * @param okButtonText button text
+     */
+    public void showPermissionMessage(String permission, String title, String body, String okButtonText);
+}

--- a/docs/demos/android/src/main/java/com/codenameone/developerguide/advancedtopics/PermissionSnippets.java
+++ b/docs/demos/android/src/main/java/com/codenameone/developerguide/advancedtopics/PermissionSnippets.java
@@ -7,6 +7,7 @@ import com.codename1.ui.Form;
 import com.codename1.ui.layouts.BoxLayout;
 import com.codename1.ui.list.MultiButton;
 import com.codename1.impl.android.AndroidNativeUtil;
+import com.codename1.impl.android.PermissionPromptCallback;
 
 /**
  * Snippets related to Android runtime permissions.
@@ -52,4 +53,33 @@ public class PermissionSnippets {
         // you have the permission, do what you need
         // end::androidCheckForPermission[]
     }
+
+
+    public void customizePermissionPromptLocalization() {
+        // tag::permissionPromptLocalization[]
+        com.codename1.ui.plaf.UIManager.getInstance().setBundle(new java.util.Hashtable<String, String>() {{
+            put("android.permission.READ_CONTACTS", "Localized rationale for contacts");
+            put("android.permission.READ_CONTACTS.title", "Localized permission title");
+            put("android.permission.READ_CONTACTS.askAgain", "Localized ask again");
+            put("android.permission.READ_CONTACTS.dontAsk", "Localized don't ask");
+        }});
+        // end::permissionPromptLocalization[]
+    }
+
+    public void installNativePermissionPromptCallback() {
+        // tag::androidPermissionPromptCallback[]
+        AndroidNativeUtil.setPermissionPromptCallback(new PermissionPromptCallback() {
+            @Override
+            public boolean showPermissionPrompt(String permission, String title, String body, String positiveButtonText, String negativeButtonText) {
+                return com.codename1.ui.Dialog.show(title, body, positiveButtonText, negativeButtonText);
+            }
+
+            @Override
+            public void showPermissionMessage(String permission, String title, String body, String okButtonText) {
+                com.codename1.ui.Dialog.show(title, body, okButtonText, null);
+            }
+        });
+        // end::androidPermissionPromptCallback[]
+    }
+
 }

--- a/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
+++ b/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
@@ -563,22 +563,35 @@ There are no explicit code changes needed for this functionality to "just work".
 
 TIP: Some behaviors that never occurred on Android but were perfectly legal in the past might start occurring with the switch to the new API. E.g. the location manager might be null and your app must always be ready to deal with such a situation
 
-When permission is requested a user will be seamlessly prompted/warned, Codename One has builtin text to control such prompts but you might want to customize the text. You can customize permission text via the `Display` properties e.g. to customize the text of the contacts permission we can do something such as:
+When permission is requested a user will be seamlessly prompted/warned. You can customize the permission text via `Display` properties. E.g. to customize the rationale text of the contacts permission:
 
 [source,java]
 ----
 include::../demos/android/src/main/java/com/codenameone/developerguide/advancedtopics/PermissionSnippets.java[tag=permissionPrompt,indent=0]
 ----
 
-This is optional as there is a default value defined. You can define this once in the `init(Object)` method but for some extreme cases permission might be needed for different things e.g. you might ask for this permission with one reason at one point in the app and with a different reason at another point in the app.
+The Android port also checks `UIManager.localize()` for localized values before falling back to `Display` properties. You can provide localized strings for the permission body and dialog buttons/title using keys based on the permission name:
 
-The following permission keys are supported: "android.permission.READ_PHONE_STATE"
-`android.permission.WRITE_EXTERNAL_STORAGE`,
-`android.permission.ACCESS_FINE_LOCATION`,
-`android.permission.SEND_SMS`,
-`android.permission.READ_CONTACTS`,
-`android.permission.WRITE_CONTACTS`,
-`android.permission.RECORD_AUDIO`.
+[source,java]
+----
+include::../demos/android/src/main/java/com/codenameone/developerguide/advancedtopics/PermissionSnippets.java[tag=permissionPromptLocalization,indent=0]
+----
+
+For example, if the permission key is `android.permission.READ_CONTACTS`, you can localize these keys:
+
+* `android.permission.READ_CONTACTS` (dialog body)
+* `android.permission.READ_CONTACTS.title`
+* `android.permission.READ_CONTACTS.askAgain`
+* `android.permission.READ_CONTACTS.dontAsk`
+
+The same pattern applies to other permissions. `android.permission.ACCESS_BACKGROUND_LOCATION` also supports:
+`android.permission.ACCESS_BACKGROUND_LOCATION.settings`,
+`android.permission.ACCESS_BACKGROUND_LOCATION.cancel`,
+`android.permission.ACCESS_BACKGROUND_LOCATION.explanation_title`,
+`android.permission.ACCESS_BACKGROUND_LOCATION.explanation_body`, and
+`android.permission.ACCESS_BACKGROUND_LOCATION.ok`.
+
+This is optional as there is a default value defined. You can define this once in the `init(Object)` method but for some extreme cases permission might be needed for different things e.g. you might ask for this permission with one reason at one point in the app and with a different reason at another point in the app.
 
 ===== Simulating Prompts
 
@@ -604,6 +617,15 @@ include::../demos/android/src/main/java/com/codenameone/developerguide/advancedt
 ----
 
 This will prompt the user with the native UI and later on with the fallback option as described above. Notice that the `checkForPermission` method is a blocking method and it will return when there is a final conclusion on the subject. It uses `invokeAndBlock` and can be safely invoked on the event dispatch thread without concern.
+
+By default, fallback prompts are displayed using Codename One's `Dialog.show(...)`. If you are writing native Android code and need to use your own prompt implementation, you can install a custom callback:
+
+[source,java]
+----
+include::../demos/android/src/main/java/com/codenameone/developerguide/advancedtopics/PermissionSnippets.java[tag=androidPermissionPromptCallback,indent=0]
+----
+
+Pass `null` to `AndroidNativeUtil.setPermissionPromptCallback()` to restore the default behavior.
 
 === On Device Debugging
 


### PR DESCRIPTION
### Motivation
- Reduce duplication and keep `AndroidImplementation.java` smaller by extracting the permission callback contract to a dedicated top-level type. 
- Make the native API consistent so both `AndroidImplementation` and `AndroidNativeUtil` use the same `PermissionPromptCallback` interface instead of two different nested definitions.
- Ensure the `permissionPromptCallback` field is declared with the other static fields near the top of `AndroidImplementation` for clarity.

### Description
- Added a new top-level interface `com.codename1.impl.android.PermissionPromptCallback` in `Ports/Android/src/com/codename1/impl/android/PermissionPromptCallback.java` and removed the nested interface definitions. 
- Moved the static `permissionPromptCallback` field into the main static field section of `AndroidImplementation` and kept the existing setter/getter and prompt helpers (`setPermissionPromptCallback`, `getPermissionPromptCallback`, `showPermissionPrompt`, `showPermissionMessage`).
- Simplified `AndroidNativeUtil.setPermissionPromptCallback(...)` to delegate directly to `AndroidImplementation.setPermissionPromptCallback(...)` and removed the adapter code. 
- Updated the demo snippet in `docs/demos/android/.../PermissionSnippets.java` to import and use the shared `PermissionPromptCallback` type.

### Testing
- Ran `git diff --check` to validate whitespace/formatting issues and it succeeded. 
- Ran `git status --short` as a sanity check on working tree changes and it succeeded. 
- Attempted the fast smoke test script `./scripts/fast-core-unit-smoke.sh` with the Java 8 environment variables but it failed because the expected Java 8 runtime path is not present in this environment (failure due to missing `JAVA_HOME`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698be4d7961083318fa1091a5f84adae)