### PR TITLE
Fix lightweight Picker traversal controls when non-traversable

### DIFF
--- a/CodenameOne/src/com/codename1/ui/spinner/Picker.java
+++ b/CodenameOne/src/com/codename1/ui/spinner/Picker.java
@@ -622,7 +622,7 @@ public class Picker extends Button {
 
                     Component next = null;
                     Form f = getComponentForm();
-                    if (f != null) {
+                    if (f != null && Picker.this.isTraversable()) {
                         if (command == COMMAND_NEXT) {
                             next = f.getNextComponent(Picker.this);
                         } else if (command == COMMAND_PREV) {
@@ -791,7 +791,7 @@ public class Picker extends Button {
                 //        getNextFocusDown() != null ? getNextFocusDown() :
                 //        null;
                 ListIterator<Component> traversalIt = getComponentForm().getTabIterator(Picker.this);
-                if (traversalIt.hasNext()) {
+                if (Picker.this.isTraversable() && traversalIt.hasNext()) {
                     nextButton = new Button("", isTablet ? "PickerButtonTablet" : "PickerButton");
                     // Javascript port needs to know that this button is going to try to
                     // focus a text field (possibly) so that it can prepare the text field
@@ -812,7 +812,7 @@ public class Picker extends Button {
 
                 Button prevButton = null;
 
-                if (traversalIt.hasPrevious()) {
+                if (Picker.this.isTraversable() && traversalIt.hasPrevious()) {
                     prevButton = new Button("", isTablet ? "PickerButtonTablet" : "PickerButton");
 
                     // Javascript port needs to know that this button is going to try to


### PR DESCRIPTION
### Summary
- Hide lightweight `Picker` next/previous controls when the picker itself is not traversable.
- Prevent lightweight picker next/previous commands from moving focus out of a non-traversable picker.
- Keep the lightweight popup behavior aligned with `Component#setTraversable(false)` / preferred tab index traversal.

### Problem
`Picker` defaults into the focus traversal order by setting a preferred tab index in its constructor. Applications can opt a picker out of traversal via `setTraversable(false)`, which makes the component absent from the form's tab iterator.

The lightweight picker popup still calls `Form#getTabIterator(Picker.this)` to decide whether to show previous/next buttons. When the picker has been made non-traversable, the tab iterator cannot find it and initializes its current position to `-1`. In that state `hasNext()` may still return the first traversable component in the form, and `hasPrevious()` may return the last traversable component. As a result, the lightweight popup can display traversal controls even though the picker opted out of traversal.

Pressing one of those controls then calls `getNextComponent(Picker.this)` / `getPreviousComponent(Picker.this)`, requests focus on an unrelated component, and starts editing it. On Android this can surface as an unexpected native text editor appearing for a later `TextField` immediately after the picker closes.

### Fix
Gate both sides of the lightweight picker traversal behavior on `Picker.this.isTraversable()`:

- the previous/next buttons are only created for traversable pickers;
- `COMMAND_NEXT` / `COMMAND_PREV` only attempt focus transfer for traversable pickers.

This preserves the existing traversal behavior for normal traversable pickers while respecting applications that explicitly call `setTraversable(false)`.

### Verification
- Reproduced in an Android app with a lightweight string `Picker` followed by numeric `TextField`s.
- Before this patch: `picker.setTraversable(false)` still shows the previous/next arrow buttons; pressing an arrow closes the picker and starts editing a numeric text field.
- With this patch: non-traversable lightweight pickers do not expose or execute previous/next traversal controls.
- Ran `git diff --check` on the branch.