### PR TITLE
Close #1449: regression-test ChartComponent axis-locked panning

### DIFF
--- a/CodenameOne/src/com/codename1/charts/ChartComponent.java
+++ b/CodenameOne/src/com/codename1/charts/ChartComponent.java
@@ -751,7 +751,10 @@ public class ChartComponent extends Component {
         }
     }
 
-    /// Enables or disables pan on x and y axes separately.
+    /// Enables or disables pan on x and y axes separately. Pass a different
+    /// value for each axis to lock panning to a single direction; for example
+    /// `setPanEnabled(true, false)` lets the user pan left/right but pins the
+    /// Y axis (a useful pattern for time-series charts).
     ///
     /// #### Parameters
     ///

--- a/maven/core-unittests/src/test/java/com/codename1/charts/ChartComponentTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/charts/ChartComponentTest.java
@@ -161,6 +161,85 @@ class ChartComponentTest extends UITestBase {
         assertThrows(RuntimeException.class, () -> component.setZoomLimits(1, 2, 3, 4));
     }
 
+    /// Regression for [#1449](https://github.com/codenameone/CodenameOne/issues/1449)
+    /// -- the 2015 reporter asked for a way to "freeze the y axis panning and
+    /// only allow panning left to right" because vertical panning was
+    /// disrupting the chart. The XYMultipleSeriesRenderer already exposes
+    /// setPanEnabled(boolean,boolean); these tests pin down the end-to-end
+    /// behaviour through ChartComponent.pointerDragged so the locked axis
+    /// truly cannot drift during a drag.
+    @Test
+    void dragWithOnlyXPanEnabledLeavesYRangeUnchanged() {
+        ChartComponent component = newPanTestChart(true /*x*/, false /*y*/);
+        XYMultipleSeriesRenderer renderer = renderer(component);
+
+        component.pointerDragged(new int[]{50}, new int[]{50});
+        component.pointerDragged(new int[]{20}, new int[]{20});
+
+        assertNotEquals(0.0, renderer.getXAxisMin(),
+                "Pan on X should have moved the X axis range");
+        assertNotEquals(10.0, renderer.getXAxisMax(),
+                "Pan on X should have moved the X axis range");
+        assertEquals(0.0, renderer.getYAxisMin(),
+                "Pan on Y was disabled but the Y axis minimum drifted");
+        assertEquals(10.0, renderer.getYAxisMax(),
+                "Pan on Y was disabled but the Y axis maximum drifted");
+    }
+
+    @Test
+    void dragWithOnlyYPanEnabledLeavesXRangeUnchanged() {
+        ChartComponent component = newPanTestChart(false /*x*/, true /*y*/);
+        XYMultipleSeriesRenderer renderer = renderer(component);
+
+        component.pointerDragged(new int[]{50}, new int[]{50});
+        component.pointerDragged(new int[]{20}, new int[]{20});
+
+        assertEquals(0.0, renderer.getXAxisMin(),
+                "Pan on X was disabled but the X axis minimum drifted");
+        assertEquals(10.0, renderer.getXAxisMax(),
+                "Pan on X was disabled but the X axis maximum drifted");
+        assertNotEquals(0.0, renderer.getYAxisMin(),
+                "Pan on Y should have moved the Y axis range");
+        assertNotEquals(10.0, renderer.getYAxisMax(),
+                "Pan on Y should have moved the Y axis range");
+    }
+
+    @Test
+    void dragWithBothAxesPanEnabledMovesBoth() {
+        ChartComponent component = newPanTestChart(true, true);
+        XYMultipleSeriesRenderer renderer = renderer(component);
+
+        component.pointerDragged(new int[]{50}, new int[]{50});
+        component.pointerDragged(new int[]{20}, new int[]{20});
+
+        assertNotEquals(0.0, renderer.getXAxisMin());
+        assertNotEquals(10.0, renderer.getXAxisMax());
+        assertNotEquals(0.0, renderer.getYAxisMin());
+        assertNotEquals(10.0, renderer.getYAxisMax());
+    }
+
+    private static XYMultipleSeriesRenderer renderer(ChartComponent component) {
+        return (XYMultipleSeriesRenderer) ((XYChart) component.getChart()).getRenderer();
+    }
+
+    /// Build a 100x100 ChartComponent at the origin with a zero-padding/margin
+    /// renderer and an initial range of [0,10] on both axes. This gives the
+    /// drag math a clean 1 chart-unit per 10 screen-pixel scale factor.
+    private static ChartComponent newPanTestChart(boolean panX, boolean panY) {
+        XYMultipleSeriesRenderer renderer = new XYMultipleSeriesRenderer();
+        renderer.setMargins(new int[]{0, 0, 0, 0});
+        renderer.setRange(new double[]{0, 10, 0, 10});
+        StubXYChart chart = new StubXYChart(renderer);
+        ChartComponent component = new PositionedChartComponent(chart, 0, 0);
+        component.setWidth(100);
+        component.setHeight(100);
+        component.getAllStyles().setPadding(0, 0, 0, 0);
+        // setPanEnabled(boolean) and the boolean-pair version both flow through
+        // the renderer; call the per-axis version last so it wins.
+        component.setPanEnabled(panX, panY);
+        return component;
+    }
+
     private void setCurrentTransform(ChartComponent component, Transform transform) throws Exception {
         Field field = ChartComponent.class.getDeclaredField("currentTransform");
         field.setAccessible(true);


### PR DESCRIPTION
## Summary

Closes [#1449](https://github.com/codenameone/CodenameOne/issues/1449), the next-oldest open issue (filed April 2015).

The 2015 reporter asked for a way to *"freeze the y axis panning and only allow panning left to right"* because vertical pans were disrupting their chart layout. That capability shipped two years later in [commit `99d13827b`](https://github.com/codenameone/CodenameOne/commit/99d13827b) (April 2017, *"Improved panning and zooming in ChartComponent when using an XYChart or subclasses"*) via [`XYMultipleSeriesRenderer.setPanEnabled(boolean, boolean)`](https://github.com/codenameone/CodenameOne/blob/master/CodenameOne/src/com/codename1/charts/renderers/XYMultipleSeriesRenderer.java#L827) and the matching [`ChartComponent.setPanEnabled(boolean, boolean)`](https://github.com/codenameone/CodenameOne/blob/master/CodenameOne/src/com/codename1/charts/ChartComponent.java#L761) wrapper, but no end-to-end drag test covered the lock-axis behaviour and the issue was never closed.

## Changes

1. **Three regression tests** in [`ChartComponentTest`](https://github.com/codenameone/CodenameOne/blob/fix-1449-chart-axis-locked-panning/maven/core-unittests/src/test/java/com/codename1/charts/ChartComponentTest.java) that drive `ChartComponent.pointerDragged` through a 100×100 chart with a zero-padding/margin renderer and an initial `[0, 10]` range on both axes:
    - `dragWithOnlyXPanEnabledLeavesYRangeUnchanged` — with `setPanEnabled(true, false)`, a 30-pixel diagonal drag moves the X range while Y stays pinned to `[0, 10]`.
    - `dragWithOnlyYPanEnabledLeavesXRangeUnchanged` — the mirror case.
    - `dragWithBothAxesPanEnabledMovesBoth` — sanity check that the default still pans both axes.
2. **Doc-comment expansion** on `setPanEnabled(boolean, boolean)` to call out the axis-locked use case with a concrete example. This is the discoverability hook the 2015 reporter (and anyone hitting the same wish today) needs.

## Test plan

- [x] All three new tests pass locally on the JDK 8 build.
- [x] The original gap was real: a first cut of the helper that called `component.setPanEnabled(true)` first clobbered the per-axis flags (because `XYMultipleSeriesRenderer.setPanEnabled(boolean)` calls `setPanEnabled(enabled, enabled)` per its own javadoc). Tests caught that immediately with `expected: <0.0> but was: <-3.0>`. After ordering the helper so the per-axis call wins, all three are green — which also proves that *as long as the per-axis API is used last*, the 2017 fix really does keep the locked axis pinned.
- [x] Full chart sweep — 40 tests across `BarChartTest`, `PieChartTest`, `DoughnutChartTest`, `ChartComponentTest`, the `RadarChartSampleTest` regression and other `*Chart*` suites — all green.
- [x] No Unicode characters in the touched sources (per the project's ASCII-only rule).
- [ ] CI verification.

## What this does not change

The 2015 report also mentioned that *"the screen has some problems repainting"* during vertical pans. That part is too vague to act on without a concrete reproducer and is also moot for users who lock the Y axis. If anyone still hits a chart-repaint problem after locking the axis, a fresh focused issue with a repro is the right next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)