### PR TITLE
Fix JavaScript build target log message

### DIFF
--- a/Samples/SampleProjectTemplate/build.xml
+++ b/Samples/SampleProjectTemplate/build.xml
@@ -350,7 +350,7 @@
 
     <target name="build-for-javascript" depends="clean,copy-javascript-override,copy-libs,jar,clean-override">
         <property name="javascript.targetType" value="javascript"/>
-        <echo message="Building iOS for target ${javascript.targetType}"/>
+        <echo message="Building JavaScript for target ${javascript.targetType}"/>
         <codeNameOne 
             jarFile="${dist.jar}"
             displayName="${codename1.displayName}"

--- a/maven/codenameone-maven-plugin/src/main/resources/com/codename1/maven/buildxml-template.xml
+++ b/maven/codenameone-maven-plugin/src/main/resources/com/codename1/maven/buildxml-template.xml
@@ -83,7 +83,7 @@ This the Ant build script used by the CN1BuildMojo for sending to the build serv
 
     <target name="javascript" depends="">
         <property name="javascript.targetType" value="javascript"/>
-        <echo message="Building iOS for target ${javascript.targetType}"/>
+        <echo message="Building JavaScript for target ${javascript.targetType}"/>
         <codeNameOne
                 jarFile="${dist.jar}"
                 displayName="${codename1.displayName}"


### PR DESCRIPTION
### Motivation
- The `javascript` Ant/Maven build target printed an incorrect iOS-specific message, causing confusing logs when producing JavaScript builds.

### Description
- Replace the incorrect echo `Building iOS for target ${javascript.targetType}` with `Building JavaScript for target ${javascript.targetType}` in `maven/codenameone-maven-plugin/src/main/resources/com/codename1/maven/buildxml-template.xml` and `Samples/SampleProjectTemplate/build.xml`.

### Testing
- Verified the change with `rg -n -F 'Building JavaScript for target ${javascript.targetType}' maven/codenameone-maven-plugin/src/main/resources/com/codename1/maven/buildxml-template.xml Samples/SampleProjectTemplate/build.xml` which found the updated lines, and `rg -n -F 'Building iOS for target ${javascript.targetType}' ...` which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bf88985958832bb3a366de39999f5c)