### PR TITLE
Enable component inspection in classic JavaSE simulator mode

### DIFF
--- a/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
@@ -758,6 +758,13 @@ public class JavaSEPort extends CodenameOneImplementation {
     private boolean disconnectedMode;
 
     private static boolean exposeFilesystem;
+
+    private ComponentTreeInspector getOrCreateComponentTreeInspector() {
+        if (componentTreeInspector == null) {
+            componentTreeInspector = new ComponentTreeInspector();
+        }
+        return componentTreeInspector;
+    }
     private boolean scrollWheeling;
     
     private JComponent textCmp;
@@ -1863,8 +1870,9 @@ public class JavaSEPort extends CodenameOneImplementation {
         }
 
         private boolean showContextMenu(final MouseEvent me) {
-            if (componentTreeInspector == null ||
-                    !componentTreeInspector.isSimulatorRightClickEnabled() ||
+            ComponentTreeInspector inspector = getOrCreateComponentTreeInspector();
+            if (inspector == null ||
+                    !inspector.isSimulatorRightClickEnabled() ||
                     !CN.isSimulator()) {
                 return false;
             }
@@ -1886,13 +1894,14 @@ public class JavaSEPort extends CodenameOneImplementation {
 
                 @Override
                 public void actionPerformed(ActionEvent e) {
-                    if (componentTreeInspector != null && componentTreeInspector.isSimulatorRightClickEnabled()) {
+                    ComponentTreeInspector inspector = getOrCreateComponentTreeInspector();
+                    if (inspector != null && inspector.isSimulatorRightClickEnabled()) {
                         Form f = Display.getInstance().getCurrent();
                         if (f != null) {
                             int x = scaleCoordinateX(me.getX());
                             int y = scaleCoordinateY(me.getY());
                             Component cmp = f.getComponentAt(x, y);
-                            componentTreeInspector.inspectComponent(cmp);
+                            inspector.inspectComponent(cmp);
                         }
                     }
                 }
@@ -4025,7 +4034,7 @@ public class JavaSEPort extends CodenameOneImplementation {
             public void actionPerformed(ActionEvent ae) {
                 if (appFrame != null) return;
 
-                new ComponentTreeInspector().showInFrame();
+                getOrCreateComponentTreeInspector().showInFrame();
             }
         });
 


### PR DESCRIPTION
### Motivation
- The simulator "Inspect Component" action and right-click inspection only worked when the app-frame (single-window) mode initialized the `componentTreeInspector` field, leaving classic simulator mode without inspection support.
- Make the inspector available lazily so both app-frame and classic simulator modes can reuse the same inspector instance and enable inspect-element in old simulator mode.

### Description
- Added a lazy accessor `getOrCreateComponentTreeInspector()` to `JavaSEPort` to create the shared `ComponentTreeInspector` on demand (`Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java`).
- Updated the right-click context menu logic in `showContextMenu` to use the shared inspector instance when checking `isSimulatorRightClickEnabled()` and when invoking `inspectComponent`.
- Changed the Tools → Component Inspector action to call `getOrCreateComponentTreeInspector().showInFrame()` instead of creating a new detached `ComponentTreeInspector`.

### Testing
- Ran `git diff --check` which reported no issues and passed. 
- Attempted the smoke-run helper `./scripts/fast-core-unit-smoke.sh` under Java 8, but it failed in this environment because the `JAVA_HOME` path for Java 8 was not available, so unit tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cf3dfcc99483298b2c75c638756b16)