### PR TITLE
Fix #4997: guard pointerDragged against empty pointer arrays

### DIFF
--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -2066,6 +2066,10 @@ public final class Display extends CN1Constants {
         if (impl.getCurrentForm() == null) {
             return;
         }
+        if (x.length == 0) {
+            // Native ports have been observed to deliver zero-length pointer arrays
+            return;
+        }
         longPointerCharged = false;
         if (x.length == 1) {
             addPointerDragEventWithTimestamp(x[0], y[0]);


### PR DESCRIPTION
## Summary
- The Android port has been observed to dispatch a zero-length pointer array into `Display.pointerDragged(int[], int[])`. The previous code routed anything where `x.length != 1` to the multi-pointer queue, so `Form.pointerDragged(int[], int[])` would then dereference `x[0]`/`y[0]` and crash the EDT with `ArrayIndexOutOfBoundsException: length=0; index=0` (as reported in #4997).
- Drop the event at the boundary in `Display.pointerDragged` so a malformed input from a native port can't make it onto the event queue. Guarding here keeps `Form.pointerDragged` untouched and stops a single bad event from propagating further.

## Test plan
- [ ] Existing JavaSE tests pass (`ant test-javase` / `mvn test -Plocal-dev-javase`).
- [ ] Manual: simulate a `Display.getInstance().pointerDragged(new int[0], new int[0])` call and confirm no exception is thrown and no event is queued.
- [ ] Smoke-test normal single- and multi-touch drag in the simulator to confirm no regression.

Fixes #4997.

🤖 Generated with [Claude Code](https://claude.com/claude-code)