### PR TITLE
fix(ImageViewer): vertical drags bubble to scrollable parent (#3700)

### DIFF
--- a/CodenameOne/src/com/codename1/components/ImageViewer.java
+++ b/CodenameOne/src/com/codename1/components/ImageViewer.java
@@ -23,6 +23,7 @@
 package com.codename1.components;
 
 import com.codename1.ui.Component;
+import com.codename1.ui.Container;
 import com.codename1.ui.Display;
 import com.codename1.ui.Font;
 import com.codename1.ui.FontImage;
@@ -216,6 +217,7 @@ public class ImageViewer extends Component {
     private float thumbnailBarHeightMM = 6f;
     private int pointerPressedAction;
     private int pointerPressedThumbnailIndex = -1;
+    private boolean delegatingDragToParent;
 
     /// Default constructor
     public ImageViewer() {
@@ -445,7 +447,19 @@ public class ImageViewer extends Component {
         pointerPressedAction = getPointerActionAt(x, y);
         pointerPressedThumbnailIndex = getThumbnailIndexAt(x, y);
         currentZoom = zoom;
+        delegatingDragToParent = false;
         getComponentForm().addComponentAwaitingRelease(this);
+    }
+
+    private Container findScrollableYAncestor() {
+        Container p = getParent();
+        while (p != null) {
+            if (p.isScrollableY()) {
+                return p;
+            }
+            p = p.getParent();
+        }
+        return null;
     }
 
     @Override
@@ -476,6 +490,15 @@ public class ImageViewer extends Component {
     /// {@inheritDoc}
     @Override
     public void pointerReleased(int x, int y) {
+        if (delegatingDragToParent) {
+            Container p = findScrollableYAncestor();
+            delegatingDragToParent = false;
+            if (p != null) {
+                p.pointerReleased(x, y);
+            }
+            pointerPressedAction = ACTION_NONE;
+            return;
+        }
         super.pointerReleased(x, y);
         isPinchZooming = false;
         int releaseAction = getPointerActionAt(x, y);
@@ -532,6 +555,24 @@ public class ImageViewer extends Component {
     public void pointerDragged(int x, int y) {
         if (pointerPressedAction != ACTION_NONE) {
             return;
+        }
+        if (delegatingDragToParent) {
+            Container p = findScrollableYAncestor();
+            if (p != null) {
+                p.pointerDragged(x, y);
+            }
+            return;
+        }
+        int dxAbs = Math.abs(x - pressX);
+        int dyAbs = Math.abs(y - pressY);
+        if (getZoom() <= 1 && dyAbs > dxAbs) {
+            Container p = findScrollableYAncestor();
+            if (p != null) {
+                delegatingDragToParent = true;
+                p.pointerPressed(pressX, pressY);
+                p.pointerDragged(x, y);
+                return;
+            }
         }
         // could be a pan
         float distanceX = ((float) pressX - x) / getZoom();

--- a/maven/core-unittests/src/test/java/com/codename1/components/ImageViewerTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/components/ImageViewerTest.java
@@ -2,11 +2,13 @@ package com.codename1.components;
 
 import com.codename1.junit.FormTest;
 import com.codename1.junit.UITestBase;
+import com.codename1.ui.Container;
 import com.codename1.ui.Display;
 import com.codename1.ui.DisplayTest;
 import com.codename1.ui.Form;
 import com.codename1.ui.Image;
 import com.codename1.ui.layouts.BorderLayout;
+import com.codename1.ui.layouts.BoxLayout;
 import com.codename1.ui.list.DefaultListModel;
 import com.codename1.ui.list.ListModel;
 
@@ -186,6 +188,103 @@ class ImageViewerTest extends UITestBase {
         // If finished, image should be second.
     }
 
+    @FormTest
+    void verticalDragBubblesToScrollableParent() throws Exception {
+        Image image = Image.createImage(40, 40, 0xff112233);
+        ImageViewer viewer = new ImageViewer(image);
+        viewer.setAnimateZoom(false);
+
+        Container scrollable = new Container(BoxLayout.y());
+        scrollable.setScrollableY(true);
+        scrollable.add(viewer);
+        for (int i = 0; i < 20; i++) {
+            scrollable.add(new com.codename1.ui.Label("filler " + i));
+        }
+
+        Form f = new Form(new BorderLayout());
+        f.add(BorderLayout.CENTER, scrollable);
+        f.show();
+        f.setSize(new com.codename1.ui.geom.Dimension(240, 320));
+        f.layoutContainer();
+        f.revalidate();
+
+        viewer.setSize(new com.codename1.ui.geom.Dimension(240, 220));
+        viewer.setX(0);
+        viewer.setY(0);
+        viewer.pointerPressed(120, 110);
+        viewer.pointerDragged(120, 40);
+
+        assertTrue(getPrivateField(viewer, "delegatingDragToParent", Boolean.class),
+                "delegatingDragToParent must be set when vertical drag starts inside ImageViewer");
+
+        viewer.pointerDragged(120, 10);
+        viewer.pointerReleased(120, 10);
+
+        assertFalse(getPrivateField(viewer, "delegatingDragToParent", Boolean.class),
+                "delegatingDragToParent must reset on pointerReleased");
+    }
+
+    @FormTest
+    void horizontalDragInsideImageListSwipesNotBubbles() throws Exception {
+        Image a = Image.createImage(40, 40, 0xff112233);
+        Image b = Image.createImage(40, 40, 0xff445566);
+        DefaultListModel<Image> model = new DefaultListModel<>(a, b);
+        ImageViewer viewer = new ImageViewer();
+        viewer.setAnimateZoom(false);
+        viewer.setImageList(model);
+
+        Container scrollable = new Container(BoxLayout.y());
+        scrollable.setScrollableY(true);
+        scrollable.add(viewer);
+        for (int i = 0; i < 10; i++) {
+            scrollable.add(new com.codename1.ui.Label("filler " + i));
+        }
+
+        Form f = new Form(new BorderLayout());
+        f.add(BorderLayout.CENTER, scrollable);
+        f.show();
+        f.setSize(new com.codename1.ui.geom.Dimension(240, 320));
+        f.layoutContainer();
+        f.revalidate();
+
+        viewer.setSize(new com.codename1.ui.geom.Dimension(240, 220));
+        viewer.setX(0);
+        viewer.setY(0);
+
+        viewer.pointerPressed(200, 110);
+        viewer.pointerDragged(20, 110);
+
+        assertFalse(getPrivateField(viewer, "delegatingDragToParent", Boolean.class),
+                "horizontal drag must not delegate to parent");
+    }
+
+    @FormTest
+    void verticalDragWithNoScrollableAncestorStaysWithViewer() throws Exception {
+        Image image = Image.createImage(40, 40, 0xff112233);
+        ImageViewer viewer = new ImageViewer(image);
+        viewer.setAnimateZoom(false);
+
+        Container plain = new Container(BoxLayout.y());
+        plain.add(viewer);
+
+        Form f = new Form(new BorderLayout());
+        f.add(BorderLayout.CENTER, plain);
+        f.show();
+        f.setSize(new com.codename1.ui.geom.Dimension(240, 320));
+        f.layoutContainer();
+        f.revalidate();
+
+        viewer.setSize(new com.codename1.ui.geom.Dimension(240, 220));
+        viewer.setX(0);
+        viewer.setY(0);
+
+        viewer.pointerPressed(120, 110);
+        viewer.pointerDragged(120, 40);
+
+        assertFalse(getPrivateField(viewer, "delegatingDragToParent", Boolean.class),
+                "no scrollable ancestor means no delegation");
+    }
+
     @SuppressWarnings("unchecked")
     private <T> T getPrivateField(Object target, String name, Class<T> type) throws Exception {
         Field field = target.getClass().getDeclaredField(name);
@@ -193,6 +292,9 @@ class ImageViewerTest extends UITestBase {
         Object value = field.get(target);
         if (type == Float.class && value instanceof Number) {
             return (T) Float.valueOf(((Number) value).floatValue());
+        }
+        if (type == Boolean.class) {
+            return (T) Boolean.valueOf(((Boolean) value).booleanValue());
         }
         return (T) value;
     }


### PR DESCRIPTION
## Summary
- When ImageViewer is inside a scrollable container, a vertical-dominant drag at zoom=1 now routes to the first scrollable-Y ancestor instead of being swallowed.
- Pinch / pan when zoomed > 1 and horizontal swipes between images are unchanged.

Fixes #3700. Partially mitigates #3658 (the overlap-when-panning case at high zoom is a separate problem — flagged for follow-up).

## Test plan
- [x] Core compiles
- [ ] Manual: ImageViewer inside a BoxLayoutY Container — swipe up/down → parent scrolls.
- [ ] Manual: same setup, swipe left/right at zoom=1 → image cycles.
- [ ] Manual: pinch + pan at zoom > 1 → panning still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)