### PR TITLE
Fix iOS screenshot CI success message label

### DIFF
--- a/scripts/lib/cn1ss.sh
+++ b/scripts/lib/cn1ss.sh
@@ -348,6 +348,9 @@ cn1ss_process_and_report() {
     --comment-out "$comment_out"
     --summary-out "$summary_out"
   )
+  if [ -n "${CN1SS_SUCCESS_MESSAGE:-}" ]; then
+    render_args+=(--success-message "$CN1SS_SUCCESS_MESSAGE")
+  fi
   if [ -n "${CN1SS_COVERAGE_SUMMARY:-}" ]; then
     render_args+=(--coverage-summary "$CN1SS_COVERAGE_SUMMARY")
   fi

--- a/scripts/run-ios-ui-tests.sh
+++ b/scripts/run-ios-ui-tests.sh
@@ -715,6 +715,7 @@ export CN1SS_PREVIEW_DIR="$SCREENSHOT_PREVIEW_DIR"
 export CN1SS_COMMENT_MARKER="<!-- CN1SS_IOS_COMMENT -->"
 export CN1SS_COMMENT_LOG_PREFIX="[run-ios-device-tests]"
 export CN1SS_PREVIEW_SUBDIR="ios"
+export CN1SS_SUCCESS_MESSAGE="✅ Native iOS screenshot tests passed."
 
 # Load VM translation time if available
 CN1SS_VM_TIME=0


### PR DESCRIPTION
### Motivation
- CI screenshot reporter used the Android default success text for iOS runs, so iOS screenshot successes could post `✅ Native Android screenshot tests passed.` instead of an iOS-specific message.

### Description
- Pass an optional platform-specific success message into the screenshot report renderer by adding `--success-message` when `CN1SS_SUCCESS_MESSAGE` is set in `scripts/lib/cn1ss.sh`, and set `CN1SS_SUCCESS_MESSAGE` to `✅ Native iOS screenshot tests passed.` in `scripts/run-ios-ui-tests.sh`.

### Testing
- Performed shell syntax checks with `bash -n scripts/lib/cn1ss.sh` and `bash -n scripts/run-ios-ui-tests.sh`, and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a7f8051008331919d47da27918cc2)