### PR TITLE
Fix #1399: setAlwaysTensile(true) now works on the X axis too

### DIFF
--- a/CodenameOne/src/com/codename1/ui/Component.java
+++ b/CodenameOne/src/com/codename1/ui/Component.java
@@ -8228,7 +8228,7 @@ public class Component implements Animation, StyleListener, Editable {
     /// {@link #isAlwaysTensile()} dependency on {@link #isScrollableX()}.
     /// Used by {@link Container#isScrollableX()} so the X axis can honour
     /// {@code setAlwaysTensile(true)} (matching {@link Container#isScrollableY()})
-    /// without recursing through {@code isAlwaysTensile()} -&gt; {@code isScrollableX()}.
+    /// without recursing through {@code isAlwaysTensile()} -> {@code isScrollableX()}.
     boolean alwaysTensileFlag() {
         return alwaysTensile;
     }

--- a/CodenameOne/src/com/codename1/ui/Component.java
+++ b/CodenameOne/src/com/codename1/ui/Component.java
@@ -8224,6 +8224,15 @@ public class Component implements Animation, StyleListener, Editable {
         return alwaysTensile && !isScrollableX() || (refreshTask != null && !InfiniteProgress.isDefaultMaterialDesignMode());
     }
 
+    /// Raw view of the {@code alwaysTensile} flag, without the
+    /// {@link #isAlwaysTensile()} dependency on {@link #isScrollableX()}.
+    /// Used by {@link Container#isScrollableX()} so the X axis can honour
+    /// {@code setAlwaysTensile(true)} (matching {@link Container#isScrollableY()})
+    /// without recursing through {@code isAlwaysTensile()} → {@code isScrollableX()}.
+    boolean alwaysTensileFlag() {
+        return alwaysTensile;
+    }
+
     /// Enable the tensile drag to work even when a component doesn't have a scroll showable (scrollable flag still needs to be set to true)
     ///
     /// #### Parameters

--- a/CodenameOne/src/com/codename1/ui/Component.java
+++ b/CodenameOne/src/com/codename1/ui/Component.java
@@ -8228,7 +8228,7 @@ public class Component implements Animation, StyleListener, Editable {
     /// {@link #isAlwaysTensile()} dependency on {@link #isScrollableX()}.
     /// Used by {@link Container#isScrollableX()} so the X axis can honour
     /// {@code setAlwaysTensile(true)} (matching {@link Container#isScrollableY()})
-    /// without recursing through {@code isAlwaysTensile()} → {@code isScrollableX()}.
+    /// without recursing through {@code isAlwaysTensile()} -&gt; {@code isScrollableX()}.
     boolean alwaysTensileFlag() {
         return alwaysTensile;
     }

--- a/CodenameOne/src/com/codename1/ui/Container.java
+++ b/CodenameOne/src/com/codename1/ui/Container.java
@@ -3265,7 +3265,15 @@ public class Container extends Component implements Iterable<Component> {
     /// {@inheritDoc}
     @Override
     public boolean isScrollableX() {
-        return scrollableX && (getScrollDimension().getWidth() + getStyle().getHorizontalPadding() > getWidth());
+        // Mirror isScrollableY()'s alwaysTensile check so the documented #1399
+        // workaround (setAlwaysTensile(true)) produces visible scroll feedback
+        // on horizontal scrollables whose content fits the container.
+        //
+        // We consult the raw alwaysTensileFlag() rather than isAlwaysTensile()
+        // because the latter calls isScrollableX() (to suppress pull-to-refresh
+        // glow when the X axis is already scrollable), which would recurse
+        // back into us.
+        return scrollableX && (getScrollDimension().getWidth() + getStyle().getHorizontalPadding() > getWidth() || alwaysTensileFlag());
     }
 
     /// Sets whether the component should/could scroll on the X axis

--- a/maven/core-unittests/src/test/java/com/codename1/ui/ScrollableAlwaysTensileTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/ScrollableAlwaysTensileTest.java
@@ -1,0 +1,100 @@
+package com.codename1.ui;
+
+import com.codename1.junit.FormTest;
+import com.codename1.junit.UITestBase;
+import com.codename1.ui.layouts.BoxLayout;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression tests for
+ * <a href="https://github.com/codenameone/CodenameOne/issues/1399">#1399</a>
+ * — a scrollable Container whose content is smaller than the container itself
+ * should still produce scroll feedback when the user explicitly opts in via
+ * {@link Component#setAlwaysTensile(boolean)} (the workaround documented in
+ * the 2015 issue thread). The Y axis has always honoured {@code alwaysTensile}
+ * in {@link Container#isScrollableY()}; the X axis did not.
+ */
+class ScrollableAlwaysTensileTest extends UITestBase {
+
+    @FormTest
+    void containerIsNotScrollableYByDefaultWhenContentFits() {
+        Container c = new Container(BoxLayout.y());
+        c.setScrollableY(true);
+        Label small = new Label("hi");
+        small.setPreferredW(40);
+        small.setPreferredH(20);
+        c.add(small);
+        c.setWidth(400);
+        c.setHeight(800);
+        c.layoutContainer();
+
+        assertFalse(c.isScrollableY(),
+                "By design, when content fits the container is not 'scrollable' "
+                        + "and produces no scroll feedback. The documented workaround "
+                        + "for #1399 is setAlwaysTensile(true).");
+    }
+
+    @FormTest
+    void alwaysTensileMakesScrollableYTrueWhenContentFits() {
+        Container c = new Container(BoxLayout.y());
+        c.setScrollableY(true);
+        c.setAlwaysTensile(true);
+        Label small = new Label("hi");
+        small.setPreferredW(40);
+        small.setPreferredH(20);
+        c.add(small);
+        c.setWidth(400);
+        c.setHeight(800);
+        c.layoutContainer();
+
+        assertTrue(c.isScrollableY(),
+                "With setAlwaysTensile(true) and scrollableY=true, the container "
+                        + "must report as scrollable so paintScrollbars() and "
+                        + "pointerDragged() run during tensile feedback.");
+    }
+
+    @FormTest
+    void alwaysTensileMakesScrollableXTrueWhenContentFits() {
+        // The 2015 fix in Container.isScrollableY() that added an
+        // isAlwaysTensile() check was never mirrored to isScrollableX(). The
+        // documented #1399 workaround therefore had no effect on the X axis:
+        // setScrollableX(true) + setAlwaysTensile(true) with narrow content
+        // still reported isScrollableX() == false, so no scrollbar paint and
+        // no drag activation. After the fix both axes behave the same.
+        Container c = new Container(new com.codename1.ui.layouts.FlowLayout());
+        c.setScrollableX(true);
+        c.setAlwaysTensile(true);
+        Label small = new Label("hi");
+        small.setPreferredW(40);
+        small.setPreferredH(20);
+        c.add(small);
+        c.setWidth(800);
+        c.setHeight(200);
+        c.layoutContainer();
+
+        assertTrue(c.isScrollableX(),
+                "With setAlwaysTensile(true) and scrollableX=true, the container "
+                        + "must report as scrollable on the X axis just like "
+                        + "isScrollableY() already does, otherwise the documented "
+                        + "#1399 workaround has no effect on horizontal scrollables.");
+    }
+
+    @FormTest
+    void isScrollableXStillFalseWhenAlwaysTensileFalse() {
+        // Sanity check: the alwaysTensile override must not regress the
+        // non-alwaysTensile case. When content fits and alwaysTensile is off,
+        // isScrollableX() must still report false.
+        Container c = new Container(new com.codename1.ui.layouts.FlowLayout());
+        c.setScrollableX(true);
+        Label small = new Label("hi");
+        small.setPreferredW(40);
+        small.setPreferredH(20);
+        c.add(small);
+        c.setWidth(800);
+        c.setHeight(200);
+        c.layoutContainer();
+
+        assertFalse(c.isScrollableX());
+    }
+}

--- a/maven/core-unittests/src/test/java/com/codename1/ui/ScrollableAlwaysTensileTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/ScrollableAlwaysTensileTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Regression tests for
  * <a href="https://github.com/codenameone/CodenameOne/issues/1399">#1399</a>
- * — a scrollable Container whose content is smaller than the container itself
+ * -- a scrollable Container whose content is smaller than the container itself
  * should still produce scroll feedback when the user explicitly opts in via
  * {@link Component#setAlwaysTensile(boolean)} (the workaround documented in
  * the 2015 issue thread). The Y axis has always honoured {@code alwaysTensile}


### PR DESCRIPTION
## Summary

Closes [#1399](https://github.com/codenameone/CodenameOne/issues/1399) — the next-oldest open issue (filed March 2015).

The 2015 reporter complained that a scrollable Container whose content fits the container shows no scrollbars or edge highlight on drag. Shai's response in [comment #2](https://github.com/codenameone/CodenameOne/issues/1399#issuecomment-...) was:

> you can call: `containerList.setAlwaysTensile(true);` Which will show the scrollbars. Changing implementation to show the glow seems like a very complex task, I don't think this fix worth the risk in changing code in this critical area. I am leaving this open but lowering the priority.

The Y axis already honours that workaround in [`Container.isScrollableY()`](https://github.com/codenameone/CodenameOne/blob/master/CodenameOne/src/com/codename1/ui/Container.java#L3286): it returns `true` whenever `scrollableY && (...content overflows... || isAlwaysTensile())`. The matching check was never added to [`Container.isScrollableX()`](https://github.com/codenameone/CodenameOne/blob/master/CodenameOne/src/com/codename1/ui/Container.java#L3267), so the documented workaround had **no effect on horizontal scrollables** — `setScrollableX(true) + setAlwaysTensile(true)` with narrow content still reported `isScrollableX() == false` and produced no paintScrollbars / pointerDragged activation.

## The fix

Mirror the Y-axis check in `isScrollableX()`. The naive `... || isAlwaysTensile()` would loop forever because [`Component.isAlwaysTensile()`](https://github.com/codenameone/CodenameOne/blob/master/CodenameOne/src/com/codename1/ui/Component.java#L8223) calls `isScrollableX()` (to suppress the pull-to-refresh glow when the X axis is already scrollable):

```java
public boolean isAlwaysTensile() {
    return alwaysTensile && !isScrollableX() || (refreshTask != null && !InfiniteProgress.isDefaultMaterialDesignMode());
}
```

So we expose a tiny package-private helper [`Component.alwaysTensileFlag()`](https://github.com/codenameone/CodenameOne/blob/fix-1399-always-tensile-scrollable/CodenameOne/src/com/codename1/ui/Component.java) that returns the raw field. `Container.isScrollableX()` consults that helper rather than the public method. This:

- **Breaks the recursion.**
- **Preserves the existing `isAlwaysTensile()` semantics** used by `Container.isScrollableY()`, the maxScroll override in `Component.pointerDragged()`, the LookAndFeel glow rendering, and `List.pointerSelect()`.
- **Keeps the change surgical** — Shai's 2015 worry about touching scroll code is respected, no painting/dragging code was modified.

## Test plan

- [x] New regression test [`ScrollableAlwaysTensileTest`](https://github.com/codenameone/CodenameOne/blob/fix-1399-always-tensile-scrollable/maven/core-unittests/src/test/java/com/codename1/ui/ScrollableAlwaysTensileTest.java) covers four cases on both axes:
  1. Default (no alwaysTensile) + content fits → `isScrollableY/X == false` (no regression).
  2. `setAlwaysTensile(true) + scrollableY` + content fits → `isScrollableY == true` (existing behaviour, locked in).
  3. `setAlwaysTensile(true) + scrollableX` + content fits → `isScrollableX == true` **(new, was false on master)**.
  4. `alwaysTensile=false + scrollableX` + content fits → `isScrollableX == false` (guard).
- [x] Before the fix, case 3 fails on master with `expected: <true> but was: <false>`.
- [x] After the fix, all 4 pass.
- [x] **No regressions across 448 tests** spanning `Component`, `Container`, the full layout suite, all `*ScrollContainerTest` / `*List*Test` / `InfiniteContainerTest` / `StickyHeaderContainerTest` / `InfiniteScrollAdapterTest`, `FormTest`, every `*FormTest`, and the `LeadComponentScrolling#3079` / `SpanLabelLayeredLayoutPreferredSize#3000` / `LayeredLayoutTest#2751` regression samples.
- [ ] CI verification.

## What this doesn't do (and why)

The original reporter also asked for the X/Y axis to show edge glow ("highlighting to indicate scrolling beyond start/end") when content fits. Shai explicitly declined that in 2015 as too risky for the painting code, and the Android 4.4 device specific failure mentioned in [comment #3](https://github.com/codenameone/CodenameOne/issues/1399#issuecomment-...) is moot today (Android 4.4 is far below the current minimum SDK). This PR only fixes the lingering API gap — making the documented `setAlwaysTensile(true)` workaround work for both axes — without touching the painting/drag handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)