### PR TITLE
Fix #1511: TextField.setAlignment(CENTER) is now accepted

### DIFF
--- a/CodenameOne/src/com/codename1/ui/TextField.java
+++ b/CodenameOne/src/com/codename1/ui/TextField.java
@@ -1936,16 +1936,12 @@ public class TextField extends TextArea {
         this.leftAndRightEditingTrigger = leftAndRightEditingTrigger;
     }
 
-    /// {@inheritDoc}
-    @Override
-    public void setAlignment(int align) {
-        // CENTER alignment used to throw IllegalArgumentException here, blocking
-        // a common request (centred numeric fields, PIN entry, score widgets,
-        // etc.). The rendering pipeline already handles CENTER via the parent
-        // TextArea.setAlignment which just routes to Style.setAlignment, so
-        // accept it and delegate. See #1511.
-        super.setAlignment(align);
-    }
+    // setAlignment(int) used to be overridden here purely to throw
+    // IllegalArgumentException for Component.CENTER. That block is gone; the
+    // override is no longer needed because the parent TextArea.setAlignment
+    // already routes to Style.setAlignment and the rendering pipeline handles
+    // CENTER identically to LEFT/RIGHT. Removing the override also keeps PMD
+    // happy (UselessOverridingMethod). See #1511.
 
     /// {@inheritDoc}
     @Override

--- a/CodenameOne/src/com/codename1/ui/TextField.java
+++ b/CodenameOne/src/com/codename1/ui/TextField.java
@@ -1939,11 +1939,12 @@ public class TextField extends TextArea {
     /// {@inheritDoc}
     @Override
     public void setAlignment(int align) {
-        if (align == Component.CENTER) {
-            throw new IllegalArgumentException("CENTER alignment is not supported in TextField.");
-        } else {
-            super.setAlignment(align);
-        }
+        // CENTER alignment used to throw IllegalArgumentException here, blocking
+        // a common request (centred numeric fields, PIN entry, score widgets,
+        // etc.). The rendering pipeline already handles CENTER via the parent
+        // TextArea.setAlignment which just routes to Style.setAlignment, so
+        // accept it and delegate. See #1511.
+        super.setAlignment(align);
     }
 
     /// {@inheritDoc}

--- a/maven/core-unittests/src/test/java/com/codename1/ui/TextFieldCenterAlignmentTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/TextFieldCenterAlignmentTest.java
@@ -1,0 +1,49 @@
+package com.codename1.ui;
+
+import com.codename1.junit.FormTest;
+import com.codename1.junit.UITestBase;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression test for
+ * https://github.com/codenameone/CodenameOne/issues/1511
+ * -- the 2015 reporter could not centre-align a TextField with a NUMERIC
+ * constraint. TextField.setAlignment(CENTER) used to throw
+ * IllegalArgumentException; this verifies the API now accepts CENTER and the
+ * underlying Style is updated, matching TextArea behaviour.
+ */
+class TextFieldCenterAlignmentTest extends UITestBase {
+
+    @FormTest
+    void setAlignmentCenterIsAcceptedOnTextField() {
+        TextField tf = new TextField();
+        tf.setConstraint(TextField.NUMERIC);
+        // Pre-fix this call threw "CENTER alignment is not supported in
+        // TextField." See #1511.
+        assertDoesNotThrow(() -> tf.setAlignment(Component.CENTER));
+
+        // The proxy returned by getAllStyles() doesn't track its own
+        // alignment, so read the real underlying styles.
+        assertEquals(Component.CENTER, tf.getUnselectedStyle().getAlignment(),
+                "Unselected style alignment must reflect the setAlignment(CENTER) call.");
+        assertEquals(Component.CENTER, tf.getSelectedStyle().getAlignment(),
+                "Selected style alignment must reflect the setAlignment(CENTER) call.");
+        // Constraint should be unaffected by the alignment change.
+        assertEquals(TextField.NUMERIC, tf.getConstraint());
+    }
+
+    @FormTest
+    void setAlignmentLeftRightAndCenterAllWork() {
+        TextField tf = new TextField();
+
+        tf.setAlignment(Component.LEFT);
+        assertEquals(Component.LEFT, tf.getUnselectedStyle().getAlignment());
+
+        tf.setAlignment(Component.CENTER);
+        assertEquals(Component.CENTER, tf.getUnselectedStyle().getAlignment());
+
+        tf.setAlignment(Component.RIGHT);
+        assertEquals(Component.RIGHT, tf.getUnselectedStyle().getAlignment());
+    }
+}


### PR DESCRIPTION
## Summary

Closes [#1511](https://github.com/codenameone/CodenameOne/issues/1511). The 2015 reporter wanted a centre-aligned ``TextField`` with a ``NUMERIC`` constraint (PIN entry / score widgets / calculator-style inputs). ``TextField.setAlignment(Component.CENTER)`` had thrown ``IllegalArgumentException("CENTER alignment is not supported in TextField.")`` since the very [first commit in 2012](https://github.com/codenameone/CodenameOne/commit/2615a8b9b), so the reporter had to settle for ``TextArea`` (which accepts CENTER but does not enforce the NUMERIC constraint as tightly).

There is no technical reason for the restriction:

- ``TextArea.setAlignment`` already accepts CENTER and just routes to ``Style.setAlignment`` like every other Component.
- No special-case code in the focus caret, native edit overlay, or render path looked at the CENTER value with intent to reject it.

Dropping the IAE and delegating to ``super.setAlignment`` lets a numeric-constrained TextField be centred while keeping its constraint, exactly what the reporter asked for.

## Test plan

- [x] New regression test [``TextFieldCenterAlignmentTest``](https://github.com/codenameone/CodenameOne/blob/fix-1511-textfield-center-alignment/maven/core-unittests/src/test/java/com/codename1/ui/TextFieldCenterAlignmentTest.java):
    - ``setAlignmentCenterIsAcceptedOnTextField``: the IAE no longer fires, the underlying ``Style.getAlignment()`` is CENTER on both selected and unselected styles, and the ``NUMERIC`` constraint is preserved.
    - ``setAlignmentLeftRightAndCenterAllWork``: round-trip through LEFT → CENTER → RIGHT.
- [x] Full TextField/TextArea sweep -- **64 tests** including ``TextAreaTest``, the ``TextFieldCaretColorTest#2780`` and ``TextFieldHintStylingTest`` regression samples -- stays green.
- [x] ASCII-only sources verified.
- [ ] CI verification.

## Why I had to fix one test assertion mid-implementation

The first cut of the test asserted on ``tf.getAllStyles().getAlignment()``. ``Component.getAllStyles()`` returns a [proxy Style](https://github.com/codenameone/CodenameOne/blob/master/CodenameOne/src/com/codename1/ui/Component.java#L723) whose ``setAlignment`` fans out to the four sub-styles but does not update the proxy's own ``align`` field, so the proxy's getter always returned the original LEFT. Reading from ``getUnselectedStyle().getAlignment()`` / ``getSelectedStyle().getAlignment()`` is the correct round-trip and exposes the real behaviour the test cares about. That's a subtle gotcha worth flagging in the codebase but it is not part of #1511.

🤖 Generated with [Claude Code](https://claude.com/claude-code)