### PR TITLE
Fix Xcode 26 Google sign-in build break + CI guard

### DIFF
--- a/.github/workflows/ios-packaging.yml
+++ b/.github/workflows/ios-packaging.yml
@@ -41,13 +41,18 @@ jobs:
     timeout-minutes: 45
     # Exercises both CocoaPods and SPM in a single Xcode project. Catches
     # regressions in either dependency manager (each pathway runs end to end)
-    # and additionally validates that they coexist correctly.
+    # and additionally validates that they coexist correctly. Also turns on
+    # Google sign-in so GoogleConnectImpl.m is compiled under Xcode -- catches
+    # signature drift between hand-written iOS port .m files and the
+    # ParparVM-generated `set_field_*` headers, which is otherwise invisible
+    # until a customer enables Google sign-in.
     env:
       IOS_DEPENDENCY_ARGS: >-
         -Dcodename1.arg.ios.dependencyManager=both
         -Dcodename1.arg.ios.pods=AFNetworking
         -Dcodename1.arg.ios.spm.packages=swift-collections|https://github.com/apple/swift-collections.git|from:1.1.0
         -Dcodename1.arg.ios.spm.products.swift-collections=Collections
+        -Dcodename1.arg.ios.gplus.clientId=000000000000-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.apps.googleusercontent.com
 
     steps:
       - uses: actions/checkout@v4

--- a/Ports/iOSPort/nativeSources/FacebookImpl.m
+++ b/Ports/iOSPort/nativeSources/FacebookImpl.m
@@ -64,14 +64,14 @@ void com_codename1_impl_ios_IOSNative_facebookLogin___java_lang_Object(CN1_THREA
             if (result.isCancelled) {
                 // Handle cancellations
 #ifdef NEW_CODENAME_ONE_VM
-                set_field_com_codename1_social_FacebookImpl_loginCancelled(threadStateData, JAVA_TRUE, instance);
+                set_field_com_codename1_social_FacebookImpl_loginCancelled(JAVA_TRUE, instance);
 #else
                 com_codename1_social_FacebookImpl* impl = (com_codename1_social_FacebookImpl*)instance;
                 impl->fields.com_codename1_social_FacebookImpl.loginCancelled_ = TRUE;
 #endif
             } else {
 #ifdef NEW_CODENAME_ONE_VM
-                set_field_com_codename1_social_FacebookImpl_loginCompleted(threadStateData, JAVA_TRUE, instance);
+                set_field_com_codename1_social_FacebookImpl_loginCompleted(JAVA_TRUE, instance);
 #else
                 com_codename1_social_FacebookImpl* impl = (com_codename1_social_FacebookImpl*)instance;
 #endif

--- a/Ports/iOSPort/nativeSources/GoogleConnectImpl.m
+++ b/Ports/iOSPort/nativeSources/GoogleConnectImpl.m
@@ -70,8 +70,8 @@ void com_codename1_impl_ios_IOSNative_googleLogin___java_lang_Object(CN1_THREAD_
         JAVA_OBJECT d = com_codename1_ui_Display_getInstance__(CN1_THREAD_GET_STATE_PASS_SINGLE_ARG);
         JAVA_OBJECT jClientID = virtual_com_codename1_ui_Display_getProperty___java_lang_String_java_lang_String_R_java_lang_String(CN1_THREAD_STATE_PASS_ARG d, fromNSString(CN1_THREAD_STATE_PASS_ARG @"ios.gplus.clientId"), JAVA_NULL);
         if (jClientID == JAVA_NULL) {
-            set_field_com_codename1_social_GoogleImpl_loginMessage(CN1_THREAD_GET_STATE_PASS_ARG fromNSString(CN1_THREAD_GET_STATE_PASS_ARG @"Failed to log in due to a configuration error."), googleLoginCallback);
-            set_field_com_codename1_social_GoogleImpl_loginCompleted(CN1_THREAD_GET_STATE_PASS_ARG JAVA_TRUE, googleLoginCallback);
+            set_field_com_codename1_social_GoogleImpl_loginMessage(fromNSString(CN1_THREAD_GET_STATE_PASS_ARG @"Failed to log in due to a configuration error."), googleLoginCallback);
+            set_field_com_codename1_social_GoogleImpl_loginCompleted(JAVA_TRUE, googleLoginCallback);
             googleLoginCallback = NULL;
             CN1Log(@"Could not login to Google Plus because 'ios.gplus.clientId' property is not set.  Ensure that the ios.gplus.clientId build hint is set");
             return;
@@ -88,8 +88,8 @@ void com_codename1_impl_ios_IOSNative_googleLogin___java_lang_Object(CN1_THREAD_
             BOOL isGooglePlusInstalled = [[UIApplication sharedApplication] canOpenURL: [NSURL
                                                                                          URLWithString:@"gplus://"]];
             if (!isGooglePlusInstalled) {
-                set_field_com_codename1_social_GoogleImpl_loginMessage(CN1_THREAD_GET_STATE_PASS_ARG fromNSString(CN1_THREAD_GET_STATE_PASS_ARG @"Please install the Google Plus app on your device in order to log in with Google Plus."), googleLoginCallback);
-                set_field_com_codename1_social_GoogleImpl_loginCompleted(CN1_THREAD_GET_STATE_PASS_ARG JAVA_TRUE, googleLoginCallback);
+                set_field_com_codename1_social_GoogleImpl_loginMessage(fromNSString(CN1_THREAD_GET_STATE_PASS_ARG @"Please install the Google Plus app on your device in order to log in with Google Plus."), googleLoginCallback);
+                set_field_com_codename1_social_GoogleImpl_loginCompleted(JAVA_TRUE, googleLoginCallback);
                 googleLoginCallback = NULL;
                 CN1Log(@"Could not log into Google plus because the Google Plus app isn't installed and the ios.gplus.requireGplusAppForLogin property is set to true.  This limitation is to work around Apple app store rejections caused by logging in with Safari");
                 return;
@@ -127,11 +127,11 @@ void com_codename1_impl_ios_GoogleConnectImpl_finishedWithAuth(GTMOAuth2Authenti
     
     if (googleLoginCallback != NULL) {
         if (error != nil) {
-            set_field_com_codename1_social_GoogleImpl_loginMessage(CN1_THREAD_GET_STATE_PASS_ARG fromNSString(CN1_THREAD_GET_STATE_PASS_ARG [error localizedDescription]), googleLoginCallback);
+            set_field_com_codename1_social_GoogleImpl_loginMessage(fromNSString(CN1_THREAD_GET_STATE_PASS_ARG [error localizedDescription]), googleLoginCallback);
         } else {
-            set_field_com_codename1_social_GoogleImpl_loginMessage(CN1_THREAD_GET_STATE_PASS_ARG JAVA_NULL, googleLoginCallback);
+            set_field_com_codename1_social_GoogleImpl_loginMessage(JAVA_NULL, googleLoginCallback);
         }
-        set_field_com_codename1_social_GoogleImpl_loginCompleted(CN1_THREAD_GET_STATE_PASS_ARG JAVA_TRUE, googleLoginCallback);
+        set_field_com_codename1_social_GoogleImpl_loginCompleted(JAVA_TRUE, googleLoginCallback);
         googleLoginCallback = NULL;
     }
     
@@ -152,11 +152,11 @@ void com_codename1_impl_ios_GoogleConnectImpl_finishedWithAuth(GIDGoogleUser *us
     
     if (googleLoginCallback != NULL) {
         if (error != nil) {
-            set_field_com_codename1_social_GoogleImpl_loginMessage(CN1_THREAD_GET_STATE_PASS_ARG fromNSString(CN1_THREAD_GET_STATE_PASS_ARG [error localizedDescription]), googleLoginCallback);
+            set_field_com_codename1_social_GoogleImpl_loginMessage(fromNSString(CN1_THREAD_GET_STATE_PASS_ARG [error localizedDescription]), googleLoginCallback);
         } else {
-            set_field_com_codename1_social_GoogleImpl_loginMessage(CN1_THREAD_GET_STATE_PASS_ARG JAVA_NULL, googleLoginCallback);
+            set_field_com_codename1_social_GoogleImpl_loginMessage(JAVA_NULL, googleLoginCallback);
         }
-        set_field_com_codename1_social_GoogleImpl_loginCompleted(CN1_THREAD_GET_STATE_PASS_ARG JAVA_TRUE, googleLoginCallback);
+        set_field_com_codename1_social_GoogleImpl_loginCompleted(JAVA_TRUE, googleLoginCallback);
         googleLoginCallback = NULL;
     }
     


### PR DESCRIPTION
## Summary
- Customer reported a Google sign-in iOS build failure on Xcode 26 / iOS SDK 26.2 and suspected a CocoaPods regression. The pods install cleanly (`AppAuth 1.7.6`, `GTMAppAuth 1.3.1`, `GoogleSignIn 5.0.2`); the real failure is in hand-written `Ports/iOSPort/nativeSources/GoogleConnectImpl.m`:

  ```
  GoogleConnectImpl.m:73: error: too many arguments to function call, expected 2, have 3
    set_field_com_codename1_social_GoogleImpl_loginMessage(
        CN1_THREAD_GET_STATE_PASS_ARG fromNSString(... ), googleLoginCallback);
  ```

  The ParparVM translator's instance-field setters take `(value, instance)` — `vm/ByteCodeTranslator/.../ByteCodeClass.java:909` literally comments *"Instance field setters don't use thread context directly."* But the call sites prepend `CN1_THREAD_GET_STATE_PASS_ARG` (which expands to `getThreadLocalData(),`), so the call passes 3 args. The bug has been latent since commit 922f94672 (2020); older clang accepted it with a warning, Xcode 26's clang rejects it as a hard error.
- Removed `CN1_THREAD_GET_STATE_PASS_ARG`/`threadStateData` from the 10 `set_field_*` call sites in `GoogleConnectImpl.m` and the 2 identical-pattern call sites in `FacebookImpl.m`.
- Extended `.github/workflows/ios-packaging.yml` to set `ios.gplus.clientId`, which flips on `INCLUDE_GOOGLE_CONNECT` + `GOOGLE_SIGNIN` and pulls in the GoogleSignIn pod. From now on, every PR that touches `Ports/iOSPort/**` actually compiles `GoogleConnectImpl.m` under Xcode 26 — so any future signature drift between hand-written .m files and translator-generated `set_field_*` headers fails CI immediately.

## Test plan
- [ ] CI: ios-packaging workflow runs `build-ios-app.sh` and `xcodebuild` on a project with Google sign-in enabled; the new client-ID arg should cause `GoogleConnectImpl.m` to compile (would have caught this bug pre-fix)
- [ ] Customer rebuild on Xcode 26 with `ios.pods=AppAuth` + Google sign-in succeeds
- [ ] Existing AFNetworking / SPM coexistence path still green
- [ ] Quick local check (optional): generate an `ios-source` build with `ios.gplus.clientId=...` set, open in Xcode 26, confirm `GoogleConnectImpl.m` compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)