### PR TITLE
Fix #5067: InteractionDialog dispose leaves dialog visible without animateShow

### DIFF
--- a/CodenameOne/src/com/codename1/components/InteractionDialog.java
+++ b/CodenameOne/src/com/codename1/components/InteractionDialog.java
@@ -441,6 +441,17 @@ public class InteractionDialog extends Container implements AbstractDialog {
 
                 pp.revalidate();
                 cleanupLayer(f);
+                // remove() above triggers the recursive deinitialize()
+                // path which already runs cleanupLayer() and detaches the
+                // layered pane wrapper, so by the time pp.revalidate()
+                // runs pp has no Form in its parent chain and never
+                // bubbles a repaint up to the form. The animateShow path
+                // is masked because the animation itself drives a paint
+                // cycle. Without it, dispose() can leave the old dialog
+                // pixels on screen until something else (scroll, hover)
+                // forces a redraw (#5067). Force a form-level revalidate
+                // so the next paint cycle clears those pixels.
+                f.revalidateWithAnimationSafety();
             } else {
                 p.remove();
             }

--- a/maven/core-unittests/src/test/java/com/codename1/components/InteractionDialogTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/components/InteractionDialogTest.java
@@ -97,6 +97,61 @@ class InteractionDialogTest extends UITestBase {
         dialog.dispose();
     }
 
+    @FormTest
+    void disposeWithoutAnimationSchedulesFormRepaint() {
+        // Regression for #5067: with setAnimateShow(false) +
+        // setFormMode(true), dispose() removed the dialog from the form
+        // tree but never asked the form to repaint, so the previously
+        // painted dialog pixels stayed on screen until something else
+        // (scrolling, hover) forced a redraw. dispose() -> remove()
+        // triggers the recursive deinitialize() path, which runs
+        // cleanupLayer() and detaches the layered pane wrapper before
+        // the outer dispose gets to call pp.revalidate(). By then pp
+        // has no Form in its parent chain, so the revalidate never
+        // bubbles up to a Form.repaint(). dispose() must trigger a
+        // form-level revalidate after cleanupLayer so the next paint
+        // cycle clears the old dialog pixels. NB: this test requires a
+        // shown form so the recursive deinitialize path actually fires
+        // -- with just setCurrentForm the dialog isn't initialized and
+        // dispose hits a different (working) code path that masks the
+        // bug.
+        RepaintCountingForm form = new RepaintCountingForm();
+        form.show();
+        InteractionDialog dialog = new InteractionDialog();
+        dialog.setAnimateShow(false);
+        dialog.setFormMode(true);
+        dialog.setDisposeWhenPointerOutOfBounds(false);
+        Rectangle rect = new Rectangle(0, 0, 50, 50);
+        dialog.showPopupDialog(rect);
+        assertTrue(dialog.isShowing(), "dialog should be on the layered pane before dispose");
+
+        // Reset the counter so we only observe repaint() calls triggered
+        // by dispose itself, not the ones from show.
+        form.repaintCount = 0;
+
+        dialog.dispose();
+
+        assertFalse(dialog.isShowing(), "dispose must detach the dialog from the form tree");
+        assertTrue(form.repaintCount > 0,
+                "#5067: dispose() must trigger a form repaint so the old dialog pixels "
+                        + "are cleared without needing scroll/hover to force a redraw; "
+                        + "observed " + form.repaintCount + " calls");
+    }
+
+    private static class RepaintCountingForm extends Form {
+        int repaintCount;
+
+        RepaintCountingForm() {
+            super(new BorderLayout());
+        }
+
+        @Override
+        public void repaint() {
+            repaintCount++;
+            super.repaint();
+        }
+    }
+
     @Test
     void showPopupDialogStraddlingMidlineDoesNotOverlapTarget() {
         // Regression for #5028: when the anchor rect straddles the


### PR DESCRIPTION
## Summary

- `InteractionDialog.dispose()` left the dialog visible on screen when `setAnimateShow(false)` + `setFormMode(true)`. Scrolling or hovering would make it disappear, but the dialog otherwise stayed painted until the next external repaint trigger.
- Trigger a form-level revalidate at the end of `dispose()` so the next paint cycle reliably clears the old dialog pixels.
- Add a regression test (`disposeWithoutAnimationSchedulesFormRepaint`) in `InteractionDialogTest`.

## Root cause

`dispose()` ends with:

```java
Container pp = getLayeredPane(f);
remove();                    // <-- triggers recursive deinitialize()
...
pp.revalidate();             // <-- relies on pp's parent chain to reach the form
cleanupLayer(f);
```

The `remove()` invokes `Component.deinitializeImpl()` → `InteractionDialog.deinitialize()`, which already runs its own `cleanupLayer(f)` and detaches the layered-pane wrapper (`pp`) from the form. By the time the outer `pp.revalidate()` runs, `pp.getComponentForm()` returns `null`, so `revalidateInternal` falls through `Container.java:1606` and never calls `Form.repaint()`.

`setAnimateShow(true)` masked the bug because `animateUnlayoutAndWait(...)` drives its own paint cycle.

## Fix

After `cleanupLayer(f)`, call `f.revalidateWithAnimationSafety()`. This guarantees a form revalidate + repaint regardless of whether the layered-pane wrapper is still attached when the earlier `pp.revalidate()` runs.

## Regression test

The test instantiates a `RepaintCountingForm`, shows it, opens the dialog with the exact `animateShow=false` + `formMode=true` flags from the bug report, resets the counter, calls `dispose()`, and asserts `repaint()` was invoked at least once. The test fails on master (0 calls) and passes with this fix (1 call).

Note: the test requires `form.show()` (rather than just `implementation.setCurrentForm(form)`) so the dialog actually initialises -- without initialisation, the recursive `deinitialize()` path doesn't fire and `dispose()` hits a different (working) code path that masks the bug.

## Test plan

- [x] `mvn -pl core-unittests -am test -Dtest=InteractionDialogTest -DunitTests` — all 10 tests pass
- [x] Full core-unittests suite (`mvn -pl core-unittests -am test -DunitTests`) — 2634 tests pass
- [x] Verified the new test fails on master (`observed 0 calls`) and passes with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)