### PR TITLE
Defer lightweight Picker traversal editing until dismiss completes

### DIFF
--- a/CodenameOne/src/com/codename1/ui/spinner/Picker.java
+++ b/CodenameOne/src/com/codename1/ui/spinner/Picker.java
@@ -596,7 +596,6 @@ public class Picker extends Button {
                     currentSpinner = null;
                 }
                 restoreContentPane();
-                dlg.disposeToTheBottom();
                 if (command == COMMAND_CANCEL) {
                     // Roll back any setX calls made while the popup was showing
                     // (e.g. a custom "+7 days" button) so getDate() returns the
@@ -609,6 +608,7 @@ public class Picker extends Button {
                     preEditValue = null;
                     preEditDateValueExplicitlySet = false;
                     updateValue();
+                    dlg.disposeToTheBottom();
                 } else {
                     preEditValue = null;
                     preEditDateValueExplicitlySet = false;
@@ -629,9 +629,17 @@ public class Picker extends Button {
                             next = f.getPreviousComponent(Picker.this);
                         }
                     }
-                    if (next != null) {
-                        next.requestFocus();
-                        next.startEditingAsync();
+                    final Component nextToEdit = next;
+                    if (nextToEdit != null) {
+                        dlg.disposeToTheBottom(new Runnable() {
+                            @Override
+                            public void run() {
+                                nextToEdit.requestFocus();
+                                nextToEdit.startEditingAsync();
+                            }
+                        });
+                    } else {
+                        dlg.disposeToTheBottom();
                     }
                 }
             }


### PR DESCRIPTION
### Summary
- Defer lightweight `Picker` previous/next focus transfer until the popup dismiss animation has completed.
- Start editing the next component from the `disposeToTheBottom()` completion callback instead of immediately after requesting the dismiss.

### Problem
The lightweight `Picker` supports previous/next traversal buttons. When a traversal button is pressed, `endEditing()` currently calls `dlg.disposeToTheBottom()` and then immediately requests focus and calls `startEditingAsync()` on the next component.

`InteractionDialog#disposeToTheBottom()` is animated. On Android, `startEditingAsync()` creates and positions a native `EditText` overlay for the target `TextField`. If that happens while the picker popup is still being dismissed and the form content pane has only just been restored from the picker padding/invisible-area adjustment, the native editor can be positioned using stale geometry. In a reproduced Android case, traversing from a lightweight picker to a numeric `TextField` opened the numeric keyboard but rendered the field value outside of the field.

### Fix
For traversal commands that resolve to a next/previous component, this patch passes a completion callback to `disposeToTheBottom()` and starts editing only after the lightweight picker has finished dismissing. Cancel and Done without traversal continue to dismiss normally.

This keeps the existing traversal behavior, but avoids starting the next native edit session while the outgoing picker popup is still in its dismiss/layout transition.

### Verification
- Reproduced on Android with a lightweight string `Picker` followed by numeric `TextField`s and `picker.setTraversable(true)`.
- Before this patch: pressing the picker down-arrow to reach a numeric text field opens the keyboard and can render the field value outside the field.
- This patch changes the focus/edit timing so the next editor is created after the picker dismiss callback.
- Ran `git diff --check` on the branch.