### PR TITLE
CI: cache Maven, Gradle, CocoaPods and bump action versions

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -18,14 +18,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up JDK 8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
-        java-version: 1.8
-        java-package: jdk
+        java-version: '8'
+        distribution: 'temurin'
+        cache: 'maven'
     - name: Install dependencies
-      run: sudo apt-get update && sudo apt-get install xvfb
+      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends xvfb
     - name: Build with Maven
       run: |
         cd maven

--- a/.github/workflows/designer.yml
+++ b/.github/workflows/designer.yml
@@ -27,19 +27,31 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up JDK 8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
-          java-package: jdk
+          java-version: '8'
+          distribution: 'temurin'
+          cache: 'maven'
 
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends xvfb unzip
 
+      - name: Cache cn1-binaries
+        uses: actions/cache@v4
+        with:
+          path: ../cn1-binaries
+          key: cn1-binaries-${{ runner.os }}-designer
+          restore-keys: |
+            cn1-binaries-${{ runner.os }}-
+
       - name: Fetch cn1 binaries
         run: |
-          wget https://github.com/codenameone/cn1-binaries/archive/refs/heads/master.zip
-          unzip master.zip -d ..
-          mv ../cn1-binaries-master ../cn1-binaries
+          if [ ! -d ../cn1-binaries ] || [ -z "$(ls -A ../cn1-binaries 2>/dev/null)" ]; then
+            wget -q https://github.com/codenameone/cn1-binaries/archive/refs/heads/master.zip
+            unzip -q master.zip -d ..
+            rm -rf ../cn1-binaries
+            mv ../cn1-binaries-master ../cn1-binaries
+          fi
           mkdir -p maven/target
           rm -rf maven/target/cn1-binaries
           cp -R ../cn1-binaries maven/target/cn1-binaries

--- a/.github/workflows/ios-packaging.yml
+++ b/.github/workflows/ios-packaging.yml
@@ -56,6 +56,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Cache CocoaPods and user gems
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gem
+            ~/Library/Caches/CocoaPods
+            ~/.cocoapods/repos
+          key: ${{ runner.os }}-pods-v1-${{ hashFiles('scripts/setup-workspace.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-v1-
+
       - name: Ensure CocoaPods tooling
         run: |
           mkdir -p ~/.codenameone
@@ -63,7 +74,9 @@ jobs:
           set -euo pipefail
           GEM_USER_DIR="$(ruby -e 'print Gem.user_dir')"
           export PATH="$GEM_USER_DIR/bin:$PATH"
-          gem install cocoapods xcodeproj --no-document --user-install
+          if ! command -v pod >/dev/null 2>&1; then
+            gem install cocoapods xcodeproj --no-document --user-install
+          fi
           pod --version
 
       - name: Compute setup-workspace hash
@@ -84,6 +97,14 @@ jobs:
           key: ${{ runner.os }}-cn1-tools-${{ steps.setup_hash.outputs.hash }}
           restore-keys: |
             ${{ runner.os }}-cn1-tools-
+
+      - name: Cache Maven repository
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-
 
       - name: Restore cn1-binaries cache
         uses: actions/cache@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,7 +53,7 @@ jobs:
         java-version: [8, 17, 21]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Validate Java 25 markdown docs style (CodenameOne + CLDC11)
         run: ./.github/scripts/validate-java25-markdown-docs.sh
       - name: Set up Java

--- a/.github/workflows/release-on-maven-central.yml
+++ b/.github/workflows/release-on-maven-central.yml
@@ -10,11 +10,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Maven Central Repository
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          java-version: '8'
+          distribution: 'temurin'
+          cache: 'maven'
           server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD

--- a/.github/workflows/scripts-android.yml
+++ b/.github/workflows/scripts-android.yml
@@ -126,6 +126,24 @@ jobs:
           key: ${{ runner.os }}-cn1-tools-${{ hashFiles('scripts/setup-workspace.sh') }}
           restore-keys: |
             ${{ runner.os }}-cn1-tools-
+      - name: Cache Maven repository
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-m2-android-${{ matrix.id }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-android-${{ matrix.id }}-
+            ${{ runner.os }}-m2-
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ matrix.id }}-${{ hashFiles('scripts/hellocodenameone/**/build.gradle*', 'scripts/hellocodenameone/**/gradle-wrapper.properties', 'Ports/Android/build.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-${{ matrix.id }}-
+            ${{ runner.os }}-gradle-
       - name: Setup workspace
         run: ./scripts/setup-workspace.sh -q -DskipTests
       - name: Build Android port

--- a/.github/workflows/scripts-ios-native.yml
+++ b/.github/workflows/scripts-ios-native.yml
@@ -66,6 +66,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Cache CocoaPods and user gems
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gem
+            ~/Library/Caches/CocoaPods
+            ~/.cocoapods/repos
+          key: ${{ runner.os }}-pods-v1-${{ hashFiles('scripts/setup-workspace.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-v1-
+
       - name: Ensure CocoaPods tooling
         run: |
           mkdir -p ~/.codenameone
@@ -76,7 +87,9 @@ jobs:
           fi
           GEM_USER_DIR="$(ruby -e 'print Gem.user_dir')"
           export PATH="$GEM_USER_DIR/bin:$PATH"
-          gem install cocoapods xcodeproj --no-document --user-install
+          if ! command -v pod >/dev/null 2>&1; then
+            gem install cocoapods xcodeproj --no-document --user-install
+          fi
           pod --version
 
       - name: Compute setup-workspace hash
@@ -95,6 +108,14 @@ jobs:
           key: ${{ runner.os }}-cn1-tools-${{ steps.setup_hash.outputs.hash }}
           restore-keys: |
             ${{ runner.os }}-cn1-tools-
+
+      - name: Cache Maven repository
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-
 
       - name: Restore cn1-binaries cache
         uses: actions/cache@v4

--- a/.github/workflows/scripts-ios.yml
+++ b/.github/workflows/scripts-ios.yml
@@ -76,6 +76,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Cache CocoaPods and user gems
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gem
+            ~/Library/Caches/CocoaPods
+            ~/.cocoapods/repos
+          key: ${{ runner.os }}-pods-v1-${{ hashFiles('scripts/setup-workspace.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-v1-
 
       - name: Ensure CocoaPods tooling
         run: |
@@ -87,7 +97,9 @@ jobs:
           fi
           GEM_USER_DIR="$(ruby -e 'print Gem.user_dir')"
           export PATH="$GEM_USER_DIR/bin:$PATH"
-          gem install cocoapods xcodeproj --no-document --user-install
+          if ! command -v pod >/dev/null 2>&1; then
+            gem install cocoapods xcodeproj --no-document --user-install
+          fi
           pod --version
 
       - name: Compute setup-workspace hash
@@ -106,6 +118,14 @@ jobs:
           key: ${{ runner.os }}-cn1-tools-${{ steps.setup_hash.outputs.hash }}
           restore-keys: |
             ${{ runner.os }}-cn1-tools-
+
+      - name: Cache Maven repository
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-
 
       - name: Restore cn1-binaries cache
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary

Reduces CI run time (especially on macOS runners) by caching dependency downloads that were previously refetched on every build, and bumps several workflows off deprecated `actions/checkout@v1`/`@v2` and `actions/setup-java@v1`.

No coverage changes — every test that runs today still runs.

## Changes per workflow

- **`scripts-ios.yml`, `scripts-ios-native.yml`, `ios-packaging.yml`**
  - Cache `~/.m2/repository` (was missed — `setup-workspace.sh` was redownloading every Maven dep on every run).
  - Cache `~/Library/Caches/CocoaPods`, `~/.cocoapods/repos`, and `~/.gem` so CocoaPods spec mirror and the `cocoapods`/`xcodeproj` gems persist.
  - Skip `gem install cocoapods xcodeproj` when `pod` is already on PATH from the restored cache.

- **`scripts-android.yml`**
  - Cache `~/.m2/repository` and `~/.gradle/{caches,wrapper}`.
  - Caches are matrix-keyed (`matrix.id`) so JDK 8 / 17 / 21 rows don't pollute each other.

- **`pr.yml`**
  - `actions/checkout@v1` → `@v4` (v1 doesn't shallow-clone and is significantly slower).

- **`ant.yml`**
  - `actions/checkout@v1` → `@v4`.
  - `actions/setup-java@v1` → `@v4` with `cache: 'maven'` (was missing entirely).
  - Kept as-is otherwise — this workflow runs `tests/all.sh` and `maven/integration-tests/all.sh` (archetype roundtrip, kotlin app, googlemaps demo, native interfaces, css fonts, migrations) which aren't covered elsewhere.

- **`designer.yml`**
  - `actions/setup-java@v1` → `@v4` with `cache: 'maven'`.
  - Cache `../cn1-binaries`; skip the `wget master.zip` + `unzip` on cache hit.

- **`release-on-maven-central.yml`**
  - `actions/checkout@v2` → `@v4`, `actions/setup-java@v1` → `@v4` with `cache: 'maven'`.

## Cache key strategy

- Maven repo: keyed on `hashFiles('**/pom.xml')` with a prefix `restore-keys` fallback so partial restores still help when poms change.
- Gradle: keyed on `build.gradle*` + wrapper hashes; matrix-scoped on Android.
- CocoaPods/gems: keyed on `setup-workspace.sh` hash — stable across builds since the gem versions don't drift.
- All caches scope by `runner.os` so Linux and macOS warm independently.

## Expected savings (rough, after first warm run)

| Workflow | Estimated saving |
|---|---|
| iOS workflows (×3) | ~5–8 min/run each |
| Android (×3 matrix) | ~3–4 min/run each |
| Designer | ~2–3 min/run |
| ant.yml | ~3–5 min/run |
| Release deploy | ~3–5 min/run |

## Test plan

- [ ] Verify all 8 modified workflows parse (done locally with `yaml.safe_load`).
- [ ] First push: caches will be cold — runs should still pass, just at current speed.
- [ ] Second push: confirm `Cache restored from key:` lines appear in step logs and step durations drop.
- [ ] Confirm Android matrix rows don't share cache (each `matrix.id` should write its own key).
- [ ] Confirm CocoaPods cache hit skips `gem install` (look for `pod --version` succeeding without a preceding install).

🤖 Generated with [Claude Code](https://claude.com/claude-code)