### PR TITLE
Improve CN1 playground side menu dark mode, disable swipe, and add mobile responsiveness

### DIFF
--- a/scripts/cn1playground/common/src/main/css/theme.css
+++ b/scripts/cn1playground/common/src/main/css/theme.css
@@ -399,6 +399,18 @@ TabDark {
     text-align: center;
 }
 
+TabSelected {
+    background: #ffffff;
+    color: #111827;
+    border: 1px solid #94a3b8;
+}
+
+TabSelectedDark {
+    background: #1f2937;
+    color: #f8fafc;
+    border: 1px solid #64748b;
+}
+
 TabsContainer {
     background: #e5e7eb;
 }

--- a/scripts/cn1playground/common/src/main/java/com/codenameone/playground/CN1Playground.java
+++ b/scripts/cn1playground/common/src/main/java/com/codenameone/playground/CN1Playground.java
@@ -572,6 +572,7 @@ public class CN1Playground extends Lifecycle {
         websiteThemeNative = NativeLookup.create(WebsiteThemeNative.class);
         refreshWebsiteTheme(form);
         UITimer.timer(900, true, form, () -> refreshWebsiteTheme(form));
+        UITimer.timer(250, true, form, this::syncOpenSideMenuTheme);
     }
 
     private void notifyWebsiteUiReady() {
@@ -676,6 +677,8 @@ public class CN1Playground extends Lifecycle {
         sideMenuPalette.put("SideNavigationPanel.bgTransparency", 255);
         sideMenuPalette.put("SideNavigationPanelDark.bgColor", bgColor);
         sideMenuPalette.put("SideNavigationPanelDark.bgTransparency", 255);
+        sideMenuPalette.put("RightSideNavigationPanel.bgColor", bgColor);
+        sideMenuPalette.put("RightSideNavigationPanel.bgTransparency", 255);
 
         sideMenuPalette.put("StatusBarSideMenu.bgColor", bgColor);
         sideMenuPalette.put("StatusBarSideMenu.bgTransparency", 255);
@@ -686,6 +689,36 @@ public class CN1Playground extends Lifecycle {
         sideMenuPalette.put("SideCommand.bgTransparency", 255);
         sideMenuPalette.put("SideCommand.border", com.codename1.ui.plaf.Border.createLineBorder(2, borderColor));
         UIManager.getInstance().addThemeProps(sideMenuPalette);
+    }
+
+    private void syncOpenSideMenuTheme() {
+        Form current = Display.getInstance().getCurrent();
+        if (current == null) {
+            return;
+        }
+        applySideMenuContainerTheme(current);
+    }
+
+    private void applySideMenuContainerTheme(Component component) {
+        if (component == null) {
+            return;
+        }
+        String uiid = component.getUIID();
+        if ("SideNavigationPanel".equals(uiid)
+                || "SideNavigationPanelDark".equals(uiid)
+                || "RightSideNavigationPanel".equals(uiid)
+                || "StatusBarSideMenu".equals(uiid)
+                || "StatusBarSideMenuDark".equals(uiid)) {
+            applyWebsiteTheme(component, websiteDarkMode);
+            component.getAllStyles().setBgTransparency(255);
+            component.getAllStyles().setBgColor(websiteDarkMode ? 0x0f172a : 0xffffff);
+        }
+        if (component instanceof Container) {
+            Container cnt = (Container) component;
+            for (int i = 0; i < cnt.getComponentCount(); i++) {
+                applySideMenuContainerTheme(cnt.getComponentAt(i));
+            }
+        }
     }
 
     private void applyWebsiteTheme(Component component, boolean dark) {
@@ -747,6 +780,7 @@ public class CN1Playground extends Lifecycle {
             case "PlaygroundPanel":
             case "PlaygroundPreview":
             case "SideNavigationPanel":
+            case "RightSideNavigationPanel":
             case "StatusBarSideMenu":
             case "PlaygroundSideCommand":
             case "PlaygroundSideCommandLine1":


### PR DESCRIPTION
### Motivation
- Make the playground side menu behave correctly in dark mode and avoid accidental open gestures. 
- Reduce the side menu footprint on desktop and provide a more usable layout on touch/mobile devices by showing preview in a tab instead of side-by-side.

### Description
- Use a desktop detection helper `isDesktopLayout()` and keep the existing `SplitPane` (with the 25% editor sizing target) for desktop while switching to a tabbed container for mobile by returning a `Tabs` with `Editor` and `Preview` tabs. 
- Disable side-menu swipe gestures globally for the playground with `Toolbar.setEnableSideMenuSwipe(false)` to prevent accidental triggering. 
- Expand dark-mode support by adding side-menu related UIIDs (e.g. `SideNavigationPanel`, `PlaygroundSideCommand`, `PlaygroundMenuSection`, etc.) to the `supportsDarkVariant` list so menu components receive dark variants. 
- Add side-menu landscape size theme constants (`sideMenuSizeLandscapeInt` and `sideMenuSizeTabLandscapeInt`) to `theme.css` so the menu opens narrower (approximately 25% visible width) in desktop/landscape layouts.

### Testing
- Attempted to build the playground with `cd scripts/cn1playground && ./build.sh` but the script is not executable in this environment, so the build did not run. (failed)
- Attempted `cd scripts/cn1playground && bash build.sh`, but the script invokes `./mvnw` which is not executable here, so the build did not complete. (failed)
- Attempted `cd scripts/cn1playground && bash ./mvnw -pl common -DskipTests package`, but the Maven wrapper failed to download dependencies due to network/proxy restrictions in this environment. (failed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d0c18e51e4832983fb4b391ea03e5c)