### PR TITLE
Skip CN1MetalShaders.metal when ios.metal build hint is off

### DIFF
--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
@@ -718,6 +718,11 @@ public class IPhoneBuilder extends Executor {
         } else {
             new File(buildinRes, "MainWindowMETAL.xib").delete();
             new File(buildinRes, "CodenameOne_METALViewController.xib").delete();
+            // The .metal shader file isn't guarded by an #ifdef like the
+            // companion .m files, so leaving it in the project forces Xcode
+            // to invoke the Metal toolchain — which Xcode 26 ships as a
+            // separately-downloaded component that build servers don't have.
+            new File(buildinRes, "CN1MetalShaders.metal").delete();
         }
 
 


### PR DESCRIPTION
## Summary
- The `.metal` shader file has no `#ifdef CN1_USE_METAL` guard (Metal Shading Language doesn't wrap the same way the companion `.m` files do), so it was always copied into the generated Xcode project regardless of the `ios.metal` build hint.
- Xcode 26 ships the Metal Toolchain as a separately-downloaded component, so build servers without it failed compilation with `error: cannot execute tool 'metal' due to missing Metal Toolchain` even when the build hint was off.
- Fix mirrors the existing `MainWindowMETAL.xib` / `CodenameOne_METALViewController.xib` cleanup in the `!useMetal` branch. The same fix has already been applied (and pushed) to BuildDaemon.

## Why CI didn't catch this
The non-Metal `build-ios` job runs on GitHub's `macos-15` runner, which has the Metal Toolchain pre-cached. So the leaked `.metal` file silently compiled on CI. Production build servers ship a leaner Xcode 26 install without the toolchain, exposing the bug only there.

## Test plan
- [ ] `build-ios` workflow still passes (GL path, `ios.metal` unset)
- [ ] `build-ios-metal` workflow still passes (Metal path, `ios.metal=true`)
- [ ] Build server produces a working iOS build for a project without `ios.metal=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)