### PR TITLE
Prefer moveTaskToBack when minimizing Android app

### DIFF
--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -1569,12 +1569,28 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
 
     @Override
     public boolean minimizeApplication() {
+        Activity activity = getActivity();
+        if (activity != null) {
+            // Move the app task to background instead of explicitly launching HOME.
+            // Some OEM launchers are no longer exported and can throw SecurityException
+            // when invoked via an ACTION_MAIN/CATEGORY_HOME intent.
+            if (activity.moveTaskToBack(true)) {
+                return true;
+            }
+        }
+
+        // Fallback for edge-cases where there is no active activity/task.
         Intent startMain = new Intent(Intent.ACTION_MAIN);
         startMain.addCategory(Intent.CATEGORY_HOME);
         startMain.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         startMain.putExtra("WaitForResult", Boolean.FALSE);
-        getContext().startActivity(startMain);
-        return true;
+        try {
+            getContext().startActivity(startMain);
+            return true;
+        } catch (SecurityException ex) {
+            Log.e("Codename One", "Unable to minimize application", ex);
+            return false;
+        }
     }
 
     @Override


### PR DESCRIPTION
### Motivation
- Minimize flow currently starts an `ACTION_MAIN`/`CATEGORY_HOME` intent which can throw `SecurityException` on some OEM launchers that are not exported, causing app failures when the user presses back.

### Description
- Updated `AndroidImplementation.minimizeApplication()` to check `getActivity()` and call `Activity.moveTaskToBack(true)` and return `true` when it succeeds.
- Added an intent-based fallback that constructs an `ACTION_MAIN`/`CATEGORY_HOME` intent with `FLAG_ACTIVITY_NEW_TASK` and `WaitForResult` extras for cases with no active activity/task.
- Wrapped the fallback `startActivity` call in a `try/catch` for `SecurityException` and log the error while returning `false` to avoid crashing.

### Testing
- Ran the repository smoke script `./scripts/fast-core-unit-smoke.sh` (the CI-intended quick check) but it failed due to the environment missing the required Java 8 `JAVA_HOME` path so unit tests could not be executed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994885d1c5c8331a5d26e05e1467526)