### PR TITLE
Fix Javadoc "Open in playground" links to use base64-encoded code payload

### DIFF
--- a/maven/javadoc-resources/javadoc-highlight-init.js
+++ b/maven/javadoc-resources/javadoc-highlight-init.js
@@ -15,6 +15,22 @@ document.addEventListener('DOMContentLoaded', () => {
     return className.includes('language-java') || className.includes('lang-java');
   };
 
+  const encodePlaygroundCode = (codeText) => {
+    try {
+      if (typeof TextEncoder !== 'undefined') {
+        const bytes = new TextEncoder().encode(codeText);
+        let binary = '';
+        bytes.forEach((byte) => {
+          binary += String.fromCharCode(byte);
+        });
+        return btoa(binary);
+      }
+    } catch (e) {
+      // Fall through to the URI-encoding based fallback below.
+    }
+    return btoa(unescape(encodeURIComponent(codeText)));
+  };
+
   const addPlaygroundLink = (pre, codeText) => {
     if (!codeText || pre.nextElementSibling?.classList.contains('cn1-open-playground-link')) {
       return;
@@ -25,7 +41,7 @@ document.addEventListener('DOMContentLoaded', () => {
     linkContainer.style.margin = '6px 0 14px 0';
 
     const link = document.createElement('a');
-    link.href = `${playgroundBase}${encodeURIComponent(codeText)}`;
+    link.href = `${playgroundBase}${encodePlaygroundCode(codeText)}`;
     link.target = '_blank';
     link.rel = 'noopener noreferrer';
     link.textContent = 'Open in playground';


### PR DESCRIPTION
### Motivation
- Javadoc "Open in playground" links were appending URI-encoded snippet text via `encodeURIComponent`, which produces links the playground does not accept. 
- The playground expects a base64 UTF-8 payload in the `code` query parameter, so snippets must be base64-encoded before being appended.

### Description
- Updated `maven/javadoc-resources/javadoc-highlight-init.js` to replace `encodeURIComponent` with a new `encodePlaygroundCode()` helper. 
- `encodePlaygroundCode()` UTF-8 encodes the snippet using `TextEncoder` when available, converts the bytes to a binary string and applies `btoa()`, with a compatibility fallback of `btoa(unescape(encodeURIComponent(codeText)))` when necessary. 
- The `addPlaygroundLink()` function now sets `link.href` to `${playgroundBase}${encodePlaygroundCode(codeText)}` so the playground receives a base64 payload.

### Testing
- Verified encoding behavior by running a Node-based base64 check (using `Buffer.from(code, 'utf8').toString('base64')`) against a sample Java snippet and confirmed the output matches the expected playground payload. 
- No automated test failures were observed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ca7a836acc83298eb1090507cefe84)