### PR TITLE
Clarify fade scrollbar speed semantics and document theme key

### DIFF
--- a/CodenameOne/src/com/codename1/ui/plaf/LookAndFeel.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/LookAndFeel.java
@@ -1490,7 +1490,19 @@ public abstract class LookAndFeel {
 
     /// #### Parameters
     ///
-    /// - `fadeScrollBarSpeed`: the fadeScrollBarSpeed to set
+    /// - `fadeScrollBarSpeed`: per-frame opacity decrement used for fading the scrollbar.
+    ///   Larger values fade out faster.
+    ///
+    /// #### Notes
+    ///
+    /// - This value is **not milliseconds**.
+    /// - Approximate fade duration in milliseconds:
+    ///   `durationMs ~= (255 / fadeScrollBarSpeed) * (1000 / Display.getInstance().getFrameRate())`
+    /// - At 60 FPS, common values are:
+    ///   - `5`  -> about `850ms`
+    ///   - `3`  -> about `1400ms`
+    ///   - `2`  -> about `2100ms`
+    ///   - `1`  -> about `4250ms`
     public void setFadeScrollBarSpeed(int fadeScrollBarSpeed) {
         this.fadeScrollBarSpeed = fadeScrollBarSpeed;
     }

--- a/docs/developer-guide/Advanced-Theming.asciidoc
+++ b/docs/developer-guide/Advanced-Theming.asciidoc
@@ -238,6 +238,9 @@ SoftKey, Touch, Bar, Title, Right, Native
 |fadeScrollBarBool
 |Boolean indicating if the scrollbar should fade when there is inactivity
 
+|setFadeScrollBarSpeed(int) _(API)_
+|Sets the per-frame opacity decrement for scrollbar fading (not milliseconds). Approximate fade duration is `durationMs ~= (255 / speed) * (1000 / frameRate)`. At 60 FPS: speed `5` ~= `850ms`, `3` ~= `1400ms`, `2` ~= `2100ms`, `1` ~= `4250ms`
+
 |fadeScrollEdgeBool
 |Places a fade effect at the edges of the screen to indicate that it's possible to scroll until we reach the edge (common on Android)
 


### PR DESCRIPTION
### Motivation

- Clarify the meaning and units of the `fadeScrollBarSpeed` setting so developers can tune scrollbar fade duration correctly.

### Description

- Expanded the Javadoc for `LookAndFeel#setFadeScrollBarSpeed(int)` to state that the value is a per-frame opacity decrement (not milliseconds), added the approximate duration formula `durationMs ~= (255 / fadeScrollBarSpeed) * (1000 / Display.getInstance().getFrameRate())`, and included example values for 60 FPS.
- Added a `setFadeScrollBarSpeed(int) _(API)_` entry to `docs/developer-guide/Advanced-Theming.asciidoc` with the same explanation and examples.

### Testing

- Ran a full project compilation and documentation build; both succeeded.
- Existing automated unit tests were executed and passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d3b7299afc832984816930759d240e)