### PR TITLE
Update Lifecycle.java getCurrentForm javadoc

### DIFF
--- a/CodenameOne/src/com/codename1/system/Lifecycle.java
+++ b/CodenameOne/src/com/codename1/system/Lifecycle.java
@@ -146,8 +146,19 @@ public class Lifecycle {
     /// Callback when the app is destroyed
     public void destroy() {
     }
-
-    /// The current form within the application lifecycle which possibly differs from the one in the implementation
+    
+    /// Returns the form currently stored by this `Lifecycle` instance for
+    /// application resume handling.
+    ///
+    /// In most application code, use `CN.getCurrentForm()` instead, as it returns
+    /// the form that is actually displayed on the screen. This method is only useful
+    /// when subclassing `Lifecycle` and you need to inspect or customize the form
+    /// remembered by `stop()` and restored by `start()`, which may differ from the
+    /// form currently displayed by the Codename One implementation.
+    ///
+    /// #### Returns
+    ///
+    /// the form stored in this lifecycle, or `null` if no form has been stored
     protected Form getCurrentForm() {
         return current;
     }


### PR DESCRIPTION
I am clarifying this JavaDoc primarily for AI agents rather than humans. In one of my applications, the generative AI confused Lifecycle.getCurrentForm() with CN.getCurrentForm(). Clearly specifying the difference in the JavaDoc can help prevent this issue.