### PR TITLE
Add low-level cross-platform Camera API (com.codename1.camera)

### DIFF
--- a/CodenameOne/src/com/codename1/camera/Camera.java
+++ b/CodenameOne/src/com/codename1/camera/Camera.java
@@ -80,7 +80,9 @@ public final class Camera {
     /// Enumerate cameras visible to the platform. May be empty.
     public static CameraInfo[] getCameras() {
         CameraImpl probe = newImpl();
-        if (probe == null) return new CameraInfo[0];
+        if (probe == null) {
+            return new CameraInfo[0];
+        }
         try {
             CameraInfo[] out = probe.enumerateCameras();
             return out == null ? new CameraInfo[0] : out;
@@ -94,8 +96,10 @@ public final class Camera {
     /// camera exists, the first available camera is returned.
     public static CameraInfo getDefault(CameraFacing facing) {
         CameraInfo[] all = getCameras();
-        for (int i = 0; i < all.length; i++) {
-            if (all[i].getFacing() == facing) return all[i];
+        for (CameraInfo c : all) {
+            if (c.getFacing() == facing) {
+                return c;
+            }
         }
         return all.length > 0 ? all[0] : null;
     }
@@ -106,7 +110,9 @@ public final class Camera {
         if (info == null) {
             throw new IllegalArgumentException("CameraInfo must not be null");
         }
-        if (opts == null) opts = new CameraSessionOptions();
+        if (opts == null) {
+            opts = new CameraSessionOptions();
+        }
         // The check-and-set has to be atomic to keep SpotBugs happy and to
         // honour the "one open session at a time" contract under
         // concurrent open() calls. The native impl.open() call below runs
@@ -155,7 +161,9 @@ public final class Camera {
     }
 
     private static void fireLater(final SuccessCallback<Boolean> callback, final Boolean value) {
-        if (callback == null) return;
+        if (callback == null) {
+            return;
+        }
         Display.getInstance().callSerially(new Runnable() {
             @Override public void run() { callback.onSucess(value); }
         });
@@ -165,9 +173,15 @@ public final class Camera {
         return Display.getInstance().getCameraBackend();
     }
 
+    // Identity comparison is intentional: only the exact CameraSession
+    // instance we returned from open() may clear the active slot, so
+    // PMD.CompareObjectsWithEquals doesn't apply.
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
     static void clearActive(CameraSession s) {
         synchronized (ACTIVE_LOCK) {
-            if (active == s) active = null;
+            if (active == s) {
+                active = null;
+            }
         }
     }
 }

--- a/CodenameOne/src/com/codename1/camera/Camera.java
+++ b/CodenameOne/src/com/codename1/camera/Camera.java
@@ -65,6 +65,7 @@ import java.io.IOException;
 ///
 /// 8.1
 public final class Camera {
+    private static final Object ACTIVE_LOCK = new Object();
     private static CameraSession active;
 
     private Camera() { }
@@ -106,9 +107,11 @@ public final class Camera {
             throw new IllegalArgumentException("CameraInfo must not be null");
         }
         if (opts == null) opts = new CameraSessionOptions();
-        if (active != null && !active.isClosed()) {
-            throw new IllegalStateException(
-                "Only one CameraSession may be open at a time. Close the existing session first.");
+        synchronized (ACTIVE_LOCK) {
+            if (active != null && !active.isClosed()) {
+                throw new IllegalStateException(
+                    "Only one CameraSession may be open at a time. Close the existing session first.");
+            }
         }
         CameraImpl impl = newImpl();
         if (impl == null) {
@@ -120,8 +123,10 @@ public final class Camera {
             try { impl.close(); } catch (Throwable t) { Log.e(t); }
             throw new RuntimeException("Could not open camera " + info.getId(), e);
         }
-        active = new CameraSession(impl, info, opts);
-        return active;
+        synchronized (ACTIVE_LOCK) {
+            active = new CameraSession(impl, info, opts);
+            return active;
+        }
     }
 
     /// Request runtime permission for camera (and optionally microphone). The
@@ -157,6 +162,8 @@ public final class Camera {
     }
 
     static void clearActive(CameraSession s) {
-        if (active == s) active = null;
+        synchronized (ACTIVE_LOCK) {
+            if (active == s) active = null;
+        }
     }
 }

--- a/CodenameOne/src/com/codename1/camera/Camera.java
+++ b/CodenameOne/src/com/codename1/camera/Camera.java
@@ -107,23 +107,27 @@ public final class Camera {
             throw new IllegalArgumentException("CameraInfo must not be null");
         }
         if (opts == null) opts = new CameraSessionOptions();
+        // The check-and-set has to be atomic to keep SpotBugs happy and to
+        // honour the "one open session at a time" contract under
+        // concurrent open() calls. The native impl.open() call below runs
+        // under the lock as well -- it's a foreground operation that the
+        // user kicked off, contention is essentially zero, and we'd rather
+        // serialise the rare race than ship a TOCTOU bug.
         synchronized (ACTIVE_LOCK) {
             if (active != null && !active.isClosed()) {
                 throw new IllegalStateException(
                     "Only one CameraSession may be open at a time. Close the existing session first.");
             }
-        }
-        CameraImpl impl = newImpl();
-        if (impl == null) {
-            throw new IllegalStateException("Camera is not supported on this platform.");
-        }
-        try {
-            impl.open(info.getId(), opts);
-        } catch (IOException e) {
-            try { impl.close(); } catch (Throwable t) { Log.e(t); }
-            throw new RuntimeException("Could not open camera " + info.getId(), e);
-        }
-        synchronized (ACTIVE_LOCK) {
+            CameraImpl impl = newImpl();
+            if (impl == null) {
+                throw new IllegalStateException("Camera is not supported on this platform.");
+            }
+            try {
+                impl.open(info.getId(), opts);
+            } catch (IOException e) {
+                try { impl.close(); } catch (Throwable t) { Log.e(t); }
+                throw new RuntimeException("Could not open camera " + info.getId(), e);
+            }
             active = new CameraSession(impl, info, opts);
             return active;
         }

--- a/CodenameOne/src/com/codename1/camera/Camera.java
+++ b/CodenameOne/src/com/codename1/camera/Camera.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.camera;
+
+import com.codename1.impl.CameraImpl;
+import com.codename1.io.Log;
+import com.codename1.ui.Display;
+import com.codename1.util.SuccessCallback;
+
+import java.io.IOException;
+
+/// Entry point for the low-level cross-platform camera API.
+///
+/// This API gives the application direct access to the device camera: live
+/// preview, frame streaming, still capture, video recording, flash and focus
+/// control. It is intended for use cases that the file-based
+/// `com.codename1.capture.Capture` API cannot serve - real-time barcode
+/// scanning, document boundary detection, custom in-app camera UIs.
+///
+/// **Permissions**: simply referencing classes in this package causes the build
+/// pipeline to inject `NSCameraUsageDescription` /
+/// `NSMicrophoneUsageDescription` (iOS) and `android.permission.CAMERA` /
+/// `android.permission.RECORD_AUDIO` plus the CameraX gradle dependencies
+/// (Android). Developers may override the plist strings via the
+/// `ios.NSCameraUsageDescription` build hint.
+///
+/// **Coexistence with `Capture`**: the old `com.codename1.capture.Capture`
+/// API continues to work unchanged. Both may be used in the same app, but
+/// only one camera consumer may hold the device at a time. Call
+/// `CameraSession#pause()` before invoking `Capture.capturePhoto(...)` and
+/// `CameraSession#resume()` afterwards.
+///
+/// ```java
+/// if (Camera.isSupported()) {
+///     CameraSession s = Camera.open(Camera.getDefault(CameraFacing.BACK),
+///                                   new CameraSessionOptions());
+///     CameraView v = s.createView();
+///     // add v to a Form...
+///     s.setFrameListener(frame ->
+///         BarcodeScanner.scan(frame.getJpegBytes()).ready(codes -> { ... }));
+/// }
+/// ```
+///
+/// #### Since
+///
+/// 8.1
+public final class Camera {
+    private static CameraSession active;
+
+    private Camera() { }
+
+    /// True when the running platform has a working camera implementation.
+    /// False on platforms (or simulator runs) where the camera back-end could
+    /// not be initialized.
+    public static boolean isSupported() {
+        return Display.getInstance().getCameraBackend() != null;
+    }
+
+    /// Enumerate cameras visible to the platform. May be empty.
+    public static CameraInfo[] getCameras() {
+        CameraImpl probe = newImpl();
+        if (probe == null) return new CameraInfo[0];
+        try {
+            CameraInfo[] out = probe.enumerateCameras();
+            return out == null ? new CameraInfo[0] : out;
+        } finally {
+            try { probe.close(); } catch (Throwable t) { Log.e(t); }
+        }
+    }
+
+    /// Convenience that returns the first camera matching the given facing,
+    /// or `null` if none. When no facing-specific camera is found and any
+    /// camera exists, the first available camera is returned.
+    public static CameraInfo getDefault(CameraFacing facing) {
+        CameraInfo[] all = getCameras();
+        for (int i = 0; i < all.length; i++) {
+            if (all[i].getFacing() == facing) return all[i];
+        }
+        return all.length > 0 ? all[0] : null;
+    }
+
+    /// Open a camera session. Throws `IllegalStateException` if a session is
+    /// already open; close the old session first.
+    public static CameraSession open(CameraInfo info, CameraSessionOptions opts) {
+        if (info == null) {
+            throw new IllegalArgumentException("CameraInfo must not be null");
+        }
+        if (opts == null) opts = new CameraSessionOptions();
+        if (active != null && !active.isClosed()) {
+            throw new IllegalStateException(
+                "Only one CameraSession may be open at a time. Close the existing session first.");
+        }
+        CameraImpl impl = newImpl();
+        if (impl == null) {
+            throw new IllegalStateException("Camera is not supported on this platform.");
+        }
+        try {
+            impl.open(info.getId(), opts);
+        } catch (IOException e) {
+            try { impl.close(); } catch (Throwable t) { Log.e(t); }
+            throw new RuntimeException("Could not open camera " + info.getId(), e);
+        }
+        active = new CameraSession(impl, info, opts);
+        return active;
+    }
+
+    /// Request runtime permission for camera (and optionally microphone). The
+    /// callback receives `true` when both are granted, `false` otherwise.
+    /// On iOS this is a no-op that delivers `true` immediately; the system
+    /// prompts the first time the camera is actually started.
+    public static void requestPermissions(final boolean audio, final SuccessCallback<Boolean> callback) {
+        CameraImpl impl = newImpl();
+        if (impl == null) {
+            fireLater(callback, Boolean.FALSE);
+            return;
+        }
+        try {
+            impl.open("__permission_probe__", new CameraSessionOptions().captureAudio(audio));
+            // open() throws on permission denial; if we get here permissions are granted.
+            fireLater(callback, Boolean.TRUE);
+        } catch (Throwable t) {
+            fireLater(callback, Boolean.FALSE);
+        } finally {
+            try { impl.close(); } catch (Throwable t) { Log.e(t); }
+        }
+    }
+
+    private static void fireLater(final SuccessCallback<Boolean> callback, final Boolean value) {
+        if (callback == null) return;
+        Display.getInstance().callSerially(new Runnable() {
+            @Override public void run() { callback.onSucess(value); }
+        });
+    }
+
+    private static CameraImpl newImpl() {
+        return Display.getInstance().getCameraBackend();
+    }
+
+    static void clearActive(CameraSession s) {
+        if (active == s) active = null;
+    }
+}

--- a/CodenameOne/src/com/codename1/camera/Camera.java
+++ b/CodenameOne/src/com/codename1/camera/Camera.java
@@ -60,10 +60,6 @@ import java.io.IOException;
 ///         BarcodeScanner.scan(frame.getJpegBytes()).ready(codes -> { ... }));
 /// }
 /// ```
-///
-/// #### Since
-///
-/// 8.1
 public final class Camera {
     private static final Object ACTIVE_LOCK = new Object();
     private static CameraSession active;

--- a/CodenameOne/src/com/codename1/camera/Camera.java
+++ b/CodenameOne/src/com/codename1/camera/Camera.java
@@ -87,7 +87,11 @@ public final class Camera {
             CameraInfo[] out = probe.enumerateCameras();
             return out == null ? new CameraInfo[0] : out;
         } finally {
-            try { probe.close(); } catch (Throwable t) { Log.e(t); }
+            try {
+                probe.close();
+            } catch (Throwable t) {
+                Log.e(t);
+            }
         }
     }
 
@@ -131,7 +135,11 @@ public final class Camera {
             try {
                 impl.open(info.getId(), opts);
             } catch (IOException e) {
-                try { impl.close(); } catch (Throwable t) { Log.e(t); }
+                try {
+                    impl.close();
+                } catch (Throwable t) {
+                    Log.e(t);
+                }
                 throw new RuntimeException("Could not open camera " + info.getId(), e);
             }
             active = new CameraSession(impl, info, opts);
@@ -156,7 +164,11 @@ public final class Camera {
         } catch (Throwable t) {
             fireLater(callback, Boolean.FALSE);
         } finally {
-            try { impl.close(); } catch (Throwable t) { Log.e(t); }
+            try {
+                impl.close();
+            } catch (Throwable t) {
+                Log.e(t);
+            }
         }
     }
 
@@ -165,7 +177,9 @@ public final class Camera {
             return;
         }
         Display.getInstance().callSerially(new Runnable() {
-            @Override public void run() { callback.onSucess(value); }
+            @Override public void run() {
+                callback.onSucess(value);
+            }
         });
     }
 

--- a/CodenameOne/src/com/codename1/camera/CameraFacing.java
+++ b/CodenameOne/src/com/codename1/camera/CameraFacing.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.camera;
+
+/// Direction a camera faces relative to the device screen.
+public enum CameraFacing {
+    /// Camera on the same side as the display (selfie camera).
+    FRONT,
+
+    /// Camera on the opposite side of the display (the main rear camera).
+    BACK,
+
+    /// Externally attached camera (USB, accessory). Rare; not supported on all platforms.
+    EXTERNAL
+}

--- a/CodenameOne/src/com/codename1/camera/CameraFrame.java
+++ b/CodenameOne/src/com/codename1/camera/CameraFrame.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.camera;
+
+/// A single frame delivered to a `FrameListener`.
+///
+/// **Lifetime**: the byte arrays returned by this class are valid only while
+/// `FrameListener#onFrame(CameraFrame)` is on the stack. After it returns the
+/// framework may reuse or release the underlying buffers. Clone any data you
+/// need to keep.
+public final class CameraFrame {
+    private final byte[] jpegBytes;
+    private final byte[] rawBytes;
+    private final int width;
+    private final int height;
+    private final int rotationDegrees;
+    private final long timestampNanos;
+    private final FrameFormat format;
+
+    /// Used by platform implementations.
+    public CameraFrame(byte[] jpegBytes, byte[] rawBytes,
+                       int width, int height,
+                       int rotationDegrees, long timestampNanos,
+                       FrameFormat format) {
+        this.jpegBytes = jpegBytes;
+        this.rawBytes = rawBytes;
+        this.width = width;
+        this.height = height;
+        this.rotationDegrees = rotationDegrees;
+        this.timestampNanos = timestampNanos;
+        this.format = format;
+    }
+
+    /// JPEG-encoded bytes for this frame. Always non-null regardless of the
+    /// requested `FrameFormat`; the framework encodes raw frames into JPEG
+    /// on demand for AI module consumption.
+    public byte[] getJpegBytes() { return jpegBytes; }
+
+    /// Raw pixel bytes in the format requested via
+    /// `CameraSessionOptions#frameFormat(FrameFormat)`. `null` when the
+    /// requested format was `FrameFormat#JPEG`.
+    public byte[] getRawBytes() { return rawBytes; }
+
+    public int getWidth() { return width; }
+    public int getHeight() { return height; }
+
+    /// Clockwise rotation in degrees (0, 90, 180, 270) that should be applied
+    /// to the bytes to display them upright.
+    public int getRotationDegrees() { return rotationDegrees; }
+
+    /// Monotonic timestamp in nanoseconds. Useful for measuring inter-frame
+    /// intervals.
+    public long getTimestampNanos() { return timestampNanos; }
+
+    public FrameFormat getFormat() { return format; }
+}

--- a/CodenameOne/src/com/codename1/camera/CameraFrame.java
+++ b/CodenameOne/src/com/codename1/camera/CameraFrame.java
@@ -54,23 +54,37 @@ public final class CameraFrame {
     /// JPEG-encoded bytes for this frame. Always non-null regardless of the
     /// requested `FrameFormat`; the framework encodes raw frames into JPEG
     /// on demand for AI module consumption.
-    public byte[] getJpegBytes() { return jpegBytes; }
+    public byte[] getJpegBytes() {
+        return jpegBytes;
+    }
 
     /// Raw pixel bytes in the format requested via
     /// `CameraSessionOptions#frameFormat(FrameFormat)`. `null` when the
     /// requested format was `FrameFormat#JPEG`.
-    public byte[] getRawBytes() { return rawBytes; }
+    public byte[] getRawBytes() {
+        return rawBytes;
+    }
 
-    public int getWidth() { return width; }
-    public int getHeight() { return height; }
+    public int getWidth() {
+        return width;
+    }
+    public int getHeight() {
+        return height;
+    }
 
     /// Clockwise rotation in degrees (0, 90, 180, 270) that should be applied
     /// to the bytes to display them upright.
-    public int getRotationDegrees() { return rotationDegrees; }
+    public int getRotationDegrees() {
+        return rotationDegrees;
+    }
 
     /// Monotonic timestamp in nanoseconds. Useful for measuring inter-frame
     /// intervals.
-    public long getTimestampNanos() { return timestampNanos; }
+    public long getTimestampNanos() {
+        return timestampNanos;
+    }
 
-    public FrameFormat getFormat() { return format; }
+    public FrameFormat getFormat() {
+        return format;
+    }
 }

--- a/CodenameOne/src/com/codename1/camera/CameraFrame.java
+++ b/CodenameOne/src/com/codename1/camera/CameraFrame.java
@@ -65,9 +65,12 @@ public final class CameraFrame {
         return rawBytes;
     }
 
+    /// Pixel width of the frame.
     public int getWidth() {
         return width;
     }
+
+    /// Pixel height of the frame.
     public int getHeight() {
         return height;
     }
@@ -84,6 +87,8 @@ public final class CameraFrame {
         return timestampNanos;
     }
 
+    /// Pixel format actually used for `#getRawBytes()`. JPEG bytes returned by
+    /// `#getJpegBytes()` are always JPEG-encoded regardless of this value.
     public FrameFormat getFormat() {
         return format;
     }

--- a/CodenameOne/src/com/codename1/camera/CameraInfo.java
+++ b/CodenameOne/src/com/codename1/camera/CameraInfo.java
@@ -50,18 +50,30 @@ public final class CameraInfo {
     }
 
     /// Opaque, platform-specific identifier. Stable for the lifetime of the process.
-    public String getId() { return id; }
+    public String getId() {
+        return id;
+    }
 
-    public CameraFacing getFacing() { return facing; }
+    public CameraFacing getFacing() {
+        return facing;
+    }
 
     /// Supported still-photo resolutions, largest first. May be empty on platforms
     /// (e.g. the JavaSE simulator) that don't expose a discrete list.
-    public Dimension[] getPhotoSizes() { return photoSizes; }
+    public Dimension[] getPhotoSizes() {
+        return photoSizes;
+    }
 
     /// Supported preview/frame-stream resolutions. May be empty on platforms that
     /// don't expose a discrete list.
-    public Dimension[] getPreviewSizes() { return previewSizes; }
+    public Dimension[] getPreviewSizes() {
+        return previewSizes;
+    }
 
-    public boolean hasFlash() { return hasFlash; }
-    public boolean hasAutoFocus() { return hasAutoFocus; }
+    public boolean hasFlash() {
+        return hasFlash;
+    }
+    public boolean hasAutoFocus() {
+        return hasAutoFocus;
+    }
 }

--- a/CodenameOne/src/com/codename1/camera/CameraInfo.java
+++ b/CodenameOne/src/com/codename1/camera/CameraInfo.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.camera;
+
+import com.codename1.ui.geom.Dimension;
+
+/// Describes a physical camera available on the device.
+///
+/// Returned by `Camera#getCameras()` and `Camera#getDefault(CameraFacing)`.
+/// Instances are immutable and may be passed to `Camera#open(CameraInfo, CameraSessionOptions)`.
+public final class CameraInfo {
+    private final String id;
+    private final CameraFacing facing;
+    private final Dimension[] photoSizes;
+    private final Dimension[] previewSizes;
+    private final boolean hasFlash;
+    private final boolean hasAutoFocus;
+
+    /// Used by platform implementations. Application code obtains instances through
+    /// `Camera#getCameras()`.
+    public CameraInfo(String id, CameraFacing facing,
+                      Dimension[] photoSizes, Dimension[] previewSizes,
+                      boolean hasFlash, boolean hasAutoFocus) {
+        this.id = id;
+        this.facing = facing;
+        this.photoSizes = photoSizes == null ? new Dimension[0] : photoSizes;
+        this.previewSizes = previewSizes == null ? new Dimension[0] : previewSizes;
+        this.hasFlash = hasFlash;
+        this.hasAutoFocus = hasAutoFocus;
+    }
+
+    /// Opaque, platform-specific identifier. Stable for the lifetime of the process.
+    public String getId() { return id; }
+
+    public CameraFacing getFacing() { return facing; }
+
+    /// Supported still-photo resolutions, largest first. May be empty on platforms
+    /// (e.g. the JavaSE simulator) that don't expose a discrete list.
+    public Dimension[] getPhotoSizes() { return photoSizes; }
+
+    /// Supported preview/frame-stream resolutions. May be empty on platforms that
+    /// don't expose a discrete list.
+    public Dimension[] getPreviewSizes() { return previewSizes; }
+
+    public boolean hasFlash() { return hasFlash; }
+    public boolean hasAutoFocus() { return hasAutoFocus; }
+}

--- a/CodenameOne/src/com/codename1/camera/CameraInfo.java
+++ b/CodenameOne/src/com/codename1/camera/CameraInfo.java
@@ -54,6 +54,7 @@ public final class CameraInfo {
         return id;
     }
 
+    /// Direction this camera faces relative to the device screen.
     public CameraFacing getFacing() {
         return facing;
     }
@@ -70,9 +71,13 @@ public final class CameraInfo {
         return previewSizes;
     }
 
+    /// True if this camera has a flash/torch the application can drive
+    /// via `CameraSession#setFlashMode(FlashMode)`.
     public boolean hasFlash() {
         return hasFlash;
     }
+
+    /// True if this camera supports tap-to-focus / autofocus.
     public boolean hasAutoFocus() {
         return hasAutoFocus;
     }

--- a/CodenameOne/src/com/codename1/camera/CameraSession.java
+++ b/CodenameOne/src/com/codename1/camera/CameraSession.java
@@ -92,6 +92,10 @@ public final class CameraSession implements AutoCloseable {
     /// Backwards-compatible alias for `#setFrameListener(FrameListener)`.
     public void addFrameListener(FrameListener l) { setFrameListener(l); }
 
+    // Identity comparison is intentional: addFrameListener stores the
+    // exact callback reference, removeFrameListener only removes the same
+    // instance.
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
     public void removeFrameListener(FrameListener l) {
         if (this.frameListener == l) {
             setFrameListener(null);
@@ -118,7 +122,9 @@ public final class CameraSession implements AutoCloseable {
     /// Release the session. Idempotent.
     @Override
     public void close() {
-        if (closed) return;
+        if (closed) {
+            return;
+        }
         closed = true;
         try {
             impl.close();

--- a/CodenameOne/src/com/codename1/camera/CameraSession.java
+++ b/CodenameOne/src/com/codename1/camera/CameraSession.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.camera;
+
+import com.codename1.impl.CameraImpl;
+import com.codename1.util.AsyncResource;
+
+import java.io.IOException;
+
+/// Active camera session. Obtained from `Camera#open(CameraInfo, CameraSessionOptions)`.
+///
+/// Only one `CameraSession` may be open at a time; opening a second throws
+/// `IllegalStateException`. Closing the session releases the camera hardware
+/// and invalidates any `CameraView` returned by `#createView()`.
+///
+/// Sessions may be paused (releasing hardware while keeping the session object)
+/// and resumed; this is the right pattern when the app temporarily uses the
+/// classic `com.codename1.capture.Capture` API while a session is open, since
+/// the OS-level camera device is single-tenant.
+public final class CameraSession implements AutoCloseable {
+    private final CameraImpl impl;
+    private final CameraInfo info;
+    private final CameraSessionOptions options;
+    private FrameListener frameListener;
+    private CameraView view;
+    private boolean closed;
+
+    CameraSession(CameraImpl impl, CameraInfo info, CameraSessionOptions options) {
+        this.impl = impl;
+        this.info = info;
+        this.options = options;
+    }
+
+    /// Create the live preview component. Each session owns one view; subsequent
+    /// calls return the same instance.
+    public CameraView createView() {
+        if (view == null) {
+            view = new CameraView(this, impl.createPreviewPeer());
+        }
+        return view;
+    }
+
+    /// Capture a still photo with default options.
+    public AsyncResource<CapturedPhoto> takePhoto() {
+        return takePhoto(new PhotoCaptureOptions());
+    }
+
+    public AsyncResource<CapturedPhoto> takePhoto(PhotoCaptureOptions opts) {
+        AsyncResource<CapturedPhoto> out = new AsyncResource<CapturedPhoto>();
+        impl.takePhoto(opts == null ? new PhotoCaptureOptions() : opts, out);
+        return out;
+    }
+
+    /// Begin recording video to the given FileSystemStorage path. The returned
+    /// `VideoRecording` is the handle used to stop the recording.
+    public VideoRecording startVideoRecording(String filePath) {
+        try {
+            impl.startVideoRecording(filePath, options.isCaptureAudio());
+        } catch (IOException e) {
+            throw new RuntimeException("Could not start video recording", e);
+        }
+        return new VideoRecording(impl, filePath);
+    }
+
+    /// Install a frame listener. At most one frame listener may be active per
+    /// session; installing a second replaces the first. Pass `null` to remove.
+    public void setFrameListener(FrameListener l) {
+        this.frameListener = l;
+        impl.setFrameListener(l, options.getFrameFormat(), options.getFrameMaxFps());
+    }
+
+    /// Backwards-compatible alias for `#setFrameListener(FrameListener)`.
+    public void addFrameListener(FrameListener l) { setFrameListener(l); }
+
+    public void removeFrameListener(FrameListener l) {
+        if (this.frameListener == l) {
+            setFrameListener(null);
+        }
+    }
+
+    public void setFlashMode(FlashMode m) { impl.setFlashMode(m); }
+    public void setZoom(float ratio) { impl.setZoom(ratio); }
+
+    /// Request a focus operation at the normalized preview coordinate
+    /// (`0.0` top-left, `1.0` bottom-right).
+    public void focus(float xNorm, float yNorm) { impl.focus(xNorm, yNorm); }
+
+    public CameraInfo getInfo() { return info; }
+
+    public CameraSessionOptions getOptions() { return options; }
+
+    /// Release the hardware but keep this session object alive. Pair with
+    /// `#resume()`.
+    public void pause() { impl.pause(); }
+
+    public void resume() { impl.resume(); }
+
+    /// Release the session. Idempotent.
+    @Override
+    public void close() {
+        if (closed) return;
+        closed = true;
+        try {
+            impl.close();
+        } finally {
+            Camera.clearActive(this);
+        }
+    }
+
+    public boolean isClosed() { return closed; }
+
+    CameraImpl getImpl() { return impl; }
+}

--- a/CodenameOne/src/com/codename1/camera/CameraSession.java
+++ b/CodenameOne/src/com/codename1/camera/CameraSession.java
@@ -90,7 +90,9 @@ public final class CameraSession implements AutoCloseable {
     }
 
     /// Backwards-compatible alias for `#setFrameListener(FrameListener)`.
-    public void addFrameListener(FrameListener l) { setFrameListener(l); }
+    public void addFrameListener(FrameListener l) {
+        setFrameListener(l);
+    }
 
     // Identity comparison is intentional: addFrameListener stores the
     // exact callback reference, removeFrameListener only removes the same
@@ -102,22 +104,36 @@ public final class CameraSession implements AutoCloseable {
         }
     }
 
-    public void setFlashMode(FlashMode m) { impl.setFlashMode(m); }
-    public void setZoom(float ratio) { impl.setZoom(ratio); }
+    public void setFlashMode(FlashMode m) {
+        impl.setFlashMode(m);
+    }
+    public void setZoom(float ratio) {
+        impl.setZoom(ratio);
+    }
 
     /// Request a focus operation at the normalized preview coordinate
     /// (`0.0` top-left, `1.0` bottom-right).
-    public void focus(float xNorm, float yNorm) { impl.focus(xNorm, yNorm); }
+    public void focus(float xNorm, float yNorm) {
+        impl.focus(xNorm, yNorm);
+    }
 
-    public CameraInfo getInfo() { return info; }
+    public CameraInfo getInfo() {
+        return info;
+    }
 
-    public CameraSessionOptions getOptions() { return options; }
+    public CameraSessionOptions getOptions() {
+        return options;
+    }
 
     /// Release the hardware but keep this session object alive. Pair with
     /// `#resume()`.
-    public void pause() { impl.pause(); }
+    public void pause() {
+        impl.pause();
+    }
 
-    public void resume() { impl.resume(); }
+    public void resume() {
+        impl.resume();
+    }
 
     /// Release the session. Idempotent.
     @Override
@@ -133,7 +149,11 @@ public final class CameraSession implements AutoCloseable {
         }
     }
 
-    public boolean isClosed() { return closed; }
+    public boolean isClosed() {
+        return closed;
+    }
 
-    CameraImpl getImpl() { return impl; }
+    CameraImpl getImpl() {
+        return impl;
+    }
 }

--- a/CodenameOne/src/com/codename1/camera/CameraSession.java
+++ b/CodenameOne/src/com/codename1/camera/CameraSession.java
@@ -65,6 +65,9 @@ public final class CameraSession implements AutoCloseable {
         return takePhoto(new PhotoCaptureOptions());
     }
 
+    /// Capture a still photo using the given options (size, quality, file
+    /// path). The returned `AsyncResource` resolves on the EDT with the
+    /// captured photo, or fires its error callback if capture fails.
     public AsyncResource<CapturedPhoto> takePhoto(PhotoCaptureOptions opts) {
         AsyncResource<CapturedPhoto> out = new AsyncResource<CapturedPhoto>();
         impl.takePhoto(opts == null ? new PhotoCaptureOptions() : opts, out);
@@ -104,9 +107,14 @@ public final class CameraSession implements AutoCloseable {
         }
     }
 
+    /// Set the flash / torch behavior. No-op on cameras whose
+    /// `CameraInfo#hasFlash()` is false.
     public void setFlashMode(FlashMode m) {
         impl.setFlashMode(m);
     }
+
+    /// Set the zoom ratio where `1.0` is no zoom and values above `1.0`
+    /// zoom in. The platform implementation clamps to the supported range.
     public void setZoom(float ratio) {
         impl.setZoom(ratio);
     }
@@ -117,10 +125,13 @@ public final class CameraSession implements AutoCloseable {
         impl.focus(xNorm, yNorm);
     }
 
+    /// The `CameraInfo` for the physical camera this session is attached to.
     public CameraInfo getInfo() {
         return info;
     }
 
+    /// The options the session was opened with. Read-only snapshot; mutating
+    /// it after `Camera#open(CameraInfo, CameraSessionOptions)` has no effect.
     public CameraSessionOptions getOptions() {
         return options;
     }
@@ -131,6 +142,8 @@ public final class CameraSession implements AutoCloseable {
         impl.pause();
     }
 
+    /// Re-acquire the hardware after `#pause()`. No-op if the session is
+    /// already running.
     public void resume() {
         impl.resume();
     }
@@ -149,6 +162,7 @@ public final class CameraSession implements AutoCloseable {
         }
     }
 
+    /// True once `#close()` has been called on this session.
     public boolean isClosed() {
         return closed;
     }

--- a/CodenameOne/src/com/codename1/camera/CameraSessionOptions.java
+++ b/CodenameOne/src/com/codename1/camera/CameraSessionOptions.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.camera;
+
+/// Configuration for a `CameraSession`. Fluent builder.
+///
+/// All sizes are advisory; the platform may snap to its nearest supported
+/// resolution.
+public final class CameraSessionOptions {
+    private int previewWidth;
+    private int previewHeight;
+    private int photoWidth;
+    private int photoHeight;
+    private FrameFormat frameFormat = FrameFormat.JPEG;
+    private int frameMaxFps = 15;
+    private boolean captureAudio = true;
+    private boolean enableStabilization;
+
+    public CameraSessionOptions previewSize(int width, int height) {
+        this.previewWidth = width;
+        this.previewHeight = height;
+        return this;
+    }
+
+    public CameraSessionOptions photoSize(int width, int height) {
+        this.photoWidth = width;
+        this.photoHeight = height;
+        return this;
+    }
+
+    /// Format for frames delivered to `FrameListener`. Default `FrameFormat#JPEG`.
+    public CameraSessionOptions frameFormat(FrameFormat format) {
+        this.frameFormat = format == null ? FrameFormat.JPEG : format;
+        return this;
+    }
+
+    /// Cap on frame delivery rate to `FrameListener`s. Default 15.
+    /// Set to 0 to deliver every frame the camera produces.
+    public CameraSessionOptions frameMaxFps(int fps) {
+        this.frameMaxFps = Math.max(0, fps);
+        return this;
+    }
+
+    /// Whether to capture audio for video recording. Default true.
+    /// When false, no microphone permission is requested at session open.
+    public CameraSessionOptions captureAudio(boolean b) {
+        this.captureAudio = b;
+        return this;
+    }
+
+    /// Whether to request optical/electronic stabilization when supported.
+    /// Default false.
+    public CameraSessionOptions enableStabilization(boolean b) {
+        this.enableStabilization = b;
+        return this;
+    }
+
+    public int getPreviewWidth() { return previewWidth; }
+    public int getPreviewHeight() { return previewHeight; }
+    public int getPhotoWidth() { return photoWidth; }
+    public int getPhotoHeight() { return photoHeight; }
+    public FrameFormat getFrameFormat() { return frameFormat; }
+    public int getFrameMaxFps() { return frameMaxFps; }
+    public boolean isCaptureAudio() { return captureAudio; }
+    public boolean isStabilizationEnabled() { return enableStabilization; }
+}

--- a/CodenameOne/src/com/codename1/camera/CameraSessionOptions.java
+++ b/CodenameOne/src/com/codename1/camera/CameraSessionOptions.java
@@ -36,12 +36,18 @@ public final class CameraSessionOptions {
     private boolean captureAudio = true;
     private boolean enableStabilization;
 
+    /// Requested preview / frame-stream resolution. The platform may snap
+    /// to its nearest supported size. Pass `0` for either dimension to let
+    /// the platform pick.
     public CameraSessionOptions previewSize(int width, int height) {
         this.previewWidth = width;
         this.previewHeight = height;
         return this;
     }
 
+    /// Requested still-photo resolution. The platform may snap to its
+    /// nearest supported size. Pass `0` for either dimension to use the
+    /// camera's default photo size.
     public CameraSessionOptions photoSize(int width, int height) {
         this.photoWidth = width;
         this.photoHeight = height;
@@ -75,27 +81,42 @@ public final class CameraSessionOptions {
         return this;
     }
 
+    /// Requested preview width, or `0` to let the platform pick.
     public int getPreviewWidth() {
         return previewWidth;
     }
+
+    /// Requested preview height, or `0` to let the platform pick.
     public int getPreviewHeight() {
         return previewHeight;
     }
+
+    /// Requested still-photo width, or `0` to use the camera default.
     public int getPhotoWidth() {
         return photoWidth;
     }
+
+    /// Requested still-photo height, or `0` to use the camera default.
     public int getPhotoHeight() {
         return photoHeight;
     }
+
+    /// Pixel format requested for `FrameListener` delivery.
     public FrameFormat getFrameFormat() {
         return frameFormat;
     }
+
+    /// Cap on frames-per-second delivered to listeners; `0` means uncapped.
     public int getFrameMaxFps() {
         return frameMaxFps;
     }
+
+    /// True if the session should request the microphone for video recording.
     public boolean isCaptureAudio() {
         return captureAudio;
     }
+
+    /// True if optical/electronic stabilization was requested.
     public boolean isStabilizationEnabled() {
         return enableStabilization;
     }

--- a/CodenameOne/src/com/codename1/camera/CameraSessionOptions.java
+++ b/CodenameOne/src/com/codename1/camera/CameraSessionOptions.java
@@ -75,12 +75,28 @@ public final class CameraSessionOptions {
         return this;
     }
 
-    public int getPreviewWidth() { return previewWidth; }
-    public int getPreviewHeight() { return previewHeight; }
-    public int getPhotoWidth() { return photoWidth; }
-    public int getPhotoHeight() { return photoHeight; }
-    public FrameFormat getFrameFormat() { return frameFormat; }
-    public int getFrameMaxFps() { return frameMaxFps; }
-    public boolean isCaptureAudio() { return captureAudio; }
-    public boolean isStabilizationEnabled() { return enableStabilization; }
+    public int getPreviewWidth() {
+        return previewWidth;
+    }
+    public int getPreviewHeight() {
+        return previewHeight;
+    }
+    public int getPhotoWidth() {
+        return photoWidth;
+    }
+    public int getPhotoHeight() {
+        return photoHeight;
+    }
+    public FrameFormat getFrameFormat() {
+        return frameFormat;
+    }
+    public int getFrameMaxFps() {
+        return frameMaxFps;
+    }
+    public boolean isCaptureAudio() {
+        return captureAudio;
+    }
+    public boolean isStabilizationEnabled() {
+        return enableStabilization;
+    }
 }

--- a/CodenameOne/src/com/codename1/camera/CameraView.java
+++ b/CodenameOne/src/com/codename1/camera/CameraView.java
@@ -63,6 +63,7 @@ public final class CameraView extends Container {
         }
     }
 
+    /// The `CameraSession` backing this view.
     public CameraSession getSession() {
         return session;
     }
@@ -73,14 +74,18 @@ public final class CameraView extends Container {
         this.mirrored = m;
     }
 
+    /// True when the preview is horizontally mirrored.
     public boolean isMirrored() {
         return mirrored;
     }
 
+    /// How the live preview is fitted inside the component bounds.
+    /// Defaults to `ScaleType#CROP` (filling the view, cropping at edges).
     public void setScaleType(ScaleType s) {
         this.scaleType = s == null ? ScaleType.CROP : s;
     }
 
+    /// Current scale type. Defaults to `ScaleType#CROP`.
     public ScaleType getScaleType() {
         return scaleType;
     }

--- a/CodenameOne/src/com/codename1/camera/CameraView.java
+++ b/CodenameOne/src/com/codename1/camera/CameraView.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.camera;
+
+import com.codename1.ui.Container;
+import com.codename1.ui.PeerComponent;
+import com.codename1.ui.layouts.BorderLayout;
+
+/// Component that renders a live camera preview. Created via
+/// `CameraSession#createView()` and added to a form like any other component.
+///
+/// ```java
+/// CameraInfo info = Camera.getDefault(CameraFacing.BACK);
+/// CameraSession session = Camera.open(info, new CameraSessionOptions());
+/// CameraView view = session.createView();
+/// view.setScaleType(ScaleType.CROP);
+///
+/// Form f = new Form("Camera", new BorderLayout());
+/// f.add(BorderLayout.CENTER, view);
+/// f.show();
+///
+/// session.setFrameListener(frame ->
+///     BarcodeScanner.scan(frame.getJpegBytes()).ready(codes -> {
+///         if (codes.length > 0) Log.p("scanned " + codes[0]);
+///     }));
+/// ```
+///
+/// The view holds a back-reference to its `CameraSession`; closing the session
+/// while the view is still attached to a form leaves the view rendering its
+/// last frame as a still image.
+public final class CameraView extends Container {
+    private final CameraSession session;
+    private final PeerComponent peer;
+    private boolean mirrored;
+    private ScaleType scaleType = ScaleType.CROP;
+
+    CameraView(CameraSession session, PeerComponent peer) {
+        super(new BorderLayout());
+        this.session = session;
+        this.peer = peer;
+        if (peer != null) {
+            add(BorderLayout.CENTER, peer);
+        }
+    }
+
+    public CameraSession getSession() { return session; }
+
+    /// Whether to horizontally mirror the preview. Usually `true` for front
+    /// cameras (matches the "mirror" feel users expect from a selfie view).
+    public void setMirrored(boolean m) {
+        this.mirrored = m;
+    }
+
+    public boolean isMirrored() { return mirrored; }
+
+    public void setScaleType(ScaleType s) {
+        this.scaleType = s == null ? ScaleType.CROP : s;
+    }
+
+    public ScaleType getScaleType() { return scaleType; }
+
+    /// Exposed for ports that need to update the preview node directly.
+    public PeerComponent getPreviewPeer() { return peer; }
+}

--- a/CodenameOne/src/com/codename1/camera/CameraView.java
+++ b/CodenameOne/src/com/codename1/camera/CameraView.java
@@ -63,7 +63,9 @@ public final class CameraView extends Container {
         }
     }
 
-    public CameraSession getSession() { return session; }
+    public CameraSession getSession() {
+        return session;
+    }
 
     /// Whether to horizontally mirror the preview. Usually `true` for front
     /// cameras (matches the "mirror" feel users expect from a selfie view).
@@ -71,14 +73,20 @@ public final class CameraView extends Container {
         this.mirrored = m;
     }
 
-    public boolean isMirrored() { return mirrored; }
+    public boolean isMirrored() {
+        return mirrored;
+    }
 
     public void setScaleType(ScaleType s) {
         this.scaleType = s == null ? ScaleType.CROP : s;
     }
 
-    public ScaleType getScaleType() { return scaleType; }
+    public ScaleType getScaleType() {
+        return scaleType;
+    }
 
     /// Exposed for ports that need to update the preview node directly.
-    public PeerComponent getPreviewPeer() { return peer; }
+    public PeerComponent getPreviewPeer() {
+        return peer;
+    }
 }

--- a/CodenameOne/src/com/codename1/camera/CapturedPhoto.java
+++ b/CodenameOne/src/com/codename1/camera/CapturedPhoto.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.camera;
+
+import com.codename1.ui.Image;
+
+import java.io.IOException;
+
+/// Result of a still-photo capture via `CameraSession#takePhoto()`.
+///
+/// Both an in-memory JPEG byte array and a file path are returned; the framework
+/// always saves to the app-private storage so that the bytes survive the callback
+/// scope.
+public final class CapturedPhoto {
+    private final byte[] jpegBytes;
+    private final String filePath;
+    private final int width;
+    private final int height;
+
+    /// Used by platform implementations.
+    public CapturedPhoto(byte[] jpegBytes, String filePath, int width, int height) {
+        this.jpegBytes = jpegBytes;
+        this.filePath = filePath;
+        this.width = width;
+        this.height = height;
+    }
+
+    /// JPEG-encoded bytes of the captured photo. Hand directly to the
+    /// `com.codename1.ai.*` modules without re-reading from disk.
+    public byte[] getJpegBytes() { return jpegBytes; }
+
+    /// FileSystemStorage path the JPEG was saved to. The file is in the
+    /// application's private storage and persists until the app deletes it.
+    public String getFilePath() { return filePath; }
+
+    public int getWidth() { return width; }
+    public int getHeight() { return height; }
+
+    /// Convenience: decode the JPEG bytes into a Codename One `Image`.
+    public Image toImage() throws IOException {
+        return Image.createImage(jpegBytes, 0, jpegBytes.length);
+    }
+}

--- a/CodenameOne/src/com/codename1/camera/CapturedPhoto.java
+++ b/CodenameOne/src/com/codename1/camera/CapturedPhoto.java
@@ -57,9 +57,12 @@ public final class CapturedPhoto {
         return filePath;
     }
 
+    /// Pixel width of the captured photo.
     public int getWidth() {
         return width;
     }
+
+    /// Pixel height of the captured photo.
     public int getHeight() {
         return height;
     }

--- a/CodenameOne/src/com/codename1/camera/CapturedPhoto.java
+++ b/CodenameOne/src/com/codename1/camera/CapturedPhoto.java
@@ -47,14 +47,22 @@ public final class CapturedPhoto {
 
     /// JPEG-encoded bytes of the captured photo. Hand directly to the
     /// `com.codename1.ai.*` modules without re-reading from disk.
-    public byte[] getJpegBytes() { return jpegBytes; }
+    public byte[] getJpegBytes() {
+        return jpegBytes;
+    }
 
     /// FileSystemStorage path the JPEG was saved to. The file is in the
     /// application's private storage and persists until the app deletes it.
-    public String getFilePath() { return filePath; }
+    public String getFilePath() {
+        return filePath;
+    }
 
-    public int getWidth() { return width; }
-    public int getHeight() { return height; }
+    public int getWidth() {
+        return width;
+    }
+    public int getHeight() {
+        return height;
+    }
 
     /// Convenience: decode the JPEG bytes into a Codename One `Image`.
     public Image toImage() throws IOException {

--- a/CodenameOne/src/com/codename1/camera/FlashMode.java
+++ b/CodenameOne/src/com/codename1/camera/FlashMode.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.camera;
+
+/// Flash behavior for still capture or continuous illumination.
+public enum FlashMode {
+    /// Flash never fires.
+    OFF,
+
+    /// Flash fires for every still capture.
+    ON,
+
+    /// Camera decides whether to fire flash based on scene lighting.
+    AUTO,
+
+    /// Flash stays on continuously as a torch (also lights the preview).
+    TORCH
+}

--- a/CodenameOne/src/com/codename1/camera/FrameFormat.java
+++ b/CodenameOne/src/com/codename1/camera/FrameFormat.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.camera;
+
+/// Pixel format requested for `CameraFrame` data delivered to a `FrameListener`.
+///
+/// `JPEG` is the default and the right choice for feeding frames into the
+/// `com.codename1.ai.*` modules, all of which accept JPEG `byte[]` directly.
+/// Raw formats (`NV21`, `RGBA8888`) are useful when an application performs
+/// its own pixel processing and wants to avoid the JPEG encode/decode round-trip.
+public enum FrameFormat {
+    /// JPEG-encoded bytes available via `CameraFrame#getJpegBytes()`.
+    /// Always available regardless of the requested format; this is the
+    /// universal format for AI/vision module integration.
+    JPEG,
+
+    /// YUV 4:2:0 NV21 layout available via `CameraFrame#getRawBytes()`.
+    /// Useful for low-level pixel work on Android-style pipelines.
+    NV21,
+
+    /// 32-bit RGBA available via `CameraFrame#getRawBytes()`.
+    /// Width * height * 4 bytes.
+    RGBA8888
+}

--- a/CodenameOne/src/com/codename1/camera/FrameListener.java
+++ b/CodenameOne/src/com/codename1/camera/FrameListener.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.camera;
+
+/// Receives camera frames from an active `CameraSession`.
+///
+/// **Threading**: `#onFrame(CameraFrame)` is invoked on a non-EDT background thread.
+/// Do not touch UI directly. The standard pattern is to hand the JPEG bytes to one of
+/// the `com.codename1.ai.*` modules (whose `AsyncResource.ready(...)` callbacks already
+/// hop back to EDT), or to call `com.codename1.ui.Display#callSerially(Runnable)` yourself
+/// before updating the UI.
+///
+/// **Backpressure**: only one frame is delivered at a time per session. If a previous
+/// `onFrame` call is still running when a new frame arrives, the older frame is
+/// dropped silently. This is the right default for AI scanning use cases.
+///
+/// **Memory**: the byte arrays returned by `CameraFrame#getJpegBytes()` and
+/// `CameraFrame#getRawBytes()` are owned by the framework and become invalid once
+/// `onFrame` returns. Listeners that need to retain bytes past the callback must
+/// clone them.
+public interface FrameListener {
+    void onFrame(CameraFrame frame);
+}

--- a/CodenameOne/src/com/codename1/camera/PhotoCaptureOptions.java
+++ b/CodenameOne/src/com/codename1/camera/PhotoCaptureOptions.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.camera;
+
+/// Per-capture options for `CameraSession#takePhoto(PhotoCaptureOptions)`.
+/// A builder; chain calls fluently.
+public final class PhotoCaptureOptions {
+    private int width;
+    private int height;
+    private int jpegQuality = 90;
+    private String filePath;
+
+    /// Requested photo dimensions. `0` (the default for either) means use the
+    /// camera's default photo size.
+    public PhotoCaptureOptions size(int width, int height) {
+        this.width = width;
+        this.height = height;
+        return this;
+    }
+
+    /// JPEG encoding quality 1-100. Default 90.
+    public PhotoCaptureOptions jpegQuality(int q) {
+        if (q < 1) q = 1;
+        if (q > 100) q = 100;
+        this.jpegQuality = q;
+        return this;
+    }
+
+    /// Override the destination file path (FileSystemStorage path).
+    /// When unset, the framework saves to a temp file under the app home.
+    public PhotoCaptureOptions filePath(String path) {
+        this.filePath = path;
+        return this;
+    }
+
+    public int getWidth() { return width; }
+    public int getHeight() { return height; }
+    public int getJpegQuality() { return jpegQuality; }
+    public String getFilePath() { return filePath; }
+}

--- a/CodenameOne/src/com/codename1/camera/PhotoCaptureOptions.java
+++ b/CodenameOne/src/com/codename1/camera/PhotoCaptureOptions.java
@@ -57,8 +57,16 @@ public final class PhotoCaptureOptions {
         return this;
     }
 
-    public int getWidth() { return width; }
-    public int getHeight() { return height; }
-    public int getJpegQuality() { return jpegQuality; }
-    public String getFilePath() { return filePath; }
+    public int getWidth() {
+        return width;
+    }
+    public int getHeight() {
+        return height;
+    }
+    public int getJpegQuality() {
+        return jpegQuality;
+    }
+    public String getFilePath() {
+        return filePath;
+    }
 }

--- a/CodenameOne/src/com/codename1/camera/PhotoCaptureOptions.java
+++ b/CodenameOne/src/com/codename1/camera/PhotoCaptureOptions.java
@@ -40,8 +40,12 @@ public final class PhotoCaptureOptions {
 
     /// JPEG encoding quality 1-100. Default 90.
     public PhotoCaptureOptions jpegQuality(int q) {
-        if (q < 1) q = 1;
-        if (q > 100) q = 100;
+        if (q < 1) {
+            q = 1;
+        }
+        if (q > 100) {
+            q = 100;
+        }
         this.jpegQuality = q;
         return this;
     }

--- a/CodenameOne/src/com/codename1/camera/PhotoCaptureOptions.java
+++ b/CodenameOne/src/com/codename1/camera/PhotoCaptureOptions.java
@@ -57,15 +57,23 @@ public final class PhotoCaptureOptions {
         return this;
     }
 
+    /// Requested capture width, or `0` to use the camera default.
     public int getWidth() {
         return width;
     }
+
+    /// Requested capture height, or `0` to use the camera default.
     public int getHeight() {
         return height;
     }
+
+    /// JPEG encoding quality 1-100.
     public int getJpegQuality() {
         return jpegQuality;
     }
+
+    /// Configured destination FileSystemStorage path, or `null` if the
+    /// framework should pick a temp path.
     public String getFilePath() {
         return filePath;
     }

--- a/CodenameOne/src/com/codename1/camera/ScaleType.java
+++ b/CodenameOne/src/com/codename1/camera/ScaleType.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.camera;
+
+/// How the live preview from a `CameraView` is fitted inside its component bounds.
+public enum ScaleType {
+    /// Scale uniformly so the entire preview is visible, letterboxing if needed.
+    FIT,
+
+    /// Scale non-uniformly to fill the bounds (preview may be stretched).
+    FILL,
+
+    /// Scale uniformly to fill the bounds, cropping the edges as needed.
+    /// This is what most camera apps do.
+    CROP
+}

--- a/CodenameOne/src/com/codename1/camera/VideoRecording.java
+++ b/CodenameOne/src/com/codename1/camera/VideoRecording.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.camera;
+
+import com.codename1.impl.CameraImpl;
+import com.codename1.util.AsyncResource;
+
+/// Handle for an in-progress video recording started via
+/// `CameraSession#startVideoRecording(String)`. Call `#stop()` (fire-and-forget)
+/// or `#stopAndAwait()` (returns the final file path) to finish recording.
+///
+/// **Container format** is platform-specific: iOS produces `.mov`, Android `.mp4`,
+/// the JavaScript port `.webm`. Inspect the file extension of the returned path
+/// before consuming the result.
+public final class VideoRecording {
+    private final CameraImpl impl;
+    private final String requestedPath;
+    private final long startNanos;
+    private volatile boolean stopped;
+
+    /// Used by platform implementations.
+    public VideoRecording(CameraImpl impl, String requestedPath) {
+        this.impl = impl;
+        this.requestedPath = requestedPath;
+        this.startNanos = System.nanoTime();
+    }
+
+    /// Stop recording without waiting for the file to be finalized.
+    /// Use `#stopAndAwait()` if you need the final file path.
+    public void stop() {
+        if (stopped) return;
+        stopped = true;
+        impl.stopVideoRecording(null);
+    }
+
+    /// Stop recording and resolve with the final file path once the file is closed.
+    public AsyncResource<String> stopAndAwait() {
+        AsyncResource<String> out = new AsyncResource<String>();
+        if (stopped) {
+            out.complete(requestedPath);
+            return out;
+        }
+        stopped = true;
+        impl.stopVideoRecording(out);
+        return out;
+    }
+
+    public long getElapsedMillis() {
+        return (System.nanoTime() - startNanos) / 1000000L;
+    }
+
+    public boolean isRecording() { return !stopped; }
+
+    /// The file path that was requested when the recording started. The actual
+    /// final path returned by `#stopAndAwait()` may differ slightly (different
+    /// extension) depending on the platform's container format.
+    public String getRequestedPath() { return requestedPath; }
+}

--- a/CodenameOne/src/com/codename1/camera/VideoRecording.java
+++ b/CodenameOne/src/com/codename1/camera/VideoRecording.java
@@ -75,10 +75,14 @@ public final class VideoRecording {
         return System.currentTimeMillis() - startMillis;
     }
 
-    public boolean isRecording() { return !stopped; }
+    public boolean isRecording() {
+        return !stopped;
+    }
 
     /// The file path that was requested when the recording started. The actual
     /// final path returned by `#stopAndAwait()` may differ slightly (different
     /// extension) depending on the platform's container format.
-    public String getRequestedPath() { return requestedPath; }
+    public String getRequestedPath() {
+        return requestedPath;
+    }
 }

--- a/CodenameOne/src/com/codename1/camera/VideoRecording.java
+++ b/CodenameOne/src/com/codename1/camera/VideoRecording.java
@@ -36,6 +36,10 @@ public final class VideoRecording {
     private final CameraImpl impl;
     private final String requestedPath;
     private final long startMillis;
+    // volatile is intentional: stop() may be called from a background thread
+    // while isRecording() is polled from the EDT, and the publish/subscribe
+    // semantics are exactly what volatile provides.
+    @SuppressWarnings("PMD.AvoidUsingVolatile")
     private volatile boolean stopped;
 
     /// Used by platform implementations.
@@ -48,7 +52,9 @@ public final class VideoRecording {
     /// Stop recording without waiting for the file to be finalized.
     /// Use `#stopAndAwait()` if you need the final file path.
     public void stop() {
-        if (stopped) return;
+        if (stopped) {
+            return;
+        }
         stopped = true;
         impl.stopVideoRecording(null);
     }

--- a/CodenameOne/src/com/codename1/camera/VideoRecording.java
+++ b/CodenameOne/src/com/codename1/camera/VideoRecording.java
@@ -35,14 +35,14 @@ import com.codename1.util.AsyncResource;
 public final class VideoRecording {
     private final CameraImpl impl;
     private final String requestedPath;
-    private final long startNanos;
+    private final long startMillis;
     private volatile boolean stopped;
 
     /// Used by platform implementations.
     public VideoRecording(CameraImpl impl, String requestedPath) {
         this.impl = impl;
         this.requestedPath = requestedPath;
-        this.startNanos = System.nanoTime();
+        this.startMillis = System.currentTimeMillis();
     }
 
     /// Stop recording without waiting for the file to be finalized.
@@ -66,7 +66,7 @@ public final class VideoRecording {
     }
 
     public long getElapsedMillis() {
-        return (System.nanoTime() - startNanos) / 1000000L;
+        return System.currentTimeMillis() - startMillis;
     }
 
     public boolean isRecording() { return !stopped; }

--- a/CodenameOne/src/com/codename1/camera/VideoRecording.java
+++ b/CodenameOne/src/com/codename1/camera/VideoRecording.java
@@ -71,10 +71,12 @@ public final class VideoRecording {
         return out;
     }
 
+    /// Milliseconds since the recording started.
     public long getElapsedMillis() {
         return System.currentTimeMillis() - startMillis;
     }
 
+    /// True until `#stop()` or `#stopAndAwait()` has been called.
     public boolean isRecording() {
         return !stopped;
     }

--- a/CodenameOne/src/com/codename1/impl/CameraImpl.java
+++ b/CodenameOne/src/com/codename1/impl/CameraImpl.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.impl;
+
+import com.codename1.camera.CameraInfo;
+import com.codename1.camera.CameraSessionOptions;
+import com.codename1.camera.CapturedPhoto;
+import com.codename1.camera.FlashMode;
+import com.codename1.camera.FrameFormat;
+import com.codename1.camera.FrameListener;
+import com.codename1.camera.PhotoCaptureOptions;
+import com.codename1.ui.PeerComponent;
+import com.codename1.util.AsyncResource;
+
+import java.io.IOException;
+
+/// Per-session platform contract behind `com.codename1.camera.CameraSession`.
+///
+/// **Not part of the public API.** Each port (iOS / Android / JavaSE / JavaScript)
+/// subclasses this with a concrete implementation; `CodenameOneImplementation#createCameraImpl()`
+/// is the factory. One `CameraImpl` instance backs exactly one `CameraSession`.
+///
+/// @hidden
+public abstract class CameraImpl {
+
+    /// Returns the set of cameras the platform exposes. May be called before
+    /// `#open(String, CameraSessionOptions)` to let the application pick.
+    public abstract CameraInfo[] enumerateCameras();
+
+    /// Open the named camera and configure capture pipelines according to `opts`.
+    /// Implementations should honor the audio/no-audio flag and only request
+    /// microphone permission when audio capture is requested.
+    public abstract void open(String cameraId, CameraSessionOptions opts) throws IOException;
+
+    /// Create a preview component for this session. Called at most once per
+    /// session; the implementation should return a native peer that renders the
+    /// live preview into the form. May return `null` on platforms that don't
+    /// support a live preview.
+    public abstract PeerComponent createPreviewPeer();
+
+    /// Capture a still photo with the given per-shot options.
+    /// Resolve the result on the EDT.
+    public abstract void takePhoto(PhotoCaptureOptions opts, AsyncResource<CapturedPhoto> result);
+
+    /// Begin recording video to `filePath`. The path is a FileSystemStorage path;
+    /// the actual extension produced may differ depending on the platform's
+    /// container format.
+    public abstract void startVideoRecording(String filePath, boolean audio) throws IOException;
+
+    /// Stop the in-progress recording. If `result` is non-null, resolve it on
+    /// the EDT with the final file path.
+    public abstract void stopVideoRecording(AsyncResource<String> result);
+
+    /// Install (or remove, when `listener` is null) a single frame listener.
+    /// Implementations must invoke the listener on a background thread and
+    /// must drop frames silently when the previous invocation is still running.
+    public abstract void setFrameListener(FrameListener listener, FrameFormat format, int maxFps);
+
+    public abstract void setFlashMode(FlashMode mode);
+
+    /// 1.0 = no zoom; values above 1.0 zoom in. Implementations clamp to
+    /// the supported range.
+    public abstract void setZoom(float ratio);
+
+    /// Tap-to-focus at the normalized (`0.0` to `1.0`) preview coordinate.
+    public abstract void focus(float xNorm, float yNorm);
+
+    /// Release the underlying hardware but keep the session object usable.
+    /// Followed by `#resume()` to re-acquire.
+    public abstract void pause();
+    public abstract void resume();
+
+    /// Release all native resources for this session. Subsequent calls become
+    /// no-ops.
+    public abstract void close();
+}

--- a/CodenameOne/src/com/codename1/impl/CameraImpl.java
+++ b/CodenameOne/src/com/codename1/impl/CameraImpl.java
@@ -76,6 +76,8 @@ public abstract class CameraImpl {
     /// must drop frames silently when the previous invocation is still running.
     public abstract void setFrameListener(FrameListener listener, FrameFormat format, int maxFps);
 
+    /// Set the flash / torch mode. Implementations should be a no-op on
+    /// cameras without a flash.
     public abstract void setFlashMode(FlashMode mode);
 
     /// 1.0 = no zoom; values above 1.0 zoom in. Implementations clamp to
@@ -88,6 +90,8 @@ public abstract class CameraImpl {
     /// Release the underlying hardware but keep the session object usable.
     /// Followed by `#resume()` to re-acquire.
     public abstract void pause();
+
+    /// Re-acquire the hardware after a `#pause()`.
     public abstract void resume();
 
     /// Release all native resources for this session. Subsequent calls become

--- a/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
+++ b/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
@@ -6771,6 +6771,15 @@ public abstract class CodenameOneImplementation {
     public void capturePhoto(ActionListener response) {
     }
 
+    /// Factory for the low-level `com.codename1.camera.Camera` API. Each call
+    /// returns a fresh per-session backend, or `null` on platforms that do not
+    /// implement the new API. Subclasses override to wire in their port.
+    ///
+    /// @hidden
+    public CameraImpl createCameraImpl() {
+        return null;
+    }
+
     /// Captures a screenshot of the screen.
     ///
     /// #### Returns

--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -5674,6 +5674,16 @@ public final class Display extends CN1Constants {
         return impl.hasCamera();
     }
 
+    /// Creates a fresh per-session backend for the low-level
+    /// `com.codename1.camera.Camera` API. Returns `null` on platforms that do
+    /// not implement the new API. Application code should use `Camera.open(...)`
+    /// rather than calling this directly.
+    ///
+    /// @hidden
+    public com.codename1.impl.CameraImpl getCameraBackend() {
+        return impl.createCameraImpl();
+    }
+
     /// Indicates whether the native picker dialog is supported for the given type
     /// which can include one of PICKER_TYPE_DATE_AND_TIME, PICKER_TYPE_TIME, PICKER_TYPE_DATE
     ///

--- a/Ports/Android/src/com/codename1/impl/android/AndroidCameraImpl.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidCameraImpl.java
@@ -307,7 +307,7 @@ public class AndroidCameraImpl extends CameraImpl {
                     "androidx.camera.core.Preview$SurfaceProvider");
             clsPreview.getMethod("setSurfaceProvider", surfaceProviderCls)
                     .invoke(preview, surfaceProvider);
-            return Display.getInstance().getImplementation().createNativePeer(previewView);
+            return PeerComponent.create(previewView);
         } catch (Throwable t) {
             Log.e(TAG, "Could not create preview view", t);
             return null;

--- a/Ports/Android/src/com/codename1/impl/android/AndroidCameraImpl.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidCameraImpl.java
@@ -96,7 +96,6 @@ public class AndroidCameraImpl extends CameraImpl {
     private static Class<?> clsPreviewBuilder;
     private static Class<?> clsImageCapture;
     private static Class<?> clsImageCaptureBuilder;
-    private static Class<?> clsImageCaptureOnImageCapturedCallback;
     private static Class<?> clsImageAnalysis;
     private static Class<?> clsImageAnalysisBuilder;
     private static Class<?> clsImageAnalysisAnalyzer;
@@ -145,8 +144,6 @@ public class AndroidCameraImpl extends CameraImpl {
             clsPreviewBuilder = Class.forName("androidx.camera.core.Preview$Builder");
             clsImageCapture = Class.forName("androidx.camera.core.ImageCapture");
             clsImageCaptureBuilder = Class.forName("androidx.camera.core.ImageCapture$Builder");
-            clsImageCaptureOnImageCapturedCallback = Class.forName(
-                    "androidx.camera.core.ImageCapture$OnImageCapturedCallback");
             clsImageAnalysis = Class.forName("androidx.camera.core.ImageAnalysis");
             clsImageAnalysisBuilder = Class.forName("androidx.camera.core.ImageAnalysis$Builder");
             clsImageAnalysisAnalyzer = Class.forName("androidx.camera.core.ImageAnalysis$Analyzer");
@@ -320,97 +317,29 @@ public class AndroidCameraImpl extends CameraImpl {
             result.error(new IllegalStateException("Camera not opened"));
             return;
         }
-        // ImageCapture#takePicture(Executor, OnImageCapturedCallback)
-        try {
-            Object callback = Proxy.newProxyInstance(
-                    clsImageCaptureOnImageCapturedCallback.getClassLoader(),
-                    new Class<?>[] { clsImageCaptureOnImageCapturedCallback },
-                    new InvocationHandler() {
-                        @Override
-                        public Object invoke(Object proxy, Method m, Object[] args) {
-                            String name = m.getName();
-                            if ("onCaptureSuccess".equals(name)) {
-                                handlePhotoCaptured(args[0], opts, result);
-                                return null;
-                            }
-                            if ("onError".equals(name)) {
-                                final Throwable t = (Throwable) args[0];
-                                Display.getInstance().callSerially(new Runnable() {
-                                    @Override public void run() { result.error(t); }
-                                });
-                                return null;
-                            }
-                            return null;
-                        }
-                    });
-            // Anonymous proxy approach: Build an OnImageCapturedCallback subclass
-            // via Proxy. CameraX's API actually expects an abstract class, not an
-            // interface. Proxy can't subclass; we need to extend the abstract
-            // class. Use a small inner-class approach via the cgcheckedclassgen
-            // pattern, or fall back to reflection on the implementation. To
-            // keep this implementation compact and portable, we extend at
-            // runtime via a generated subclass loaded from a baked sub-class
-            // that the build server bundles into the user app jar.
-            //
-            // Until that is wired up, use the alternate takePicture(Executor,
-            // File, OnImageSavedCallback) signature which CameraX supports
-            // and which lets us pass an interface-style callback.
-            takePictureToFile(opts, result);
-            // suppress unused warning
-            if (callback == callback) { /* no-op */ }
-        } catch (Throwable t) {
-            result.error(t);
-        }
-    }
-
-    private void takePictureToFile(final PhotoCaptureOptions opts,
-                                   final AsyncResource<CapturedPhoto> result) {
+        // CameraX's in-memory OnImageCapturedCallback is an abstract class
+        // that java.lang.reflect.Proxy can't subclass. Use the to-file
+        // takePicture(OutputFileOptions, Executor, OnImageSavedCallback)
+        // overload instead -- OnImageSavedCallback is an interface, so Proxy
+        // works. We read the resulting JPEG back into memory before
+        // resolving the AsyncResource.
         try {
             final String filePath = opts.getFilePath() != null
                     ? opts.getFilePath()
                     : tempPhotoPath();
             final File outputFile = new File(absolutePath(filePath));
-            // Build OutputFileOptions
             Class<?> ofoBuilderCls = Class.forName(
                     "androidx.camera.core.ImageCapture$OutputFileOptions$Builder");
             Constructor<?> ofoCtor = ofoBuilderCls.getConstructor(File.class);
             Object ofoBuilder = ofoCtor.newInstance(outputFile);
             Object outputFileOptions = ofoBuilderCls.getMethod("build").invoke(ofoBuilder);
 
-            // Build OnImageSavedCallback (interface, so Proxy works)
             Class<?> savedCbCls = Class.forName(
                     "androidx.camera.core.ImageCapture$OnImageSavedCallback");
             Object savedCb = Proxy.newProxyInstance(savedCbCls.getClassLoader(),
                     new Class<?>[] { savedCbCls },
-                    new InvocationHandler() {
-                        @Override public Object invoke(Object p, Method m, Object[] a) {
-                            String n = m.getName();
-                            if ("onImageSaved".equals(n)) {
-                                Display.getInstance().callSerially(new Runnable() {
-                                    @Override public void run() {
-                                        try {
-                                            byte[] bytes = readAll(outputFile);
-                                            int[] wh = readJpegSize(bytes);
-                                            result.complete(new CapturedPhoto(
-                                                    bytes, filePath, wh[0], wh[1]));
-                                        } catch (Throwable t) {
-                                            result.error(t);
-                                        }
-                                    }
-                                });
-                                return null;
-                            }
-                            if ("onError".equals(n)) {
-                                final Throwable t = (Throwable) a[0];
-                                Display.getInstance().callSerially(new Runnable() {
-                                    @Override public void run() { result.error(t); }
-                                });
-                                return null;
-                            }
-                            return null;
-                        }
-                    });
-            // ImageCapture#takePicture(OutputFileOptions, Executor, OnImageSavedCallback)
+                    new ImageSavedHandler(outputFile, filePath, result));
+
             Class<?> ofoCls = Class.forName(
                     "androidx.camera.core.ImageCapture$OutputFileOptions");
             clsImageCapture.getMethod("takePicture", ofoCls, Executor.class, savedCbCls)
@@ -420,10 +349,46 @@ public class AndroidCameraImpl extends CameraImpl {
         }
     }
 
-    private void handlePhotoCaptured(Object imageProxy, PhotoCaptureOptions opts,
-                                     AsyncResource<CapturedPhoto> result) {
-        // Reserved for the in-memory path. Currently unused: see takePicture
-        // To-File path above. Kept around so the proxy callback compiles.
+    /// Static inner class so SpotBugs doesn't flag it as SIC_INNER_SHOULD_BE_STATIC_ANON
+    /// (and so we don't pin the AndroidCameraImpl instance for the duration of
+    /// a slow shutter / write).
+    private static final class ImageSavedHandler implements InvocationHandler {
+        private final File outputFile;
+        private final String filePath;
+        private final AsyncResource<CapturedPhoto> result;
+
+        ImageSavedHandler(File outputFile, String filePath, AsyncResource<CapturedPhoto> result) {
+            this.outputFile = outputFile;
+            this.filePath = filePath;
+            this.result = result;
+        }
+
+        @Override public Object invoke(Object p, Method m, Object[] a) {
+            String n = m.getName();
+            if ("onImageSaved".equals(n)) {
+                Display.getInstance().callSerially(new Runnable() {
+                    @Override public void run() {
+                        try {
+                            byte[] bytes = readAll(outputFile);
+                            int[] wh = readJpegSize(bytes);
+                            result.complete(new CapturedPhoto(
+                                    bytes, filePath, wh[0], wh[1]));
+                        } catch (Throwable t) {
+                            result.error(t);
+                        }
+                    }
+                });
+                return null;
+            }
+            if ("onError".equals(n)) {
+                final Throwable t = (Throwable) a[0];
+                Display.getInstance().callSerially(new Runnable() {
+                    @Override public void run() { result.error(t); }
+                });
+                return null;
+            }
+            return null;
+        }
     }
 
     @Override

--- a/Ports/Android/src/com/codename1/impl/android/AndroidCameraImpl.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidCameraImpl.java
@@ -1,0 +1,663 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.impl.android;
+
+import android.Manifest;
+import android.app.Activity;
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.ImageFormat;
+import android.graphics.Matrix;
+import android.graphics.Rect;
+import android.graphics.YuvImage;
+import android.media.Image;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.codename1.camera.CameraFacing;
+import com.codename1.camera.CameraFrame;
+import com.codename1.camera.CameraInfo;
+import com.codename1.camera.CameraSessionOptions;
+import com.codename1.camera.CapturedPhoto;
+import com.codename1.camera.FlashMode;
+import com.codename1.camera.FrameFormat;
+import com.codename1.camera.FrameListener;
+import com.codename1.camera.PhotoCaptureOptions;
+import com.codename1.impl.CameraImpl;
+import com.codename1.io.FileSystemStorage;
+import com.codename1.ui.Display;
+import com.codename1.ui.PeerComponent;
+import com.codename1.ui.geom.Dimension;
+import com.codename1.util.AsyncResource;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.nio.ByteBuffer;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/// Android implementation of `CameraImpl` backed by CameraX
+/// (`androidx.camera:camera-core` + `camera-camera2` + `camera-lifecycle`
+/// + `camera-view` + `camera-video`). Those dependencies are added to the
+/// end-user app's `build.gradle` automatically by
+/// `AiDependencyTable` (entry "com/codename1/camera/").
+///
+/// Because the Codename One Android port itself does not have CameraX on
+/// its compile classpath, all CameraX calls go through reflection. This
+/// matches the existing pattern in `com.codename1.io.oidc.OidcBrowserNativeImpl`
+/// and `com.codename1.io.webauthn.WebAuthnNativeImpl`.
+///
+/// @hidden
+public class AndroidCameraImpl extends CameraImpl {
+
+    private static final String TAG = "AndroidCameraImpl";
+
+    // Reflectively-loaded CameraX class references. Resolved lazily because
+    // they may not be present at port load time -- only the end-user app
+    // build pulls them in via Gradle.
+    private static volatile boolean cxResolved;
+    private static Class<?> clsProcessCameraProvider;
+    private static Class<?> clsCameraSelector;
+    private static Class<?> clsCameraSelectorBuilder;
+    private static Class<?> clsPreview;
+    private static Class<?> clsPreviewBuilder;
+    private static Class<?> clsImageCapture;
+    private static Class<?> clsImageCaptureBuilder;
+    private static Class<?> clsImageCaptureOnImageCapturedCallback;
+    private static Class<?> clsImageAnalysis;
+    private static Class<?> clsImageAnalysisBuilder;
+    private static Class<?> clsImageAnalysisAnalyzer;
+    private static Class<?> clsUseCase;
+    private static Class<?> clsCameraXProxy;
+    private static Class<?> clsPreviewView;
+    private static Class<?> clsProcessLifecycleOwner;
+    private static Class<?> clsLifecycleOwner;
+    private static Object frontLensFacing;
+    private static Object backLensFacing;
+
+    private final Activity activity;
+    private Object cameraProvider;
+    private Object camera;
+    private Object preview;
+    private Object imageCapture;
+    private Object imageAnalysis;
+    private View previewView;
+    private final AtomicBoolean listenerBusy = new AtomicBoolean();
+    private volatile FrameListener frameListener;
+    private volatile FrameFormat frameFormat = FrameFormat.JPEG;
+    private CameraInfo info;
+    private CameraSessionOptions options;
+    private Executor cameraExecutor;
+    private boolean isFrontFacing;
+    private boolean closed;
+
+    public AndroidCameraImpl(Activity activity) {
+        this.activity = activity;
+    }
+
+    // --------------------------------------------------------------------
+    // Reflection setup
+    // --------------------------------------------------------------------
+
+    private static synchronized boolean ensureCameraXResolved() {
+        if (cxResolved) {
+            return clsProcessCameraProvider != null;
+        }
+        cxResolved = true;
+        try {
+            clsProcessCameraProvider = Class.forName("androidx.camera.lifecycle.ProcessCameraProvider");
+            clsCameraSelector = Class.forName("androidx.camera.core.CameraSelector");
+            clsCameraSelectorBuilder = Class.forName("androidx.camera.core.CameraSelector$Builder");
+            clsPreview = Class.forName("androidx.camera.core.Preview");
+            clsPreviewBuilder = Class.forName("androidx.camera.core.Preview$Builder");
+            clsImageCapture = Class.forName("androidx.camera.core.ImageCapture");
+            clsImageCaptureBuilder = Class.forName("androidx.camera.core.ImageCapture$Builder");
+            clsImageCaptureOnImageCapturedCallback = Class.forName(
+                    "androidx.camera.core.ImageCapture$OnImageCapturedCallback");
+            clsImageAnalysis = Class.forName("androidx.camera.core.ImageAnalysis");
+            clsImageAnalysisBuilder = Class.forName("androidx.camera.core.ImageAnalysis$Builder");
+            clsImageAnalysisAnalyzer = Class.forName("androidx.camera.core.ImageAnalysis$Analyzer");
+            clsUseCase = Class.forName("androidx.camera.core.UseCase");
+            clsPreviewView = Class.forName("androidx.camera.view.PreviewView");
+            clsProcessLifecycleOwner = Class.forName("androidx.lifecycle.ProcessLifecycleOwner");
+            clsLifecycleOwner = Class.forName("androidx.lifecycle.LifecycleOwner");
+
+            frontLensFacing = clsCameraSelector.getField("LENS_FACING_FRONT").get(null);
+            backLensFacing = clsCameraSelector.getField("LENS_FACING_BACK").get(null);
+            return true;
+        } catch (Throwable t) {
+            Log.w(TAG, "CameraX classes not present on classpath: " + t.getMessage());
+            clsProcessCameraProvider = null;
+            return false;
+        }
+    }
+
+    // --------------------------------------------------------------------
+    // CameraImpl
+    // --------------------------------------------------------------------
+
+    @Override
+    public CameraInfo[] enumerateCameras() {
+        if (!ensureCameraXResolved()) {
+            return new CameraInfo[] {
+                new CameraInfo("back", CameraFacing.BACK,
+                        new Dimension[0], new Dimension[0], false, true)
+            };
+        }
+        return new CameraInfo[] {
+            new CameraInfo("back", CameraFacing.BACK,
+                    new Dimension[] { new Dimension(1920, 1080), new Dimension(1280, 720) },
+                    new Dimension[] { new Dimension(1280, 720),  new Dimension(640, 480) },
+                    true, true),
+            new CameraInfo("front", CameraFacing.FRONT,
+                    new Dimension[] { new Dimension(1280, 720),  new Dimension(640, 480) },
+                    new Dimension[] { new Dimension(1280, 720) },
+                    false, true)
+        };
+    }
+
+    @Override
+    public void open(String cameraId, CameraSessionOptions opts) throws IOException {
+        this.options = opts == null ? new CameraSessionOptions() : opts;
+        this.isFrontFacing = "front".equals(cameraId);
+        this.info = isFrontFacing ? enumerateCameras()[1] : enumerateCameras()[0];
+
+        if ("__permission_probe__".equals(cameraId)) {
+            requireCameraPermission();
+            if (options.isCaptureAudio()) requireAudioPermission();
+            return;
+        }
+
+        if (!ensureCameraXResolved()) {
+            throw new IOException("CameraX is not on the runtime classpath. "
+                    + "Make sure the build server injected the androidx.camera deps.");
+        }
+
+        requireCameraPermission();
+        if (options.isCaptureAudio()) requireAudioPermission();
+
+        cameraExecutor = Executors.newSingleThreadExecutor();
+
+        try {
+            // Build a CameraSelector for our facing.
+            Object selectorBuilder = clsCameraSelectorBuilder.getConstructor().newInstance();
+            clsCameraSelectorBuilder.getMethod("requireLensFacing", int.class)
+                    .invoke(selectorBuilder, isFrontFacing ? frontLensFacing : backLensFacing);
+            Object selector = clsCameraSelectorBuilder.getMethod("build").invoke(selectorBuilder);
+
+            // Preview
+            Object previewBuilder = clsPreviewBuilder.getConstructor().newInstance();
+            preview = clsPreviewBuilder.getMethod("build").invoke(previewBuilder);
+
+            // ImageCapture
+            Object icBuilder = clsImageCaptureBuilder.getConstructor().newInstance();
+            imageCapture = clsImageCaptureBuilder.getMethod("build").invoke(icBuilder);
+
+            // ImageAnalysis (only built if we need frame delivery)
+            Object iaBuilder = clsImageAnalysisBuilder.getConstructor().newInstance();
+            clsImageAnalysisBuilder.getMethod("setTargetResolution",
+                    Class.forName("android.util.Size"))
+                    .invoke(iaBuilder,
+                            new android.util.Size(
+                                    options.getPreviewWidth() > 0 ? options.getPreviewWidth() : 640,
+                                    options.getPreviewHeight() > 0 ? options.getPreviewHeight() : 480));
+            // STRATEGY_KEEP_ONLY_LATEST = 0 in CameraX
+            try {
+                clsImageAnalysisBuilder.getMethod("setBackpressureStrategy", int.class)
+                        .invoke(iaBuilder, 0);
+            } catch (Throwable ignored) { /* old CameraX */ }
+            imageAnalysis = clsImageAnalysisBuilder.getMethod("build").invoke(iaBuilder);
+
+            installFrameAnalyzer();
+
+            // Get the singleton ProcessCameraProvider asynchronously and bind.
+            final Object cameraSelectorFinal = selector;
+            Method getInstance = clsProcessCameraProvider.getMethod("getInstance", Context.class);
+            final Object futureProvider = getInstance.invoke(null, activity.getApplicationContext());
+            // ListenableFuture#addListener(Runnable, Executor)
+            Method addListener = futureProvider.getClass()
+                    .getMethod("addListener", Runnable.class, Executor.class);
+            final IOException[] openErr = new IOException[1];
+            final Object lock = new Object();
+            final boolean[] done = new boolean[1];
+            addListener.invoke(futureProvider, new Runnable() {
+                @Override public void run() {
+                    try {
+                        cameraProvider = futureProvider.getClass().getMethod("get").invoke(futureProvider);
+                        Object lifecycleOwner = clsProcessLifecycleOwner
+                                .getMethod("get").invoke(null);
+                        // bindToLifecycle(LifecycleOwner, CameraSelector, UseCase[])
+                        Method bind = clsProcessCameraProvider.getMethod("bindToLifecycle",
+                                clsLifecycleOwner, clsCameraSelector,
+                                java.lang.reflect.Array.newInstance(clsUseCase, 0).getClass());
+                        Object useCases = java.lang.reflect.Array.newInstance(clsUseCase, 3);
+                        java.lang.reflect.Array.set(useCases, 0, preview);
+                        java.lang.reflect.Array.set(useCases, 1, imageCapture);
+                        java.lang.reflect.Array.set(useCases, 2, imageAnalysis);
+                        camera = bind.invoke(cameraProvider, lifecycleOwner, cameraSelectorFinal, useCases);
+                    } catch (Throwable t) {
+                        openErr[0] = new IOException("CameraX bind failed: " + t.getMessage(), t);
+                    } finally {
+                        synchronized (lock) { done[0] = true; lock.notifyAll(); }
+                    }
+                }
+            }, mainExecutor());
+
+            // Wait up to 5s for binding.
+            synchronized (lock) {
+                long deadline = System.currentTimeMillis() + 5000;
+                while (!done[0] && System.currentTimeMillis() < deadline) {
+                    try { lock.wait(200); } catch (InterruptedException ignored) { }
+                }
+            }
+            if (openErr[0] != null) throw openErr[0];
+            if (camera == null) throw new IOException("CameraX bind timed out");
+        } catch (IOException e) {
+            throw e;
+        } catch (Throwable t) {
+            throw new IOException("Could not open Android camera: " + t.getMessage(), t);
+        }
+    }
+
+    @Override
+    public PeerComponent createPreviewPeer() {
+        if (!ensureCameraXResolved()) return null;
+        try {
+            // PreviewView pv = new PreviewView(activity);
+            Constructor<?> ctor = clsPreviewView.getConstructor(Context.class);
+            previewView = (View) ctor.newInstance(activity);
+            // Hook the preview UseCase's surface provider to the PreviewView.
+            Object surfaceProvider = clsPreviewView.getMethod("getSurfaceProvider")
+                    .invoke(previewView);
+            // Preview#setSurfaceProvider(SurfaceProvider)
+            Class<?> surfaceProviderCls = Class.forName(
+                    "androidx.camera.core.Preview$SurfaceProvider");
+            clsPreview.getMethod("setSurfaceProvider", surfaceProviderCls)
+                    .invoke(preview, surfaceProvider);
+            return Display.getInstance().getImplementation().createNativePeer(previewView);
+        } catch (Throwable t) {
+            Log.e(TAG, "Could not create preview view", t);
+            return null;
+        }
+    }
+
+    @Override
+    public void takePhoto(final PhotoCaptureOptions opts, final AsyncResource<CapturedPhoto> result) {
+        if (imageCapture == null) {
+            result.error(new IllegalStateException("Camera not opened"));
+            return;
+        }
+        // ImageCapture#takePicture(Executor, OnImageCapturedCallback)
+        try {
+            Object callback = Proxy.newProxyInstance(
+                    clsImageCaptureOnImageCapturedCallback.getClassLoader(),
+                    new Class<?>[] { clsImageCaptureOnImageCapturedCallback },
+                    new InvocationHandler() {
+                        @Override
+                        public Object invoke(Object proxy, Method m, Object[] args) {
+                            String name = m.getName();
+                            if ("onCaptureSuccess".equals(name)) {
+                                handlePhotoCaptured(args[0], opts, result);
+                                return null;
+                            }
+                            if ("onError".equals(name)) {
+                                final Throwable t = (Throwable) args[0];
+                                Display.getInstance().callSerially(new Runnable() {
+                                    @Override public void run() { result.error(t); }
+                                });
+                                return null;
+                            }
+                            return null;
+                        }
+                    });
+            // Anonymous proxy approach: Build an OnImageCapturedCallback subclass
+            // via Proxy. CameraX's API actually expects an abstract class, not an
+            // interface. Proxy can't subclass; we need to extend the abstract
+            // class. Use a small inner-class approach via the cgcheckedclassgen
+            // pattern, or fall back to reflection on the implementation. To
+            // keep this implementation compact and portable, we extend at
+            // runtime via a generated subclass loaded from a baked sub-class
+            // that the build server bundles into the user app jar.
+            //
+            // Until that is wired up, use the alternate takePicture(Executor,
+            // File, OnImageSavedCallback) signature which CameraX supports
+            // and which lets us pass an interface-style callback.
+            takePictureToFile(opts, result);
+            // suppress unused warning
+            if (callback == callback) { /* no-op */ }
+        } catch (Throwable t) {
+            result.error(t);
+        }
+    }
+
+    private void takePictureToFile(final PhotoCaptureOptions opts,
+                                   final AsyncResource<CapturedPhoto> result) {
+        try {
+            final String filePath = opts.getFilePath() != null
+                    ? opts.getFilePath()
+                    : tempPhotoPath();
+            final File outputFile = new File(absolutePath(filePath));
+            // Build OutputFileOptions
+            Class<?> ofoBuilderCls = Class.forName(
+                    "androidx.camera.core.ImageCapture$OutputFileOptions$Builder");
+            Constructor<?> ofoCtor = ofoBuilderCls.getConstructor(File.class);
+            Object ofoBuilder = ofoCtor.newInstance(outputFile);
+            Object outputFileOptions = ofoBuilderCls.getMethod("build").invoke(ofoBuilder);
+
+            // Build OnImageSavedCallback (interface, so Proxy works)
+            Class<?> savedCbCls = Class.forName(
+                    "androidx.camera.core.ImageCapture$OnImageSavedCallback");
+            Object savedCb = Proxy.newProxyInstance(savedCbCls.getClassLoader(),
+                    new Class<?>[] { savedCbCls },
+                    new InvocationHandler() {
+                        @Override public Object invoke(Object p, Method m, Object[] a) {
+                            String n = m.getName();
+                            if ("onImageSaved".equals(n)) {
+                                Display.getInstance().callSerially(new Runnable() {
+                                    @Override public void run() {
+                                        try {
+                                            byte[] bytes = readAll(outputFile);
+                                            int[] wh = readJpegSize(bytes);
+                                            result.complete(new CapturedPhoto(
+                                                    bytes, filePath, wh[0], wh[1]));
+                                        } catch (Throwable t) {
+                                            result.error(t);
+                                        }
+                                    }
+                                });
+                                return null;
+                            }
+                            if ("onError".equals(n)) {
+                                final Throwable t = (Throwable) a[0];
+                                Display.getInstance().callSerially(new Runnable() {
+                                    @Override public void run() { result.error(t); }
+                                });
+                                return null;
+                            }
+                            return null;
+                        }
+                    });
+            // ImageCapture#takePicture(OutputFileOptions, Executor, OnImageSavedCallback)
+            Class<?> ofoCls = Class.forName(
+                    "androidx.camera.core.ImageCapture$OutputFileOptions");
+            clsImageCapture.getMethod("takePicture", ofoCls, Executor.class, savedCbCls)
+                    .invoke(imageCapture, outputFileOptions, cameraExecutor, savedCb);
+        } catch (Throwable t) {
+            result.error(t);
+        }
+    }
+
+    private void handlePhotoCaptured(Object imageProxy, PhotoCaptureOptions opts,
+                                     AsyncResource<CapturedPhoto> result) {
+        // Reserved for the in-memory path. Currently unused: see takePicture
+        // To-File path above. Kept around so the proxy callback compiles.
+    }
+
+    @Override
+    public void startVideoRecording(String filePath, boolean audio) throws IOException {
+        // Video recording via CameraX requires VideoCapture which is shipped
+        // in androidx.camera:camera-video. Implementing it via reflection in
+        // this v1 is intentionally limited: most apps use the legacy
+        // com.codename1.capture.Capture#captureVideo for full-file recording
+        // and the new API for preview/photo/frames. A full reflective
+        // implementation would mirror the takePicture-to-file pattern above
+        // against Recorder + PendingRecording.
+        throw new IOException("Video recording via CameraX is not yet supported on Android. "
+                + "Use com.codename1.capture.Capture.captureVideo() for video.");
+    }
+
+    @Override
+    public void stopVideoRecording(AsyncResource<String> result) {
+        if (result != null) {
+            result.error(new IllegalStateException("Video recording not active"));
+        }
+    }
+
+    @Override
+    public void setFrameListener(FrameListener listener, FrameFormat format, int maxFps) {
+        this.frameListener = listener;
+        this.frameFormat = format == null ? FrameFormat.JPEG : format;
+    }
+
+    private void installFrameAnalyzer() {
+        if (imageAnalysis == null) return;
+        try {
+            Object analyzer = Proxy.newProxyInstance(
+                    clsImageAnalysisAnalyzer.getClassLoader(),
+                    new Class<?>[] { clsImageAnalysisAnalyzer },
+                    new InvocationHandler() {
+                        @Override public Object invoke(Object p, Method m, Object[] a) {
+                            if ("analyze".equals(m.getName())) {
+                                onImageProxy(a[0]);
+                            }
+                            return null;
+                        }
+                    });
+            clsImageAnalysis.getMethod("setAnalyzer", Executor.class, clsImageAnalysisAnalyzer)
+                    .invoke(imageAnalysis, cameraExecutor, analyzer);
+        } catch (Throwable t) {
+            Log.w(TAG, "Could not install frame analyzer: " + t.getMessage());
+        }
+    }
+
+    private void onImageProxy(Object imageProxy) {
+        FrameListener l = frameListener;
+        if (l == null) {
+            // Always close the proxy or CameraX will stop delivering.
+            closeImageProxy(imageProxy);
+            return;
+        }
+        if (!listenerBusy.compareAndSet(false, true)) {
+            closeImageProxy(imageProxy);
+            return;
+        }
+        try {
+            // Convert ImageProxy -> Image -> JPEG bytes
+            byte[] jpeg = null;
+            int w = 0, h = 0;
+            int rotation = 0;
+            try {
+                Image img = (Image) imageProxy.getClass().getMethod("getImage").invoke(imageProxy);
+                Object imageInfo = imageProxy.getClass().getMethod("getImageInfo").invoke(imageProxy);
+                rotation = (Integer) imageInfo.getClass().getMethod("getRotationDegrees").invoke(imageInfo);
+                if (img != null) {
+                    w = img.getWidth();
+                    h = img.getHeight();
+                    jpeg = yuvImageToJpeg(img);
+                }
+            } catch (Throwable t) {
+                Log.w(TAG, "Frame conversion failed: " + t.getMessage());
+            }
+            if (jpeg != null) {
+                l.onFrame(new CameraFrame(jpeg, null, w, h, rotation,
+                        System.nanoTime(), frameFormat));
+            }
+        } finally {
+            listenerBusy.set(false);
+            closeImageProxy(imageProxy);
+        }
+    }
+
+    private static void closeImageProxy(Object imageProxy) {
+        try {
+            imageProxy.getClass().getMethod("close").invoke(imageProxy);
+        } catch (Throwable ignored) { }
+    }
+
+    private static byte[] yuvImageToJpeg(Image image) {
+        if (image.getFormat() == ImageFormat.JPEG) {
+            ByteBuffer buf = image.getPlanes()[0].getBuffer();
+            byte[] out = new byte[buf.remaining()];
+            buf.get(out);
+            return out;
+        }
+        // YUV_420_888 -> NV21 -> JPEG via YuvImage
+        int w = image.getWidth();
+        int h = image.getHeight();
+        Image.Plane[] planes = image.getPlanes();
+        ByteBuffer y = planes[0].getBuffer();
+        ByteBuffer u = planes[1].getBuffer();
+        ByteBuffer v = planes[2].getBuffer();
+        int ySize = y.remaining();
+        int uSize = u.remaining();
+        int vSize = v.remaining();
+        byte[] nv21 = new byte[ySize + uSize + vSize];
+        y.get(nv21, 0, ySize);
+        v.get(nv21, ySize, vSize);
+        u.get(nv21, ySize + vSize, uSize);
+        YuvImage yuv = new YuvImage(nv21, ImageFormat.NV21, w, h, null);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        yuv.compressToJpeg(new Rect(0, 0, w, h), 80, baos);
+        return baos.toByteArray();
+    }
+
+    @Override
+    public void setFlashMode(FlashMode mode) {
+        if (imageCapture == null) return;
+        try {
+            int code = mode == null ? 2
+                    : mode == FlashMode.OFF ? 2
+                    : mode == FlashMode.ON ? 1
+                    : 0; // AUTO
+            clsImageCapture.getMethod("setFlashMode", int.class).invoke(imageCapture, code);
+        } catch (Throwable ignored) { }
+    }
+
+    @Override
+    public void setZoom(float ratio) {
+        if (camera == null) return;
+        try {
+            Object cameraControl = camera.getClass().getMethod("getCameraControl").invoke(camera);
+            cameraControl.getClass().getMethod("setZoomRatio", float.class).invoke(cameraControl, ratio);
+        } catch (Throwable ignored) { }
+    }
+
+    @Override
+    public void focus(float xNorm, float yNorm) {
+        // Reflective focus would need MeteringPointFactory + FocusMeteringAction
+        // builder reflection. Left as a documented no-op in v1.
+    }
+
+    @Override
+    public void pause() {
+        // CameraX is bound to ProcessLifecycleOwner -- it pauses automatically
+        // when the activity does. Explicit pause for a custom session would
+        // require unbinding/rebinding; deferred.
+    }
+
+    @Override
+    public void resume() {
+        // See pause().
+    }
+
+    @Override
+    public void close() {
+        if (closed) return;
+        closed = true;
+        try {
+            if (cameraProvider != null) {
+                clsProcessCameraProvider.getMethod("unbindAll").invoke(cameraProvider);
+            }
+        } catch (Throwable ignored) { }
+        previewView = null;
+        camera = null;
+        preview = null;
+        imageCapture = null;
+        imageAnalysis = null;
+        cameraProvider = null;
+        frameListener = null;
+    }
+
+    // --------------------------------------------------------------------
+    // Helpers
+    // --------------------------------------------------------------------
+
+    private void requireCameraPermission() throws IOException {
+        if (!AndroidNativeUtil.checkForPermission(Manifest.permission.CAMERA,
+                "Required to access the camera.")) {
+            throw new IOException("Camera permission denied");
+        }
+    }
+
+    private void requireAudioPermission() throws IOException {
+        if (!AndroidNativeUtil.checkForPermission(Manifest.permission.RECORD_AUDIO,
+                "Required to capture audio for video recording.")) {
+            throw new IOException("Microphone permission denied");
+        }
+    }
+
+    private static Executor mainExecutor() {
+        final Handler h = new Handler(Looper.getMainLooper());
+        return new Executor() {
+            @Override public void execute(Runnable r) { h.post(r); }
+        };
+    }
+
+    private static String tempPhotoPath() {
+        FileSystemStorage fs = FileSystemStorage.getInstance();
+        String dir = fs.getAppHomePath();
+        if (!dir.endsWith("/")) dir += "/";
+        return dir + "cn1_photo_" + System.currentTimeMillis() + ".jpg";
+    }
+
+    private static String absolutePath(String fsStoragePath) {
+        // Map FileSystemStorage path (file://...) to a plain filesystem path.
+        if (fsStoragePath.startsWith("file:")) {
+            return fsStoragePath.substring(fsStoragePath.indexOf(':') + 1);
+        }
+        return fsStoragePath;
+    }
+
+    private static byte[] readAll(File f) throws IOException {
+        java.io.InputStream in = new java.io.FileInputStream(f);
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            byte[] buf = new byte[8192];
+            int n;
+            while ((n = in.read(buf)) >= 0) baos.write(buf, 0, n);
+            return baos.toByteArray();
+        } finally {
+            in.close();
+        }
+    }
+
+    private static int[] readJpegSize(byte[] bytes) {
+        BitmapFactory.Options o = new BitmapFactory.Options();
+        o.inJustDecodeBounds = true;
+        BitmapFactory.decodeByteArray(bytes, 0, bytes.length, o);
+        return new int[] { o.outWidth, o.outHeight };
+    }
+}

--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -9960,6 +9960,13 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
         }
     }
 
+    @Override
+    public com.codename1.impl.CameraImpl createCameraImpl() {
+        Activity act = getActivity();
+        if (act == null) return null;
+        return new AndroidCameraImpl(act);
+    }
+
     // Deeper-network connectivity platform factories. Each returns a small
     // platform-specific class living under
     // com.codename1.impl.android.connectivity. Those classes are loaded

--- a/Ports/JavaSE/src/com/codename1/impl/javase/JavaSECameraImpl.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JavaSECameraImpl.java
@@ -52,9 +52,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -181,17 +178,23 @@ public class JavaSECameraImpl extends CameraImpl {
         final int quality = opts.getJpegQuality();
         final String customPath = opts.getFilePath();
         final AsyncResource<CapturedPhoto> out = result;
-        ensureScheduler().execute(() -> {
-            try {
-                BufferedImage img = renderFrame(w, h, true);
-                byte[] jpeg = encodeJpeg(img, quality);
-                String path = customPath != null ? customPath : tempPath("photo", ".jpg");
-                writeBytes(path, jpeg);
-                CapturedPhoto cp = new CapturedPhoto(jpeg, path, w, h);
-                Display.getInstance().callSerially(() -> out.complete(cp));
-            } catch (Throwable t) {
-                Log.e(t);
-                Display.getInstance().callSerially(() -> out.error(t));
+        ensureScheduler().execute(new Runnable() {
+            @Override public void run() {
+                try {
+                    BufferedImage img = renderFrame(w, h, true);
+                    byte[] jpeg = encodeJpeg(img, quality);
+                    String path = customPath != null ? customPath : tempPath("photo", ".jpg");
+                    writeBytes(path, jpeg);
+                    final CapturedPhoto cp = new CapturedPhoto(jpeg, path, w, h);
+                    Display.getInstance().callSerially(new Runnable() {
+                        @Override public void run() { out.complete(cp); }
+                    });
+                } catch (final Throwable t) {
+                    Log.e(t);
+                    Display.getInstance().callSerially(new Runnable() {
+                        @Override public void run() { out.error(t); }
+                    });
+                }
             }
         });
     }
@@ -213,7 +216,10 @@ public class JavaSECameraImpl extends CameraImpl {
         final String path = activeVideoPath;
         activeVideoPath = null;
         if (result != null) {
-            Display.getInstance().callSerially(() -> result.complete(path));
+            final AsyncResource<String> out = result;
+            Display.getInstance().callSerially(new Runnable() {
+                @Override public void run() { out.complete(path); }
+            });
         }
     }
 
@@ -268,7 +274,9 @@ public class JavaSECameraImpl extends CameraImpl {
         ScheduledExecutorService s = ensureScheduler();
         if (frameTask != null) frameTask.cancel(false);
         long periodMs = Math.max(33, 1000L / Math.max(1, fpsCap));
-        frameTask = s.scheduleAtFixedRate(this::tick, 0, periodMs, TimeUnit.MILLISECONDS);
+        frameTask = s.scheduleAtFixedRate(new Runnable() {
+            @Override public void run() { tick(); }
+        }, 0, periodMs, TimeUnit.MILLISECONDS);
     }
 
     private void restartScheduler() {
@@ -298,9 +306,11 @@ public class JavaSECameraImpl extends CameraImpl {
                     ? options.getPreviewHeight() : DEFAULT_PREVIEW_H;
             BufferedImage img = renderFrame(w, h, false);
             currentFrame = img;
-            JPanel p = previewPanel;
+            final JPanel p = previewPanel;
             if (p != null) {
-                javax.swing.SwingUtilities.invokeLater(p::repaint);
+                javax.swing.SwingUtilities.invokeLater(new Runnable() {
+                    @Override public void run() { p.repaint(); }
+                });
             }
             FrameListener l = frameListener;
             if (l == null) return;
@@ -327,27 +337,35 @@ public class JavaSECameraImpl extends CameraImpl {
         String src = System.getProperty(SOURCE_PROP);
         if (src == null || src.isEmpty()) return;
         try {
-            Path p = Paths.get(src);
-            if (Files.isDirectory(p)) {
-                try (java.util.stream.Stream<Path> stream = Files.list(p)) {
-                    stream.sorted()
-                          .filter(f -> {
-                              String n = f.getFileName().toString().toLowerCase();
-                              return n.endsWith(".jpg") || n.endsWith(".jpeg") || n.endsWith(".png");
-                          })
-                          .forEach(f -> {
-                              try (InputStream in = Files.newInputStream(f)) {
-                                  BufferedImage img = ImageIO.read(in);
-                                  if (img != null) sourceFrames.add(img);
-                              } catch (IOException e) {
-                                  Log.e(e);
-                              }
-                          });
+            File f = new File(src);
+            if (f.isDirectory()) {
+                File[] entries = f.listFiles();
+                if (entries != null) {
+                    java.util.Arrays.sort(entries);
+                    for (File entry : entries) {
+                        String n = entry.getName().toLowerCase();
+                        if (n.endsWith(".jpg") || n.endsWith(".jpeg") || n.endsWith(".png")) {
+                            InputStream in = null;
+                            try {
+                                in = new java.io.FileInputStream(entry);
+                                BufferedImage img = ImageIO.read(in);
+                                if (img != null) sourceFrames.add(img);
+                            } catch (IOException e) {
+                                Log.e(e);
+                            } finally {
+                                if (in != null) { try { in.close(); } catch (IOException ignored) { } }
+                            }
+                        }
+                    }
                 }
-            } else if (Files.isRegularFile(p)) {
-                try (InputStream in = Files.newInputStream(p)) {
+            } else if (f.isFile()) {
+                InputStream in = null;
+                try {
+                    in = new java.io.FileInputStream(f);
                     BufferedImage img = ImageIO.read(in);
                     if (img != null) sourceFrames.add(img);
+                } finally {
+                    if (in != null) { try { in.close(); } catch (IOException ignored) { } }
                 }
             }
         } catch (Throwable t) {

--- a/Ports/JavaSE/src/com/codename1/impl/javase/JavaSECameraImpl.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JavaSECameraImpl.java
@@ -1,0 +1,480 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.impl.javase;
+
+import com.codename1.camera.CameraFacing;
+import com.codename1.camera.CameraFrame;
+import com.codename1.camera.CameraInfo;
+import com.codename1.camera.CameraSessionOptions;
+import com.codename1.camera.CapturedPhoto;
+import com.codename1.camera.FlashMode;
+import com.codename1.camera.FrameFormat;
+import com.codename1.camera.FrameListener;
+import com.codename1.camera.PhotoCaptureOptions;
+import com.codename1.impl.CameraImpl;
+import com.codename1.io.FileSystemStorage;
+import com.codename1.io.Log;
+import com.codename1.ui.Display;
+import com.codename1.ui.PeerComponent;
+import com.codename1.ui.geom.Dimension;
+import com.codename1.util.AsyncResource;
+
+import javax.imageio.ImageIO;
+import javax.swing.JPanel;
+
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/// JavaSE / simulator implementation of `CameraImpl`. Generates synthetic JPEG
+/// frames so the rest of the app (AI modules, frame listeners, etc.) can be
+/// exercised against the real `Camera` API without webcam hardware.
+///
+/// Source can be overridden:
+/// - `-Dcn1.camera.source=/path/to/file.jpg` - emit the same image every tick.
+/// - `-Dcn1.camera.source=/path/to/folder` - cycle through the JPEGs in that folder.
+/// - default - generate a synthetic frame with a colored background and a tick
+///   counter (zero on-disk dependencies, still a real JPEG decodable by AI modules).
+///
+/// Frame rate can be overridden with `-Dcn1.camera.fps=10`.
+///
+/// @hidden
+public class JavaSECameraImpl extends CameraImpl {
+
+    private static final int DEFAULT_PREVIEW_W = 640;
+    private static final int DEFAULT_PREVIEW_H = 480;
+    private static final int DEFAULT_PHOTO_W = 1920;
+    private static final int DEFAULT_PHOTO_H = 1080;
+    private static final String SOURCE_PROP = "cn1.camera.source";
+    private static final String FPS_PROP = "cn1.camera.fps";
+
+    private static boolean hintsEnsured;
+
+    private final List<BufferedImage> sourceFrames = new ArrayList<>();
+    private final AtomicInteger frameIndex = new AtomicInteger();
+    private final AtomicBoolean listenerBusy = new AtomicBoolean();
+
+    private ScheduledExecutorService scheduler;
+    private ScheduledFuture<?> frameTask;
+    private JPanel previewPanel;
+    private CameraSessionOptions options;
+    private CameraInfo info;
+    private volatile BufferedImage currentFrame;
+    private volatile FrameListener frameListener;
+    private volatile FrameFormat frameFormat = FrameFormat.JPEG;
+    private volatile int fpsCap = 15;
+    private volatile boolean paused;
+    private volatile boolean closed;
+    private volatile String activeVideoPath;
+    private volatile long videoStartNanos;
+
+    public JavaSECameraImpl() {
+        ensureSimulatorHints();
+    }
+
+    @Override
+    public CameraInfo[] enumerateCameras() {
+        return new CameraInfo[] {
+            new CameraInfo("simulator-back", CameraFacing.BACK,
+                    new Dimension[] { new Dimension(DEFAULT_PHOTO_W, DEFAULT_PHOTO_H),
+                                      new Dimension(1280, 720),
+                                      new Dimension(DEFAULT_PREVIEW_W, DEFAULT_PREVIEW_H) },
+                    new Dimension[] { new Dimension(DEFAULT_PREVIEW_W, DEFAULT_PREVIEW_H),
+                                      new Dimension(320, 240) },
+                    false, true),
+            new CameraInfo("simulator-front", CameraFacing.FRONT,
+                    new Dimension[] { new Dimension(1280, 720),
+                                      new Dimension(DEFAULT_PREVIEW_W, DEFAULT_PREVIEW_H) },
+                    new Dimension[] { new Dimension(DEFAULT_PREVIEW_W, DEFAULT_PREVIEW_H) },
+                    false, false)
+        };
+    }
+
+    @Override
+    public void open(String cameraId, CameraSessionOptions opts) throws IOException {
+        this.options = opts == null ? new CameraSessionOptions() : opts;
+        this.info = enumerateCameras()[0];
+        if ("__permission_probe__".equals(cameraId)) {
+            return;
+        }
+        if (cameraId != null) {
+            for (CameraInfo c : enumerateCameras()) {
+                if (cameraId.equals(c.getId())) {
+                    this.info = c;
+                    break;
+                }
+            }
+        }
+        loadSourceFrames();
+        int requestedFps = Integer.getInteger(FPS_PROP, options.getFrameMaxFps() > 0 ? options.getFrameMaxFps() : 5);
+        this.fpsCap = Math.max(1, Math.min(30, requestedFps));
+        startScheduler();
+    }
+
+    @Override
+    public PeerComponent createPreviewPeer() {
+        if (previewPanel == null) {
+            previewPanel = new JPanel() {
+                @Override
+                protected void paintComponent(java.awt.Graphics g) {
+                    super.paintComponent(g);
+                    BufferedImage f = currentFrame;
+                    if (f != null) {
+                        g.drawImage(f, 0, 0, getWidth(), getHeight(), null);
+                    } else {
+                        g.setColor(Color.DARK_GRAY);
+                        g.fillRect(0, 0, getWidth(), getHeight());
+                    }
+                }
+            };
+            previewPanel.setBackground(Color.BLACK);
+            previewPanel.setPreferredSize(new java.awt.Dimension(DEFAULT_PREVIEW_W, DEFAULT_PREVIEW_H));
+        }
+        return PeerComponent.create(previewPanel);
+    }
+
+    @Override
+    public void takePhoto(PhotoCaptureOptions opts, AsyncResource<CapturedPhoto> result) {
+        if (opts == null) opts = new PhotoCaptureOptions();
+        final int w = opts.getWidth() > 0 ? opts.getWidth() : DEFAULT_PHOTO_W;
+        final int h = opts.getHeight() > 0 ? opts.getHeight() : DEFAULT_PHOTO_H;
+        final int quality = opts.getJpegQuality();
+        final String customPath = opts.getFilePath();
+        final AsyncResource<CapturedPhoto> out = result;
+        ensureScheduler().execute(() -> {
+            try {
+                BufferedImage img = renderFrame(w, h, true);
+                byte[] jpeg = encodeJpeg(img, quality);
+                String path = customPath != null ? customPath : tempPath("photo", ".jpg");
+                writeBytes(path, jpeg);
+                CapturedPhoto cp = new CapturedPhoto(jpeg, path, w, h);
+                Display.getInstance().callSerially(() -> out.complete(cp));
+            } catch (Throwable t) {
+                Log.e(t);
+                Display.getInstance().callSerially(() -> out.error(t));
+            }
+        });
+    }
+
+    @Override
+    public void startVideoRecording(String filePath, boolean audio) throws IOException {
+        this.activeVideoPath = filePath;
+        this.videoStartNanos = System.nanoTime();
+        // Touch the destination so consumers can play it back even if no real
+        // encoder runs in the simulator. The bytes are a placeholder still
+        // frame; production ports produce real video.
+        BufferedImage img = renderFrame(DEFAULT_PHOTO_W, DEFAULT_PHOTO_H, true);
+        byte[] jpeg = encodeJpeg(img, 80);
+        writeBytes(filePath, jpeg);
+    }
+
+    @Override
+    public void stopVideoRecording(AsyncResource<String> result) {
+        final String path = activeVideoPath;
+        activeVideoPath = null;
+        if (result != null) {
+            Display.getInstance().callSerially(() -> result.complete(path));
+        }
+    }
+
+    @Override
+    public void setFrameListener(FrameListener listener, FrameFormat format, int maxFps) {
+        this.frameListener = listener;
+        this.frameFormat = format == null ? FrameFormat.JPEG : format;
+        if (maxFps > 0) {
+            this.fpsCap = Math.max(1, Math.min(30, maxFps));
+            restartScheduler();
+        }
+    }
+
+    @Override public void setFlashMode(FlashMode mode) { /* no-op in simulator */ }
+    @Override public void setZoom(float ratio) { /* no-op in simulator */ }
+    @Override public void focus(float xNorm, float yNorm) { /* no-op in simulator */ }
+
+    @Override
+    public void pause() {
+        paused = true;
+        if (frameTask != null) {
+            frameTask.cancel(false);
+            frameTask = null;
+        }
+    }
+
+    @Override
+    public void resume() {
+        if (closed) return;
+        paused = false;
+        startScheduler();
+    }
+
+    @Override
+    public void close() {
+        if (closed) return;
+        closed = true;
+        if (frameTask != null) {
+            frameTask.cancel(false);
+            frameTask = null;
+        }
+        if (scheduler != null) {
+            scheduler.shutdownNow();
+            scheduler = null;
+        }
+        frameListener = null;
+        sourceFrames.clear();
+    }
+
+    private void startScheduler() {
+        if (paused || closed) return;
+        ScheduledExecutorService s = ensureScheduler();
+        if (frameTask != null) frameTask.cancel(false);
+        long periodMs = Math.max(33, 1000L / Math.max(1, fpsCap));
+        frameTask = s.scheduleAtFixedRate(this::tick, 0, periodMs, TimeUnit.MILLISECONDS);
+    }
+
+    private void restartScheduler() {
+        if (scheduler == null) return;
+        startScheduler();
+    }
+
+    private ScheduledExecutorService ensureScheduler() {
+        if (scheduler == null) {
+            scheduler = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
+                @Override public Thread newThread(Runnable r) {
+                    Thread t = new Thread(r, "JavaSECameraImpl");
+                    t.setDaemon(true);
+                    return t;
+                }
+            });
+        }
+        return scheduler;
+    }
+
+    private void tick() {
+        if (closed || paused) return;
+        try {
+            int w = options != null && options.getPreviewWidth() > 0
+                    ? options.getPreviewWidth() : DEFAULT_PREVIEW_W;
+            int h = options != null && options.getPreviewHeight() > 0
+                    ? options.getPreviewHeight() : DEFAULT_PREVIEW_H;
+            BufferedImage img = renderFrame(w, h, false);
+            currentFrame = img;
+            JPanel p = previewPanel;
+            if (p != null) {
+                javax.swing.SwingUtilities.invokeLater(p::repaint);
+            }
+            FrameListener l = frameListener;
+            if (l == null) return;
+            if (!listenerBusy.compareAndSet(false, true)) {
+                // Previous frame still being processed; drop this one.
+                return;
+            }
+            try {
+                byte[] jpeg = encodeJpeg(img, 80);
+                byte[] raw = frameFormat == FrameFormat.JPEG ? null : extractRaw(img, frameFormat);
+                CameraFrame frame = new CameraFrame(jpeg, raw, w, h, 0,
+                        System.nanoTime(), frameFormat);
+                l.onFrame(frame);
+            } finally {
+                listenerBusy.set(false);
+            }
+        } catch (Throwable t) {
+            Log.e(t);
+        }
+    }
+
+    private void loadSourceFrames() {
+        sourceFrames.clear();
+        String src = System.getProperty(SOURCE_PROP);
+        if (src == null || src.isEmpty()) return;
+        try {
+            Path p = Paths.get(src);
+            if (Files.isDirectory(p)) {
+                try (java.util.stream.Stream<Path> stream = Files.list(p)) {
+                    stream.sorted()
+                          .filter(f -> {
+                              String n = f.getFileName().toString().toLowerCase();
+                              return n.endsWith(".jpg") || n.endsWith(".jpeg") || n.endsWith(".png");
+                          })
+                          .forEach(f -> {
+                              try (InputStream in = Files.newInputStream(f)) {
+                                  BufferedImage img = ImageIO.read(in);
+                                  if (img != null) sourceFrames.add(img);
+                              } catch (IOException e) {
+                                  Log.e(e);
+                              }
+                          });
+                }
+            } else if (Files.isRegularFile(p)) {
+                try (InputStream in = Files.newInputStream(p)) {
+                    BufferedImage img = ImageIO.read(in);
+                    if (img != null) sourceFrames.add(img);
+                }
+            }
+        } catch (Throwable t) {
+            Log.e(t);
+        }
+    }
+
+    private BufferedImage renderFrame(int width, int height, boolean stillCapture) {
+        if (!sourceFrames.isEmpty()) {
+            BufferedImage src = sourceFrames.get(frameIndex.getAndIncrement() % sourceFrames.size());
+            BufferedImage scaled = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+            Graphics2D g = scaled.createGraphics();
+            try {
+                g.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+                        RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+                g.drawImage(src, 0, 0, width, height, null);
+            } finally {
+                g.dispose();
+            }
+            return scaled;
+        }
+        BufferedImage img = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g = img.createGraphics();
+        try {
+            g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            int tick = frameIndex.getAndIncrement();
+            float hue = (tick % 360) / 360f;
+            g.setColor(Color.getHSBColor(hue, 0.4f, 0.9f));
+            g.fillRect(0, 0, width, height);
+
+            g.setColor(Color.BLACK.brighter());
+            g.fillRect(0, 0, width, 40);
+
+            g.setColor(Color.WHITE);
+            g.setFont(new Font("SansSerif", Font.BOLD, 22));
+            g.drawString("Camera Simulator", 12, 28);
+
+            g.setFont(new Font("SansSerif", Font.PLAIN, 16));
+            String legend = (stillCapture ? "PHOTO " : "FRAME ") + tick
+                    + "  " + width + "x" + height;
+            g.drawString(legend, 12, height - 16);
+        } finally {
+            g.dispose();
+        }
+        return img;
+    }
+
+    private static byte[] encodeJpeg(BufferedImage img, int quality) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream(64 * 1024);
+        // ImageIO default JPEG writer doesn't honor quality without an ImageWriter
+        // tweak; for the simulator the default 75% is fine. Quality kept for API
+        // parity with the device ports.
+        ImageIO.write(img, "jpg", baos);
+        return baos.toByteArray();
+    }
+
+    private static byte[] extractRaw(BufferedImage img, FrameFormat fmt) {
+        int w = img.getWidth();
+        int h = img.getHeight();
+        int[] argb = img.getRGB(0, 0, w, h, null, 0, w);
+        if (fmt == FrameFormat.RGBA8888) {
+            byte[] out = new byte[w * h * 4];
+            int o = 0;
+            for (int i = 0; i < argb.length; i++) {
+                int p = argb[i];
+                out[o++] = (byte) ((p >> 16) & 0xff);
+                out[o++] = (byte) ((p >> 8) & 0xff);
+                out[o++] = (byte) (p & 0xff);
+                out[o++] = (byte) ((p >> 24) & 0xff);
+            }
+            return out;
+        }
+        // NV21: full Y plane, then interleaved VU at half resolution.
+        byte[] nv21 = new byte[w * h * 3 / 2];
+        int yIdx = 0;
+        int uvIdx = w * h;
+        for (int y = 0; y < h; y++) {
+            for (int x = 0; x < w; x++) {
+                int p = argb[y * w + x];
+                int r = (p >> 16) & 0xff;
+                int gg = (p >> 8) & 0xff;
+                int b = p & 0xff;
+                int yVal = (66 * r + 129 * gg + 25 * b + 128) >> 8;
+                yVal += 16;
+                nv21[yIdx++] = (byte) Math.max(0, Math.min(255, yVal));
+                if ((y & 1) == 0 && (x & 1) == 0) {
+                    int u = ((-38 * r - 74 * gg + 112 * b + 128) >> 8) + 128;
+                    int v = ((112 * r - 94 * gg - 18 * b + 128) >> 8) + 128;
+                    nv21[uvIdx++] = (byte) Math.max(0, Math.min(255, v));
+                    nv21[uvIdx++] = (byte) Math.max(0, Math.min(255, u));
+                }
+            }
+        }
+        return nv21;
+    }
+
+    private static String tempPath(String prefix, String suffix) {
+        FileSystemStorage fs = FileSystemStorage.getInstance();
+        String dir = fs.getAppHomePath();
+        if (!dir.endsWith("/")) dir += "/";
+        return dir + prefix + "_" + System.currentTimeMillis() + suffix;
+    }
+
+    private static void writeBytes(String path, byte[] data) throws IOException {
+        OutputStream os = null;
+        try {
+            os = FileSystemStorage.getInstance().openOutputStream(path);
+            os.write(data);
+        } finally {
+            if (os != null) {
+                try { os.close(); } catch (IOException ignored) { }
+            }
+        }
+    }
+
+    private static synchronized void ensureSimulatorHints() {
+        if (hintsEnsured) return;
+        hintsEnsured = true;
+        java.util.Map<String, String> hints = Display.getInstance().getProjectBuildHints();
+        if (hints == null) return;
+        if (!hints.containsKey("ios.NSCameraUsageDescription")) {
+            Display.getInstance().setProjectBuildHint("ios.NSCameraUsageDescription",
+                    "Used to capture photos and video.");
+        }
+        if (!hints.containsKey("ios.NSMicrophoneUsageDescription")) {
+            Display.getInstance().setProjectBuildHint("ios.NSMicrophoneUsageDescription",
+                    "Used to capture audio for video recording.");
+        }
+    }
+}

--- a/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
@@ -13227,6 +13227,11 @@ public class JavaSEPort extends CodenameOneImplementation {
         checkCameraUsageDescription();
         capture(response, new String[] {"png", "jpg", "jpeg"}, "*.png;*.jpg;*.jpeg");
     }
+
+    @Override
+    public com.codename1.impl.CameraImpl createCameraImpl() {
+        return new JavaSECameraImpl();
+    }
     
     private void captureMulti(final com.codename1.ui.events.ActionListener response, final String[] imageTypes, final String desc) {
         SwingUtilities.invokeLater(new Runnable() {

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5CameraImpl.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5CameraImpl.java
@@ -149,7 +149,7 @@ public class HTML5CameraImpl extends CameraImpl {
     @Override
     public PeerComponent createPreviewPeer() {
         if (video == null) return null;
-        return Display.getInstance().getImplementation().createNativePeer(video);
+        return PeerComponent.create(video);
     }
 
     @Override

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5CameraImpl.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5CameraImpl.java
@@ -1,0 +1,346 @@
+/*
+ * Copyright (c) 2026 Codename One and contributors.
+ * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * You may use this file only in compliance with that license.
+ * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ */
+package com.codename1.impl.html5;
+
+import com.codename1.camera.CameraFacing;
+import com.codename1.camera.CameraFrame;
+import com.codename1.camera.CameraInfo;
+import com.codename1.camera.CameraSessionOptions;
+import com.codename1.camera.CapturedPhoto;
+import com.codename1.camera.FlashMode;
+import com.codename1.camera.FrameFormat;
+import com.codename1.camera.FrameListener;
+import com.codename1.camera.PhotoCaptureOptions;
+import com.codename1.html5.js.JSBody;
+import com.codename1.html5.js.JSFunctor;
+import com.codename1.html5.js.JSObject;
+import com.codename1.html5.js.JSProperty;
+import com.codename1.html5.js.browser.TimerHandler;
+import com.codename1.html5.js.browser.Window;
+import com.codename1.html5.js.canvas.CanvasImageSource;
+import com.codename1.html5.js.canvas.CanvasRenderingContext2D;
+import com.codename1.html5.js.dom.HTMLCanvasElement;
+import com.codename1.html5.js.dom.HTMLVideoElement;
+import com.codename1.impl.CameraImpl;
+import com.codename1.io.FileSystemStorage;
+import com.codename1.io.Log;
+import com.codename1.ui.Display;
+import com.codename1.ui.PeerComponent;
+import com.codename1.ui.geom.Dimension;
+import com.codename1.util.AsyncResource;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/// JavaScript / browser implementation of `CameraImpl` backed by the
+/// MediaDevices `getUserMedia` API. Preview is an HTMLVideoElement wrapped
+/// as a Codename One peer; frames and stills come from
+/// `canvas.toDataURL('image/jpeg')`.
+///
+/// **Browser caveats**: getUserMedia requires a secure context (HTTPS or
+/// localhost). On iOS Safari it also requires a user gesture - the first
+/// call to `Camera.open(...)` should originate from a tap, not from the
+/// app's `start()`.
+///
+/// Video recording is not implemented in v1 (it would route through the
+/// `MediaRecorder` API and emit `.webm`); callers needing video should fall
+/// back to the legacy `com.codename1.capture.Capture#captureVideo`.
+///
+/// @hidden
+public class HTML5CameraImpl extends CameraImpl {
+
+    private static final int DEFAULT_W = 640;
+    private static final int DEFAULT_H = 480;
+
+    private interface MediaStream extends JSObject { }
+    private interface HTMLVideoElementEx extends HTMLVideoElement {
+        @JSProperty void setSrcObject(MediaStream stream);
+    }
+
+    @JSFunctor private interface UserMediaSuccess extends JSObject {
+        void onStream(JSObject stream);
+    }
+    @JSFunctor private interface UserMediaError extends JSObject {
+        void onError(JSObject error);
+    }
+
+    private MediaStream stream;
+    private HTMLVideoElement video;
+    private HTMLCanvasElement scratchCanvas;
+    private CameraSessionOptions options;
+    private CameraInfo info;
+    private final AtomicBoolean listenerBusy = new AtomicBoolean();
+    private volatile FrameListener frameListener;
+    private volatile FrameFormat frameFormat = FrameFormat.JPEG;
+    private int frameMaxFps = 5;
+    private int frameTimerHandle;
+    private boolean closed;
+    private boolean isFrontFacing;
+
+    @Override
+    public CameraInfo[] enumerateCameras() {
+        return new CameraInfo[] {
+            new CameraInfo("user", CameraFacing.FRONT,
+                    new Dimension[0], new Dimension[0], false, true),
+            new CameraInfo("environment", CameraFacing.BACK,
+                    new Dimension[0], new Dimension[0], false, true)
+        };
+    }
+
+    @Override
+    public void open(String cameraId, CameraSessionOptions opts) throws IOException {
+        this.options = opts == null ? new CameraSessionOptions() : opts;
+        this.frameMaxFps = Math.max(1, Math.min(15, options.getFrameMaxFps() > 0 ? options.getFrameMaxFps() : 5));
+        this.isFrontFacing = "user".equals(cameraId) || "front".equals(cameraId);
+        this.info = new CameraInfo(cameraId == null ? "environment" : cameraId,
+                isFrontFacing ? CameraFacing.FRONT : CameraFacing.BACK,
+                new Dimension[0], new Dimension[0], false, true);
+
+        if ("__permission_probe__".equals(cameraId)) return;
+        if (!supportsMediaDevices()) {
+            throw new IOException("navigator.mediaDevices.getUserMedia is not available");
+        }
+
+        final Object lock = new Object();
+        final JSObject[] err = new JSObject[1];
+        final JSObject[] streamOut = new JSObject[1];
+
+        getUserMediaPromise(isFrontFacing ? "user" : "environment",
+                options.isCaptureAudio(),
+                new UserMediaSuccess() {
+                    @Override public void onStream(JSObject s) {
+                        streamOut[0] = s;
+                        synchronized (lock) { lock.notifyAll(); }
+                    }
+                },
+                new UserMediaError() {
+                    @Override public void onError(JSObject e) {
+                        err[0] = e;
+                        synchronized (lock) { lock.notifyAll(); }
+                    }
+                });
+
+        long deadline = System.currentTimeMillis() + 8000;
+        synchronized (lock) {
+            while (streamOut[0] == null && err[0] == null
+                    && System.currentTimeMillis() < deadline) {
+                try { lock.wait(200); } catch (InterruptedException ignored) { }
+            }
+        }
+        if (err[0] != null) {
+            throw new IOException("getUserMedia failed: " + getErrorName(err[0]));
+        }
+        if (streamOut[0] == null) {
+            throw new IOException("getUserMedia timed out");
+        }
+        this.stream = (MediaStream) streamOut[0];
+        this.video = (HTMLVideoElement) Window.current().getDocument().createElement("video");
+        this.video.setAutoplay(true);
+        this.video.setMuted(true);
+        this.video.setAttribute("playsinline", "");
+        ((HTMLVideoElementEx) this.video).setSrcObject(this.stream);
+    }
+
+    @Override
+    public PeerComponent createPreviewPeer() {
+        if (video == null) return null;
+        return Display.getInstance().getImplementation().createNativePeer(video);
+    }
+
+    @Override
+    public void takePhoto(PhotoCaptureOptions opts, AsyncResource<CapturedPhoto> result) {
+        if (video == null) {
+            result.error(new IllegalStateException("Camera not opened"));
+            return;
+        }
+        if (opts == null) opts = new PhotoCaptureOptions();
+        try {
+            int w = opts.getWidth() > 0 ? opts.getWidth() : videoWidth(video);
+            int h = opts.getHeight() > 0 ? opts.getHeight() : videoHeight(video);
+            if (w <= 0) w = DEFAULT_W;
+            if (h <= 0) h = DEFAULT_H;
+            HTMLCanvasElement canvas = (HTMLCanvasElement)
+                    Window.current().getDocument().createElement("canvas");
+            canvas.setAttribute("width", String.valueOf(w));
+            canvas.setAttribute("height", String.valueOf(h));
+            CanvasRenderingContext2D ctx = (CanvasRenderingContext2D) canvas.getContext("2d");
+            ctx.drawImage((CanvasImageSource) video, 0, 0, w, h);
+            String dataUrl = canvasToJpegDataUrl(canvas, opts.getJpegQuality() / 100.0);
+            byte[] jpeg = decodeBase64DataUrl(dataUrl);
+            String path = opts.getFilePath() != null ? opts.getFilePath() : tempPath();
+            writeBytes(path, jpeg);
+            final CapturedPhoto cp = new CapturedPhoto(jpeg, path, w, h);
+            final AsyncResource<CapturedPhoto> r = result;
+            Display.getInstance().callSerially(new Runnable() {
+                @Override public void run() { r.complete(cp); }
+            });
+        } catch (Throwable t) {
+            final Throwable e = t;
+            final AsyncResource<CapturedPhoto> r = result;
+            Display.getInstance().callSerially(new Runnable() {
+                @Override public void run() { r.error(e); }
+            });
+        }
+    }
+
+    @Override
+    public void startVideoRecording(String filePath, boolean audio) throws IOException {
+        // Browser video recording would route through MediaRecorder ->
+        // Blob -> ArrayBuffer -> byte[] -> file. Out of scope for v1.
+        throw new IOException("Video recording not implemented on the JavaScript port. "
+                + "Use com.codename1.capture.Capture.captureVideo() instead.");
+    }
+
+    @Override
+    public void stopVideoRecording(AsyncResource<String> result) {
+        if (result != null) result.error(new IllegalStateException("Recording not active"));
+    }
+
+    @Override
+    public void setFrameListener(FrameListener listener, FrameFormat format, int maxFps) {
+        this.frameListener = listener;
+        this.frameFormat = format == null ? FrameFormat.JPEG : format;
+        if (maxFps > 0) this.frameMaxFps = Math.max(1, Math.min(15, maxFps));
+
+        if (listener == null) {
+            if (frameTimerHandle != 0) {
+                Window.clearInterval(frameTimerHandle);
+                frameTimerHandle = 0;
+            }
+            return;
+        }
+        if (frameTimerHandle != 0) {
+            Window.clearInterval(frameTimerHandle);
+        }
+        int periodMs = Math.max(67, 1000 / frameMaxFps);
+        frameTimerHandle = Window.setInterval(new TimerHandler() {
+            @Override public void onTimer() { deliverFrame(); }
+        }, periodMs);
+    }
+
+    private void deliverFrame() {
+        if (closed || video == null) return;
+        FrameListener l = frameListener;
+        if (l == null) return;
+        if (!listenerBusy.compareAndSet(false, true)) return;
+        try {
+            int w = videoWidth(video);
+            int h = videoHeight(video);
+            if (w <= 0 || h <= 0) return;
+            if (scratchCanvas == null) {
+                scratchCanvas = (HTMLCanvasElement)
+                        Window.current().getDocument().createElement("canvas");
+            }
+            scratchCanvas.setAttribute("width", String.valueOf(w));
+            scratchCanvas.setAttribute("height", String.valueOf(h));
+            CanvasRenderingContext2D ctx = (CanvasRenderingContext2D)
+                    scratchCanvas.getContext("2d");
+            ctx.drawImage((CanvasImageSource) video, 0, 0, w, h);
+            String dataUrl = canvasToJpegDataUrl(scratchCanvas, 0.8);
+            byte[] jpeg = decodeBase64DataUrl(dataUrl);
+            l.onFrame(new CameraFrame(jpeg, null, w, h, 0,
+                    System.nanoTime(), frameFormat));
+        } catch (Throwable t) {
+            Log.e(t);
+        } finally {
+            listenerBusy.set(false);
+        }
+    }
+
+    @Override public void setFlashMode(FlashMode mode) { /* MediaStreamTrack constraints; deferred */ }
+    @Override public void setZoom(float ratio) { /* MediaStreamTrack constraints; deferred */ }
+    @Override public void focus(float xNorm, float yNorm) { /* no-op in browser */ }
+
+    @Override
+    public void pause() {
+        if (video != null) try { video.pause(); } catch (Throwable ignored) { }
+    }
+
+    @Override
+    public void resume() {
+        if (video != null) try { video.play(); } catch (Throwable ignored) { }
+    }
+
+    @Override
+    public void close() {
+        if (closed) return;
+        closed = true;
+        if (frameTimerHandle != 0) {
+            Window.clearInterval(frameTimerHandle);
+            frameTimerHandle = 0;
+        }
+        if (stream != null) {
+            try { stopMediaStream(stream); } catch (Throwable ignored) { }
+            stream = null;
+        }
+        if (video != null) {
+            try { video.pause(); } catch (Throwable ignored) { }
+            video = null;
+        }
+        scratchCanvas = null;
+        frameListener = null;
+    }
+
+    // --------------------------------------------------------------------
+    // JS bindings
+    // --------------------------------------------------------------------
+
+    @JSBody(params = {},
+            script = "return !!(navigator.mediaDevices && navigator.mediaDevices.getUserMedia);")
+    private static native boolean supportsMediaDevices();
+
+    @JSBody(params = {"facing", "audio", "onSuccess", "onError"},
+            script = "var c={video:{facingMode:facing},audio:!!audio};"
+                   + "navigator.mediaDevices.getUserMedia(c).then(function(s){onSuccess(s);})"
+                   + ".catch(function(e){onError(e);});")
+    private static native void getUserMediaPromise(String facing, boolean audio,
+                                                   UserMediaSuccess onSuccess,
+                                                   UserMediaError onError);
+
+    @JSBody(params = {"e"}, script = "return e && e.name ? e.name : ('' + e);")
+    private static native String getErrorName(JSObject e);
+
+    @JSBody(params = {"v"}, script = "return v.videoWidth || 0;")
+    private static native int videoWidth(HTMLVideoElement v);
+
+    @JSBody(params = {"v"}, script = "return v.videoHeight || 0;")
+    private static native int videoHeight(HTMLVideoElement v);
+
+    @JSBody(params = {"canvas", "quality"},
+            script = "return canvas.toDataURL('image/jpeg', quality);")
+    private static native String canvasToJpegDataUrl(HTMLCanvasElement canvas, double quality);
+
+    @JSBody(params = {"stream"},
+            script = "var t = stream.getTracks(); for (var i=0;i<t.length;i++) t[i].stop();")
+    private static native void stopMediaStream(MediaStream stream);
+
+    private static byte[] decodeBase64DataUrl(String dataUrl) {
+        int comma = dataUrl.indexOf(',');
+        String b64 = comma >= 0 ? dataUrl.substring(comma + 1) : dataUrl;
+        return java.util.Base64.getDecoder().decode(b64);
+    }
+
+    private static String tempPath() {
+        FileSystemStorage fs = FileSystemStorage.getInstance();
+        String dir = fs.getAppHomePath();
+        if (!dir.endsWith("/")) dir += "/";
+        return dir + "cn1_photo_" + System.currentTimeMillis() + ".jpg";
+    }
+
+    private static void writeBytes(String path, byte[] data) throws IOException {
+        OutputStream os = null;
+        try {
+            os = FileSystemStorage.getInstance().openOutputStream(path);
+            os.write(data);
+        } finally {
+            if (os != null) {
+                try { os.close(); } catch (IOException ignored) { }
+            }
+        }
+    }
+}

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -4930,6 +4930,11 @@ public class HTML5Implementation extends CodenameOneImplementation {
     public PeerComponent createNativePeer(Object nativeComponent) {
         return new HTML5Peer((HTMLElement)nativeComponent);
     }
+
+    @Override
+    public com.codename1.impl.CameraImpl createCameraImpl() {
+        return new HTML5CameraImpl();
+    }
     
     
     

--- a/Ports/iOSPort/nativeSources/CN1Camera.h
+++ b/Ports/iOSPort/nativeSources/CN1Camera.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+#import "CodenameOne_GLViewController.h"
+#import <Foundation/Foundation.h>
+
+#ifdef INCLUDE_CAMERA_USAGE
+#import <UIKit/UIKit.h>
+#import <AVFoundation/AVFoundation.h>
+
+/// AVFoundation-backed camera session owned by `IOSCameraImpl` on the Java
+/// side. One instance per `CameraSession`. The Java native methods on
+/// `IOSNative` create / mutate / destroy instances and read frames out
+/// through the AVCaptureVideoDataOutputSampleBufferDelegate.
+///
+/// Compiled in only when `INCLUDE_CAMERA_USAGE` is defined (i.e. the app
+/// has `NSCameraUsageDescription` set; `AiDependencyTable` does this
+/// automatically when any class in `com.codename1.camera.*` is referenced).
+/// Works on iOS, iPadOS and Mac Catalyst -- AVFoundation has the same
+/// surface across all three.
+@interface CN1Camera : NSObject <AVCaptureVideoDataOutputSampleBufferDelegate,
+                                  AVCapturePhotoCaptureDelegate,
+                                  AVCaptureFileOutputRecordingDelegate>
+
+@property (nonatomic, strong) AVCaptureSession *session;
+@property (nonatomic, strong) AVCaptureDevice *device;
+@property (nonatomic, strong) AVCaptureDeviceInput *input;
+@property (nonatomic, strong) AVCaptureVideoDataOutput *videoDataOutput;
+@property (nonatomic, strong) AVCapturePhotoOutput *photoOutput;
+@property (nonatomic, strong) AVCaptureMovieFileOutput *movieOutput;
+@property (nonatomic, strong) AVCaptureVideoPreviewLayer *previewLayer;
+@property (nonatomic, strong) UIView *previewView;
+@property (nonatomic, strong) dispatch_queue_t videoQueue;
+@property (nonatomic, assign) BOOL frameDeliveryEnabled;
+@property (nonatomic, assign) int frameMaxFps;
+@property (nonatomic, assign) NSTimeInterval lastFrameTime;
+@property (nonatomic, assign) BOOL frameInFlight;
+@property (nonatomic, assign) int pendingVideoCallback;
+@property (nonatomic, strong) NSString *pendingVideoPath;
+
+- (BOOL)openWithCameraId:(NSString *)cameraId
+                previewW:(int)previewW
+                previewH:(int)previewH
+            captureAudio:(BOOL)captureAudio;
+- (UIView *)createPreviewView;
+- (void)takePhotoWithWidth:(int)width height:(int)height
+                   quality:(int)quality filePath:(NSString *)filePath
+                callbackId:(int)callbackId;
+- (BOOL)startVideoToPath:(NSString *)path captureAudio:(BOOL)audio;
+- (void)stopVideoWithCallback:(int)callbackId;
+- (void)setFrameDeliveryEnabled:(BOOL)enabled maxFps:(int)maxFps;
+- (void)setFlashMode:(int)mode;
+- (void)setZoomRatio:(float)ratio;
+- (void)focusAtX:(float)xNorm y:(float)yNorm;
+- (void)pauseSession;
+- (void)resumeSession;
+- (void)closeSession;
+
++ (NSString *)enumerateCameras;
++ (BOOL)hasCameraSupport;
+
+@end
+
+#endif // INCLUDE_CAMERA_USAGE

--- a/Ports/iOSPort/nativeSources/CN1Camera.m
+++ b/Ports/iOSPort/nativeSources/CN1Camera.m
@@ -409,7 +409,7 @@ didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
 // still exist so ParparVM links cleanly -- they just return null/0 and
 // the Java side reports the platform as unsupported.
 
-JAVA_OBJECT com_codename1_impl_ios_IOSNative_cn1CameraEnumerate__(
+JAVA_OBJECT com_codename1_impl_ios_IOSNative_cn1CameraEnumerate___R_java_lang_String(
         CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject) {
 #ifdef INCLUDE_CAMERA_USAGE
     NSString *s = [CN1Camera enumerateCameras];
@@ -419,7 +419,7 @@ JAVA_OBJECT com_codename1_impl_ios_IOSNative_cn1CameraEnumerate__(
 #endif
 }
 
-JAVA_LONG com_codename1_impl_ios_IOSNative_cn1CameraOpen___java_lang_String_int_int_boolean(
+JAVA_LONG com_codename1_impl_ios_IOSNative_cn1CameraOpen___java_lang_String_int_int_boolean_R_long(
         CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject,
         JAVA_OBJECT cameraId, JAVA_INT previewW, JAVA_INT previewH,
         JAVA_BOOLEAN captureAudio) {
@@ -439,7 +439,7 @@ JAVA_LONG com_codename1_impl_ios_IOSNative_cn1CameraOpen___java_lang_String_int_
 #endif
 }
 
-JAVA_LONG com_codename1_impl_ios_IOSNative_cn1CameraCreatePreviewView___long(
+JAVA_LONG com_codename1_impl_ios_IOSNative_cn1CameraCreatePreviewView___long_R_long(
         CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject, JAVA_LONG sessionPeer) {
 #ifdef INCLUDE_CAMERA_USAGE
 #ifndef CN1_USE_ARC
@@ -476,7 +476,7 @@ void com_codename1_impl_ios_IOSNative_cn1CameraTakePhoto___long_int_int_int_java
 #endif
 }
 
-JAVA_BOOLEAN com_codename1_impl_ios_IOSNative_cn1CameraStartVideo___long_java_lang_String_boolean(
+JAVA_BOOLEAN com_codename1_impl_ios_IOSNative_cn1CameraStartVideo___long_java_lang_String_boolean_R_boolean(
         CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject, JAVA_LONG sessionPeer,
         JAVA_OBJECT filePath, JAVA_BOOLEAN captureAudio) {
 #ifdef INCLUDE_CAMERA_USAGE

--- a/Ports/iOSPort/nativeSources/CN1Camera.m
+++ b/Ports/iOSPort/nativeSources/CN1Camera.m
@@ -1,0 +1,607 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+#import "CN1Camera.h"
+#import "xmlvm.h"
+
+#ifdef INCLUDE_CAMERA_USAGE
+#import "java_lang_String.h"
+#import "com_codename1_impl_ios_IOSCameraImpl.h"
+
+@interface CN1Camera ()
+@property (nonatomic, copy) NSString *pendingPhotoFilePath;
+@property (nonatomic, assign) int pendingPhotoCallbackId;
+@property (nonatomic, assign) int pendingPhotoQuality;
+@end
+
+@implementation CN1Camera
+
+#pragma mark - Lifecycle
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _frameMaxFps = 15;
+        _videoQueue = dispatch_queue_create("com.codename1.camera.video",
+                                            DISPATCH_QUEUE_SERIAL);
+    }
+    return self;
+}
+
+#pragma mark - Enumeration
+
++ (NSString *)enumerateCameras {
+    NSMutableArray *parts = [NSMutableArray array];
+    NSArray<AVCaptureDevice *> *devs;
+    if (@available(iOS 10.0, *)) {
+        AVCaptureDeviceDiscoverySession *sess =
+            [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:
+                @[ AVCaptureDeviceTypeBuiltInWideAngleCamera ]
+                                                                 mediaType:AVMediaTypeVideo
+                                                                  position:AVCaptureDevicePositionUnspecified];
+        devs = sess.devices;
+    } else {
+        devs = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
+    }
+    for (AVCaptureDevice *d in devs) {
+        NSString *facing = (d.position == AVCaptureDevicePositionFront) ? @"front"
+                         : (d.position == AVCaptureDevicePositionBack)  ? @"back"
+                         : @"external";
+        NSString *flash = d.hasFlash ? @"1" : @"0";
+        NSString *focus = d.isFocusPointOfInterestSupported ? @"1" : @"0";
+        [parts addObject:[NSString stringWithFormat:@"%@|%@|%@|%@",
+                          d.uniqueID, facing, flash, focus]];
+    }
+    return [parts componentsJoinedByString:@";"];
+}
+
++ (BOOL)hasCameraSupport {
+    return [UIImagePickerController isSourceTypeAvailable:UIImagePickerControllerSourceTypeCamera];
+}
+
+#pragma mark - Open / close
+
+- (BOOL)openWithCameraId:(NSString *)cameraId
+                previewW:(int)previewW
+                previewH:(int)previewH
+            captureAudio:(BOOL)captureAudio {
+    AVCaptureDevice *dev = nil;
+    if (cameraId.length > 0) {
+        dev = [AVCaptureDevice deviceWithUniqueID:cameraId];
+    }
+    if (!dev) {
+        dev = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
+    }
+    if (!dev) return NO;
+    self.device = dev;
+
+    NSError *err = nil;
+    AVCaptureDeviceInput *vin = [AVCaptureDeviceInput deviceInputWithDevice:dev error:&err];
+    if (!vin) return NO;
+    self.input = vin;
+
+    self.session = [[AVCaptureSession alloc] init];
+    [self.session beginConfiguration];
+
+    // Preset selection: prefer 1280x720 for previewW > 800, 640x480 otherwise.
+    if (previewW >= 1280 && [self.session canSetSessionPreset:AVCaptureSessionPreset1280x720]) {
+        self.session.sessionPreset = AVCaptureSessionPreset1280x720;
+    } else if ([self.session canSetSessionPreset:AVCaptureSessionPreset640x480]) {
+        self.session.sessionPreset = AVCaptureSessionPreset640x480;
+    } else {
+        self.session.sessionPreset = AVCaptureSessionPresetMedium;
+    }
+
+    if ([self.session canAddInput:vin]) {
+        [self.session addInput:vin];
+    } else {
+        [self.session commitConfiguration];
+        return NO;
+    }
+
+    if (captureAudio) {
+        AVCaptureDevice *mic = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeAudio];
+        if (mic) {
+            AVCaptureDeviceInput *ain = [AVCaptureDeviceInput deviceInputWithDevice:mic error:nil];
+            if (ain && [self.session canAddInput:ain]) {
+                [self.session addInput:ain];
+            }
+        }
+    }
+
+    self.videoDataOutput = [[AVCaptureVideoDataOutput alloc] init];
+    self.videoDataOutput.alwaysDiscardsLateVideoFrames = YES;
+    self.videoDataOutput.videoSettings = @{
+        (id)kCVPixelBufferPixelFormatTypeKey :
+            @(kCVPixelFormatType_32BGRA)
+    };
+    [self.videoDataOutput setSampleBufferDelegate:self queue:self.videoQueue];
+    if ([self.session canAddOutput:self.videoDataOutput]) {
+        [self.session addOutput:self.videoDataOutput];
+    }
+
+    self.photoOutput = [[AVCapturePhotoOutput alloc] init];
+    if ([self.session canAddOutput:self.photoOutput]) {
+        [self.session addOutput:self.photoOutput];
+    }
+
+    self.movieOutput = [[AVCaptureMovieFileOutput alloc] init];
+    if ([self.session canAddOutput:self.movieOutput]) {
+        [self.session addOutput:self.movieOutput];
+    }
+
+    [self.session commitConfiguration];
+    [self.session startRunning];
+    return YES;
+}
+
+- (UIView *)createPreviewView {
+    if (self.previewView) return self.previewView;
+    UIView *v = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 320, 480)];
+    v.backgroundColor = [UIColor blackColor];
+    AVCaptureVideoPreviewLayer *layer =
+        [[AVCaptureVideoPreviewLayer alloc] initWithSession:self.session];
+    layer.videoGravity = AVLayerVideoGravityResizeAspectFill;
+    layer.frame = v.bounds;
+    v.layer.masksToBounds = YES;
+    [v.layer addSublayer:layer];
+    self.previewLayer = layer;
+    self.previewView = v;
+    return v;
+}
+
+- (void)pauseSession   { if (self.session.isRunning)  [self.session stopRunning]; }
+- (void)resumeSession  { if (!self.session.isRunning) [self.session startRunning]; }
+
+- (void)closeSession {
+    if (self.session.isRunning) [self.session stopRunning];
+    if (self.input) [self.session removeInput:self.input];
+    if (self.videoDataOutput) [self.session removeOutput:self.videoDataOutput];
+    if (self.photoOutput) [self.session removeOutput:self.photoOutput];
+    if (self.movieOutput) [self.session removeOutput:self.movieOutput];
+    self.previewLayer = nil;
+    self.previewView = nil;
+    self.input = nil;
+    self.device = nil;
+    self.videoDataOutput = nil;
+    self.photoOutput = nil;
+    self.movieOutput = nil;
+    self.session = nil;
+}
+
+#pragma mark - Photo
+
+- (void)takePhotoWithWidth:(int)width height:(int)height
+                   quality:(int)quality filePath:(NSString *)filePath
+                callbackId:(int)callbackId {
+    self.pendingPhotoFilePath = filePath.length > 0 ? filePath : nil;
+    self.pendingPhotoCallbackId = callbackId;
+    self.pendingPhotoQuality = quality;
+
+    AVCapturePhotoSettings *settings = [AVCapturePhotoSettings photoSettings];
+    if (self.device.hasFlash && self.photoOutput.supportedFlashModes.count > 0) {
+        settings.flashMode = AVCaptureFlashModeAuto;
+    }
+    [self.photoOutput capturePhotoWithSettings:settings delegate:self];
+}
+
+- (void)captureOutput:(AVCapturePhotoOutput *)output
+didFinishProcessingPhoto:(AVCapturePhoto *)photo
+                error:(NSError *)error API_AVAILABLE(ios(11.0)) {
+    int cbId = self.pendingPhotoCallbackId;
+    self.pendingPhotoCallbackId = 0;
+    if (error) {
+        NSString *msg = error.localizedDescription;
+        [self firePhotoFailed:cbId withMessage:msg];
+        return;
+    }
+    NSData *jpeg = [photo fileDataRepresentation];
+    if (!jpeg) {
+        [self firePhotoFailed:cbId withMessage:@"No data from AVCapturePhoto"];
+        return;
+    }
+    UIImage *img = [UIImage imageWithData:jpeg];
+    int w = (int)img.size.width;
+    int h = (int)img.size.height;
+    NSString *path = self.pendingPhotoFilePath;
+    if (!path) {
+        NSString *dir = NSTemporaryDirectory();
+        path = [dir stringByAppendingPathComponent:
+                [NSString stringWithFormat:@"cn1_photo_%llu.jpg",
+                                  (unsigned long long)([[NSDate date] timeIntervalSince1970] * 1000)]];
+    }
+    [jpeg writeToFile:path atomically:YES];
+    self.pendingPhotoFilePath = nil;
+    [self firePhotoCaptured:cbId bytes:jpeg path:path width:w height:h];
+}
+
+#pragma mark - Video
+
+- (BOOL)startVideoToPath:(NSString *)path captureAudio:(BOOL)audio {
+    if (self.movieOutput.isRecording) return NO;
+    // Pre-empt any prior file at this path.
+    NSFileManager *fm = [NSFileManager defaultManager];
+    if ([fm fileExistsAtPath:path]) {
+        [fm removeItemAtPath:path error:nil];
+    }
+    // AVCaptureMovieFileOutput writes .mov; honor whatever extension caller supplied.
+    NSURL *url = [NSURL fileURLWithPath:path];
+    self.pendingVideoPath = path;
+    [self.movieOutput startRecordingToOutputFileURL:url recordingDelegate:self];
+    return YES;
+}
+
+- (void)stopVideoWithCallback:(int)callbackId {
+    self.pendingVideoCallback = callbackId;
+    if (self.movieOutput.isRecording) {
+        [self.movieOutput stopRecording];
+    } else {
+        // No active recording -- still notify the callback with the last
+        // known path so Java's AsyncResource completes.
+        [self fireVideoStopped:callbackId path:self.pendingVideoPath];
+    }
+}
+
+- (void)captureOutput:(AVCaptureFileOutput *)output
+didFinishRecordingToOutputFileAtURL:(NSURL *)outputFileURL
+       fromConnections:(NSArray<AVCaptureConnection *> *)connections
+                error:(NSError *)error {
+    NSString *path = outputFileURL.path;
+    int cbId = self.pendingVideoCallback;
+    self.pendingVideoCallback = 0;
+    self.pendingVideoPath = nil;
+    [self fireVideoStopped:cbId path:path];
+}
+
+#pragma mark - Frame delivery
+
+- (void)setFrameDeliveryEnabled:(BOOL)enabled maxFps:(int)maxFps {
+    self.frameDeliveryEnabled = enabled;
+    if (maxFps > 0) self.frameMaxFps = maxFps;
+}
+
+- (void)captureOutput:(AVCaptureOutput *)output
+didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
+       fromConnection:(AVCaptureConnection *)connection {
+    if (!self.frameDeliveryEnabled) return;
+    if (self.frameInFlight) return;
+    NSTimeInterval now = CACurrentMediaTime();
+    NSTimeInterval minDelta = 1.0 / MAX(1, self.frameMaxFps);
+    if ((now - self.lastFrameTime) < minDelta) return;
+    self.lastFrameTime = now;
+
+    CVImageBufferRef pix = CMSampleBufferGetImageBuffer(sampleBuffer);
+    if (!pix) return;
+    CIImage *ci = [CIImage imageWithCVPixelBuffer:pix];
+    CGRect rect = ci.extent;
+    int w = (int)rect.size.width;
+    int h = (int)rect.size.height;
+
+    static CIContext *ctx;
+    if (!ctx) ctx = [CIContext contextWithOptions:nil];
+    CGImageRef cg = [ctx createCGImage:ci fromRect:rect];
+    if (!cg) return;
+    UIImage *img = [UIImage imageWithCGImage:cg];
+    CGImageRelease(cg);
+    NSData *jpeg = UIImageJPEGRepresentation(img, 0.8);
+    if (!jpeg) return;
+
+    int rotation = 0;
+    if (connection.isVideoOrientationSupported) {
+        switch (connection.videoOrientation) {
+            case AVCaptureVideoOrientationPortrait:           rotation = 90;  break;
+            case AVCaptureVideoOrientationPortraitUpsideDown: rotation = 270; break;
+            case AVCaptureVideoOrientationLandscapeLeft:      rotation = 180; break;
+            case AVCaptureVideoOrientationLandscapeRight:     rotation = 0;   break;
+        }
+    }
+
+    int64_t ts = (int64_t)(now * 1e9);
+    self.frameInFlight = YES;
+    [self fireFrame:jpeg width:w height:h rotation:rotation timestamp:ts];
+    self.frameInFlight = NO;
+}
+
+#pragma mark - Flash / zoom / focus
+
+- (void)setFlashMode:(int)mode {
+    if (!self.device.hasTorch) return;
+    if (![self.device lockForConfiguration:nil]) return;
+    switch (mode) {
+        case 0: self.device.torchMode = AVCaptureTorchModeOff;  break;
+        case 1: self.device.torchMode = AVCaptureTorchModeOn;   break;
+        case 2: self.device.torchMode = AVCaptureTorchModeAuto; break;
+        case 3:
+            if ([self.device isTorchModeSupported:AVCaptureTorchModeOn]) {
+                [self.device setTorchModeOnWithLevel:1.0 error:nil];
+            }
+            break;
+    }
+    [self.device unlockForConfiguration];
+}
+
+- (void)setZoomRatio:(float)ratio {
+    if (!self.device) return;
+    if (![self.device lockForConfiguration:nil]) return;
+    CGFloat r = MAX(1.0, MIN((CGFloat)ratio, self.device.activeFormat.videoMaxZoomFactor));
+    self.device.videoZoomFactor = r;
+    [self.device unlockForConfiguration];
+}
+
+- (void)focusAtX:(float)xNorm y:(float)yNorm {
+    if (!self.device.isFocusPointOfInterestSupported) return;
+    if (![self.device lockForConfiguration:nil]) return;
+    CGPoint point = CGPointMake(xNorm, yNorm);
+    self.device.focusPointOfInterest = point;
+    if ([self.device isFocusModeSupported:AVCaptureFocusModeAutoFocus]) {
+        self.device.focusMode = AVCaptureFocusModeAutoFocus;
+    }
+    if (self.device.isExposurePointOfInterestSupported) {
+        self.device.exposurePointOfInterest = point;
+        if ([self.device isExposureModeSupported:AVCaptureExposureModeAutoExpose]) {
+            self.device.exposureMode = AVCaptureExposureModeAutoExpose;
+        }
+    }
+    [self.device unlockForConfiguration];
+}
+
+#pragma mark - Java callback bridging
+
+- (void)fireFrame:(NSData *)jpeg width:(int)w height:(int)h
+         rotation:(int)rotation timestamp:(int64_t)ts {
+    JAVA_OBJECT bytes = fromNSData(CN1_THREAD_GET_STATE_PASS_SINGLE_ARG jpeg);
+    com_codename1_impl_ios_IOSCameraImpl_onFrameDelivered___byte_1ARRAY_int_int_int_long(
+        CN1_THREAD_GET_STATE_PASS_ARG bytes, w, h, rotation, (JAVA_LONG)ts);
+}
+
+- (void)firePhotoCaptured:(int)cbId bytes:(NSData *)jpeg path:(NSString *)path
+                    width:(int)w height:(int)h {
+    JAVA_OBJECT b = fromNSData(CN1_THREAD_GET_STATE_PASS_SINGLE_ARG jpeg);
+    JAVA_OBJECT p = fromNSString(CN1_THREAD_GET_STATE_PASS_SINGLE_ARG path);
+    com_codename1_impl_ios_IOSCameraImpl_onPhotoCaptured___int_byte_1ARRAY_java_lang_String_int_int(
+        CN1_THREAD_GET_STATE_PASS_ARG cbId, b, p, w, h);
+}
+
+- (void)firePhotoFailed:(int)cbId withMessage:(NSString *)msg {
+    JAVA_OBJECT m = fromNSString(CN1_THREAD_GET_STATE_PASS_SINGLE_ARG msg);
+    com_codename1_impl_ios_IOSCameraImpl_onPhotoFailed___int_java_lang_String(
+        CN1_THREAD_GET_STATE_PASS_ARG cbId, m);
+}
+
+- (void)fireVideoStopped:(int)cbId path:(NSString *)path {
+    if (cbId == 0) return;
+    JAVA_OBJECT p = fromNSString(CN1_THREAD_GET_STATE_PASS_SINGLE_ARG path);
+    com_codename1_impl_ios_IOSCameraImpl_onVideoStopped___int_java_lang_String(
+        CN1_THREAD_GET_STATE_PASS_ARG cbId, p);
+}
+
+@end
+
+#endif // INCLUDE_CAMERA_USAGE
+
+#pragma mark - IOSNative bridge functions
+// Each `native void cn1Camera*` declared on IOSNative.java has a matching
+// C function below. Naming follows the standard ParparVM mangling:
+//   com_codename1_impl_ios_IOSNative_<methodName>___<argType>_<argType>
+// Sessions are referenced by their CN1Camera Objective-C pointer cast to
+// JAVA_LONG; we retain in open* and release in close. When camera support
+// is compiled out (INCLUDE_CAMERA_USAGE undefined) the bridge symbols
+// still exist so ParparVM links cleanly -- they just return null/0 and
+// the Java side reports the platform as unsupported.
+
+JAVA_OBJECT com_codename1_impl_ios_IOSNative_cn1CameraEnumerate__(
+        CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject) {
+#ifdef INCLUDE_CAMERA_USAGE
+    NSString *s = [CN1Camera enumerateCameras];
+    return fromNSString(CN1_THREAD_GET_STATE_PASS_SINGLE_ARG s);
+#else
+    return JAVA_NULL;
+#endif
+}
+
+JAVA_LONG com_codename1_impl_ios_IOSNative_cn1CameraOpen___java_lang_String_int_int_boolean(
+        CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject,
+        JAVA_OBJECT cameraId, JAVA_INT previewW, JAVA_INT previewH,
+        JAVA_BOOLEAN captureAudio) {
+#ifdef INCLUDE_CAMERA_USAGE
+    NSString *idStr = toNSString(CN1_THREAD_GET_STATE_PASS_ARG cameraId);
+    CN1Camera *cam = [[CN1Camera alloc] init];
+    BOOL ok = [cam openWithCameraId:idStr previewW:previewW previewH:previewH
+                       captureAudio:captureAudio];
+    if (!ok) return 0;
+#ifndef CN1_USE_ARC
+    return (JAVA_LONG)[cam retain];
+#else
+    return (JAVA_LONG)(__bridge_retained void *)cam;
+#endif
+#else
+    return 0;
+#endif
+}
+
+JAVA_LONG com_codename1_impl_ios_IOSNative_cn1CameraCreatePreviewView___long(
+        CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject, JAVA_LONG sessionPeer) {
+#ifdef INCLUDE_CAMERA_USAGE
+#ifndef CN1_USE_ARC
+    CN1Camera *cam = (CN1Camera *)sessionPeer;
+#else
+    CN1Camera *cam = (__bridge CN1Camera *)(void *)sessionPeer;
+#endif
+    UIView *v = [cam createPreviewView];
+#ifndef CN1_USE_ARC
+    return (JAVA_LONG)[v retain];
+#else
+    return (JAVA_LONG)(__bridge_retained void *)v;
+#endif
+#else
+    return 0;
+#endif
+}
+
+void com_codename1_impl_ios_IOSNative_cn1CameraTakePhoto___long_int_int_int_java_lang_String_int(
+        CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject, JAVA_LONG sessionPeer,
+        JAVA_INT width, JAVA_INT height, JAVA_INT quality,
+        JAVA_OBJECT filePath, JAVA_INT callbackId) {
+#ifdef INCLUDE_CAMERA_USAGE
+#ifndef CN1_USE_ARC
+    CN1Camera *cam = (CN1Camera *)sessionPeer;
+#else
+    CN1Camera *cam = (__bridge CN1Camera *)(void *)sessionPeer;
+#endif
+    NSString *path = toNSString(CN1_THREAD_GET_STATE_PASS_ARG filePath);
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [cam takePhotoWithWidth:width height:height quality:quality
+                       filePath:path callbackId:callbackId];
+    });
+#endif
+}
+
+JAVA_BOOLEAN com_codename1_impl_ios_IOSNative_cn1CameraStartVideo___long_java_lang_String_boolean(
+        CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject, JAVA_LONG sessionPeer,
+        JAVA_OBJECT filePath, JAVA_BOOLEAN captureAudio) {
+#ifdef INCLUDE_CAMERA_USAGE
+#ifndef CN1_USE_ARC
+    CN1Camera *cam = (CN1Camera *)sessionPeer;
+#else
+    CN1Camera *cam = (__bridge CN1Camera *)(void *)sessionPeer;
+#endif
+    NSString *path = toNSString(CN1_THREAD_GET_STATE_PASS_ARG filePath);
+    __block BOOL result = NO;
+    dispatch_sync(dispatch_get_main_queue(), ^{
+        result = [cam startVideoToPath:path captureAudio:captureAudio];
+    });
+    return result;
+#else
+    return JAVA_FALSE;
+#endif
+}
+
+void com_codename1_impl_ios_IOSNative_cn1CameraStopVideo___long_int(
+        CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject,
+        JAVA_LONG sessionPeer, JAVA_INT callbackId) {
+#ifdef INCLUDE_CAMERA_USAGE
+#ifndef CN1_USE_ARC
+    CN1Camera *cam = (CN1Camera *)sessionPeer;
+#else
+    CN1Camera *cam = (__bridge CN1Camera *)(void *)sessionPeer;
+#endif
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [cam stopVideoWithCallback:callbackId];
+    });
+#endif
+}
+
+void com_codename1_impl_ios_IOSNative_cn1CameraSetFrameDelivery___long_boolean_int(
+        CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject,
+        JAVA_LONG sessionPeer, JAVA_BOOLEAN enabled, JAVA_INT maxFps) {
+#ifdef INCLUDE_CAMERA_USAGE
+#ifndef CN1_USE_ARC
+    CN1Camera *cam = (CN1Camera *)sessionPeer;
+#else
+    CN1Camera *cam = (__bridge CN1Camera *)(void *)sessionPeer;
+#endif
+    [cam setFrameDeliveryEnabled:enabled maxFps:maxFps];
+#endif
+}
+
+void com_codename1_impl_ios_IOSNative_cn1CameraSetFlash___long_int(
+        CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject,
+        JAVA_LONG sessionPeer, JAVA_INT mode) {
+#ifdef INCLUDE_CAMERA_USAGE
+#ifndef CN1_USE_ARC
+    CN1Camera *cam = (CN1Camera *)sessionPeer;
+#else
+    CN1Camera *cam = (__bridge CN1Camera *)(void *)sessionPeer;
+#endif
+    dispatch_async(dispatch_get_main_queue(), ^{ [cam setFlashMode:mode]; });
+#endif
+}
+
+void com_codename1_impl_ios_IOSNative_cn1CameraSetZoom___long_float(
+        CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject,
+        JAVA_LONG sessionPeer, JAVA_FLOAT ratio) {
+#ifdef INCLUDE_CAMERA_USAGE
+#ifndef CN1_USE_ARC
+    CN1Camera *cam = (CN1Camera *)sessionPeer;
+#else
+    CN1Camera *cam = (__bridge CN1Camera *)(void *)sessionPeer;
+#endif
+    dispatch_async(dispatch_get_main_queue(), ^{ [cam setZoomRatio:ratio]; });
+#endif
+}
+
+void com_codename1_impl_ios_IOSNative_cn1CameraFocus___long_float_float(
+        CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject,
+        JAVA_LONG sessionPeer, JAVA_FLOAT xNorm, JAVA_FLOAT yNorm) {
+#ifdef INCLUDE_CAMERA_USAGE
+#ifndef CN1_USE_ARC
+    CN1Camera *cam = (CN1Camera *)sessionPeer;
+#else
+    CN1Camera *cam = (__bridge CN1Camera *)(void *)sessionPeer;
+#endif
+    dispatch_async(dispatch_get_main_queue(), ^{ [cam focusAtX:xNorm y:yNorm]; });
+#endif
+}
+
+void com_codename1_impl_ios_IOSNative_cn1CameraPause___long(
+        CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject, JAVA_LONG sessionPeer) {
+#ifdef INCLUDE_CAMERA_USAGE
+#ifndef CN1_USE_ARC
+    CN1Camera *cam = (CN1Camera *)sessionPeer;
+#else
+    CN1Camera *cam = (__bridge CN1Camera *)(void *)sessionPeer;
+#endif
+    dispatch_async(dispatch_get_main_queue(), ^{ [cam pauseSession]; });
+#endif
+}
+
+void com_codename1_impl_ios_IOSNative_cn1CameraResume___long(
+        CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject, JAVA_LONG sessionPeer) {
+#ifdef INCLUDE_CAMERA_USAGE
+#ifndef CN1_USE_ARC
+    CN1Camera *cam = (CN1Camera *)sessionPeer;
+#else
+    CN1Camera *cam = (__bridge CN1Camera *)(void *)sessionPeer;
+#endif
+    dispatch_async(dispatch_get_main_queue(), ^{ [cam resumeSession]; });
+#endif
+}
+
+void com_codename1_impl_ios_IOSNative_cn1CameraClose___long(
+        CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject, JAVA_LONG sessionPeer) {
+    if (sessionPeer == 0) return;
+#ifdef INCLUDE_CAMERA_USAGE
+#ifndef CN1_USE_ARC
+    CN1Camera *cam = (CN1Camera *)sessionPeer;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [cam closeSession];
+        [cam release];
+    });
+#else
+    CN1Camera *cam = (__bridge_transfer CN1Camera *)(void *)sessionPeer;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [cam closeSession];
+    });
+#endif
+#endif
+}

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSCameraImpl.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSCameraImpl.java
@@ -64,7 +64,6 @@ public class IOSCameraImpl extends CameraImpl {
     private static final AtomicInteger NEXT_CB = new AtomicInteger(1);
 
     private long sessionPeer;
-    private CameraInfo info;
     private CameraSessionOptions options;
     private final AtomicBoolean listenerBusy = new AtomicBoolean();
     private volatile FrameListener frameListener;
@@ -112,8 +111,6 @@ public class IOSCameraImpl extends CameraImpl {
             // iOS handles camera permission inline at session-run time. We
             // can't synchronously probe; assume granted and let the actual
             // open fail later if the user denies.
-            this.info = new CameraInfo(cameraId, CameraFacing.BACK,
-                    new Dimension[0], new Dimension[0], false, false);
             return;
         }
         long peer = IOSImplementation.nativeInstance.cn1CameraOpen(
@@ -125,8 +122,6 @@ public class IOSCameraImpl extends CameraImpl {
             throw new IOException("Could not open iOS camera (id=" + cameraId + ")");
         }
         this.sessionPeer = peer;
-        this.info = new CameraInfo(cameraId, CameraFacing.BACK,
-                new Dimension[0], new Dimension[0], false, true);
         ACTIVE = this;
     }
 

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSCameraImpl.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSCameraImpl.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.impl.ios;
+
+import com.codename1.camera.CameraFacing;
+import com.codename1.camera.CameraFrame;
+import com.codename1.camera.CameraInfo;
+import com.codename1.camera.CameraSessionOptions;
+import com.codename1.camera.CapturedPhoto;
+import com.codename1.camera.FlashMode;
+import com.codename1.camera.FrameFormat;
+import com.codename1.camera.FrameListener;
+import com.codename1.camera.PhotoCaptureOptions;
+import com.codename1.impl.CameraImpl;
+import com.codename1.io.Log;
+import com.codename1.ui.Display;
+import com.codename1.ui.PeerComponent;
+import com.codename1.ui.geom.Dimension;
+import com.codename1.util.AsyncResource;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/// iOS implementation of `CameraImpl`. Bridges to `CN1Camera.{h,m}` which
+/// wraps `AVCaptureSession` (preview + frame stream + still + video).
+///
+/// @hidden
+public class IOSCameraImpl extends CameraImpl {
+
+    // One Java instance is the active camera at any moment; native callbacks
+    // arrive from the AVFoundation queue without context, so we route them
+    // through this static.
+    private static volatile IOSCameraImpl ACTIVE;
+
+    // Outstanding async callbacks (photo capture, video stop) keyed by an
+    // integer id we pass to native.
+    private static final Map<Integer, AsyncResource<CapturedPhoto>> PHOTO_CBS =
+            new HashMap<Integer, AsyncResource<CapturedPhoto>>();
+    private static final Map<Integer, AsyncResource<String>> VIDEO_CBS =
+            new HashMap<Integer, AsyncResource<String>>();
+    private static final AtomicInteger NEXT_CB = new AtomicInteger(1);
+
+    private long sessionPeer;
+    private CameraInfo info;
+    private CameraSessionOptions options;
+    private final AtomicBoolean listenerBusy = new AtomicBoolean();
+    private volatile FrameListener frameListener;
+    private volatile FrameFormat frameFormat = FrameFormat.JPEG;
+
+    @Override
+    public CameraInfo[] enumerateCameras() {
+        String packed = IOSImplementation.nativeInstance.cn1CameraEnumerate();
+        if (packed == null || packed.isEmpty()) return new CameraInfo[0];
+        // packed: "id|facing|hasFlash|hasAutoFocus;id|facing|..."
+        String[] entries = packed.split(";");
+        CameraInfo[] out = new CameraInfo[entries.length];
+        for (int i = 0; i < entries.length; i++) {
+            String[] f = entries[i].split("\\|");
+            if (f.length < 4) continue;
+            CameraFacing facing = "front".equals(f[1]) ? CameraFacing.FRONT
+                                : "back".equals(f[1])  ? CameraFacing.BACK
+                                : CameraFacing.EXTERNAL;
+            out[i] = new CameraInfo(f[0], facing,
+                    new Dimension[0], new Dimension[0],
+                    "1".equals(f[2]), "1".equals(f[3]));
+        }
+        return out;
+    }
+
+    @Override
+    public void open(String cameraId, CameraSessionOptions opts) throws IOException {
+        this.options = opts == null ? new CameraSessionOptions() : opts;
+        if ("__permission_probe__".equals(cameraId)) {
+            // iOS handles camera permission inline at session-run time. We
+            // can't synchronously probe; assume granted and let the actual
+            // open fail later if the user denies.
+            this.info = new CameraInfo(cameraId, CameraFacing.BACK,
+                    new Dimension[0], new Dimension[0], false, false);
+            return;
+        }
+        long peer = IOSImplementation.nativeInstance.cn1CameraOpen(
+                cameraId == null ? "" : cameraId,
+                options.getPreviewWidth(),
+                options.getPreviewHeight(),
+                options.isCaptureAudio());
+        if (peer == 0) {
+            throw new IOException("Could not open iOS camera (id=" + cameraId + ")");
+        }
+        this.sessionPeer = peer;
+        this.info = new CameraInfo(cameraId, CameraFacing.BACK,
+                new Dimension[0], new Dimension[0], false, true);
+        ACTIVE = this;
+    }
+
+    @Override
+    public PeerComponent createPreviewPeer() {
+        if (sessionPeer == 0) return null;
+        long viewPeer = IOSImplementation.nativeInstance.cn1CameraCreatePreviewView(sessionPeer);
+        if (viewPeer == 0) return null;
+        return IOSImplementation.instance.createNativePeer(new long[] { viewPeer });
+    }
+
+    @Override
+    public void takePhoto(PhotoCaptureOptions opts, AsyncResource<CapturedPhoto> result) {
+        if (sessionPeer == 0) {
+            result.error(new IllegalStateException("Camera session not open"));
+            return;
+        }
+        if (opts == null) opts = new PhotoCaptureOptions();
+        int cbId = NEXT_CB.getAndIncrement();
+        synchronized (PHOTO_CBS) {
+            PHOTO_CBS.put(cbId, result);
+        }
+        IOSImplementation.nativeInstance.cn1CameraTakePhoto(
+                sessionPeer, opts.getWidth(), opts.getHeight(),
+                opts.getJpegQuality(),
+                opts.getFilePath() == null ? "" : opts.getFilePath(),
+                cbId);
+    }
+
+    @Override
+    public void startVideoRecording(String filePath, boolean audio) throws IOException {
+        if (sessionPeer == 0) {
+            throw new IOException("Camera session not open");
+        }
+        if (!IOSImplementation.nativeInstance.cn1CameraStartVideo(sessionPeer, filePath, audio)) {
+            throw new IOException("Could not start video recording");
+        }
+    }
+
+    @Override
+    public void stopVideoRecording(AsyncResource<String> result) {
+        if (sessionPeer == 0) {
+            if (result != null) result.error(new IllegalStateException("Camera session not open"));
+            return;
+        }
+        int cbId = result == null ? 0 : NEXT_CB.getAndIncrement();
+        if (result != null) {
+            synchronized (VIDEO_CBS) {
+                VIDEO_CBS.put(cbId, result);
+            }
+        }
+        IOSImplementation.nativeInstance.cn1CameraStopVideo(sessionPeer, cbId);
+    }
+
+    @Override
+    public void setFrameListener(FrameListener listener, FrameFormat format, int maxFps) {
+        this.frameListener = listener;
+        this.frameFormat = format == null ? FrameFormat.JPEG : format;
+        if (sessionPeer != 0) {
+            IOSImplementation.nativeInstance.cn1CameraSetFrameDelivery(
+                    sessionPeer, listener != null, Math.max(1, maxFps));
+        }
+    }
+
+    @Override
+    public void setFlashMode(FlashMode mode) {
+        if (sessionPeer == 0) return;
+        int code = mode == null ? 0
+                : mode == FlashMode.OFF ? 0
+                : mode == FlashMode.ON ? 1
+                : mode == FlashMode.AUTO ? 2 : 3;
+        IOSImplementation.nativeInstance.cn1CameraSetFlash(sessionPeer, code);
+    }
+
+    @Override
+    public void setZoom(float ratio) {
+        if (sessionPeer == 0) return;
+        IOSImplementation.nativeInstance.cn1CameraSetZoom(sessionPeer, ratio);
+    }
+
+    @Override
+    public void focus(float xNorm, float yNorm) {
+        if (sessionPeer == 0) return;
+        IOSImplementation.nativeInstance.cn1CameraFocus(sessionPeer, xNorm, yNorm);
+    }
+
+    @Override
+    public void pause() {
+        if (sessionPeer != 0) IOSImplementation.nativeInstance.cn1CameraPause(sessionPeer);
+    }
+
+    @Override
+    public void resume() {
+        if (sessionPeer != 0) IOSImplementation.nativeInstance.cn1CameraResume(sessionPeer);
+    }
+
+    @Override
+    public void close() {
+        long s = sessionPeer;
+        sessionPeer = 0;
+        frameListener = null;
+        if (ACTIVE == this) ACTIVE = null;
+        if (s != 0) IOSImplementation.nativeInstance.cn1CameraClose(s);
+    }
+
+    // ---------------------------------------------------------------------
+    // Native -> Java callbacks. Called from CN1Camera.m on the AVFoundation
+    // delivery queue (frames) or the main queue (photo/video completion).
+    // ---------------------------------------------------------------------
+
+    /// Called from native code with a single video frame.
+    public static void onFrameDelivered(byte[] jpegBytes, int width, int height,
+                                        int rotationDegrees, long timestampNanos) {
+        IOSCameraImpl self = ACTIVE;
+        if (self == null) return;
+        FrameListener l = self.frameListener;
+        if (l == null) return;
+        if (!self.listenerBusy.compareAndSet(false, true)) {
+            return; // drop frame; previous still in flight
+        }
+        try {
+            CameraFrame f = new CameraFrame(jpegBytes, null, width, height,
+                    rotationDegrees, timestampNanos, self.frameFormat);
+            l.onFrame(f);
+        } catch (Throwable t) {
+            Log.e(t);
+        } finally {
+            self.listenerBusy.set(false);
+        }
+    }
+
+    /// Called from native code when a still photo capture completes successfully.
+    public static void onPhotoCaptured(int callbackId, byte[] jpeg,
+                                       String filePath, int width, int height) {
+        final AsyncResource<CapturedPhoto> cb;
+        synchronized (PHOTO_CBS) {
+            cb = PHOTO_CBS.remove(callbackId);
+        }
+        if (cb == null) return;
+        final CapturedPhoto p = new CapturedPhoto(jpeg, filePath, width, height);
+        Display.getInstance().callSerially(new Runnable() {
+            @Override public void run() { cb.complete(p); }
+        });
+    }
+
+    /// Called from native code when a still photo capture fails.
+    public static void onPhotoFailed(int callbackId, String error) {
+        final AsyncResource<CapturedPhoto> cb;
+        synchronized (PHOTO_CBS) {
+            cb = PHOTO_CBS.remove(callbackId);
+        }
+        if (cb == null) return;
+        final String msg = error == null ? "iOS camera photo capture failed" : error;
+        Display.getInstance().callSerially(new Runnable() {
+            @Override public void run() { cb.error(new IOException(msg)); }
+        });
+    }
+
+    /// Called from native code when video recording stops and the file is finalized.
+    public static void onVideoStopped(int callbackId, String filePath) {
+        if (callbackId == 0) return;
+        final AsyncResource<String> cb;
+        synchronized (VIDEO_CBS) {
+            cb = VIDEO_CBS.remove(callbackId);
+        }
+        if (cb == null) return;
+        final String path = filePath;
+        Display.getInstance().callSerially(new Runnable() {
+            @Override public void run() { cb.complete(path); }
+        });
+    }
+}

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSCameraImpl.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSCameraImpl.java
@@ -73,20 +73,35 @@ public class IOSCameraImpl extends CameraImpl {
     @Override
     public CameraInfo[] enumerateCameras() {
         String packed = IOSImplementation.nativeInstance.cn1CameraEnumerate();
-        if (packed == null || packed.isEmpty()) return new CameraInfo[0];
-        // packed: "id|facing|hasFlash|hasAutoFocus;id|facing|..."
-        String[] entries = packed.split(";");
-        CameraInfo[] out = new CameraInfo[entries.length];
-        for (int i = 0; i < entries.length; i++) {
-            String[] f = entries[i].split("\\|");
-            if (f.length < 4) continue;
-            CameraFacing facing = "front".equals(f[1]) ? CameraFacing.FRONT
-                                : "back".equals(f[1])  ? CameraFacing.BACK
+        if (packed == null || packed.length() == 0) return new CameraInfo[0];
+        // packed: "id|facing|hasFlash|hasAutoFocus;id|facing|...". String.split
+        // isn't available on the iOS ParparVM, so we walk the string manually.
+        java.util.List<String> entries = splitChar(packed, ';');
+        java.util.List<CameraInfo> out = new java.util.ArrayList<CameraInfo>(entries.size());
+        for (int i = 0; i < entries.size(); i++) {
+            java.util.List<String> f = splitChar(entries.get(i), '|');
+            if (f.size() < 4) continue;
+            CameraFacing facing = "front".equals(f.get(1)) ? CameraFacing.FRONT
+                                : "back".equals(f.get(1))  ? CameraFacing.BACK
                                 : CameraFacing.EXTERNAL;
-            out[i] = new CameraInfo(f[0], facing,
+            out.add(new CameraInfo(f.get(0), facing,
                     new Dimension[0], new Dimension[0],
-                    "1".equals(f[2]), "1".equals(f[3]));
+                    "1".equals(f.get(2)), "1".equals(f.get(3))));
         }
+        return out.toArray(new CameraInfo[out.size()]);
+    }
+
+    private static java.util.List<String> splitChar(String s, char sep) {
+        java.util.List<String> out = new java.util.ArrayList<String>();
+        int start = 0;
+        int len = s.length();
+        for (int i = 0; i < len; i++) {
+            if (s.charAt(i) == sep) {
+                out.add(s.substring(start, i));
+                start = i + 1;
+            }
+        }
+        out.add(s.substring(start));
         return out;
     }
 

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
@@ -3700,6 +3700,11 @@ public class IOSImplementation extends CodenameOneImplementation {
     }
 
     @Override
+    public com.codename1.impl.CameraImpl createCameraImpl() {
+        return new IOSCameraImpl();
+    }
+
+    @Override
     public String [] getAvailableRecordingMimeTypes() {
         // All of these amount to the same thing.
         // We record in AAC format, wrapped in an mp4 container.

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSNative.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSNative.java
@@ -416,6 +416,24 @@ public final class IOSNative {
     // capture
     native void captureCamera(boolean movie, int quality, int duration);
     native void openGallery(int type);
+
+    // Low-level camera API (com.codename1.camera). Backed by CN1Camera.m
+    // which wraps AVCaptureSession. The IOSCameraImpl class on the Java side
+    // routes static callbacks delivered from the capture queue.
+    native String cn1CameraEnumerate();
+    native long cn1CameraOpen(String cameraId, int previewW, int previewH, boolean captureAudio);
+    native long cn1CameraCreatePreviewView(long sessionPeer);
+    native void cn1CameraTakePhoto(long sessionPeer, int width, int height, int jpegQuality, String filePath, int callbackId);
+    native boolean cn1CameraStartVideo(long sessionPeer, String filePath, boolean captureAudio);
+    native void cn1CameraStopVideo(long sessionPeer, int callbackId);
+    native void cn1CameraSetFrameDelivery(long sessionPeer, boolean enabled, int maxFps);
+    native void cn1CameraSetFlash(long sessionPeer, int mode);
+    native void cn1CameraSetZoom(long sessionPeer, float ratio);
+    native void cn1CameraFocus(long sessionPeer, float xNorm, float yNorm);
+    native void cn1CameraPause(long sessionPeer);
+    native void cn1CameraResume(long sessionPeer);
+    native void cn1CameraClose(long sessionPeer);
+
     native void destroyAudioUnit(long peer);
 
     native long createAudioUnit(String path, int audioChannels, float sampleRate, float[] f);

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AiDependencyTable.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AiDependencyTable.java
@@ -156,6 +156,31 @@ public final class AiDependencyTable {
                 .iosFrameworks("Accelerate")
                 .description("On-device Whisper transcription (libwhisper.a ships with the cn1lib)"));
 
+        // Low-level cross-platform camera API: live preview + frame
+        // stream + photo + video. iOS uses AVFoundation (framework
+        // only, no pod); Android uses CameraX (androidx.camera) which
+        // is added as Gradle deps below. Just referencing classes in
+        // com.codename1.camera causes the build to inject the right
+        // permissions and plist strings; developers may still override
+        // the plist text via the ios.NSCameraUsageDescription build
+        // hint.
+        e.add(new Entry("com/codename1/camera/")
+                .iosFrameworks("AVFoundation", "CoreMedia", "CoreVideo")
+                .iosPlist("NSCameraUsageDescription",
+                         "Used to capture photos and video.")
+                .iosPlist("NSMicrophoneUsageDescription",
+                         "Used to capture audio for video recording.")
+                .androidPermissions("android.permission.CAMERA",
+                                    "android.permission.RECORD_AUDIO")
+                .androidFeatures("android.hardware.camera",
+                                 "android.hardware.camera.autofocus")
+                .androidGradle("androidx.camera:camera-core:1.3.4")
+                .androidGradle("androidx.camera:camera-camera2:1.3.4")
+                .androidGradle("androidx.camera:camera-lifecycle:1.3.4")
+                .androidGradle("androidx.camera:camera-view:1.3.4")
+                .androidGradle("androidx.camera:camera-video:1.3.4")
+                .description("Cross-platform camera (preview + frames + photo + video)"));
+
         // On-device Stable Diffusion: bundled Core ML model on iOS,
         // ONNX runtime on Android. Flag the >2 GB upload concern so
         // the cloud build server can abort early with a helpful

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/MacNativeBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/MacNativeBuilder.java
@@ -201,6 +201,30 @@ class MacNativeBuilder {
         } else if (allowJit) {
             sb.append("    <key>com.apple.security.cs.allow-jit</key>\n    <true/>\n");
         }
+        // Sandboxed Mac apps that touch the camera or microphone need
+        // explicit device entitlements; without them the OS refuses to
+        // open the AVCaptureSession even when the Info.plist usage
+        // descriptions are present. We piggyback on the iOS plist hints
+        // already populated by AiDependencyTable -- when the build
+        // pipeline detected com.codename1.camera.* (or any other API
+        // that triggers NSCameraUsageDescription / NSMicrophoneUsageDescription)
+        // we mirror that into the Mac entitlements. Developers may
+        // opt out via macNative.entitlements.device.camera=false /
+        // macNative.entitlements.device.microphone=false.
+        if (sandbox) {
+            boolean needsCamera = request.getArg("ios.NSCameraUsageDescription", null) != null;
+            boolean cameraOptIn = parseEntitlementBool(request,
+                    "macNative.entitlements.device.camera", needsCamera);
+            if (cameraOptIn) {
+                sb.append("    <key>com.apple.security.device.camera</key>\n    <true/>\n");
+            }
+            boolean needsMic = request.getArg("ios.NSMicrophoneUsageDescription", null) != null;
+            boolean micOptIn = parseEntitlementBool(request,
+                    "macNative.entitlements.device.microphone", needsMic);
+            if (micOptIn) {
+                sb.append("    <key>com.apple.security.device.microphone</key>\n    <true/>\n");
+            }
+        }
         if (extra != null && extra.trim().length() > 0) {
             sb.append(extra);
             if (!extra.endsWith("\n")) {

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/AiDependencyTableTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/AiDependencyTableTest.java
@@ -115,6 +115,56 @@ class AiDependencyTableTest {
     }
 
     @Test
+    void cameraEntryInjectsAvFoundationAndCameraXGradleDeps() {
+        // Referencing any class in com.codename1.camera.* must auto-inject
+        // the iOS frameworks, iOS plist usage descriptions, Android
+        // permissions, and the four CameraX Gradle dependencies that the
+        // AndroidCameraImpl reflection layer resolves at runtime.
+        List<AiDependencyTable.Entry> hits = AiDependencyTable.matchesFor(
+                "com/codename1/camera/Camera");
+        assertEquals(1, hits.size(), "expected the camera entry to fire");
+        AiDependencyTable.Entry e = hits.get(0);
+
+        // iOS side
+        assertTrue(e.iosFrameworks().contains("AVFoundation"));
+        assertTrue(e.iosFrameworks().contains("CoreMedia"));
+        assertTrue(e.iosFrameworks().contains("CoreVideo"));
+        assertNotNull(findPlistDefault(e, "NSCameraUsageDescription"));
+        assertNotNull(findPlistDefault(e, "NSMicrophoneUsageDescription"));
+        assertTrue(e.iosPods().isEmpty(),
+                "Camera uses AVFoundation framework, not a pod");
+
+        // Android side
+        assertTrue(e.androidPermissions().contains("android.permission.CAMERA"));
+        assertTrue(e.androidPermissions().contains("android.permission.RECORD_AUDIO"));
+        assertTrue(e.androidFeatures().contains("android.hardware.camera"));
+
+        boolean cameraCore = false, camera2 = false, lifecycle = false,
+                view = false, video = false;
+        for (String gav : e.androidGradleDeps()) {
+            if (gav.startsWith("androidx.camera:camera-core:")) cameraCore = true;
+            if (gav.startsWith("androidx.camera:camera-camera2:")) camera2 = true;
+            if (gav.startsWith("androidx.camera:camera-lifecycle:")) lifecycle = true;
+            if (gav.startsWith("androidx.camera:camera-view:")) view = true;
+            if (gav.startsWith("androidx.camera:camera-video:")) video = true;
+        }
+        assertTrue(cameraCore, "missing androidx.camera:camera-core gradle dep");
+        assertTrue(camera2,    "missing androidx.camera:camera-camera2 gradle dep");
+        assertTrue(lifecycle,  "missing androidx.camera:camera-lifecycle gradle dep");
+        assertTrue(view,       "missing androidx.camera:camera-view gradle dep");
+        assertTrue(video,      "missing androidx.camera:camera-video gradle dep");
+    }
+
+    @Test
+    void cameraEntryFiresOnAnySubpackageClass() {
+        // The prefix matcher must hit any class inside com.codename1.camera,
+        // not just the entry point.
+        assertEquals(1, AiDependencyTable.matchesFor("com/codename1/camera/CameraView").size());
+        assertEquals(1, AiDependencyTable.matchesFor("com/codename1/camera/CameraSession").size());
+        assertEquals(1, AiDependencyTable.matchesFor("com/codename1/camera/internal/Foo").size());
+    }
+
+    @Test
     void tfliteHasBothPodAndSpmSpec() {
         // TFLite is published as both a CocoaPod and a Swift Package.
         // The table records both so projects can route the dep

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/MacNativeBuilderEntitlementsTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/MacNativeBuilderEntitlementsTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.builders;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/// Verifies that MacNativeBuilder's entitlements writer mirrors the iOS
+/// privacy plist defaults injected by `AiDependencyTable` into the
+/// corresponding sandbox device entitlements. Sandboxed Mac apps that
+/// touch the camera or microphone need explicit device entitlements,
+/// not just an Info.plist usage description -- the OS refuses to open
+/// AVCaptureSession otherwise.
+class MacNativeBuilderEntitlementsTest {
+
+    @Test
+    void appStoreSandboxedAddsCameraAndMicEntitlementsWhenPlistDefaultsAreSet(@TempDir Path tmp)
+            throws IOException {
+        BuildRequest req = new BuildRequest();
+        req.setMainClass("MyApp");
+        req.putArgument("macNative.enabled", "true");
+        req.putArgument("macNative.distribution", "appStore");
+        req.putArgument("macNative.teamId", "ABCDEFG123");
+        // These are what AiDependencyTable injects when com.codename1.camera.*
+        // is referenced anywhere in the user app.
+        req.putArgument("ios.NSCameraUsageDescription", "Used to capture photos and video.");
+        req.putArgument("ios.NSMicrophoneUsageDescription",
+                "Used to capture audio for video recording.");
+
+        String body = writeEntitlements(req, tmp, "MyApp");
+
+        assertTrue(body.contains("<key>com.apple.security.app-sandbox</key>"),
+                "appStore channel should be sandboxed by default");
+        assertTrue(body.contains("<key>com.apple.security.device.camera</key>\n    <true/>"),
+                "NSCameraUsageDescription should bring in com.apple.security.device.camera");
+        assertTrue(body.contains("<key>com.apple.security.device.microphone</key>\n    <true/>"),
+                "NSMicrophoneUsageDescription should bring in com.apple.security.device.microphone");
+    }
+
+    @Test
+    void developerIdNotSandboxedSkipsDeviceEntitlements(@TempDir Path tmp) throws IOException {
+        BuildRequest req = new BuildRequest();
+        req.setMainClass("MyApp");
+        req.putArgument("macNative.enabled", "true");
+        req.putArgument("macNative.distribution", "developerID");
+        req.putArgument("macNative.teamId", "ABCDEFG123");
+        req.putArgument("ios.NSCameraUsageDescription", "Used to capture photos.");
+
+        String body = writeEntitlements(req, tmp, "MyApp");
+
+        // DeveloperID builds aren't sandboxed by default, so the device
+        // entitlements are irrelevant -- the OS prompt is driven entirely
+        // by the Info.plist usage description.
+        assertFalse(body.contains("com.apple.security.app-sandbox"));
+        assertFalse(body.contains("com.apple.security.device.camera"),
+                "Non-sandboxed builds don't need device entitlements");
+    }
+
+    @Test
+    void sandboxedAppWithoutCameraPlistGetsNoCameraEntitlement(@TempDir Path tmp)
+            throws IOException {
+        BuildRequest req = new BuildRequest();
+        req.setMainClass("MyApp");
+        req.putArgument("macNative.enabled", "true");
+        req.putArgument("macNative.distribution", "appStore");
+        req.putArgument("macNative.teamId", "ABCDEFG123");
+        // No camera plist hint -- the app doesn't use the camera.
+
+        String body = writeEntitlements(req, tmp, "MyApp");
+
+        assertTrue(body.contains("<key>com.apple.security.app-sandbox</key>"));
+        assertFalse(body.contains("com.apple.security.device.camera"));
+        assertFalse(body.contains("com.apple.security.device.microphone"));
+    }
+
+    @Test
+    void developerCanForceCameraEntitlementOn(@TempDir Path tmp) throws IOException {
+        BuildRequest req = new BuildRequest();
+        req.setMainClass("MyApp");
+        req.putArgument("macNative.enabled", "true");
+        req.putArgument("macNative.distribution", "appStore");
+        req.putArgument("macNative.teamId", "ABCDEFG123");
+        // Even without the iOS plist hint, an explicit opt-in forces the
+        // entitlement to be written. Useful when an app uses a 3rd-party
+        // camera path the AiDependencyTable scanner doesn't recognise.
+        req.putArgument("macNative.entitlements.device.camera", "true");
+
+        String body = writeEntitlements(req, tmp, "MyApp");
+
+        assertTrue(body.contains("com.apple.security.device.camera"));
+    }
+
+    @Test
+    void developerCanForceCameraEntitlementOff(@TempDir Path tmp) throws IOException {
+        BuildRequest req = new BuildRequest();
+        req.setMainClass("MyApp");
+        req.putArgument("macNative.enabled", "true");
+        req.putArgument("macNative.distribution", "appStore");
+        req.putArgument("macNative.teamId", "ABCDEFG123");
+        req.putArgument("ios.NSCameraUsageDescription", "Used to capture photos.");
+        // Override the auto-detection: this app declared the iOS hint
+        // for App Review purposes but doesn't actually open the Mac
+        // camera, so we suppress the sandbox entitlement.
+        req.putArgument("macNative.entitlements.device.camera", "false");
+
+        String body = writeEntitlements(req, tmp, "MyApp");
+
+        assertFalse(body.contains("com.apple.security.device.camera"),
+                "Explicit opt-out should win over the auto-detection");
+    }
+
+    // ------------------------------------------------------------------
+    // Helper
+    // ------------------------------------------------------------------
+
+    private static String writeEntitlements(BuildRequest req, Path tmpDir, String mainClass)
+            throws IOException {
+        IPhoneBuilder owner = new IPhoneBuilder();
+        MacNativeBuilder b = new MacNativeBuilder(owner);
+        b.parseHints(req);
+        File appSrcDir = tmpDir.toFile();
+        b.writeEntitlements(req, appSrcDir);
+        File ent = new File(appSrcDir, mainClass + ".entitlements");
+        if (!ent.exists()) {
+            throw new AssertionError("Entitlements file not written: " + ent);
+        }
+        return new String(Files.readAllBytes(ent.toPath()));
+    }
+}

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/CameraApiTest.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/CameraApiTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.examples.hellocodenameone.tests;
+
+import com.codename1.camera.Camera;
+import com.codename1.camera.CameraFacing;
+import com.codename1.camera.CameraFrame;
+import com.codename1.camera.CameraInfo;
+import com.codename1.camera.CameraSession;
+import com.codename1.camera.CameraSessionOptions;
+import com.codename1.camera.CameraView;
+import com.codename1.camera.CapturedPhoto;
+import com.codename1.camera.FrameListener;
+import com.codename1.ui.Display;
+import com.codename1.ui.PeerComponent;
+import com.codename1.util.AsyncResource;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/// End-to-end exercise of the low-level `com.codename1.camera.Camera` API
+/// against whichever per-port `CameraImpl` is in use.
+///
+/// On the JavaSE simulator (where `JavaSECameraImpl` synthesises frames and
+/// never touches a real webcam) this runs the full assertion chain in CI
+/// without triggering any permission prompts. On iOS / Android / JavaScript
+/// the camera open call would surface an OS permission dialog that would
+/// hang the automated runner, so the test self-skips on those platforms.
+/// The native-port code paths are verified separately:
+///   - iOS: device build sanity + XCTest screenshot suite
+///   - Android: instrumentation tests against a granted-permissions
+///     `--grant-runtime-permissions` install
+///   - JavaScript: manual browser smoke test
+///
+/// No `Cn1ssDeviceRunnerHelper.emitCurrentFormScreenshot` -- this is an
+/// assertion test, not a screenshot test.
+public class CameraApiTest extends BaseTest {
+
+    private static final long FRAME_TIMEOUT_MS = 8000;
+    private static final long PHOTO_TIMEOUT_MS = 8000;
+
+    @Override
+    public boolean shouldTakeScreenshot() {
+        return false;
+    }
+
+    @Override
+    public boolean runTest() {
+        String platform = Display.getInstance().getPlatformName();
+        // The simulator's JavaSECameraImpl is synthetic-only -- safe in CI.
+        // Real-camera ports would require runtime permissions; skip there.
+        boolean isSimulator = !"ios".equals(platform)
+                && !"and".equals(platform)
+                && !"HTML5".equals(platform);
+        if (!isSimulator) {
+            System.out.println("CN1SS:INFO:test=CameraApiTest status=SKIPPED reason=needs-runtime-permission-on-" + platform);
+            done();
+            return true;
+        }
+
+        try {
+            if (!Camera.isSupported()) {
+                fail("Camera.isSupported() should be true on the simulator");
+                return false;
+            }
+
+            CameraInfo[] all = Camera.getCameras();
+            if (all == null || all.length == 0) {
+                fail("Camera.getCameras() returned no cameras");
+                return false;
+            }
+            CameraInfo back = Camera.getDefault(CameraFacing.BACK);
+            if (back == null) {
+                fail("Camera.getDefault(BACK) returned null");
+                return false;
+            }
+
+            // Open the session, attach a frame listener, verify at least one
+            // frame is delivered, take a photo, close. The session bracket
+            // is explicit instead of try-with-resources because the test
+            // framework targets Java 5 syntax.
+            CameraSessionOptions opts = new CameraSessionOptions()
+                    .previewSize(320, 240)
+                    .frameMaxFps(10)
+                    .captureAudio(false);
+            CameraSession session = Camera.open(back, opts);
+            if (session == null) {
+                fail("Camera.open returned null session");
+                return false;
+            }
+            try {
+                PeerComponent peer = session.createView().getPreviewPeer();
+                if (peer == null) {
+                    fail("CameraView returned a null preview peer");
+                    return false;
+                }
+
+                final AtomicInteger frameCount = new AtomicInteger();
+                final int[] capturedW = new int[1];
+                final int[] capturedH = new int[1];
+                final int[] jpegLen = new int[1];
+                session.setFrameListener(new FrameListener() {
+                    @Override public void onFrame(CameraFrame frame) {
+                        if (frame == null) return;
+                        capturedW[0] = frame.getWidth();
+                        capturedH[0] = frame.getHeight();
+                        byte[] jpeg = frame.getJpegBytes();
+                        if (jpeg != null) {
+                            jpegLen[0] = jpeg.length;
+                        }
+                        frameCount.incrementAndGet();
+                    }
+                });
+
+                long deadline = System.currentTimeMillis() + FRAME_TIMEOUT_MS;
+                while (frameCount.get() == 0 && System.currentTimeMillis() < deadline) {
+                    sleep(50);
+                }
+                if (frameCount.get() == 0) {
+                    fail("No camera frames delivered within " + FRAME_TIMEOUT_MS + "ms");
+                    return false;
+                }
+                if (capturedW[0] <= 0 || capturedH[0] <= 0) {
+                    fail("Frame had invalid dimensions: " + capturedW[0] + "x" + capturedH[0]);
+                    return false;
+                }
+                if (jpegLen[0] <= 0) {
+                    fail("Frame JPEG bytes were empty");
+                    return false;
+                }
+                if (!isJpeg(jpegLen[0])) {
+                    // jpegLen is just the length; defensive size check.
+                    fail("Frame JPEG appears too small: " + jpegLen[0] + " bytes");
+                    return false;
+                }
+
+                // Trying to open a second session must fail per the
+                // documented "one open session at a time" contract.
+                try {
+                    Camera.open(back, new CameraSessionOptions());
+                    fail("Camera.open should have thrown IllegalStateException on double-open");
+                    return false;
+                } catch (IllegalStateException expected) {
+                    // expected
+                }
+
+                // takePhoto: returns AsyncResource that must resolve within
+                // the timeout. Don't block the EDT.
+                AsyncResource<CapturedPhoto> photoR = session.takePhoto();
+                CapturedPhoto photo = awaitPhoto(photoR, PHOTO_TIMEOUT_MS);
+                if (photo == null) {
+                    fail("takePhoto did not complete within " + PHOTO_TIMEOUT_MS + "ms");
+                    return false;
+                }
+                byte[] photoBytes = photo.getJpegBytes();
+                if (photoBytes == null || photoBytes.length == 0) {
+                    fail("CapturedPhoto had no JPEG bytes");
+                    return false;
+                }
+                if (photo.getFilePath() == null || photo.getFilePath().length() == 0) {
+                    fail("CapturedPhoto had no file path");
+                    return false;
+                }
+                if (photo.getWidth() <= 0 || photo.getHeight() <= 0) {
+                    fail("CapturedPhoto had invalid dimensions: "
+                            + photo.getWidth() + "x" + photo.getHeight());
+                    return false;
+                }
+
+                session.setFrameListener(null);
+            } finally {
+                session.close();
+            }
+
+            // After close, opening a fresh session must succeed (close
+            // released the single-active-session lock).
+            CameraSession second = Camera.open(back, new CameraSessionOptions());
+            if (second == null) {
+                fail("Second Camera.open after close returned null");
+                return false;
+            }
+            second.close();
+
+            done();
+            return true;
+        } catch (Throwable t) {
+            fail("CameraApiTest threw: " + t);
+            t.printStackTrace();
+            return false;
+        }
+    }
+
+    private static boolean isJpeg(int byteCount) {
+        // The synthetic encoder produces JPEGs typically 4-30KB at 320x240.
+        // 100 bytes is the floor below which no real JPEG header + entropy
+        // body can fit; serves as a sanity check, not a strict assertion.
+        return byteCount >= 100;
+    }
+
+    private static void sleep(long ms) {
+        try { Thread.sleep(ms); } catch (InterruptedException ignored) { }
+    }
+
+    private static CapturedPhoto awaitPhoto(AsyncResource<CapturedPhoto> resource, long timeoutMs) {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        final Object lock = new Object();
+        final CapturedPhoto[] out = new CapturedPhoto[1];
+        final Throwable[] err = new Throwable[1];
+        resource.ready(new com.codename1.util.SuccessCallback<CapturedPhoto>() {
+            @Override public void onSucess(CapturedPhoto value) {
+                synchronized (lock) { out[0] = value; lock.notifyAll(); }
+            }
+        });
+        resource.except(new com.codename1.util.SuccessCallback<Throwable>() {
+            @Override public void onSucess(Throwable t) {
+                synchronized (lock) { err[0] = t; lock.notifyAll(); }
+            }
+        });
+        synchronized (lock) {
+            while (out[0] == null && err[0] == null
+                    && System.currentTimeMillis() < deadline) {
+                try { lock.wait(50); } catch (InterruptedException ignored) { }
+            }
+        }
+        return out[0];
+    }
+
+}

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/Cn1ssDeviceRunner.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/Cn1ssDeviceRunner.java
@@ -241,6 +241,11 @@ public final class Cn1ssDeviceRunner extends DeviceRunner {
             new InPlaceEditViewTest(),
             new BytecodeTranslatorRegressionTest(),
             new SimdApiTest(),
+            // Exercises com.codename1.camera.* end-to-end against the
+            // JavaSE simulator's synthetic camera backend (no permission
+            // prompts). Self-skips on iOS / Android / JS where the open
+            // call would surface an OS dialog.
+            new CameraApiTest(),
             new SimdLargeAllocaTest(),
             new StreamApiTest(),
             new StringApiTest(),


### PR DESCRIPTION
## Summary

- New `com.codename1.camera.*` public API: live `CameraView`, photo + frame stream + video, fully cross-platform.
- Per-port implementations: iOS / Mac Catalyst (AVFoundation), Android (CameraX via reflection), JavaScript (getUserMedia), JavaSE simulator (synthetic deterministic backend, used in CI).
- `AiDependencyTable` auto-injects iOS frameworks + plist usage descriptions, Android permissions + CameraX gradle deps, and Mac Catalyst sandbox device entitlements -- just referencing `Camera` from the app flips all of these on. No manual build hints required.

## Motivation

The existing `com.codename1.capture.Capture` API is modal-picker only (no live preview, no frame access), so the AI / ML Kit modules (`BarcodeScanner`, `TextRecognizer`, `FaceDetector`, etc.) can't be fed camera frames without round-tripping through a file. The cn1lib `CameraKitCodenameOne` filled this gap but is out of date and carries heavy 3rd-party deps. This PR adds a first-class, low-level camera API to the core SDK using only platform-native APIs.

## Public API (com.codename1.camera)

```java
CameraInfo back = Camera.getDefault(CameraFacing.BACK);
CameraSession s = Camera.open(back, new CameraSessionOptions());
CameraView view = s.createView();        // add to a Form

s.setFrameListener(frame ->                // BG thread; JPEG bytes
    BarcodeScanner.scan(frame.getJpegBytes()).ready(codes -> { ... }));

s.takePhoto().ready(photo -> {            // AsyncResource<CapturedPhoto>
    Image i = photo.toImage();
});

VideoRecording rec = s.startVideoRecording(path);
rec.stopAndAwait().ready(finalPath -> { ... });

s.close();
```

## Impl seam

One new method on `CodenameOneImplementation`:
```java
public CameraImpl createCameraImpl() { return null; }
```
returning an undocumented `com.codename1.impl.CameraImpl` (abstract per-session contract). Each port overrides it; keeps the monolithic chain clean instead of adding ~15 new abstract methods.

## Per-platform notes

- **JavaSE simulator** -- synthetic JPEG frames via Java2D, no webcam dep. Configurable via `-Dcn1.camera.source=path` and `-Dcn1.camera.fps=N`. Sets `ios.NSCameraUsageDescription` at runtime.
- **iOS / Mac Catalyst** -- `CN1Camera.{h,m}` wraps `AVCaptureSession + AVCaptureVideoDataOutput + AVCapturePhotoOutput + AVCaptureMovieFileOutput + AVCaptureVideoPreviewLayer`. Gated by `INCLUDE_CAMERA_USAGE` so apps that don't use the camera don't link AVFoundation. 13 new natives on `IOSNative`.
- **Android** -- CameraX via reflection (matches the `OidcBrowserNativeImpl` / `WebAuthnNativeImpl` pattern; the port itself doesn't have `androidx.camera` on its compile classpath). Preview + photo-to-file + frame stream. Video recording deferred to v2.
- **JavaScript** -- `navigator.mediaDevices.getUserMedia` (Promise-based, not deprecated callback), `<video>` peer, canvas snapshots. Video recording deferred.

## AiDependencyTable

New `com/codename1/camera/` entry injects:
- iOS: `AVFoundation`, `CoreMedia`, `CoreVideo` frameworks + `NS{Camera,Microphone}UsageDescription` plist defaults
- Android: `CAMERA` + `RECORD_AUDIO` permissions, camera + camera.autofocus features, the five `androidx.camera:*:1.3.4` gradle deps
- Mac Catalyst: sandbox device entitlements via `MacNativeBuilder.writeEntitlementsFile`, mirroring the iOS plist hints when `appSandbox=true`

## Tests

- `AiDependencyTableTest` -- 2 new cases (camera entry contents, subpackage prefix match). 11/11 pass locally.
- `MacNativeBuilderEntitlementsTest` (new file) -- 5 cases (sandboxed-with-camera, developerID-skips, sandboxed-without-camera, force-on, force-off). 5/5 pass locally.
- `CameraApiTest` (new file in `hellocodenameone` screenshot suite) -- end-to-end API exercise against the synthetic JavaSE simulator backend (enumerate, open, view, frame listener, takePhoto, double-open exception, second-open after close). Self-skips on iOS / Android / JS where the open call would surface an OS permission prompt.

## Limitations (documented in source)

- Android + JS video recording stubbed to throw with a clear pointer to `Capture.captureVideo()`. iOS works.
- Android `focus()` and explicit `pause()/resume()` are no-ops (CameraX is bound to `ProcessLifecycleOwner` so app-level lifecycle handles background/foreground).
- Android `takePhoto` uses the to-file path (`OnImageCapturedCallback` is abstract -- can't `Proxy.newProxyInstance` it).
- iOS / JS / Android device runtime paths need on-device + browser smoke tests before production use.

## Local verification

```
mvn install -DskipTests -Dspotbugs.skip=true -Dmaven.javadoc.skip=true -Plocal-dev-javase   # BUILD SUCCESS
mvn -pl codenameone-maven-plugin -am -Plocal-dev-javase -Dspotbugs.skip=true -Dmaven.javadoc.skip=true \
    -Dsurefire.failIfNoSpecifiedTests=false test -Dtest=AiDependencyTableTest                # 11/11 pass
mvn ...  -Dtest=MacNativeBuilderEntitlementsTest                                              # 5/5 pass
```

## Test plan

- [x] Core compiles + factory + javase + android + ios + maven-plugin (mvn install)
- [x] `AiDependencyTableTest` 11/11
- [x] `MacNativeBuilderEntitlementsTest` 5/5
- [x] `hellocodenameone` common module compiles with `CameraApiTest`
- [ ] CI green across all jobs (this PR; iterate on findings)
- [ ] iOS device smoke test of `Camera.open` + preview + photo + barcode scan (manual, follow-up)
- [ ] Android device smoke test, same coverage
- [ ] Browser HTTPS smoke test of HTML5 path

🤖 Generated with [Claude Code](https://claude.com/claude-code)