### PR TITLE
Add GitHub icon/link to homepage Open Source strip

### DIFF
--- a/docs/website/assets/css/extended/cn1-home.css
+++ b/docs/website/assets/css/extended/cn1-home.css
@@ -83,22 +83,6 @@ body.dark.cn1-homepage {
     padding-top: 40px;
 }
 
-.cn1-homepage .header::before {
-    content: "Open Source & Free";
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 40px;
-    background: var(--cn1-home-strip-bg);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 18px;
-    font-weight: 700;
-    color: var(--cn1-home-strip-text);
-}
-
 .cn1-homepage .nav {
     display: flex;
     flex-wrap: nowrap;
@@ -267,8 +251,7 @@ body:not(.dark) .cn1-brand-logo {
     padding-top: 40px;
 }
 
-.cn1-header::before {
-    content: "Open Source & Free";
+.cn1-top-strip {
     position: fixed;
     top: 0;
     left: 0;
@@ -278,9 +261,25 @@ body:not(.dark) .cn1-brand-logo {
     display: flex;
     align-items: center;
     justify-content: center;
+}
+
+.cn1-top-strip__link {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
     font-size: 18px;
     font-weight: 700;
     color: var(--cn1-home-strip-text);
+    text-decoration: none;
+}
+
+.cn1-top-strip__link:hover,
+.cn1-top-strip__link:focus-visible {
+    text-decoration: underline;
+}
+
+.cn1-top-strip__link i {
+    font-size: 20px;
 }
 
 .cn1-header .nav {
@@ -1540,12 +1539,12 @@ body:not(.dark) .cn1-theme-toggle-btn {
 }
 
 @media (max-width: 1400px) {
-    .cn1-homepage .header::before {
+    .cn1-top-strip__link {
         font-size: 18px;
     }
 
-    .cn1-header::before {
-        font-size: 18px;
+    .cn1-top-strip__link i {
+        font-size: 20px;
     }
 
     .cn1-homepage .logo a {

--- a/docs/website/layouts/partials/header.html
+++ b/docs/website/layouts/partials/header.html
@@ -40,6 +40,12 @@
 {{- end }}
 
 <header class="header cn1-header">
+    <div class="cn1-top-strip">
+        <a class="cn1-top-strip__link" href="https://github.com/codenameone/CodenameOne" target="_blank" rel="noopener noreferrer">
+            <i class="fab fa-github" aria-hidden="true"></i>
+            <span>Open Source &amp; Free</span>
+        </a>
+    </div>
     <nav class="nav cn1-nav">
         <div class="logo">
             {{- $label_text := (site.Params.label.text | default site.Title) }}


### PR DESCRIPTION
### Motivation
- Make the existing “Open Source & Free” site strip interactive and link directly to the repository so visitors can open the project on GitHub in a new tab.
- Replace the CSS pseudo-element text with real markup so the banner can include an icon and accessible link semantics.

### Description
- Added an inline top strip in the shared header partial at `docs/website/layouts/partials/header.html` containing an anchor to `https://github.com/codenameone/CodenameOne` with `target="_blank"` and `rel="noopener noreferrer"` and a Font Awesome GitHub icon.
- Removed the pseudo-element text approach and introduced `.cn1-top-strip` and `.cn1-top-strip__link` styles in `docs/website/assets/css/extended/cn1-home.css` to control layout, icon sizing, hover/focus behavior, and responsiveness.
- Updated the media query rules to keep the new strip and icon sizing consistent across viewport widths.

### Testing
- Attempted an automated Hugo site build with `cd docs/website && hugo --minify --destination /tmp/cn1-site-test`, which failed because `hugo` is not installed in the environment (no site build artifacts produced).
- No other automated test suites were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cc9f37bfd08329b47b08eaf32351f7)