### PR TITLE
Add documentation for `ios.uiscene` build hint

### DIFF
--- a/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
+++ b/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
@@ -258,6 +258,9 @@ Currently only supported for App Store builds.  See https://www.codenameone.com/
 |ios.keyboardOpen
 |Flips between iOS keyboard open mode and auto-fold keyboard mode. Defaults to true which means the keyboard will remain open and not fold automatically when editing moves to another field.
 
+|ios.uiscene
+|true/false (defaults to false). Experimental flag to enable iOS UIScene lifecycle support. UIScene lets iOS manage one or more app UI sessions independently, improving lifecycle handling in modern iOS versions. Apple has indicated UIScene will be required starting with iOS 27, so this flag can be used to prepare your app ahead of that transition.
+
 |ios.urlScheme
 |Allows intercepting a URL call using the syntax `<string>urlPrefix<string>`
 


### PR DESCRIPTION
### Motivation
- Add documentation for a new iOS build hint `ios.uiscene` which enables experimental UIScene lifecycle support to help apps prepare for upcoming iOS lifecycle changes.

### Description
- Documented the new `ios.uiscene` build hint in the advanced topics guide as a `true/false` flag with a default of `false` and described its purpose and rationale. 

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9094265bc8331a06df5391693f45f)