### PR TITLE
Ignore common local artifacts in Initializr projects

### DIFF
--- a/scripts/initializr/.gitignore
+++ b/scripts/initializr/.gitignore
@@ -1,5 +1,6 @@
 # Maven build outputs
 **/target/
+TEST-*.xml
 
 # IntelliJ IDEA
 .idea/
@@ -9,6 +10,7 @@
 .DS_Store
 Thumbs.db
 *~
+*.bak
 
 # Codename One simulator artifacts
 common/codenameone_settings.properties


### PR DESCRIPTION
This updates the Initializr project template `.gitignore` to exclude two additional local artifacts that can be created during normal Codename One/Maven usage:

- `TEST-*.xml`: JUnit-style XML reports that can be generated when running Codename One tests locally.
- `*.bak`: backup files that may be created by tooling or manual project maintenance, e.g. temporary backup copies of Maven/CN1 project files.

These files are local/generated artifacts and should not normally be committed by users starting from a freshly generated Codename One project.

No runtime code is changed. This only affects newly generated Initializr projects.