### PR TITLE
readArrayStackArgument() now reads from the stack snapshot passed into handleEvent()

### DIFF
--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -1813,12 +1813,19 @@ public final class Display extends CN1Constants {
             if (this.dropEvents) {
                 return;
             }
+            if (!hasInputEventStackCapacity(2)) {
+                return;
+            }
             inputEventStack[inputEventStackPointer] = type;
             inputEventStackPointer++;
             inputEventStack[inputEventStackPointer] = code;
             inputEventStackPointer++;
             lock.notifyAll();
         }
+    }
+
+    private boolean hasInputEventStackCapacity(int additionalSlots) {
+        return inputEventStackPointer + additionalSlots < inputEventStack.length;
     }
 
     /// Checks if the control key is currently down.  Only relevant for desktop ports.
@@ -1924,6 +1931,9 @@ public final class Display extends CN1Constants {
             if (this.dropEvents) {
                 return;
             }
+            if (!hasInputEventStackCapacity(3)) {
+                return;
+            }
             inputEventStack[inputEventStackPointer] = type;
             inputEventStackPointer++;
             inputEventStack[inputEventStackPointer] = x;
@@ -1937,6 +1947,9 @@ public final class Display extends CN1Constants {
     private void addPointerEvent(int type, int[] x, int[] y) {
         synchronized (lock) {
             if (this.dropEvents) {
+                return;
+            }
+            if (!hasInputEventStackCapacity(3 + x.length + y.length)) {
                 return;
             }
             inputEventStack[inputEventStackPointer] = type;
@@ -1968,6 +1981,9 @@ public final class Display extends CN1Constants {
                     inputEventStack[lastDragOffset + 1] = y;
                     inputEventStack[lastDragOffset + 2] = (int) (System.currentTimeMillis() - displayInitTime);
                 } else {
+                    if (!hasInputEventStackCapacity(4)) {
+                        return;
+                    }
                     inputEventStack[inputEventStackPointer] = POINTER_DRAGGED;
                     inputEventStackPointer++;
                     lastDragOffset = inputEventStackPointer;
@@ -1992,6 +2008,9 @@ public final class Display extends CN1Constants {
                 return;
             }
             try {
+                if (!hasInputEventStackCapacity(4)) {
+                    return;
+                }
                 inputEventStack[inputEventStackPointer] = type;
                 inputEventStackPointer++;
                 inputEventStack[inputEventStackPointer] = x;
@@ -2118,6 +2137,9 @@ public final class Display extends CN1Constants {
 
     private void addSizeChangeEvent(int type, int w, int h) {
         synchronized (lock) {
+            if (!hasInputEventStackCapacity(3)) {
+                return;
+            }
             inputEventStack[inputEventStackPointer] = type;
             inputEventStackPointer++;
             inputEventStack[inputEventStackPointer] = w;
@@ -2154,6 +2176,9 @@ public final class Display extends CN1Constants {
 
     private void addNotifyEvent(int type) {
         synchronized (lock) {
+            if (!hasInputEventStackCapacity(1)) {
+                return;
+            }
             inputEventStack[inputEventStackPointer] = type;
             inputEventStackPointer++;
             lock.notifyAll();

--- a/maven/core-unittests/src/test/java/com/codename1/ui/DisplayTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/DisplayTest.java
@@ -1,5 +1,6 @@
 package com.codename1.ui;
 
+import com.codename1.junit.FormTest;
 import com.codename1.junit.UITestBase;
 import com.codename1.ui.plaf.Style;
 import org.junit.jupiter.api.AfterEach;
@@ -119,14 +120,51 @@ public class DisplayTest extends UITestBase {
         Display display = Display.getInstance();
         Field stackField = Display.class.getDeclaredField("inputEventStackTmp");
         stackField.setAccessible(true);
+        int[] originalStack = (int[]) stackField.get(display);
         stackField.set(display, new int[]{0, 999, 999});
 
-        Method readArray = Display.class.getDeclaredMethod("readArrayStackArgument", int[].class, int.class);
-        readArray.setAccessible(true);
+        try {
+            Method readArray = Display.class.getDeclaredMethod("readArrayStackArgument", int[].class, int.class);
+            readArray.setAccessible(true);
 
-        int[] sourceStack = new int[]{2, 10, 20};
-        int[] decoded = (int[]) readArray.invoke(display, sourceStack, 0);
-        assertArrayEquals(new int[]{10, 20}, decoded);
+            int[] sourceStack = new int[]{2, 10, 20};
+            int[] decoded = (int[]) readArray.invoke(display, sourceStack, 0);
+            assertArrayEquals(new int[]{10, 20}, decoded);
+        } finally {
+            stackField.set(display, originalStack);
+        }
+    }
+
+    @FormTest
+    void testInputEventStackRemainsBoundedForPointerBurst() throws Exception {
+        Display display = Display.getInstance();
+        Field stackField = Display.class.getDeclaredField("inputEventStack");
+        stackField.setAccessible(true);
+        Field stackTmpField = Display.class.getDeclaredField("inputEventStackTmp");
+        stackTmpField.setAccessible(true);
+        Field pointerField = Display.class.getDeclaredField("inputEventStackPointer");
+        pointerField.setAccessible(true);
+        int[] originalStack = (int[]) stackField.get(display);
+        int[] originalStackTmp = (int[]) stackTmpField.get(display);
+        int originalPointer = pointerField.getInt(display);
+
+        try {
+            stackField.set(display, new int[4]);
+            stackTmpField.set(display, new int[4]);
+            pointerField.setInt(display, 0);
+
+            for (int i = 0; i < 20; i++) {
+                display.pointerPressed(new int[]{10}, new int[]{10});
+                display.pointerReleased(new int[]{10}, new int[]{10});
+            }
+
+            int[] bounded = (int[]) stackField.get(display);
+            assertEquals(4, bounded.length);
+        } finally {
+            stackField.set(display, originalStack);
+            stackTmpField.set(display, originalStackTmp);
+            pointerField.setInt(display, originalPointer);
+        }
     }
 
 }


### PR DESCRIPTION
This is instead of the mutable inputEventStackTmp field, so nested EDT stack swaps can’t corrupt multi-pointer decoding.