### PR TITLE
iOS: Defer updateCanvas on foreground to avoid iPad display size flip

### DIFF
--- a/Ports/iOSPort/nativeSources/CodenameOne_GLAppDelegate.m
+++ b/Ports/iOSPort/nativeSources/CodenameOne_GLAppDelegate.m
@@ -218,7 +218,16 @@ static void installSignalHandlers() {
     com_codename1_impl_ios_IOSImplementation_applicationWillEnterForeground__(CN1_THREAD_GET_STATE_PASS_SINGLE_ARG);
     CodenameOne_GLViewController* vc = [CodenameOne_GLViewController instance];
     if (vc != nil) {
-        [vc updateCanvas:YES];
+        // Defer updateCanvas by one run-loop cycle so that UIKit has a chance to
+        // settle the root view bounds after foreground transition.  Calling this
+        // too early can report the short edge for width/height on iPad, which
+        // causes a transient wrong screen-size event between stop/start.
+        dispatch_async(dispatch_get_main_queue(), ^{
+            CodenameOne_GLViewController* deferredVc = [CodenameOne_GLViewController instance];
+            if (deferredVc != nil) {
+                [deferredVc updateCanvas:YES];
+            }
+        });
     }
 }
 


### PR DESCRIPTION
### Motivation
- On iPad the app could report the short edge as the display width/height when resuming from background, producing a transient incorrect screen-size event (e.g. 1536 vs 2048) between stop/restart lifecycle callbacks.

### Description
- Change in `Ports/iOSPort/nativeSources/CodenameOne_GLAppDelegate.m`: `cn1ApplicationWillEnterForeground` now defers the call to `updateCanvas:YES` using `dispatch_async(dispatch_get_main_queue(), ^{ ... })` so UIKit can settle the root view bounds before the canvas is updated.

### Testing
- Attempted to run the quick smoke script `./scripts/fast-core-unit-smoke.sh` with `JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64`, but the environment does not contain Java 8 so the test run failed and no automated tests were executed in this container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e1b84430d883298c741b349e0a08df)