### PR TITLE
Fix CI flake: JavaSEPortFontMappingTest leaks JavaSEPort.instance

### DIFF
--- a/maven/javase/src/test/java/com/codename1/impl/javase/JavaSEPortFontMappingTest.java
+++ b/maven/javase/src/test/java/com/codename1/impl/javase/JavaSEPortFontMappingTest.java
@@ -5,20 +5,37 @@ import java.util.Set;
 import java.lang.reflect.Field;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class JavaSEPortFontMappingTest {
-    
+
     private Boolean originalIsIOS;
+    private JavaSEPort originalInstance;
+    private boolean instanceCaptured;
+
+    @BeforeEach
+    public void captureInstance() {
+        // new JavaSEPort() inside the loadTrueTypeFont tests overwrites the
+        // global JavaSEPort.instance via the port's constructor. Other test
+        // classes (CodenameOneExtensionTest) reach back through that static
+        // to drive the live Display, so leaking the throwaway port across
+        // test classes causes order-dependent failures.
+        originalInstance = JavaSEPort.instance;
+        instanceCaptured = true;
+    }
 
     @AfterEach
     public void tearDown() throws Exception {
         JavaSEPort.clearAvailableFontNamesLowercaseForTest();
         if (originalIsIOS != null) {
             setIsIOS(originalIsIOS.booleanValue());
+        }
+        if (instanceCaptured) {
+            JavaSEPort.instance = originalInstance;
         }
     }
 


### PR DESCRIPTION
## Summary

- `JavaSEPortFontMappingTest` constructs `new JavaSEPort()` inside two tests, and the constructor unconditionally assigns `instance = this`, so the throwaway port leaks into the global static.
- If `CodenameOneExtensionTest` runs in the same JVM after `Display` has already been initialized (e.g. by `PaintScopeTest`), the extension's `@LargerText` / `@Orientation` handling mutates the wrong port via `JavaSEPort.instance` while `Display.impl` still references the original — assertions then read stale defaults (1.0 / landscape).
- Order-dependent latent flake (not caused by any recent change): master's 04:52 run discovered `CodenameOneExtensionTest` first and passed; the 07:33 PR run picked the failing interleaving and surfaced two failures.

Fix: capture `JavaSEPort.instance` in `@BeforeEach` and restore it in `@AfterEach` so this test no longer leaks across test classes. It is the only test in the repo that constructs `new JavaSEPort()`, so this single change closes the flake.

## Test plan

- [x] `mvn -pl javase test -Plocal-dev-javase` — all 70 tests pass.
- [x] Synthetic reproducer (init Display, construct `new JavaSEPort()`, run `CodenameOneExtensionTest`) reproduced the CI failure verbatim before the fix.
- [x] Same reproducer driving `JavaSEPortFontMappingTest`'s `@BeforeEach`/`@AfterEach` passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)