### PR TITLE
maven: surface real Ant/server error in AntExecutor failures

### DIFF
--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/ant/AntExecutor.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/ant/AntExecutor.java
@@ -1,6 +1,10 @@
 package com.codename1.ant;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
 import java.util.Properties;
 
 import org.apache.tools.ant.BuildException;
@@ -31,47 +35,102 @@ public class AntExecutor {
     public static boolean executeAntTask(String buildXmlFileFullPath, String target, Properties properties) {
 
         boolean success = false;
-        DefaultLogger consoleLogger = getConsoleLogger();
 
-        // Prepare Ant project
-        Project project = new Project();
-        File buildFile = new File(buildXmlFileFullPath);
+        // Tee stdout/stderr so that, on failure, we can recover server-reported
+        // error details (such as the JSON body returned by the build server) that
+        // the build client prints but does not propagate via the exception message.
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        PrintStream originalOut = System.out;
+        PrintStream originalErr = System.err;
+        PrintStream teeOut = new PrintStream(new TeeOutputStream(originalOut, captured), true);
+        PrintStream teeErr = new PrintStream(new TeeOutputStream(originalErr, captured), true);
 
-        project.setBasedir(buildFile.getParentFile().getAbsolutePath());
-        project.setBaseDir(buildFile.getParentFile());
+        DefaultLogger consoleLogger = new DefaultLogger();
+        consoleLogger.setErrorPrintStream(teeErr);
+        consoleLogger.setOutputPrintStream(teeOut);
+        consoleLogger.setMessageOutputLevel(Project.MSG_INFO);
 
-        project.setUserProperty("ant.file", buildFile.getAbsolutePath());
-        if (properties != null) {
-            for (String k : properties.stringPropertyNames()) {
-                project.setProperty(k, properties.getProperty(k));
-            }
-        }
+        System.setOut(teeOut);
+        System.setErr(teeErr);
 
-        project.addBuildListener(consoleLogger);
-
-        // Capture event for Ant script build start / stop / failure
         try {
-            project.fireBuildStarted();
-            project.init();
-            ProjectHelper projectHelper = ProjectHelper.getProjectHelper();
+            // Prepare Ant project
+            Project project = new Project();
+            File buildFile = new File(buildXmlFileFullPath);
 
-            project.addReference("ant.projectHelper", projectHelper);
+            project.setBasedir(buildFile.getParentFile().getAbsolutePath());
+            project.setBaseDir(buildFile.getParentFile());
 
-            projectHelper.parse(project, buildFile);
+            project.setUserProperty("ant.file", buildFile.getAbsolutePath());
+            if (properties != null) {
+                for (String k : properties.stringPropertyNames()) {
+                    project.setProperty(k, properties.getProperty(k));
+                }
+            }
 
-            // If no target specified then default target will be executed.
-            String targetToExecute = (target != null && target.trim().length() > 0) ? target.trim() : project.getDefaultTarget();
-            project.executeTarget(targetToExecute);
-            project.fireBuildFinished(null);
-            success = true;
-        } catch (BuildException buildException) {
-            project.fireBuildFinished(buildException);
-            throw new RuntimeException("!!! Unable to restart the IEHS App !!!", buildException);
+            project.addBuildListener(consoleLogger);
+
+            // Capture event for Ant script build start / stop / failure
+            try {
+                project.fireBuildStarted();
+                project.init();
+                ProjectHelper projectHelper = ProjectHelper.getProjectHelper();
+
+                project.addReference("ant.projectHelper", projectHelper);
+
+                projectHelper.parse(project, buildFile);
+
+                // If no target specified then default target will be executed.
+                String targetToExecute = (target != null && target.trim().length() > 0) ? target.trim() : project.getDefaultTarget();
+                project.executeTarget(targetToExecute);
+                project.fireBuildFinished(null);
+                success = true;
+            } catch (BuildException buildException) {
+                project.fireBuildFinished(buildException);
+                teeOut.flush();
+                teeErr.flush();
+                String detail = extractServerErrorDetail(captured.toString());
+                StringBuilder message = new StringBuilder("Ant task failed: ").append(buildException.getMessage());
+                if (detail != null) {
+                    message.append(System.lineSeparator()).append(detail);
+                }
+                throw new RuntimeException(message.toString(), buildException);
+            }
+        } finally {
+            System.setOut(originalOut);
+            System.setErr(originalErr);
         }
 
         return success;
+    }
 
-
+    /**
+     * Scans build output for server-reported error markers (HTTP status, response
+     * message, JSON error body) and returns them joined by newlines, or {@code null}
+     * if none were found.
+     */
+    static String extractServerErrorDetail(String log) {
+        if (log == null || log.isEmpty()) {
+            return null;
+        }
+        StringBuilder sb = new StringBuilder();
+        String[] lines = log.split("\\r?\\n");
+        for (String raw : lines) {
+            String line = raw.trim();
+            if (line.isEmpty()) {
+                continue;
+            }
+            if (line.startsWith("Response message from server is:")
+                    || line.startsWith("Server Detailed Error Message:")
+                    || line.startsWith("Server returned HTTP response code:")
+                    || line.contains("Server returned HTTP response code:")) {
+                if (sb.length() > 0) {
+                    sb.append(System.lineSeparator());
+                }
+                sb.append(line);
+            }
+        }
+        return sb.length() == 0 ? null : sb.toString();
     }
 
     /**
@@ -88,4 +147,44 @@ public class AntExecutor {
         return consoleLogger;
     }
 
+    /**
+     * OutputStream that writes to two underlying streams. Used to forward Ant
+     * output to the original console while also retaining a copy for diagnostics.
+     */
+    private static final class TeeOutputStream extends OutputStream {
+        private final OutputStream a;
+        private final OutputStream b;
+
+        TeeOutputStream(OutputStream a, OutputStream b) {
+            this.a = a;
+            this.b = b;
+        }
+
+        @Override
+        public void write(int byteValue) throws IOException {
+            a.write(byteValue);
+            b.write(byteValue);
+        }
+
+        @Override
+        public void write(byte[] buf, int off, int len) throws IOException {
+            a.write(buf, off, len);
+            b.write(buf, off, len);
+        }
+
+        @Override
+        public void flush() throws IOException {
+            a.flush();
+            b.flush();
+        }
+
+        @Override
+        public void close() throws IOException {
+            try {
+                a.close();
+            } finally {
+                b.close();
+            }
+        }
+    }
 }

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/ant/AntExecutor.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/ant/AntExecutor.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.util.Properties;
 
 import org.apache.tools.ant.BuildException;
@@ -42,8 +43,14 @@ public class AntExecutor {
         ByteArrayOutputStream captured = new ByteArrayOutputStream();
         PrintStream originalOut = System.out;
         PrintStream originalErr = System.err;
-        PrintStream teeOut = new PrintStream(new TeeOutputStream(originalOut, captured), true);
-        PrintStream teeErr = new PrintStream(new TeeOutputStream(originalErr, captured), true);
+        PrintStream teeOut;
+        PrintStream teeErr;
+        try {
+            teeOut = new PrintStream(new TeeOutputStream(originalOut, captured), true, "UTF-8");
+            teeErr = new PrintStream(new TeeOutputStream(originalErr, captured), true, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException("UTF-8 not supported", e);
+        }
 
         DefaultLogger consoleLogger = new DefaultLogger();
         consoleLogger.setErrorPrintStream(teeErr);
@@ -89,7 +96,13 @@ public class AntExecutor {
                 project.fireBuildFinished(buildException);
                 teeOut.flush();
                 teeErr.flush();
-                String detail = extractServerErrorDetail(captured.toString());
+                String capturedText;
+                try {
+                    capturedText = captured.toString("UTF-8");
+                } catch (UnsupportedEncodingException e) {
+                    throw new IllegalStateException("UTF-8 not supported", e);
+                }
+                String detail = extractServerErrorDetail(capturedText);
                 StringBuilder message = new StringBuilder("Ant task failed: ").append(buildException.getMessage());
                 if (detail != null) {
                     message.append(System.lineSeparator()).append(detail);
@@ -131,20 +144,6 @@ public class AntExecutor {
             }
         }
         return sb.length() == 0 ? null : sb.toString();
-    }
-
-    /**
-     * Logger to log output generated while executing ant script in console
-     *
-     * @return
-     */
-    private static DefaultLogger getConsoleLogger() {
-        DefaultLogger consoleLogger = new DefaultLogger();
-        consoleLogger.setErrorPrintStream(System.err);
-        consoleLogger.setOutputPrintStream(System.out);
-        consoleLogger.setMessageOutputLevel(Project.MSG_INFO);
-
-        return consoleLogger;
     }
 
     /**

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/ant/AntExecutorTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/ant/AntExecutorTest.java
@@ -1,0 +1,43 @@
+package com.codename1.ant;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class AntExecutorTest {
+
+    @Test
+    public void returnsNullWhenNoServerErrorMarkers() {
+        assertNull(AntExecutor.extractServerErrorDetail(null));
+        assertNull(AntExecutor.extractServerErrorDetail(""));
+        assertNull(AntExecutor.extractServerErrorDetail("Just some build output\nNothing interesting here"));
+    }
+
+    @Test
+    public void capturesServerJsonBodyAndStatus() {
+        String log = "Sending build request to the server, notice that the build might take a while to complete!\n"
+                + "Sending build to account: shai@codenameone.com\n"
+                + "Response message from server is: Internal Server Error\n"
+                + "Server Detailed Error Message: {\"timestamp\":\"2026-05-10T03:43:19.633+00:00\",\"status\":500,\"error\":\"Internal Server Error\",\"path\":\"/appsec/7.0/build/upload\"}\n"
+                + "java.io.IOException: Server returned HTTP response code: 500 for URL: https://cloud.codenameone.com/appsec/7.0/build/upload\n"
+                + "    at java.base/sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1700)";
+
+        String detail = AntExecutor.extractServerErrorDetail(log);
+
+        assertTrue("expected response message line, got: " + detail,
+                detail.contains("Response message from server is: Internal Server Error"));
+        assertTrue("expected JSON body, got: " + detail,
+                detail.contains("Server Detailed Error Message: {\"timestamp\""));
+        assertTrue("expected HTTP status line, got: " + detail,
+                detail.contains("Server returned HTTP response code: 500"));
+    }
+
+    @Test
+    public void ignoresUnrelatedLines() {
+        String log = "Building project\nCompiling sources\nResponse message from server is: OK\nDone";
+        String detail = AntExecutor.extractServerErrorDetail(log);
+        assertEquals("Response message from server is: OK", detail);
+    }
+}


### PR DESCRIPTION
## Summary

- Replace the hardcoded `"!!! Unable to restart the IEHS App !!!"` RuntimeException in `AntExecutor` (a stale boilerplate string from the file's borrowed `srccodes.com` template) with the actual `BuildException` message so the failure is clear.
- Tee `System.out`/`System.err` during the Ant build and, on failure, scan the captured output for server-error markers (`Response message from server is:`, `Server Detailed Error Message:`, `Server returned HTTP response code:`) and append them to the thrown exception message. This surfaces the JSON body returned by the build server (which the build client prints to stdout but never propagates via the exception chain).
- Console output is still forwarded to the original streams, so the user-visible build log is unchanged.
- Add `AntExecutorTest` covering the marker extraction.

## Motivation

A Maven Android build that hit a server-side HTTP 500 on `/appsec/7.0/build/upload` produced this misleading error:

```
Failed to execute goal ... !!! Unable to restart the IEHS App !!!
```

while the relevant detail — `{"timestamp":"...","status":500,"error":"Internal Server Error","path":"/appsec/7.0/build/upload"}` — was visible only earlier in the log and not in the exception message.

## Test plan

- [x] `mvn test -Dtest=AntExecutorTest` — passes (3/3).
- [x] `mvn compile` for `codenameone-maven-plugin` — clean.
- [ ] Reproduce with a triggered server build failure and confirm the response JSON shows up in the Maven failure message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)