### PR TITLE
Update Developer Guide revdate to build date

### DIFF
--- a/scripts/website/build.sh
+++ b/scripts/website/build.sh
@@ -343,6 +343,9 @@ build_developer_guide_for_site() {
   rm -f "${WEBSITE_DIR}/static/developer-guide.html"
   mkdir -p "${html_out}" "${guide_dir}" "${generated_dir}"
 
+  local build_date
+  build_date="$(date +%Y-%m-%d)"
+
   (
     cd "${REPO_ROOT}"
     asciidoctor \
@@ -350,6 +353,7 @@ build_developer_guide_for_site() {
       -a linkcss \
       -a copycss \
       -a rouge-css=style \
+      -a revdate="${build_date}" \
       -D "${html_out}" \
       -o developer-guide-full.html \
       docs/developer-guide/developer-guide.asciidoc


### PR DESCRIPTION
## Summary
- The website build pipeline regenerates the Developer Guide HTML but never overrode the `:revdate:` baked into `docs/developer-guide/developer-guide.asciidoc`, so the header kept showing `version DEV-SNAPSHOT, 2025-10-20` regardless of when the site was built.
- Pass `-a revdate=$(date +%Y-%m-%d)` to the asciidoctor invocation in `scripts/website/build.sh` so the rendered guide shows the actual generation date.

## Test plan
- [ ] Run the website build (`WEBSITE_INCLUDE_DEVGUIDE=true` path through `scripts/website/build.sh`) and confirm the Developer Guide header date matches today.
- [ ] Spot-check the resulting `developer-guide-content.html` fragment for the updated date string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)