### PR TITLE
Fix agent tool Codename One version selection

### DIFF
--- a/scripts/initializr/common/src/main/resources/skill/tools/IsApiSupported.java
+++ b/scripts/initializr/common/src/main/resources/skill/tools/IsApiSupported.java
@@ -4,7 +4,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
@@ -90,7 +89,42 @@ public class IsApiSupported {
             }
         }
         if (candidates.isEmpty()) return null;
-        candidates.sort(Comparator.comparing((Path p) -> p.getFileName().toString()).reversed());
+        candidates.sort((a, b) -> compareVersions(versionOf(b), versionOf(a)));
         return candidates.get(0);
+    }
+
+    private static String versionOf(Path jar) {
+        Path versionDir = jar.getParent();
+        return versionDir == null ? "" : versionDir.getFileName().toString();
+    }
+
+    private static int compareVersions(String left, String right) {
+        String[] leftParts = left.split("-", 2);
+        String[] rightParts = right.split("-", 2);
+        int numeric = compareNumericVersions(leftParts[0], rightParts[0]);
+        if (numeric != 0) return numeric;
+        String leftSuffix = leftParts.length > 1 ? leftParts[1] : "";
+        String rightSuffix = rightParts.length > 1 ? rightParts[1] : "";
+        return leftSuffix.compareTo(rightSuffix);
+    }
+
+    private static int compareNumericVersions(String left, String right) {
+        String[] leftParts = left.split("\\.");
+        String[] rightParts = right.split("\\.");
+        int max = Math.max(leftParts.length, rightParts.length);
+        for (int i = 0; i < max; i++) {
+            int comparison = Integer.compare(versionPart(leftParts, i), versionPart(rightParts, i));
+            if (comparison != 0) return comparison;
+        }
+        return 0;
+    }
+
+    private static int versionPart(String[] parts, int index) {
+        if (index >= parts.length) return 0;
+        try {
+            return Integer.parseInt(parts[index]);
+        } catch (NumberFormatException ex) {
+            return 0;
+        }
     }
 }

--- a/scripts/initializr/common/src/main/resources/skill/tools/IsCssValid.java
+++ b/scripts/initializr/common/src/main/resources/skill/tools/IsCssValid.java
@@ -9,7 +9,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 
 /// Validates that a Codename One theme.css file compiles cleanly via the
@@ -83,8 +82,7 @@ public class IsCssValid {
                 System.exit(1);
             }
 
-            Method getTheme = resourceCls.getDeclaredMethod("getTheme", String.class);
-            getTheme.setAccessible(true);
+            Method getTheme = resourceCls.getMethod("getTheme", String.class);
             Object theme = getTheme.invoke(resource, "AgentValidationTheme");
             if (theme == null) {
                 System.out.println("INVALID");
@@ -115,7 +113,42 @@ public class IsCssValid {
             }
         }
         if (candidates.isEmpty()) return null;
-        candidates.sort(Comparator.comparing((Path p) -> p.getFileName().toString()).reversed());
+        candidates.sort((a, b) -> compareVersions(versionOf(b), versionOf(a)));
         return candidates.get(0);
+    }
+
+    private static String versionOf(Path jar) {
+        Path versionDir = jar.getParent();
+        return versionDir == null ? "" : versionDir.getFileName().toString();
+    }
+
+    private static int compareVersions(String left, String right) {
+        String[] leftParts = left.split("-", 2);
+        String[] rightParts = right.split("-", 2);
+        int numeric = compareNumericVersions(leftParts[0], rightParts[0]);
+        if (numeric != 0) return numeric;
+        String leftSuffix = leftParts.length > 1 ? leftParts[1] : "";
+        String rightSuffix = rightParts.length > 1 ? rightParts[1] : "";
+        return leftSuffix.compareTo(rightSuffix);
+    }
+
+    private static int compareNumericVersions(String left, String right) {
+        String[] leftParts = left.split("\\.");
+        String[] rightParts = right.split("\\.");
+        int max = Math.max(leftParts.length, rightParts.length);
+        for (int i = 0; i < max; i++) {
+            int comparison = Integer.compare(versionPart(leftParts, i), versionPart(rightParts, i));
+            if (comparison != 0) return comparison;
+        }
+        return 0;
+    }
+
+    private static int versionPart(String[] parts, int index) {
+        if (index >= parts.length) return 0;
+        try {
+            return Integer.parseInt(parts[index]);
+        } catch (NumberFormatException ex) {
+            return 0;
+        }
     }
 }


### PR DESCRIPTION
This fixes version discovery in the Codename One agent tools generated by Initializr.

The tools currently sort Maven artifact jar names lexicographically. This can select an older version such as `7.0.26` instead of a newer version such as `7.0.243`, because string ordering does not match semantic/numeric version ordering.

This PR changes the sorting logic in:

- `IsApiSupported.java`
- `IsCssValid.java`

The tools now compare the Maven version directory numerically, so the latest installed Codename One version is selected correctly.

I also fixed `IsCssValid.java` to use `getMethod("getTheme", ...)` instead of `getDeclaredMethod(...)`, because `getTheme(String)` is a public method inherited from `Resources`, not declared directly on `MutableResource`.

Verification:

- `IsApiSupported` now selects `java-runtime/7.0.243` correctly.
- `IsCssValid` now selects `codenameone-core/7.0.243` and `java-runtime/7.0.243`.
- `IsCssValid` successfully validates a minimal valid CSS file.