### PR TITLE
CI: more cache coverage, drop redundant triggers and a duplicate build step

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,7 @@ jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
-    timeout-minutes: 360
+    timeout-minutes: 60
     permissions:
       security-events: write
       packages: read

--- a/.github/workflows/developer-guide-docs.yml
+++ b/.github/workflows/developer-guide-docs.yml
@@ -2,7 +2,6 @@ name: Build Developer Guide Docs
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'docs/developer-guide/**'
       - 'docs/demos/**'

--- a/.github/workflows/javadocs.yml
+++ b/.github/workflows/javadocs.yml
@@ -2,6 +2,12 @@ name: Build JavaDocs
 
 on:
   pull_request:
+    paths:
+      - 'CodenameOne/src/**/*.java'
+      - 'Ports/**/src/**/*.java'
+      - 'maven/**/src/main/java/**/*.java'
+      - '.github/scripts/build_javadocs.sh'
+      - '.github/workflows/javadocs.yml'
   push:
     branches:
       - master

--- a/.github/workflows/parparvm-tests.yml
+++ b/.github/workflows/parparvm-tests.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '8'
+          cache: 'maven'
       - name: Save JDK 8 Path
         run: echo "JDK_8_HOME=$JAVA_HOME" >> $GITHUB_ENV
 
@@ -73,13 +74,12 @@ jobs:
       - name: Save JDK 25 Path
         run: echo "JDK_25_HOME=$JAVA_HOME" >> $GITHUB_ENV
 
-      # Restore JDK 8 as the main runner
+      # Restore JDK 8 as the main runner (cache is on the first setup-java JDK 8 above)
       - name: Restore JDK 8
         uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '8'
-          cache: 'maven'
 
       - name: Set up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -347,14 +347,6 @@ jobs:
       - name: Build iOS VM
         run: mvn -f vm/ByteCodeTranslator/pom.xml package
 
-      - name: Build CLDC 11 VM
-        run: |
-          ANT_OPTS_ARGS=""
-          if [ "${{ matrix.java-version }}" != "8" ]; then
-            ANT_OPTS_ARGS="-Djavac.source=1.8 -Djavac.target=1.8"
-          fi
-          ant $ANT_OPTS_ARGS -noinput -buildfile Ports/CLDC11/build.xml jar
-
       - name: Upload a Build Artifact
         if: matrix.java-version == 8
         uses: actions/upload-artifact@v4

--- a/.github/workflows/scripts-javascript.yml
+++ b/.github/workflows/scripts-javascript.yml
@@ -56,6 +56,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set TMPDIR
+        run: echo "TMPDIR=${{ runner.temp }}" >> $GITHUB_ENV
+
+      - name: Cache codenameone-tools
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/codenameone-tools
+          key: ${{ runner.os }}-cn1-tools-${{ hashFiles('scripts/setup-workspace.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-cn1-tools-
+
       - name: Set up Java 8 for ParparVM
         uses: actions/setup-java@v4
         with:
@@ -83,12 +94,33 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Cache npm modules for scripts/
+        uses: actions/cache@v4
+        with:
+          path: scripts/node_modules
+          key: ${{ runner.os }}-scripts-npm-playwright-v1
+          restore-keys: |
+            ${{ runner.os }}-scripts-npm-
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-chromium-v1
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
       - name: Install Playwright Chromium
         run: |
           cd scripts
           npm init -y 2>/dev/null || true
           npm install playwright
-          npx playwright install --with-deps chromium
+          if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
+            npx playwright install-deps chromium
+          else
+            npx playwright install --with-deps chromium
+          fi
 
       - name: Install Xvfb for headless Java AWT
         run: sudo apt-get update && sudo apt-get install -y xvfb

--- a/.github/workflows/website-docs.yml
+++ b/.github/workflows/website-docs.yml
@@ -2,7 +2,6 @@ name: Build Hugo Website
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'docs/website/**'
       - 'scripts/cn1playground/**'


### PR DESCRIPTION
## Summary

Round 2 of CI optimizations, building on #4834. All low-risk; no test coverage changes. The remaining structural items (pr.yml Maven+Ant dedupe, iOS port artifact sharing across workflows, dropping `push:` triggers on test-only workflows) are bigger changes and will land as their own focused PRs.

## Changes

- **`parparvm-tests.yml`**: Move `cache: 'maven'` from the 6th `setup-java` invocation (a "Restore JDK 8" step) onto the first JDK 8 install. The cache restore now happens *before* the five JDK installs, not after.
- **`scripts-javascript.yml`**: Add three caches:
  - `codenameone-tools` (the JDK 8/17 + Maven binaries that `setup-workspace.sh` downloads itself — was previously the only `scripts-*.yml` workflow without this cache)
  - `scripts/node_modules` (npm install of `playwright`)
  - `~/.cache/ms-playwright` (the ~150 MB Chromium binary — on cache hit we use `install-deps chromium` to install only the OS packages, skipping the browser download)
- **`developer-guide-docs.yml` + `website-docs.yml`**: Drop the `ready_for_review` trigger type. The default `[opened, synchronize, reopened]` covers everything; `ready_for_review` only fires on draft → ready transitions where the head SHA hasn't changed since the last `synchronize`, so the workflow has already run.
- **`javadocs.yml`**: Add a `paths:` filter so it only runs when Java sources, the build script, or the workflow itself change. Previously ran on every PR including pure docs/CI/typo PRs.
- **`codeql.yml`**: Drop `timeout-minutes` from 360 (6h) to 60. CodeQL on this codebase finishes well under 30 min; a 6-hour ceiling lets a hung run burn money.
- **`pr.yml`**: Remove the "Build CLDC 11 VM" step. It ran the byte-identical ant command as "Build CLDC11 JAR" earlier in the same job:
  ```
  ant $ANT_OPTS_ARGS -noinput -buildfile Ports/CLDC11/build.xml jar
  ```
  Both targeted the same buildfile and the same `jar` target.

## Expected savings

- `scripts-javascript.yml` (cache hit): ~3–5 min/run (skips the JDK redownloads in setup-workspace.sh and the Chromium download).
- `parparvm-tests.yml` (cache hit): ~30s earlier in the job — small but real.
- `pr.yml`: removes one redundant ant invocation × 3 matrix rows.
- `javadocs.yml`: zero CI for PRs that don't touch Java sources (was ~31s/run).
- `codeql.yml`: bound on a worst-case stuck run.

## What I didn't include and why

- **pr.yml Maven + Ant double-build dedupe (M3/M4)** — touches the structure of the main PR job; deserves a focused review on its own.
- **iOS port artifact sharing across workflows (M5/M6)** — biggest macOS win, but needs a `workflow_call` reusable workflow and careful artifact-key design.
- **Dropping `push:` triggers on test-only workflows (L6)** — would halve master-merge CI cost but changes the signal model; should be reviewed deliberately.

## Test plan

- [ ] All 7 modified workflows parse (verified locally with `yaml.safe_load`).
- [ ] Confirm `Cache restored from key:` lines appear for the new cn1-tools / npm / Playwright caches in `scripts-javascript.yml` on a second run.
- [ ] Confirm `parparvm-tests` job logs show the `cache: maven` restore early in the job.
- [ ] Confirm CLDC11 jar is still produced (the first "Build CLDC11 JAR" step still runs unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)