### PR TITLE
Status-bar tap: scroll the visible scroll pane, not the first one

### DIFF
--- a/CodenameOne/src/com/codename1/ui/Form.java
+++ b/CodenameOne/src/com/codename1/ui/Form.java
@@ -695,7 +695,7 @@ public class Form extends Container {
     }
 
     /// Locates the scrollable-Y descendant that is actually visible to the
-    /// user inside the Form viewport. Used by the status-bar tap → scroll-to-top
+    /// user inside the Form viewport. Used by the status-bar tap -> scroll-to-top
     /// path on iOS.
     ///
     /// Strategy: collect every visible scrollable-Y descendant whose absolute

--- a/CodenameOne/src/com/codename1/ui/Form.java
+++ b/CodenameOne/src/com/codename1/ui/Form.java
@@ -709,7 +709,10 @@ public class Form extends Container {
             return null;
         }
         Form f = c.getComponentForm();
-        int vx, vy, vw, vh;
+        int vx;
+        int vy;
+        int vw;
+        int vh;
         if (f != null) {
             vx = f.getAbsoluteX();
             vy = f.getAbsoluteY();

--- a/CodenameOne/src/com/codename1/ui/Form.java
+++ b/CodenameOne/src/com/codename1/ui/Form.java
@@ -694,24 +694,75 @@ public class Form extends Container {
         }
     }
 
+    /// Locates the scrollable-Y descendant that is actually visible to the
+    /// user inside the Form viewport. Used by the status-bar tap → scroll-to-top
+    /// path on iOS.
+    ///
+    /// Strategy: collect every visible scrollable-Y descendant whose absolute
+    /// bounds intersect the Form viewport, pick the one with the largest
+    /// visible (intersected) area, and tiebreak in favor of a scroller that
+    /// is currently scrolled (`getScrollY() > 0`). A naive depth-first walk
+    /// would return the first scrollable in tree order, which picks the
+    /// hidden first tab inside a `Tabs` instead of the on-screen one.
     Component findScrollableChild(Container c) {
-        if (c.isScrollableY()) {
-            return c;
+        if (c == null) {
+            return null;
         }
-        int count = c.getComponentCount();
-        for (int iter = 0; iter < count; iter++) {
-            Component comp = c.getComponentAt(iter);
-            if (comp.isScrollableY()) {
-                return comp;
-            }
-            if (comp instanceof Container) {
-                Component chld = findScrollableChild((Container) comp);
-                if (chld != null) {
-                    return chld;
-                }
+        Form f = c.getComponentForm();
+        int vx, vy, vw, vh;
+        if (f != null) {
+            vx = f.getAbsoluteX();
+            vy = f.getAbsoluteY();
+            vw = f.getWidth();
+            vh = f.getHeight();
+        } else {
+            vx = c.getAbsoluteX();
+            vy = c.getAbsoluteY();
+            vw = c.getWidth();
+            vh = c.getHeight();
+        }
+        Component[] best = new Component[1];
+        long[] bestArea = new long[]{-1L};
+        int[] bestScrolled = new int[]{-1};
+        collectVisibleScrollableY(c, vx, vy, vw, vh, best, bestArea, bestScrolled);
+        return best[0];
+    }
+
+    private void collectVisibleScrollableY(Component cmp, int vx, int vy, int vw, int vh,
+            Component[] best, long[] bestArea, int[] bestScrolled) {
+        if (cmp == null || !cmp.isVisible()) {
+            return;
+        }
+        int ax = cmp.getAbsoluteX();
+        int ay = cmp.getAbsoluteY();
+        int aw = cmp.getWidth();
+        int ah = cmp.getHeight();
+        int ix1 = Math.max(vx, ax);
+        int iy1 = Math.max(vy, ay);
+        int ix2 = Math.min(vx + vw, ax + aw);
+        int iy2 = Math.min(vy + vh, ay + ah);
+        int iw = ix2 - ix1;
+        int ih = iy2 - iy1;
+        if (iw <= 0 || ih <= 0) {
+            return;
+        }
+        if (cmp.isScrollableY()) {
+            long area = (long) iw * (long) ih;
+            int scrolled = cmp.getScrollY() > 0 ? 1 : 0;
+            if (area > bestArea[0]
+                    || (area == bestArea[0] && scrolled > bestScrolled[0])) {
+                bestArea[0] = area;
+                bestScrolled[0] = scrolled;
+                best[0] = cmp;
             }
         }
-        return null;
+        if (cmp instanceof Container) {
+            Container container = (Container) cmp;
+            int count = container.getComponentCount();
+            for (int i = 0; i < count; i++) {
+                collectVisibleScrollableY(container.getComponentAt(i), vx, vy, vw, vh, best, bestArea, bestScrolled);
+            }
+        }
     }
 
     /// {@inheritDoc}


### PR DESCRIPTION
## Summary
- `Form#findScrollableChild` walked the tree depth-first and returned the first scrollable-Y descendant, which inside a `Tabs` is the off-screen *first* tab — so the iOS status-bar tap scrolled-to-top the wrong pane.
- Replaced with a strategy that collects every visible scrollable-Y descendant, intersects each one's absolute bounds with the Form viewport, and picks the one with the largest visible area. Tiebreak prefers a scroller with `getScrollY() > 0` (the others are already at top anyway).
- `Tabs` lays inactive tab content off-screen via `TabsLayout`, so viewport intersection filters it naturally — no special-casing needed.

Refs #3589 (the last comment in that issue).

## Test plan
- [ ] Build core: `cd maven && mvn -pl core -am compile -Plocal-dev-javase -DskipTests` (verified locally)
- [ ] Manual: Form with `Tabs`, multiple tabs each containing a long scrollable list. Scroll down in tab 2, switch to it, tap iOS status bar — expect tab 2 to scroll to top (today it does nothing visible because tab 1 is the one that gets the call).
- [ ] Manual: Form with a single scrollable content pane — behavior unchanged.
- [ ] Manual: Form with `paintsTitleBarBool=false` (Toolbar status-bar path at `Toolbar.java:2560`) — same fix applies via the shared method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)