### PR TITLE
Fix CLDC11 JavaDoc warnings caused by malformed doc tags

### DIFF
--- a/Ports/CLDC11/src/java/text/DateFormat.java
+++ b/Ports/CLDC11/src/java/text/DateFormat.java
@@ -68,7 +68,7 @@ public class DateFormat extends Format {
 
 	/// Format a given object.
 	///
-	/// @obj object to be formatted.
+	/// Parameter `obj`: object to be formatted.
 	///
 	/// #### Returns
 	///

--- a/Ports/CLDC11/src/java/util/AbstractMap.java
+++ b/Ports/CLDC11/src/java/util/AbstractMap.java
@@ -34,10 +34,8 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
 
     /// An immutable key-value mapping.
     ///
-    /// @param
-    /// the type of key
-    /// @param
-    /// the type of value
+    /// Type parameter `K`: the type of key
+    /// Type parameter `V`: the type of value
     ///
     /// #### Since
     ///
@@ -157,10 +155,8 @@ public abstract class AbstractMap<K, V> implements Map<K, V> {
 
     /// A key-value mapping.
     ///
-    /// @param
-    /// the type of key
-    /// @param
-    /// the type of value
+    /// Type parameter `K`: the type of key
+    /// Type parameter `V`: the type of value
     ///
     /// #### Since
     ///

--- a/Ports/CLDC11/src/java/util/AbstractQueue.java
+++ b/Ports/CLDC11/src/java/util/AbstractQueue.java
@@ -22,8 +22,7 @@ package java.util;
 /// that they throw exceptions to indicate some error instead of returning true
 /// or false.
 ///
-/// @param
-/// the type of the element in the collection.
+/// Type parameter `E`: the type of the element in the collection.
 public abstract class AbstractQueue<E> extends AbstractCollection<E> implements
         Queue<E> {
 

--- a/Ports/CLDC11/src/java/util/ArrayDeque.java
+++ b/Ports/CLDC11/src/java/util/ArrayDeque.java
@@ -24,8 +24,7 @@ package java.util;
 ///
 /// All optional operations are supported, and the elements can be any objects.
 ///
-/// @param
-/// the type of elements in this collection
+/// Type parameter `E`: the type of elements in this collection
 ///
 /// #### Since
 ///

--- a/Ports/CLDC11/src/java/util/Arrays.java
+++ b/Ports/CLDC11/src/java/util/Arrays.java
@@ -277,8 +277,7 @@ public class Arrays {
     /// Performs a binary search for the specified element in the specified
     /// sorted array using the Comparator to compare elements.
     ///
-    /// @param
-    /// type of object
+    /// Type parameter `T`: type of object
     ///
     /// #### Parameters
     ///
@@ -726,8 +725,7 @@ public class Arrays {
     /// Performs a binary search for the specified element in a part of the
     /// specified sorted array using the Comparator to compare elements.
     ///
-    /// @param
-    /// type of object
+    /// Type parameter `T`: type of object
     ///
     /// #### Parameters
     ///
@@ -3865,7 +3863,7 @@ public class Arrays {
 
     /// Copies elements in original array to a new array, from index
     /// start(inclusive) to end(exclusive). The first element (if any) in the new
-    /// array is original[from], and other elements in the new array are in the
+    /// array is original[`from`], and other elements in the new array are in the
     /// original order. The padding value whose index is bigger than or equal to
     /// original.length - start is false.
     ///
@@ -3908,7 +3906,7 @@ public class Arrays {
 
     /// Copies elements in original array to a new array, from index
     /// start(inclusive) to end(exclusive). The first element (if any) in the new
-    /// array is original[from], and other elements in the new array are in the
+    /// array is original[`from`], and other elements in the new array are in the
     /// original order. The padding value whose index is bigger than or equal to
     /// original.length - start is (byte)0.
     ///
@@ -3951,7 +3949,7 @@ public class Arrays {
 
     /// Copies elements in original array to a new array, from index
     /// start(inclusive) to end(exclusive). The first element (if any) in the new
-    /// array is original[from], and other elements in the new array are in the
+    /// array is original[`from`], and other elements in the new array are in the
     /// original order. The padding value whose index is bigger than or equal to
     /// original.length - start is '\\u000'.
     ///
@@ -3994,7 +3992,7 @@ public class Arrays {
 
     /// Copies elements in original array to a new array, from index
     /// start(inclusive) to end(exclusive). The first element (if any) in the new
-    /// array is original[from], and other elements in the new array are in the
+    /// array is original[`from`], and other elements in the new array are in the
     /// original order. The padding value whose index is bigger than or equal to
     /// original.length - start is 0d.
     ///
@@ -4037,7 +4035,7 @@ public class Arrays {
 
     /// Copies elements in original array to a new array, from index
     /// start(inclusive) to end(exclusive). The first element (if any) in the new
-    /// array is original[from], and other elements in the new array are in the
+    /// array is original[`from`], and other elements in the new array are in the
     /// original order. The padding value whose index is bigger than or equal to
     /// original.length - start is 0f.
     ///
@@ -4080,7 +4078,7 @@ public class Arrays {
 
     /// Copies elements in original array to a new array, from index
     /// start(inclusive) to end(exclusive). The first element (if any) in the new
-    /// array is original[from], and other elements in the new array are in the
+    /// array is original[`from`], and other elements in the new array are in the
     /// original order. The padding value whose index is bigger than or equal to
     /// original.length - start is 0.
     ///
@@ -4123,7 +4121,7 @@ public class Arrays {
 
     /// Copies elements in original array to a new array, from index
     /// start(inclusive) to end(exclusive). The first element (if any) in the new
-    /// array is original[from], and other elements in the new array are in the
+    /// array is original[`from`], and other elements in the new array are in the
     /// original order. The padding value whose index is bigger than or equal to
     /// original.length - start is 0L.
     ///
@@ -4166,7 +4164,7 @@ public class Arrays {
 
     /// Copies elements in original array to a new array, from index
     /// start(inclusive) to end(exclusive). The first element (if any) in the new
-    /// array is original[from], and other elements in the new array are in the
+    /// array is original[`from`], and other elements in the new array are in the
     /// original order. The padding value whose index is bigger than or equal to
     /// original.length - start is (short)0.
     ///

--- a/Ports/CLDC11/src/java/util/Collections.java
+++ b/Ports/CLDC11/src/java/util/Collections.java
@@ -2665,8 +2665,7 @@ public class Collections {
     /// Answers a set backed by a map. And the map must be empty when this method
     /// is called.
     ///
-    /// @param
-    /// type of elements in set
+    /// Type parameter `E`: type of elements in set
     ///
     /// #### Parameters
     ///
@@ -2693,8 +2692,7 @@ public class Collections {
     /// Answers a LIFO Queue as a view of a Deque. Methods in the returned Queue
     /// need to be re-written to implement the LIFO feature.
     ///
-    /// @param
-    /// type of elements
+    /// Type parameter `T`: type of elements
     ///
     /// #### Parameters
     ///

--- a/Ports/CLDC11/src/java/util/Deque.java
+++ b/Ports/CLDC11/src/java/util/Deque.java
@@ -32,8 +32,7 @@ package java.util;
 /// A deque can also remove interior elements by removeFirstOccurrence and
 /// removeLastOccurrence methods. A deque can not access elements by index.
 ///
-/// @param
-/// the type of elements in this collection
+/// Type parameter `E`: the type of elements in this collection
 ///
 /// #### Since
 ///

--- a/Ports/CLDC11/src/java/util/Iterator.java
+++ b/Ports/CLDC11/src/java/util/Iterator.java
@@ -26,8 +26,7 @@ package java.util;
 /// `hasNext()` may throw a `ConcurrentModificationException`.
 /// Iterators with this behavior are called fail-fast iterators.
 ///
-/// @param
-/// the type of object returned by the iterator.
+/// Type parameter `E`: the type of object returned by the iterator.
 public interface Iterator<E> {
     /// Returns whether there are more elements to iterate, i.e. whether the
     /// iterator is positioned in front of an element.

--- a/Ports/CLDC11/src/java/util/NavigableMap.java
+++ b/Ports/CLDC11/src/java/util/NavigableMap.java
@@ -19,10 +19,8 @@ package java.util;
 /// NavigableMap is a SortedMap with navigation methods answering the closest
 /// matches for specified item.
 ///
-/// @param
-/// the type of key
-/// @param
-/// the type of value
+/// Type parameter `K`: the type of key
+/// Type parameter `V`: the type of value
 ///
 /// #### Since
 ///

--- a/Ports/CLDC11/src/java/util/NavigableSet.java
+++ b/Ports/CLDC11/src/java/util/NavigableSet.java
@@ -20,8 +20,7 @@ package java.util;
 /// NavigableSet is a SortedSet with navigation methods answering the closest
 /// matches for specified item.
 ///
-/// @param
-/// the type of element
+/// Type parameter `E`: the type of element
 ///
 /// #### Since
 ///

--- a/Ports/CLDC11/src/java/util/PriorityQueue.java
+++ b/Ports/CLDC11/src/java/util/PriorityQueue.java
@@ -313,8 +313,7 @@ public class PriorityQueue<E> extends AbstractQueue<E> {
     /// will return a new array with the size of the argument array and size of
     /// the queue.
     ///
-    /// @param
-    /// the type of elements in the array
+    /// Type parameter `T`: the type of elements in the array
     ///
     /// #### Parameters
     ///

--- a/Ports/CLDC11/src/java/util/TreeMap.java
+++ b/Ports/CLDC11/src/java/util/TreeMap.java
@@ -21,10 +21,8 @@ package java.util;
 /// and removing) are supported. The values can be any objects. The keys can be
 /// any objects which are comparable to each other either using their natural
 ///
-/// @param
-/// type of key
-/// @param
-/// type of value
+/// Type parameter `K`: type of key
+/// Type parameter `V`: type of value
 ///
 /// #### Since
 ///


### PR DESCRIPTION
### Motivation

- CI JavaDoc builds produced numerous warnings from malformed top-level `@param` pseudo-tags and invalid custom tags in CLDC11 sources, causing noise and potential documentation regressions.
- Several occurrences of `original[from]` in `Arrays` comments triggered unresolved markdown reference warnings during Javadoc processing.
- The goal is to eliminate these warnings by making the doc comments compatible with the Javadoc tool used in CI.

### Description

- Replaced malformed top-level `/// @param` pseudo-tags used to describe type parameters with plain prose lines like `Type parameter `K`: ...` or `Type parameter `E`: ...` in generic classes and interfaces across CLDC11 source files including `AbstractMap`, `AbstractQueue`, `ArrayDeque`, `Arrays`, `Collections`, `Deque`, `Iterator`, `NavigableMap`, `NavigableSet`, `PriorityQueue`, and `TreeMap`.
- Converted an invalid custom `/// @obj` tag in `DateFormat` to a standard parameter description `Parameter `obj`: ...` to remove the unknown tag warning.
- Escaped bracketed text `original[from]` in `Arrays` documentation to `original[`from`]` to avoid markdown/Javadoc reference resolution warnings.

### Testing

- Attempted to run the fast smoke check with Java 8 via `./scripts/fast-core-unit-smoke.sh` (invoked with `JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64`), but the runner lacks the Java 8 installation so Maven did not start and the smoke check failed due to `JAVA_HOME` being unavailable.
- Performed automated text scans using `rg` to confirm the malformed `/// @param` and `/// @obj` patterns were removed or replaced, and verified no remaining matches for those patterns in the edited files.
- Changes were committed locally after verification (`git commit`), and no unit-test suite was executed in this environment because Java 8 is not present for Maven-based tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d26be457c48329915be6f78f10496a)