### PR TITLE
Add DialogScreenshotTest to HelloCodenameOne screenshot suite

### DIFF
--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/Cn1ssDeviceRunner.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/Cn1ssDeviceRunner.java
@@ -69,6 +69,7 @@ public final class Cn1ssDeviceRunner extends DeviceRunner {
             new BrowserComponentScreenshotTest(),
             new MediaPlaybackScreenshotTest(),
             new SheetScreenshotTest(),
+            new DialogScreenshotTest(),
             new ImageViewerNavigationScreenshotTest(),
             // Keep this as the last screenshot test; orientation changes can leak into subsequent screenshots.
             new OrientationLockScreenshotTest(),

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/DialogScreenshotTest.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/DialogScreenshotTest.java
@@ -1,0 +1,44 @@
+package com.codenameone.examples.hellocodenameone.tests;
+
+import com.codename1.ui.Dialog;
+import com.codename1.ui.Display;
+import com.codename1.ui.Form;
+import com.codename1.ui.Label;
+import com.codename1.ui.layouts.BorderLayout;
+import com.codename1.ui.layouts.BoxLayout;
+
+import java.util.Timer;
+import java.util.TimerTask;
+
+public class DialogScreenshotTest extends BaseTest {
+    @Override
+    public boolean runTest() {
+        Form form = new Form("Dialog Test", new BorderLayout());
+        form.add(BorderLayout.CENTER, new Label("Preparing dialog screenshot"));
+        form.show();
+
+        Dialog dialog = new Dialog("Dialog");
+        dialog.setLayout(BoxLayout.y());
+        dialog.add(new Label("Dialog content"));
+        dialog.add(new Label("Modal screenshot verification"));
+
+        Timer timer = new Timer();
+        timer.schedule(new TimerTask() {
+            @Override
+            public void run() {
+                Display.getInstance().callSerially(() -> {
+                    try {
+                        Cn1ssDeviceRunnerHelper.emitCurrentFormScreenshot("Dialog");
+                    } finally {
+                        dialog.dispose();
+                        done();
+                        timer.cancel();
+                    }
+                });
+            }
+        }, 700);
+
+        dialog.showPacked(BorderLayout.CENTER, true);
+        return true;
+    }
+}


### PR DESCRIPTION
### Motivation
- Add coverage for modal `Dialog` rendering so screenshots capture dialogs that block the EDT. 
- Use a non-`UITimer` mechanism to schedule work off the modal path and then `callSerially` to run screenshot logic on the EDT.

### Description
- Added `DialogScreenshotTest` at `scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/DialogScreenshotTest.java` which shows a form, opens a modal `Dialog`, uses `java.util.Timer` to schedule a callback that calls `Display.callSerially(...)`, emits a screenshot with `Cn1ssDeviceRunnerHelper.emitCurrentFormScreenshot(...)`, disposes the dialog, and calls `done()`.
- Registered the test in the screenshot suite by adding `new DialogScreenshotTest()` into the `TEST_CLASSES` list in `Cn1ssDeviceRunner` so it runs with the existing screenshot tests.

### Testing
- Attempted to compile the HelloCodenameOne module with `cd scripts/hellocodenameone && ./mvnw -pl common -DskipTests compile`, but the wrapper failed due to a network/download error for the wrapper distribution (environment network issue). 
- Also attempted `cd scripts/hellocodenameone && mvn -pl common -DskipTests compile`, which failed because `com.codenameone:codenameone-maven-plugin:8.0-SNAPSHOT` could not be resolved in this environment, so module compilation could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b838fe4818833198b45df3ed87263d)