### PR TITLE
Fix StackOverflowError in Display.setCurrent off-EDT (#4811)

### DIFF
--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -1495,8 +1495,17 @@ public final class Display extends CN1Constants {
         if (edt == null) {
             throw new IllegalStateException("Initialize must be invoked before setCurrent!");
         }
-        Form current = impl.getCurrentForm();
 
+        if (!isEdt()) {
+            // when not running callSerially executes synchronously and would recurse here forever (#4811)
+            if (!codenameOneRunning) {
+                throw new IllegalStateException("Display.setCurrent must be invoked after Codename One has started running. Call it from start() or via callSerially.");
+            }
+            callSerially(new RunnableWrapper(newForm, null, reverse));
+            return;
+        }
+
+        Form current = impl.getCurrentForm();
 
         if (autoFoldVKBOnFormSwitch && !(newForm instanceof Dialog)) {
             setShowVirtualKeyboard(false);
@@ -1526,11 +1535,6 @@ public final class Display extends CN1Constants {
                 default:
                     break;
             }
-        }
-
-        if (!isEdt()) {
-            callSerially(new RunnableWrapper(newForm, null, reverse));
-            return;
         }
 
         if (current != null) {


### PR DESCRIPTION
## Summary

- Fixes #4811 — `Display.setCurrent` invoked from a non-EDT thread recursed infinitely into `callSerially` -> `RunnableWrapper.run` -> `setCurrent` until the JVM stack overflowed (the SOH happened to surface in `getDefaultVirtualKeyboard`/`setShowVirtualKeyboard` because those frames sit on top of the loop).
- Root cause: when `codenameOneRunning` is `false` (e.g. before init has fully completed or after `deinitialize`), `callSerially` falls back to executing the runnable synchronously on the calling thread, which re-enters `setCurrent` in the same off-EDT state.
- Move the `!isEdt()` dispatch ahead of any UI work in `setCurrent` (so VKB folding, revalidate/repaint, and editing-text branches always execute on the EDT) and fail fast with a clear `IllegalStateException` when the EDT cannot accept the call.

## Test plan

- [ ] `mvn -pl core compile -Plocal-dev-javase` succeeds (verified locally).
- [ ] Existing JavaSE tests pass (`ant test-javase` / `mvn test -Plocal-dev-javase`).
- [ ] Manual: invoking `Display.getInstance().setCurrent(form, false)` from a background thread before `init` (or after `deinitialize`) now throws `IllegalStateException` with a clear message instead of crashing with `StackOverflowError`.
- [ ] Normal off-EDT `setCurrent` calls (during a running app) continue to dispatch through `callSerially` and show the form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)