### PR TITLE
Fix #1592: pointerDragged honours isEnabled() like pointerPressed/Released

### DIFF
--- a/CodenameOne/src/com/codename1/ui/Form.java
+++ b/CodenameOne/src/com/codename1/ui/Form.java
@@ -3617,10 +3617,15 @@ public class Form extends Container {
             }
             cmp = LeadUtil.leadParentImpl(cmp);
 
-            LeadUtil.pointerDragged(cmp, x, y);
+            // Mirror the isEnabled() gate that pointerPressed and the
+            // sidemenu-drag branch above already apply: a disabled component
+            // must not receive drag events. See #1592.
+            if (cmp.isEnabled()) {
+                LeadUtil.pointerDragged(cmp, x, y);
 
-            if (cmp == pressedCmp && cmp.isStickyDrag()) { //NOPMD CompareObjectsWithEquals
-                stickyDrag = cmp;
+                if (cmp == pressedCmp && cmp.isStickyDrag()) { //NOPMD CompareObjectsWithEquals
+                    stickyDrag = cmp;
+                }
             }
         }
     }
@@ -3687,10 +3692,15 @@ public class Form extends Container {
             if (!isScrollWheeling && cmp.isFocusable() && cmp.isEnabled()) {
                 setFocused(cmp);
             }
-            LeadUtil.pointerDragged(cmp, x, y);
+            // Mirror the isEnabled() gate that pointerPressed and the
+            // sidemenu-drag branch above already apply: a disabled component
+            // must not receive drag events. See #1592.
+            if (cmp.isEnabled()) {
+                LeadUtil.pointerDragged(cmp, x, y);
 
-            if (cmp == pressedCmp && cmp.isStickyDrag()) { //NOPMD CompareObjectsWithEquals
-                stickyDrag = cmp;
+                if (cmp == pressedCmp && cmp.isStickyDrag()) { //NOPMD CompareObjectsWithEquals
+                    stickyDrag = cmp;
+                }
             }
         }
     }

--- a/maven/core-unittests/src/test/java/com/codename1/ui/DisabledPointerDraggedRoutingTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/DisabledPointerDraggedRoutingTest.java
@@ -1,0 +1,76 @@
+package com.codename1.ui;
+
+import com.codename1.junit.FormTest;
+import com.codename1.junit.UITestBase;
+import com.codename1.ui.layouts.BorderLayout;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression test for
+ * https://github.com/codenameone/CodenameOne/issues/1592
+ * -- Form.pointerDragged must not route drag events to a disabled
+ * component. pointerPressed and pointerReleased already skip disabled
+ * components; pointerDragged did not, which the 2015 reporter flagged as an
+ * inconsistency.
+ */
+class DisabledPointerDraggedRoutingTest extends UITestBase {
+
+    private static class DragCountingComponent extends Component {
+        int dragCount;
+
+        @Override
+        public void pointerDragged(int x, int y) {
+            dragCount++;
+            super.pointerDragged(x, y);
+        }
+
+        @Override
+        public void pointerDragged(int[] x, int[] y) {
+            dragCount++;
+            super.pointerDragged(x, y);
+        }
+    }
+
+    @FormTest
+    void enabledComponentReceivesDragEvents() {
+        Form form = Display.getInstance().getCurrent();
+        form.setLayout(new BorderLayout());
+
+        DragCountingComponent c = new DragCountingComponent();
+        c.setEnabled(true);
+        form.add(BorderLayout.CENTER, c);
+        form.revalidate();
+
+        int x = c.getAbsoluteX() + 5;
+        int y = c.getAbsoluteY() + 5;
+        form.pointerPressed(x, y);
+        form.pointerDragged(x + 30, y + 30);
+        form.pointerReleased(x + 30, y + 30);
+
+        assertTrue(c.dragCount > 0,
+                "Sanity check: an enabled component must still receive drag events.");
+    }
+
+    @FormTest
+    void disabledComponentDoesNotReceiveDragEvents() {
+        Form form = Display.getInstance().getCurrent();
+        form.setLayout(new BorderLayout());
+
+        DragCountingComponent c = new DragCountingComponent();
+        c.setEnabled(false);
+        form.add(BorderLayout.CENTER, c);
+        form.revalidate();
+
+        int x = c.getAbsoluteX() + 5;
+        int y = c.getAbsoluteY() + 5;
+        form.pointerPressed(x, y);
+        form.pointerDragged(x + 30, y + 30);
+        form.pointerReleased(x + 30, y + 30);
+
+        assertEquals(0, c.dragCount,
+                "A disabled component must not receive pointerDragged events. "
+                        + "pointerPressed and pointerReleased already gate on "
+                        + "isEnabled(); pointerDragged must do the same. See #1592.");
+    }
+}


### PR DESCRIPTION
## Summary

Closes [#1592](https://github.com/codenameone/CodenameOne/issues/1592). The 2015 reporter noted that ``Form.pointerDragged`` was routing drag events to a sub-component regardless of ``cmp.isEnabled()``, even though ``pointerPressed`` and the sidemenu drag branch in the same class already gate on ``isEnabled``. A disabled component could therefore still observe drag events that originated over its bounds — an inconsistency the reporter flagged as a *"Minor bug"*.

## Fix

Both overloads of ``Form.pointerDragged`` — ``pointerDragged(int, int)`` and ``pointerDragged(int[], int[])`` — now wrap the routed ``LeadUtil.pointerDragged(cmp, x, y)`` call in an ``if (cmp.isEnabled())`` block, matching the pattern already used in the sidemenu branch (``cmp != null && cmp.isEnabled()``) and in ``pointerPressed``.

The ``setFocused()`` helper above the gate is already guarded by ``cmp.isEnabled()`` so focus-on-drag behaviour is unchanged.

## Test plan

- [x] New regression test [``DisabledPointerDraggedRoutingTest``](https://github.com/codenameone/CodenameOne/blob/fix-1592-pointerdragged-disabled/maven/core-unittests/src/test/java/com/codename1/ui/DisabledPointerDraggedRoutingTest.java) drives ``form.pointerPressed/Dragged/Released`` through a ``Component`` subclass whose ``pointerDragged`` increments a counter, with two cases:
    - **enabled component**: counter > 0 (sanity).
    - **disabled component**: counter == 0 (regression).
- [x] Before the fix the disabled-component test reports 1 (proving the bug); after the fix it reports 0.
- [x] Full drag/pointer/form sweep — **60 tests** across ``DragEventsTest``, ``PointerEventsTest``, ``FormTest``, ``DraggableLeadComponentTest``, ``DragFinishedListener#3056Test`` and the ``LongPointerPressSample`` / ``NullPointerOnEDTSample#2992`` regression samples — all green.
- [x] ASCII-only sources verified.
- [ ] CI verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)