### PR TITLE
Fix concrete invoke dependency resolution when method context is null

### DIFF
--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/CustomInvoke.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/CustomInvoke.java
@@ -94,7 +94,7 @@ public class CustomInvoke extends Instruction {
         String dependencyOwner = owner;
         if (origOpcode == Opcodes.INVOKEVIRTUAL) {
             ByteCodeClass bc = Parser.getClassObject(owner.replace('/', '_').replace('$', '_'));
-            String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc);
+            String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc, true);
             if (resolvedConcreteOwner != null) {
                 dependencyOwner = resolvedConcreteOwner;
             }
@@ -150,11 +150,14 @@ public class CustomInvoke extends Instruction {
         return findActualOwner(bc.getBaseClassObject());
     }
 
-    private String resolveConcreteInvokeOwner(ByteCodeClass ownerClass) {
+    private String resolveConcreteInvokeOwner(ByteCodeClass ownerClass, boolean allowMissingMethodContext) {
         if (ownerClass == null || ownerClass.getConcreteClass() == null) {
             return null;
         }
         String currentClass = getMethod() != null ? getMethod().getClsName() : null;
+        if (currentClass == null && !allowMissingMethodContext) {
+            return null;
+        }
         String ownerName = ownerClass.getClsName();
         if (currentClass != null && (ownerName.equals(currentClass) || currentClass.startsWith(ownerName + "_"))) {
             return null;
@@ -209,7 +212,7 @@ public class CustomInvoke extends Instruction {
                     if (bc.isMethodPrivate(name, desc)) {
                         isVirtual = false;
                     } else {
-                        String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc);
+                        String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc, false);
                         if (resolvedConcreteOwner != null) {
                             invokeOwner = resolvedConcreteOwner;
                             isVirtual = false;
@@ -320,7 +323,7 @@ public class CustomInvoke extends Instruction {
                     if (bc.isMethodPrivate(name, desc)) {
                         isVirtual = false;
                     } else {
-                        String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc);
+                        String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc, false);
                         if (resolvedConcreteOwner != null) {
                             invokeOwner = resolvedConcreteOwner;
                             isVirtual = false;

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/CustomInvoke.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/CustomInvoke.java
@@ -151,12 +151,12 @@ public class CustomInvoke extends Instruction {
     }
 
     private String resolveConcreteInvokeOwner(ByteCodeClass ownerClass) {
-        if (ownerClass == null || ownerClass.getConcreteClass() == null || getMethod() == null) {
+        if (ownerClass == null || ownerClass.getConcreteClass() == null) {
             return null;
         }
-        String currentClass = getMethod().getClsName();
+        String currentClass = getMethod() != null ? getMethod().getClsName() : null;
         String ownerName = ownerClass.getClsName();
-        if (ownerName.equals(currentClass) || currentClass.startsWith(ownerName + "_")) {
+        if (currentClass != null && (ownerName.equals(currentClass) || currentClass.startsWith(ownerName + "_"))) {
             return null;
         }
         ByteCodeClass concreteClass = Parser.getClassObject(ownerClass.getConcreteClass().replace('/', '_').replace('$', '_'));

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Invoke.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Invoke.java
@@ -149,12 +149,12 @@ public class Invoke extends Instruction {
     }
 
     private String resolveConcreteInvokeOwner(ByteCodeClass ownerClass) {
-        if (ownerClass == null || ownerClass.getConcreteClass() == null || getMethod() == null) {
+        if (ownerClass == null || ownerClass.getConcreteClass() == null) {
             return null;
         }
-        String currentClass = getMethod().getClsName();
+        String currentClass = getMethod() != null ? getMethod().getClsName() : null;
         String ownerName = ownerClass.getClsName();
-        if (ownerName.equals(currentClass) || currentClass.startsWith(ownerName + "_")) {
+        if (currentClass != null && (ownerName.equals(currentClass) || currentClass.startsWith(ownerName + "_"))) {
             return null;
         }
         ByteCodeClass concreteClass = Parser.getClassObject(ownerClass.getConcreteClass().replace('/', '_').replace('$', '_'));

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Invoke.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Invoke.java
@@ -92,7 +92,7 @@ public class Invoke extends Instruction {
         String dependencyOwner = owner;
         if (opcode == Opcodes.INVOKEVIRTUAL) {
             ByteCodeClass bc = Parser.getClassObject(owner.replace('/', '_').replace('$', '_'));
-            String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc);
+            String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc, true);
             if (resolvedConcreteOwner != null) {
                 dependencyOwner = resolvedConcreteOwner;
             }
@@ -148,11 +148,14 @@ public class Invoke extends Instruction {
         return findActualOwner(bc.getBaseClassObject());
     }
 
-    private String resolveConcreteInvokeOwner(ByteCodeClass ownerClass) {
+    private String resolveConcreteInvokeOwner(ByteCodeClass ownerClass, boolean allowMissingMethodContext) {
         if (ownerClass == null || ownerClass.getConcreteClass() == null) {
             return null;
         }
         String currentClass = getMethod() != null ? getMethod().getClsName() : null;
+        if (currentClass == null && !allowMissingMethodContext) {
+            return null;
+        }
         String ownerName = ownerClass.getClsName();
         if (currentClass != null && (ownerName.equals(currentClass) || currentClass.startsWith(ownerName + "_"))) {
             return null;
@@ -194,7 +197,7 @@ public class Invoke extends Instruction {
                     if (bc.isMethodPrivate(name, desc)) {
                         isVirtual = false;
                     } else {
-                        String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc);
+                        String resolvedConcreteOwner = resolveConcreteInvokeOwner(bc, false);
                         if (resolvedConcreteOwner != null) {
                             invokeOwner = resolvedConcreteOwner;
                             isVirtual = false;


### PR DESCRIPTION
### Motivation
- Dependency collection could run without a method context, and `resolveConcreteInvokeOwner()` previously bail/returned `null` when `getMethod()` was unavailable which caused concrete-class header/includes to be skipped and later produced calls to targets without declarations.

### Description
- Stop requiring `getMethod()` to be non-null in `Invoke.resolveConcreteInvokeOwner()` and `CustomInvoke.resolveConcreteInvokeOwner()` so concrete-owner resolution can run during dependency analysis even when no method context exists.
- Make the `currentClass` lookup null-safe and keep the self/inner-class guard only when `currentClass` is present.
- Changes touch `vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/Invoke.java` and `.../CustomInvoke.java` with small, equivalent edits in both files.

### Testing
- Ran `mvn -f vm/ByteCodeTranslator/pom.xml -DskipTests compile` which succeeded. 
- Attempted the Java 8 setup `export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 && export PATH="$JAVA_HOME/bin:$PATH" && mvn -f vm/ByteCodeTranslator/pom.xml -DskipTests compile` but that failed because the documented Java 8 path is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69de462d9088832997b65291cf18b878)