### PR TITLE
Add opt-in Android seek-preview workaround to reduce black-frame on paused seeks

### DIFF
--- a/CodenameOne/src/com/codename1/media/Media.java
+++ b/CodenameOne/src/com/codename1/media/Media.java
@@ -353,6 +353,15 @@ public interface Media {
     /// Write-only variable that can be used with getVariable() to set whether this
     /// video should include embedded native controls.
     String VARIABLE_NATIVE_CONTRLOLS_EMBEDDED = "nativeControlsVisible";
+    
+    /**
+     * Optional boolean flag to enable an Android-specific workaround for flaky
+     * black-frame previews after {@link #setTime(int)} on paused video.
+     * <p>The default is {@code false}. When enabled, Android may perform an
+     * additional internal refresh seek to force a frame redraw without changing
+     * behaviour on other platforms.
+     */
+    String VARIABLE_ANDROID_SEEK_PREVIEW_WORKAROUND = "androidSeekPreviewWorkaround";
 
     /// Starts playing or recording the media file
     void play();

--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -7641,6 +7641,7 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
         private final EventDispatcher stateChangeListeners = new EventDispatcher();
         private PlayRequest pendingPlayRequest;
         private PauseRequest pendingPauseRequest;
+        private boolean androidSeekPreviewWorkaroundEnabled;
 
         @Override
         public State getState() {
@@ -7960,7 +7961,29 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
         @Override
         public void setTime(int time) {
             if(nativeVideo != null){
-                nativeVideo.seekTo(time);
+                final int seekTime = time;
+                activity.runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (nativeVideo == null) {
+                            return;
+                        }
+                        nativeVideo.seekTo(seekTime);
+                        if (androidSeekPreviewWorkaroundEnabled && !nativeVideo.isPlaying()) {
+                            final int refreshSeekTime = Math.max(0, seekTime - 1);
+                            nativeVideo.postDelayed(new Runnable() {
+                                @Override
+                                public void run() {
+                                    if (nativeVideo != null && !nativeVideo.isPlaying()) {
+                                        nativeVideo.seekTo(refreshSeekTime);
+                                        nativeVideo.seekTo(seekTime);
+                                        nativeVideo.invalidate();
+                                    }
+                                }
+                            }, 60);
+                        }
+                    }
+                });
             }
         }
 
@@ -8118,6 +8141,10 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
         public void setVariable(String key, Object value) {
             if (nativeVideo != null && Media.VARIABLE_NATIVE_CONTRLOLS_EMBEDDED.equals(key) && value instanceof Boolean) {
                 setNativeController((Boolean)value);
+                return;
+            }
+            if (Media.VARIABLE_ANDROID_SEEK_PREVIEW_WORKAROUND.equals(key) && value instanceof Boolean) {
+                androidSeekPreviewWorkaroundEnabled = ((Boolean)value).booleanValue();
             }
         }
 


### PR DESCRIPTION
### Motivation

- Some Android devices intermittently show a black poster/preview frame after calling `setTime(int)` (seek) on a paused video, so a low-risk workaround is needed that does not change default behavior for other platforms or existing apps.

### Description

- Added a new opt-in media variable constant `Media.VARIABLE_ANDROID_SEEK_PREVIEW_WORKAROUND` in `CodenameOne/src/com/codename1/media/Media.java` to let apps enable an Android-specific workaround.
- Added a boolean flag `androidSeekPreviewWorkaroundEnabled` to the Android `Video` implementation and wired `setVariable(...)` to accept the new key in `Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java`.
- Modified `setTime(int)` to run seeks on the Android UI thread and, when the new flag is enabled and the video is not playing, schedule a short delayed refresh sequence (`seekTo(t-1)`, `seekTo(t)` and `invalidate()`) to encourage a frame redraw without altering default behavior.
- The workaround is disabled by default to preserve backward compatibility and only affects Android when explicitly enabled.

### Testing

- Attempted to run the fast core smoke script (`./scripts/fast-core-unit-smoke.sh`) with the Java 8 toolchain as required by CI, but it failed in this environment because `JAVA_HOME` was not defined correctly for Java 8, so no automated unit tests were executed.
- Static inspection and local file edits were performed to ensure the new constant and Android flag are added and used correctly, and no other platform code paths were changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ccb79ddd248329a5589986e7230091)