### PR TITLE
Support .unselected selectors in CSSThemeCompiler

### DIFF
--- a/CodenameOne/src/com/codename1/ui/css/CSSThemeCompiler.java
+++ b/CodenameOne/src/com/codename1/ui/css/CSSThemeCompiler.java
@@ -321,6 +321,9 @@ public class CSSThemeCompiler {
     }
 
     private String statePrefix(String pseudo) {
+        if ("unselected".equals(pseudo)) {
+            return "";
+        }
         if ("selected".equals(pseudo)) {
             return "sel#";
         }

--- a/maven/core-unittests/src/test/java/com/codename1/ui/css/CSSThemeCompilerTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/css/CSSThemeCompilerTest.java
@@ -98,4 +98,15 @@ public class CSSThemeCompilerTest extends UITestBase {
         assertEquals("ff0000", theme.get("$DarkButton.press#fgColor"));
     }
 
+    @Test
+    public void testCompilesUnselectedStateSelector() {
+        CSSThemeCompiler compiler = new CSSThemeCompiler();
+        MutableResource resource = new MutableResource();
+
+        compiler.compile("Button.unselected{color:white;}", resource, "Theme");
+
+        Hashtable theme = resource.getTheme("Theme");
+        assertEquals("ffffff", theme.get("Button.fgColor"));
+    }
+
 }


### PR DESCRIPTION
### Motivation
- The CSSThemeCompiler did not recognize the `.unselected` state/class, so selectors like `Button.unselected { ... }` would not compile into the theme and runtime unselected styles.

### Description
- Map the `unselected` pseudo/class to the default (no prefix) theme keys by returning `""` in `statePrefix("unselected")` in `CSSThemeCompiler`.
- Add `testCompilesUnselectedStateSelector()` to `CSSThemeCompilerTest` to assert that `Button.unselected{color:white;}` compiles to `Button.fgColor = ffffff`.

### Testing
- Attempted to run the unit tests with `cd maven && mvn -pl core-unittests -am -DunitTests=true -Dmaven.javadoc.skip=true -Plocal-dev-javase -Dtest=CSSThemeCompilerTest test`, but the build could not resolve dependencies from Maven Central (HTTP 403), so the tests did not execute in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c9f1dbff7083299a3267e0e630b14f)