### PR TITLE
iOS Metal: fix stale framebuffer on rotation (#4954)

### DIFF
--- a/Ports/iOSPort/nativeSources/CodenameOne_GLViewController.m
+++ b/Ports/iOSPort/nativeSources/CodenameOne_GLViewController.m
@@ -2540,7 +2540,7 @@ bool lockDrawing;
     // the display width/height each time to match the view, without performing other resizing
     // details, so it is possible that the size change event still needs to be sent
     // even if the display width already matches the value we're given here.
-    [[self eaglView] updateFrameBufferSize:(int)size.width h:(int)size.height];
+    [[self eaglView] updateFrameBufferSize:(int)(size.width * scaleValue) h:(int)(size.height * scaleValue)];
     displayWidth = (int)size.width * scaleValue;
     displayHeight = (int)size.height * scaleValue;
     screenSizeChanged(displayWidth, displayHeight);
@@ -3282,9 +3282,14 @@ BOOL prefersStatusBarHidden = NO;
     }
     
     // simply create a property of 'BOOL' type
-    [[self eaglView] updateFrameBufferSize:(int)size.width h:(int)size.height];
+    // Pass physical pixels: viewWillTransitionToSize: fires before UIKit
+    // updates the view's bounds, so on the Metal backend the EAGLView's
+    // bounds read would still return the previous orientation. The
+    // METALView resize logic trusts these parameters; the EAGLView
+    // implementation is a no-op (#4954).
+    [[self eaglView] updateFrameBufferSize:(int)(size.width * scaleValue) h:(int)(size.height * scaleValue)];
     [[self eaglView] deleteFramebuffer];
-    
+
     displayWidth = (int)size.width * scaleValue;
     displayHeight = (int)size.height * scaleValue;
     
@@ -3325,7 +3330,7 @@ BOOL prefersStatusBarHidden = NO;
         return;
     }
 
-    [[self eaglView] updateFrameBufferSize:(int)self.view.bounds.size.width h:(int)self.view.bounds.size.height];
+    [[self eaglView] updateFrameBufferSize:(int)(self.view.bounds.size.width * scaleValue) h:(int)(self.view.bounds.size.height * scaleValue)];
     [[self eaglView] deleteFramebuffer];
 
     displayWidth = (int)self.view.bounds.size.width * scaleValue;

--- a/Ports/iOSPort/nativeSources/METALView.m
+++ b/Ports/iOSPort/nativeSources/METALView.m
@@ -228,16 +228,28 @@ extern BOOL isRetinaBug();
 
 
 -(void)updateFrameBufferSize:(int)w h:(int)h {
-    // Ignore the passed w/h -- CodenameOne_GLViewController.m calls this with
-    // logical points (self.view.bounds.size), but the Metal drawable and
-    // projection must be in physical pixels. The GL path tolerates the
-    // logical-point argument because EAGLView.updateFrameBufferSize: is a
-    // no-op (dimensions get read back from the renderbuffer after the layer
-    // is bound). For Metal we always compute from our own layer bounds.
-    CGSize sz = self.bounds.size;
-    CGFloat s = self.contentScaleFactor;
-    int pw = (int)(sz.width * s);
-    int ph = (int)(sz.height * s);
+    // Trust caller-supplied physical-pixel dimensions; fall back to bounds
+    // only if the caller passes 0. Reading self.bounds alone is unsafe
+    // during rotation: viewWillTransitionToSize: in CodenameOne_GLView-
+    // Controller fires BEFORE UIKit updates the view's bounds, so a
+    // bounds-derived size matches the cached (old) framebuffer dimensions
+    // and the early-return below would leave screenTexture, the projection
+    // matrix and stencil texture at the previous orientation. CAMetalLayer's
+    // drawableSize is auto-resized by UIKit on rotation, so the next
+    // drawFrame would blit the old-sized screenTexture into the new-sized
+    // drawable -- portrait content lands in a corner of the landscape
+    // drawable and the remaining pixels read back uninitialised, surfacing
+    // as the smeared/pink frames reported in #4954. The callers in this
+    // file (initWithCoder, layoutSubviews) and the GLViewController callers
+    // all pass physical pixels.
+    int pw = w;
+    int ph = h;
+    if (pw <= 0 || ph <= 0) {
+        CGSize sz = self.bounds.size;
+        CGFloat s = self.contentScaleFactor;
+        pw = (int)(sz.width * s);
+        ph = (int)(sz.height * s);
+    }
     if (pw <= 0 || ph <= 0) return;
     if (pw == framebufferWidth && ph == framebufferHeight) {
         return;


### PR DESCRIPTION
## Summary

Fixes #4954 — Metal rendering shows smeared / pink frames when an app is launched in one orientation and rotated to another.

## Root cause

`viewWillTransitionToSize:` in `CodenameOne_GLViewController.m` fires **before** UIKit updates the view's bounds. It forwards the upcoming size to `METALView.updateFrameBufferSize:h:`, but that function ignored its parameters and read `self.bounds.size` instead — which still reflects the previous orientation at that lifecycle point. The function then sees `(pw, ph) == (framebufferWidth, framebufferHeight)` and early-returns without recreating anything.

Result:

- `screenTexture` (the persistent `MTLLoadActionLoad` render target) stays at the previous orientation's size.
- `projectionMatrix`, `stencilTexture`, `framebufferWidth/Height` all stay stale.
- CAMetalLayer's `drawableSize` is auto-resized by UIKit, so the next `drawFrame` blits the old-sized `screenTexture` into a new-sized drawable. The previous orientation's content lands in a corner, the rest of the drawable reads uninitialised, and the user sees smeared/pink frames.

`layoutSubviews` eventually fires with correct bounds and self-heals, which is why the artefact is transient — but the bad frame(s) reach the screen on real hardware.

## Fix

Two parts, both surgical:

1. **`METALView.m`** — `updateFrameBufferSize:h:` now trusts the caller-supplied physical-pixel dimensions and only falls back to `self.bounds` when the caller passes 0. Old comment about ignoring the parameters has been updated to reflect the new contract and the rotation race that motivates it.

2. **`CodenameOne_GLViewController.m`** — three call sites (`viewWillTransitionToSize:`, `didRotateFromInterfaceOrientation:`, and `updateCanvas:`) now multiply by `scaleValue` so the parameter is unambiguously in physical pixels. `EAGLView.updateFrameBufferSize:` is a no-op so the GL path is unaffected; the existing `METALView` callers (`initWithCoder`, `layoutSubviews`) already passed physical pixels.

## Why no screenshot test

We discussed adding a launch-in-landscape → rotate-to-portrait screenshot test, but the artefact only shows up in the 1–2 frames between `viewWillTransitionToSize:` and `layoutSubviews` (i.e. before the self-heal). Catching that window reliably from a CI screenshot harness would be flaky; the `OrientationLockScreenshotTest` already waits 1500 ms for layout to settle precisely because earlier captures produce run-over-run jitter. The fix is small, local, and ships with the diagnosis in the commit message so a future regression can be traced quickly.

## Test plan

- [ ] On a physical iPhone, build hellocodenameone with `codename1.arg.ios.metal=true`, launch in landscape, rotate to portrait — confirm no smear/pink frame.
- [ ] Same on simulator (could not reproduce the bug on simulator pre-fix; verifying parity post-fix).
- [ ] Existing iOS Metal CI screenshot suite (`build-ios-metal`) — no goldens should drift; the changed path is only exercised on actual rotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)