### PR TITLE
Fix Maven Central release: add <name> to cn1-ai-* child POMs

### DIFF
--- a/maven/cn1-ai-mlkit-barcode/android/pom.xml
+++ b/maven/cn1-ai-mlkit-barcode/android/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-barcode-android</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-barcode-android</name>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/maven/cn1-ai-mlkit-barcode/common/pom.xml
+++ b/maven/cn1-ai-mlkit-barcode/common/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-barcode-common</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-barcode-common</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/maven/cn1-ai-mlkit-barcode/ios/pom.xml
+++ b/maven/cn1-ai-mlkit-barcode/ios/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-barcode-ios</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-barcode-ios</name>
 
     <build>
         <sourceDirectory>src/main/dummy</sourceDirectory>

--- a/maven/cn1-ai-mlkit-barcode/javascript/pom.xml
+++ b/maven/cn1-ai-mlkit-barcode/javascript/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-barcode-javascript</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-barcode-javascript</name>
 
     <build>
         <sourceDirectory>src/main/dummy</sourceDirectory>

--- a/maven/cn1-ai-mlkit-barcode/javase/pom.xml
+++ b/maven/cn1-ai-mlkit-barcode/javase/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-barcode-javase</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-barcode-javase</name>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/maven/cn1-ai-mlkit-barcode/lib/pom.xml
+++ b/maven/cn1-ai-mlkit-barcode/lib/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-barcode-lib</artifactId>
     <packaging>pom</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-barcode-lib</name>
 
     <dependencies>
         <dependency>

--- a/maven/cn1-ai-mlkit-docscan/android/pom.xml
+++ b/maven/cn1-ai-mlkit-docscan/android/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-docscan-android</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-docscan-android</name>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/maven/cn1-ai-mlkit-docscan/common/pom.xml
+++ b/maven/cn1-ai-mlkit-docscan/common/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-docscan-common</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-docscan-common</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/maven/cn1-ai-mlkit-docscan/ios/pom.xml
+++ b/maven/cn1-ai-mlkit-docscan/ios/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-docscan-ios</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-docscan-ios</name>
 
     <build>
         <sourceDirectory>src/main/dummy</sourceDirectory>

--- a/maven/cn1-ai-mlkit-docscan/javascript/pom.xml
+++ b/maven/cn1-ai-mlkit-docscan/javascript/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-docscan-javascript</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-docscan-javascript</name>
 
     <build>
         <sourceDirectory>src/main/dummy</sourceDirectory>

--- a/maven/cn1-ai-mlkit-docscan/javase/pom.xml
+++ b/maven/cn1-ai-mlkit-docscan/javase/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-docscan-javase</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-docscan-javase</name>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/maven/cn1-ai-mlkit-docscan/lib/pom.xml
+++ b/maven/cn1-ai-mlkit-docscan/lib/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-docscan-lib</artifactId>
     <packaging>pom</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-docscan-lib</name>
 
     <dependencies>
         <dependency>

--- a/maven/cn1-ai-mlkit-face/android/pom.xml
+++ b/maven/cn1-ai-mlkit-face/android/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-face-android</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-face-android</name>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/maven/cn1-ai-mlkit-face/common/pom.xml
+++ b/maven/cn1-ai-mlkit-face/common/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-face-common</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-face-common</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/maven/cn1-ai-mlkit-face/ios/pom.xml
+++ b/maven/cn1-ai-mlkit-face/ios/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-face-ios</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-face-ios</name>
 
     <build>
         <sourceDirectory>src/main/dummy</sourceDirectory>

--- a/maven/cn1-ai-mlkit-face/javascript/pom.xml
+++ b/maven/cn1-ai-mlkit-face/javascript/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-face-javascript</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-face-javascript</name>
 
     <build>
         <sourceDirectory>src/main/dummy</sourceDirectory>

--- a/maven/cn1-ai-mlkit-face/javase/pom.xml
+++ b/maven/cn1-ai-mlkit-face/javase/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-face-javase</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-face-javase</name>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/maven/cn1-ai-mlkit-face/lib/pom.xml
+++ b/maven/cn1-ai-mlkit-face/lib/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-face-lib</artifactId>
     <packaging>pom</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-face-lib</name>
 
     <dependencies>
         <dependency>

--- a/maven/cn1-ai-mlkit-labeling/android/pom.xml
+++ b/maven/cn1-ai-mlkit-labeling/android/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-labeling-android</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-labeling-android</name>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/maven/cn1-ai-mlkit-labeling/common/pom.xml
+++ b/maven/cn1-ai-mlkit-labeling/common/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-labeling-common</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-labeling-common</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/maven/cn1-ai-mlkit-labeling/ios/pom.xml
+++ b/maven/cn1-ai-mlkit-labeling/ios/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-labeling-ios</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-labeling-ios</name>
 
     <build>
         <sourceDirectory>src/main/dummy</sourceDirectory>

--- a/maven/cn1-ai-mlkit-labeling/javascript/pom.xml
+++ b/maven/cn1-ai-mlkit-labeling/javascript/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-labeling-javascript</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-labeling-javascript</name>
 
     <build>
         <sourceDirectory>src/main/dummy</sourceDirectory>

--- a/maven/cn1-ai-mlkit-labeling/javase/pom.xml
+++ b/maven/cn1-ai-mlkit-labeling/javase/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-labeling-javase</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-labeling-javase</name>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/maven/cn1-ai-mlkit-labeling/lib/pom.xml
+++ b/maven/cn1-ai-mlkit-labeling/lib/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-labeling-lib</artifactId>
     <packaging>pom</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-labeling-lib</name>
 
     <dependencies>
         <dependency>

--- a/maven/cn1-ai-mlkit-langid/android/pom.xml
+++ b/maven/cn1-ai-mlkit-langid/android/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-langid-android</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-langid-android</name>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/maven/cn1-ai-mlkit-langid/common/pom.xml
+++ b/maven/cn1-ai-mlkit-langid/common/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-langid-common</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-langid-common</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/maven/cn1-ai-mlkit-langid/ios/pom.xml
+++ b/maven/cn1-ai-mlkit-langid/ios/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-langid-ios</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-langid-ios</name>
 
     <build>
         <sourceDirectory>src/main/dummy</sourceDirectory>

--- a/maven/cn1-ai-mlkit-langid/javascript/pom.xml
+++ b/maven/cn1-ai-mlkit-langid/javascript/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-langid-javascript</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-langid-javascript</name>
 
     <build>
         <sourceDirectory>src/main/dummy</sourceDirectory>

--- a/maven/cn1-ai-mlkit-langid/javase/pom.xml
+++ b/maven/cn1-ai-mlkit-langid/javase/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-langid-javase</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-langid-javase</name>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/maven/cn1-ai-mlkit-langid/lib/pom.xml
+++ b/maven/cn1-ai-mlkit-langid/lib/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-langid-lib</artifactId>
     <packaging>pom</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-langid-lib</name>
 
     <dependencies>
         <dependency>

--- a/maven/cn1-ai-mlkit-pose/android/pom.xml
+++ b/maven/cn1-ai-mlkit-pose/android/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-pose-android</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-pose-android</name>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/maven/cn1-ai-mlkit-pose/common/pom.xml
+++ b/maven/cn1-ai-mlkit-pose/common/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-pose-common</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-pose-common</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/maven/cn1-ai-mlkit-pose/ios/pom.xml
+++ b/maven/cn1-ai-mlkit-pose/ios/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-pose-ios</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-pose-ios</name>
 
     <build>
         <sourceDirectory>src/main/dummy</sourceDirectory>

--- a/maven/cn1-ai-mlkit-pose/javascript/pom.xml
+++ b/maven/cn1-ai-mlkit-pose/javascript/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-pose-javascript</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-pose-javascript</name>
 
     <build>
         <sourceDirectory>src/main/dummy</sourceDirectory>

--- a/maven/cn1-ai-mlkit-pose/javase/pom.xml
+++ b/maven/cn1-ai-mlkit-pose/javase/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-pose-javase</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-pose-javase</name>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/maven/cn1-ai-mlkit-pose/lib/pom.xml
+++ b/maven/cn1-ai-mlkit-pose/lib/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-pose-lib</artifactId>
     <packaging>pom</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-pose-lib</name>
 
     <dependencies>
         <dependency>

--- a/maven/cn1-ai-mlkit-segmentation/android/pom.xml
+++ b/maven/cn1-ai-mlkit-segmentation/android/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-segmentation-android</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-segmentation-android</name>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/maven/cn1-ai-mlkit-segmentation/common/pom.xml
+++ b/maven/cn1-ai-mlkit-segmentation/common/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-segmentation-common</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-segmentation-common</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/maven/cn1-ai-mlkit-segmentation/ios/pom.xml
+++ b/maven/cn1-ai-mlkit-segmentation/ios/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-segmentation-ios</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-segmentation-ios</name>
 
     <build>
         <sourceDirectory>src/main/dummy</sourceDirectory>

--- a/maven/cn1-ai-mlkit-segmentation/javascript/pom.xml
+++ b/maven/cn1-ai-mlkit-segmentation/javascript/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-segmentation-javascript</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-segmentation-javascript</name>
 
     <build>
         <sourceDirectory>src/main/dummy</sourceDirectory>

--- a/maven/cn1-ai-mlkit-segmentation/javase/pom.xml
+++ b/maven/cn1-ai-mlkit-segmentation/javase/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-segmentation-javase</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-segmentation-javase</name>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/maven/cn1-ai-mlkit-segmentation/lib/pom.xml
+++ b/maven/cn1-ai-mlkit-segmentation/lib/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-segmentation-lib</artifactId>
     <packaging>pom</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-segmentation-lib</name>
 
     <dependencies>
         <dependency>

--- a/maven/cn1-ai-mlkit-smartreply/android/pom.xml
+++ b/maven/cn1-ai-mlkit-smartreply/android/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-smartreply-android</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-smartreply-android</name>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/maven/cn1-ai-mlkit-smartreply/common/pom.xml
+++ b/maven/cn1-ai-mlkit-smartreply/common/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-smartreply-common</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-smartreply-common</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/maven/cn1-ai-mlkit-smartreply/ios/pom.xml
+++ b/maven/cn1-ai-mlkit-smartreply/ios/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-smartreply-ios</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-smartreply-ios</name>
 
     <build>
         <sourceDirectory>src/main/dummy</sourceDirectory>

--- a/maven/cn1-ai-mlkit-smartreply/javascript/pom.xml
+++ b/maven/cn1-ai-mlkit-smartreply/javascript/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-smartreply-javascript</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-smartreply-javascript</name>
 
     <build>
         <sourceDirectory>src/main/dummy</sourceDirectory>

--- a/maven/cn1-ai-mlkit-smartreply/javase/pom.xml
+++ b/maven/cn1-ai-mlkit-smartreply/javase/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-smartreply-javase</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-smartreply-javase</name>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/maven/cn1-ai-mlkit-smartreply/lib/pom.xml
+++ b/maven/cn1-ai-mlkit-smartreply/lib/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-smartreply-lib</artifactId>
     <packaging>pom</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-smartreply-lib</name>
 
     <dependencies>
         <dependency>

--- a/maven/cn1-ai-mlkit-text/android/pom.xml
+++ b/maven/cn1-ai-mlkit-text/android/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-text-android</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-text-android</name>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/maven/cn1-ai-mlkit-text/common/pom.xml
+++ b/maven/cn1-ai-mlkit-text/common/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-text-common</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-text-common</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/maven/cn1-ai-mlkit-text/ios/pom.xml
+++ b/maven/cn1-ai-mlkit-text/ios/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-text-ios</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-text-ios</name>
 
     <build>
         <sourceDirectory>src/main/dummy</sourceDirectory>

--- a/maven/cn1-ai-mlkit-text/javascript/pom.xml
+++ b/maven/cn1-ai-mlkit-text/javascript/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-text-javascript</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-text-javascript</name>
 
     <build>
         <sourceDirectory>src/main/dummy</sourceDirectory>

--- a/maven/cn1-ai-mlkit-text/javase/pom.xml
+++ b/maven/cn1-ai-mlkit-text/javase/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-text-javase</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-text-javase</name>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/maven/cn1-ai-mlkit-text/lib/pom.xml
+++ b/maven/cn1-ai-mlkit-text/lib/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-text-lib</artifactId>
     <packaging>pom</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-text-lib</name>
 
     <dependencies>
         <dependency>

--- a/maven/cn1-ai-mlkit-translate/android/pom.xml
+++ b/maven/cn1-ai-mlkit-translate/android/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-translate-android</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-translate-android</name>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/maven/cn1-ai-mlkit-translate/common/pom.xml
+++ b/maven/cn1-ai-mlkit-translate/common/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-translate-common</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-translate-common</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/maven/cn1-ai-mlkit-translate/ios/pom.xml
+++ b/maven/cn1-ai-mlkit-translate/ios/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-translate-ios</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-translate-ios</name>
 
     <build>
         <sourceDirectory>src/main/dummy</sourceDirectory>

--- a/maven/cn1-ai-mlkit-translate/javascript/pom.xml
+++ b/maven/cn1-ai-mlkit-translate/javascript/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-translate-javascript</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-translate-javascript</name>
 
     <build>
         <sourceDirectory>src/main/dummy</sourceDirectory>

--- a/maven/cn1-ai-mlkit-translate/javase/pom.xml
+++ b/maven/cn1-ai-mlkit-translate/javase/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-translate-javase</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-translate-javase</name>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/maven/cn1-ai-mlkit-translate/lib/pom.xml
+++ b/maven/cn1-ai-mlkit-translate/lib/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-mlkit-translate-lib</artifactId>
     <packaging>pom</packaging>
+    <name>Codename One AI: cn1-ai-mlkit-translate-lib</name>
 
     <dependencies>
         <dependency>

--- a/maven/cn1-ai-stablediffusion/android/pom.xml
+++ b/maven/cn1-ai-stablediffusion/android/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-stablediffusion-android</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-stablediffusion-android</name>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/maven/cn1-ai-stablediffusion/common/pom.xml
+++ b/maven/cn1-ai-stablediffusion/common/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-stablediffusion-common</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-stablediffusion-common</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/maven/cn1-ai-stablediffusion/ios/pom.xml
+++ b/maven/cn1-ai-stablediffusion/ios/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-stablediffusion-ios</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-stablediffusion-ios</name>
 
     <build>
         <sourceDirectory>src/main/dummy</sourceDirectory>

--- a/maven/cn1-ai-stablediffusion/javascript/pom.xml
+++ b/maven/cn1-ai-stablediffusion/javascript/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-stablediffusion-javascript</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-stablediffusion-javascript</name>
 
     <build>
         <sourceDirectory>src/main/dummy</sourceDirectory>

--- a/maven/cn1-ai-stablediffusion/javase/pom.xml
+++ b/maven/cn1-ai-stablediffusion/javase/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-stablediffusion-javase</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-stablediffusion-javase</name>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/maven/cn1-ai-stablediffusion/lib/pom.xml
+++ b/maven/cn1-ai-stablediffusion/lib/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-stablediffusion-lib</artifactId>
     <packaging>pom</packaging>
+    <name>Codename One AI: cn1-ai-stablediffusion-lib</name>
 
     <dependencies>
         <dependency>

--- a/maven/cn1-ai-tflite/android/pom.xml
+++ b/maven/cn1-ai-tflite/android/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-tflite-android</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-tflite-android</name>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/maven/cn1-ai-tflite/common/pom.xml
+++ b/maven/cn1-ai-tflite/common/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-tflite-common</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-tflite-common</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/maven/cn1-ai-tflite/ios/pom.xml
+++ b/maven/cn1-ai-tflite/ios/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-tflite-ios</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-tflite-ios</name>
 
     <build>
         <sourceDirectory>src/main/dummy</sourceDirectory>

--- a/maven/cn1-ai-tflite/javascript/pom.xml
+++ b/maven/cn1-ai-tflite/javascript/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-tflite-javascript</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-tflite-javascript</name>
 
     <build>
         <sourceDirectory>src/main/dummy</sourceDirectory>

--- a/maven/cn1-ai-tflite/javase/pom.xml
+++ b/maven/cn1-ai-tflite/javase/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-tflite-javase</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-tflite-javase</name>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/maven/cn1-ai-tflite/lib/pom.xml
+++ b/maven/cn1-ai-tflite/lib/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-tflite-lib</artifactId>
     <packaging>pom</packaging>
+    <name>Codename One AI: cn1-ai-tflite-lib</name>
 
     <dependencies>
         <dependency>

--- a/maven/cn1-ai-whisper/android/pom.xml
+++ b/maven/cn1-ai-whisper/android/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-whisper-android</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-whisper-android</name>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/maven/cn1-ai-whisper/common/pom.xml
+++ b/maven/cn1-ai-whisper/common/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-whisper-common</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-whisper-common</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/maven/cn1-ai-whisper/ios/pom.xml
+++ b/maven/cn1-ai-whisper/ios/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-whisper-ios</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-whisper-ios</name>
 
     <build>
         <sourceDirectory>src/main/dummy</sourceDirectory>

--- a/maven/cn1-ai-whisper/javascript/pom.xml
+++ b/maven/cn1-ai-whisper/javascript/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-whisper-javascript</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-whisper-javascript</name>
 
     <build>
         <sourceDirectory>src/main/dummy</sourceDirectory>

--- a/maven/cn1-ai-whisper/javase/pom.xml
+++ b/maven/cn1-ai-whisper/javase/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-whisper-javase</artifactId>
     <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-whisper-javase</name>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/maven/cn1-ai-whisper/lib/pom.xml
+++ b/maven/cn1-ai-whisper/lib/pom.xml
@@ -12,6 +12,7 @@
 
     <artifactId>cn1-ai-whisper-lib</artifactId>
     <packaging>pom</packaging>
+    <name>Codename One AI: cn1-ai-whisper-lib</name>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
## Summary

- The 7.0.245 release ([workflow run](https://github.com/codenameone/CodenameOne/actions/runs/26621203950)) failed because Sonatype Central rejected the bundle with `Project name is missing` for 78 of the new `cn1-ai-*` child POMs.
- The aggregator POMs (`maven/cn1-ai-*/pom.xml`) carried `<name>`, but every `common`, `ios`, `android`, `javase`, `javascript`, and `lib` child was missing it. Maven does not inherit `<name>` from a parent, so the whole reactor bundle failed validation as a unit and nothing reached Maven Central.
- Added `<name>Codename One AI: ${artifactId}</name>` to each affected child POM, matching the aggregator naming convention. Other publish-required descriptors (description, url, scm, licenses, developers) are inherited from the root POM and were not flagged by Sonatype.

## Verification

- `xmllint` xpath check across `maven/cn1-ai-*/**/pom.xml`: 91 of 91 now have a top-level `<name>` (was 13 of 91 before).
- Spot-checked POMs are still well-formed XML (`xmllint --noout`).
- Diff is mechanical: exactly one inserted line per file (78 files, 78 insertions).

## Test plan

- [ ] After merge, cut a fresh release tag (e.g. `7.0.246`) — Sonatype will not accept a republish of the `7.0.245` coordinates.
- [ ] Watch the `Release on Maven Central` workflow: the central-publishing step should complete validation, and the safety-net poll should confirm the artifact within ~30 min.
- [ ] Confirm the `Website CN1 Version PR` workflow runs to completion (it polls for `codenameone-maven-plugin` on Maven Central).

🤖 Generated with [Claude Code](https://claude.com/claude-code)