### PR TITLE
Fix Metal stencil mismatch in mutable-image seed pass (#5103)

### DIFF
--- a/Ports/iOSPort/nativeSources/CN1Metalcompat.m
+++ b/Ports/iOSPort/nativeSources/CN1Metalcompat.m
@@ -1431,7 +1431,32 @@ void CN1MetalEnsureMutableTexture(GLUIImage *image, int width, int height) {
                 seedPass.colorAttachments[0].texture = tex;
                 seedPass.colorAttachments[0].loadAction = MTLLoadActionLoad;
                 seedPass.colorAttachments[0].storeAction = MTLStoreActionStore;
+                // Pipelines in CN1MetalPipelineCache declare
+                // stencilAttachmentPixelFormat=Stencil8 (polygon-clip #3921),
+                // so every pass that binds one must attach a Stencil8 texture
+                // or Metal aborts in setRenderPipelineState: with a pixel-
+                // format mismatch (issue #5103). The seed draw never engages
+                // the stencil test, so a throwaway clear-on-load attachment
+                // is sufficient.
+                id<MTLTexture> seedStencilTex = nil;
+                MTLTextureDescriptor *seedStencilDesc = [MTLTextureDescriptor
+                    texture2DDescriptorWithPixelFormat:MTLPixelFormatStencil8
+                    width:(NSUInteger)width height:(NSUInteger)height mipmapped:NO];
+                seedStencilDesc.usage = MTLTextureUsageRenderTarget;
+                seedStencilDesc.storageMode = MTLStorageModePrivate;
+                seedStencilTex = [device newTextureWithDescriptor:seedStencilDesc];
+                if (seedStencilTex != nil) {
+                    seedPass.stencilAttachment.texture = seedStencilTex;
+                    seedPass.stencilAttachment.loadAction = MTLLoadActionClear;
+                    seedPass.stencilAttachment.storeAction = MTLStoreActionDontCare;
+                    seedPass.stencilAttachment.clearStencil = 0;
+                }
                 id<MTLRenderCommandEncoder> seedEnc = [setupCb renderCommandEncoderWithDescriptor:seedPass];
+#ifndef CN1_USE_ARC
+                // renderCommandEncoderWithDescriptor: retains attachments for
+                // the duration of the encoded pass; drop our +1 now.
+                [seedStencilTex release];
+#endif
                 [seedEnc setViewport:(MTLViewport){0.0, 0.0, (double)width, (double)height, 0.0, 1.0}];
                 [seedEnc setRenderPipelineState:seedState];
 


### PR DESCRIPTION
## Summary

- Fixes #5103. iOS apps built with Metal enabled crash to a white screen on the first form that paints a seeded mutable image. The Metal validation layer aborts in `setRenderPipelineState:` with `For stencil attachment, the renderPipelineState pixelFormat must be MTLPixelFormatInvalid, as no texture is set.`
- Root cause: every pipeline in `CN1MetalPipelineCache.m` declares `stencilAttachmentPixelFormat = MTLPixelFormatStencil8` (added with the polygon-clip stencil work in #3921), so every render pass that binds one must attach a Stencil8 texture. The seed pass in `CN1MetalEnsureMutableTexture` (used to carry an existing `UIImage`'s pixels — `gausianBlurImage`, `FontImage` thumbnails, etc. — into a freshly-allocated mutable target) was built with only a colour attachment but then bound the TexturedRGBA pipeline.
- Fix: allocate a throwaway Stencil8 render-target texture for the seed pass, mirroring the pattern already used in `CN1MetalBeginMutableImageDraw` a few lines below. The seed draw never engages the stencil test, so `loadAction=Clear` / `storeAction=DontCare` is sufficient.

The sibling `clearPass` immediately above the seed pass does not need the same fix — it never calls `setRenderPipelineState:` (it just clears the colour attachment and ends the encoder), so the validation rule is not triggered.

## Test plan

- [ ] Build an iOS app (locally via Xcode) on a screen that paints a `FontImage`/`gausianBlurImage`-derived mutable image and confirm the app no longer crashes on the first form.
- [ ] Run the polygon-clip-under-rotation screenshot test from #3921 to confirm the main mutable draw path still renders correctly.
- [ ] Verify no Metal validation warnings appear in the Xcode console during seeded mutable-image draws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)