### PR TITLE
Skip Cloudflare Pages deploy when API token is not configured

### DIFF
--- a/.github/workflows/website-docs.yml
+++ b/.github/workflows/website-docs.yml
@@ -72,13 +72,23 @@ jobs:
           path: docs/website/public
           if-no-files-found: error
 
+      - name: Check Cloudflare deploy credentials
+        if: ${{ github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master') && (secrets.CLOUDFLARE_API_TOKEN == '' && secrets.CF_API_TOKEN == '') }}
+        run: |
+          echo "::warning::Skipping Cloudflare Pages deploy because no API token secret is configured. Set CLOUDFLARE_API_TOKEN (preferred) or CF_API_TOKEN."
+
       - name: Deploy to Cloudflare Pages
-        if: ${{ github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master') }}
+        if: ${{ github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master') && (secrets.CLOUDFLARE_API_TOKEN != '' || secrets.CF_API_TOKEN != '') }}
         uses: cloudflare/wrangler-action@v3
+        env:
+          # Keep these env vars explicit so Wrangler can authenticate in non-interactive CI.
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID }}
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # Also pass through action inputs for compatibility with wrangler-action versions.
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID }}
           command: >-
             pages deploy docs/website/public
-            --project-name=${{ vars.CLOUDFLARE_PAGES_PROJECT_NAME || secrets.CLOUDFLARE_PAGES_PROJECT_NAME || 'codenameone' }}
+            --project-name=${{ vars.CLOUDFLARE_PAGES_PROJECT_NAME || secrets.CLOUDFLARE_PAGES_PROJECT_NAME || secrets.CF_PAGES_PROJECT_NAME || 'codenameone' }}
             --branch=${{ github.ref_name }}


### PR DESCRIPTION
### Motivation
- Wrangler fails in non-interactive CI when `CLOUDFLARE_API_TOKEN` is empty, causing the `pages deploy` step to hard-fail. 
- The workflow should avoid invoking `wrangler` when no API token is present to prevent spurious CI failures. 
- Repositories sometimes use alternative secret names, so the deploy logic should accept `CF_*` fallbacks for token, account, and project name.

### Description
- Add a `Check Cloudflare deploy credentials` step that emits a warning (instead of failing) when neither `CLOUDFLARE_API_TOKEN` nor `CF_API_TOKEN` is set for `main`/`master` push events. 
- Require a non-empty token in the `Deploy to Cloudflare Pages` step `if` condition and export `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` in the step `env` using fallbacks to `CF_API_TOKEN` and `CF_ACCOUNT_ID`. 
- Update action inputs and the `--project-name` argument to include fallbacks (`apiToken`, `accountId`, and `vars/secrets` including `CF_PAGES_PROJECT_NAME`) so the action works across different secret naming conventions.

### Testing
- Parsed the updated workflow YAML with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/website-docs.yml'); puts 'ok'"`, which succeeded and printed `ok`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f29e3a26883318571e55b1ce04045)