### PR TITLE
Fix iOS localized icons: inject CFBundleIconName so actool emits CFBundleAlternateIcons

### DIFF
--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
@@ -2807,7 +2807,14 @@ public class IPhoneBuilder extends Executor {
         // resulting partial Info.plist already contains the correct
         // CFBundleIcons entries, so we deliberately do not inject any
         // CFBundleAlternateIcons fragment here. Doing so would conflict with
-        // actool's output during the Info.plist merge.
+        // actool's output during the Info.plist merge. We do, however, need
+        // to inject CFBundleIconName -- without it actool will not emit the
+        // partial Info.plist containing CFBundleIcons / CFBundleAlternateIcons,
+        // and -[UIApplication setAlternateIconName:] would then fail at runtime
+        // because the bundle does not advertise the alternate icons.
+        if (!localizedIcons.isEmpty() && !inject.contains("CFBundleIconName")) {
+            inject += "\n<key>CFBundleIconName</key>\n<string>AppIcon</string>";
+        }
         String locationUsageDescription = null;
         if (xcodeVersion >= 9) {
             if ( (locationUsageDescription = request.getArg("ios.locationUsageDescription", null)) != null ){


### PR DESCRIPTION
## Summary

- The asset-catalog approach for localized iOS launcher icons (introduced in #4789, refined in #4831) relies on `actool` generating a partial `Info.plist` containing `CFBundleIcons` / `CFBundleAlternateIcons` from the asset catalog. Xcode then merges that partial into the app's final `Info.plist` so `-[UIApplication setAlternateIconName:completionHandler:]` can resolve alternate icons at runtime.
- **`actool` only emits that partial plist when `CFBundleIconName` is present in the source `Info.plist`.** Our template (`vm/ByteCodeTranslator/src/template/template/template-Info.plist`) only has the legacy `CFBundleIconFiles` array, so the alternate icons get compiled into the `.car` but the bundle never advertises them. Calling `setAlternateIconName:` then fails with "alternate icon name not found in bundle" — which is the symptom a customer just hit on a build.
- Inject `<key>CFBundleIconName</key><string>AppIcon</string>` into `Info.plist` whenever `localizedIcons` is non-empty (the only path that needs it), so `actool` produces the merged plist with both `CFBundlePrimaryIcon` and `CFBundleAlternateIcons`, and the runtime selector wired up in `CodenameOne_GLAppDelegate.m` can switch to the locale-specific icon.

## Verification on a customer build

Customer's generated sources had everything but the plist key:
- `Images.xcassets/AppIcon_ar_AE.appiconset` and `AppIcon_en_AE.appiconset` correctly created with PNGs and `Contents.json` ✅
- `project.pbxproj` had `ASSETCATALOG_COMPILER_ALTERNATE_APPICON_NAMES = "AppIcon_ar_AE AppIcon_en_AE"` ✅
- `CodenameOne_GLAppDelegate.m` had the `setAlternateIconName:` selector ✅
- `hPLUS-Info.plist` was missing `CFBundleIconName` ❌  ← root cause

A matching change is going out to the BuildDaemon (the production build server uses that codebase, not this maven plugin source directly).

## Test plan

- [ ] `mvn test -Plocal-dev-javase` in `maven/codenameone-maven-plugin/` passes (43/43 ✅ locally)
- [ ] On a project with `cn1_icon_<lang>[_<COUNTRY>].png` files in `native/ios/` (or in the resources), trigger an iOS build and confirm:
  - `*-Info.plist` in the generated Xcode source now contains `<key>CFBundleIconName</key><string>AppIcon</string>`
  - The built `.app`'s final `Info.plist` (post-`actool` merge) contains `CFBundleIcons` → `CFBundleAlternateIcons` with one entry per locale
  - On device: switching the system language to one of the registered locales causes the launcher icon to switch on next launch
- [ ] Build a project **without** any `cn1_icon_*.png` files and confirm the new key is **not** injected (regression guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)