### PR TITLE
iOS: orientation-validate canvas size on iPad foreground (#4767)

### DIFF
--- a/Ports/iOSPort/nativeSources/CodenameOne_GLAppDelegate.m
+++ b/Ports/iOSPort/nativeSources/CodenameOne_GLAppDelegate.m
@@ -248,7 +248,16 @@ static void installSignalHandlers() {
     com_codename1_impl_ios_IOSImplementation_applicationWillEnterForeground__(CN1_THREAD_GET_STATE_PASS_SINGLE_ARG);
     CodenameOne_GLViewController* vc = [CodenameOne_GLViewController instance];
     if (vc != nil) {
-        [vc updateCanvas:YES];
+        // Defer to the next runloop so UIKit can settle the view bounds
+        // after the snapshot rotation. updateCanvas itself also
+        // orientation-validates the bounds for an extra safety net under
+        // UIScene on iPad (issue #4767).
+        dispatch_async(dispatch_get_main_queue(), ^{
+            CodenameOne_GLViewController* deferredVc = [CodenameOne_GLViewController instance];
+            if (deferredVc != nil) {
+                [deferredVc updateCanvas:YES];
+            }
+        });
     }
 }
 

--- a/Ports/iOSPort/nativeSources/CodenameOne_GLViewController.m
+++ b/Ports/iOSPort/nativeSources/CodenameOne_GLViewController.m
@@ -167,6 +167,33 @@ static void updateDisplayMetricsFromView(UIView *view) {
     displayWidth = (int)(view.bounds.size.width * scaleValue);
     displayHeight = (int)(view.bounds.size.height * scaleValue);
 }
+
+// On iPad with UIScene, view.bounds (and even window.bounds) can transiently
+// be in the snapshot orientation between sceneDidEnterBackground and the
+// first post-foreground layout pass. Cross-check against the windowScene's
+// interfaceOrientation -- which reflects what the user actually sees -- and
+// swap the dimensions if they contradict it. Without this, sampling bounds
+// during the foreground transition publishes a swapped-dimension
+// screenSizeChanged event between stop and start (issue #4767).
+static CGSize cn1OrientationCorrectSize(UIView *view) {
+    CGSize size = view.bounds.size;
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
+    if (@available(iOS 13.0, *)) {
+        UIWindowScene *scene = view.window.windowScene;
+        if (scene != nil) {
+            UIInterfaceOrientation o = scene.interfaceOrientation;
+            if (o != UIInterfaceOrientationUnknown) {
+                BOOL shouldBePortrait = UIInterfaceOrientationIsPortrait(o);
+                BOOL isPortrait = size.height >= size.width;
+                if (shouldBePortrait != isPortrait) {
+                    return CGSizeMake(size.height, size.width);
+                }
+            }
+        }
+    }
+#endif
+    return size;
+}
 BOOL forceSlideUpField;
 static UIScrollView *cn1StatusBarTapProxy = nil;
 
@@ -2020,22 +2047,22 @@ bool lockDrawing;
     if(touchesArray != nil) {
         [touchesArray removeAllObjects];
     }
-    int currentWidth = (int)self.view.bounds.size.width * scaleValue;
+    CGSize size = cn1OrientationCorrectSize(self.view);
     //if(currentWidth != displayWidth) {
     // Note:  While it may be tempting to only update the frame buffer if the size has changed,
-    // doing that causes a bug whereby the app may paint with the wrong dimensions 
+    // doing that causes a bug whereby the app may paint with the wrong dimensions
     // when opening from the background on iPad with multitasking enabled.
     // https://github.com/codenameone/CodenameOne/issues/2819
     // This may be caused by the fact the getDisplayWidthImpl() and getDisplayHeightImpl() update
     // the display width/height each time to match the view, without performing other resizing
     // details, so it is possible that the size change event still needs to be sent
     // even if the display width already matches the value we're given here.
-    [[self eaglView] updateFrameBufferSize:(int)self.view.bounds.size.width h:(int)self.view.bounds.size.height];
-    updateDisplayMetricsFromView(self.view);
-    displayWidth = currentWidth;
+    [[self eaglView] updateFrameBufferSize:(int)size.width h:(int)size.height];
+    displayWidth = (int)size.width * scaleValue;
+    displayHeight = (int)size.height * scaleValue;
     screenSizeChanged(displayWidth, displayHeight);
     //}
-    
+
 }
 
 - (BOOL)canBecomeFirstResponder {


### PR DESCRIPTION
## Summary

- Restores the next-runloop deferral around `updateCanvas:` in `cn1ApplicationWillEnterForeground` so UIKit has a tick to settle view bounds after the snapshot rotation.
- Cross-checks `view.bounds` against the windowScene's `interfaceOrientation` inside `updateCanvas:` and swaps the dimensions when they contradict it -- catches the failure even when the deferred call still fires before UIKit has restored bounds.

## Why

Previous attempt (#4808 / a09b9162) correctly filters `viewWillTransitionToSize:` during the background snapshot pass, but it then calls `updateCanvas:` synchronously inside `cn1ApplicationWillEnterForeground`. On iPad with UIScene, `view.bounds` is still in the snapshot orientation at that point, so the synchronous call republishes the swapped dimensions through `screenSizeChanged` -- the exact transient wrong size the user reports between stop and start in #4767.

The interface orientation reported by the windowScene is authoritative for what the user actually sees, so it can be used as a tiebreaker when the bounds and the orientation disagree.

## Test plan

- [ ] Verify on physical iPad in landscape: home → reopen no longer reports a portrait-orientation `screenSizeChanged` between stop and start.
- [ ] Verify on physical iPad in portrait: home → reopen no longer reports a landscape-orientation `screenSizeChanged` between stop and start.
- [ ] Confirm normal interactive rotation (`viewWillTransitionToSize:`) still propagates correctly.
- [ ] Confirm iPhone behavior is unchanged.
- [ ] Confirm UIScene-disabled (`ios.uiscene=false`) builds still behave correctly.

Fixes #4767

🤖 Generated with [Claude Code](https://claude.com/claude-code)