### PR TITLE
Resilient Display/UIManager bindings and add Java-snippet-to-playground-uri CLI

### DIFF
--- a/scripts/cn1playground/common/src/main/java/com/codenameone/playground/PlaygroundRunner.java
+++ b/scripts/cn1playground/common/src/main/java/com/codenameone/playground/PlaygroundRunner.java
@@ -124,8 +124,8 @@ final class PlaygroundRunner {
         interpreter.set("theme", context.getTheme());
         interpreter.set("hostForm", context.getHostForm());
         interpreter.set("previewRoot", context.getPreviewRoot());
-        interpreter.set("Display", Display.getInstance());
-        interpreter.set("UIManager", UIManager.getInstance());
+        interpreter.set("Display", resolveDisplayBinding());
+        interpreter.set("UIManager", resolveUiManagerBinding());
         interpreter.set("FontImage", FontImage.class);
         interpreter.set("CN", com.codename1.ui.CN.class);
         interpreter.set("BoxLayout", BoxLayout.class);
@@ -139,6 +139,22 @@ final class PlaygroundRunner {
         namespace.importPackage("com.codename1.components");
         namespace.importPackage("com.codename1.ui.geom");
         namespace.importClass("com.codenameone.playground.PlaygroundContext");
+    }
+
+    private Object resolveDisplayBinding() {
+        try {
+            return Display.getInstance();
+        } catch (Throwable ex) {
+            return Display.class;
+        }
+    }
+
+    private Object resolveUiManagerBinding() {
+        try {
+            return UIManager.getInstance();
+        } catch (Throwable ex) {
+            return UIManager.class;
+        }
     }
 
     private String adaptScript(String script) {

--- a/scripts/cn1playground/common/src/test/java/com/codenameone/playground/JavaSnippetToPlaygroundUriHarness.java
+++ b/scripts/cn1playground/common/src/test/java/com/codenameone/playground/JavaSnippetToPlaygroundUriHarness.java
@@ -1,0 +1,167 @@
+package com.codenameone.playground;
+
+
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public final class JavaSnippetToPlaygroundUriHarness {
+    private static final String PREFIX = "/playground/?code=";
+
+    private JavaSnippetToPlaygroundUriHarness() {
+    }
+
+    public static void main(String[] args) {
+        try {
+            String source = loadSource(args);
+            if (source == null) {
+                emitError("UNEXPECTED_ERROR", "No snippet source provided", 1, 1);
+                return;
+            }
+
+            PlaygroundContext context = new PlaygroundContext(null, null, null, new PlaygroundContext.Logger() {
+                public void log(String message) {
+                }
+            });
+
+            PlaygroundRunner runner = new PlaygroundRunner();
+            PlaygroundRunner.RunResult result = runner.run(source, context);
+            if (result.getComponent() != null) {
+                System.out.println(PREFIX + encodeLikePlayground(source));
+                return;
+            }
+
+            PlaygroundRunner.Diagnostic diagnostic = result.getDiagnostics().isEmpty() ? null : result.getDiagnostics().get(0);
+            int line = diagnostic == null ? 1 : Math.max(1, diagnostic.line);
+            int column = diagnostic == null ? 1 : Math.max(1, diagnostic.column);
+            String message = diagnostic == null ? "Script execution failed" : diagnostic.message;
+            emitError(classifyErrorType(message), message, line, column);
+        } catch (Throwable ex) {
+            String message = ex.getMessage();
+            if (message == null || message.length() == 0) {
+                message = ex.getClass().getName();
+            }
+            emitError("UNEXPECTED_ERROR", message, 1, 1);
+        }
+    }
+
+    private static String loadSource(String[] args) throws IOException {
+        if (args.length == 0) {
+            return slurp(System.in);
+        }
+        if (args.length == 2 && "--file".equals(args[0])) {
+            InputStream input = new FileInputStream(args[1]);
+            try {
+                return slurp(input);
+            } finally {
+                input.close();
+            }
+        }
+        throw new IOException("Unsupported arguments. Expected --file <path> or stdin.");
+    }
+
+    private static String slurp(InputStream input) throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(input, "UTF-8"));
+        StringBuilder out = new StringBuilder();
+        String line;
+        boolean first = true;
+        while ((line = reader.readLine()) != null) {
+            if (!first) {
+                out.append('\n');
+            }
+            out.append(line);
+            first = false;
+        }
+        return out.toString();
+    }
+
+    private static String encodeLikePlayground(String source)
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        CN1Playground playground = new CN1Playground();
+        Method method = CN1Playground.class.getDeclaredMethod("encodeSharedScript", String.class);
+        method.setAccessible(true);
+        Object encoded = method.invoke(playground, source);
+        return encoded == null ? "" : encoded.toString();
+    }
+
+    private static String classifyErrorType(String message) {
+        if (message == null) {
+            return "UNEXPECTED_ERROR";
+        }
+        if (message.startsWith("Parse error:")) {
+            return "PARSE_ERROR";
+        }
+        if (message.startsWith("Lexer error:")) {
+            return "LEXER_ERROR";
+        }
+        if (message.startsWith("Unexpected error:")) {
+            return "UNEXPECTED_ERROR";
+        }
+        if (message.indexOf("Lifecycle script defines init(Object) but is missing start().") >= 0
+                || message.indexOf("Lifecycle start() did not show a Form and did not return a Component.") >= 0) {
+            return "LIFECYCLE_CONTRACT_ERROR";
+        }
+        if (message.indexOf("Script did not produce a previewable Component.") >= 0
+                || message.indexOf("instead of a previewable Component.") >= 0
+                || message.indexOf("Script must return a com.codename1.ui.Component") >= 0) {
+            return "NO_PREVIEWABLE_COMPONENT";
+        }
+        return "EVAL_ERROR";
+    }
+
+    private static void emitError(String errorType, String message, int line, int column) {
+        System.out.println("{\"ok\":false,\"errorType\":\"" + jsonEscape(errorType)
+                + "\",\"message\":\"" + jsonEscape(message)
+                + "\",\"line\":" + Math.max(1, line)
+                + ",\"column\":" + Math.max(1, column) + "}");
+    }
+
+    private static String jsonEscape(String value) {
+        if (value == null) {
+            return "";
+        }
+        StringBuilder out = new StringBuilder(value.length() + 16);
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            switch (ch) {
+                case '"':
+                    out.append("\\\"");
+                    break;
+                case '\\':
+                    out.append("\\\\");
+                    break;
+                case '\b':
+                    out.append("\\b");
+                    break;
+                case '\f':
+                    out.append("\\f");
+                    break;
+                case '\n':
+                    out.append("\\n");
+                    break;
+                case '\r':
+                    out.append("\\r");
+                    break;
+                case '\t':
+                    out.append("\\t");
+                    break;
+                default:
+                    if (ch < 32) {
+                        out.append("\\u");
+                        String hex = Integer.toHexString(ch);
+                        for (int j = hex.length(); j < 4; j++) {
+                            out.append('0');
+                        }
+                        out.append(hex);
+                    } else {
+                        out.append(ch);
+                    }
+            }
+        }
+        return out.toString();
+    }
+}

--- a/scripts/java-snippet-to-playground-uri.sh
+++ b/scripts/java-snippet-to-playground-uri.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+BUILD_DIR="${TMPDIR:-/tmp}/cn1-snippet-cli"
+CLASSES_DIR="$BUILD_DIR/classes"
+SOURCES_FILE="$BUILD_DIR/sources.txt"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/java-snippet-to-playground-uri.sh --file <path>
+  cat snippet.java | scripts/java-snippet-to-playground-uri.sh
+
+Converts a Java snippet into a Codename One playground URI.
+
+Output:
+  - Success: /playground/?code=<base64url>
+  - Failure: {"ok":false,"errorType":"...","message":"...","line":n,"column":n}
+USAGE
+}
+
+INPUT_MODE="stdin"
+INPUT_FILE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --file)
+      shift
+      if [[ $# -eq 0 ]]; then
+        echo "Missing value for --file" >&2
+        usage >&2
+        exit 2
+      fi
+      INPUT_MODE="file"
+      INPUT_FILE="$1"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+TMP_INPUT="$(mktemp)"
+trap 'rm -f "$TMP_INPUT"' EXIT
+
+if [[ "$INPUT_MODE" == "file" ]]; then
+  if [[ ! -f "$INPUT_FILE" ]]; then
+    echo "File not found: $INPUT_FILE" >&2
+    exit 2
+  fi
+  cat "$INPUT_FILE" > "$TMP_INPUT"
+else
+  if [[ -t 0 ]]; then
+    echo "No input provided. Use --file or pipe snippet via stdin." >&2
+    usage >&2
+    exit 2
+  fi
+  cat > "$TMP_INPUT"
+fi
+
+mkdir -p "$BUILD_DIR" "$CLASSES_DIR"
+
+# Build a javac source list from repository sources, excluding BeanShell desktop/classpath files
+# that are not needed by the CN1 playground runtime.
+: > "$SOURCES_FILE"
+while IFS= read -r src; do
+  case "$src" in
+    */bsh/classpath/*) continue ;;
+    */bsh/commands/dir.java) continue ;;
+    */bsh/util/ClassBrowser.java) continue ;;
+  esac
+  printf '%s\n' "$src" >> "$SOURCES_FILE"
+done < <(find \
+  "$ROOT_DIR/CodenameOne/src" \
+  "$ROOT_DIR/Factory/src" \
+  "$ROOT_DIR/scripts/cn1playground/common/src/main/java/com/codenameone/playground" \
+  "$ROOT_DIR/scripts/cn1playground/common/src/main/java/bsh" \
+  "$ROOT_DIR/scripts/cn1playground/common/src/main/java/bsh/cn1" \
+  "$ROOT_DIR/scripts/cn1playground/common/src/main/java/bsh/cn1/gen" \
+  -name '*.java' -print)
+
+printf '%s\n' "$ROOT_DIR/scripts/cn1playground/common/src/test/java/com/codenameone/playground/JavaSnippetToPlaygroundUriHarness.java" >> "$SOURCES_FILE"
+
+javac -encoding UTF-8 -d "$CLASSES_DIR" @"$SOURCES_FILE" >/dev/null 2>&1
+
+java -cp "$CLASSES_DIR" com.codenameone.playground.JavaSnippetToPlaygroundUriHarness --file "$TMP_INPUT"


### PR DESCRIPTION
### Motivation

- Make the playground runner robust in environments where `Display.getInstance()` or `UIManager.getInstance()` cannot be initialized (e.g., headless/CLI contexts). 
- Provide a small CLI/harness to convert a Java snippet into a Codename One playground URI so snippets can be encoded/validated outside of the playground web UI.

### Description

- Replace direct bindings of `Display.getInstance()` and `UIManager.getInstance()` in `PlaygroundRunner.bindGlobals` with `resolveDisplayBinding()` and `resolveUiManagerBinding()` methods that return the class object on failure to obtain a running instance. 
- Add `JavaSnippetToPlaygroundUriHarness` test harness that loads a snippet (from stdin or `--file`), executes it through `PlaygroundRunner`, prints the playground URI on success, and emits JSON error information on failure. 
- Add `scripts/java-snippet-to-playground-uri.sh` which compiles the required sources to a temporary classes directory and runs the harness, supporting both stdin and `--file` input modes.

### Testing

- Compiled the sources via the provided script using `javac` as part of the harness pipeline, and the compilation step completed successfully. 
- Executed the CLI script `scripts/java-snippet-to-playground-uri.sh` with a simple snippet provided via stdin and with `--file <path>`, and the harness produced the expected `/playground/?code=...` output on success and JSON error output on failure. 
- No other automated unit tests were modified or required by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c8eb5dd61883298e0bb1b69086361d)