### PR TITLE
Add Maven goals to print and set Codename One user token

### DIFF
--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/PrintUserTokenMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/PrintUserTokenMojo.java
@@ -1,0 +1,22 @@
+package com.codename1.maven;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+
+import java.util.prefs.Preferences;
+
+@Mojo(name = "print-user-token", requiresProject = false)
+public class PrintUserTokenMojo extends AbstractMojo {
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        Preferences prefs = Preferences.userRoot().node("/com/codename1/ui");
+        String token = prefs.get("token", null);
+        if (token == null || token.isEmpty()) {
+            throw new MojoFailureException("No user token found in preferences at /com/codename1/ui");
+        }
+        System.out.println(token);
+    }
+}

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/SetUserTokenMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/SetUserTokenMojo.java
@@ -1,0 +1,35 @@
+package com.codename1.maven;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import java.util.prefs.Preferences;
+
+@Mojo(name = "set-user-token", requiresProject = false)
+public class SetUserTokenMojo extends AbstractMojo {
+
+    @Parameter(property = "token", required = true)
+    private String token;
+
+    @Parameter(property = "user", required = true)
+    private String user;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        if (token == null || token.trim().isEmpty()) {
+            throw new MojoFailureException("Missing required parameter: -Dtoken=<token>");
+        }
+        if (user == null || user.trim().isEmpty()) {
+            throw new MojoFailureException("Missing required parameter: -Duser=<email>");
+        }
+
+        Preferences prefs = Preferences.userRoot().node("/com/codename1/ui");
+        prefs.put("token", token);
+        prefs.put("user", user);
+
+        getLog().info("Saved Codename One user token and user email to preferences node /com/codename1/ui");
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide Maven goals to extract the Codename One user token from a machine and to populate the same token (and user email) into the preferences so CI can reuse a logged-in session for automated builds. 
- Store/read the credentials from the existing preferences node `Preferences.userRoot().node("/com/codename1/ui")` to match the runtime storage used by the platform.

### Description
- Added `PrintUserTokenMojo` (`print-user-token`) which reads `Preferences.userRoot().node("/com/codename1/ui").get("token", null)` and prints the token or fails with a clear error when missing (`maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/PrintUserTokenMojo.java`).
- Added `SetUserTokenMojo` (`set-user-token`) which accepts `-Dtoken` and `-Duser`, validates both, and writes them to the preferences node as `token` and `user` (`maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/SetUserTokenMojo.java`).
- Both goals are annotated with `@Mojo(... requiresProject = false)` so they can be executed outside of a project checkout (e.g. on CI or developer machines).

### Testing
- Attempted to compile the plugin with Java 8 using `export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64; export PATH="$JAVA_HOME/bin:$PATH"; cd maven && mvn -pl codenameone-maven-plugin -am -DskipTests compile`, which started but stalled due to downloading and cloning `cn1-binaries` in this environment. 
- Also attempted `cd maven/codenameone-maven-plugin && mvn -DskipTests compile` which failed with unresolved local snapshot dependencies such as `com.codenameone:codenameone-designer:jar:jar-with-dependencies:8.0-SNAPSHOT`, `com.codenameone:java-runtime:jar:8.0-SNAPSHOT`, and others, so the module could not be fully built here. 
- No automated unit tests were added for these Mojos in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699748f39c5483318a5f08c71ef072aa)