### PR TITLE
feat(NetworkManager): add ping(url, timeoutMillis) reachability probe (#3669)

### DIFF
--- a/CodenameOne/src/com/codename1/io/NetworkManager.java
+++ b/CodenameOne/src/com/codename1/io/NetworkManager.java
@@ -886,8 +886,8 @@ public final class NetworkManager {
     }
 
     /// Issues a blocking HTTP HEAD request to `url` and returns whether the
-    /// server responded within `timeoutMillis`. Any response — including 4xx
-    /// or 5xx — is treated as a successful ping (the network round-trip
+    /// server responded within `timeoutMillis`. Any response - including 4xx
+    /// or 5xx - is treated as a successful ping (the network round-trip
     /// completed). Only socket errors, DNS failures, and timeouts return
     /// false.
     ///

--- a/CodenameOne/src/com/codename1/io/NetworkManager.java
+++ b/CodenameOne/src/com/codename1/io/NetworkManager.java
@@ -885,6 +885,44 @@ public final class NetworkManager {
         return getCurrentNetworkType() != NETWORK_TYPE_NONE;
     }
 
+    /// Issues a blocking HTTP HEAD request to `url` and returns whether the
+    /// server responded within `timeoutMillis`. Any response — including 4xx
+    /// or 5xx — is treated as a successful ping (the network round-trip
+    /// completed). Only socket errors, DNS failures, and timeouts return
+    /// false.
+    ///
+    /// Use this for reachability probes against a known endpoint when
+    /// [#isConnected] (a fast device-side network-type check) isn't strong
+    /// enough. Must not be invoked from the EDT.
+    ///
+    /// #### Parameters
+    ///
+    /// - `url`: the URL to probe; typically a small static endpoint
+    ///
+    /// - `timeoutMillis`: maximum time to wait for the request to complete; pass
+    /// 0 to use the connection's default timeout
+    ///
+    /// #### Returns
+    ///
+    /// true if the server responded, false on timeout, DNS, or socket error
+    public boolean ping(String url, int timeoutMillis) {
+        if (url == null) {
+            throw new IllegalArgumentException("url is null");
+        }
+        ConnectionRequest cr = new ConnectionRequest();
+        cr.setUrl(url);
+        cr.setPost(false);
+        cr.setHttpMethod("HEAD");
+        cr.setFailSilently(true);
+        cr.setReadResponseForErrors(false);
+        if (timeoutMillis > 0) {
+            cr.setTimeout(timeoutMillis);
+            cr.setReadTimeout(timeoutMillis);
+        }
+        addToQueueAndWait(cr);
+        return cr.getResponseCode() > 0;
+    }
+
     /// Registers `l` to be notified when the device's active network type
     /// changes (WiFi <-> Cellular <-> None <-> ...). The listener is invoked
     /// on the EDT. Safe to call multiple times with the same listener; only

--- a/maven/core-unittests/src/test/java/com/codename1/io/NetworkManagerTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/io/NetworkManagerTest.java
@@ -231,6 +231,25 @@ class NetworkManagerTest extends com.codename1.junit.UITestBase {
     }
 
     @FormTest
+    void pingReturnsTrueWhenServerResponds() {
+        TestCodenameOneImplementation.getInstance().addNetworkMockResponse(
+                "http://example.com/health", 200, "OK", new byte[0]);
+        assertTrue(manager.ping("http://example.com/health", 5000));
+    }
+
+    @FormTest
+    void pingReturnsTrueOn404() {
+        TestCodenameOneImplementation.getInstance().addNetworkMockResponse(
+                "http://example.com/missing", 404, "Not Found", new byte[0]);
+        assertTrue(manager.ping("http://example.com/missing", 5000));
+    }
+
+    @Test
+    void pingNullUrlThrows() {
+        assertThrows(IllegalArgumentException.class, () -> manager.ping(null, 1000));
+    }
+
+    @FormTest
     void testAddToQueueAndWait() throws Exception {
         final ConnectionRequest req = new ConnectionRequest() {
             @Override


### PR DESCRIPTION
## Summary
- Add \`NetworkManager#ping(String url, int timeoutMillis)\` that fires a HEAD request through the connection queue and returns whether the server responded.
- Any HTTP status counts as success — only timeouts, DNS failures, and socket errors return false.
- Pairs with \`isConnected()\` (device-side network-type check) for a real server-reach probe.

Fixes #3669.

## Test plan
- [x] Core compiles
- [ ] Manual: \`NetworkManager.getInstance().ping(\"https://www.codenameone.com\", 5000)\` → true
- [ ] Manual: \`NetworkManager.getInstance().ping(\"https://10.255.255.1\", 1000)\` → false

🤖 Generated with [Claude Code](https://claude.com/claude-code)