### PR TITLE
Fix WMI_WRONG_MAP_ITERATOR in JSONParser and make SpotBugs fail CI

### DIFF
--- a/CodenameOne/src/com/codename1/io/JSONParser.java
+++ b/CodenameOne/src/com/codename1/io/JSONParser.java
@@ -849,8 +849,9 @@ public class JSONParser implements JSONParseCallback {
             sb.append('{');
             boolean first = true;
             Map m = (Map) o;
-            for (Object kObj : m.keySet()) {
-                Object v = m.get(kObj);
+            for (Object entryObj : m.entrySet()) {
+                Map.Entry entry = (Map.Entry) entryObj;
+                Object v = entry.getValue();
                 if (v == null) {
                     // Null-valued entries are dropped on purpose; if
                     // a caller really needs `"k":null` on the wire,
@@ -861,7 +862,7 @@ public class JSONParser implements JSONParseCallback {
                     sb.append(',');
                 }
                 first = false;
-                writeJsonString(sb, kObj.toString());
+                writeJsonString(sb, entry.getKey().toString());
                 sb.append(':');
                 writeJsonValue(sb, v);
             }

--- a/maven/core-unittests/pom.xml
+++ b/maven/core-unittests/pom.xml
@@ -84,7 +84,17 @@
                         <id>spotbugs</id>
                         <phase>verify</phase>
                         <goals>
+                            <!--
+                            The `spotbugs` goal generates the XML report but does NOT
+                            break the build on findings. The `check` goal re-uses the
+                            report and fails the build when any bug is reported, which
+                            is what CI relies on to surface regressions like
+                            WMI_WRONG_MAP_ITERATOR. Both goals are bound so the report
+                            artifact is still produced for the quality summary even
+                            when `check` aborts the build.
+                            -->
                             <goal>spotbugs</goal>
+                            <goal>check</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
## Summary
- Replaced `keySet()` + `m.get(key)` iteration in `JSONParser.writeJsonValue` with `entrySet()` iteration, clearing the SpotBugs WMI_WRONG_MAP_ITERATOR warning at `CodenameOne/src/com/codename1/io/JSONParser.java:853`. Null-drop semantics and the surrounding comment are preserved.
- Added the `check` goal to the SpotBugs execution in `maven/core-unittests/pom.xml`. The previous binding only ran the `spotbugs` goal, which generates the XML report but does not abort the build on findings regardless of `failOnError`. `check` honors the existing `Low` threshold and `failOnError=true`, so any new violation (such as another WMI_WRONG_MAP_ITERATOR) will fail CI instead of being silently uploaded as a quality artifact. The `spotbugs` goal stays bound so the quality-artifact pipeline still receives the XML report on success.

## Test plan
- [x] `mvn -DunitTests=true -pl core-unittests -am -DskipTests -Plocal-dev-javase verify` (JDK 8) — SpotBugs `check` reports `BugInstance size is 0` and build succeeds.
- [ ] PR CI builds (matrix on JDK 8/17/21) — confirm `check` runs and does not regress other modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)