### PR TITLE
Fix Cloudflare Pages deploy auth in website workflow

### DIFF
--- a/.github/workflows/website-docs.yml
+++ b/.github/workflows/website-docs.yml
@@ -75,10 +75,15 @@ jobs:
       - name: Deploy to Cloudflare Pages
         if: ${{ github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master') }}
         uses: cloudflare/wrangler-action@v3
+        env:
+          # Keep these env vars explicit so Wrangler can authenticate in non-interactive CI.
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID }}
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # Also pass through action inputs for compatibility with wrangler-action versions.
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID }}
           command: >-
             pages deploy docs/website/public
-            --project-name=${{ vars.CLOUDFLARE_PAGES_PROJECT_NAME || secrets.CLOUDFLARE_PAGES_PROJECT_NAME || 'codenameone' }}
+            --project-name=${{ vars.CLOUDFLARE_PAGES_PROJECT_NAME || secrets.CLOUDFLARE_PAGES_PROJECT_NAME || secrets.CF_PAGES_PROJECT_NAME || 'codenameone' }}
             --branch=${{ github.ref_name }}


### PR DESCRIPTION
### Motivation
- Wrangler was failing in CI because it requires `CLOUDFLARE_API_TOKEN` to be present in the environment in non-interactive runs, causing `pages deploy` to error.
- The workflow needed to expose the token and account id directly to the step and support alternate secret naming used in some repos/orgs.

### Description
- Export `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` in the deploy step `env` so the `wrangler` CLI can authenticate in non-interactive CI.
- Keep `apiToken` and `accountId` inputs for `cloudflare/wrangler-action@v3` but add fallbacks to `CF_API_TOKEN` and `CF_ACCOUNT_ID` secret names for compatibility.
- Add a fallback `CF_PAGES_PROJECT_NAME` secret in the `--project-name` argument to cover alternative secret naming conventions.
- Preserve the original push-branch condition and deploy command behavior.

### Testing
- Parsed the updated workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/website-docs.yml'); puts 'ok'"`, which succeeded and printed `ok`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f29e3a26883318571e55b1ce04045)