### PR TITLE
Fix socket write NPE and avoid throwaway allocation on partial writes (#5139)

### DIFF
--- a/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
+++ b/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
@@ -9338,6 +9338,30 @@ public abstract class CodenameOneImplementation {
     public void writeToSocketStream(Object socket, byte[] data) {
     }
 
+    /// Write a range of the given byte array to the socket. The default implementation
+    /// copies the requested range into a fresh array and delegates to
+    /// {@link #writeToSocketStream(Object, byte[])}; platform ports that can write a
+    /// sub-range natively should override this to avoid the intermediate allocation.
+    ///
+    /// #### Parameters
+    ///
+    /// - `socket`: the socket instance
+    ///
+    /// - `data`: the buffer containing the data to write
+    ///
+    /// - `offset`: the offset within the buffer at which to start writing
+    ///
+    /// - `len`: the number of bytes to write
+    public void writeToSocketStream(Object socket, byte[] data, int offset, int len) {
+        if (offset == 0 && len == data.length) {
+            writeToSocketStream(socket, data);
+            return;
+        }
+        byte[] arr = new byte[len];
+        System.arraycopy(data, offset, arr, 0, len);
+        writeToSocketStream(socket, arr);
+    }
+
     private void mkdirs(FileSystemStorage fs, String path) {
         int lastPos = path.lastIndexOf('/');
         if (lastPos >= 0) {

--- a/CodenameOne/src/com/codename1/io/Socket.java
+++ b/CodenameOne/src/com/codename1/io/Socket.java
@@ -411,29 +411,38 @@ public final class Socket {
             }
         }
 
+        // Routes all the write overloads through a single guarded path. The native
+        // socket handle can be torn down (e.g. the connection dropped) while a writer
+        // thread is still pushing data; before this guard that surfaced as an opaque
+        // NullPointerException deep in the platform implementation rather than an
+        // IOException the caller can handle. See issue #5139.
+        private void writeImpl(byte[] b, int off, int len) throws IOException {
+            if (impl == null) {
+                throw new IOException("Socket is not connected");
+            }
+            Util.getImplementation().writeToSocketStream(impl, b, off, len);
+            handleSocketError();
+        }
+
         @Override
         public void write(byte[] b, int off, int len) throws IOException {
-            if (off == 0 && len == b.length) {
-                Util.getImplementation().writeToSocketStream(impl, b);
-                handleSocketError();
-                return;
+            if (b == null) {
+                throw new NullPointerException();
             }
-            byte[] arr = new byte[len];
-            System.arraycopy(b, off, arr, 0, len);
-            Util.getImplementation().writeToSocketStream(impl, arr);
-            handleSocketError();
+            if (off < 0 || len < 0 || off > b.length - len) {
+                throw new IndexOutOfBoundsException();
+            }
+            writeImpl(b, off, len);
         }
 
         @Override
         public void write(byte[] b) throws IOException {
-            Util.getImplementation().writeToSocketStream(impl, b);
-            handleSocketError();
+            writeImpl(b, 0, b.length);
         }
 
         @Override
         public void write(int b) throws IOException {
-            Util.getImplementation().writeToSocketStream(impl, new byte[]{(byte) b});
-            handleSocketError();
+            writeImpl(new byte[]{(byte) b}, 0, 1);
         }
 
         // PMD thinks we need to override finalize. Ugh.

--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -10580,9 +10580,13 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
         }
 
         public void writeToStream(byte[] param) {
+            writeToStream(param, 0, param.length);
+        }
+
+        public void writeToStream(byte[] param, int offset, int len) {
             try {
                 OutputStream os = getOutput();
-                os.write(param);
+                os.write(param, offset, len);
                 os.flush();
             } catch(IOException err) {
                 errorMessage = err.toString();
@@ -10727,6 +10731,11 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
     @Override
     public void writeToSocketStream(Object socket, byte[] data) {
         ((SocketImpl)socket).writeToStream(data);
+    }
+
+    @Override
+    public void writeToSocketStream(Object socket, byte[] data, int offset, int len) {
+        ((SocketImpl)socket).writeToStream(data, offset, len);
     }
 
     //Begin new Graphics Work

--- a/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
@@ -15239,9 +15239,13 @@ public class JavaSEPort extends CodenameOneImplementation {
         }
 
         public void writeToStream(byte[] param) {
+            writeToStream(param, 0, param.length);
+        }
+
+        public void writeToStream(byte[] param, int offset, int len) {
             try {
                 OutputStream os = getOutput();
-                os.write(param);
+                os.write(param, offset, len);
                 os.flush();
             } catch(IOException err) {
                 socketInstance = null;	// no longer connected
@@ -15383,6 +15387,11 @@ public class JavaSEPort extends CodenameOneImplementation {
     @Override
     public void writeToSocketStream(Object socket, byte[] data) {
         ((SocketImpl)socket).writeToStream(data);
+    }
+
+    @Override
+    public void writeToSocketStream(Object socket, byte[] data, int offset, int len) {
+        ((SocketImpl)socket).writeToStream(data, offset, len);
     }
 
     /**

--- a/Ports/iOSPort/nativeSources/IOSNative.m
+++ b/Ports/iOSPort/nativeSources/IOSNative.m
@@ -8039,6 +8039,14 @@ NSData* arrayToData(JAVA_OBJECT arr) {
     return d;
 }
 
+NSData* arrayToDataRange(JAVA_OBJECT arr, int offset, int len) {
+    if (arr == JAVA_NULL) return nil;
+    JAVA_ARRAY byteArray = (JAVA_ARRAY)arr;
+    char* data = (char*)byteArray->data;
+    NSData* d = [NSData dataWithBytes:(data + offset * byteArray->primitiveSize) length:len * byteArray->primitiveSize];
+    return d;
+}
+
 JAVA_OBJECT nsDataToByteArr(NSData *data) {
     NSData* d = data;
     JAVA_OBJECT byteArray = allocArray(getThreadLocalData(), [d length] / sizeof(JAVA_ARRAY_BYTE), &class_array1__JAVA_BYTE, sizeof(JAVA_ARRAY_BYTE), 1);
@@ -8108,6 +8116,14 @@ NSData* arrayToData(JAVA_OBJECT arr) {
     org_xmlvm_runtime_XMLVMArray* byteArray = (org_xmlvm_runtime_XMLVMArray*)arr;
     void* data = (void*)byteArray->fields.org_xmlvm_runtime_XMLVMArray.array_;
     NSData* d = [NSData dataWithBytes:data length:byteArray->fields.org_xmlvm_runtime_XMLVMArray.length_];
+    return d;
+}
+
+NSData* arrayToDataRange(JAVA_OBJECT arr, int offset, int len) {
+    if (arr == JAVA_NULL) return nil;
+    org_xmlvm_runtime_XMLVMArray* byteArray = (org_xmlvm_runtime_XMLVMArray*)arr;
+    char* data = (char*)byteArray->fields.org_xmlvm_runtime_XMLVMArray.array_;
+    NSData* d = [NSData dataWithBytes:(data + offset) length:len];
     return d;
 }
 
@@ -9225,6 +9241,13 @@ void com_codename1_impl_ios_IOSNative_writeToSocketStream___long_byte_1ARRAY(CN1
     POOL_BEGIN();
     SocketImpl* impl = (BRIDGE_CAST SocketImpl*)((void *)socket);
     [impl writeToStream:arrayToData(data)];
+    POOL_END();
+}
+
+void com_codename1_impl_ios_IOSNative_writeToSocketStream___long_byte_1ARRAY_int_int(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject, JAVA_LONG socket, JAVA_OBJECT data, JAVA_INT offset, JAVA_INT len) {
+    POOL_BEGIN();
+    SocketImpl* impl = (BRIDGE_CAST SocketImpl*)((void *)socket);
+    [impl writeToStream:arrayToDataRange(data, offset, len)];
     POOL_END();
 }
 

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
@@ -10320,6 +10320,11 @@ public class IOSImplementation extends CodenameOneImplementation {
     }
 
     @Override
+    public void writeToSocketStream(Object socket, byte[] data, int offset, int len) {
+        nativeInstance.writeToSocketStream(((Long)socket).longValue(), data, offset, len);
+    }
+
+    @Override
     public void splitString(String source, char separator, ArrayList<String> out) {
         nativeInstance.splitString(source, separator, out);
     }

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSNative.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSNative.java
@@ -610,6 +610,7 @@ public final class IOSNative {
     public native int getSocketAvailableInput(long socket);
     public native byte[] readFromSocketStream(long socket);
     public native void writeToSocketStream(long socket, byte[] data);
+    public native void writeToSocketStream(long socket, byte[] data, int offset, int len);
 
     
     // Paths


### PR DESCRIPTION
Fixes the two problems raised in #5139 about the socket write path.

### 1. NPE instead of IOException
The reported crash was a `NullPointerException` thrown deep in the platform implementation:

```
at com_codename1_impl_ios_IOSImplementation.writeToSocketStream:9242
at com_codename1_io_Socket_SocketOutputStream.write:423
```

The only Java-level null dereference in that path is `((Long)socket).longValue()` in `IOSImplementation.writeToSocketStream` when the socket handle is null — i.e. a writer thread reached a socket whose native handle was already torn down. That surfaced as an opaque NPE rather than an `IOException` the caller could catch.

`SocketOutputStream` now routes all three `write(...)` overloads through a single guarded helper that throws `IOException("Socket is not connected")` when the handle is null, and validates the `offset`/`len` arguments of `write(byte[], int, int)`.

### 2. Throwaway allocation on partial writes
As noted in the issue, `write(b, off, len)` with a non-zero offset allocated a fresh `byte[]` and `System.arraycopy`'d into it on every call, purely to hand a whole-array view to the implementation.

This adds an offset-aware `writeToSocketStream(Object socket, byte[] data, int offset, int len)` to the implementation API:

- **`CodenameOneImplementation`** — default implementation keeps the copy (backward compatible for any port/lib that doesn't override it).
- **iOS** — overrides it and threads `offset`/`len` down to a new native binding; the C side builds a sub-range `NSData` via a new `arrayToDataRange` helper, so no intermediate Java array is allocated.
- **Android** / **JavaSE** — override it to call `OutputStream.write(data, offset, len)` directly.

### Notes
- iOS adds one native method (`IOSNative.writeToSocketStream(long, byte[], int, int)`); the iOS port must be rebuilt.
- `core` compiles cleanly with JDK 8. `JavaSEPort.java` compiles (the only errors in a local `javase` build are pre-existing JavaFX-not-on-classpath issues in the unrelated `fx/` package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)