### PR TITLE
Make `DisableScreenshots` take effect at runtime on iOS and Android

### DIFF
--- a/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
+++ b/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
@@ -7711,6 +7711,14 @@ public abstract class CodenameOneImplementation {
     public void blockCopyPaste(boolean blockCopyPaste) {
 
     }
+    
+    /// Enables/disables screenshot blocking behavior where supported by the platform.
+    ///
+    /// #### Parameters
+    ///
+    /// - `disable`: True to disable screenshots/screen capture where possible.
+    public void setDisableScreenshots(boolean disable) {
+    }
 
     /// Checks if this platform supports custom database paths.  On platforms
     /// where this returns true, `#openOrCreateDB(java.lang.String)`

--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -3659,6 +3659,9 @@ public final class Display extends CN1Constants {
         if ("blockCopyPaste".equals(key)) {
             impl.blockCopyPaste("true".equals(value));
         }
+        if ("DisableScreenshots".equals(key)) {
+            impl.setDisableScreenshots("true".equalsIgnoreCase(value));
+        }
         if ("Component.revalidateOnStyleChange".equals(key)) {
             Component.setRevalidateOnStyleChange("true".equalsIgnoreCase(value));
         }

--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -260,6 +260,24 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
     public static CodenameOneActivity getActivity() {
         return activity;
     }
+    
+    @Override
+    public void setDisableScreenshots(final boolean disable) {
+        final CodenameOneActivity a = getActivity();
+        if (a == null || a.getWindow() == null) {
+            return;
+        }
+        a.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                if (disable) {
+                    a.getWindow().addFlags(WindowManager.LayoutParams.FLAG_SECURE);
+                } else {
+                    a.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
+                }
+            }
+        });
+    }
 
     /**
      * @param aActivity the activity to set

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
@@ -224,6 +224,11 @@ public class IOSImplementation extends CodenameOneImplementation {
             nativeInstance.setDisableScreenshots(true);
         }
     }
+    
+    @Override
+    public void setDisableScreenshots(boolean disable) {
+        nativeInstance.setDisableScreenshots(disable);
+    }
 
     public void setThreadPriority(Thread t, int p) {
     }


### PR DESCRIPTION
### Motivation
- `DisableScreenshots` was only observed during platform init, so calling `Display.getInstance().setProperty("DisableScreenshots", "true")` later (e.g. in the app `init(Object)` lifecycle method) could be too late to enable native screenshot blocking on iOS. 
- The native iOS mechanism is best-effort (it reacts to active capture/recording and overlays the UI), so the property should be applied whenever the app toggles it at runtime to meet developer expectations.

### Description
- Forward `DisableScreenshots` from `Display.setProperty(...)` to the platform implementation by calling `impl.setDisableScreenshots(...)` when that key is set. 
- Add a new `setDisableScreenshots(boolean)` method with a default no-op implementation in `CodenameOneImplementation`. 
- Implement `setDisableScreenshots(boolean)` in `IOSImplementation` to forward to the native bridge `nativeInstance.setDisableScreenshots(...)`. 
- Implement `setDisableScreenshots(boolean)` in `AndroidImplementation` to add/clear `WindowManager.LayoutParams.FLAG_SECURE` on the UI thread so toggling the property at runtime takes effect on Android as well.

### Testing
- Attempted the quick smoke helper `./scripts/fast-core-unit-smoke.sh` with Java 8 unset and with a local Java install; runs failed due to environment constraints (missing standard Java 8 path and Maven dependency resolution errors from Maven Central producing HTTP 403), so automated unit tests could not be completed here. 
- No repository unit tests were successfully executed in this environment due to the above failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ca0913d78483299376c682b46826a5)