### PR TITLE
Fix #5069: null-guard layered pane parent in InteractionDialog popup

### DIFF
--- a/CodenameOne/src/com/codename1/components/InteractionDialog.java
+++ b/CodenameOne/src/com/codename1/components/InteractionDialog.java
@@ -782,13 +782,20 @@ public class InteractionDialog extends Container implements AbstractDialog {
         }
 
 
-        int availableHeight = getLayeredPane(f).getParent().getHeight();
-        if (availableHeight == 0) {
-            availableHeight = CN.getDisplayHeight();
-        }
-        int availableWidth = getLayeredPane(f).getParent().getWidth();
-        if (availableWidth == 0) {
-            availableWidth = CN.getDisplayWidth();
+        // Layered-pane parent can be momentarily detached when a previous
+        // formMode dialog was disposed (cleanupLayer removes the inner pane
+        // from its parent while the form may still be mid-animation, see
+        // #5069). Fall back to display dimensions instead of NPE'ing.
+        Container layeredParent = getLayeredPane(f).getParent();
+        int availableHeight = CN.getDisplayHeight();
+        int availableWidth = CN.getDisplayWidth();
+        if (layeredParent != null) {
+            if (layeredParent.getHeight() != 0) {
+                availableHeight = layeredParent.getHeight();
+            }
+            if (layeredParent.getWidth() != 0) {
+                availableWidth = layeredParent.getWidth();
+            }
         }
         int width = Math.min(availableWidth, prefWidth);
         setWidth(width);


### PR DESCRIPTION
## Summary

Fixes #5069. `InteractionDialog.showPopupDialogImpl` was dereferencing `getLayeredPane(f).getParent()` to size the popup against the available area:

```java
int availableHeight = getLayeredPane(f).getParent().getHeight();
...
int availableWidth = getLayeredPane(f).getParent().getWidth();
```

That parent can be momentarily null — e.g. when a previous `formMode` `InteractionDialog` was just disposed: `cleanupLayer` calls `c.remove()` on the inner `FormLayer` container, detaching it from `formLayeredPane` while a form animation may still be in flight, and the next popup can see the intermediate state. The reporter hit this on 7.0.244 with a chained dismiss-then-show flow involving formMode dialogs.

The fix grabs the parent once, treats `null` the same way the existing code already treats a zero `getHeight()/getWidth()`, and falls back to the display dimensions. No behavior change in the common path.

## Test plan
- [x] `mvn -pl core -am compile -DskipTests` (JDK 8) — clean build.
- [ ] User to confirm the NPE no longer fires in their reproduction (the issue notes it isn't reproducible in isolation outside the reporter's app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)