### PR TITLE
initializr: default useLargerTextScaleBool to true in generated theme.css

### DIFF
--- a/scripts/initializr/common/src/main/java/com/codename1/initializr/model/GeneratorModel.java
+++ b/scripts/initializr/common/src/main/java/com/codename1/initializr/model/GeneratorModel.java
@@ -201,6 +201,7 @@ public class GeneratorModel {
             content = injectLocalizationBootstrap(targetPath, content);
         }
         if (isBareTemplate() && "common/src/main/css/theme.css".equals(targetPath)) {
+            content = ensureDefaultLargeTextScale(content);
             content += buildThemeCss();
         }
         if ("common/pom.xml".equals(targetPath)) {
@@ -429,6 +430,27 @@ public class GeneratorModel {
 
     private boolean isBareTemplate() {
         return template == Template.BAREBONES || template == Template.KOTLIN;
+    }
+
+    private static String ensureDefaultLargeTextScale(String css) {
+        if (css.indexOf("useLargerTextScaleBool") >= 0) {
+            return css;
+        }
+        int constantsStart = css.indexOf("#Constants");
+        if (constantsStart < 0) {
+            return css + "\n\n#Constants {\n    useLargerTextScaleBool: true;\n}\n";
+        }
+        int blockStart = css.indexOf('{', constantsStart);
+        if (blockStart < 0) {
+            return css;
+        }
+        int blockEnd = css.indexOf('}', blockStart);
+        if (blockEnd < 0) {
+            return css;
+        }
+        return css.substring(0, blockEnd)
+                + "    useLargerTextScaleBool: true;\n"
+                + css.substring(blockEnd);
     }
 
     private String buildReadmeMarkdown() {

--- a/scripts/initializr/common/src/test/java/com/codename1/initializr/model/GeneratorModelMatrixTest.java
+++ b/scripts/initializr/common/src/test/java/com/codename1/initializr/model/GeneratorModelMatrixTest.java
@@ -192,8 +192,17 @@ public class GeneratorModelMatrixTest extends AbstractTest {
         assertCommonPom(entries, template, packageName, mainClassName, false);
         assertSettings(entries, template, packageName, mainClassName, false);
         assertMainSourceFile(entries, template, packageName, mainClassName, false);
+        assertThemeDefaults(entries, template);
         assertLocalizationBundles(entries, template, false);
         assertNoTemplatePlaceholders(entries, template);
+    }
+
+    private void assertThemeDefaults(Map<String, byte[]> entries, Template template) {
+        if (template != Template.BAREBONES && template != Template.KOTLIN) {
+            return;
+        }
+        String themeCss = getText(entries, "common/src/main/css/theme.css");
+        assertContains(themeCss, "useLargerTextScaleBool: true;", "Barebones templates should default useLargerTextScaleBool to true");
     }
 
     private static byte[] createProjectZip(IDE ide, Template template, String appName, String packageName) throws IOException {


### PR DESCRIPTION
### Motivation

- New projects generated by the Initializr should opt in to larger text scaling by default so apps start with accessible text sizing.

### Description

- Injected a safe, idempotent `useLargerTextScaleBool: true;` into barebones/Kotlin `theme.css` when generating a project by adding `ensureDefaultLargeTextScale` and invoking it before `buildThemeCss()` in `GeneratorModel`.
- The injection looks for an existing `useLargerTextScaleBool` and leaves the CSS unchanged if present, otherwise it adds the constant inside an existing `#Constants` block or appends a new `#Constants` block.
- Added an assertion in `GeneratorModelMatrixTest` to verify barebones and Kotlin templates produce `common/src/main/css/theme.css` containing `useLargerTextScaleBool: true;`.
- Modified files: `scripts/initializr/common/src/main/java/com/codename1/initializr/model/GeneratorModel.java` and `scripts/initializr/common/src/test/java/com/codename1/initializr/model/GeneratorModelMatrixTest.java`.

### Testing

- Attempted to run the matrix test with `cd scripts/initializr/common && mvn -Dtest=GeneratorModelMatrixTest test` but the environment failed to run Maven due to external resolution errors (Maven Central returned 403 for plugin resolution), so the test could not be executed here.
- An attempted run with `JAVA_HOME` set also failed because the Java 8 path was not available in this environment, so no local test run succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ccd14f8fdc8329b721f856c2a8df66)