### PR TITLE
Restore Graphics state around paint dispatches (#5102 follow-up)

### DIFF
--- a/CodenameOne/src/com/codename1/ui/Component.java
+++ b/CodenameOne/src/com/codename1/ui/Component.java
@@ -3001,10 +3001,16 @@ public class Component implements Animation, StyleListener, Editable {
             int scrollX = getScrollX();
             int scrollY = getScrollY();
             g.translate(-scrollX, -scrollY);
+            int sColor = g.getColor();
+            int sAlpha = g.getAlpha();
+            Font sFont = g.getFont();
             Display.impl.beginPaintScope(g.getGraphics(), this);
             try {
                 paint(g);
             } finally {
+                g.setColor(sColor);
+                g.setAlpha(sAlpha);
+                g.setFont(sFont);
                 Display.impl.endPaintScope(g.getGraphics(), this);
             }
             g.translate(scrollX, scrollY);
@@ -3012,10 +3018,16 @@ public class Component implements Animation, StyleListener, Editable {
                 paintScrollbars(g);
             }
         } else {
+            int sColor = g.getColor();
+            int sAlpha = g.getAlpha();
+            Font sFont = g.getFont();
             Display.impl.beginPaintScope(g.getGraphics(), this);
             try {
                 paint(g);
             } finally {
+                g.setColor(sColor);
+                g.setAlpha(sAlpha);
+                g.setFont(sFont);
                 Display.impl.endPaintScope(g.getGraphics(), this);
             }
         }
@@ -3405,17 +3417,29 @@ public class Component implements Animation, StyleListener, Editable {
                 rect.getSize().setWidth(par.getWidth());
                 rect.getSize().setHeight(par.getHeight());
             }
+            int sColor = g.getColor();
+            int sAlpha = g.getAlpha();
+            Font sFont = g.getFont();
             Display.impl.beginPaintScope(g.getGraphics(), p);
             try {
                 p.paint(g, rect);
             } finally {
+                g.setColor(sColor);
+                g.setAlpha(sAlpha);
+                g.setFont(sFont);
                 Display.impl.endPaintScope(g.getGraphics(), p);
             }
         }
+        int sColor = g.getColor();
+        int sAlpha = g.getAlpha();
+        Font sFont = g.getFont();
         Display.impl.beginPaintScope(g.getGraphics(), par);
         try {
             par.paintBackground(g);
         } finally {
+            g.setColor(sColor);
+            g.setAlpha(sAlpha);
+            g.setFont(sFont);
             Display.impl.endPaintScope(g.getGraphics(), par);
         }
         ((Container) par).paintIntersecting(g, c, x, y, w, h, false, 0);
@@ -3490,17 +3514,29 @@ public class Component implements Animation, StyleListener, Editable {
         }
         if (getStyle().getBgPainter() != null) {
             Painter bp = getStyle().getBgPainter();
+            int sColor = g.getColor();
+            int sAlpha = g.getAlpha();
+            Font sFont = g.getFont();
             Display.impl.beginPaintScope(g.getGraphics(), bp);
             try {
                 bp.paint(g, bounds);
             } finally {
+                g.setColor(sColor);
+                g.setAlpha(sAlpha);
+                g.setFont(sFont);
                 Display.impl.endPaintScope(g.getGraphics(), bp);
             }
         }
+        int sColor = g.getColor();
+        int sAlpha = g.getAlpha();
+        Font sFont = g.getFont();
         Display.impl.beginPaintScope(g.getGraphics(), this);
         try {
             paintBackground(g);
         } finally {
+            g.setColor(sColor);
+            g.setAlpha(sAlpha);
+            g.setFont(sFont);
             Display.impl.endPaintScope(g.getGraphics(), this);
         }
         paintRippleEffect(g);
@@ -5131,10 +5167,16 @@ public class Component implements Animation, StyleListener, Editable {
 
         g.translate(-getX(), -getY());
         paintComponentBackground(g);
+        int sColor = g.getColor();
+        int sAlpha = g.getAlpha();
+        Font sFont = g.getFont();
         Display.impl.beginPaintScope(g.getGraphics(), this);
         try {
             paint(g);
         } finally {
+            g.setColor(sColor);
+            g.setAlpha(sAlpha);
+            g.setFont(sFont);
             Display.impl.endPaintScope(g.getGraphics(), this);
         }
         if (isBorderPainted()) {
@@ -5182,10 +5224,16 @@ public class Component implements Animation, StyleListener, Editable {
 
         g.translate(-getX(), -getY());
         paintComponentBackground(g);
+        int sColor = g.getColor();
+        int sAlpha = g.getAlpha();
+        Font sFont = g.getFont();
         Display.impl.beginPaintScope(g.getGraphics(), this);
         try {
             paint(g);
         } finally {
+            g.setColor(sColor);
+            g.setAlpha(sAlpha);
+            g.setFont(sFont);
             Display.impl.endPaintScope(g.getGraphics(), this);
         }
         if (isBorderPainted()) {

--- a/CodenameOne/src/com/codename1/ui/Form.java
+++ b/CodenameOne/src/com/codename1/ui/Form.java
@@ -1123,18 +1123,30 @@ public class Form extends Container {
             int tx = g.getTranslateX();
             int ty = g.getTranslateY();
             g.translate(-tx, -ty);
+            int sColor = g.getColor();
+            int sAlpha = g.getAlpha();
+            Font sFont = g.getFont();
             Display.impl.beginPaintScope(g.getGraphics(), glassPane);
             try {
                 glassPane.paint(g, getBounds());
             } finally {
+                g.setColor(sColor);
+                g.setAlpha(sAlpha);
+                g.setFont(sFont);
                 Display.impl.endPaintScope(g.getGraphics(), glassPane);
             }
             g.translate(tx, ty);
         }
+        int sColor = g.getColor();
+        int sAlpha = g.getAlpha();
+        Font sFont = g.getFont();
         Display.impl.beginPaintScope(g.getGraphics(), this);
         try {
             paintGlass(g);
         } finally {
+            g.setColor(sColor);
+            g.setAlpha(sAlpha);
+            g.setFont(sFont);
             Display.impl.endPaintScope(g.getGraphics(), this);
         }
         if (dragged != null && dragged.isDragAndDropInitialized()) {

--- a/maven/javase/src/test/java/com/codename1/impl/javase/PaintScopeTest.java
+++ b/maven/javase/src/test/java/com/codename1/impl/javase/PaintScopeTest.java
@@ -24,6 +24,13 @@ package com.codename1.impl.javase;
 
 import com.codename1.io.Log;
 import com.codename1.testing.junit.CodenameOneTest;
+import com.codename1.testing.junit.RunOnEdt;
+import com.codename1.ui.Component;
+import com.codename1.ui.Font;
+import com.codename1.ui.Graphics;
+import com.codename1.ui.Image;
+import com.codename1.ui.Painter;
+import com.codename1.ui.geom.Rectangle;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
@@ -219,6 +226,125 @@ public class PaintScopeTest {
         } finally {
             port().disposeGraphics(g);
             g.dispose();
+            log.restore();
+        }
+    }
+
+    @Test
+    @RunOnEdt
+    public void componentPaintLeakIsAbsorbedByFrameworkWrapper() {
+        // Issue #5102 root-cause fix: framework callers in Component/Form save
+        // and restore color/font/alpha around each Painter / paint() dispatch,
+        // so a leaky paint method can no longer poison the next draw on iOS or
+        // spam the simulator log. This test paints a real Component whose
+        // paint() deliberately leaks all three properties and verifies:
+        //   1) the outer Graphics state is unchanged afterwards (real bug fix),
+        //   2) the simulator's paint-scope checker never logs a warning
+        //      (the spam in the bug report is gone).
+        CapturingLog log = new CapturingLog();
+        log.install();
+        try {
+            final int leakColor = 0xff00ff;
+            final int leakAlpha = 77;
+            final Font leakFont = Font.createSystemFont(Font.FACE_MONOSPACE,
+                    Font.STYLE_BOLD, Font.SIZE_LARGE);
+
+            Component leaky = new Component() {
+                @Override
+                public void paint(Graphics g) {
+                    g.setColor(leakColor);
+                    g.setAlpha(leakAlpha);
+                    g.setFont(leakFont);
+                }
+
+                @Override
+                protected void paintBackground(Graphics g) {
+                    g.setColor(leakColor);
+                    g.setAlpha(leakAlpha);
+                    g.setFont(leakFont);
+                }
+            };
+            leaky.setX(0);
+            leaky.setY(0);
+            leaky.setWidth(40);
+            leaky.setHeight(40);
+
+            Image img = Image.createImage(40, 40);
+            Graphics g = img.getGraphics();
+            int outerColor = 0x123456;
+            int outerAlpha = 200;
+            Font outerFont = Font.createSystemFont(Font.FACE_SYSTEM,
+                    Font.STYLE_PLAIN, Font.SIZE_SMALL);
+            g.setColor(outerColor);
+            g.setAlpha(outerAlpha);
+            g.setFont(outerFont);
+
+            leaky.paintComponent(g, true);
+
+            assertEquals(outerColor, g.getColor(),
+                    "framework wrapper must restore color after a leaky paint");
+            assertEquals(outerAlpha, g.getAlpha(),
+                    "framework wrapper must restore alpha after a leaky paint");
+            assertEquals(outerFont, g.getFont(),
+                    "framework wrapper must restore font after a leaky paint");
+            assertTrue(log.messages.isEmpty(),
+                    "framework restore must happen before endPaintScope so the"
+                            + " simulator checker never sees a leak (log was: "
+                            + log.messages + ")");
+        } finally {
+            log.restore();
+        }
+    }
+
+    @Test
+    @RunOnEdt
+    public void bgPainterLeakIsAbsorbedByFrameworkWrapper() {
+        // Same protection as above but on the Painter.paint dispatch used for
+        // a Style's BgPainter -- that was the most common offender in the bug
+        // report (`com.codename1.ui.Component$BGPainter`).
+        CapturingLog log = new CapturingLog();
+        log.install();
+        try {
+            final int leakColor = 0x00ff00;
+            final int leakAlpha = 88;
+            final Font leakFont = Font.createSystemFont(Font.FACE_MONOSPACE,
+                    Font.STYLE_ITALIC, Font.SIZE_LARGE);
+
+            Painter leakyPainter = new Painter() {
+                @Override
+                public void paint(Graphics g, Rectangle rect) {
+                    g.setColor(leakColor);
+                    g.setAlpha(leakAlpha);
+                    g.setFont(leakFont);
+                }
+            };
+
+            Component host = new Component() {};
+            host.setX(0);
+            host.setY(0);
+            host.setWidth(40);
+            host.setHeight(40);
+            host.getUnselectedStyle().setBgPainter(leakyPainter);
+
+            Image img = Image.createImage(40, 40);
+            Graphics g = img.getGraphics();
+            int outerColor = 0x654321;
+            int outerAlpha = 210;
+            Font outerFont = Font.createSystemFont(Font.FACE_SYSTEM,
+                    Font.STYLE_PLAIN, Font.SIZE_MEDIUM);
+            g.setColor(outerColor);
+            g.setAlpha(outerAlpha);
+            g.setFont(outerFont);
+
+            host.paintComponent(g, true);
+
+            assertEquals(outerColor, g.getColor());
+            assertEquals(outerAlpha, g.getAlpha());
+            assertEquals(outerFont, g.getFont());
+            assertTrue(log.messages.isEmpty(),
+                    "BgPainter leaks must be absorbed silently (log was: "
+                            + log.messages + ")");
+        } finally {
             log.restore();
         }
     }


### PR DESCRIPTION
## Summary

Follow-up to #5111. Where #5111 silenced the simulator log spam via dedup, this PR fixes the underlying iOS-affecting leak so the warnings never need to fire at all.

`Component.internalPaintImpl`, `Component.paintBackgroundImpl`, `Component.paintBackgroundParent`, `Component.getDragImage`, `Component.toImage`, and `Form.paintGlassImpl` now snapshot `color`/`alpha`/`font` around each `Painter.paint` / `paint(Graphics)` / `paintBackground(Graphics)` / `paintGlass(Graphics)` dispatch and restore them *before* `endPaintScope`. Effects:

- On iOS / Android / any device port: state leaks from framework painters (`Component$BGPainter`, `Toolbar`, `Button`, `TextArea`, etc.) and from user paint overrides can no longer poison the next paint -- the framework guarantees the Graphics is in the same state after the dispatch as it was before. This is the actual #5058-class bug, fixed at the framework level rather than depending on every painter to be polite.
- On the simulator: the paint-scope checker sees a clean scope, so the cosmetic warnings the user reported in #5102 stop firing altogether (not just deduped).

The #5111 dedup is kept as a backstop for direct misuse of `Display.impl.beginPaintScope/endPaintScope` and for clip / transform leaks (which the framework wrappers do not touch).

## Tests

Two new integration tests in `PaintScopeTest` paint a real `Component` / `Painter` whose overrides deliberately leak color, alpha, *and* font, then assert that:
1. The outer `Graphics` state is restored after `paintComponent(...)` -- the real iOS bug is fixed.
2. The simulator checker logged zero `paint-scope:` warnings -- the spam is gone, not just deduped.

`mvn -pl javase -am test -Plocal-dev-javase` -- 73/73 pass.

Fixes #5102.

## Test plan

- [x] `mvn -pl javase -am test -Plocal-dev-javase` -- 73/73 pass (PaintScopeTest now 9/9).
- [ ] Run the simulator against an app with a custom paint() that leaks state, confirm no spam.
- [ ] Smoke-test on iOS to confirm no visual regressions from the new save/restore around painter dispatch (color/alpha/font are now reset at the framework boundary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)