### PR TITLE
Bundle UpdateCodenameOne.jar with the maven plugin

### DIFF
--- a/maven/codenameone-maven-plugin/pom.xml
+++ b/maven/codenameone-maven-plugin/pom.xml
@@ -296,7 +296,10 @@
                         <configuration>
                             <target>
                                 <mkdir dir="${project.build.outputDirectory}"/>
+                                <mkdir dir="${project.build.outputDirectory}/com/codename1/maven"/>
                                 <copy file="${cn1.binaries}/Stubber.jar" todir="${project.build.outputDirectory}"/>
+                                <copy file="${maven.multiModuleProjectDirectory}/UpdateCodenameOne.jar"
+                                      todir="${project.build.outputDirectory}/com/codename1/maven"/>
                             </target>
                         </configuration>
 

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/AbstractCN1Mojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/AbstractCN1Mojo.java
@@ -706,43 +706,60 @@ public abstract class AbstractCN1Mojo extends AbstractMojo {
     }
     
     public static final String UPDATE_CODENAMEONE_JAR_URL = "https://www.codenameone.com/files/updates/UpdateCodenameOne.jar";
+    public static final String UPDATE_CODENAMEONE_JAR_FALLBACK_URL = "https://github.com/codenameone/CodenameOne/raw/refs/heads/master/maven/UpdateCodenameOne.jar";
+    public static final String UPDATE_CODENAMEONE_JAR_RESOURCE = "/com/codename1/maven/UpdateCodenameOne.jar";
     public static final String JPDATE_CODENAMEONE_JAR_PATH = System.getProperty("user.home") + File.separator + ".codenameone" + File.separator + "UpdateCodenameOne.jar";
 
-    
-    protected void installUpdater() throws IOException {
-        String destinationPath = JPDATE_CODENAMEONE_JAR_PATH;
-        FileOutputStream os = null;
-        InputStream is = null;
-        try {
-            File re = new File(destinationPath);
 
-            if (!re.exists()) {
-                getLog().info("Installing Codename One Updater from "+UPDATE_CODENAMEONE_JAR_URL);
-                is = new URL(UPDATE_CODENAMEONE_JAR_URL).openStream();
-                os = new FileOutputStream(re);
-                byte[] buf = new byte[65536];
-                int len = 0;
-                while ((len = is.read(buf)) > -1) {
-                    os.write(buf, 0, len);
+    protected void installUpdater() throws IOException {
+        File re = new File(JPDATE_CODENAMEONE_JAR_PATH);
+        if (re.exists()) {
+            getLog().debug("Designer is up to date");
+            return;
+        }
+        re.getParentFile().mkdirs();
+
+        InputStream bundled = AbstractCN1Mojo.class.getResourceAsStream(UPDATE_CODENAMEONE_JAR_RESOURCE);
+        if (bundled != null) {
+            getLog().info("Installing Codename One Updater from bundled plugin resource");
+            try {
+                copyToFile(bundled, re);
+                return;
+            } finally {
+                try { bundled.close(); } catch (IOException ignore) {}
+            }
+        }
+
+        IOException lastFailure = null;
+        for (String url : new String[] { UPDATE_CODENAMEONE_JAR_URL, UPDATE_CODENAMEONE_JAR_FALLBACK_URL }) {
+            getLog().info("Installing Codename One Updater from " + url);
+            InputStream is = null;
+            try {
+                is = new URL(url).openStream();
+                copyToFile(is, re);
+                return;
+            } catch (IOException ex) {
+                lastFailure = ex;
+                getLog().warn("Failed to download Codename One Updater from " + url + ": " + ex.getMessage());
+            } finally {
+                if (is != null) {
+                    try { is.close(); } catch (IOException ignore) {}
                 }
-            } else {
-                getLog().debug("Designer is up to date");
+            }
+        }
+        throw lastFailure != null ? lastFailure : new IOException("Failed to install Codename One updater");
+    }
+
+    private static void copyToFile(InputStream is, File dest) throws IOException {
+        FileOutputStream os = new FileOutputStream(dest);
+        try {
+            byte[] buf = new byte[65536];
+            int len;
+            while ((len = is.read(buf)) > -1) {
+                os.write(buf, 0, len);
             }
         } finally {
-            if (os != null) {
-                try {
-                    os.close();
-                } catch (IOException ex) {
-                    getLog().error("Error closing output stream", ex);
-                }
-            }
-            if (is != null) {
-                try {
-                    is.close();
-                } catch (IOException ex) {
-                    getLog().error("Error closing input stream", ex);
-                }
-            }
+            os.close();
         }
     }
     

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/AbstractCN1Mojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/AbstractCN1Mojo.java
@@ -719,47 +719,35 @@ public abstract class AbstractCN1Mojo extends AbstractMojo {
         }
         re.getParentFile().mkdirs();
 
-        InputStream bundled = AbstractCN1Mojo.class.getResourceAsStream(UPDATE_CODENAMEONE_JAR_RESOURCE);
-        if (bundled != null) {
-            getLog().info("Installing Codename One Updater from bundled plugin resource");
-            try {
+        try (InputStream bundled = AbstractCN1Mojo.class.getResourceAsStream(UPDATE_CODENAMEONE_JAR_RESOURCE)) {
+            if (bundled != null) {
+                getLog().info("Installing Codename One Updater from bundled plugin resource");
                 copyToFile(bundled, re);
                 return;
-            } finally {
-                try { bundled.close(); } catch (IOException ignore) {}
             }
         }
 
         IOException lastFailure = null;
         for (String url : new String[] { UPDATE_CODENAMEONE_JAR_URL, UPDATE_CODENAMEONE_JAR_FALLBACK_URL }) {
             getLog().info("Installing Codename One Updater from " + url);
-            InputStream is = null;
-            try {
-                is = new URL(url).openStream();
+            try (InputStream is = new URL(url).openStream()) {
                 copyToFile(is, re);
                 return;
             } catch (IOException ex) {
                 lastFailure = ex;
                 getLog().warn("Failed to download Codename One Updater from " + url + ": " + ex.getMessage());
-            } finally {
-                if (is != null) {
-                    try { is.close(); } catch (IOException ignore) {}
-                }
             }
         }
         throw lastFailure != null ? lastFailure : new IOException("Failed to install Codename One updater");
     }
 
     private static void copyToFile(InputStream is, File dest) throws IOException {
-        FileOutputStream os = new FileOutputStream(dest);
-        try {
+        try (FileOutputStream os = new FileOutputStream(dest)) {
             byte[] buf = new byte[65536];
             int len;
             while ((len = is.read(buf)) > -1) {
                 os.write(buf, 0, len);
             }
-        } finally {
-            os.close();
         }
     }
     


### PR DESCRIPTION
## Summary
- Fixes intermittent `Failed to install Codename One updater` build failures caused by flaky downloads from `https://www.codenameone.com/files/updates/UpdateCodenameOne.jar`.
- The 12KB updater jar is now copied into the plugin's classpath at build time (alongside `Stubber.jar`), so it ships with the plugin from Maven Central and no network call is needed for it.
- `installUpdater()` extracts the bundled resource first, then falls back to the `codenameone.com` URL, then to the GitHub raw URL — mirroring the fallback chain already in `maven/pom.xml`.

## Test plan
- [x] `mvn -pl codenameone-maven-plugin install` succeeds on JDK 8.
- [x] Verified `com/codename1/maven/UpdateCodenameOne.jar` is present inside the produced `codenameone-maven-plugin-*.jar`.
- [ ] On a clean machine with `~/.codenameone/UpdateCodenameOne.jar` removed, run any Mojo that calls `updateCodenameOne(...)` (e.g. `cn1:update`) and confirm log says `Installing Codename One Updater from bundled plugin resource`.
- [ ] Confirm the file written to `~/.codenameone/UpdateCodenameOne.jar` matches the bundled copy and the existing updater flow continues normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)