### PR TITLE
ci: set base branch for initializr version bump PR workflow

### DIFF
--- a/.github/workflows/initializr-cn1-version-pr.yml
+++ b/.github/workflows/initializr-cn1-version-pr.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Create pull request
         uses: peter-evans/create-pull-request@v6
         with:
+          base: ${{ github.event.repository.default_branch }}
           commit-message: "scripts/initializr: bump Codename One versions to ${{ github.event.release.tag_name || github.ref_name }}"
           title: "scripts/initializr: bump Codename One versions to ${{ github.event.release.tag_name || github.ref_name }}"
           body: |


### PR DESCRIPTION
### Motivation
- The `peter-evans/create-pull-request` action fails when the workflow runs from a detached HEAD (tag/release), so an explicit `base` branch is required to create the PR reliably.

### Description
- Add `base: ${{ github.event.repository.default_branch }}` to the `peter-evans/create-pull-request@v6` inputs in ` .github/workflows/initializr-cn1-version-pr.yml` to ensure the PR targets the repository default branch when triggered from tags/releases.

### Testing
- Ran `git diff --check` which succeeded and confirmed the `base` input is present in ` .github/workflows/initializr-cn1-version-pr.yml`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a12273f5ec8331b742ab5c42c8a359)