### PR TITLE
Fix cn1-playground reflection mapping generation with released source roots

### DIFF
--- a/scripts/cn1playground/tools/src/main/java/com/codenameone/playground/tools/GenerateCN1AccessRegistry.java
+++ b/scripts/cn1playground/tools/src/main/java/com/codenameone/playground/tools/GenerateCN1AccessRegistry.java
@@ -46,7 +46,6 @@ public final class GenerateCN1AccessRegistry {
     private static final String HELPER_CLASS_PREFIX = "GeneratedAccess_";
     private static final int FIND_CLASS_CHUNK_SIZE = 64;
     private static final char MEMBER_SEPARATOR = '\u001f';
-    private static final Map<String, Boolean> RUNTIME_PUBLIC_TYPE_CACHE = new HashMap<String, Boolean>();
 
     private static final String[] INDEX_PACKAGE_PREFIXES = new String[]{
             "com.codename1.",
@@ -101,7 +100,6 @@ public final class GenerateCN1AccessRegistry {
         for (SourceClass sourceClass : indexedClasses.values()) {
             knownTypes.addAll(sourceClass.nestedTypes.values());
         }
-        knownTypes = filterKnownTypes(knownTypes);
 
         List<ApiClass> apiClasses = new ArrayList<ApiClass>();
         for (SourceClass sourceClass : indexedClasses.values()) {
@@ -1016,7 +1014,6 @@ private static List<ApiMethod> filterBridgeLikeMethods(List<ApiMethod> methods, 
     private static boolean isDispatchClass(ApiClass apiClass) {
         return (apiClass.packageName.startsWith("com.codename1.")
                 && !isPackageOrChild(apiClass.packageName, "com.codename1.impl"))
-                && isPublicRuntimeType(apiClass.qualifiedName)
                 || isSupportedJavaDispatchPackage(apiClass.packageName)
                 || "com.codenameone.playground".equals(apiClass.packageName)
                 || apiClass.packageName.startsWith("com.codenameone.playground.");
@@ -1041,11 +1038,6 @@ private static List<ApiMethod> filterBridgeLikeMethods(List<ApiMethod> methods, 
         if ("void".equals(name)) {
             return true;
         }
-        if (name.startsWith("com.codename1.")) {
-            if (!isPublicRuntimeType(name)) {
-                return false;
-            }
-        }
         return !name.startsWith("java.lang.reflect.")
                 && !name.startsWith("java.lang.annotation.")
                 && !name.startsWith("java.lang.invoke.")
@@ -1058,28 +1050,6 @@ private static List<ApiMethod> filterBridgeLikeMethods(List<ApiMethod> methods, 
                 && !name.startsWith("java.util.concurrent.")
                 && !name.startsWith("java.util.function.")
                 && !name.startsWith("java.util.stream.");
-    }
-
-    private static boolean isPublicRuntimeType(String className) {
-        Boolean cached = RUNTIME_PUBLIC_TYPE_CACHE.get(className);
-        if (cached != null) {
-            return cached.booleanValue();
-        }
-        Class<?> runtimeClass = loadRuntimeClass(className);
-        boolean supported = runtimeClass != null && java.lang.reflect.Modifier.isPublic(runtimeClass.getModifiers());
-        RUNTIME_PUBLIC_TYPE_CACHE.put(className, Boolean.valueOf(supported));
-        return supported;
-    }
-
-    private static LinkedHashSet<String> filterKnownTypes(LinkedHashSet<String> knownTypes) {
-        LinkedHashSet<String> filtered = new LinkedHashSet<String>();
-        for (String knownType : knownTypes) {
-            if (knownType.startsWith("com.codename1.") && !isPublicRuntimeType(knownType)) {
-                continue;
-            }
-            filtered.add(knownType);
-        }
-        return filtered;
     }
 
     private static boolean isPackageOrChild(String name, String packageName) {


### PR DESCRIPTION
### Motivation
- The playground generator moved to scanning downloaded CN1 source jars and runs without CN1 runtime jars on the tool classpath, but the generator still filtered CN1 types by attempting to load them at runtime which caused valid CN1 types to be dropped and produced broken reflection mappings.

### Description
- Remove runtime-class visibility filtering for `com.codename1.*` types by deleting `isPublicRuntimeType`/`filterKnownTypes` usage and the associated cache so discovery no longer depends on `Class.forName` for CN1 types.
- Adjust `isDispatchClass` and `isSupportedType` logic to keep package-level exclusions (e.g. `com.codename1.impl`) while avoiding runtime visibility checks that are invalid for the source-jar workflow.
- Change is limited to `scripts/cn1playground/tools/src/main/java/com/codenameone/playground/tools/GenerateCN1AccessRegistry.java` to restore correct reflection registry generation from source roots.

### Testing
- Compiled the generator with `javac -d /tmp/cn1tool scripts/cn1playground/tools/src/main/java/com/codenameone/playground/tools/GenerateCN1AccessRegistry.java`, which succeeded.
- Attempted to run `./scripts/cn1playground/tools/generate-cn1-access-registry.sh` and `CN1_VERSION=7.0.230 ./scripts/cn1playground/tools/generate-cn1-access-registry.sh`, but both runs failed to download source jars due to `curl: (22) 403` from the Maven endpoint in this environment, preventing a full end-to-end generation smoke test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ca5db3d3f88329bd9c69fe07f2e3e7)