### PR TITLE
Fix generate-native-interfaces classpath handling and add overwrite/warn behavior

### DIFF
--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/GenerateNativeInterfaces.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/GenerateNativeInterfaces.java
@@ -1,7 +1,7 @@
 package com.codename1.maven;
 
 
-import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Execute;
@@ -32,6 +32,9 @@ public class GenerateNativeInterfaces extends AbstractCN1Mojo {
 
     @Parameter(property = "cn1.generateNativeInterfaces.kotlin", defaultValue = "false")
     private boolean generateAndroidKotlin;
+
+    @Parameter(property = "cn1.generateNativeInterfaces.overwrite", defaultValue = "false")
+    private boolean overwrite;
 
     @Override
     protected void executeImpl() throws MojoExecutionException, MojoFailureException {
@@ -84,32 +87,9 @@ public class GenerateNativeInterfaces extends AbstractCN1Mojo {
 
         if (classFile.exists()) {
 
-            // Build a comprehensive classpath including all dependencies
-            List<URL> classpathUrls = new ArrayList<>();
-
-            // Add project output directory
-            classpathUrls.add(new File(project.getBuild().getOutputDirectory()).toURI().toURL());
-
-            // Add codenameone-core
-            File cn1CoreJar = getJar("com.codenameone", "codenameone-core");
-            if (cn1CoreJar != null) {
-                classpathUrls.add(cn1CoreJar.toURI().toURL());
-            }
-
-            // Add all project dependencies (including cn1libs with classifiers)
-            for (Artifact artifact : project.getArtifacts()) {
-                // Skip provided and test scoped dependencies
-                if ("provided".equals(artifact.getScope()) || "test".equals(artifact.getScope())) {
-                    continue;
-                }
-
-                File artifactFile = getJar(artifact);
-                if (artifactFile != null && artifactFile.exists()) {
-                    classpathUrls.add(artifactFile.toURI().toURL());
-                }
-            }
-
-            URLClassLoader cl = new URLClassLoader(classpathUrls.toArray(new URL[0]));
+            // Build classpath using compile classpath elements so class loading works
+            // for all project dependencies.
+            URLClassLoader cl = createProjectClassLoader();
             String classPath = relativePath
                     .replace("\\", ".")
                     .replace("/", ".")
@@ -128,9 +108,43 @@ public class GenerateNativeInterfaces extends AbstractCN1Mojo {
         }
 
 
-        g.generateCode(project.getBasedir().getCanonicalFile().getParentFile(), false);
+        File destination = project.getBasedir().getCanonicalFile().getParentFile();
+        if (!overwrite) {
+            List<File> existingFiles = g.getExistingFiles(destination);
+            if (!existingFiles.isEmpty()) {
+                getLog().warn("Native interface files already exist for " + c.getName() + ". Skipping generation.");
+                for (File existingFile : existingFiles) {
+                    getLog().warn("Existing file: " + existingFile.getAbsolutePath());
+                }
+                getLog().warn("To overwrite these files, run: mvn cn1:generate-native-interfaces -Dcn1.generateNativeInterfaces.overwrite=true");
+                return;
+            }
+        }
+
+        g.generateCode(destination, overwrite);
 
 
+    }
+
+    private URLClassLoader createProjectClassLoader() throws IOException {
+        List<URL> classpathUrls = new ArrayList<>();
+        try {
+            for (Object element : project.getCompileClasspathElements()) {
+                String pathElement = String.valueOf(element);
+                File file = new File(pathElement);
+                if (file.exists()) {
+                    classpathUrls.add(file.toURI().toURL());
+                }
+            }
+        } catch (DependencyResolutionRequiredException ex) {
+            throw new IOException("Failed to resolve compile classpath for native interface generation", ex);
+        }
+
+        if (classpathUrls.isEmpty()) {
+            classpathUrls.add(new File(project.getBuild().getOutputDirectory()).toURI().toURL());
+        }
+
+        return new URLClassLoader(classpathUrls.toArray(new URL[0]), this.getClass().getClassLoader());
     }
 
     private static interface ClassScanner {

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/StubGenerator.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/StubGenerator.java
@@ -30,6 +30,8 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.codename1.maven.PathUtil.path;
 
@@ -163,11 +165,41 @@ public class StubGenerator {
      * Returns true if native files might need overwriting
      */
     public boolean isFilesExist(File destination) {
-        initFileNames(destination);
-        return androidFile.exists() || androidKotlinFile.exists() || iosHFile.exists() || iosMFile.exists() || iosSwiftFile.exists() ||
-                csFile.exists() || javaseFile.exists() || jsFile.exists();
+        return !getExistingFiles(destination).isEmpty();
     }
 
+    /**
+     * Returns all existing native implementation files for this interface.
+     */
+    public List<File> getExistingFiles(File destination) {
+        initFileNames(destination);
+        List<File> out = new ArrayList<>();
+        if (androidFile.exists()) {
+            out.add(androidFile);
+        }
+        if (androidKotlinFile.exists()) {
+            out.add(androidKotlinFile);
+        }
+        if (iosHFile.exists()) {
+            out.add(iosHFile);
+        }
+        if (iosMFile.exists()) {
+            out.add(iosMFile);
+        }
+        if (iosSwiftFile.exists()) {
+            out.add(iosSwiftFile);
+        }
+        if (csFile.exists()) {
+            out.add(csFile);
+        }
+        if (javaseFile.exists()) {
+            out.add(javaseFile);
+        }
+        if (jsFile.exists()) {
+            out.add(jsFile);
+        }
+        return out;
+    }
 
 
     /**

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/StubGeneratorTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/StubGeneratorTest.java
@@ -6,7 +6,9 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -27,6 +29,22 @@ class StubGeneratorTest {
             enabledGenerator.generateCode(tempDir, false);
             assertTrue(iosSwift.exists());
             assertTrue(androidKotlin.exists());
+        } finally {
+            deleteTree(tempDir);
+        }
+    }
+
+    @Test
+    void existingFilesAreReportedForWarnMode() throws Exception {
+        File tempDir = Files.createTempDirectory("cn1-stubgen-existing").toFile();
+        try {
+            StubGenerator generator = StubGenerator.create(new SystemStreamLog(), TestNativeInterface.class, true, true);
+            generator.generateCode(tempDir, false);
+
+            StubGenerator checker = StubGenerator.create(new SystemStreamLog(), TestNativeInterface.class, true, true);
+            List<File> existing = checker.getExistingFiles(tempDir);
+            assertEquals(8, existing.size());
+            assertTrue(checker.isFilesExist(tempDir));
         } finally {
             deleteTree(tempDir);
         }


### PR DESCRIPTION
### Motivation
- `generate-native-interfaces` could fail to load classes when the project has Maven dependencies and it also unconditionally skipped regeneration when files already existed; users need a safe warn mode and an explicit overwrite option.

### Description
- Use the Maven compile classpath (`project.getCompileClasspathElements()`) to build the classloader via a new `createProjectClassLoader()` so project dependencies are visible when loading classes for stub generation.
- Add a new plugin parameter `cn1.generateNativeInterfaces.overwrite` (default `false`) to control whether generated native files are overwritten or not.
- Implement warn-mode behavior that, when `overwrite` is false and implementation files already exist, logs warnings listing the existing files and suggests the `-Dcn1.generateNativeInterfaces.overwrite=true` command, and otherwise proceeds to regenerate when overwrite is true.
- Add `StubGenerator#getExistingFiles()` and refactor `StubGenerator#isFilesExist()` to use it, and add a unit test `existingFilesAreReportedForWarnMode` to cover existing-file detection.

### Testing
- Attempted to run `cd maven && mvn -pl codenameone-maven-plugin -Dtest=StubGeneratorTest test -DskipITs` to execute the plugin unit tests, but the build failed in this environment due to missing local snapshot artifacts (`com.codenameone:*:8.0-SNAPSHOT`), so tests could not be completed end-to-end.
- A prior attempt to run Maven with Java 8 via `export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64` failed in this environment because that Java installation path is not present, so the Java 8 requirement could not be enforced here.
- The repository unit test `StubGeneratorTest` was extended with `existingFilesAreReportedForWarnMode`, but execution of that test was blocked by the described environment/dependency limitations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ddf46ed1f88329918b972d15ea99fc)