### PR TITLE
Prevent NPE when refreshing active geofences

### DIFF
--- a/CodenameOne/src/com/codename1/location/GeofenceManager.java
+++ b/CodenameOne/src/com/codename1/location/GeofenceManager.java
@@ -502,6 +502,7 @@ public final class GeofenceManager implements Iterable<Geofence> {
         LocationManager.getLocationManager().setBackgroundLocationListener(null);
         List<String> activeIds = new ArrayList<String>(getActiveKeys(false));
         List<String> activeKeys = getActiveKeys(false);
+        Map<String, Geofence> activeFences = getActiveFences(false);
         for (String id : activeIds) {
             Geofence g = getFences(false).get(id);
             if (!forceRefresh && g != null) {

--- a/maven/core-unittests/src/test/java/com/codename1/location/GeofenceManagerTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/location/GeofenceManagerTest.java
@@ -85,6 +85,19 @@ class GeofenceManagerTest extends UITestBase {
         assertFalse(locationManager.removedIds.contains("near"));
     }
 
+
+    @FormTest
+    void updateForceRefreshHandlesMissingPersistedActiveFenceMap() {
+        Geofence geofence = createGeofence("rehydrated", 0.0, 0.0, 50, -1L);
+        manager.add(geofence);
+        manager.update(1000);
+
+        storage.deleteStorageFile("$AsyncGeoStreamer.activegeofences$");
+
+        assertDoesNotThrow(() -> manager.update(1000, true));
+        assertTrue(locationManager.removedIds.contains("rehydrated"));
+    }
+
     @FormTest
     void updateWithNullLocationRegistersBackgroundListener() {
         locationManager.setCurrentLocation(null);


### PR DESCRIPTION
### Motivation
- Fix a regression where `GeofenceManager.update(..., true)` could hit a `NullPointerException` when the in-memory `activeFences` map was not initialized but persisted state was missing.

### Description
- Initialize the cached `activeFences` map early in `GeofenceManager.update(boolean, Location)` by calling `getActiveFences(false)` before any removals to avoid null dereference.
- Add a regression test `updateForceRefreshHandlesMissingPersistedActiveFenceMap` in `GeofenceManagerTest` that deletes the persisted active-fence storage key and verifies a forced update does not throw and removes the geofence.

### Testing
- Ran the unit test module for the `GeofenceManager` test with Java 8 using `mvn -pl core-unittests -am -DfailIfNoTests=false -DunitTests=true -Dmaven.javadoc.skip=true -Dtest=GeofenceManagerTest test` and the `GeofenceManagerTest` suite passed (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1936d16b8833199e35f3f34a0bc5e)