### PR TITLE
Fix iOS native stub -stop selector ambiguity on Xcode 26

### DIFF
--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
@@ -1438,7 +1438,7 @@ public class IPhoneBuilder extends Executor {
                     if(!(returnType.equals(Void.class) || returnType.equals(Void.TYPE))) {
                         mFileBody += "    " + typeToXMLVMName(returnType) + " returnValue = " + convertToJavaMethod(returnType);
                     }
-                    mFileBody += "[ptr " + name;
+                    mFileBody += "[((" + classNameWithUnderscores + "Impl*)ptr) " + name;
                     
                     if(returnType.getName().equals("com.codename1.ui.PeerComponent")) {
                         javaImplSourceFile += "    public native long " + name + "(";


### PR DESCRIPTION
## Summary

- Cast `ptr` to the lib's concrete peer class in the generated `[ptr methodName...]` message send, so clang resolves the selector against the lib's own `@interface` instead of against `id`.
- Fixes Xcode 26 / iOS 26 SDK builds of any cn1lib whose native interface declares a method whose name collides with a `- (void)…` selector exposed by AVFoundation / Foundation (e.g. `stop`, `play`, `pause`, `start`, …).

## Why

The generated stub `native_<class>ImplCodenameOne.m` messages the native peer through an `id`-typed pointer:

```objc
id ptr = (id)get_field_..._nativePeer(me);
JAVA_BOOLEAN returnValue = [ptr stop];
```

On the iOS 26 SDK, AVFoundation pulls in many classes with `- (void)stop` — `AVAudioEngine`, `AVAudioPlayer`, `AVAudioPlayerNode`, `AVAudioRecorder`, `AVAudioSequencer`, `AVMIDIPlayer`, `AVCaptureExternalDisplayConfigurator`, `NSNetServices`, … Clang in Xcode 26 picks one of those `void` declarations when resolving the selector against `id`, and the build fails with:

```
error: initializing 'JAVA_BOOLEAN' (aka 'int') with an expression of incompatible type 'void'
  104 |     JAVA_BOOLEAN returnValue = [ptr stop];
```

(Reported in the wild against CN1Webserver, which has `-(BOOL)stop`. Hiding `GCDWebServer.h` in [shannah/CN1Webserver#1](https://github.com/shannah/CN1Webserver/pull/1) removed one source of collision but could not prevent AVFoundation — that header arrives transitively via `CodenameOne_GLViewController.h`, so the same error reappears against AVFoundation's `-stop` overloads.)

## Approach

The stub already `#import`s `<classNameWithUnderscores>Impl.h`, which declares `@interface <classNameWithUnderscores>Impl` (a convention every cn1lib follows — verified across core tests, TestNativeInterfaces, parse4cn1, firebase-cn1, etc.). Casting `ptr` at the message send gives clang a known receiver type so the selector resolves against the lib's `@interface`, not against the global `id` pool.

Runtime dispatch is unchanged — Objective-C method lookup is dynamic, the cast is a compile-time hint only. **No cn1lib needs to be rebuilt** once the new builder is deployed.

## Test plan

- [ ] iOS release build of a CN1Webserver-using app on Xcode 26.x succeeds.
- [ ] iOS builds of existing cn1libs (parse4cn1, firebase, googleplay, etc.) still succeed.
- [ ] `start`, `stop`, `isRunning`, etc. continue to function at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)