### PR TITLE
Stabilize HelloCodenameOne orientation screenshot capture

### DIFF
--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/OrientationLockScreenshotTest.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/OrientationLockScreenshotTest.java
@@ -16,7 +16,7 @@ public class OrientationLockScreenshotTest extends BaseTest {
             @Override
             protected void onShowCompleted() {
                 CN.lockOrientation(false);
-                UITimer.timer(300, false, this, () -> {
+                waitForOrientation(this, false, () -> {
                     Cn1ssDeviceRunnerHelper.emitCurrentFormScreenshot("landscape");
                     CN.lockOrientation(true);
                     waitForOrientation(this, true, OrientationLockScreenshotTest.this::done);


### PR DESCRIPTION
### Motivation

- The orientation screenshot test could capture a portrait image because it used a fixed 300ms delay after requesting landscape, which is insufficient on slower devices or simulators.

### Description

- In `scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/OrientationLockScreenshotTest.java` replaced the fixed `UITimer.timer(300, ...)` delay with a call to `waitForOrientation(this, false, ...)` so the test waits for confirmed landscape before calling `Cn1ssDeviceRunnerHelper.emitCurrentFormScreenshot("landscape")`, while preserving the subsequent re-lock-to-portrait and verification.

### Testing

- Attempted to compile the module with `cd scripts/hellocodenameone && mvn -pl common -am -DskipTests compile`, but the build could not complete due to a missing plugin artifact `com.codenameone:codenameone-maven-plugin:8.0-SNAPSHOT`, so no automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a07c5d8e648331a1a113087757654c)