### PR TITLE
Fix #1523: expose Slider.setProgressInternal as protected

### DIFF
--- a/CodenameOne/src/com/codename1/ui/Slider.java
+++ b/CodenameOne/src/com/codename1/ui/Slider.java
@@ -302,7 +302,11 @@ public class Slider extends Label implements ActionSource {
         return value;
     }
 
-    private void setProgressInternal(int value) {
+    /// Internal slider-value updater used by drag/keyboard/setProgress paths.
+    /// Exposed as `protected` so subclasses (e.g. range-slider style multi-
+    /// thumb sliders) can route their own input through the same value-set +
+    /// repaint pipeline as the built-in handlers. See #1523.
+    protected void setProgressInternal(int value) {
         this.value = value;
         if (renderValueOnTop || renderPercentageOnTop) {
             super.setText(formattedValue(value));

--- a/maven/core-unittests/src/test/java/com/codename1/ui/SliderSetProgressInternalScopeTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/SliderSetProgressInternalScopeTest.java
@@ -1,0 +1,63 @@
+package com.codename1.ui;
+
+import com.codename1.junit.FormTest;
+import com.codename1.junit.UITestBase;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression for
+ * https://github.com/codenameone/CodenameOne/issues/1523
+ * -- the 2015 reporter could not implement a range slider on top of
+ * {@link Slider} because setProgressInternal(int) was private. This test
+ * pins the method to protected (visible to subclasses) and verifies that a
+ * subclass override actually intercepts the calls the built-in pointer/
+ * keyboard handlers funnel through.
+ */
+class SliderSetProgressInternalScopeTest extends UITestBase {
+
+    /// A subclass-visible probe: counts how many times setProgressInternal is
+    /// called and what values it sees. If the method ever regresses back to
+    /// private, this class will fail to compile.
+    private static class ProbeSlider extends Slider {
+        int callCount;
+        int lastValue;
+
+        @Override
+        protected void setProgressInternal(int value) {
+            callCount++;
+            lastValue = value;
+            super.setProgressInternal(value);
+        }
+    }
+
+    @Test
+    void subclassCanOverrideSetProgressInternal() {
+        ProbeSlider s = new ProbeSlider();
+        s.setMinValue(0);
+        s.setMaxValue(100);
+
+        // setProgress goes through setProgressInternal -- the subclass must
+        // observe the call.
+        s.setProgress(42);
+        assertEquals(1, s.callCount,
+                "subclass override of setProgressInternal must intercept setProgress");
+        assertEquals(42, s.lastValue);
+        assertEquals(42, s.getProgress());
+    }
+
+    @Test
+    void subclassOverrideStaysOnTheValueSetterPath() {
+        ProbeSlider s = new ProbeSlider();
+        s.setMinValue(0);
+        s.setMaxValue(10);
+
+        s.setProgress(3);
+        s.setProgress(7);
+        s.setProgress(0);
+        assertEquals(3, s.callCount);
+        assertEquals(0, s.lastValue);
+        assertEquals(0, s.getProgress());
+    }
+}


### PR DESCRIPTION
## Summary

Closes [#1523](https://github.com/codenameone/CodenameOne/issues/1523). The 2015 reporter wanted to build a range slider on top of ``Slider`` but couldn't because ``setProgressInternal(int)`` was ``private``. Every value-set path in the class — ``setProgress``, ``pointerDragged`` ([line 531](https://github.com/codenameone/CodenameOne/blob/master/CodenameOne/src/com/codename1/ui/Slider.java#L531)), pointer-released ([line 585](https://github.com/codenameone/CodenameOne/blob/master/CodenameOne/src/com/codename1/ui/Slider.java#L585)), the keyboard repeat handlers ([lines 646, 654, 662, 670](https://github.com/codenameone/CodenameOne/blob/master/CodenameOne/src/com/codename1/ui/Slider.java#L646)) — funnels through this method, so a subclass that wants to intercept value changes has no clean hook.

Promote the method to ``protected`` and add a short javadoc explaining the contract. No behavioural change for existing callers; the access widening is source- and binary-compatible.

## Test plan

- [x] New regression test [``SliderSetProgressInternalScopeTest``](https://github.com/codenameone/CodenameOne/blob/fix-1523-slider-setprogress-protected/maven/core-unittests/src/test/java/com/codename1/ui/SliderSetProgressInternalScopeTest.java) defines a ``ProbeSlider`` subclass with ``@Override protected void setProgressInternal(int)``. **If the method ever regresses back to ``private`` this class will fail to compile**, and the assertions verify that the override is actually called when ``setProgress`` runs (1 call → seen, 3 calls → seen, final value reported correctly).
- [x] Full ``*Slider*`` test sweep — 27 tests across ``SliderSetProgressInternalScopeTest`` / ``ComboBoxTabsSliderTest`` / ``SliderBridgeTest`` — all green.
- [x] ASCII-only sources verified.
- [ ] CI verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)