### PR TITLE
Implement String.format across runtimes and add StandardCharsets constants; update tests

### DIFF
--- a/Ports/CLDC11/src/java/lang/String.java
+++ b/Ports/CLDC11/src/java/lang/String.java
@@ -548,6 +548,10 @@ public final class String implements CharSequence, Comparable<String> {
     public CharSequence subSequence(int start, int end) {
         return substring(start, end);
     }
+    
+    public static String format(String format, Object... args) {
+        return null; //TODO codavaj!!
+    }
 
     /**
      * Checks if string contains the given char sequence.

--- a/Ports/CLDC11/src/java/nio/charset/StandardCharsets.java
+++ b/Ports/CLDC11/src/java/nio/charset/StandardCharsets.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ */
+package java.nio.charset;
+
+/**
+ * Minimal charset constants supported by CLDC11 stubs.
+ */
+public final class StandardCharsets {
+    private StandardCharsets() {
+    }
+
+    public static final Charset UTF_8 = new Charset("UTF-8", new String[0]);
+    public static final Charset US_ASCII = new Charset("US-ASCII", new String[0]);
+    public static final Charset ISO_8859_1 = new Charset("ISO-8859-1", new String[0]);
+}

--- a/vm/ByteCodeTranslator/src/javascript/parparvm_runtime.js
+++ b/vm/ByteCodeTranslator/src/javascript/parparvm_runtime.js
@@ -1108,24 +1108,68 @@ bindNative(["cn1_java_lang_String_charsToBytes_char_1ARRAY_char_1ARRAY_R_byte_1A
   return out;
 });
 bindNative(["cn1_java_lang_String_format_java_lang_String_java_lang_Object_1ARRAY_R_java_lang_String"], function*(format, args) {
-  let index = 0;
+  const text = jvm.toNativeString(format);
   const values = [];
   if (args && args.__array) {
     for (let i = 0; i < args.length; i++) {
-      values.push(yield* runtimeToNativeString(args[i]));
+      values.push(args[i]);
     }
   }
-  const result = jvm.toNativeString(format).replace(/%[%sdifc]/g, function(token) {
-    if (token === "%%") {
-      return "%";
+
+  const nextArgString = function*(token) {
+    const arg = values.length ? values.shift() : null;
+    if (token === "c") {
+      const native = yield* runtimeToNativeString(arg);
+      if (native == null || native.length === 0) {
+        return "";
+      }
+      if (native.length === 1) {
+        return native;
+      }
+      const asInt = parseInt(native, 10);
+      return isNaN(asInt) ? native.charAt(0) : String.fromCharCode(asInt);
     }
-    const value = values[index++];
-    if (token === "%c") {
-      return String.fromCharCode(value | 0);
+    return yield* runtimeToNativeString(arg);
+  };
+
+  let out = "";
+  for (let i = 0; i < text.length; i++) {
+    const ch = text.charAt(i);
+    if (ch !== "%" || i === text.length - 1) {
+      out += ch;
+      continue;
     }
-    return value;
-  });
-  return createJavaString(result);
+
+    const next = text.charAt(i + 1);
+    if (next === "%") {
+      out += "%";
+      i++;
+      continue;
+    }
+
+    let j = i + 1;
+    while (j < text.length && "-#+ 0,(".indexOf(text.charAt(j)) >= 0) {
+      j++;
+    }
+    while (j < text.length && text.charAt(j) >= "0" && text.charAt(j) <= "9") {
+      j++;
+    }
+    if (j < text.length && text.charAt(j) === ".") {
+      j++;
+      while (j < text.length && text.charAt(j) >= "0" && text.charAt(j) <= "9") {
+        j++;
+      }
+    }
+    const token = j < text.length ? text.charAt(j) : "";
+    if ("sdifc".indexOf(token) >= 0) {
+      out += yield* nextArgString(token);
+      i = j;
+    } else {
+      out += "%";
+    }
+  }
+
+  return createJavaString(out);
 });
 bindNative(["cn1_java_lang_StringToReal_parseDblImpl_java_lang_String_int_R_double"], function*(value, exponentIndex) {
   const text = jvm.toNativeString(value);

--- a/vm/ByteCodeTranslator/src/nativeMethods.m
+++ b/vm/ByteCodeTranslator/src/nativeMethods.m
@@ -2021,7 +2021,45 @@ JAVA_OBJECT java_lang_String_format___java_lang_String_java_lang_Object_1ARRAY_R
     finishedNativeAllocations();
     return out;
 #else
-    // TODO: Implement stub
-    return format; // Stub
+    JAVA_OBJECT builder = __NEW_INSTANCE_java_lang_StringBuilder(threadStateData);
+    int formatLength = java_lang_String_length___R_int(threadStateData, format);
+    JAVA_ARRAY argsArray = (JAVA_ARRAY)args;
+    JAVA_ARRAY_OBJECT* values = argsArray == JAVA_NULL ? JAVA_NULL : (JAVA_ARRAY_OBJECT*)argsArray->data;
+    int valuesLength = argsArray == JAVA_NULL ? 0 : argsArray->length;
+    int argIndex = 0;
+
+    for (int i = 0; i < formatLength; i++) {
+        JAVA_CHAR ch = java_lang_String_charAt___int_R_char(threadStateData, format, i);
+        if (ch != '%' || i == formatLength - 1) {
+            java_lang_StringBuilder_append___char_R_java_lang_StringBuilder(threadStateData, builder, ch);
+            continue;
+        }
+
+        JAVA_CHAR token = java_lang_String_charAt___int_R_char(threadStateData, format, i + 1);
+        i++;
+        if (token == '%') {
+            java_lang_StringBuilder_append___char_R_java_lang_StringBuilder(threadStateData, builder, '%');
+            continue;
+        }
+
+        if (argIndex >= valuesLength || values == JAVA_NULL) {
+            java_lang_StringBuilder_append___char_R_java_lang_StringBuilder(threadStateData, builder, '%');
+            java_lang_StringBuilder_append___char_R_java_lang_StringBuilder(threadStateData, builder, token);
+            continue;
+        }
+
+        JAVA_OBJECT value = values[argIndex++];
+        JAVA_OBJECT valueText = java_lang_String_valueOf___java_lang_Object_R_java_lang_String(threadStateData, value);
+        if (token == 'c') {
+            int valueTextLength = java_lang_String_length___R_int(threadStateData, valueText);
+            if (valueTextLength > 0) {
+                JAVA_CHAR out = java_lang_String_charAt___int_R_char(threadStateData, valueText, 0);
+                java_lang_StringBuilder_append___char_R_java_lang_StringBuilder(threadStateData, builder, out);
+            }
+        } else {
+            java_lang_StringBuilder_append___java_lang_String_R_java_lang_StringBuilder(threadStateData, builder, valueText);
+        }
+    }
+    return java_lang_StringBuilder_toString___R_java_lang_String(threadStateData, builder);
 #endif
 }

--- a/vm/JavaAPI/src/java/nio/charset/StandardCharsets.java
+++ b/vm/JavaAPI/src/java/nio/charset/StandardCharsets.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ */
+package java.nio.charset;
+
+/**
+ * Minimal charset constants supported by Codename One's JavaAPI.
+ */
+public final class StandardCharsets {
+    private StandardCharsets() {
+    }
+
+    public static final Charset UTF_8 = new Charset("UTF-8", new String[0]);
+    public static final Charset US_ASCII = new Charset("US-ASCII", new String[0]);
+    public static final Charset ISO_8859_1 = new Charset("ISO-8859-1", new String[0]);
+}

--- a/vm/tests/src/test/java/com/codename1/tools/translator/JavascriptRuntimeSemanticsTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/JavascriptRuntimeSemanticsTest.java
@@ -45,7 +45,7 @@ class JavascriptRuntimeSemanticsTest {
     void executesBroaderJavaApiCoverageInWorkerRuntime(CompilerHelper.CompilerConfig config) throws Exception {
         WorkerRunResult result = translateAndRunFixture(config, "JsJavaApiCoverageApp.java", "JsJavaApiCoverageApp");
 
-        assertEquals(255, result.result, "Translated runtime should execute the broader JavaAPI coverage fixture");
+        assertEquals(511, result.result, "Translated runtime should execute the broader JavaAPI coverage fixture");
         assertTrue(result.errorMessage == null || result.errorMessage.isEmpty(), "Worker should not emit an error message");
     }
 

--- a/vm/tests/src/test/resources/com/codename1/tools/translator/JsJavaApiCoverageApp.java
+++ b/vm/tests/src/test/resources/com/codename1/tools/translator/JsJavaApiCoverageApp.java
@@ -1,4 +1,5 @@
 import java.lang.reflect.Array;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
 public class JsJavaApiCoverageApp {
@@ -34,9 +35,14 @@ public class JsJavaApiCoverageApp {
             mask |= 8;
         }
 
-        String formatted = String.format("%s-%d", "cn1", Integer.valueOf(7));
-        if ("cn1-7".equals(formatted)) {
+        String formatted = String.format("%s-%d-%c%%", "cn1", Integer.valueOf(7), Character.valueOf('A'));
+        if ("cn1-7-A%".equals(formatted)) {
             mask |= 16;
+        }
+        
+        byte[] utf8 = "cn1".getBytes(StandardCharsets.UTF_8);
+        if (utf8.length == 3 && utf8[0] == 'c' && utf8[1] == 'n' && utf8[2] == '1') {
+            mask |= 256;
         }
 
         int[] src = new int[] {1, 2, 3};


### PR DESCRIPTION
### Motivation
- Provide missing Java API pieces used by translated code, namely `String.format` and minimal `StandardCharsets` constants, to improve JavaAPI coverage in the CLDC11 and translator runtimes.
- Replace stubs with actual formatting behavior so translated Java code using format specifiers (including `%c` and literal `%%`) behaves correctly in both native and JS runtimes.
- Enable correct UTF-8 bytes handling via `StandardCharsets.UTF_8` to allow `String.getBytes(StandardCharsets.UTF_8)` to work in tests and translated apps.

### Description
- Added `java.nio.charset.StandardCharsets` to both `Ports/CLDC11` and `vm/JavaAPI` providing `UTF_8`, `US_ASCII`, and `ISO_8859_1` constants.
- Added a `String.format(String, Object...)` stub declaration to `Ports/CLDC11/src/java/lang/String.java` (signature present for the platform).
- Implemented JavaScript runtime formatting in `parparvm_runtime.js` for `cn1_java_lang_String_format...` with proper parsing of `%%`, `%s`, `%d`, `%i`, `%f`, and `%c` tokens, handling flags/width/precision scanning and converting runtime arguments to strings as needed.
- Implemented native (non-Apple) formatting in `nativeMethods.m` for `java_lang_String_format...`, constructing the result via a `StringBuilder` and handling `%c` specially; Apple/ObjC path remains using `NSString` formatting.
- Updated test fixtures: extended `JsJavaApiCoverageApp.java` to check `%c` and `%%` behavior and to verify `getBytes(StandardCharsets.UTF_8)` returns expected UTF-8 bytes, and updated the expected test mask accordingly.
- Adjusted `JavascriptRuntimeSemanticsTest` expected result from `255` to `511` to reflect the expanded checks.

### Testing
- Ran `vm/tests` Java unit tests including `JavascriptRuntimeSemanticsTest`, which covers `JsJavaApiCoverageApp` and worker runtime semantics, and updated the expected values; the test suite passed with the updated expectations.
- Executed the JavaScript runtime integration fixture `JsJavaApiCoverageApp` under the translator tests to validate format parsing and `StandardCharsets` usage, and it produced the expected result (mask `511`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cb8edf1cf88329908f3ebd2b00915d)