### PR TITLE
iOS: route status-bar taps into CN1 pointer handling

### DIFF
--- a/Ports/iOSPort/nativeSources/CodenameOne_GLViewController.h
+++ b/Ports/iOSPort/nativeSources/CodenameOne_GLViewController.h
@@ -163,7 +163,7 @@
 
 //ADD_INCLUDE
 
-@interface CodenameOne_GLViewController : UIViewController<UIImagePickerControllerDelegate, MFMailComposeViewControllerDelegate, 
+@interface CodenameOne_GLViewController : UIViewController<UIImagePickerControllerDelegate, MFMailComposeViewControllerDelegate, UIScrollViewDelegate,
 #ifdef CN1_USE_STOREKIT
 SKProductsRequestDelegate, SKPaymentTransactionObserver, 
 #endif

--- a/Ports/iOSPort/nativeSources/CodenameOne_GLViewController.m
+++ b/Ports/iOSPort/nativeSources/CodenameOne_GLViewController.m
@@ -167,6 +167,7 @@ static void updateDisplayMetricsFromView(UIView *view) {
     displayHeight = (int)(view.bounds.size.height * scaleValue);
 }
 BOOL forceSlideUpField;
+static UIScrollView *cn1StatusBarTapProxy = nil;
 
 
 // 1 for portrait lock, and 2 for landscape lock
@@ -1896,6 +1897,7 @@ static CodenameOne_GLViewController *sharedSingleton;
     [self.adView loadAd];
     [super viewDidLoad];
     updateDisplayMetricsFromView(self.view);
+    [self cn1InstallStatusBarTapProxy];
     //replaceViewDidLoad
     [self initGoogleConnect];
 }
@@ -1908,10 +1910,41 @@ static CodenameOne_GLViewController *sharedSingleton;
 - (void)viewDidLoad {
     [super viewDidLoad];
     updateDisplayMetricsFromView(self.view);
+    [self cn1InstallStatusBarTapProxy];
     //replaceViewDidLoad
     [self initGoogleConnect];
 }
 #endif
+
+- (void)cn1InstallStatusBarTapProxy {
+    if (cn1StatusBarTapProxy != nil) {
+        return;
+    }
+    cn1StatusBarTapProxy = [[UIScrollView alloc] initWithFrame:self.view.bounds];
+    cn1StatusBarTapProxy.delegate = self;
+    cn1StatusBarTapProxy.backgroundColor = [UIColor clearColor];
+    cn1StatusBarTapProxy.contentSize = CGSizeMake(1, 2);
+    cn1StatusBarTapProxy.contentOffset = CGPointMake(0, 1);
+    cn1StatusBarTapProxy.scrollsToTop = YES;
+    cn1StatusBarTapProxy.userInteractionEnabled = NO;
+    cn1StatusBarTapProxy.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    cn1StatusBarTapProxy.alpha = 0.0f;
+    [self.view addSubview:cn1StatusBarTapProxy];
+}
+
+- (BOOL)scrollViewShouldScrollToTop:(UIScrollView *)scrollView {
+    if (scrollView == cn1StatusBarTapProxy) {
+        int xArray[1];
+        int yArray[1];
+        xArray[0] = displayWidth / 2;
+        yArray[0] = 0;
+        pointerPressedC(xArray, yArray, 1);
+        pointerReleasedC(xArray, yArray, 1);
+        cn1StatusBarTapProxy.contentOffset = CGPointMake(0, 1);
+        return NO;
+    }
+    return YES;
+}
 
 - (void)initGoogleConnect {
 #ifdef INCLUDE_GOOGLE_CONNECT
@@ -2485,6 +2518,11 @@ BOOL prefersStatusBarHidden = NO;
 #ifdef INCLUDE_MOPUB
     self.adView = nil;
 #endif
+    
+#ifndef CN1_USE_ARC
+    [cn1StatusBarTapProxy release];
+#endif
+    cn1StatusBarTapProxy = nil;
     
 #ifndef CN1_USE_ARC
     [super dealloc];


### PR DESCRIPTION
### Motivation
- iOS handles status-bar taps at the native level which can prevent Codename One pointer events from reaching the existing status-bar component logic, so status-bar taps should be routed into the CN1 pointer pipeline.
- Provide a native-side hook that converts the OS status-bar tap into the existing CN1 press/release callbacks so Java-side `createStatusBar()` logic can trigger scroll-to-top.

### Description
- Added `UIScrollViewDelegate` conformance to `CodenameOne_GLViewController` to receive the system status-bar tap callback via `scrollViewShouldScrollToTop:`.
- Introduced an invisible `UIScrollView` named `cn1StatusBarTapProxy` installed from `viewDidLoad` that has `scrollsToTop = YES` and is sized to the view so the system will invoke the delegate on a status-bar tap.
- Implemented `scrollViewShouldScrollToTop:` to synthesize a top-edge pointer press/release by calling `pointerPressedC(...)` and `pointerReleasedC(...)` with coordinates at the top center, and then reset the proxy content offset to avoid visible scrolling.
- Set autoresizing and interaction properties for the proxy and added cleanup in `dealloc` (respecting non-ARC release conventions) so it survives rotations/layout and doesn't leak.

### Testing
- Attempted the fast smoke helper `./scripts/fast-core-unit-smoke.sh` following repository guidance to validate core unit tests, but the script failed in this environment because the Java 8 toolchain was not available (`JAVA_HOME` not configured to a Java 8 runtime), so no tests executed.
- No other automated tests were run in this environment; runtime validation is recommended on an iOS device/simulator with Java 8 present for the helper script to run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d367bf2c708329b68b579e899ec88b)