### PR TITLE
CI: share iOS port build across iOS workflows via reusable workflow

### DIFF
--- a/.github/workflows/_build-ios-port.yml
+++ b/.github/workflows/_build-ios-port.yml
@@ -1,54 +1,28 @@
-name: Test iOS packaging
+name: _Build iOS port (reusable)
+
+# Reusable workflow that runs scripts/setup-workspace.sh + scripts/build-ios-port.sh
+# once per workflow run, populating shared caches that downstream test jobs (in
+# scripts-ios.yml, scripts-ios-native.yml, ios-packaging.yml) restore via the
+# same cache keys.
+#
+# A separate "cn1-built" cache is keyed on the CN1 source hash with no restore-
+# keys (exact match only). On hit, the entire setup-workspace + build-ios-port
+# sequence is skipped — the iOS port artifact in ~/.m2/repository/com/codenameone
+# is already correct for the current source state.
+#
+# This cache is shared across all three iOS workflows on the same branch, so
+# whichever workflow runs first populates it and the others skip the rebuild.
 
 on:
-  pull_request:
-    paths:
-      - '.github/workflows/ios-packaging.yml'
-      - '.github/workflows/_build-ios-port.yml'
-      - 'maven/codenameone-maven-plugin/**'
-      - 'vm/ByteCodeTranslator/**'
-      - 'Ports/iOSPort/**'
-      - 'scripts/build-ios-app.sh'
-      - 'scripts/run-ios-ui-tests.sh'
-      - 'scripts/run-ios-native-tests.sh'
-      - 'scripts/ios/**'
-      - 'scripts/hellocodenameone/**'
-      - '!docs/**'
-  push:
-    branches: [ master ]
-    paths:
-      - '.github/workflows/ios-packaging.yml'
-      - '.github/workflows/_build-ios-port.yml'
-      - 'maven/codenameone-maven-plugin/**'
-      - 'vm/ByteCodeTranslator/**'
-      - 'Ports/iOSPort/**'
-      - 'scripts/build-ios-app.sh'
-      - 'scripts/run-ios-ui-tests.sh'
-      - 'scripts/run-ios-native-tests.sh'
-      - 'scripts/ios/**'
-      - 'scripts/hellocodenameone/**'
-      - '!docs/**'
+  workflow_call:
 
 jobs:
-  build-port:
-    uses: ./.github/workflows/_build-ios-port.yml
-
-  packaging:
-    needs: build-port
-    permissions:
-      contents: read
+  build:
     runs-on: macos-15
-    timeout-minutes: 45
-    # Exercises both CocoaPods and SPM in a single Xcode project. Catches
-    # regressions in either dependency manager (each pathway runs end to end)
-    # and additionally validates that they coexist correctly.
-    env:
-      IOS_DEPENDENCY_ARGS: >-
-        -Dcodename1.arg.ios.dependencyManager=both
-        -Dcodename1.arg.ios.pods=AFNetworking
-        -Dcodename1.arg.ios.spm.packages=swift-collections|https://github.com/apple/swift-collections.git|from:1.1.0
-        -Dcodename1.arg.ios.spm.products.swift-collections=Collections
-
+    timeout-minutes: 60
+    concurrency:
+      group: mac-ios-port-${{ github.workflow }}-${{ github.ref_name }}
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
 
@@ -68,6 +42,9 @@ jobs:
           mkdir -p ~/.codenameone
           cp maven/UpdateCodenameOne.jar ~/.codenameone/
           set -euo pipefail
+          if ! command -v ruby >/dev/null; then
+            echo "ruby not found"; exit 1
+          fi
           GEM_USER_DIR="$(ruby -e 'print Gem.user_dir')"
           export PATH="$GEM_USER_DIR/bin:$PATH"
           if ! command -v pod >/dev/null 2>&1; then
@@ -125,49 +102,33 @@ jobs:
           restore-keys: |
             cn1-binaries-${{ runner.os }}-
 
-      - name: Restore built CN1 + iOS port artifacts
-        uses: actions/cache/restore@v4
+      # Built CN1 + iOS port artifacts. Restored after the m2 cache so it
+      # overwrites any stale com/codenameone subtree pulled in by the broader
+      # m2 cache (whose key is keyed on POMs, not source).
+      - name: Cache built CN1 + iOS port artifacts
+        id: cn1_built
+        uses: actions/cache@v4
         with:
           path: |
             ~/.m2/repository/com/codenameone
             Themes
             Ports/iOSPort/nativeSources
           key: cn1-built-${{ runner.os }}-${{ steps.src_hash.outputs.hash }}
-          fail-on-cache-miss: true
 
-      - name: Build sample iOS app
-        id: build_ios_app
-        run: ./scripts/build-ios-app.sh -q -DskipTests
-        timeout-minutes: 30
+      - name: Setup workspace
+        if: steps.cn1_built.outputs.cache-hit != 'true'
+        run: ./scripts/setup-workspace.sh -q -DskipTests
+        timeout-minutes: 40
 
-      - name: Run iOS UI smoke
-        env:
-          ARTIFACTS_DIR: ${{ github.workspace }}/artifacts/ios-packaging
+      - name: Build iOS port
+        if: steps.cn1_built.outputs.cache-hit != 'true'
+        run: ./scripts/build-ios-port.sh -q -DskipTests
+        timeout-minutes: 40
+
+      - name: Report cache outcome
         run: |
-          set -euo pipefail
-          mkdir -p "${ARTIFACTS_DIR}"
-          ./scripts/run-ios-ui-tests.sh \
-            "${{ steps.build_ios_app.outputs.workspace }}" \
-            "" \
-            "${{ steps.build_ios_app.outputs.scheme }}"
-        timeout-minutes: 30
-
-      - name: Run native iOS notification tests
-        env:
-          ARTIFACTS_DIR: ${{ github.workspace }}/artifacts/ios-packaging-native
-        run: |
-          set -euo pipefail
-          mkdir -p "${ARTIFACTS_DIR}"
-          ./scripts/run-ios-native-tests.sh \
-            "${{ steps.build_ios_app.outputs.workspace }}" \
-            "${{ steps.build_ios_app.outputs.scheme }}"
-        timeout-minutes: 20
-
-      - name: Upload packaging artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ios-packaging
-          path: artifacts
-          if-no-files-found: warn
-          retention-days: 14
+          if [ "${{ steps.cn1_built.outputs.cache-hit }}" = "true" ]; then
+            echo "cn1-built cache HIT for key cn1-built-${{ runner.os }}-${{ steps.src_hash.outputs.hash }} — setup-workspace and build-ios-port were skipped."
+          else
+            echo "cn1-built cache MISS for key cn1-built-${{ runner.os }}-${{ steps.src_hash.outputs.hash }} — built fresh."
+          fi

--- a/.github/workflows/parparvm-tests.yml
+++ b/.github/workflows/parparvm-tests.yml
@@ -3,6 +3,7 @@ name: ParparVM Java Tests
 on:
   pull_request:
     paths:
+      - '.github/workflows/parparvm-tests.yml'
       - 'vm/**'
       - 'Ports/JavaScriptPort/**'
       - '!vm/**/README.md'
@@ -11,6 +12,7 @@ on:
   push:
     branches: [ master, main ]
     paths:
+      - '.github/workflows/parparvm-tests.yml'
       - 'vm/**'
       - 'Ports/JavaScriptPort/**'
       - '!vm/**/README.md'

--- a/.github/workflows/scripts-ios-native.yml
+++ b/.github/workflows/scripts-ios-native.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/scripts-ios-native.yml'
+      - '.github/workflows/_build-ios-port.yml'
       - 'scripts/setup-workspace.sh'
       - 'scripts/build-ios-port.sh'
       - 'scripts/build-ios-app.sh'
@@ -30,6 +31,7 @@ on:
     branches: [ master ]
     paths:
       - '.github/workflows/scripts-ios-native.yml'
+      - '.github/workflows/_build-ios-port.yml'
       - 'scripts/setup-workspace.sh'
       - 'scripts/build-ios-port.sh'
       - 'scripts/build-ios-app.sh'
@@ -54,11 +56,15 @@ on:
       - '!maven/core-unittests/**'
 
 jobs:
+  build-port:
+    uses: ./.github/workflows/_build-ios-port.yml
+
   native-ios:
+    needs: build-port
     permissions:
       contents: read
     runs-on: macos-15
-    timeout-minutes: 65
+    timeout-minutes: 45
     concurrency:
       group: mac-ci-${{ github.workflow }}-${{ github.ref_name }}
       cancel-in-progress: true
@@ -98,6 +104,23 @@ jobs:
           set -euo pipefail
           echo "hash=$(shasum -a 256 scripts/setup-workspace.sh | awk '{print $1}')" >> "$GITHUB_OUTPUT"
 
+      - name: Compute CN1 source hash
+        id: src_hash
+        run: |
+          set -euo pipefail
+          SRC_HASH=$(find CodenameOne/src Ports/iOSPort vm/JavaAPI vm/ByteCodeTranslator Themes \
+              -type f \( -name '*.java' -o -name '*.m' -o -name '*.h' -o -name '*.xml' -o -name '*.properties' -o -name '*.css' \) 2>/dev/null \
+              | sort | xargs shasum -a 256 | shasum -a 256 | awk '{print $1}')
+          POM_HASH=$(find . -name 'pom.xml' -not -path './scripts/*' 2>/dev/null \
+              | sort | xargs shasum -a 256 | shasum -a 256 | awk '{print $1}')
+          SCRIPT_HASH=$(shasum -a 256 \
+              scripts/setup-workspace.sh \
+              scripts/build-ios-port.sh \
+              scripts/build-native-themes.sh \
+              .github/workflows/_build-ios-port.yml \
+              | shasum -a 256 | awk '{print $1}')
+          echo "hash=${SRC_HASH:0:16}-${POM_HASH:0:16}-${SCRIPT_HASH:0:16}" >> "$GITHUB_OUTPUT"
+
       - name: Set TMPDIR
         run: echo "TMPDIR=${{ runner.temp }}" >> $GITHUB_ENV
 
@@ -125,13 +148,15 @@ jobs:
           restore-keys: |
             cn1-binaries-${{ runner.os }}-
 
-      - name: Setup workspace
-        run: ./scripts/setup-workspace.sh -q -DskipTests
-        timeout-minutes: 40
-
-      - name: Build iOS port
-        run: ./scripts/build-ios-port.sh -q -DskipTests
-        timeout-minutes: 40
+      - name: Restore built CN1 + iOS port artifacts
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.m2/repository/com/codenameone
+            Themes
+            Ports/iOSPort/nativeSources
+          key: cn1-built-${{ runner.os }}-${{ steps.src_hash.outputs.hash }}
+          fail-on-cache-miss: true
 
       - name: Build sample iOS app
         id: build_ios_app

--- a/.github/workflows/scripts-ios.yml
+++ b/.github/workflows/scripts-ios.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/scripts-ios.yml'
+      - '.github/workflows/_build-ios-port.yml'
       - 'scripts/setup-workspace.sh'
       - 'scripts/build-ios-port.sh'
       - 'scripts/build-ios-app.sh'
@@ -32,6 +33,7 @@ on:
     branches: [ master ]
     paths:
       - '.github/workflows/scripts-ios.yml'
+      - '.github/workflows/_build-ios-port.yml'
       - 'scripts/setup-workspace.sh'
       - 'scripts/build-ios-port.sh'
       - 'scripts/build-ios-app.sh'
@@ -58,13 +60,17 @@ on:
       - '!maven/core-unittests/**'
 
 jobs:
+  build-port:
+    uses: ./.github/workflows/_build-ios-port.yml
+
   build-ios:
+    needs: build-port
     permissions:
       contents: read
       pull-requests: write
       issues: write
     runs-on: macos-15           # pinning macos-15 avoids surprises during the cutover window
-    timeout-minutes: 60         # allow enough time for dependency installs and full build
+    timeout-minutes: 45         # only sample app build + UI tests now; iOS port build runs in build-port
     concurrency:                # ensure only one mac build runs at once
       group: mac-ci-${{ github.workflow }}-${{ github.ref_name }}
       cancel-in-progress: true
@@ -108,6 +114,23 @@ jobs:
           set -euo pipefail
           echo "hash=$(shasum -a 256 scripts/setup-workspace.sh | awk '{print $1}')" >> "$GITHUB_OUTPUT"
 
+      - name: Compute CN1 source hash
+        id: src_hash
+        run: |
+          set -euo pipefail
+          SRC_HASH=$(find CodenameOne/src Ports/iOSPort vm/JavaAPI vm/ByteCodeTranslator Themes \
+              -type f \( -name '*.java' -o -name '*.m' -o -name '*.h' -o -name '*.xml' -o -name '*.properties' -o -name '*.css' \) 2>/dev/null \
+              | sort | xargs shasum -a 256 | shasum -a 256 | awk '{print $1}')
+          POM_HASH=$(find . -name 'pom.xml' -not -path './scripts/*' 2>/dev/null \
+              | sort | xargs shasum -a 256 | shasum -a 256 | awk '{print $1}')
+          SCRIPT_HASH=$(shasum -a 256 \
+              scripts/setup-workspace.sh \
+              scripts/build-ios-port.sh \
+              scripts/build-native-themes.sh \
+              .github/workflows/_build-ios-port.yml \
+              | shasum -a 256 | awk '{print $1}')
+          echo "hash=${SRC_HASH:0:16}-${POM_HASH:0:16}-${SCRIPT_HASH:0:16}" >> "$GITHUB_OUTPUT"
+
       - name: Set TMPDIR
         run: echo "TMPDIR=${{ runner.temp }}" >> $GITHUB_ENV
 
@@ -135,23 +158,15 @@ jobs:
           restore-keys: |
             cn1-binaries-${{ runner.os }}-
 
-# Temporary disabled due to github issue: https://github.com/actions/runner/issues/4134
-#      - name: Restore cn1-binaries cache
-#        uses: actions/cache@v4
-#        with:
-#          path: ../cn1-binaries
-#          key: cn1-binaries-${{ runner.os }}-${{ hashFiles('scripts/setup-workspace.sh') }}
-#          restore-keys: |
-#            cn1-binaries-${{ runner.os }}-
-
-      - name: Setup workspace
-        run: ./scripts/setup-workspace.sh -q -DskipTests
-        # per-step timeout
-        timeout-minutes: 40
-
-      - name: Build iOS port
-        run: ./scripts/build-ios-port.sh -q -DskipTests
-        timeout-minutes: 40
+      - name: Restore built CN1 + iOS port artifacts
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            ~/.m2/repository/com/codenameone
+            Themes
+            Ports/iOSPort/nativeSources
+          key: cn1-built-${{ runner.os }}-${{ steps.src_hash.outputs.hash }}
+          fail-on-cache-miss: true
 
       - name: Build sample iOS app and compile workspace
         id: build-ios-app


### PR DESCRIPTION
## Summary

The biggest remaining iOS performance gap from the original audit: **the iOS port is built from scratch in every iOS workflow on every PR** (5 builds across `scripts-ios.yml`, `scripts-ios-native.yml`, and `ios-packaging.yml`'s 3-row matrix). This PR makes that build run **at most once per workflow run**, and shares the result across workflows when source hasn't changed.

## How

A new reusable workflow `.github/workflows/_build-ios-port.yml` (workflow_call) runs setup-workspace + build-ios-port. Each of the 3 iOS workflows now has 2 jobs:

```
build-port (uses _build-ios-port.yml)  →  test job (needs: build-port)
```

The test job just restores the populated caches and runs `build-ios-app.sh` + tests. It uses `actions/cache/restore@v4` with `fail-on-cache-miss: true` so a missing cache is a clear error, not silent regression.

## The cache that does the heavy lifting

A new `cn1-built` cache stores the built CN1 + iOS port artifacts:

- `~/.m2/repository/com/codenameone`
- `Themes/`
- `Ports/iOSPort/nativeSources/`

Keyed on a composite hash of:
- All Java / Objective-C / theme source under `CodenameOne/src`, `Ports/iOSPort`, `vm/JavaAPI`, `vm/ByteCodeTranslator`, `Themes/`
- Every `pom.xml`
- `setup-workspace.sh`, `build-ios-port.sh`, `build-native-themes.sh`, and the reusable workflow itself

**No `restore-keys`** — exact match only. A stale artifact set never satisfies a different source state.

The cn1-built cache is restored *after* the broader `~/.m2/repository` cache so it overwrites any stale `com/codenameone/` subtree pulled in by the POM-keyed m2 cache.

On cache hit, `build-port` skips both `setup-workspace` and `build-ios-port` and the job finishes in ~1–2 min instead of ~30 min. The 3 test jobs then restore the cache and run.

## Cross-workflow benefit (the M6 part)

The `cn1-built-${runner.os}-${source-hash}` cache key is identical across all 3 iOS workflows. When scripts-ios.yml runs first on a PR and populates the cache, ios-packaging.yml and scripts-ios-native.yml later in the same PR cache-hit and skip their entire iOS port rebuild.

A PR that doesn't touch CN1 / iOS port source at all will hit the cache from master's last successful run.

## Expected savings

Rough timings:

| Scenario | Before | After |
|---|---|---|
| First run, source changed | ~33 min × 3 matrix in parallel = ~37 min wall, ~99 min CPU | ~30 min build-port → ~10 min × 3 in parallel = ~40 min wall, ~60 min CPU |
| Subsequent run, source unchanged | ~37 min wall, ~99 min CPU | ~2 min build-port → ~10 min × 3 in parallel = ~12 min wall, ~32 min CPU |
| Cross-workflow on same PR | 3 × ~33 min = ~99 min macOS minutes | First workflow: ~33 min, others hit cache: ~12 min each → ~57 min total |

So the warm-cache path (the common case for typical PRs) goes from ~37 min wall-clock to ~12 min, and three iOS workflows on the same PR collectively go from ~3 × 33 min to ~33 + 12 + 12 min.

## Bonus: parparvm-tests.yml self-trigger bug

`parparvm-tests.yml`'s `paths:` filter didn't include itself, so my changes to that workflow in #4836 never actually triggered the workflow's own validation. Fixed by adding `.github/workflows/parparvm-tests.yml` to its `paths:` list.

## Risks / things to watch

- **`fail-on-cache-miss: true` on the test jobs.** If the cn1-built cache somehow doesn't survive the build-port → test-job handoff (e.g., GitHub cache eviction in the seconds between jobs), the test jobs fail loudly. This is intentional — silent fall-through could mask a problem.
- **Hash completeness.** The source hash covers Java, Objective-C, theme, properties, XML, CSS files plus all POMs and the build scripts. If a build output changes based on a file we didn't include, we'd serve a stale artifact. The composite is conservative; happy to tighten or loosen if you spot a gap.
- **First-run wall-clock is slightly slower** (~40 min vs ~37 min) because build-port is serial before the matrix. The CPU savings (~40 min less per first run) offset that, and every subsequent run is dramatically faster.
- **Within-PR cancellation.** The reusable workflow has its own `concurrency:` group (`mac-ios-port-${{ github.workflow }}-${{ github.ref_name }}`) so a new push cancels the in-flight build-port too.

## Test plan

- [ ] All 5 modified/new workflows parse (verified locally with `yaml.safe_load`).
- [ ] First PR run (cold cache): all 3 iOS workflows succeed; `build-port` does the full build, test jobs find the cn1-built cache and skip ahead to `build-ios-app.sh`.
- [ ] Second push on same PR (warm cache): build-port logs "cn1-built cache HIT — setup-workspace and build-ios-port were skipped." Test jobs run as before.
- [ ] Verify cross-workflow share: if scripts-ios.yml runs first then ios-packaging.yml runs later on the same PR, ios-packaging.yml's build-port logs a cache hit.
- [ ] Confirm parparvm-tests.yml runs on this PR (since it modifies `.github/workflows/parparvm-tests.yml`, which is now in the paths filter).

## Out of scope (kept as future work)

- M3/M4: Dedupe the Maven + Ant double-build inside `pr.yml`.
- L6: Drop redundant `push:` triggers on test-only workflows.
- Apply the same reusable-workflow pattern to scripts-android.yml + scripts-javase.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)