### PR TITLE
Support side border shorthands in CSSBorder

### DIFF
--- a/CodenameOne/src/com/codename1/ui/plaf/CSSBorder.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/CSSBorder.java
@@ -210,31 +210,13 @@ public class CSSBorder extends Border {
                 return border.borderSideWidth(side, cssPropertyValue);
             }
         });
-        decorators.put("border-width-" + sideName, new Decorator() {
-            @Override
-            public CSSBorder decorate(CSSBorder border, String cssProperty, String cssPropertyValue) {
-                return border.borderSideWidth(side, cssPropertyValue);
-            }
-        });
         decorators.put("border-" + sideName + "-style", new Decorator() {
             @Override
             public CSSBorder decorate(CSSBorder border, String cssProperty, String cssPropertyValue) {
                 return border.borderSideStyle(side, cssPropertyValue);
             }
         });
-        decorators.put("border-style-" + sideName, new Decorator() {
-            @Override
-            public CSSBorder decorate(CSSBorder border, String cssProperty, String cssPropertyValue) {
-                return border.borderSideStyle(side, cssPropertyValue);
-            }
-        });
         decorators.put("border-" + sideName + "-color", new Decorator() {
-            @Override
-            public CSSBorder decorate(CSSBorder border, String cssProperty, String cssPropertyValue) {
-                return border.borderSideColor(side, cssPropertyValue);
-            }
-        });
-        decorators.put("border-color-" + sideName, new Decorator() {
             @Override
             public CSSBorder decorate(CSSBorder border, String cssProperty, String cssPropertyValue) {
                 return border.borderSideColor(side, cssPropertyValue);
@@ -1138,32 +1120,37 @@ public class CSSBorder extends Border {
     }
 
     private CSSBorder borderSide(int side, String value) {
-        ensureStrokeDefaults();
-        String[] parts = Util.split(value, " ");
-        boolean foundWidth = false;
-        boolean foundStyle = false;
-        boolean foundColor = false;
-        for (String part : parts) {
-            String token = part.trim();
-            if (token.length() == 0) {
-                continue;
+        try {
+            ensureStrokeDefaults();
+            String[] parts = Util.split(value, " ");
+            boolean foundWidth = false;
+            boolean foundStyle = false;
+            boolean foundColor = false;
+            for (String part : parts) {
+                String token = part.trim();
+                if (token.length() == 0) {
+                    continue;
+                }
+                if (!foundWidth && BorderStroke.validateThickness(token)) {
+                    borderSideWidth(side, token);
+                    foundWidth = true;
+                    continue;
+                }
+                if (!foundStyle && validateBorderStyle(token)) {
+                    borderSideStyle(side, token);
+                    foundStyle = true;
+                    continue;
+                }
+                if (!foundColor && Color.validate(token)) {
+                    borderSideColor(side, token);
+                    foundColor = true;
+                    continue;
+                }
+                throw new IllegalArgumentException("Unsupported border side token " + token);
             }
-            if (!foundWidth && BorderStroke.validateThickness(token)) {
-                borderSideWidth(side, token);
-                foundWidth = true;
-                continue;
-            }
-            if (!foundStyle && validateBorderStyle(token)) {
-                borderSideStyle(side, token);
-                foundStyle = true;
-                continue;
-            }
-            if (!foundColor && Color.validate(token)) {
-                borderSideColor(side, token);
-                foundColor = true;
-                continue;
-            }
-            throw new IllegalArgumentException("Unsupported border side token " + token);
+        } catch (Throwable t) {
+            Log.e(t);
+            throw new RuntimeException("Failed parsing border side: " + value, t);
         }
         return this;
     }

--- a/CodenameOne/src/com/codename1/ui/plaf/CSSBorder.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/CSSBorder.java
@@ -179,6 +179,10 @@ public class CSSBorder extends Border {
                 return border.borderWidth(cssPropertyValue);
             }
         });
+        addBorderSideDecorators("top", TOP);
+        addBorderSideDecorators("right", RIGHT);
+        addBorderSideDecorators("bottom", BOTTOM);
+        addBorderSideDecorators("left", LEFT);
         decorators.put("border-image", new Decorator() {
             @Override
             public CSSBorder decorate(CSSBorder border, String cssProperty, String cssPropertyValue) {
@@ -189,6 +193,51 @@ public class CSSBorder extends Border {
             @Override
             public CSSBorder decorate(CSSBorder border, String cssProperty, String cssPropertyValue) {
                 return border.boxShadow(cssPropertyValue);
+            }
+        });
+    }
+
+    private static void addBorderSideDecorators(final String sideName, final int side) {
+        decorators.put("border-" + sideName, new Decorator() {
+            @Override
+            public CSSBorder decorate(CSSBorder border, String cssProperty, String cssPropertyValue) {
+                return border.borderSide(side, cssPropertyValue);
+            }
+        });
+        decorators.put("border-" + sideName + "-width", new Decorator() {
+            @Override
+            public CSSBorder decorate(CSSBorder border, String cssProperty, String cssPropertyValue) {
+                return border.borderSideWidth(side, cssPropertyValue);
+            }
+        });
+        decorators.put("border-width-" + sideName, new Decorator() {
+            @Override
+            public CSSBorder decorate(CSSBorder border, String cssProperty, String cssPropertyValue) {
+                return border.borderSideWidth(side, cssPropertyValue);
+            }
+        });
+        decorators.put("border-" + sideName + "-style", new Decorator() {
+            @Override
+            public CSSBorder decorate(CSSBorder border, String cssProperty, String cssPropertyValue) {
+                return border.borderSideStyle(side, cssPropertyValue);
+            }
+        });
+        decorators.put("border-style-" + sideName, new Decorator() {
+            @Override
+            public CSSBorder decorate(CSSBorder border, String cssProperty, String cssPropertyValue) {
+                return border.borderSideStyle(side, cssPropertyValue);
+            }
+        });
+        decorators.put("border-" + sideName + "-color", new Decorator() {
+            @Override
+            public CSSBorder decorate(CSSBorder border, String cssProperty, String cssPropertyValue) {
+                return border.borderSideColor(side, cssPropertyValue);
+            }
+        });
+        decorators.put("border-color-" + sideName, new Decorator() {
+            @Override
+            public CSSBorder decorate(CSSBorder border, String cssProperty, String cssPropertyValue) {
+                return border.borderSideColor(side, cssPropertyValue);
             }
         });
     }
@@ -1086,6 +1135,62 @@ public class CSSBorder extends Border {
 
         }
         return this;
+    }
+
+    private CSSBorder borderSide(int side, String value) {
+        ensureStrokeDefaults();
+        String[] parts = Util.split(value, " ");
+        boolean foundWidth = false;
+        boolean foundStyle = false;
+        boolean foundColor = false;
+        for (String part : parts) {
+            String token = part.trim();
+            if (token.length() == 0) {
+                continue;
+            }
+            if (!foundWidth && BorderStroke.validateThickness(token)) {
+                borderSideWidth(side, token);
+                foundWidth = true;
+                continue;
+            }
+            if (!foundStyle && validateBorderStyle(token)) {
+                borderSideStyle(side, token);
+                foundStyle = true;
+                continue;
+            }
+            if (!foundColor && Color.validate(token)) {
+                borderSideColor(side, token);
+                foundColor = true;
+                continue;
+            }
+            throw new IllegalArgumentException("Unsupported border side token " + token);
+        }
+        return this;
+    }
+
+    private CSSBorder borderSideWidth(int side, String width) {
+        ensureStrokeDefaults();
+        stroke[side].thickness = BorderStroke.parseThickness(width.trim());
+        return this;
+    }
+
+    private CSSBorder borderSideStyle(int side, String style) {
+        ensureStrokeDefaults();
+        stroke[side].type = getBorderStyle(style.trim());
+        return this;
+    }
+
+    private CSSBorder borderSideColor(int side, String color) {
+        ensureStrokeDefaults();
+        stroke[side].color = Color.parse(color.trim());
+        return this;
+    }
+
+    private void ensureStrokeDefaults() {
+        if (stroke != null) {
+            return;
+        }
+        borderStroke("0 none transparent");
     }
 
     /// Sets the border styles.  Supported styles: none, hidden, dotted, dashed, solid.

--- a/maven/core-unittests/src/test/java/com/codename1/ui/css/CSSThemeCompilerTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/css/CSSThemeCompilerTest.java
@@ -109,4 +109,20 @@ public class CSSThemeCompilerTest extends UITestBase {
         assertEquals("ffffff", theme.get("Button.fgColor"));
     }
 
+    @Test
+    public void testCompilesSideBorderShorthand() {
+        CSSThemeCompiler compiler = new CSSThemeCompiler();
+        MutableResource resource = new MutableResource();
+
+        compiler.compile("SideCommand{border:none;border-bottom:2px solid #cccccc;}", resource, "Theme");
+
+        Hashtable theme = resource.getTheme("Theme");
+        assertTrue(theme.get("SideCommand.border") instanceof CSSBorder);
+        String css = ((CSSBorder) theme.get("SideCommand.border")).toCSSString();
+        assertTrue(css.contains("border-style:none none solid none"));
+        assertTrue(css.contains("border-width:"));
+        assertTrue(css.contains("2px"));
+        assertTrue(css.contains("#ccccccff"));
+    }
+
 }

--- a/maven/core-unittests/src/test/java/com/codename1/ui/css/CSSThemeCompilerTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/css/CSSThemeCompilerTest.java
@@ -125,4 +125,21 @@ public class CSSThemeCompilerTest extends UITestBase {
         assertTrue(css.contains("#ccccccff"));
     }
 
+    @Test
+    public void testCompilesSideBorderLonghands() {
+        CSSThemeCompiler compiler = new CSSThemeCompiler();
+        MutableResource resource = new MutableResource();
+
+        compiler.compile(
+                "SideCommand{border:none;border-top-width:3px;border-top-style:dashed;border-top-color:#ff0000;}",
+                resource, "Theme");
+
+        Hashtable theme = resource.getTheme("Theme");
+        assertTrue(theme.get("SideCommand.border") instanceof CSSBorder);
+        String css = ((CSSBorder) theme.get("SideCommand.border")).toCSSString();
+        assertTrue(css.contains("border-style:dashed none none none"));
+        assertTrue(css.contains("3px"));
+        assertTrue(css.contains("#ff0000ff"));
+    }
+
 }


### PR DESCRIPTION
This adds support for side-specific CSS border shorthands in `CSSBorder`.

Context: the Initializr template CSS uses declarations such as:

```css
SideCommand {
    border-bottom: 2px solid #cccccc;
}
```

This is accepted by the regular Designer/Maven CSS compiler, but the lightweight `CSSThemeCompiler` paths used by Initializr preview / agent validation eventually pass this declaration to `CSSBorder`, where it fails with:

```text
Unsupported CSS property: border-bottom
```

The issue is that `CSSBorder` supported general border properties such as `border-width`, `border-style`, and `border-color`, but not side-specific shorthand properties like:

- `border-top`
- `border-right`
- `border-bottom`
- `border-left`

This PR adds support for those side-specific border shorthands, plus the corresponding side-specific longhands such as `border-bottom-width`, `border-bottom-style`, and `border-bottom-color`.

I also added a regression test covering:

```css
SideCommand {
    border: none;
    border-bottom: 2px solid #cccccc;
}
```

Verification:

```bash
mvn -DunitTests -pl core-unittests -am -Dtest=CSSThemeCompilerTest -DfailIfNoTests=false test
mvn -DunitTests -pl core-unittests -am -Dtest=CSSBorderTest,BorderAndPlafTest -DfailIfNoTests=false test
```

Results:

- `CSSThemeCompilerTest`: 5 tests, 0 failures, 0 errors
- `CSSBorderTest` + `BorderAndPlafTest`: 18 tests, 0 failures, 0 errors
