### PR TITLE
Deprecate unsupported InteractionDialog popup bias overloads

### DIFF
--- a/CodenameOne/src/com/codename1/components/InteractionDialog.java
+++ b/CodenameOne/src/com/codename1/components/InteractionDialog.java
@@ -637,8 +637,11 @@ public class InteractionDialog extends Container implements AbstractDialog {
     ///
     /// - `c`: the context component which is used to position the dialog and can also be pointed at
     ///
-    /// - `bias`: @param bias biases the dialog to appear above/below or to the sides.
-    /// This is ignored if there isn't enough space
+    /// - `bias`: directional bias value. This parameter is not supported.
+    ///
+    /// #### Deprecated
+    ///
+    /// @deprecated The `bias` parameter is not supported for `InteractionDialog` popups. Use `#showPopupDialog(Component)` instead.
     public void showPopupDialog(Component c, boolean bias) {
         if (c == null) {
             throw new IllegalArgumentException("Component cannot be null");
@@ -653,7 +656,7 @@ public class InteractionDialog extends Container implements AbstractDialog {
         componentPos.setX(componentPos.getX() - c.getScrollX());
         componentPos.setY(componentPos.getY() - c.getScrollY());
         setOwner(c);
-        showPopupDialog(componentPos, bias);
+        showPopupDialog(componentPos);
     }
 
     /// A popup dialog is shown with the context of a component and  its selection. You should use `#setDisposeWhenPointerOutOfBounds(boolean)` to make it dispose
@@ -664,7 +667,7 @@ public class InteractionDialog extends Container implements AbstractDialog {
     ///
     /// - `rect`: the screen rectangle to which the popup should point
     public void showPopupDialog(Rectangle rect) {
-        showPopupDialog(rect, Display.getInstance().isPortrait());
+        showPopupDialogImpl(rect, Display.getInstance().isPortrait());
     }
 
     /// A popup dialog is shown with the context of a component and  its selection. You should use `#setDisposeWhenPointerOutOfBounds(boolean)` to make it dispose
@@ -675,9 +678,16 @@ public class InteractionDialog extends Container implements AbstractDialog {
     ///
     /// - `rect`: the screen rectangle to which the popup should point
     ///
-    /// - `bias`: @param bias biases the dialog to appear above/below or to the sides.
-    /// This is ignored if there isn't enough space
+    /// - `bias`: directional bias value. This parameter is not supported.
+    ///
+    /// #### Deprecated
+    ///
+    /// @deprecated The `bias` parameter is not supported for `InteractionDialog` popups. Use `#showPopupDialog(Rectangle)` instead.
     public void showPopupDialog(Rectangle rect, boolean bias) {
+        showPopupDialog(rect);
+    }
+
+    private void showPopupDialogImpl(Rectangle rect, boolean bias) {
         if (rect == null) {
             throw new IllegalArgumentException("rect cannot be null");
         }


### PR DESCRIPTION
### Motivation

- The `bias` parameter for `InteractionDialog` popups is not supported and should not be relied upon, so overloads accepting it must be deprecated in documentation rather than removed to avoid breaking callers. 
- Deprecation is performed via Javadoc (markdown mode) per project conventions (Javadoc 25 markdown style) rather than using the `@Deprecated` annotation.

### Description

- Updated the Javadoc for `showPopupDialog(Component, boolean)` and `showPopupDialog(Rectangle, boolean)` to state that the `bias` parameter is not supported and added a `#### Deprecated` section with an `@deprecated` note that points callers to the no-bias overloads. 
- Changed the deprecated overloads to ignore the `bias` argument and delegate to the supported overloads so existing call sites continue to work. 
- Extracted the popup placement implementation into a private helper `showPopupDialogImpl(Rectangle, boolean)` and updated the non-deprecated `showPopupDialog(Rectangle)` to call that helper. 
- Kept the public API surface intact while documenting the unsupported parameter in the Javadoc instead of annotating with `@Deprecated`.

### Testing

- Attempted to run the fast smoke test script `./scripts/fast-core-unit-smoke.sh` using Java 8 as required by the repo (`JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64`), but the run failed due to the Java 8 toolchain not being available in the environment (invalid `JAVA_HOME`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69de1c94410c8329aa6b6a9c668adbac)