### PR TITLE
feat(Graphics): add isVisible(x,y,w,h) primitive (#3846)

### DIFF
--- a/CodenameOne/src/com/codename1/ui/Graphics.java
+++ b/CodenameOne/src/com/codename1/ui/Graphics.java
@@ -406,7 +406,7 @@ public final class Graphics {
     /// rectangle, i.e. anything drawn into it would be at least partially
     /// visible.
     ///
-    /// Use this to skip work for off-screen draws — typical case is a zoomed
+    /// Use this to skip work for off-screen draws - typical case is a zoomed
     /// canvas where most images fall outside the visible window and should
     /// not be decoded or scaled.
     ///

--- a/CodenameOne/src/com/codename1/ui/Graphics.java
+++ b/CodenameOne/src/com/codename1/ui/Graphics.java
@@ -401,6 +401,52 @@ public final class Graphics {
         return impl.getClipHeight(nativeGraphics);
     }
 
+    /// Returns true if the given rectangle (in the current Graphics coordinate
+    /// space, with the active translation applied) intersects the current clip
+    /// rectangle, i.e. anything drawn into it would be at least partially
+    /// visible.
+    ///
+    /// Use this to skip work for off-screen draws — typical case is a zoomed
+    /// canvas where most images fall outside the visible window and should
+    /// not be decoded or scaled.
+    ///
+    /// ```java
+    /// if (g.isVisible(x, y, w, h)) {
+    ///     g.drawImage(image, x, y, w, h);
+    /// }
+    /// ```
+    ///
+    /// Note: shape-clipped graphics ([#setClip(Shape)]) and arbitrary
+    /// affine transforms fall back to the bounding rectangle of the clip;
+    /// this matches the precision actually used by the platform draw calls.
+    ///
+    /// #### Parameters
+    ///
+    /// - `x`: left edge of the rectangle
+    ///
+    /// - `y`: top edge of the rectangle
+    ///
+    /// - `w`: width of the rectangle
+    ///
+    /// - `h`: height of the rectangle
+    ///
+    /// #### Returns
+    ///
+    /// true if the rectangle intersects the current clip
+    public boolean isVisible(int x, int y, int w, int h) {
+        if (w <= 0 || h <= 0) {
+            return false;
+        }
+        int cx = getClipX();
+        int cy = getClipY();
+        int cw = getClipWidth();
+        int ch = getClipHeight();
+        if (cw <= 0 || ch <= 0) {
+            return false;
+        }
+        return x < cx + cw && y < cy + ch && x + w > cx && y + h > cy;
+    }
+
     /// Clips the given rectangle by intersecting with the current clipping region, this
     /// method can thus only shrink the clipping region and never increase it.
     ///

--- a/maven/core-unittests/src/test/java/com/codename1/ui/GraphicsTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/GraphicsTest.java
@@ -97,6 +97,41 @@ class GraphicsTest extends UITestBase {
     }
 
     @FormTest
+    void testIsVisibleReturnsTrueWhenRectInsideClip() {
+        implementation.setClip(nativeGraphics, 10, 20, 100, 100);
+        assertTrue(graphics.isVisible(15, 25, 5, 5));
+    }
+
+    @FormTest
+    void testIsVisibleReturnsTrueWhenRectIntersectsClip() {
+        implementation.setClip(nativeGraphics, 10, 20, 100, 100);
+        assertTrue(graphics.isVisible(5, 18, 20, 20));
+    }
+
+    @FormTest
+    void testIsVisibleReturnsFalseWhenRectOutsideClip() {
+        implementation.setClip(nativeGraphics, 10, 20, 100, 100);
+        assertFalse(graphics.isVisible(200, 200, 10, 10));
+        assertFalse(graphics.isVisible(0, 0, 5, 10));
+    }
+
+    @FormTest
+    void testIsVisibleAccountsForTranslation() {
+        implementation.setClip(nativeGraphics, 50, 50, 100, 100);
+        graphics.translate(50, 50);
+        assertTrue(graphics.isVisible(10, 10, 5, 5));
+        assertFalse(graphics.isVisible(-10, -10, 5, 5));
+    }
+
+    @FormTest
+    void testIsVisibleHandlesDegenerateRect() {
+        implementation.setClip(nativeGraphics, 0, 0, 100, 100);
+        assertFalse(graphics.isVisible(10, 10, 0, 10));
+        assertFalse(graphics.isVisible(10, 10, 10, 0));
+        assertFalse(graphics.isVisible(10, 10, -5, 5));
+    }
+
+    @FormTest
     void testGetClipAccountsForTranslation() {
         implementation.setClip(nativeGraphics, 15, 25, 30, 40);
         graphics.translate(5, 5);


### PR DESCRIPTION
## Summary
- Add \`Graphics#isVisible(int x, int y, int w, int h)\` returning whether the rect intersects the current clip (translation-aware).
- Enables off-screen culling so zoomed canvases skip image decode/scale for content outside the visible window.

Fixes #3846.

## Test plan
- [x] 5 new GraphicsTest cases (inside, intersecting, outside, translated, degenerate). All 22 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)