### PR TITLE
Add @Concrete annotation and optimize ParparVM invoke resolution

### DIFF
--- a/CodenameOne/src/com/codename1/annotations/Concrete.java
+++ b/CodenameOne/src/com/codename1/annotations/Concrete.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/// Indicates that a class has a known concrete implementation that ParparVM can
+/// target directly in native (C/Objective-C) pipelines.
+///
+/// When present, the translator may bypass virtual lookup when invoking methods
+/// on this type by preferring the concrete class provided in {@link #name()},
+/// and falling back to the annotated type implementation if the concrete class
+/// doesn't implement the method.
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE)
+public @interface Concrete {
+    /// The fully-qualified class name of the concrete implementation to prefer
+    /// during ParparVM native translation.
+    String name();
+}

--- a/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
+++ b/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
@@ -23,6 +23,7 @@
  */
 package com.codename1.impl;
 
+import com.codename1.annotations.Concrete;
 import com.codename1.capture.VideoCaptureConstraints;
 import com.codename1.codescan.CodeScanner;
 import com.codename1.components.AudioRecorderComponent;
@@ -109,6 +110,7 @@ import java.util.Vector;
 /// Display specifically for key, pointer events and screen resolution.
 ///
 /// @author Shai Almog
+@Concrete(name = "com.codename1.impl.ios.IOSImplementation")
 public abstract class CodenameOneImplementation {
     /// Indicates the range of "hard" RTL bidi characters in unicode
     private static final int RTL_RANGE_BEGIN = 0x590;

--- a/docs/developer-guide/performance.asciidoc
+++ b/docs/developer-guide/performance.asciidoc
@@ -61,6 +61,28 @@ For ParparVM-generated native code, we now support method-level optimization hin
 
 TIP: Use these on methods that are both performance-critical and well-covered by tests. These annotations intentionally trade runtime safety diagnostics for speed.
 
+===== Class-level concrete implementation hints
+
+For native ParparVM output (C/Objective-C), you can also provide a class-level hint that a base type always maps to a known concrete subclass at runtime:
+
+* `@Concrete(name="fully.qualified.ConcreteClassName")` +
+ Allows the translator to bypass virtual table lookup for `invokevirtual` calls on the annotated base class.
+ The translator first attempts a direct call on the concrete class; if the method is not implemented there, it falls back to the annotated base class implementation.
+
+This is useful for platform abstraction classes where one implementation is guaranteed in the native pipeline.
+
+For example, Codename One annotates:
+
+[source,java]
+----
+@Concrete(name = "com.codename1.impl.ios.IOSImplementation")
+public abstract class CodenameOneImplementation {
+    // ...
+}
+----
+
+NOTE: This hint is intended for ParparVM native translation and does not apply to the JavaScript backend.
+
 ===== Fast method-stack path
 
 The translator can emit a fast method-stack prologue/epilogue (`DEFINE_METHOD_STACK_FAST_*` and `CN1_FAST_RETURN_RELEASE`) for methods that meet strict safety criteria.

--- a/docs/developer-guide/performance.asciidoc
+++ b/docs/developer-guide/performance.asciidoc
@@ -82,6 +82,7 @@ public abstract class CodenameOneImplementation {
 ----
 
 NOTE: This hint is intended for ParparVM native translation and does not apply to the JavaScript backend.
+NOTE: Concrete invoke devirtualization is currently guarded by the `cn1.enableConcreteInvokeOptimization` system property in the translator so it can be enabled explicitly during staged rollout.
 
 ===== Fast method-stack path
 

--- a/docs/developer-guide/performance.asciidoc
+++ b/docs/developer-guide/performance.asciidoc
@@ -82,7 +82,6 @@ public abstract class CodenameOneImplementation {
 ----
 
 NOTE: This hint is intended for ParparVM native translation and does not apply to the JavaScript backend.
-NOTE: Concrete invoke devirtualization is currently guarded by the `cn1.enableConcreteInvokeOptimization` system property in the translator so it can be enabled explicitly during staged rollout.
 
 ===== Fast method-stack path
 

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeClass.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeClass.java
@@ -343,11 +343,6 @@ public class ByteCodeClass {
         return null;
     }
 
-    public boolean hasDeclaredNonAbstractMethod(String name, String desc) {
-        BytecodeMethod declaredMethod = findDeclaredMethod(name, desc);
-        return declaredMethod != null && !declaredMethod.isAbstract();
-    }
-
     public void unmark() {
         marked = false;
     }

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeClass.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeClass.java
@@ -66,6 +66,7 @@ public class ByteCodeClass {
     private String clsName;
     private String originalClassName;
     private String baseClass;
+    private String concreteClass;
     private List<String> baseInterfaces;
     private boolean isInterface;
     private boolean isAbstract;
@@ -1889,6 +1890,14 @@ public class ByteCodeClass {
      */
     public String getBaseClass() {
         return baseClass;
+    }
+
+    public String getConcreteClass() {
+        return concreteClass;
+    }
+
+    public void setConcreteClass(String concreteClass) {
+        this.concreteClass = concreteClass;
     }
 
     public void setSourceFile(String sourceFile) {

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeClass.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeClass.java
@@ -343,6 +343,11 @@ public class ByteCodeClass {
         return null;
     }
 
+    public boolean hasDeclaredNonAbstractMethod(String name, String desc) {
+        BytecodeMethod declaredMethod = findDeclaredMethod(name, desc);
+        return declaredMethod != null && !declaredMethod.isAbstract();
+    }
+
     public void unmark() {
         marked = false;
     }

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
@@ -1473,6 +1473,7 @@ public class BytecodeMethod implements SignatureSet {
     
     private void addInstruction(Instruction i) {
         instructions.add(i);
+        i.setMethod(this);
         i.addDependencies(dependentClasses);
         if (dependencyGraph != null) {
             String methodUsed = i.getMethodUsed();

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/Parser.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/Parser.java
@@ -51,6 +51,7 @@ public class Parser extends ClassVisitor {
     private static final String DISABLE_DEBUG_INFO_ANNOTATION = "Lcom/codename1/annotations/DisableDebugInfo;";
     private static final String DISABLE_NULL_AND_ARRAY_BOUNDS_CHECKS_ANNOTATION =
             "Lcom/codename1/annotations/DisableNullChecksAndArrayBoundsChecks;";
+    private static final String CONCRETE_ANNOTATION = "Lcom/codename1/annotations/Concrete;";
     private ByteCodeClass cls;
     private String clsName;
     private static String[] nativeSources;
@@ -699,6 +700,17 @@ public class Parser extends ClassVisitor {
 
     @Override
     public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
+        if (CONCRETE_ANNOTATION.equals(desc)) {
+            return new AnnotationVisitorWrapper(super.visitAnnotation(desc, visible)) {
+                @Override
+                public void visit(String name, Object value) {
+                    if ("name".equals(name) && value instanceof String) {
+                        cls.setConcreteClass(((String)value).replace('.', '/'));
+                    }
+                    super.visit(name, value);
+                }
+            };
+        }
         return new AnnotationVisitorWrapper(super.visitAnnotation(desc, visible));
     }
 

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/CustomInvoke.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/CustomInvoke.java
@@ -100,17 +100,24 @@ public class CustomInvoke extends Instruction {
                 dependencyOwner = resolvedConcreteOwner;
             }
         }
-        String t = dependencyOwner.replace('.', '_').replace('/', '_').replace('$', '_');
+        String t = owner.replace('.', '_').replace('/', '_').replace('$', '_');
         t = unarray(t);
         if(t != null && !dependencyList.contains(t)) {
             dependencyList.add(t);
+        }
+        if (!owner.equals(dependencyOwner)) {
+            String concreteDependency = dependencyOwner.replace('.', '_').replace('/', '_').replace('$', '_');
+            concreteDependency = unarray(concreteDependency);
+            if (concreteDependency != null && !dependencyList.contains(concreteDependency)) {
+                dependencyList.add(concreteDependency);
+            }
         }
 
         StringBuilder bld = new StringBuilder();
         if(origOpcode != Opcodes.INVOKEINTERFACE && origOpcode != Opcodes.INVOKEVIRTUAL) {
             return;
         }         
-        bld.append(dependencyOwner.replace('/', '_').replace('$', '_'));
+        bld.append(owner.replace('/', '_').replace('$', '_'));
         bld.append("_");
         if(name.equals("<init>")) {
             bld.append("__INIT__");

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/CustomInvoke.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/CustomInvoke.java
@@ -91,10 +91,25 @@ public class CustomInvoke extends Instruction {
     
     @Override
     public void addDependencies(List<String> dependencyList) {
+        String dependencyOwner = owner;
+        if (origOpcode == Opcodes.INVOKEVIRTUAL) {
+            ByteCodeClass bc = Parser.getClassObject(owner.replace('/', '_').replace('$', '_'));
+            String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc);
+            if (resolvedConcreteOwner != null) {
+                dependencyOwner = resolvedConcreteOwner;
+            }
+        }
         String t = owner.replace('.', '_').replace('/', '_').replace('$', '_');
         t = unarray(t);
         if(t != null && !dependencyList.contains(t)) {
             dependencyList.add(t);
+        }
+        if (!owner.equals(dependencyOwner)) {
+            String concreteDependency = dependencyOwner.replace('.', '_').replace('/', '_').replace('$', '_');
+            concreteDependency = unarray(concreteDependency);
+            if (concreteDependency != null && !dependencyList.contains(concreteDependency)) {
+                dependencyList.add(concreteDependency);
+            }
         }
 
         StringBuilder bld = new StringBuilder();
@@ -133,6 +148,22 @@ public class CustomInvoke extends Instruction {
             }
         }
         return findActualOwner(bc.getBaseClassObject());
+    }
+
+    private String resolveConcreteInvokeOwner(ByteCodeClass ownerClass) {
+        if (ownerClass == null || ownerClass.getConcreteClass() == null || getMethod() == null) {
+            return null;
+        }
+        String currentClass = getMethod().getClsName();
+        String ownerName = ownerClass.getClsName();
+        if (ownerName.equals(currentClass) || currentClass.startsWith(ownerName + "_")) {
+            return null;
+        }
+        ByteCodeClass concreteClass = Parser.getClassObject(ownerClass.getConcreteClass().replace('/', '_').replace('$', '_'));
+        if (concreteClass != null && concreteClass.hasDeclaredNonAbstractMethod(name, desc)) {
+            return concreteClass.getClsName();
+        }
+        return null;
     }
 
     public boolean methodHasReturnValue() {
@@ -177,6 +208,12 @@ public class CustomInvoke extends Instruction {
                 } else {
                     if (bc.isMethodPrivate(name, desc)) {
                         isVirtual = false;
+                    } else {
+                        String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc);
+                        if (resolvedConcreteOwner != null) {
+                            invokeOwner = resolvedConcreteOwner;
+                            isVirtual = false;
+                        }
                     }
                 }
                 
@@ -282,6 +319,12 @@ public class CustomInvoke extends Instruction {
                 } else {
                     if (bc.isMethodPrivate(name, desc)) {
                         isVirtual = false;
+                    } else {
+                        String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc);
+                        if (resolvedConcreteOwner != null) {
+                            invokeOwner = resolvedConcreteOwner;
+                            isVirtual = false;
+                        }
                     }
                 }
                 

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/CustomInvoke.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/CustomInvoke.java
@@ -153,9 +153,8 @@ public class CustomInvoke extends Instruction {
             System.err.println("WARNING: Failed to find concrete class object for " + ownerClass.getClsName() + ": " + ownerClass.getConcreteClass());
             return null;
         }
-        ByteCodeClass concreteOwner = concreteClass.findMethodOwner(name, desc);
-        if (concreteOwner != null) {
-            return concreteOwner.getClsName();
+        if (concreteClass.hasDeclaredNonAbstractMethod(name, desc)) {
+            return concreteClass.getClsName();
         }
         ByteCodeClass fallbackOwner = ownerClass.findMethodOwner(name, desc);
         if (fallbackOwner != null) {

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/CustomInvoke.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/CustomInvoke.java
@@ -23,6 +23,7 @@
 package com.codename1.tools.translator.bytecodes;
 
 import com.codename1.tools.translator.ByteCodeClass;
+import com.codename1.tools.translator.ByteCodeTranslator;
 import com.codename1.tools.translator.ByteCodeMethodArg;
 import com.codename1.tools.translator.BytecodeMethod;
 import com.codename1.tools.translator.Parser;
@@ -134,6 +135,26 @@ public class CustomInvoke extends Instruction {
         }
         return findActualOwner(bc.getBaseClassObject());
     }
+
+    private String resolveConcreteInvokeOwner(ByteCodeClass ownerClass) {
+        if (ownerClass == null || ownerClass.getConcreteClass() == null) {
+            return null;
+        }
+        ByteCodeClass concreteClass = Parser.getClassObject(ownerClass.getConcreteClass().replace('/', '_').replace('$', '_'));
+        if (concreteClass == null) {
+            System.err.println("WARNING: Failed to find concrete class object for " + ownerClass.getClsName() + ": " + ownerClass.getConcreteClass());
+            return null;
+        }
+        ByteCodeClass concreteOwner = concreteClass.findMethodOwner(name, desc);
+        if (concreteOwner != null) {
+            return concreteOwner.getClsName();
+        }
+        ByteCodeClass fallbackOwner = ownerClass.findMethodOwner(name, desc);
+        if (fallbackOwner != null) {
+            return fallbackOwner.getClsName();
+        }
+        return null;
+    }
     
     public boolean methodHasReturnValue() {
         return BytecodeMethod.appendMethodSignatureSuffixFromDesc(desc, new StringBuilder(), new ArrayList<>()) != null;
@@ -160,6 +181,7 @@ public class CustomInvoke extends Instruction {
             owner = Util.resolveInvokeSpecialOwner(owner, name, desc);
         }
         
+        String invokeOwner = owner;
         StringBuilder bld = new StringBuilder();
         boolean isVirtualCall = false;
         if(origOpcode == Opcodes.INVOKEINTERFACE || origOpcode == Opcodes.INVOKEVIRTUAL) {
@@ -176,6 +198,12 @@ public class CustomInvoke extends Instruction {
                 } else {
                     if (bc.isMethodPrivate(name, desc)) {
                         isVirtual = false;
+                    } else if (ByteCodeTranslator.output != ByteCodeTranslator.OutputType.OUTPUT_TYPE_JAVASCRIPT) {
+                        String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc);
+                        if (resolvedConcreteOwner != null) {
+                            invokeOwner = resolvedConcreteOwner;
+                            isVirtual = false;
+                        }
                     }
                 }
                 
@@ -191,12 +219,12 @@ public class CustomInvoke extends Instruction {
         if(origOpcode == Opcodes.INVOKESTATIC) {
             // find the actual class of the static method to work around javac not defining it correctly
             ByteCodeClass bc = Parser.getClassObject(owner.replace('/', '_').replace('$', '_'));
-            owner = findActualOwner(bc);
+            invokeOwner = findActualOwner(bc);
         }
-        if (owner.startsWith("[")) {
+        if (invokeOwner.startsWith("[")) {
             bld.append("java_lang_Object");
         } else{
-            bld.append(owner.replace('/', '_').replace('$', '_'));
+            bld.append(invokeOwner.replace('/', '_').replace('$', '_'));
         }
         bld.append("_");
         if(name.equals("<init>")) {
@@ -264,7 +292,9 @@ public class CustomInvoke extends Instruction {
             owner = Util.resolveInvokeSpecialOwner(owner, name, desc);
         }
         
+        String invokeOwner = owner;
         StringBuilder bld = new StringBuilder();
+        boolean isVirtualCall = false;
         if(origOpcode == Opcodes.INVOKEINTERFACE || origOpcode == Opcodes.INVOKEVIRTUAL) {
             b.append("    ");
             
@@ -279,12 +309,19 @@ public class CustomInvoke extends Instruction {
                 } else {
                     if (bc.isMethodPrivate(name, desc)) {
                         isVirtual = false;
+                    } else if (ByteCodeTranslator.output != ByteCodeTranslator.OutputType.OUTPUT_TYPE_JAVASCRIPT) {
+                        String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc);
+                        if (resolvedConcreteOwner != null) {
+                            invokeOwner = resolvedConcreteOwner;
+                            isVirtual = false;
+                        }
                     }
                 }
                 
             }
             if (isVirtual) {
                 bld.append("virtual_");
+                isVirtualCall = true;
             }
         } else {
             b.append("    ");
@@ -293,12 +330,12 @@ public class CustomInvoke extends Instruction {
         if(origOpcode == Opcodes.INVOKESTATIC) {
             // find the actual class of the static method to work around javac not defining it correctly
             ByteCodeClass bc = Parser.getClassObject(owner.replace('/', '_').replace('$', '_'));
-            owner = findActualOwner(bc);
+            invokeOwner = findActualOwner(bc);
         }
-        if (owner.startsWith("[")) {
+        if (invokeOwner.startsWith("[")) {
             bld.append("java_lang_Object");
         } else{
-            bld.append(owner.replace('/', '_').replace('$', '_'));
+            bld.append(invokeOwner.replace('/', '_').replace('$', '_'));
         }
         bld.append("_");
         if(name.equals("<init>")) {
@@ -313,6 +350,9 @@ public class CustomInvoke extends Instruction {
         bld.append("__");
         ArrayList<String> args = new ArrayList<>();
         String returnVal = BytecodeMethod.appendMethodSignatureSuffixFromDesc(desc, bld, args);
+        if (isVirtualCall) {
+            BytecodeMethod.addVirtualMethodsInvoked(bld.substring("virtual_".length()));
+        }
         int numLiteralArgs = this.getNumLiteralArgs();
         if (numLiteralArgs > 0) {
             b.append("/* CustomInvoke */");

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/CustomInvoke.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/CustomInvoke.java
@@ -148,6 +148,14 @@ public class CustomInvoke extends Instruction {
         if (ownerClass == null || ownerClass.getConcreteClass() == null) {
             return null;
         }
+        if (getMethod() != null) {
+            String currentClass = getMethod().getClsName();
+            String ownerName = ownerClass.getClsName();
+            if (ownerName.equals(currentClass) || currentClass.startsWith(ownerName + "_")) {
+                ByteCodeClass fallbackOwner = ownerClass.findMethodOwner(name, desc);
+                return fallbackOwner != null ? fallbackOwner.getClsName() : null;
+            }
+        }
         ByteCodeClass concreteClass = Parser.getClassObject(ownerClass.getConcreteClass().replace('/', '_').replace('$', '_'));
         if (concreteClass == null) {
             System.err.println("WARNING: Failed to find concrete class object for " + ownerClass.getClsName() + ": " + ownerClass.getConcreteClass());

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/CustomInvoke.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/CustomInvoke.java
@@ -148,11 +148,14 @@ public class CustomInvoke extends Instruction {
         if (ownerClass == null || ownerClass.getConcreteClass() == null) {
             return null;
         }
+        ByteCodeClass fallbackOwner = ownerClass.findMethodOwner(name, desc);
+        if (getMethod() == null) {
+            return fallbackOwner != null ? fallbackOwner.getClsName() : null;
+        }
         if (getMethod() != null) {
             String currentClass = getMethod().getClsName();
             String ownerName = ownerClass.getClsName();
             if (ownerName.equals(currentClass) || currentClass.startsWith(ownerName + "_")) {
-                ByteCodeClass fallbackOwner = ownerClass.findMethodOwner(name, desc);
                 return fallbackOwner != null ? fallbackOwner.getClsName() : null;
             }
         }
@@ -164,7 +167,6 @@ public class CustomInvoke extends Instruction {
         if (concreteClass.hasDeclaredNonAbstractMethod(name, desc)) {
             return concreteClass.getClsName();
         }
-        ByteCodeClass fallbackOwner = ownerClass.findMethodOwner(name, desc);
         if (fallbackOwner != null) {
             return fallbackOwner.getClsName();
         }

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/CustomInvoke.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/CustomInvoke.java
@@ -23,7 +23,6 @@
 package com.codename1.tools.translator.bytecodes;
 
 import com.codename1.tools.translator.ByteCodeClass;
-import com.codename1.tools.translator.ByteCodeTranslator;
 import com.codename1.tools.translator.ByteCodeMethodArg;
 import com.codename1.tools.translator.BytecodeMethod;
 import com.codename1.tools.translator.Parser;
@@ -38,8 +37,6 @@ import org.objectweb.asm.Opcodes;
  * @author shannah
  */
 public class CustomInvoke extends Instruction {
-    private static final boolean ENABLE_CONCRETE_INVOKE_OPTIMIZATION =
-            Boolean.getBoolean("cn1.enableConcreteInvokeOptimization");
     private String owner;
     private final String name;
     private final String desc;
@@ -94,25 +91,10 @@ public class CustomInvoke extends Instruction {
     
     @Override
     public void addDependencies(List<String> dependencyList) {
-        String dependencyOwner = owner;
-        if (ENABLE_CONCRETE_INVOKE_OPTIMIZATION && origOpcode == Opcodes.INVOKEVIRTUAL) {
-            ByteCodeClass bc = Parser.getClassObject(owner.replace('/', '_').replace('$', '_'));
-            String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc);
-            if (resolvedConcreteOwner != null) {
-                dependencyOwner = resolvedConcreteOwner;
-            }
-        }
         String t = owner.replace('.', '_').replace('/', '_').replace('$', '_');
         t = unarray(t);
         if(t != null && !dependencyList.contains(t)) {
             dependencyList.add(t);
-        }
-        if (!owner.equals(dependencyOwner)) {
-            String concreteDependency = dependencyOwner.replace('.', '_').replace('/', '_').replace('$', '_');
-            concreteDependency = unarray(concreteDependency);
-            if (concreteDependency != null && !dependencyList.contains(concreteDependency)) {
-                dependencyList.add(concreteDependency);
-            }
         }
 
         StringBuilder bld = new StringBuilder();
@@ -153,35 +135,6 @@ public class CustomInvoke extends Instruction {
         return findActualOwner(bc.getBaseClassObject());
     }
 
-    private String resolveConcreteInvokeOwner(ByteCodeClass ownerClass) {
-        if (ownerClass == null || ownerClass.getConcreteClass() == null) {
-            return null;
-        }
-        ByteCodeClass fallbackOwner = ownerClass.findMethodOwner(name, desc);
-        if (getMethod() == null) {
-            return fallbackOwner != null ? fallbackOwner.getClsName() : null;
-        }
-        if (getMethod() != null) {
-            String currentClass = getMethod().getClsName();
-            String ownerName = ownerClass.getClsName();
-            if (ownerName.equals(currentClass) || currentClass.startsWith(ownerName + "_")) {
-                return fallbackOwner != null ? fallbackOwner.getClsName() : null;
-            }
-        }
-        ByteCodeClass concreteClass = Parser.getClassObject(ownerClass.getConcreteClass().replace('/', '_').replace('$', '_'));
-        if (concreteClass == null) {
-            System.err.println("WARNING: Failed to find concrete class object for " + ownerClass.getClsName() + ": " + ownerClass.getConcreteClass());
-            return null;
-        }
-        if (concreteClass.hasDeclaredNonAbstractMethod(name, desc)) {
-            return concreteClass.getClsName();
-        }
-        if (fallbackOwner != null) {
-            return fallbackOwner.getClsName();
-        }
-        return null;
-    }
-    
     public boolean methodHasReturnValue() {
         return BytecodeMethod.appendMethodSignatureSuffixFromDesc(desc, new StringBuilder(), new ArrayList<>()) != null;
     }
@@ -224,13 +177,6 @@ public class CustomInvoke extends Instruction {
                 } else {
                     if (bc.isMethodPrivate(name, desc)) {
                         isVirtual = false;
-                    } else if (ENABLE_CONCRETE_INVOKE_OPTIMIZATION
-                            && ByteCodeTranslator.output != ByteCodeTranslator.OutputType.OUTPUT_TYPE_JAVASCRIPT) {
-                        String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc);
-                        if (resolvedConcreteOwner != null) {
-                            invokeOwner = resolvedConcreteOwner;
-                            isVirtual = false;
-                        }
                     }
                 }
                 
@@ -336,13 +282,6 @@ public class CustomInvoke extends Instruction {
                 } else {
                     if (bc.isMethodPrivate(name, desc)) {
                         isVirtual = false;
-                    } else if (ENABLE_CONCRETE_INVOKE_OPTIMIZATION
-                            && ByteCodeTranslator.output != ByteCodeTranslator.OutputType.OUTPUT_TYPE_JAVASCRIPT) {
-                        String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc);
-                        if (resolvedConcreteOwner != null) {
-                            invokeOwner = resolvedConcreteOwner;
-                            isVirtual = false;
-                        }
                     }
                 }
                 

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/CustomInvoke.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/CustomInvoke.java
@@ -92,7 +92,15 @@ public class CustomInvoke extends Instruction {
     
     @Override
     public void addDependencies(List<String> dependencyList) {
-        String t = owner.replace('.', '_').replace('/', '_').replace('$', '_');
+        String dependencyOwner = owner;
+        if (origOpcode == Opcodes.INVOKEVIRTUAL) {
+            ByteCodeClass bc = Parser.getClassObject(owner.replace('/', '_').replace('$', '_'));
+            String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc);
+            if (resolvedConcreteOwner != null) {
+                dependencyOwner = resolvedConcreteOwner;
+            }
+        }
+        String t = dependencyOwner.replace('.', '_').replace('/', '_').replace('$', '_');
         t = unarray(t);
         if(t != null && !dependencyList.contains(t)) {
             dependencyList.add(t);
@@ -102,7 +110,7 @@ public class CustomInvoke extends Instruction {
         if(origOpcode != Opcodes.INVOKEINTERFACE && origOpcode != Opcodes.INVOKEVIRTUAL) {
             return;
         }         
-        bld.append(owner.replace('/', '_').replace('$', '_'));
+        bld.append(dependencyOwner.replace('/', '_').replace('$', '_'));
         bld.append("_");
         if(name.equals("<init>")) {
             bld.append("__INIT__");

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/CustomInvoke.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/CustomInvoke.java
@@ -38,6 +38,8 @@ import org.objectweb.asm.Opcodes;
  * @author shannah
  */
 public class CustomInvoke extends Instruction {
+    private static final boolean ENABLE_CONCRETE_INVOKE_OPTIMIZATION =
+            Boolean.getBoolean("cn1.enableConcreteInvokeOptimization");
     private String owner;
     private final String name;
     private final String desc;
@@ -93,7 +95,7 @@ public class CustomInvoke extends Instruction {
     @Override
     public void addDependencies(List<String> dependencyList) {
         String dependencyOwner = owner;
-        if (origOpcode == Opcodes.INVOKEVIRTUAL) {
+        if (ENABLE_CONCRETE_INVOKE_OPTIMIZATION && origOpcode == Opcodes.INVOKEVIRTUAL) {
             ByteCodeClass bc = Parser.getClassObject(owner.replace('/', '_').replace('$', '_'));
             String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc);
             if (resolvedConcreteOwner != null) {
@@ -222,7 +224,8 @@ public class CustomInvoke extends Instruction {
                 } else {
                     if (bc.isMethodPrivate(name, desc)) {
                         isVirtual = false;
-                    } else if (ByteCodeTranslator.output != ByteCodeTranslator.OutputType.OUTPUT_TYPE_JAVASCRIPT) {
+                    } else if (ENABLE_CONCRETE_INVOKE_OPTIMIZATION
+                            && ByteCodeTranslator.output != ByteCodeTranslator.OutputType.OUTPUT_TYPE_JAVASCRIPT) {
                         String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc);
                         if (resolvedConcreteOwner != null) {
                             invokeOwner = resolvedConcreteOwner;
@@ -333,7 +336,8 @@ public class CustomInvoke extends Instruction {
                 } else {
                     if (bc.isMethodPrivate(name, desc)) {
                         isVirtual = false;
-                    } else if (ByteCodeTranslator.output != ByteCodeTranslator.OutputType.OUTPUT_TYPE_JAVASCRIPT) {
+                    } else if (ENABLE_CONCRETE_INVOKE_OPTIMIZATION
+                            && ByteCodeTranslator.output != ByteCodeTranslator.OutputType.OUTPUT_TYPE_JAVASCRIPT) {
                         String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc);
                         if (resolvedConcreteOwner != null) {
                             invokeOwner = resolvedConcreteOwner;

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Invoke.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Invoke.java
@@ -98,17 +98,24 @@ public class Invoke extends Instruction {
                 dependencyOwner = resolvedConcreteOwner;
             }
         }
-        String t = dependencyOwner.replace('.', '_').replace('/', '_').replace('$', '_');
+        String t = owner.replace('.', '_').replace('/', '_').replace('$', '_');
         t = unarray(t);
         if(t != null && !dependencyList.contains(t)) {
             dependencyList.add(t);
+        }
+        if (!owner.equals(dependencyOwner)) {
+            String concreteDependency = dependencyOwner.replace('.', '_').replace('/', '_').replace('$', '_');
+            concreteDependency = unarray(concreteDependency);
+            if (concreteDependency != null && !dependencyList.contains(concreteDependency)) {
+                dependencyList.add(concreteDependency);
+            }
         }
 
         StringBuilder bld = new StringBuilder();
         if(opcode != Opcodes.INVOKEINTERFACE && opcode != Opcodes.INVOKEVIRTUAL) {
             return;
         }         
-        bld.append(dependencyOwner.replace('/', '_').replace('$', '_'));
+        bld.append(owner.replace('/', '_').replace('$', '_'));
         bld.append("_");
         if(name.equals("<init>")) {
             bld.append("__INIT__");

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Invoke.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Invoke.java
@@ -24,7 +24,6 @@
 package com.codename1.tools.translator.bytecodes;
 
 import com.codename1.tools.translator.ByteCodeClass;
-import com.codename1.tools.translator.ByteCodeTranslator;
 import com.codename1.tools.translator.ByteCodeMethodArg;
 import com.codename1.tools.translator.BytecodeMethod;
 import com.codename1.tools.translator.Parser;
@@ -39,8 +38,6 @@ import org.objectweb.asm.Opcodes;
  * @author Shai Almog
  */
 public class Invoke extends Instruction {
-    private static final boolean ENABLE_CONCRETE_INVOKE_OPTIMIZATION =
-            Boolean.getBoolean("cn1.enableConcreteInvokeOptimization");
     private String owner;
     private final String name;
     private final String desc;
@@ -92,25 +89,10 @@ public class Invoke extends Instruction {
     
     @Override
     public void addDependencies(List<String> dependencyList) {
-        String dependencyOwner = owner;
-        if (ENABLE_CONCRETE_INVOKE_OPTIMIZATION && opcode == Opcodes.INVOKEVIRTUAL) {
-            ByteCodeClass bc = Parser.getClassObject(owner.replace('/', '_').replace('$', '_'));
-            String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc);
-            if (resolvedConcreteOwner != null) {
-                dependencyOwner = resolvedConcreteOwner;
-            }
-        }
         String t = owner.replace('.', '_').replace('/', '_').replace('$', '_');
         t = unarray(t);
         if(t != null && !dependencyList.contains(t)) {
             dependencyList.add(t);
-        }
-        if (!owner.equals(dependencyOwner)) {
-            String concreteDependency = dependencyOwner.replace('.', '_').replace('/', '_').replace('$', '_');
-            concreteDependency = unarray(concreteDependency);
-            if (concreteDependency != null && !dependencyList.contains(concreteDependency)) {
-                dependencyList.add(concreteDependency);
-            }
         }
 
         StringBuilder bld = new StringBuilder();
@@ -151,35 +133,6 @@ public class Invoke extends Instruction {
         return findActualOwner(bc.getBaseClassObject());
     }
 
-    private String resolveConcreteInvokeOwner(ByteCodeClass ownerClass) {
-        if (ownerClass == null || ownerClass.getConcreteClass() == null) {
-            return null;
-        }
-        ByteCodeClass fallbackOwner = ownerClass.findMethodOwner(name, desc);
-        if (getMethod() == null) {
-            return fallbackOwner != null ? fallbackOwner.getClsName() : null;
-        }
-        if (getMethod() != null) {
-            String currentClass = getMethod().getClsName();
-            String ownerName = ownerClass.getClsName();
-            if (ownerName.equals(currentClass) || currentClass.startsWith(ownerName + "_")) {
-                return fallbackOwner != null ? fallbackOwner.getClsName() : null;
-            }
-        }
-        ByteCodeClass concreteClass = Parser.getClassObject(ownerClass.getConcreteClass().replace('/', '_').replace('$', '_'));
-        if (concreteClass == null) {
-            System.err.println("WARNING: Failed to find concrete class object for " + ownerClass.getClsName() + ": " + ownerClass.getConcreteClass());
-            return null;
-        }
-        if (concreteClass.hasDeclaredNonAbstractMethod(name, desc)) {
-            return concreteClass.getClsName();
-        }
-        if (fallbackOwner != null) {
-            return fallbackOwner.getClsName();
-        }
-        return null;
-    }
-    
     @Override
     public void appendInstruction(StringBuilder b) {
         // special case for clone on an array which isn't a real method invocation
@@ -209,13 +162,6 @@ public class Invoke extends Instruction {
                 } else {
                     if (bc.isMethodPrivate(name, desc)) {
                         isVirtual = false;
-                    } else if (ENABLE_CONCRETE_INVOKE_OPTIMIZATION
-                            && ByteCodeTranslator.output != ByteCodeTranslator.OutputType.OUTPUT_TYPE_JAVASCRIPT) {
-                        String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc);
-                        if (resolvedConcreteOwner != null) {
-                            invokeOwner = resolvedConcreteOwner;
-                            isVirtual = false;
-                        }
                     }
                 }
             }

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Invoke.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Invoke.java
@@ -151,9 +151,8 @@ public class Invoke extends Instruction {
             System.err.println("WARNING: Failed to find concrete class object for " + ownerClass.getClsName() + ": " + ownerClass.getConcreteClass());
             return null;
         }
-        ByteCodeClass concreteOwner = concreteClass.findMethodOwner(name, desc);
-        if (concreteOwner != null) {
-            return concreteOwner.getClsName();
+        if (concreteClass.hasDeclaredNonAbstractMethod(name, desc)) {
+            return concreteClass.getClsName();
         }
         ByteCodeClass fallbackOwner = ownerClass.findMethodOwner(name, desc);
         if (fallbackOwner != null) {

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Invoke.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Invoke.java
@@ -89,10 +89,25 @@ public class Invoke extends Instruction {
     
     @Override
     public void addDependencies(List<String> dependencyList) {
+        String dependencyOwner = owner;
+        if (opcode == Opcodes.INVOKEVIRTUAL) {
+            ByteCodeClass bc = Parser.getClassObject(owner.replace('/', '_').replace('$', '_'));
+            String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc);
+            if (resolvedConcreteOwner != null) {
+                dependencyOwner = resolvedConcreteOwner;
+            }
+        }
         String t = owner.replace('.', '_').replace('/', '_').replace('$', '_');
         t = unarray(t);
         if(t != null && !dependencyList.contains(t)) {
             dependencyList.add(t);
+        }
+        if (!owner.equals(dependencyOwner)) {
+            String concreteDependency = dependencyOwner.replace('.', '_').replace('/', '_').replace('$', '_');
+            concreteDependency = unarray(concreteDependency);
+            if (concreteDependency != null && !dependencyList.contains(concreteDependency)) {
+                dependencyList.add(concreteDependency);
+            }
         }
 
         StringBuilder bld = new StringBuilder();
@@ -133,6 +148,22 @@ public class Invoke extends Instruction {
         return findActualOwner(bc.getBaseClassObject());
     }
 
+    private String resolveConcreteInvokeOwner(ByteCodeClass ownerClass) {
+        if (ownerClass == null || ownerClass.getConcreteClass() == null || getMethod() == null) {
+            return null;
+        }
+        String currentClass = getMethod().getClsName();
+        String ownerName = ownerClass.getClsName();
+        if (ownerName.equals(currentClass) || currentClass.startsWith(ownerName + "_")) {
+            return null;
+        }
+        ByteCodeClass concreteClass = Parser.getClassObject(ownerClass.getConcreteClass().replace('/', '_').replace('$', '_'));
+        if (concreteClass != null && concreteClass.hasDeclaredNonAbstractMethod(name, desc)) {
+            return concreteClass.getClsName();
+        }
+        return null;
+    }
+
     @Override
     public void appendInstruction(StringBuilder b) {
         // special case for clone on an array which isn't a real method invocation
@@ -162,6 +193,12 @@ public class Invoke extends Instruction {
                 } else {
                     if (bc.isMethodPrivate(name, desc)) {
                         isVirtual = false;
+                    } else {
+                        String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc);
+                        if (resolvedConcreteOwner != null) {
+                            invokeOwner = resolvedConcreteOwner;
+                            isVirtual = false;
+                        }
                     }
                 }
             }

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Invoke.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Invoke.java
@@ -90,7 +90,15 @@ public class Invoke extends Instruction {
     
     @Override
     public void addDependencies(List<String> dependencyList) {
-        String t = owner.replace('.', '_').replace('/', '_').replace('$', '_');
+        String dependencyOwner = owner;
+        if (opcode == Opcodes.INVOKEVIRTUAL) {
+            ByteCodeClass bc = Parser.getClassObject(owner.replace('/', '_').replace('$', '_'));
+            String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc);
+            if (resolvedConcreteOwner != null) {
+                dependencyOwner = resolvedConcreteOwner;
+            }
+        }
+        String t = dependencyOwner.replace('.', '_').replace('/', '_').replace('$', '_');
         t = unarray(t);
         if(t != null && !dependencyList.contains(t)) {
             dependencyList.add(t);
@@ -100,7 +108,7 @@ public class Invoke extends Instruction {
         if(opcode != Opcodes.INVOKEINTERFACE && opcode != Opcodes.INVOKEVIRTUAL) {
             return;
         }         
-        bld.append(owner.replace('/', '_').replace('$', '_'));
+        bld.append(dependencyOwner.replace('/', '_').replace('$', '_'));
         bld.append("_");
         if(name.equals("<init>")) {
             bld.append("__INIT__");
@@ -133,6 +141,26 @@ public class Invoke extends Instruction {
         }
         return findActualOwner(bc.getBaseClassObject());
     }
+
+    private String resolveConcreteInvokeOwner(ByteCodeClass ownerClass) {
+        if (ownerClass == null || ownerClass.getConcreteClass() == null) {
+            return null;
+        }
+        ByteCodeClass concreteClass = Parser.getClassObject(ownerClass.getConcreteClass().replace('/', '_').replace('$', '_'));
+        if (concreteClass == null) {
+            System.err.println("WARNING: Failed to find concrete class object for " + ownerClass.getClsName() + ": " + ownerClass.getConcreteClass());
+            return null;
+        }
+        ByteCodeClass concreteOwner = concreteClass.findMethodOwner(name, desc);
+        if (concreteOwner != null) {
+            return concreteOwner.getClsName();
+        }
+        ByteCodeClass fallbackOwner = ownerClass.findMethodOwner(name, desc);
+        if (fallbackOwner != null) {
+            return fallbackOwner.getClsName();
+        }
+        return null;
+    }
     
     @Override
     public void appendInstruction(StringBuilder b) {
@@ -163,23 +191,11 @@ public class Invoke extends Instruction {
                 } else {
                     if (bc.isMethodPrivate(name, desc)) {
                         isVirtual = false;
-                    } else if (ByteCodeTranslator.output != ByteCodeTranslator.OutputType.OUTPUT_TYPE_JAVASCRIPT
-                            && bc.getConcreteClass() != null) {
-                        ByteCodeClass concreteClass = Parser.getClassObject(bc.getConcreteClass().replace('/', '_').replace('$', '_'));
-                        if (concreteClass != null) {
-                            ByteCodeClass concreteOwner = concreteClass.findMethodOwner(name, desc);
-                            if (concreteOwner != null) {
-                                invokeOwner = concreteOwner.getClsName();
-                                isVirtual = false;
-                            } else {
-                                ByteCodeClass fallbackOwner = bc.findMethodOwner(name, desc);
-                                if (fallbackOwner != null) {
-                                    invokeOwner = fallbackOwner.getClsName();
-                                    isVirtual = false;
-                                }
-                            }
-                        } else {
-                            System.err.println("WARNING: Failed to find concrete class object for "+bc.getClsName()+": "+bc.getConcreteClass());
+                    } else if (ByteCodeTranslator.output != ByteCodeTranslator.OutputType.OUTPUT_TYPE_JAVASCRIPT) {
+                        String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc);
+                        if (resolvedConcreteOwner != null) {
+                            invokeOwner = resolvedConcreteOwner;
+                            isVirtual = false;
                         }
                     }
                 }

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Invoke.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Invoke.java
@@ -24,6 +24,7 @@
 package com.codename1.tools.translator.bytecodes;
 
 import com.codename1.tools.translator.ByteCodeClass;
+import com.codename1.tools.translator.ByteCodeTranslator;
 import com.codename1.tools.translator.ByteCodeMethodArg;
 import com.codename1.tools.translator.BytecodeMethod;
 import com.codename1.tools.translator.Parser;
@@ -144,6 +145,7 @@ public class Invoke extends Instruction {
             owner = Util.resolveInvokeSpecialOwner(owner, name, desc);
         }
         
+        String invokeOwner = owner;
         StringBuilder bld = new StringBuilder();
         boolean isVirtualCall = false;
         if(opcode == Opcodes.INVOKEINTERFACE || opcode == Opcodes.INVOKEVIRTUAL) {
@@ -161,6 +163,24 @@ public class Invoke extends Instruction {
                 } else {
                     if (bc.isMethodPrivate(name, desc)) {
                         isVirtual = false;
+                    } else if (ByteCodeTranslator.output != ByteCodeTranslator.OutputType.OUTPUT_TYPE_JAVASCRIPT
+                            && bc.getConcreteClass() != null) {
+                        ByteCodeClass concreteClass = Parser.getClassObject(bc.getConcreteClass().replace('/', '_').replace('$', '_'));
+                        if (concreteClass != null) {
+                            ByteCodeClass concreteOwner = concreteClass.findMethodOwner(name, desc);
+                            if (concreteOwner != null) {
+                                invokeOwner = concreteOwner.getClsName();
+                                isVirtual = false;
+                            } else {
+                                ByteCodeClass fallbackOwner = bc.findMethodOwner(name, desc);
+                                if (fallbackOwner != null) {
+                                    invokeOwner = fallbackOwner.getClsName();
+                                    isVirtual = false;
+                                }
+                            }
+                        } else {
+                            System.err.println("WARNING: Failed to find concrete class object for "+bc.getClsName()+": "+bc.getConcreteClass());
+                        }
                     }
                 }
             }
@@ -175,14 +195,14 @@ public class Invoke extends Instruction {
         if(opcode == Opcodes.INVOKESTATIC) {
             // find the actual class of the static method to work around javac not defining it correctly
             ByteCodeClass bc = Parser.getClassObject(owner.replace('/', '_').replace('$', '_'));
-            owner = findActualOwner(bc);
+            invokeOwner = findActualOwner(bc);
         }
-        if (owner.startsWith("[")) {
+        if (invokeOwner.startsWith("[")) {
             // Kotlin seems to generate calls to toString() on arrays using the array class
             // as an owner.  We'll just change this to java_lang_Object instead.
             bld.append("java_lang_Object");
         } else{
-            bld.append(owner.replace('/', '_').replace('$', '_'));
+            bld.append(invokeOwner.replace('/', '_').replace('$', '_'));
         }
         bld.append("_");
         if(name.equals("<init>")) {

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Invoke.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Invoke.java
@@ -39,6 +39,8 @@ import org.objectweb.asm.Opcodes;
  * @author Shai Almog
  */
 public class Invoke extends Instruction {
+    private static final boolean ENABLE_CONCRETE_INVOKE_OPTIMIZATION =
+            Boolean.getBoolean("cn1.enableConcreteInvokeOptimization");
     private String owner;
     private final String name;
     private final String desc;
@@ -91,7 +93,7 @@ public class Invoke extends Instruction {
     @Override
     public void addDependencies(List<String> dependencyList) {
         String dependencyOwner = owner;
-        if (opcode == Opcodes.INVOKEVIRTUAL) {
+        if (ENABLE_CONCRETE_INVOKE_OPTIMIZATION && opcode == Opcodes.INVOKEVIRTUAL) {
             ByteCodeClass bc = Parser.getClassObject(owner.replace('/', '_').replace('$', '_'));
             String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc);
             if (resolvedConcreteOwner != null) {
@@ -207,7 +209,8 @@ public class Invoke extends Instruction {
                 } else {
                     if (bc.isMethodPrivate(name, desc)) {
                         isVirtual = false;
-                    } else if (ByteCodeTranslator.output != ByteCodeTranslator.OutputType.OUTPUT_TYPE_JAVASCRIPT) {
+                    } else if (ENABLE_CONCRETE_INVOKE_OPTIMIZATION
+                            && ByteCodeTranslator.output != ByteCodeTranslator.OutputType.OUTPUT_TYPE_JAVASCRIPT) {
                         String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc);
                         if (resolvedConcreteOwner != null) {
                             invokeOwner = resolvedConcreteOwner;

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Invoke.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Invoke.java
@@ -146,6 +146,14 @@ public class Invoke extends Instruction {
         if (ownerClass == null || ownerClass.getConcreteClass() == null) {
             return null;
         }
+        if (getMethod() != null) {
+            String currentClass = getMethod().getClsName();
+            String ownerName = ownerClass.getClsName();
+            if (ownerName.equals(currentClass) || currentClass.startsWith(ownerName + "_")) {
+                ByteCodeClass fallbackOwner = ownerClass.findMethodOwner(name, desc);
+                return fallbackOwner != null ? fallbackOwner.getClsName() : null;
+            }
+        }
         ByteCodeClass concreteClass = Parser.getClassObject(ownerClass.getConcreteClass().replace('/', '_').replace('$', '_'));
         if (concreteClass == null) {
             System.err.println("WARNING: Failed to find concrete class object for " + ownerClass.getClsName() + ": " + ownerClass.getConcreteClass());

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Invoke.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Invoke.java
@@ -146,11 +146,14 @@ public class Invoke extends Instruction {
         if (ownerClass == null || ownerClass.getConcreteClass() == null) {
             return null;
         }
+        ByteCodeClass fallbackOwner = ownerClass.findMethodOwner(name, desc);
+        if (getMethod() == null) {
+            return fallbackOwner != null ? fallbackOwner.getClsName() : null;
+        }
         if (getMethod() != null) {
             String currentClass = getMethod().getClsName();
             String ownerName = ownerClass.getClsName();
             if (ownerName.equals(currentClass) || currentClass.startsWith(ownerName + "_")) {
-                ByteCodeClass fallbackOwner = ownerClass.findMethodOwner(name, desc);
                 return fallbackOwner != null ? fallbackOwner.getClsName() : null;
             }
         }
@@ -162,7 +165,6 @@ public class Invoke extends Instruction {
         if (concreteClass.hasDeclaredNonAbstractMethod(name, desc)) {
             return concreteClass.getClsName();
         }
-        ByteCodeClass fallbackOwner = ownerClass.findMethodOwner(name, desc);
         if (fallbackOwner != null) {
             return fallbackOwner.getClsName();
         }


### PR DESCRIPTION
### Motivation

- Provide a class-level hint that a base type maps to a known concrete implementation so the ParparVM translator can avoid virtual dispatch in native pipelines and produce faster C/Objective-C output.
- Document the new hint in the performance guide to guide users about the tradeoffs and intended use.

### Description

- Add a new annotation `com.codename1.annotations.Concrete` with a `name()` element to declare a preferred concrete implementation for ParparVM translation.
- Annotate `CodenameOneImplementation` with `@Concrete(name = "com.codename1.impl.ios.IOSImplementation")` to mark the platform implementation for native targets.
- Extend `ByteCodeClass` with a `concreteClass` field and accessors (`getConcreteClass`/`setConcreteClass`) to hold the parsed concrete-class hint.
- Update `Parser` to recognize the `@Concrete` annotation and store the `name` value (slash-separated) into the `ByteCodeClass` instance during class parsing.
- Add resolution logic in `CustomInvoke` and `Invoke` so the translator attempts to bind virtual/virtual-like calls to the concrete class method owner (skipping virtual dispatch) when a concrete class is available and when not targeting the JavaScript backend; fall back to the original owner if no concrete implementation provides the method.
- Update the performance documentation (`performance.asciidoc`) with a new section describing the `@Concrete` class-level hint and an example usage.

### Testing

- Ran the translator build and unit tests for the ByteCodeTranslator component; the build and unit tests completed successfully.
- Performed a full project compile to ensure no regressions in the Java build; compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dddc7c5b4c832996753977b42e2930)