### PR TITLE
Fix #1243: getShortWeekdays() now uses English keys after localization

### DIFF
--- a/CodenameOne/src/com/codename1/l10n/DateFormatSymbols.java
+++ b/CodenameOne/src/com/codename1/l10n/DateFormatSymbols.java
@@ -261,7 +261,11 @@ public class DateFormatSymbols implements Cloneable {
     public String[] getShortWeekdays() {
         synchronized (this) {
             if (shortWeekdays == null) {
-                shortWeekdays = createShortforms(getWeekdays(), L10N_WEEKDAY_SHORTNAME);
+                // Pass the English WEEKDAYS array (not the already-localized
+                // getWeekdays()) so resource-bundle lookups use the documented
+                // WEEKDAY_SHORTNAME_<EnglishDay> key. Matches getShortMonths().
+                // See https://github.com/codenameone/CodenameOne/issues/1243
+                shortWeekdays = createShortforms(WEEKDAYS, L10N_WEEKDAY_SHORTNAME);
             }
         }
         return shortWeekdays;

--- a/Ports/CLDC11/src/java/text/DateFormatSymbols.java
+++ b/Ports/CLDC11/src/java/text/DateFormatSymbols.java
@@ -163,7 +163,9 @@ public class DateFormatSymbols implements Cloneable {
 	public String[] getShortWeekdays() {
 		synchronized (this) {
 			if (shortWeekdays == null) {
-				shortWeekdays = createShortforms(getWeekdays(), L10N_WEEKDAY_SHORTNAME);
+				// Pass the English WEEKDAYS so resource-bundle lookups use the
+				// documented WEEKDAY_SHORTNAME_<EnglishDay> key. See #1243.
+				shortWeekdays = createShortforms(WEEKDAYS, L10N_WEEKDAY_SHORTNAME);
 			}
 		}
 		return shortWeekdays;

--- a/maven/core-unittests/src/test/java/com/codename1/l10n/DateFormatSymbolsTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/l10n/DateFormatSymbolsTest.java
@@ -1,0 +1,87 @@
+package com.codename1.l10n;
+
+import com.codename1.junit.UITestBase;
+import java.util.Calendar;
+import java.util.Hashtable;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression tests for {@link DateFormatSymbols}.
+ */
+class DateFormatSymbolsTest extends UITestBase {
+
+    /**
+     * Regression test for
+     * <a href="https://github.com/codenameone/CodenameOne/issues/1243">#1243</a>
+     * — getShortWeekdays() must look up resource-bundle keys by the English
+     * weekday name (the documented {@code WEEKDAY_SHORTNAME_<DAY>} key), not by
+     * the already-localized long name. Otherwise a Dutch user supplying
+     * {@code WEEKDAY_LONGNAME_MONDAY=maandag} and
+     * {@code WEEKDAY_SHORTNAME_MONDAY=ma} would see "maa" (the first three
+     * characters of the long name) instead of "ma".
+     */
+    @Test
+    void getShortWeekdaysUsesEnglishKeyAfterLocalization() {
+        Hashtable<String, String> bundle = new Hashtable<String, String>();
+        bundle.put("WEEKDAY_LONGNAME_MONDAY", "maandag");
+        bundle.put("WEEKDAY_SHORTNAME_MONDAY", "ma");
+        bundle.put("WEEKDAY_LONGNAME_TUESDAY", "dinsdag");
+        bundle.put("WEEKDAY_SHORTNAME_TUESDAY", "di");
+
+        DateFormatSymbols symbols = new DateFormatSymbols();
+        symbols.setResourceBundle(bundle);
+
+        String[] shortWeekdays = symbols.getShortWeekdays();
+
+        // Weekday array is Sunday-first per the DateFormatSymbols / Calendar
+        // convention: index 0 = Sunday, 1 = Monday, ...
+        assertEquals("ma", shortWeekdays[Calendar.MONDAY - 1],
+                "Localized short weekday must come from WEEKDAY_SHORTNAME_MONDAY, "
+                        + "not from a derived prefix of the long name 'maandag'");
+        assertEquals("di", shortWeekdays[Calendar.TUESDAY - 1],
+                "Localized short weekday must come from WEEKDAY_SHORTNAME_TUESDAY, "
+                        + "not from a derived prefix of the long name 'dinsdag'");
+    }
+
+    /**
+     * Sanity check: the long weekday lookup itself was already correct in the
+     * 2015 report — this test guards against a regression in the (unrelated)
+     * {@link DateFormatSymbols#getWeekdays()} behaviour while fixing
+     * {@link DateFormatSymbols#getShortWeekdays()}.
+     */
+    @Test
+    void getWeekdaysReturnsLocalizedLongNames() {
+        Hashtable<String, String> bundle = new Hashtable<String, String>();
+        bundle.put("WEEKDAY_LONGNAME_MONDAY", "maandag");
+
+        DateFormatSymbols symbols = new DateFormatSymbols();
+        symbols.setResourceBundle(bundle);
+
+        assertEquals("maandag", symbols.getWeekdays()[Calendar.MONDAY - 1]);
+    }
+
+    /**
+     * When the resource bundle has only the long name but no short name, the
+     * code should fall back to the English-derived prefix (first three
+     * characters of the English weekday name), not the prefix of the localized
+     * long name. This matches what {@link DateFormatSymbols#getShortMonths()}
+     * already does for months.
+     */
+    @Test
+    void getShortWeekdaysFallsBackToEnglishPrefixWhenShortKeyMissing() {
+        Hashtable<String, String> bundle = new Hashtable<String, String>();
+        bundle.put("WEEKDAY_LONGNAME_MONDAY", "maandag");
+        // intentionally no WEEKDAY_SHORTNAME_MONDAY
+
+        DateFormatSymbols symbols = new DateFormatSymbols();
+        symbols.setResourceBundle(bundle);
+
+        // Before the fix this would be "maa" (prefix of the localized name).
+        // After the fix it is "Mon" (prefix of the English name) — which is
+        // the same behaviour {@link DateFormatSymbols#getShortMonths()} has
+        // exhibited all along when the SHORTNAME key is missing.
+        assertEquals("Mon", symbols.getShortWeekdays()[Calendar.MONDAY - 1]);
+    }
+}

--- a/vm/JavaAPI/src/java/text/DateFormatSymbols.java
+++ b/vm/JavaAPI/src/java/text/DateFormatSymbols.java
@@ -166,7 +166,9 @@ public class DateFormatSymbols implements Cloneable {
 	public String[] getShortWeekdays() {
 		synchronized (this) {
 			if (shortWeekdays == null) {
-				shortWeekdays = createShortforms(getWeekdays(), L10N_WEEKDAY_SHORTNAME);
+				// Pass the English WEEKDAYS so resource-bundle lookups use the
+				// documented WEEKDAY_SHORTNAME_<EnglishDay> key. See #1243.
+				shortWeekdays = createShortforms(WEEKDAYS, L10N_WEEKDAY_SHORTNAME);
 			}
 		}
 		return shortWeekdays;


### PR DESCRIPTION
## Summary

- Closes the **oldest open issue** in the tracker: [#1243](https://github.com/codenameone/CodenameOne/issues/1243), filed 2014-12-28 (originally code.google.com/p/codenameone/issues/detail?id=1244, migrated to GitHub on 2015-03-27).
- `DateFormatSymbols.getShortWeekdays()` was looking up resource-bundle keys by the **localized long name** instead of by the documented English-key constant. With a Dutch bundle of `WEEKDAY_LONGNAME_MONDAY=maandag` + `WEEKDAY_SHORTNAME_MONDAY=ma`, `getShortWeekdays()` returned `"maa"` (the first three characters of the long name) instead of `"ma"`.
- One-line fix in [`com.codename1.l10n.DateFormatSymbols`](https://github.com/codenameone/CodenameOne/blob/master/CodenameOne/src/com/codename1/l10n/DateFormatSymbols.java): pass the English `WEEKDAYS` array to `createShortforms` — exactly the way [`getShortMonths()`](https://github.com/codenameone/CodenameOne/blob/master/CodenameOne/src/com/codename1/l10n/DateFormatSymbols.java#L302) already passes `MONTHS`. The reporter pinpointed this fix in the original issue body.
- Same fix applied to the two sibling JDK-API copies under [`Ports/CLDC11/src/java/text/DateFormatSymbols.java`](https://github.com/codenameone/CodenameOne/blob/master/Ports/CLDC11/src/java/text/DateFormatSymbols.java) and [`vm/JavaAPI/src/java/text/DateFormatSymbols.java`](https://github.com/codenameone/CodenameOne/blob/master/vm/JavaAPI/src/java/text/DateFormatSymbols.java) so behaviour is consistent across the core framework, the J2ME-style port and the ParparVM Java API.
- Adds [`maven/core-unittests/.../DateFormatSymbolsTest.java`](https://github.com/codenameone/CodenameOne/blob/master/maven/core-unittests/src/test/java/com/codename1/l10n/DateFormatSymbolsTest.java) with three cases:
  1. `getShortWeekdaysUsesEnglishKeyAfterLocalization` — the original 2014 repro from #1243. Fails on master with `expected: <ma> but was: <maa>`.
  2. `getWeekdaysReturnsLocalizedLongNames` — sanity check that the long-name path is untouched.
  3. `getShortWeekdaysFallsBackToEnglishPrefixWhenShortKeyMissing` — the no-shortname-key fallback now returns `"Mon"` (the English prefix) instead of `"maa"` (the localized prefix), matching what `getShortMonths()` has always done for months.

## Test plan

- [x] `mvn -pl core-unittests -Dtest=DateFormatSymbolsTest test` — 3/3 pass after the fix; before the fix, 2/3 failed with the exact symptoms the 2014 reporter described.
- [x] `mvn -pl core-unittests -Dtest='SimpleDateFormatTest,DateFormatPatternsTest,SimpleDateFormatTestTest,DateFormatTest2772PortTest,DateFormatSymbolsTest' test` — all 17 date-related tests still green, no regressions.
- [ ] CI verification.

## Behaviour change for consumers without a resource bundle

When no resource bundle is set, `getShortWeekdays()` now returns `["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]` (the prefix of the English long name). This matches the existing `getShortMonths()` behaviour and the JDK's own US-English defaults. It is the same string that the buggy code already produced for an English bundle, so apps relying on the English defaults are unaffected. Apps that have been observing the old buggy behaviour for a non-English bundle (truncated localized long names) will now correctly resolve their `WEEKDAY_SHORTNAME_*` keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)