### PR TITLE
Fix ConcurrentModificationException in GeofenceManager expiry purge

### DIFF
--- a/CodenameOne/src/com/codename1/location/GeofenceManager.java
+++ b/CodenameOne/src/com/codename1/location/GeofenceManager.java
@@ -170,9 +170,10 @@ public final class GeofenceManager implements Iterable<Geofence> {
         boolean saveFences = false;
         boolean saveActive = false;
         boolean saveActiveFences = false;
-        for (Map.Entry<String, Long> time : times.entrySet()) {
+        for (Iterator<Map.Entry<String, Long>> it = times.entrySet().iterator(); it.hasNext();) {
+            Map.Entry<String, Long> time = it.next();
             if (time.getValue() > 0L && time.getValue() < now) {
-                times.remove(time.getKey());
+                it.remove();
                 if (!saveFences && fences.containsKey(time.getKey())) {
                     saveFences = true;
                 }

--- a/maven/core-unittests/src/test/java/com/codename1/location/GeofenceManagerTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/location/GeofenceManagerTest.java
@@ -127,6 +127,22 @@ class GeofenceManagerTest extends UITestBase {
     }
 
     @FormTest
+    void updatePurgesExpiredGeofencesWithoutConcurrentModification() throws Exception {
+        Geofence first = createGeofence("expired-1", 0.0, 0.0, 50, -1L);
+        Geofence second = createGeofence("expired-2", 0.0, 0.0, 50, -1L);
+        manager.add(first, second);
+        Map<String, Long> expirations = new HashMap<String, Long>();
+        long expiredAt = System.currentTimeMillis() - 1000L;
+        expirations.put(first.getId(), expiredAt);
+        expirations.put(second.getId(), expiredAt);
+        setPrivateField("expiryTimes", expirations);
+
+        assertDoesNotThrow(() -> manager.update(1000));
+        assertFalse(manager.asMap().containsKey(first.getId()));
+        assertFalse(manager.asMap().containsKey(second.getId()));
+    }
+
+    @FormTest
     public void testGeofenceManagerListener() {
         // Instantiate the listener
         GeofenceManager.Listener listener = new GeofenceManager.Listener();
@@ -145,6 +161,13 @@ class GeofenceManagerTest extends UITestBase {
 
         listener.onEntered("test-id");
         assertTrue(MyGeofenceListener.calledEnter, "onEntered should delegate to registered listener");
+    }
+
+
+    private void setPrivateField(String name, Object value) throws Exception {
+        Field field = GeofenceManager.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(manager, value);
     }
 
     private Geofence createGeofence(String id, double lat, double lng, int radius, long expiration) {


### PR DESCRIPTION
### Motivation

- Iterating `expiryTimes.entrySet()` while removing expired entries caused a `ConcurrentModificationException` during `GeofenceManager` updates and construction, so the purge logic needed to stop mutating the map via the enhanced-for loop.

### Description

- Change `GeofenceManager.purgeExpired()` to iterate the expirations map with an explicit `Iterator` and call `it.remove()` when an entry is expired to avoid concurrent modification.
- Add a regression test `updatePurgesExpiredGeofencesWithoutConcurrentModification` to `GeofenceManagerTest` that injects expired entries and asserts `manager.update(...)` does not throw and removes the expired geofences from tracked state.
- Add a small reflective test helper `setPrivateField` used by the new test to set `expiryTimes` deterministically.

### Testing

- Ran the targeted unit tests with Java 8 using `export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64; export PATH="$JAVA_HOME/bin:$PATH"; cd maven && mvn -pl core-unittests -am -DunitTests=true -Dmaven.javadoc.skip=true -Dtest=GeofenceManagerTest -DfailIfNoTests=false test` and the `GeofenceManagerTest` suite passed (9 tests, 0 failures).
- The Maven invocation produced existing project warnings about local systemPath artifacts but the targeted tests succeeded and the build completed with `BUILD SUCCESS`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a34241c9c083319d9208f96daf32cc)