### PR TITLE
Simulator: add Dark/Light Mode toggle to the Simulate menu

### DIFF
--- a/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
@@ -4609,37 +4609,57 @@ public class JavaSEPort extends CodenameOneImplementation {
         });
         toolsMenu.add(testRecorderMenu);
 
-        /*
         JMenu darkLightModeMenu = new JMenu("Dark/Light Mode");
-        simulatorMenu.add(darkLightModeMenu);
-        final JRadioButtonMenuItem darkMode = new JRadioButtonMenuItem("Dark Mode");
-        final JRadioButtonMenuItem lightMode = new JRadioButtonMenuItem("Light Mode");
-        final JRadioButtonMenuItem unsupportedMode = new JRadioButtonMenuItem("Unsupported");
-        ButtonGroup group = new ButtonGroup();
-        group.add(darkMode);
-        group.add(lightMode);
-        group.add(unsupportedMode);
-        darkMode.addActionListener(new ActionListener() {
+        simulateMenu.add(darkLightModeMenu);
+        final JRadioButtonMenuItem darkModeItem = new JRadioButtonMenuItem("Dark Mode");
+        final JRadioButtonMenuItem lightModeItem = new JRadioButtonMenuItem("Light Mode");
+        final JRadioButtonMenuItem unsupportedModeItem = new JRadioButtonMenuItem("Unsupported");
+        ButtonGroup darkModeGroup = new ButtonGroup();
+        darkModeGroup.add(darkModeItem);
+        darkModeGroup.add(lightModeItem);
+        darkModeGroup.add(unsupportedModeItem);
+
+        String savedDarkMode = pref.get("cn1.simulator.darkMode", "unsupported");
+        if ("dark".equals(savedDarkMode)) {
+            darkMode = Boolean.TRUE;
+            darkModeItem.setSelected(true);
+        } else if ("light".equals(savedDarkMode)) {
+            darkMode = Boolean.FALSE;
+            lightModeItem.setSelected(true);
+        } else {
+            darkMode = null;
+            unsupportedModeItem.setSelected(true);
+        }
+
+        darkModeItem.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                JavaSEPort.this.darkMode = true;
+                JavaSEPort.this.darkMode = Boolean.TRUE;
+                pref.put("cn1.simulator.darkMode", "dark");
+                refreshSkin(frm);
             }
         });
 
-        lightMode.addActionListener(new ActionListener() {
+        lightModeItem.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
-                JavaSEPort.this.darkMode = false;
+                JavaSEPort.this.darkMode = Boolean.FALSE;
+                pref.put("cn1.simulator.darkMode", "light");
+                refreshSkin(frm);
             }
         });
 
-        unsupportedMode.addActionListener(new ActionListener() {
+        unsupportedModeItem.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent e) {
                 JavaSEPort.this.darkMode = null;
+                pref.put("cn1.simulator.darkMode", "unsupported");
+                refreshSkin(frm);
             }
         });
-        */
+        darkLightModeMenu.add(darkModeItem);
+        darkLightModeMenu.add(lightModeItem);
+        darkLightModeMenu.add(unsupportedModeItem);
 
         manualPurchaseSupported = pref.getBoolean("manualPurchaseSupported", true);
         managedPurchaseSupported = pref.getBoolean("managedPurchaseSupported", true);


### PR DESCRIPTION
## Summary
- Adds a **Dark/Light Mode** submenu under the simulator's **Simulate** menu with three options: Dark Mode, Light Mode, and Unsupported (default).
- Selecting an option flips `Display.isDarkMode()` (`Boolean.TRUE` / `Boolean.FALSE` / `null`) and calls `refreshSkin(...)` so themes that branch on `@darkModeBool` re-render immediately.
- The choice is persisted in `Preferences` under `cn1.simulator.darkMode` and restored on simulator startup. Default is still **Unsupported**, matching prior behavior.

The previous (commented-out) skeleton in `JavaSEPort.installMenu` is replaced by this active implementation.

## Test plan
- [ ] Launch the simulator and confirm **Simulate → Dark/Light Mode** shows the three radio items.
- [ ] In an app whose theme uses `@darkModeBool` / dark-mode CSS media queries, toggle Dark / Light / Unsupported and verify the UI re-themes immediately without restart.
- [ ] Restart the simulator and verify the selected mode is restored from preferences.
- [ ] With Unsupported selected, confirm `CN.isDarkMode()` returns `null` (so theme behavior matches platforms that don't report dark mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)