### PR TITLE
fix(EncodedImage): make dispose() release cached image and bytes (#3733)

### DIFF
--- a/CodenameOne/src/com/codename1/ui/EncodedImage.java
+++ b/CodenameOne/src/com/codename1/ui/EncodedImage.java
@@ -86,6 +86,7 @@ public class EncodedImage extends Image {
     private Object cache;
     private Image hardCache;
     private int locked;
+    private boolean disposed;
 
     private EncodedImage(byte[][] imageData) {
         super(null);
@@ -347,6 +348,43 @@ public class EncodedImage extends Image {
         hardCache = null;
     }
 
+    /// Releases the decoded image cache and the encoded byte data backing this
+    /// instance. After dispose, attempting to draw or query this image will
+    /// throw [IllegalStateException]. Intended for tight memory budgets where
+    /// the caller knows the image is no longer needed; see [Image#dispose].
+    @Override
+    public void dispose() {
+        if (disposed) {
+            return;
+        }
+        disposed = true;
+        if (hardCache != null) {
+            try {
+                hardCache.dispose();
+            } catch (Throwable ignored) {
+            }
+            hardCache = null;
+        }
+        if (cache != null) {
+            Image cached = (Image) Display.getInstance().extractHardRef(cache);
+            if (cached != null) {
+                try {
+                    cached.dispose();
+                } catch (Throwable ignored) {
+                }
+            }
+            cache = null;
+        }
+        imageData = null;
+        locked = 0;
+        super.dispose();
+    }
+
+    /// Returns true if [#dispose] has been called on this image.
+    public boolean isDisposed() {
+        return disposed;
+    }
+
     /// Returns the byte array data backing the image allowing the image to be stored
     /// and discarded completely from RAM.
     ///
@@ -354,6 +392,9 @@ public class EncodedImage extends Image {
     ///
     /// byte array used to create the image, e.g. encoded PNG, JPEG etc.
     public byte[] getImageData() {
+        if (disposed) {
+            throw new IllegalStateException("EncodedImage was disposed");
+        }
         if (imageData.length == 1) {
             return imageData[0];
         }
@@ -383,7 +424,9 @@ public class EncodedImage extends Image {
     }
 
     private Image getInternalImpl() {
-
+        if (disposed) {
+            throw new IllegalStateException("EncodedImage was disposed");
+        }
         if (imageData != null && imageData.length > 1 && lastTestedDPI != Display.getInstance().getDeviceDensity()) {
             hardCache = null;
             cache = null;

--- a/maven/core-unittests/src/test/java/com/codename1/ui/EncodedImageTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/EncodedImageTest.java
@@ -95,6 +95,17 @@ class EncodedImageTest extends UITestBase {
     }
 
     @FormTest
+    void testDisposeReleasesEncodedBytes() {
+        EncodedImage encoded = EncodedImage.create(new byte[]{1, 2, 3, 4}, 8, 8, true);
+        assertFalse(encoded.isDisposed());
+        encoded.dispose();
+        assertTrue(encoded.isDisposed());
+        assertThrows(IllegalStateException.class, encoded::getImageData);
+        encoded.dispose();
+        assertTrue(encoded.isDisposed());
+    }
+
+    @FormTest
     void testLockAndUnlockPromotesCachedImage() throws Exception {
         EncodedImage encoded = EncodedImage.create(new byte[]{1, 2, 3, 4}, 6, 6, false);
         Image actual = Image.createImage(6, 6);


### PR DESCRIPTION
## Summary
- Override `EncodedImage#dispose()` to release the `hardCache` decoded image, drop the soft/weak `cache`, and null out `imageData`.
- Add `EncodedImage#isDisposed()`.
- Throw `IllegalStateException` from `getImageData()` / `getInternalImpl()` after dispose, matching `Image#dispose()`'s "the image becomes unusable" contract.

Fixes #3733 — previously `dispose()` on an EncodedImage was a no-op, so neither the decoded native image nor the encoded byte buffers were released.

## Test plan
- [x] New `testDisposeReleasesEncodedBytes` in `EncodedImageTest` covers the disposed state and idempotence.
- [x] Existing 7 EncodedImageTest tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)