### PR TITLE
Toolbar: defer side-menu layered-pane detach to dispose onFinish

### DIFF
--- a/CodenameOne/src/com/codename1/components/InteractionDialog.java
+++ b/CodenameOne/src/com/codename1/components/InteractionDialog.java
@@ -452,6 +452,15 @@ public class InteractionDialog extends Container implements AbstractDialog {
         disposeTo(Component.LEFT);
     }
 
+    /// Removes the interaction dialog from view with an animation to the left.
+    ///
+    /// #### Parameters
+    ///
+    /// - `onFinish`: Callback called when dispose animation is complete.
+    public void disposeToTheLeft(Runnable onFinish) {
+        disposeTo(Component.LEFT, onFinish);
+    }
+
     /// Removes the interaction dialog from view with an animation to the bottom
     public void disposeToTheBottom() {
         disposeTo(Component.BOTTOM);
@@ -471,9 +480,27 @@ public class InteractionDialog extends Container implements AbstractDialog {
         disposeTo(Component.TOP);
     }
 
+    /// Removes the interaction dialog from view with an animation to the top.
+    ///
+    /// #### Parameters
+    ///
+    /// - `onFinish`: Callback called when dispose animation is complete.
+    public void disposeToTheTop(Runnable onFinish) {
+        disposeTo(Component.TOP, onFinish);
+    }
+
     /// Removes the interaction dialog from view with an animation to the right
     public void disposeToTheRight() {
         disposeTo(Component.RIGHT);
+    }
+
+    /// Removes the interaction dialog from view with an animation to the right.
+    ///
+    /// #### Parameters
+    ///
+    /// - `onFinish`: Callback called when dispose animation is complete.
+    public void disposeToTheRight(Runnable onFinish) {
+        disposeTo(Component.RIGHT, onFinish);
     }
 
     private void disposeTo(int direction) {

--- a/CodenameOne/src/com/codename1/ui/Toolbar.java
+++ b/CodenameOne/src/com/codename1/ui/Toolbar.java
@@ -446,15 +446,18 @@ public class Toolbar extends Container {
     public void closeLeftSideMenu() {
         if (onTopSideMenu) {
             if (sidemenuDialog != null && sidemenuDialog.isShowing()) {
+                final Container cnt = getComponentForm().getFormLayeredPane(Toolbar.class, false);
+                Runnable onDisposed = new Runnable() {
+                    @Override
+                    public void run() {
+                        detachToolbarLayeredPane(cnt);
+                    }
+                };
                 if (!isRTL()) {
-                    sidemenuDialog.disposeToTheLeft();
+                    sidemenuDialog.disposeToTheLeft(onDisposed);
                 } else {
-                    sidemenuDialog.disposeToTheRight();
+                    sidemenuDialog.disposeToTheRight(onDisposed);
                 }
-                Container cnt = getComponentForm().getFormLayeredPane(Toolbar.class, false);
-                Style s = cnt.getUnselectedStyle();
-                s.setBgTransparency(0);
-                cnt.remove();
             }
         } else {
             SideMenuBar.closeCurrentMenu();
@@ -465,17 +468,45 @@ public class Toolbar extends Container {
     public void closeRightSideMenu() {
         if (onTopSideMenu) {
             if (rightSidemenuDialog != null && rightSidemenuDialog.isShowing()) {
+                final Container cnt = getComponentForm().getFormLayeredPane(Toolbar.class, false);
+                Runnable onDisposed = new Runnable() {
+                    @Override
+                    public void run() {
+                        detachToolbarLayeredPane(cnt);
+                    }
+                };
                 if (!isRTL()) {
-                    rightSidemenuDialog.disposeToTheRight();
+                    rightSidemenuDialog.disposeToTheRight(onDisposed);
                 } else {
-                    rightSidemenuDialog.disposeToTheLeft();
+                    rightSidemenuDialog.disposeToTheLeft(onDisposed);
                 }
-                Container cnt = getComponentForm().getFormLayeredPane(Toolbar.class, false);
-                Style s = cnt.getUnselectedStyle();
-                s.setBgTransparency(0);
-                cnt.remove();
             }
         }
+    }
+
+    /// Detaches the Toolbar's shared FormLayeredPane once the side-menu
+    /// dispose animation has finished. Called from the dispose
+    /// onFinish callback so the Dialog's own peer-removal logic runs
+    /// against a still-attached parent. Detaching the layered pane
+    /// synchronously (which was the previous behaviour) left orphan
+    /// peer DOM elements on the JavaScript port because the Dialog's
+    /// animation callback ran after its parent had already been
+    /// removed. Only detach when the side-menu Dialog is the only
+    /// remaining child of the layered pane; otherwise another side
+    /// menu (e.g. the opposite-side one) is still showing.
+    private void detachToolbarLayeredPane(Container cnt) {
+        if (cnt == null) {
+            return;
+        }
+        if (sidemenuDialog != null && sidemenuDialog.isShowing()) {
+            return;
+        }
+        if (rightSidemenuDialog != null && rightSidemenuDialog.isShowing()) {
+            return;
+        }
+        Style s = cnt.getUnselectedStyle();
+        s.setBgTransparency(0);
+        cnt.remove();
     }
 
     /// Returns the Toolbar title Component.

--- a/maven/core-unittests/src/test/java/com/codename1/ui/ToolbarTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/ToolbarTest.java
@@ -207,4 +207,49 @@ class ToolbarTest extends UITestBase {
 
         assertEquals(1, overflowInvocation[0], "Overflow command should be invoked");
     }
+
+    /// Regression test for the JavaScript port "ghost side menu +
+    /// previous preview visible as background" bug. closeLeftSideMenu
+    /// used to synchronously detach the Toolbar's FormLayeredPane
+    /// while the sidemenu dialog was still mid-animation, leaving the
+    /// dialog's peer tree orphaned on the JS port. The fix defers the
+    /// layered-pane detach until the dispose animation completes. The
+    /// assertion here is the behaviour shift: immediately after
+    /// closeLeftSideMenu returns (synchronously, before the dispose
+    /// animation can have run to completion), the pane must still be
+    /// attached. The old code detached synchronously.
+    @FormTest
+    void closeLeftSideMenuKeepsLayeredPaneAttachedDuringDispose() {
+        implementation.setBuiltinSoundsEnabled(false);
+        Toolbar.setOnTopSideMenu(true);
+
+        Form form = Display.getInstance().getCurrent();
+        Toolbar toolbar = new Toolbar();
+        form.setToolbar(toolbar);
+        form.show();
+        form.getAnimationManager().flush();
+        flushSerialCalls();
+
+        toolbar.addCommandToSideMenu("Entry", null, evt -> { });
+
+        toolbar.openSideMenu();
+        form.getAnimationManager().flush();
+        flushSerialCalls();
+        awaitAnimations(form);
+        assertTrue(toolbar.isSideMenuShowing(), "Side menu should be showing after open");
+
+        Container pane = form.getFormLayeredPane(Toolbar.class, false);
+        assertNotNull(pane, "Toolbar layered pane must exist while menu is open");
+        assertNotNull(pane.getParent(), "Layered pane must be attached to the form tree while menu is open");
+
+        toolbar.closeLeftSideMenu();
+
+        // Pane must still be attached — the detach is deferred to the
+        // dispose onFinish so the dialog's peer teardown runs against
+        // a still-attached parent. The old pre-fix code would have
+        // nulled pane.getParent() before returning.
+        assertNotNull(pane.getParent(),
+                "Layered pane should stay attached while the dispose animation runs "
+                        + "(deferred detach regression — see Toolbar.detachToolbarLayeredPane)");
+    }
 }


### PR DESCRIPTION
The JavaScript port of the playground (and any app using the Toolbar side menu with onTopSideMenu=true) exhibited a stale-DOM bug: after closing the side menu, the previous preview/form state remained visible as a non-clickable "ghost" layer, and re-opening the menu showed two panels — a fresh slide-in on top of the stuck previous one. The simulator (Swing) paint path fully repaints each frame so the ghost wasn't visible there, which is why this only manifested on the JS port.

Root cause: Toolbar.closeLeftSideMenu / closeRightSideMenu kicked off the sidemenu Dialog's animated dispose and then immediately called `cnt.remove()` on the Toolbar's FormLayeredPane (the semi-transparent backdrop). The dispose animation is asynchronous, so the Dialog's own peer-cleanup callback (which runs at animation end and calls remove()/p.remove()/pp.removeAll() etc.) ran against a parent that had already been severed from the form tree. On the JS port peers map to persistent DOM nodes; the detached parent's DOM and the mid-animated Dialog's DOM were never properly torn down.

Fix lands in two pieces:

* InteractionDialog gains public overloads `disposeToTheLeft(Runnable)`, `disposeToTheRight(Runnable)`, and `disposeToTheTop(Runnable)` alongside the existing `disposeToTheBottom(Runnable)`. The private disposeTo(int, Runnable) already supported this — only public wiring was missing.

* Toolbar.closeLeftSideMenu / closeRightSideMenu now capture the Toolbar's FormLayeredPane and pass an onFinish runnable that calls the new detachToolbarLayeredPane helper. The helper skip-guards when either sidemenu dialog is still showing (the opposite-side close case) and only removes the pane once all dispose callbacks have fired. The pane now stays attached while the dispose animation runs, so the Dialog's peer-cleanup sees a still-attached parent.

Regression test added: ToolbarTest asserts that after closeLeftSideMenu returns synchronously, the Toolbar layered pane is still attached (the old code would have detached it immediately). All 6 Toolbar tests pass locally.