### PR TITLE
Fix iOS 26 tap regressions + ParparVM BGPainter NPE

### DIFF
--- a/CodenameOne/src/com/codename1/ui/Component.java
+++ b/CodenameOne/src/com/codename1/ui/Component.java
@@ -7000,7 +7000,7 @@ public class Component implements Animation, StyleListener, Editable {
 
         Painter bgp = getStyle().getBgPainter();
         boolean animateBackgroundB = bgp != null &&
-                bgp.getClass() != BGPainter.class &&
+                !(bgp instanceof BGPainter) &&
                 bgp instanceof Animation &&
                 ((Animation) bgp).animate();
         animateBackground = animateBackgroundB || animateBackground;

--- a/Ports/iOSPort/nativeSources/CN1TapGestureRecognizer.m
+++ b/Ports/iOSPort/nativeSources/CN1TapGestureRecognizer.m
@@ -50,8 +50,6 @@ extern BOOL CN1useTapGestureRecognizer;
     self.delegate = self;
     [ctrl.view.window addGestureRecognizer:self];
     CN1useTapGestureRecognizer = YES;
-    
-    
 }
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
@@ -60,6 +58,24 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
         return true;
     }
     return false;
+}
+
+// iOS 26 auto-installs a UITapGestureRecognizer on every UIWindow with
+// _keyboardDismissalGestureRecognized: as its action. Its default
+// cancelsTouchesInView=YES, plus its position in the window-level recognizer
+// chain ahead of ours, means it can consume tap-down events before CN1TapGR
+// ever sees touchesBegan -- the simulator's indirect-pointer-as-touch
+// dispatch tickles this path. Insist that CN1TapGR is required to fail
+// before any window-level UITapGestureRecognizer can recognise, so we keep
+// first crack at every touch regardless of what iOS installed.
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+        shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+    if (gestureRecognizer == self
+            && [otherGestureRecognizer isKindOfClass:[UITapGestureRecognizer class]]
+            && otherGestureRecognizer.view == self.view) {
+        return YES;
+    }
+    return NO;
 }
 
 /**
@@ -87,7 +103,7 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
 }
 
 - (void) touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event
-{   
+{
     [super touchesBegan:touches withEvent:event];
     POOL_BEGIN();
     if(touchesArray == nil) {

--- a/Ports/iOSPort/nativeSources/CodenameOne_GLViewController.m
+++ b/Ports/iOSPort/nativeSources/CodenameOne_GLViewController.m
@@ -2785,6 +2785,13 @@ bool lockDrawing;
         UIHoverGestureRecognizer *hover = [[UIHoverGestureRecognizer alloc]
                                            initWithTarget:self
                                                    action:@selector(cn1HandleHover:)];
+        // UIGestureRecognizer defaults cancelsTouchesInView to YES, which on
+        // simulator builds where the host-mac mouse cursor is always hovering
+        // over the window can cancel taps before they reach touchesBegan:.
+        // Hover is independent of touch; don't let it preempt.
+        hover.cancelsTouchesInView = NO;
+        hover.delaysTouchesBegan = NO;
+        hover.delaysTouchesEnded = NO;
         [self.view addGestureRecognizer:hover];
 #ifndef CN1_USE_ARC
         [hover release];


### PR DESCRIPTION
## Summary

Three independent regressions that surfaced while testing on iPhone 17 Pro / iOS 26.3 simulator under Xcode 26:

1. **ParparVM `Component$BGPainter.animate` NPE** — `Component.animate()` was using `bgp.getClass() != BGPainter.class` to skip the default background painter. That class-literal comparison failed under ParparVM and the path ran on a `BGPainter` constructed via the no-arg / `Style` / `Painter` constructors (motion fields are null in those), tripping a `NullPointerException` on `wMotion.isFinished()` in `Component$BGPainter.animate()` ~600 ms after every form show. Replaced with `!(bgp instanceof BGPainter)`, which is the intended check anyway -- `BGPainter` has no subclasses.

2. **iOS 26 keyboard-dismissal `UITapGestureRecognizer` ate every touch** — iOS 26 auto-installs a window-level `UITapGestureRecognizer` whose action is `_keyboardDismissalGestureRecognized:` and whose default `cancelsTouchesInView=YES`. It runs ahead of `CN1TapGestureRecognizer` in the recognizer chain, so tap-down events were consumed before our `touchesBegan:` ran. Implemented `shouldBeRequiredToFailByGestureRecognizer:` on `CN1TapGestureRecognizer` so any window-level `UITapGestureRecognizer` must wait for ours to fail.

3. **`UIHoverGestureRecognizer` preempted touches on the simulator** — `UIGestureRecognizer.cancelsTouchesInView` defaults to YES. In the simulator the host-mac cursor is always hovering over the window, so the hover recognizer was cancelling taps. Explicitly set `cancelsTouchesInView=NO` / `delaysTouchesBegan=NO` / `delaysTouchesEnded=NO` on the hover recognizer.

Net effect: form renders, tap fires `pointerPressed` + `Button.actionPerformed`, no recurring NPE in the EDT loop.

## Test plan

- [x] Run a minimal CN1 app on the iPhone 17 Pro / iOS 26.3 simulator under Xcode 26 — form should render and stop NPE-spam in the log
- [x] Tap a button on the form — `pointerPressed` and `actionPerformed` should fire
- [ ] Run the existing tests (`ant test-javase`) — the `Component.animate` change is the only Java edit and is a logically equivalent rewrite
- [ ] Smoke test on a real iOS 17/18 device to confirm no regression on older OS versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)