### PR TITLE
Fix for maven build error

### DIFF
--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/GenerateGuiSourcesMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/GenerateGuiSourcesMojo.java
@@ -316,7 +316,7 @@ public class GenerateGuiSourcesMojo extends AbstractCN1Mojo {
     }
 
     private static String writeXmlDocumentToString(Document xmlDocument) throws IOException {
-        TransformerFactory tf = TransformerFactory.newInstance();
+        TransformerFactory tf = createTransformerFactory();
         Transformer transformer;
         try {
             transformer = tf.newTransformer();
@@ -333,6 +333,23 @@ public class GenerateGuiSourcesMojo extends AbstractCN1Mojo {
             throw new IOException("Failed to output CodeRAD as XML document", e);
         }
 
+    }
+
+    private static TransformerFactory createTransformerFactory() {
+        try {
+            return TransformerFactory.newInstance();
+        } catch (Error ex) {
+            return createJdkTransformerFactory(ex);
+        }
+    }
+
+    private static TransformerFactory createJdkTransformerFactory(Error rootCause) {
+        try {
+            return TransformerFactory.newInstance("com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl", GenerateGuiSourcesMojo.class.getClassLoader());
+        } catch (Throwable fallbackError) {
+            rootCause.addSuppressed(fallbackError);
+            throw rootCause;
+        }
     }
 
 


### PR DESCRIPTION
Fix for:

```
[ERROR] Failed to execute goal com.codenameone:codenameone-maven-plugin:7.0.223:generate-gui-sources (generate-gui-sources) on project yumatours-common: Execution generate-gui-sources of goal com.codenameone:codenameone-maven-plugin:7.0.223:generate-gui-sources failed: A required class was missing while executing com.codenameone:codenameone-maven-plugin:7.0.223:generate-gui-sources: org/apache/xml/serializer/OutputPropertiesFactory

[ERROR] -----------------------------------------------------

[ERROR] realm = plugin>com.codenameone:codenameone-maven-plugin:7.0.223

[ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
```