### PR TITLE
Toolbar: restore setSafeArea on StatusBar button branch (#4814 regression)

### DIFF
--- a/CodenameOne/src/com/codename1/ui/Toolbar.java
+++ b/CodenameOne/src/com/codename1/ui/Toolbar.java
@@ -2549,9 +2549,7 @@ public class Toolbar extends Container {
                     });
                     bar = btn;
                 } else {
-                    Container c = new Container();
-                    c.setSafeArea(true);
-                    bar = c;
+                    bar = new Container();
                 }
                 if (getUIManager().isThemeConstant("landscapeTitleUiidBool", false)) {
                     bar.setUIID("StatusBar", "StatusBarLandscape");
@@ -2559,6 +2557,7 @@ public class Toolbar extends Container {
                     bar.setUIID("StatusBar");
                 }
                 reallocateVerticalPaddingAndMarginsToTop(bar);
+                bar.setSafeArea(true);
                 addComponent(BorderLayout.NORTH, bar);
             }
         } else {

--- a/CodenameOne/src/com/codename1/ui/Toolbar.java
+++ b/CodenameOne/src/com/codename1/ui/Toolbar.java
@@ -2531,11 +2531,9 @@ public class Toolbar extends Container {
         if (getUIManager().isThemeConstant("paintsTitleBarBool", false)) {
             // check if its already added:
             if (((BorderLayout) getLayout()).getNorth() == null) {
-                Component bar;
+                Container bar = new Container();
                 if (getUIManager().isThemeConstant("statusBarScrollsUpBool", true)) {
-                    Button btn = new Button();
-                    btn.setShowEvenIfBlank(true);
-                    btn.addActionListener(new ActionListener() {
+                    bar.addPointerReleasedListener(new ActionListener() {
                         @Override
                         public void actionPerformed(ActionEvent evt) {
                             Form parent = getComponentForm();
@@ -2547,9 +2545,6 @@ public class Toolbar extends Container {
                             }
                         }
                     });
-                    bar = btn;
-                } else {
-                    bar = new Container();
                 }
                 if (getUIManager().isThemeConstant("landscapeTitleUiidBool", false)) {
                     bar.setUIID("StatusBar", "StatusBarLandscape");


### PR DESCRIPTION
## Summary

- Fixes a regression introduced by #4814 where 36 of 37 iOS screenshot baselines diverged on master starting at commit 9f42c532f.
- The fix in #4814 wrapped StatusBar creation in an if/else but only kept `setSafeArea(true)` on the `Container` fallback. With the default `statusBarScrollsUpBool=true`, the new `Button` branch ran without safe-area treatment, so the iOS top inset was no longer reserved and every form shifted vertically.
- Move `setSafeArea(true)` below the if/else so it applies to both branches, matching the pre-#4814 behavior. The scroll-to-top fix from #4814 is preserved.

## Bisect evidence (scripts-ios.yml on master)

| run | commit | matches | diffs |
|---|---|---|---|
| 24938791654 | 3f33dabd6 (parent) | 37 | 0 |
| 24946657644 | 9f42c532f (#4814) | 1 | 36 |

All 36 failing tests still produce 1179x2556 px images (same dims as goldens), so the differences are pixel content from the missing top inset.

## Test plan

- [ ] CI: `Test iOS UI build scripts` workflow passes on this branch with screenshots matching stored references.
- [ ] Manually verify on an iOS device that tapping the status bar still scrolls the form to the top when a global Toolbar is in use (the behavior #4814 was added to fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)