### PR TITLE
Fix ios.blockScreenshotsOnEnterBackground to hide peer components

### DIFF
--- a/Ports/iOSPort/nativeSources/CodenameOne_GLAppDelegate.m
+++ b/Ports/iOSPort/nativeSources/CodenameOne_GLAppDelegate.m
@@ -216,7 +216,12 @@ static void installSignalHandlers() {
 - (void)cn1ApplicationDidEnterBackground
 {
  #ifdef CN1_BLOCK_SCREENSHOTS_ON_ENTER_BACKGROUND
-    [[CodenameOne_GLViewController instance] eaglView].hidden = YES;
+    // Hide the view controller's root view rather than just the EAGL/Metal
+    // surface. Once a peer component is added with paintPeersBehindEnabled,
+    // the controller's view is a newRoot containing both eaglView and the
+    // peerComponentsLayer (BrowserComponent's WKWebView lives in the latter)
+    // -- hiding only eaglView leaves peers visible in the app-switcher snapshot.
+    [CodenameOne_GLViewController instance].view.hidden = YES;
     cn1IsHiddenInBackground = YES;
 #endif
     if(editingComponent != nil) {
@@ -239,7 +244,7 @@ static void installSignalHandlers() {
 - (void)cn1ApplicationWillEnterForeground
 {
     if (cn1IsHiddenInBackground) {
-        [[CodenameOne_GLViewController instance] eaglView].hidden = NO;
+        [CodenameOne_GLViewController instance].view.hidden = NO;
     }
     // Clear before updateCanvas: viewWillTransitionToSize: and
     // didRotateFromInterfaceOrientation: use this to skip propagation during


### PR DESCRIPTION
## Summary
- `ios.blockScreenshotsOnEnterBackground=true` hid the EAGL/Metal surface on `applicationDidEnterBackground` but left peer components visible, so a `BrowserComponent`'s native `WKWebView` (and any other peer) still showed up in the iOS app-switcher snapshot.
- Once a peer is added with `paintPeersBehindEnabled` (the default), `EAGLView.m` / `METALView.m` re-parents into a `newRoot` that holds `eaglView` and `peerComponentsLayer` as siblings, and points `GLViewController.view` at that `newRoot`.
- Switched the hide/show in `cn1ApplicationDidEnterBackground` / `cn1ApplicationWillEnterForeground` from `eaglView.hidden` to `view.hidden`. When no peers exist `view == eaglView` so behavior is unchanged; when peers exist `view == newRoot` and both children get hidden together.

## Test plan
- [ ] Build an iOS app with `codename1.arg.ios.blockScreenshotsOnEnterBackground=true` and a `BrowserComponent` showing a recognizable page.
- [ ] Background the app (Home / app switcher) and confirm the app-switcher card no longer reveals the BrowserComponent contents.
- [ ] Re-foreground and confirm the UI (both lightweight components and the BrowserComponent) renders normally and remains interactive.
- [ ] Repeat without `paintPeersBehindEnabled` (legacy peer path) to confirm no regression on apps that don't enable peer-behind painting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)