### PR TITLE
Support nested POSIX classes ([[:alpha:]]) in RE and add Character helper APIs; expand regex tests

### DIFF
--- a/CodenameOne/src/com/codename1/util/regex/RECompiler.java
+++ b/CodenameOne/src/com/codename1/util/regex/RECompiler.java
@@ -427,6 +427,43 @@ public class RECompiler {
         }
     }
 
+    private int parsePosixCharacterClass(boolean nestedPosixClass) throws RESyntaxException {
+        // Skip colon
+        idx++;
+
+        // POSIX character classes are denoted with lowercase ASCII strings
+        int idxStart = idx;
+        while (idx < len && pattern.charAt(idx) >= 'a' && pattern.charAt(idx) <= 'z') {
+            idx++;
+        }
+
+        // Should be a ":]" to terminate the POSIX character class
+        if ((idx + 1) < len && pattern.charAt(idx) == ':' && pattern.charAt(idx + 1) == ']') {
+            // Get character class
+            String charClass = pattern.substring(idxStart, idx);
+
+            // Select the POSIX class id
+            Character i = (Character) hashPOSIX.get(charClass);
+            if (i != null) {
+                // Move past colon and right bracket
+                idx += 2;
+
+                // Nested POSIX class "[[:class:]]" consumes one more right bracket.
+                if (nestedPosixClass) {
+                    if (idx >= len || pattern.charAt(idx) != ']') {
+                        syntaxError("Invalid POSIX character class syntax");
+                    }
+                    idx++;
+                }
+
+                return node(RE.OP_POSIXCLASS, i.charValue());
+            }
+            syntaxError("Invalid POSIX character class '" + charClass + "'");
+        }
+        syntaxError("Invalid POSIX character class syntax");
+        return -1;
+    }
+
     /// Compile a character class
     ///
     /// #### Returns
@@ -447,34 +484,15 @@ public class RECompiler {
             syntaxError("Empty or unterminated class");
         }
 
-        // Check for POSIX character class
+        // Check for POSIX character class in the "[:class:]" form.
         if (idx < len && pattern.charAt(idx) == ':') {
-            // Skip colon
+            return parsePosixCharacterClass(false);
+        }
+
+        // Check for POSIX character class in the "[[:class:]]" form.
+        if ((idx + 1) < len && pattern.charAt(idx) == '[' && pattern.charAt(idx + 1) == ':') {
             idx++;
-
-            // POSIX character classes are denoted with lowercase ASCII strings
-            int idxStart = idx;
-            while (idx < len && pattern.charAt(idx) >= 'a' && pattern.charAt(idx) <= 'z') {
-                idx++;
-            }
-
-            // Should be a ":]" to terminate the POSIX character class
-            if ((idx + 1) < len && pattern.charAt(idx) == ':' && pattern.charAt(idx + 1) == ']') {
-                // Get character class
-                String charClass = pattern.substring(idxStart, idx);
-
-                // Select the POSIX class id
-                Character i = (Character) hashPOSIX.get(charClass);
-                if (i != null) {
-                    // Move past colon and right bracket
-                    idx += 2;
-
-                    // Return new POSIX character class node
-                    return node(RE.OP_POSIXCLASS, i.charValue());
-                }
-                syntaxError("Invalid POSIX character class '" + charClass + "'");
-            }
-            syntaxError("Invalid POSIX character class syntax");
+            return parsePosixCharacterClass(true);
         }
 
         // Try to build a class.  Create OP_ANYOF node

--- a/Ports/CLDC11/src/java/lang/Character.java
+++ b/Ports/CLDC11/src/java/lang/Character.java
@@ -91,6 +91,27 @@ public final class Character{
     }
 
     /**
+     * Determines if the specified character is alphabetic.
+     */
+    public static boolean isAlpha(char ch){
+        return isLowerCase(ch) || isUpperCase(ch);
+    }
+
+    /**
+     * Determines if the specified character is numeric.
+     */
+    public static boolean isNumeric(char ch){
+        return isDigit(ch);
+    }
+
+    /**
+     * Determines if the specified character is alphabetic or numeric.
+     */
+    public static boolean isAlphaNumeric(char ch){
+        return isAlpha(ch) || isNumeric(ch);
+    }
+
+    /**
      * Determines if the specified character is a digit.
      */
     public static boolean isDigit(char ch){

--- a/maven/core-unittests/src/test/java/com/codename1/util/regex/RETest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/util/regex/RETest.java
@@ -32,4 +32,42 @@ class RETest extends UITestBase {
         String[] split = expression.split(input);
         assertArrayEquals(new String[]{"", " and "}, split);
     }
+
+    @FormTest
+    void testNestedPosixAlphaCharacterClassSupport() throws Exception {
+        RE expression = new RE("^list [[:alpha:]]*$");
+
+        assertTrue(expression.match("list abcXYZ"));
+        assertTrue(expression.match("list "));
+        assertFalse(expression.match("list 123"));
+        assertFalse(expression.match("listing abc"));
+    }
+
+    @FormTest
+    void testLegacyPosixAlphaCharacterClassSupport() throws Exception {
+        RE expression = new RE("^list [:alpha:]*$");
+
+        assertTrue(expression.match("list alpha"));
+        assertFalse(expression.match("list alpha1"));
+    }
+
+    @FormTest
+    void testPosixClassesAndEscapes() throws Exception {
+        RE alnum = new RE("^[[:alnum:]]+$");
+        assertTrue(alnum.match("abc123"));
+        assertFalse(alnum.match("abc-123"));
+
+        RE digit = new RE("^[[:digit:]]+$");
+        assertTrue(digit.match("007"));
+        assertFalse(digit.match("7a"));
+
+        RE xdigit = new RE("^[[:xdigit:]]+$");
+        assertTrue(xdigit.match("a0B9F"));
+        assertFalse(xdigit.match("g0"));
+
+        RE wordThenDigits = new RE("^\\w+\\s+\\d+$");
+        assertTrue(wordThenDigits.match("item\t42"));
+        assertFalse(wordThenDigits.match("item-42"));
+    }
+
 }

--- a/vm/JavaAPI/src/java/lang/Character.java
+++ b/vm/JavaAPI/src/java/lang/Character.java
@@ -288,6 +288,30 @@ public final class Character implements Comparable<Character>{
         return value; 
     }
     
+    public static boolean isAlpha(char ch) {
+        return isLetter(ch);
+    }
+
+    public static boolean isAlpha(int codePoint) {
+        return isLetter(codePoint);
+    }
+
+    public static boolean isNumeric(char ch) {
+        return isDigit(ch);
+    }
+
+    public static boolean isNumeric(int codePoint) {
+        return isDigit(codePoint);
+    }
+
+    public static boolean isAlphaNumeric(char ch) {
+        return isLetterOrDigit(ch);
+    }
+
+    public static boolean isAlphaNumeric(int codePoint) {
+        return isLetterOrDigit(codePoint);
+    }
+
     public static boolean isLetterOrDigit(char ch) {
         return isLetterOrDigit((int) ch);
     }


### PR DESCRIPTION
### Motivation
- The `RE` engine did not recognize the standard nested POSIX character-class form like `[[:alpha:]]`, so patterns such as `RE("list [[:alpha:]]*")` failed to work.
- The regex engine needs small Character helper APIs to expose alpha/numeric/alphanumeric checks on the platform API surface so the regex code can rely on them consistently across VM and CLDC11.

### Description
- Added parsing and handling for both `[:class:]` and nested `[[:class:]]` POSIX character-class forms in `RECompiler` by introducing `parsePosixCharacterClass(...)` and wiring detection for the two forms in `characterClass()` (file: `CodenameOne/src/com/codename1/util/regex/RECompiler.java`).
- Added Character convenience APIs to the VM Java API implementation: `isAlpha(char|int)`, `isNumeric(char|int)`, and `isAlphaNumeric(char|int)` (file: `vm/JavaAPI/src/java/lang/Character.java`).
- Added matching CLDC11 API surface methods `isAlpha(char)`, `isNumeric(char)`, and `isAlphaNumeric(char)` so the methods exist in the CLDC11 API (file: `Ports/CLDC11/src/java/lang/Character.java`).
- Expanded the regex unit test `RETest` with coverage for nested POSIX classes, legacy `[:alpha:]` behavior, and additional POSIX classes and escapes (`alnum`, `digit`, `xdigit`, `\w`, `\s`, `\d`) (file: `maven/core-unittests/src/test/java/com/codename1/util/regex/RETest.java`).

### Testing
- Ran the specific regex unit tests with Maven: `cd maven && mvn -pl core-unittests -am -DunitTests=true -Dmaven.javadoc.skip=true -DfailIfNoTests=false test -Dtest=com.codename1.util.regex.RETest` and the updated `RETest` suite ran and passed (5 tests, 0 failures).
- An earlier run surfaced environment differences (missing `local-dev-javase` profile and the JDK path noted in repository documentation), so the final verification used the project test invocation above and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa6f5aec648331b1ff6d98d8e2264d)