### PR TITLE
Initializr: clean up generated zips to avoid IndexedDB quota exhaustion

### DIFF
--- a/scripts/initializr/common/src/main/java/com/codename1/initializr/Initializr.java
+++ b/scripts/initializr/common/src/main/java/com/codename1/initializr/Initializr.java
@@ -196,6 +196,14 @@ public class Initializr extends Lifecycle {
         initWebsiteThemeSync(form);
         form.show();
         notifyWebsiteUiReady();
+        // Free any zips left over from previous sessions so users who already filled their
+        // browser quota recover on the next page load instead of having to clear site data
+        // by hand. Runs off the EDT because each LocalForage op blocks on a JS callback.
+        Display.getInstance().startThread(new Runnable() {
+            public void run() {
+                GeneratorModel.cleanupGeneratedZips();
+            }
+        }, "initializr-storage-cleanup").start();
     }
 
     private void notifyWebsiteUiReady() {

--- a/scripts/initializr/common/src/main/java/com/codename1/initializr/model/GeneratorModel.java
+++ b/scripts/initializr/common/src/main/java/com/codename1/initializr/model/GeneratorModel.java
@@ -112,15 +112,53 @@ public class GeneratorModel {
     }
 
     public void generate() {
+        // The JavaScript port backs openFileOutputStream with IndexedDB. The Blob handed to
+        // execute() retains the bytes, but the IndexedDB entry sticks around forever, so each
+        // generation accumulates a multi-MB record until the browser quota is exhausted.
+        cleanupGeneratedZips();
         String filePath = getAppHomePath() + appName.toLowerCase() + ".zip";
-        try (OutputStream fos = openFileOutputStream(filePath)) {
-            writeProjectZip(fos);
-        } catch (IOException err) {
-            Log.e(err);
-            ToastBar.showErrorMessage("Error generating zip: " + err);
-            return;
+        try {
+            writeProjectZipToStorage(filePath);
+        } catch (IOException firstErr) {
+            // Almost always quota-exhaustion. Clean up once more (covers orphan entries the
+            // first sweep missed, e.g. a half-written file from this attempt) and retry.
+            cleanupGeneratedZips();
+            try {
+                writeProjectZipToStorage(filePath);
+            } catch (IOException retryErr) {
+                Log.e(retryErr);
+                ToastBar.showErrorMessage(
+                        "Browser storage is full. Open your browser settings, clear site "
+                                + "data for this page, then try again.");
+                return;
+            }
         }
         execute(filePath);
+    }
+
+    private void writeProjectZipToStorage(String filePath) throws IOException {
+        try (OutputStream fos = openFileOutputStream(filePath)) {
+            writeProjectZip(fos);
+        }
+    }
+
+    public static void cleanupGeneratedZips() {
+        try {
+            String home = getAppHomePath();
+            String[] files = listFiles(home);
+            if (files == null) {
+                return;
+            }
+            for (String file : files) {
+                if (file != null && file.endsWith(".zip")) {
+                    try {
+                        delete(home + file);
+                    } catch (Throwable ignored) {
+                    }
+                }
+            }
+        } catch (Throwable ignored) {
+        }
     }
 
     void writeProjectZip(OutputStream outputStream) throws IOException {


### PR DESCRIPTION
## Summary
- Every Generate-Project click in the initializr writes a multi-MB zip into IndexedDB via `LocalForage.setItem` (the JS port's backing for `openFileOutputStream`) and never deletes it. After enough clicks the origin's IndexedDB quota is exhausted and every subsequent `setItem` — including the framework's own startup writes (font metrics, etc.) — throws `QuotaExceededException`.
- `GeneratorModel.generate()` now sweeps `*.zip` files from `getAppHomePath()` before each write, and on `IOException` cleans up again and retries once before surfacing a "Browser storage is full" toast.
- `Initializr.runApp()` kicks off the same cleanup in a background `Display.startThread` after `form.show()`, so users already stuck in the quota-full state recover on the next page load without having to clear site data by hand.

A deeper structural fix (skip IndexedDB entirely — build the zip in memory and stream the bytes directly to a browser download) is left for a follow-up.

## Test plan
- [ ] Rebuild the initializr `javascript` module and load it in a browser with a freshly-cleared origin.
- [ ] Click Generate Project repeatedly (10+) and confirm IndexedDB usage stays bounded (DevTools → Application → IndexedDB).
- [ ] In a separate session, fill IndexedDB to quota using a tiny script, reload the initializr, and confirm the background cleanup frees the zips on its own.
- [ ] Force-fail the write (e.g. wrap the JS-port quota check with a stub that always throws) and confirm the retry path + "Browser storage is full" toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)