### PR TITLE
fix(JavaSE): NetworkMonitor stretches with the simulator window (#3701)

### DIFF
--- a/Ports/JavaSE/src/com/codename1/impl/javase/NetworkMonitor.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/NetworkMonitor.java
@@ -25,6 +25,8 @@ package com.codename1.impl.javase;
 import com.codename1.io.ConnectionRequest;
 import com.codename1.io.IOAccessor;
 import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Rectangle;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.net.URLConnection;
@@ -40,7 +42,7 @@ import javax.swing.event.ListSelectionListener;
  *
  * @author Shai Almog
  */
-public class NetworkMonitor extends javax.swing.JPanel {
+public class NetworkMonitor extends javax.swing.JPanel implements Scrollable {
 
     private Map<URLConnection, NetworkRequestObject> requests = new HashMap<URLConnection, NetworkRequestObject>();
     private Map<ConnectionRequest, NetworkRequestObject> queuedRequests = new HashMap<ConnectionRequest, NetworkRequestObject>();
@@ -89,11 +91,50 @@ public class NetworkMonitor extends javax.swing.JPanel {
             });
 
             frame.pack();
+            Dimension packed = frame.getSize();
+            Rectangle screen = frame.getGraphicsConfiguration().getBounds();
+            int defaultW = Math.min(Math.max(packed.width, 1100), screen.width - 80);
+            int defaultH = Math.min(Math.max(packed.height, 700), screen.height - 80);
+            frame.setSize(defaultW, defaultH);
+            if (jSplitPane1 != null) {
+                jSplitPane1.setResizeWeight(0.25);
+                jSplitPane1.setDividerLocation(Math.max(220, defaultW / 4));
+            }
             frame.setLocationByPlatform(true);
             frame.setVisible(true);
 
         }
         return frame;
+    }
+
+    /// Scrollable implementation: when wrapped in a JScrollPane (single-window
+    /// mode via AppPanel.setScrollable), the monitor stretches to fill the
+    /// viewport width so the request list and detail tabs claim the full
+    /// available width as the simulator window resizes.
+
+    @Override
+    public Dimension getPreferredScrollableViewportSize() {
+        return getPreferredSize();
+    }
+
+    @Override
+    public int getScrollableUnitIncrement(Rectangle visibleRect, int orientation, int direction) {
+        return 16;
+    }
+
+    @Override
+    public int getScrollableBlockIncrement(Rectangle visibleRect, int orientation, int direction) {
+        return orientation == SwingConstants.VERTICAL ? visibleRect.height : visibleRect.width;
+    }
+
+    @Override
+    public boolean getScrollableTracksViewportWidth() {
+        return true;
+    }
+
+    @Override
+    public boolean getScrollableTracksViewportHeight() {
+        return false;
     }
 
     public void dispose() {


### PR DESCRIPTION
## Summary
- \`NetworkMonitor\` now implements \`Scrollable\` so it tracks viewport width when wrapped in a JScrollPane (single-window mode via \`AppPanel.setScrollable\`).
- \`showInNewWindow\` picks a sane 1100x700 default (capped to screen size) instead of \`pack()\`'s tiny preferred dimension.
- The split pane gets \`resizeWeight=0.25\` and a divider location proportional to the new window width so the request list grows with the window.

Fixes #3701 — on ultrawide monitors the Network Monitor no longer stays pinned at its packed width.

## Test plan
- [x] Compiles (\`-Plocal-dev-javase\`)
- [ ] Manual: launch simulator with Network Monitor on a wide screen, confirm pane fills horizontally and request list+detail tabs grow with window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)