### PR TITLE
Include CLDC11 Java APIs in CI JavaDoc build

### DIFF
--- a/.github/scripts/build_javadocs.sh
+++ b/.github/scripts/build_javadocs.sh
@@ -35,7 +35,7 @@ public class ImplementationFactory {
 }
 EOF
 
-find "$CN1_DIR/build/tempJavaSources" "$ROOT_DIR/Ports/CLDC11/src" -name "*.java" -not -path "$ROOT_DIR/Ports/CLDC11/src/java/*" \
+find "$CN1_DIR/build/tempJavaSources" "$ROOT_DIR/Ports/CLDC11/src" -name "*.java" \
   | /usr/bin/xargs "$JAVADOC_CMD" \
     --allow-script-in-comments \
     --add-stylesheet "$ROOT_DIR/maven/javadoc-resources/highlight.css" \


### PR DESCRIPTION
### Motivation
- The JDK 25 JavaDoc migration caused CLDC11 `java.*` packages to be omitted from the CI-generated docs, hiding the Java API surface supported by Codename One.

### Description
- Stop excluding `Ports/CLDC11/src/java/**` from the JavaDoc source list by removing the `-not -path "$ROOT_DIR/Ports/CLDC11/src/java/*"` filter in `.github/scripts/build_javadocs.sh`, so the CLDC11 sources are passed to `javadoc`.

### Testing
- Ran `./.github/scripts/build_javadocs.sh` successfully and confirmed `CodenameOne/dist/javadoc/allpackages-index.html` contains CLDC11 packages such as `java.lang` and `java.util`, and the `CodenameOne/javadocs.zip` artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c8e29764f8832986b8b201bf3f94b7)