### PR TITLE
Add package-info.java descriptors for 15 undocumented packages

### DIFF
--- a/CodenameOne/src/com/codename1/annotations/package-info.java
+++ b/CodenameOne/src/com/codename1/annotations/package-info.java
@@ -1,0 +1,6 @@
+/// Codename One specific Java annotations used by the build pipeline and the
+/// ParparVM bytecode translator to mark methods and classes for special
+/// treatment -- e.g. opting individual call sites out of debug info or
+/// null/array-bounds checks, declaring asynchronous methods, or forcing a
+/// class to be treated as concrete during devirtualization.
+package com.codename1.annotations;

--- a/CodenameOne/src/com/codename1/charts/transitions/package-info.java
+++ b/CodenameOne/src/com/codename1/charts/transitions/package-info.java
@@ -1,0 +1,7 @@
+/// Animated transitions between chart series states.
+///
+/// Concrete subclasses of `SeriesTransition` buffer changes to a chart's
+/// model and renderer so the `ChartComponent` can either tween between the
+/// previous and next state via `animateChart()` or jump to it in one shot
+/// via `updateChart()`.
+package com.codename1.charts.transitions;

--- a/CodenameOne/src/com/codename1/cloud/package-info.java
+++ b/CodenameOne/src/com/codename1/cloud/package-info.java
@@ -1,0 +1,6 @@
+/// Legacy cloud / property-binding hooks.
+///
+/// Only `BindTarget` survives here; it mapped to an older iteration of the
+/// properties framework that has since been superseded by
+/// [com.codename1.properties]. New code should use that package instead.
+package com.codename1.cloud;

--- a/CodenameOne/src/com/codename1/compat/java/util/package-info.java
+++ b/CodenameOne/src/com/codename1/compat/java/util/package-info.java
@@ -1,0 +1,9 @@
+/// Compatibility shims for `java.util` APIs that are not available on every
+/// Codename One target.
+///
+/// On platforms that lack the standard JDK class (notably older Android
+/// runtimes via the build server), the Codename One build pipeline remaps
+/// references from the standard package to the implementation here.
+/// Application code should keep using the standard `java.util` types --
+/// these classes exist only so the remap has a target to point at.
+package com.codename1.compat.java.util;

--- a/CodenameOne/src/com/codename1/io/bonjour/package-info.java
+++ b/CodenameOne/src/com/codename1/io/bonjour/package-info.java
@@ -1,0 +1,7 @@
+/// Bonjour / mDNS-SD service discovery and publication.
+///
+/// `BonjourBrowser` discovers peers advertising a given service type on the
+/// local network, and `BonjourPublisher` announces a service from the
+/// device. The native plumbing lives behind `BonjourPlatform`, which the
+/// active port implements (NSNetService on iOS, NsdManager on Android).
+package com.codename1.io.bonjour;

--- a/CodenameOne/src/com/codename1/io/oidc/package-info.java
+++ b/CodenameOne/src/com/codename1/io/oidc/package-info.java
@@ -1,0 +1,11 @@
+/// OpenID Connect (OIDC) client with PKCE.
+///
+/// `OidcClient` drives the Authorization Code + PKCE flow against any
+/// standards-compliant identity provider (Auth0, Okta, Google, Microsoft
+/// Entra, Keycloak, ...). It launches a system browser via
+/// `SystemBrowser` / `OidcBrowserNative`, exchanges the authorization code
+/// for tokens, and persists them through a pluggable `TokenStore`.
+///
+/// Companion classes (`OidcConfiguration`, `OidcTokens`, `PkceChallenge`,
+/// `OidcException`) carry configuration, results and errors.
+package com.codename1.io.oidc;

--- a/CodenameOne/src/com/codename1/io/usb/package-info.java
+++ b/CodenameOne/src/com/codename1/io/usb/package-info.java
@@ -1,0 +1,7 @@
+/// USB host-mode device access.
+///
+/// `Usb` enumerates attached `UsbDevice` instances and opens bulk
+/// input/output streams to them; `UsbDeviceListener` delivers
+/// attach/detach notifications. The native bridge is supplied by the
+/// active port through `UsbPlatform`.
+package com.codename1.io.usb;

--- a/CodenameOne/src/com/codename1/io/webauthn/package-info.java
+++ b/CodenameOne/src/com/codename1/io/webauthn/package-info.java
@@ -1,0 +1,15 @@
+/// WebAuthn / passkey client.
+///
+/// `WebAuthnClient` wraps the OS public-key credential APIs
+/// (`ASAuthorizationPlatformPublicKeyCredentialProvider` on iOS 16+,
+/// `androidx.credentials.CredentialManager` on Android API 28+) behind a
+/// portable, JSON-friendly Java surface, letting an app register and
+/// authenticate passkeys against any standards-compliant relying party --
+/// your own backend, Auth0, Firebase, etc.
+///
+/// `PublicKeyCredentialCreationOptions` /
+/// `PublicKeyCredentialRequestOptions` describe the ceremony parameters,
+/// `PublicKeyCredential` carries the result, and `WebAuthnException`
+/// reports cancellation / platform errors. `WebAuthnNative` is the SPI the
+/// active port implements.
+package com.codename1.io.webauthn;

--- a/CodenameOne/src/com/codename1/io/wifi/package-info.java
+++ b/CodenameOne/src/com/codename1/io/wifi/package-info.java
@@ -1,0 +1,14 @@
+/// WiFi inspection, scanning, connection and peer-to-peer (WiFi Direct).
+///
+/// `WiFi` exposes the current connection's SSID/BSSID/IP plus APIs to scan
+/// for and connect to nearby networks (`WiFiNetwork`, `WiFiSecurity`,
+/// `WiFiScanCallback`, `WiFiConnectCallback`).
+///
+/// `WiFiDirect` covers Android-style WiFi Direct peer discovery and
+/// session setup via `WiFiDirectPeer` and `WiFiDirectListener`.
+///
+/// `WifiPlatform` / `WifiDirectPlatform` are the SPIs the active port
+/// implements; on modern Android (10+) and iOS, the SSID/BSSID queries
+/// require runtime permissions or entitlements that the build pipeline
+/// injects automatically based on classpath scanning.
+package com.codename1.io.wifi;

--- a/CodenameOne/src/com/codename1/nfc/package-info.java
+++ b/CodenameOne/src/com/codename1/nfc/package-info.java
@@ -1,0 +1,13 @@
+/// Near Field Communication (NFC) API: read and write NDEF messages,
+/// exchange APDUs with contactless smart cards, and host-emulate as a
+/// card.
+///
+/// `Nfc.getInstance()` returns the platform implementation; supporting
+/// classes cover NDEF (`NdefMessage`, `NdefRecord`), tag discovery
+/// (`Tag`, `TagType`, `TagTechnology`, `NfcListener`,
+/// `NfcReadOptions`), specific tag technologies (`IsoDep`,
+/// `MifareClassic`, `MifareUltralight`, `NfcA`, `NfcB`, `NfcF`,
+/// `NfcV`), APDU exchange (`ApduResponse`) and host card emulation
+/// (`HostCardEmulationService`). Failures surface through `NfcError`
+/// and `NfcException`.
+package com.codename1.nfc;

--- a/CodenameOne/src/com/codename1/plugin/event/package-info.java
+++ b/CodenameOne/src/com/codename1/plugin/event/package-info.java
@@ -1,0 +1,7 @@
+/// Typed events dispatched to plugins.
+///
+/// `PluginEvent<T>` is the common base; concrete events such as
+/// `OpenGalleryEvent` and `IsGalleryTypeSupportedEvent` describe specific
+/// extension points and carry the data a plugin needs to handle (or
+/// decline) them.
+package com.codename1.plugin.event;

--- a/CodenameOne/src/com/codename1/plugin/package-info.java
+++ b/CodenameOne/src/com/codename1/plugin/package-info.java
@@ -1,0 +1,8 @@
+/// Plugin SPI for extending core framework behaviour without subclassing.
+///
+/// A `Plugin` is an `ActionListener<PluginEvent>` registered through
+/// `PluginSupport`; core code fires typed `PluginEvent` instances (see
+/// [com.codename1.plugin.event]) at well-defined extension points and the
+/// first plugin to consume the event takes over the default behaviour --
+/// for example, swapping the built-in image picker for a custom gallery.
+package com.codename1.plugin;

--- a/CodenameOne/src/com/codename1/ui/css/package-info.java
+++ b/CodenameOne/src/com/codename1/ui/css/package-info.java
@@ -1,0 +1,7 @@
+/// Runtime CSS theme compilation.
+///
+/// `CSSThemeCompiler` turns a parsed CSS theme into the binary resource
+/// structures expected by [com.codename1.ui.plaf] (styles, borders, fonts,
+/// images), and is used by the designer's CSS pipeline and by the
+/// simulator's live CSS-reload support.
+package com.codename1.ui.css;

--- a/CodenameOne/src/com/codename1/ui/layouts/mig/package-info.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/mig/package-info.java
@@ -1,0 +1,13 @@
+/// Codename One port of the MiG Layout manager.
+///
+/// `MigLayout` is a grid-based layout driven by string constraints
+/// (`LC`, `AC`, `CC`, `DimConstraint`, `BoundSize`, `UnitValue`, ...) parsed
+/// through `ConstraintParser`. The wrapper classes
+/// (`CodenameOneMiGComponentWrapper`, `CodenameOneMiGContainerWrapper`)
+/// adapt the original MiG core to the Codename One component model.
+///
+/// #### Deprecated
+///
+/// This is an experimental integration with known bugs -- do not rely on
+/// it for production. Use the layouts in [com.codename1.ui.layouts] instead.
+package com.codename1.ui.layouts.mig;

--- a/CodenameOne/src/com/codename1/util/promise/package-info.java
+++ b/CodenameOne/src/com/codename1/util/promise/package-info.java
@@ -1,0 +1,8 @@
+/// JavaScript-style `Promise` for asynchronous Codename One code.
+///
+/// `Promise` mirrors the ECMAScript Promise contract (`then`, `catch`,
+/// `finally`, `all`, `race`, `resolve`, `reject`) on top of Codename One's
+/// EDT and `invokeAndBlock` model. `Functor` and `ExecutorFunction` are
+/// the small functional interfaces the API hands callbacks to so it can
+/// remain Java 5 source-compatible.
+package com.codename1.util.promise;


### PR DESCRIPTION
## Summary
- Adds `package-info.java` for the 15 packages under `CodenameOne/src` that contain Java sources but had no package descriptor, so Javadoc and IDEs have a real summary instead of an empty page.
- Covers recently added packages (`io.webauthn`, `io.oidc`, `io.bonjour`, `io.wifi`, `io.usb`, `nfc`, `plugin`, `plugin.event`, `util.promise`) plus older ones that had simply never received one (`annotations`, `charts.transitions`, `cloud`, `compat.java.util`, `ui.css`, `ui.layouts.mig`).
- Matches the existing `///` Javadoc style and is ASCII-only (per ParparVM Android encoding constraint).

## Test plan
- [ ] `git grep -L package-info CodenameOne/src/...` shows no source-bearing package left undocumented
- [ ] `file CodenameOne/src/com/codename1/**/package-info.java` reports ASCII for all new files
- [ ] `mvn -Plocal-dev-javase -DskipTests install` (core module) still compiles cleanly