### PR TITLE
Fix #5019: revalidate lightweight Picker after shortcut button action

### DIFF
--- a/CodenameOne/src/com/codename1/ui/spinner/Picker.java
+++ b/CodenameOne/src/com/codename1/ui/spinner/Picker.java
@@ -192,18 +192,33 @@ public class Picker extends Button {
 
     /// Listener fired when a custom popup button is pressed. Static (rather than an anonymous
     /// inner class) so it does not retain a reference to the enclosing `Picker`; the only
-    /// state it needs is the matching `LightweightPopupButton` whose `action` it invokes.
+    /// state it needs is the matching `LightweightPopupButton` whose `action` it invokes
+    /// and the spinner `Component` to refresh after the action runs. The spinner reference
+    /// is dropped along with the popup dialog so it does not outlive the editing session.
     private static final class PopupButtonActionListener implements ActionListener {
         private final LightweightPopupButton popupButton;
+        private final Container spinnerContainer;
 
-        private PopupButtonActionListener(LightweightPopupButton popupButton) {
+        private PopupButtonActionListener(LightweightPopupButton popupButton, Container spinnerContainer) {
             this.popupButton = popupButton;
+            this.spinnerContainer = spinnerContainer;
         }
 
         @Override
         public void actionPerformed(ActionEvent evt) {
-            if (popupButton.action != null) {
-                popupButton.action.run();
+            if (popupButton.action == null) {
+                return;
+            }
+            popupButton.action.run();
+            // Force a layout + repaint of the spinner so a setDate / setTime /
+            // setSelectedString / setDuration call inside the action propagates
+            // to the visible wheels. Spinner3D.setModel only flags the scroller
+            // as needing a new preferred size; on Android nothing else triggers
+            // the relayout, so the wheels stay stale until the user touches
+            // them. Issue #5019.
+            if (spinnerContainer != null) {
+                spinnerContainer.revalidate();
+                spinnerContainer.repaint();
             }
         }
     }
@@ -727,8 +742,9 @@ public class Picker extends Button {
                         .setBgTransparency(0)
                         .setMargin(0)
                         .setPaddingMillimeters(3f, 0);
-                Container topCustomButtons = createLightweightPopupButtonRow(LightweightPopupButtonPlacement.ABOVE_SPINNER, isTablet);
-                Container bottomCustomButtons = createLightweightPopupButtonRow(LightweightPopupButtonPlacement.BELOW_SPINNER, isTablet);
+                final Container spinnerContainer = spinnerC instanceof Container ? (Container) spinnerC : null;
+                Container topCustomButtons = createLightweightPopupButtonRow(LightweightPopupButtonPlacement.ABOVE_SPINNER, isTablet, spinnerContainer);
+                Container bottomCustomButtons = createLightweightPopupButtonRow(LightweightPopupButtonPlacement.BELOW_SPINNER, isTablet, spinnerContainer);
                 if (topCustomButtons != null || bottomCustomButtons != null) {
                     Container spinnerSection = new Container(new BorderLayout());
                     spinnerSection.add(BorderLayout.CENTER, wrapper);
@@ -824,7 +840,7 @@ public class Picker extends Button {
                     west.add(nextButton);
                 }
 
-                Container centerButtons = createLightweightPopupButtonRow(LightweightPopupButtonPlacement.BETWEEN_CANCEL_AND_DONE, isTablet);
+                Container centerButtons = createLightweightPopupButtonRow(LightweightPopupButtonPlacement.BETWEEN_CANCEL_AND_DONE, isTablet, spinnerContainer);
                 Container buttonBar = BorderLayout.centerEastWest(centerButtons, doneButton, west);
                 buttonBar.setUIID(isTablet ? "PickerButtonBarTablet" : "PickerButtonBar");
                 dlg.getContentPane().add(BorderLayout.NORTH, buttonBar);
@@ -898,7 +914,7 @@ public class Picker extends Button {
         updateValue();
     }
 
-    private Container createLightweightPopupButtonRow(int placement, boolean isTablet) {
+    private Container createLightweightPopupButtonRow(int placement, boolean isTablet, Container spinnerContainer) {
         Container left = null;
         Container center = null;
         Container right = null;
@@ -907,7 +923,7 @@ public class Picker extends Button {
                 continue;
             }
             Button button = new Button(entry.text, isTablet ? "PickerButtonTablet" : "PickerButton");
-            button.addActionListener(new PopupButtonActionListener(entry));
+            button.addActionListener(new PopupButtonActionListener(entry, spinnerContainer));
             switch (entry.alignment) {
                 case Component.CENTER:
                     if (center == null) {


### PR DESCRIPTION
## Summary

- On Android, the lightweight `Picker` spinner wheels could stay empty/stale after a custom `addLightweightPopupButton` callback called `setDate` / `setTime` / `setSelectedString` / `setDuration` while the popup was on screen. The user had to physically touch the wheel before the new value rendered.
- `Spinner3D.setModel` only flags the scroller as needing a new preferred size; the implicit `getScene().repaint()` in `SpinnerNode.setScrollY` didn't drive a relayout on Android, so the wheels never picked up the new model dimensions.
- `PopupButtonActionListener` now revalidates and repaints the spinner container after running the user's `Runnable`, which fulfils the documented contract on `setDate` that *"if the lightweight popup is currently on screen the visible scroll wheels are also moved to the new value"*.

## Why the screenshot test didn't catch it

`LightweightPickerButtonsScreenshotTest` exercises the live-propagation path, but two things masked the bug:

1. **It calls `picker.setDate(fixedDate)` directly from a `UITimer`, not from inside a shortcut-button callback.** The bug specifically lives in the `PopupButtonActionListener` → user `Runnable` path. A bare `picker.setDate(...)` running on the EDT doesn't run alongside the button's press/release/repaint dispatch and apparently survives the next paint cycle on Android.
2. The 400ms wait between `setDate` and screenshot is enough for any latent paint to run; even though `PixelCopy` captures actual on-screen pixels, the scenario the test exercises never enters the failing state in the first place.

Follow-up worth doing in a separate PR: extend the screenshot test to programmatically tap one of the shortcut buttons (so the capture flows through `PopupButtonActionListener`), which would have caught this and would guard against regressions in the fix.

## Test plan

- [ ] Existing `LightweightPickerButtonsScreenshotTest` still passes on Android (the test path is unchanged behaviour).
- [ ] Manual: build the Android sample, open a date `Picker` with `setUseLightweightPopup(true)` and shortcut buttons that call `setDate`, tap a button, confirm wheels update without needing a touch.
- [ ] Manual: same flow on the simulator (regression check that the new `revalidate()` doesn't introduce flicker).

Fixes #5019

🤖 Generated with [Claude Code](https://claude.com/claude-code)