### PR TITLE
Fix #4991: lightweight picker popup renders zero-width on desktop JS port

### DIFF
--- a/CodenameOne/src/com/codename1/components/InteractionDialog.java
+++ b/CodenameOne/src/com/codename1/components/InteractionDialog.java
@@ -809,6 +809,18 @@ public class InteractionDialog extends Container implements AbstractDialog {
         } else {
             if (availableWidth < prefWidth && availableHeight / 2 > availableWidth - rect.getWidth()) {
                 showPortrait = true;
+            } else if (prefWidth >= rect.getX()
+                    && prefWidth >= availableWidth - rect.getX() - rect.getWidth()) {
+                // Landscape placement below picks the side of the rect with
+                // room for a side-by-side popup. When the rect spans (or
+                // nearly spans) the full available width -- e.g. a Picker in
+                // a Y-axis BoxLayout row -- neither side has room and the
+                // "popup left" else branch computes width = max(0,
+                // rect.getX()) = 0. The dialog then renders zero-width and
+                // looks invisible while still consuming the click (#4991).
+                // Fall back to portrait-style placement (centered
+                // horizontally, popping above or below the rect).
+                showPortrait = true;
             }
         }
 

--- a/maven/core-unittests/src/test/java/com/codename1/components/InteractionDialogTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/components/InteractionDialogTest.java
@@ -97,6 +97,36 @@ class InteractionDialogTest extends UITestBase {
         dialog.dispose();
     }
 
+    @Test
+    void showPopupDialogLandscapeFullWidthRectGetsVisibleSize() {
+        // Regression for #4991: in landscape, when the anchor rect spans the
+        // full available width (Picker in a Y-axis BoxLayout row), the legacy
+        // "popup left" fallback computed width = max(0, rect.getX()) = 0 and
+        // the dialog rendered zero-width. JS port desktop builds reproduced
+        // this because their viewport satisfies isTablet() (sw>=600) AND
+        // isPortrait()==false, sending Picker into the showPopupDialog branch.
+        implementation.setDisplaySize(1440, 900);
+        implementation.setPortrait(false);
+        try {
+            Form form = new Form(new BorderLayout());
+            implementation.setCurrentForm(form);
+            InteractionDialog dialog = new InteractionDialog();
+            dialog.setAnimateShow(false);
+            Label body = new Label("Body content with enough width to matter");
+            dialog.addComponent(body);
+            Rectangle fullWidthRect = new Rectangle(0, 80, 1440, 60);
+            dialog.showPopupDialog(fullWidthRect);
+            assertTrue(dialog.isShowing(), "dialog should be on the layered pane");
+            assertTrue(dialog.getWidth() > 0,
+                    "dialog must have non-zero width after a full-width anchor in landscape; got "
+                            + dialog.getWidth());
+            dialog.dispose();
+        } finally {
+            implementation.setDisplaySize(1080, 1920);
+            implementation.setPortrait(true);
+        }
+    }
+
     private <T> T getPrivateField(Object target, String name, Class<T> type) throws Exception {
         Field field = target.getClass().getDeclaredField(name);
         field.setAccessible(true);


### PR DESCRIPTION
## Summary

- Patches `InteractionDialog.showPopupDialogImpl` so a popup anchored to a full-width component falls back to portrait-style placement (centered horizontally, above/below the rect) instead of rendering at width 0.
- Adds a regression test for the landscape full-width-anchor case.

## Root cause

The landscape branch of `showPopupDialogImpl` picks the side of the anchor rect with room for a side-by-side popup:

```java
if (prefWidth < availableWidth - rect.getX() - rect.getWidth()) {
    // popup right
} else if (prefWidth < rect.getX()) {
    // popup left (true left side)
} else {
    // popup left (fallback)
    width = Math.min(prefWidth, availableWidth - (availableWidth - rect.getX()));
    x = rect.getX() - width;
    show(y, availableHeight - height - y, Math.max(0, x), Math.max(0, availableWidth - width - x));
}
```

When the anchor rect spans the full available width (typical for a `Picker` in a Y-axis `BoxLayout` row), `rect.getX() == 0` and the right-side space is `0`, so the first two branches fail. The fallback then computes `width = min(prefWidth, availableWidth - (availableWidth - 0)) = 0` and calls `show(…, 0, availableWidth)` — the dialog is added to the layered pane with zero width.

The user-visible symptom from issue #4991: the picker press animation fires but no popup appears. The bug only reproduces in environments where `HTML5Implementation.isTablet() == true && isPortrait() == false`, which is precisely a desktop browser viewport (≥ 600 CSS px on the short side, landscape). That is why the cloud preview links failed but Playground worked — Playground's preview iframe is sized like a phone, so `Picker.showInteractionDialog` takes the regular `dlg.show(top, bottom, left, right)` branch instead of `showPopupDialog`.

## Fix

In the orientation-fallback check at the top of `showPopupDialogImpl`, detect the case where neither side of the anchor rect has room for the popup and flip `showPortrait = true`. The portrait branch already centers horizontally and pops above or below the rect, which is the correct behavior for a full-width anchor.

## Test plan

- [x] `mvn -pl core-unittests test -DunitTests -Dtest=InteractionDialogTest,PickerTest` — all 9 tests pass.
- [x] Confirmed the new regression test (`showPopupDialogLandscapeFullWidthRectGetsVisibleSize`) **fails** without the fix with `dialog must have non-zero width after a full-width anchor in landscape; got 0`, and passes with the fix.
- [x] Existing `InteractionDialogTest` and `PickerTest` cases still pass.
- [ ] Reviewer: reproduce against the JS port preview at a desktop browser viewport using jsfan3's snippet from #4991 — the four pickers should now open on click.

Fixes #4991.

🤖 Generated with [Claude Code](https://claude.com/claude-code)