### PR TITLE
Automate Material Icons updates: add updater script and workflow

### DIFF
--- a/.github/scripts/update_material_icons.py
+++ b/.github/scripts/update_material_icons.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Updates Codename One Material icon font and FontImage constants from upstream."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import pathlib
+import re
+import sys
+import urllib.request
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+FONT_PATH = REPO_ROOT / "CodenameOne" / "src" / "material-design-font.ttf"
+FONT_IMAGE_PATH = REPO_ROOT / "CodenameOne" / "src" / "com" / "codename1" / "ui" / "FontImage.java"
+
+MATERIAL_FONT_URL = (
+    "https://raw.githubusercontent.com/google/material-design-icons/master/font/MaterialIcons-Regular.ttf"
+)
+MATERIAL_CODEPOINTS_URL = (
+    "https://raw.githubusercontent.com/google/material-design-icons/master/font/MaterialIcons-Regular.codepoints"
+)
+MATERIAL_CSS_URL = "https://fonts.googleapis.com/icon?family=Material+Icons"
+
+CONSTANT_DOC = "    /// Material design icon font character code see\\n    /// https://www.material.io/resources/icons/ for full list\\n"
+CONSTANT_RE = re.compile(r"^\s*public static final char MATERIAL_")
+SENTINEL = "    private static Font materialDesignFont;"
+
+
+def download_text(url: str) -> str:
+    with urllib.request.urlopen(url) as response:
+        return response.read().decode("utf-8")
+
+
+def download_bytes(url: str) -> bytes:
+    with urllib.request.urlopen(url) as response:
+        return response.read()
+
+
+def hash_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def material_constant_name(icon_name: str) -> str:
+    return "MATERIAL_" + re.sub(r"[^A-Z0-9_]", "_", icon_name.upper())
+
+
+def parse_codepoints(codepoints_text: str) -> list[tuple[str, str]]:
+    out: list[tuple[str, str]] = []
+    for line in codepoints_text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split()
+        if len(parts) != 2:
+            raise ValueError(f"Unexpected codepoints line format: {line}")
+        out.append((parts[0], parts[1]))
+    return out
+
+
+def generate_constants_block(entries: list[tuple[str, str]]) -> str:
+    lines: list[str] = []
+    for icon_name, codepoint in entries:
+        const_name = material_constant_name(icon_name)
+        lines.append(CONSTANT_DOC.rstrip("\n"))
+        lines.append(f"    public static final char {const_name} = '\\u{codepoint.upper()}';")
+    return "\n".join(lines) + "\n"
+
+
+def update_fontimage(constants_block: str, check_only: bool) -> bool:
+    source = FONT_IMAGE_PATH.read_text(encoding="utf-8")
+    lines = source.splitlines(keepends=True)
+
+    start_idx = None
+    end_idx = None
+    for i, line in enumerate(lines):
+        if start_idx is None and CONSTANT_RE.match(line):
+            start_idx = i
+        if line.strip("\n") == SENTINEL:
+            end_idx = i
+            break
+
+    if start_idx is None or end_idx is None or start_idx >= end_idx:
+        raise RuntimeError("Couldn't locate material constants block in FontImage.java")
+
+    new_source = "".join(lines[:start_idx]) + constants_block + "".join(lines[end_idx:])
+    changed = new_source != source
+    if changed and not check_only:
+        FONT_IMAGE_PATH.write_text(new_source, encoding="utf-8")
+    return changed
+
+
+def update_font(remote_font_bytes: bytes, check_only: bool) -> bool:
+    local_font_bytes = FONT_PATH.read_bytes()
+    changed = hash_bytes(local_font_bytes) != hash_bytes(remote_font_bytes)
+    if changed and not check_only:
+        FONT_PATH.write_bytes(remote_font_bytes)
+    return changed
+
+
+def extract_css_font_version(css: str) -> str | None:
+    match = re.search(r"/materialicons/v(\d+)/", css)
+    return match.group(1) if match else None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="Only check if an update is needed")
+    args = parser.parse_args()
+
+    print("Fetching Material Icons metadata...")
+    css = download_text(MATERIAL_CSS_URL)
+    version = extract_css_font_version(css)
+    if version:
+        print(f"Detected Google Fonts Material Icons version: v{version}")
+
+    remote_font = download_bytes(MATERIAL_FONT_URL)
+    codepoints = download_text(MATERIAL_CODEPOINTS_URL)
+    entries = parse_codepoints(codepoints)
+    constants_block = generate_constants_block(entries)
+
+    font_changed = update_font(remote_font, check_only=args.check)
+    constants_changed = update_fontimage(constants_block, check_only=args.check)
+
+    if font_changed or constants_changed:
+        print("Material icons update detected.")
+        return 0
+
+    print("Material icons are already up to date.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/material-icons-update.yml
+++ b/.github/workflows/material-icons-update.yml
@@ -1,0 +1,47 @@
+name: Material Icons Update
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/material-icons-update.yml'
+      - '.github/scripts/update_material_icons.py'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-material-icons:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Update Material Icons font and constants
+        run: python .github/scripts/update_material_icons.py
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "Update Material Icons font and FontImage constants"
+          title: "Update Material Icons font and FontImage constants"
+          body: |
+            ## Summary
+            - Updates `CodenameOne/src/material-design-font.ttf` from upstream Material Icons.
+            - Regenerates `FontImage.MATERIAL_*` constants from upstream codepoints.
+
+            This PR was created automatically by the weekly Material Icons update workflow.
+          branch: automation/material-icons-update
+          delete-branch: true
+          labels: |
+            dependencies
+            automation

--- a/.github/workflows/material-icons-update.yml
+++ b/.github/workflows/material-icons-update.yml
@@ -26,10 +26,12 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Update Material Icons font and constants
+      - name: Update Material Icons font and constants (scheduled/manual)
+        if: github.event_name != 'pull_request'
         run: python .github/scripts/update_material_icons.py
 
       - name: Create pull request
+        if: github.event_name != 'pull_request'
         uses: peter-evans/create-pull-request@v7
         with:
           commit-message: "Update Material Icons font and FontImage constants"
@@ -40,8 +42,30 @@ jobs:
             - Regenerates `FontImage.MATERIAL_*` constants from upstream codepoints.
 
             This PR was created automatically by the weekly Material Icons update workflow.
+          base: master
           branch: automation/material-icons-update
           delete-branch: true
           labels: |
             dependencies
             automation
+
+      - name: Build update preview for PR validation
+        if: github.event_name == 'pull_request'
+        run: |
+          python .github/scripts/update_material_icons.py
+          if git diff --quiet; then
+            echo "Material icons are already up to date." > material-icons-update-summary.txt
+          else
+            echo "Material icons update detected; see attached patch artifact." > material-icons-update-summary.txt
+            git diff --binary > material-icons-update.patch
+          fi
+
+      - name: Upload PR validation artifacts
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: material-icons-update-preview
+          path: |
+            material-icons-update-summary.txt
+            material-icons-update.patch
+          if-no-files-found: error


### PR DESCRIPTION
### Motivation
- Keep the bundled Material Icons font and the `FontImage.MATERIAL_*` constants in sync with the upstream Material Icons project to avoid manual edits.
- Automate regular checks and enable manual runs so updates are created as PRs instead of requiring ad-hoc maintenance.

### Description
- Add ` .github/scripts/update_material_icons.py` which downloads the Material Icons font and codepoints, computes hashes, generates `MATERIAL_` constant entries, and updates `CodenameOne/src/material-design-font.ttf` and `FontImage.java`, with a `--check` mode.
- The script extracts a Google Fonts version from `https://fonts.googleapis.com/icon?family=Material+Icons`, parses the `.codepoints` file, and writes regenerated constants using a sentinel and regex to locate the constants block.
- Add ` .github/workflows/material-icons-update.yml` to run the updater on a weekly cron and via `workflow_dispatch`, and to create a PR using `peter-evans/create-pull-request@v7` when changes are detected.
- The workflow commits to branch `automation/material-icons-update`, uses commit/title/body describing the changes, and applies the `dependencies` and `automation` labels.

### Testing
- No automated tests were executed as part of this PR.
- The workflow is configured to run on a weekly schedule and can be triggered manually via `workflow_dispatch` to validate the end-to-end updater and PR creation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dc501454c48329bc662fee8f647139)