### PR TITLE
Fix tap-status-bar-to-scroll when global Toolbar is in use (#3589)

### DIFF
--- a/CodenameOne/src/com/codename1/ui/Toolbar.java
+++ b/CodenameOne/src/com/codename1/ui/Toolbar.java
@@ -31,6 +31,7 @@ import com.codename1.ui.animations.Transition;
 import com.codename1.ui.events.ActionEvent;
 import com.codename1.ui.events.ActionListener;
 import com.codename1.ui.events.ScrollListener;
+import com.codename1.ui.geom.Rectangle;
 import com.codename1.ui.layouts.BorderLayout;
 import com.codename1.ui.layouts.BoxLayout;
 import com.codename1.ui.layouts.Layout;
@@ -2530,14 +2531,34 @@ public class Toolbar extends Container {
         if (getUIManager().isThemeConstant("paintsTitleBarBool", false)) {
             // check if its already added:
             if (((BorderLayout) getLayout()).getNorth() == null) {
-                Container bar = new Container();
+                Component bar;
+                if (getUIManager().isThemeConstant("statusBarScrollsUpBool", true)) {
+                    Button btn = new Button();
+                    btn.setShowEvenIfBlank(true);
+                    btn.addActionListener(new ActionListener() {
+                        @Override
+                        public void actionPerformed(ActionEvent evt) {
+                            Form parent = getComponentForm();
+                            if (parent != null) {
+                                Component c = parent.findScrollableChild(parent.getContentPane());
+                                if (c != null) {
+                                    c.scrollRectToVisible(new Rectangle(0, 0, 10, 10), c);
+                                }
+                            }
+                        }
+                    });
+                    bar = btn;
+                } else {
+                    Container c = new Container();
+                    c.setSafeArea(true);
+                    bar = c;
+                }
                 if (getUIManager().isThemeConstant("landscapeTitleUiidBool", false)) {
                     bar.setUIID("StatusBar", "StatusBarLandscape");
                 } else {
                     bar.setUIID("StatusBar");
                 }
                 reallocateVerticalPaddingAndMarginsToTop(bar);
-                bar.setSafeArea(true);
                 addComponent(BorderLayout.NORTH, bar);
             }
         } else {


### PR DESCRIPTION
## Summary
- Fixes #3589: tap-on-iOS-status-bar-to-scroll-to-top didn't work when a global `Toolbar` was in use, even with `paintsTitleBarBool` and `statusBarScrollsUpBool` enabled.
- Root cause: `Toolbar.initTitleBarStatus()` created a plain `Container` as the StatusBar component and never honored `statusBarScrollsUpBool`. The iOS native shim (`cn1StatusBarTapProxy`) forwards a fake tap at `(displayWidth/2, 0)`, but with no `Button` to receive it, nothing scrolled.
- The Toolbar path now mirrors `Form.createStatusBar()`: when `statusBarScrollsUpBool` is true (default), it creates a `Button` whose action listener calls `findScrollableChild(...)` + `scrollRectToVisible(...)`. When the constant is false, the legacy plain-`Container` behavior is preserved.
- No public API change — `Form.findScrollableChild(...)` is package-private and `Toolbar` shares the package.

## Test plan
- [ ] Build a Maven app with `paintsTitleBarBool: true` and `statusBarScrollsUpBool: true`, default global Toolbar, scrollable content (≥ a screenful).
- [ ] On a real iOS device: tap the system status bar → content scrolls to top.
- [ ] On the simulator: programmatically click the StatusBar button area → content scrolls to top.
- [ ] Verify with `statusBarScrollsUpBool: false`: tap does not scroll, layout/sizing unchanged.
- [ ] Verify on a notched device that the StatusBar UIID still sizes correctly (height comes from the StatusBar UIID's theme padding in this branch, mirroring `Form.createStatusBar`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)