### PR TITLE
initializr: drop @im AutoLocalizationBundle workaround

### DIFF
--- a/scripts/initializr/common/src/main/java/com/codename1/initializr/model/GeneratorModel.java
+++ b/scripts/initializr/common/src/main/java/com/codename1/initializr/model/GeneratorModel.java
@@ -90,7 +90,6 @@ public class GeneratorModel {
         copyZipEntriesToMap(template.CSS, mergedEntries, ZipEntryType.TEMPLATE_CSS);
         copyZipEntriesToMap(template.SOURCE_ZIP, mergedEntries, ZipEntryType.TEMPLATE_SOURCE);
         addLocalizationEntries(mergedEntries);
-        addAutoLocalizationBundleStub(mergedEntries);
 
         try (ZipOutputStream zos = new ZipOutputStream(outputStream)) {
             for (Map.Entry<String, byte[]> fileEntry : mergedEntries.entrySet()) {
@@ -102,43 +101,6 @@ public class GeneratorModel {
         }
     }
 
-
-    /**
-     * Workaround for a bug in shipped Codename One versions (<= 7.0.236) where the
-     * simulator's AutoLocalizationBundle echoes any missing key back as its own value.
-     * UIManager.setBundle queries `@im` on every bundle install, gets `"@im"` back from
-     * the wormhole, tokenizes it, queries `"@im-@im"`, gets `"@im-@im"` back, then
-     * crashes inside parseTextFieldInputMode on substring(0, indexOf('=')) for a token
-     * with no `=`. The CSS compiler subprocess (CN1CSSCLI -> Display.init -> JavaSEPort.init
-     * -> enableAutoLocalizationBundle) hits this on every initializr-generated project.
-     *
-     * The proper fix lives in JavaSEPort.AutoLocalizationBundle (don't fabricate values
-     * for `@`-prefixed meta-keys), but that requires a new framework release. As a
-     * workaround we ship an empty `Bundle.properties` with `@im=`, which:
-     *   1. Is preferred by JavaSEPort.findDefaultLocalizationBundleFile over any other
-     *      bundle file in src/main/l10n, so the AutoLocalizationBundle loads it as base.
-     *   2. Pre-populates `@im=""` in the bundle's underlying Hashtable, so
-     *      AutoLocalizationBundle.get("@im") returns "" (not the fabricated "@im"),
-     *      which has length 0, so setBundle skips the input-mode block entirely.
-     *
-     * This is unconditional (added to every generated project) because
-     * enableAutoLocalizationBundle auto-creates `src/main/l10n` even when the user
-     * didn't ask for localization bundles, so the crash hits projects without any
-     * localization too. Remove this stub once the framework fix has shipped and
-     * cn1.plugin.version is bumped past it.
-     */
-    private void addAutoLocalizationBundleStub(Map<String, byte[]> mergedEntries) throws IOException {
-        String stub = "# Workaround for the simulator AutoLocalizationBundle @im fabrication crash\n"
-                + "# in Codename One <= 7.0.236. Once the framework fix ships, this file can be removed.\n"
-                + "# See GeneratorModel.addAutoLocalizationBundleStub for the full story.\n"
-                + "@im=\n";
-        copySingleTextEntryToMap(
-                "common/src/main/l10n/Bundle.properties",
-                stub,
-                mergedEntries,
-                ZipEntryType.COMMON
-        );
-    }
 
     private void addLocalizationEntries(Map<String, byte[]> mergedEntries) throws IOException {
         if (!isBareTemplate() || !options.includeLocalizationBundles) {

--- a/scripts/initializr/common/src/test/java/com/codename1/initializr/model/GeneratorModelMatrixTest.java
+++ b/scripts/initializr/common/src/test/java/com/codename1/initializr/model/GeneratorModelMatrixTest.java
@@ -194,17 +194,7 @@ public class GeneratorModelMatrixTest extends AbstractTest {
         assertMainSourceFile(entries, template, packageName, mainClassName, false);
         assertThemeDefaults(entries, template);
         assertLocalizationBundles(entries, template, false);
-        assertAutoLocalizationBundleStub(entries);
         assertNoTemplatePlaceholders(entries, template);
-    }
-
-    private void assertAutoLocalizationBundleStub(Map<String, byte[]> entries) {
-        // Workaround stub for the simulator AutoLocalizationBundle @im fabrication crash
-        // in shipped CN1 <= 7.0.236. Must be present on every generated project (with or
-        // without localization bundles) because enableAutoLocalizationBundle auto-creates
-        // src/main/l10n in the CSS compiler subprocess and hits the crash regardless.
-        String stub = getText(entries, "common/src/main/l10n/Bundle.properties");
-        assertContains(stub, "@im=", "Generated project must ship Bundle.properties with @im= to suppress simulator wormhole crash");
     }
 
     private void assertThemeDefaults(Map<String, byte[]> entries, Template template) {


### PR DESCRIPTION
## Summary
- The simulator's AutoLocalizationBundle `@im` fabrication crash (https://github.com/codenameone/CodenameOne/discussions/4916) is fixed in the framework as of 7.0.242.
- `CN1_PLUGIN_VERSION` in `GeneratorModel` is already pinned to `7.0.242`, so the empty `common/src/main/l10n/Bundle.properties` stub injected into every generated project is no longer needed.
- Removes `addAutoLocalizationBundleStub` (and its call from `writeProjectZip`) plus the matching `assertAutoLocalizationBundleStub` test assertion.

## Test plan
- [ ] `mvn test` for the initializr common module (matrix test still passes without the stub)
- [ ] Generate a barebones project via the initializr and confirm the simulator boots without the `@im=` Bundle.properties stub

🤖 Generated with [Claude Code](https://claude.com/claude-code)