### PR TITLE
Fix #1363: copy calcPreferredSize() result instead of retaining the reference

### DIFF
--- a/CodenameOne/src/com/codename1/ui/Component.java
+++ b/CodenameOne/src/com/codename1/ui/Component.java
@@ -3839,7 +3839,21 @@ public class Component implements Animation, StyleListener, Editable {
                 if (hideInLandscape && !Display.INSTANCE.isPortrait()) {
                     preferredSize = new Dimension(0, 0);
                 } else {
-                    preferredSize = calcPreferredSize();
+                    // Copy values rather than retain the reference returned by
+                    // calcPreferredSize(). Otherwise, subclasses whose
+                    // calcPreferredSize() returns a shared Dimension (e.g.
+                    // ContainerList.Entry returning the renderer's own
+                    // preferredSize field) cause every "cached" preferredSize
+                    // to point at the same instance, so a single re-measure of
+                    // the renderer silently mutates every previously-measured
+                    // entry. See #1363.
+                    Dimension calculated = calcPreferredSize();
+                    if (preferredSize == null) {
+                        preferredSize = new Dimension(calculated.getWidth(), calculated.getHeight());
+                    } else {
+                        preferredSize.setWidth(calculated.getWidth());
+                        preferredSize.setHeight(calculated.getHeight());
+                    }
                     if (preferredSizeStr != null) {
                         Component.parsePreferredSize(preferredSizeStr, preferredSize);
                     }

--- a/maven/core-unittests/src/test/java/com/codename1/ui/ComponentPreferredSizeIsolationTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/ComponentPreferredSizeIsolationTest.java
@@ -1,0 +1,94 @@
+package com.codename1.ui;
+
+import com.codename1.junit.FormTest;
+import com.codename1.junit.UITestBase;
+import com.codename1.ui.geom.Dimension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression tests for
+ * <a href="https://github.com/codenameone/CodenameOne/issues/1363">#1363</a>
+ * — {@link Component#getPreferredSize()} must give each Component its own
+ * {@link Dimension} instance even when their {@code calcPreferredSize()}
+ * implementations all return a shared one (for example, when each entry of a
+ * {@code ContainerList} returns the same renderer component's preferred-size
+ * field).
+ */
+class ComponentPreferredSizeIsolationTest extends UITestBase {
+
+    private static final class FixedSizeComponent extends Component {
+        private final Dimension shared;
+
+        FixedSizeComponent(Dimension shared) {
+            this.shared = shared;
+        }
+
+        @Override
+        protected Dimension calcPreferredSize() {
+            return shared;
+        }
+    }
+
+    /**
+     * Two components whose {@code calcPreferredSize()} returns the same
+     * {@link Dimension} reference must end up with independent preferred-size
+     * instances after the framework caches the result. Otherwise mutating one
+     * component's preferred size (e.g. via the {@code sameWidth}/{@code
+     * sameHeight} alignment path or via a layout) silently mutates the other.
+     */
+    @FormTest
+    void twoComponentsSharingACalcDimensionGetIndependentPreferredSizes() {
+        Dimension shared = new Dimension(40, 20);
+        FixedSizeComponent a = new FixedSizeComponent(shared);
+        FixedSizeComponent b = new FixedSizeComponent(shared);
+
+        Dimension sizeA = a.getPreferredSize();
+        Dimension sizeB = b.getPreferredSize();
+
+        assertEquals(40, sizeA.getWidth());
+        assertEquals(20, sizeA.getHeight());
+        assertEquals(40, sizeB.getWidth());
+        assertEquals(20, sizeB.getHeight());
+
+        assertNotSame(sizeA, sizeB,
+                "Each component must own its preferred-size Dimension; sharing the "
+                        + "instance returned by calcPreferredSize causes #1363.");
+        assertNotSame(shared, sizeA,
+                "The cached preferred-size must not retain a reference to the "
+                        + "Dimension returned from calcPreferredSize, otherwise mutating "
+                        + "the source (e.g. a renderer's own preferredSize field) "
+                        + "silently mutates this component's cached value.");
+    }
+
+    /**
+     * Mutating the {@link Dimension} that {@code calcPreferredSize()} returned
+     * must not silently change the cached preferred size of any component that
+     * has already been measured. This is the failure mode the 2015 reporter
+     * pinpointed in {@code ContainerList.Entry}: the renderer's own
+     * {@code preferredSize} field is reused across entries, so when the
+     * renderer was re-laid-out for the next entry every previously-measured
+     * entry's "cached" size silently changed too.
+     */
+    @FormTest
+    void mutatingCalcSourceDoesNotAlterCachedPreferredSize() {
+        Dimension shared = new Dimension(40, 20);
+        FixedSizeComponent c = new FixedSizeComponent(shared);
+
+        Dimension cached = c.getPreferredSize();
+        assertEquals(40, cached.getWidth());
+        assertEquals(20, cached.getHeight());
+
+        // Simulate the renderer being re-measured for the next entry.
+        shared.setWidth(999);
+        shared.setHeight(888);
+
+        Dimension after = c.getPreferredSize();
+        assertEquals(40, after.getWidth(),
+                "Cached preferred width changed underneath us because the framework "
+                        + "kept a reference to the Dimension returned by calcPreferredSize.");
+        assertEquals(20, after.getHeight(),
+                "Cached preferred height changed underneath us because the framework "
+                        + "kept a reference to the Dimension returned by calcPreferredSize.");
+    }
+}


### PR DESCRIPTION
## Summary

Closes [#1363](https://github.com/codenameone/CodenameOne/issues/1363) — the next-oldest open issue (filed Feb 2015, 9 comments).

[`Component.preferredSizeImpl()`](https://github.com/codenameone/CodenameOne/blob/master/CodenameOne/src/com/codename1/ui/Component.java#L3833) cached the `Dimension` instance returned from `calcPreferredSize()` directly. When a subclass's `calcPreferredSize()` returns a shared `Dimension` — for example [`ContainerList.Entry.calcPreferredSize()`](https://github.com/codenameone/CodenameOne/blob/master/CodenameOne/src/com/codename1/ui/list/ContainerList.java#L470) returning the single renderer's own `preferredSize` field — every entry's "cached" preferred size ends up pointing at the same instance. The next time the renderer is re-measured (for the next entry), every previously-measured entry's cached size silently changes too, and all entries collapse to the most recently computed size. That's the failure mode the 2015 reporter pinpointed in comment #3.

The fix is what the reporter proposed in their first comment: copy the width/height into the component's own `Dimension` instead of swapping the reference. To keep callers that have already retained `getPreferredSize()` working (so they observe the updated values rather than a stale snapshot), we update the existing `Dimension` in place on re-measure and only allocate on the first measure.

## Test plan

- [x] New regression test [`ComponentPreferredSizeIsolationTest`](https://github.com/codenameone/CodenameOne/blob/fix-1363-preferred-size-shared-instance/maven/core-unittests/src/test/java/com/codename1/ui/ComponentPreferredSizeIsolationTest.java) covers two cases:
  1. Two components whose `calcPreferredSize()` returns the same `Dimension` end up with independent preferred-size instances (`assertNotSame`).
  2. Mutating the source `Dimension` after the first `getPreferredSize()` call does not alter the cached value.
- [x] Before the fix both tests fail on master with the exact symptoms (`expected: <40> but was: <999>` and `expected: not same but was: <width = 40 height = 20>`).
- [x] After the fix both tests pass.
- [x] **No regressions across 334 tests** spanning `Component`, `Container`, `InputComponent`, the full layout suite (Box/Border/Flow/Grid/Layered/Coordinate/Group/Mig/Table), `ContainerList` and the existing #3000 SpanLabel/LayeredLayout preferred-size regression.
- [ ] CI verification.

## Behaviour change for consumers

- Components whose `calcPreferredSize()` returns a unique `Dimension` every call (the vast majority — `Label.calcPreferredSize()` for example uses `getUIManager().getLookAndFeel().getLabelPreferredSize(this)` which returns a fresh `Dimension`) see no observable change.
- Components whose `calcPreferredSize()` returns a shared `Dimension` (the rare case that triggered #1363) now correctly get their own cached values that don't mutate from under them.
- Callers that hold a long-lived reference to `getPreferredSize()` continue to observe live values because we update the cached `Dimension` in place rather than swapping the reference on re-measure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)