### PR TITLE
scripts/initializr: sync template with cn1app-archetype

### DIFF
--- a/scripts/initializr/common/pom.xml
+++ b/scripts/initializr/common/pom.xml
@@ -22,6 +22,12 @@
             <artifactId>codenameone-javase</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.9.3</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
           <artifactId>initializr-ZipSupport</artifactId>
@@ -356,6 +362,19 @@
 
                 <executions>
                     <execution>
+                        <!-- Build-time SVG transcoder: any SVG dropped into
+                             src/main/css/ or src/main/svg/ is compiled into
+                             a GeneratedSVGImage subclass plus an SVGRegistry,
+                             so theme.css `url(*.svg)` references resolve at
+                             runtime to vector-rendered Image objects on every
+                             port. See docs/developer-guide/svg.md. -->
+                        <id>transcode-svg</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>transcode-svg</goal>
+                        </goals>
+                    </execution>
+                    <execution>
                         <id>generate-gui-sources</id>
                         <phase>process-sources</phase>
                         <goals>
@@ -368,6 +387,12 @@
                         <goals>
                             <goal>bytecode-compliance</goal>
                             <goal>css</goal>
+                            <!-- Scans the project's compiled bytecode for
+                                 @Route declarations and generates the
+                                 dispatcher class consumed by the per-platform
+                                 application stub. No-op for projects with no
+                                 @Route. -->
+                            <goal>process-annotations</goal>
                             <!--<goal>compile-javase-sources</goal>-->
                         </goals>
                     </execution>
@@ -384,6 +409,15 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <!--
+                  Surefire is intentionally skipped in the common module.
+                  Legacy AbstractTest classes run through `cn1:test` (wired
+                  in the javase module's "test" profile). New JUnit 5
+                  tests under src/test/java run from the javase module as
+                  well, which mounts these same sources via
+                  testSourceDirectory. Enabling Surefire here too would
+                  execute every JUnit test twice.
+                  -->
                 <configuration>
                     <skipTests>true</skipTests>
                 </configuration>

--- a/scripts/initializr/javase/pom.xml
+++ b/scripts/initializr/javase/pom.xml
@@ -72,6 +72,12 @@
           <artifactId>codenameone-javase</artifactId>
           <scope>provided</scope>
       </dependency>
+      <dependency>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter</artifactId>
+          <version>5.9.3</version>
+          <scope>test</scope>
+      </dependency>
 
   </dependencies>
   


### PR DESCRIPTION
## Summary

The initializr-served project template had drifted from `maven/cn1app-archetype/src/main/resources/archetype-resources/`, leaving freshly generated projects in a broken state for tests and missing two CN1 plugin features.

- `common/pom.xml` and `javase/pom.xml` were missing the `org.junit.jupiter:junit-jupiter:5.9.3` test-scope dep. Because the generated sample test (`common/src/test/java/.../GreetingFormTest.java`) imports `org.junit.jupiter.api.Test`, `mvn test` from a freshly generated project fails at `testCompile` in `common` with `package org.junit.jupiter.api does not exist`.
- `common/pom.xml` was missing the `codenameone-maven-plugin` `transcode-svg` execution (build-time SVG → `GeneratedSVGImage` transcoder) and the `process-annotations` goal on the `cn1-process-classes` execution (`@Route` dispatcher generation). Both are present in the archetype.

This brings the initializr template in line with the archetype on those points.

## Test plan

- [ ] Generate a fresh project from initializr after this lands, verify `common/src/test/java` JUnit 5 sample compiles and the IDE gutter run-arrow on `GreetingFormTest` resolves all imports.
- [ ] Drop an SVG into `common/src/main/svg/` and confirm a `GeneratedSVGImage` subclass is produced during `process-sources`.
- [ ] Add a class annotated with `@Route` and confirm the dispatcher class is generated during `process-classes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)