### PR TITLE
fix(JS port) #5145: retry transiently-degraded object reads to stop the ButtonTheme hard-stall

### DIFF
--- a/vm/ByteCodeTranslator/src/javascript/browser_bridge.js
+++ b/vm/ByteCodeTranslator/src/javascript/browser_bridge.js
@@ -104,22 +104,27 @@
     // and explicitly flag when the SAME id is posted more than once (the
     // smoking gun). Rate-limited; gated on the diag toggle so it is silent in
     // production.
-    if (diagEnabled) {
+    if (diagEnabled && id) {
       try {
-        if (!global.__cn1CbSeen) { global.__cn1CbSeen = Object.create(null); global.__cn1CbTraceN = 0; }
+        // Log every NUMERIC postback (id != 0) unbounded -- these are the
+        // width/height-shaped values that cross into getContext/getDocument.
+        // Correlate id with the HOSTREQ:member trace and the worker's
+        // JSO_RETRY:callId to see which read's response the worker received.
+        if (errorMessage == null && typeof value === 'number') {
+          log('DIAG:HOSTCB_NUM:id=' + id + ':num=' + value);
+        }
+        // Flag any id posted more than once with a differing shape (real
+        // round-trip ids only; id 0 is the shared no-response/fire-and-forget
+        // bucket and is expected to repeat).
+        if (!global.__cn1CbSeen) { global.__cn1CbSeen = Object.create(null); }
         var vshape = (errorMessage != null) ? 'err'
           : (typeof value === 'number') ? ('num:' + value)
           : (value && typeof value === 'object' && value.__cn1HostRef != null) ? ('ref:' + value.__cn1HostClass)
           : (typeof value);
-        if (global.__cn1CbSeen[id]) {
+        if (global.__cn1CbSeen[id] != null && global.__cn1CbSeen[id] !== vshape) {
           log('DIAG:HOSTCB_DUP:id=' + id + ':prev=' + global.__cn1CbSeen[id] + ':now=' + vshape);
-        } else {
-          global.__cn1CbSeen[id] = vshape;
         }
-        if (global.__cn1CbTraceN < 200) {
-          global.__cn1CbTraceN++;
-          log('DIAG:HOSTCB:id=' + id + ':' + vshape);
-        }
+        global.__cn1CbSeen[id] = vshape;
       } catch (_e) {}
     }
     var message;
@@ -1990,6 +1995,25 @@
       return;
     }
     if (data.type === 'host-call') {
+      // #5145: trace the request id+member for the reads that degrade, so we
+      // can correlate with the late HOSTCB id+value (which read's response the
+      // worker actually received). Watches getContext/getDocument/getWidth/
+      // getHeight. Flags if the SAME id arrives on two host-call requests.
+      if (diagEnabled && data.symbol === '__cn1_jso_bridge__' && data.args && data.args[0]) {
+        try {
+          var m = data.args[0].member;
+          if (m === 'getContext' || m === 'document' || m === 'width' || m === 'height'
+              || m === 'getBoundingClientRect') {
+            log('DIAG:HOSTREQ:id=' + data.id + ':member=' + m);
+            if (!global.__cn1ReqSeen) { global.__cn1ReqSeen = Object.create(null); }
+            if (global.__cn1ReqSeen[data.id] != null) {
+              log('DIAG:HOSTREQ_DUP:id=' + data.id + ':prev=' + global.__cn1ReqSeen[data.id] + ':now=' + m);
+            } else {
+              global.__cn1ReqSeen[data.id] = m;
+            }
+          }
+        } catch (_e) {}
+      }
       hostBridge.invoke(data.symbol, data.args || [], target || global.__parparWorker, data.id);
       return;
     }

--- a/vm/ByteCodeTranslator/src/javascript/browser_bridge.js
+++ b/vm/ByteCodeTranslator/src/javascript/browser_bridge.js
@@ -97,6 +97,31 @@
   }
 
   function postHostCallback(target, id, value, errorMessage) {
+    // #5145 host-callback id trace. The worker resumes getContext with 375
+    // (a width), but the host never computes a number for getContext
+    // (NUMBER_LEAK=0) -- so the callback channel is delivering the wrong value
+    // for an id (collision or double-post). Log every post's id + value shape,
+    // and explicitly flag when the SAME id is posted more than once (the
+    // smoking gun). Rate-limited; gated on the diag toggle so it is silent in
+    // production.
+    if (diagEnabled) {
+      try {
+        if (!global.__cn1CbSeen) { global.__cn1CbSeen = Object.create(null); global.__cn1CbTraceN = 0; }
+        var vshape = (errorMessage != null) ? 'err'
+          : (typeof value === 'number') ? ('num:' + value)
+          : (value && typeof value === 'object' && value.__cn1HostRef != null) ? ('ref:' + value.__cn1HostClass)
+          : (typeof value);
+        if (global.__cn1CbSeen[id]) {
+          log('DIAG:HOSTCB_DUP:id=' + id + ':prev=' + global.__cn1CbSeen[id] + ':now=' + vshape);
+        } else {
+          global.__cn1CbSeen[id] = vshape;
+        }
+        if (global.__cn1CbTraceN < 200) {
+          global.__cn1CbTraceN++;
+          log('DIAG:HOSTCB:id=' + id + ':' + vshape);
+        }
+      } catch (_e) {}
+    }
     var message;
     if (errorMessage == null) {
       message = { type: 'host-callback', id: id, value: value };

--- a/vm/ByteCodeTranslator/src/javascript/parparvm_runtime.js
+++ b/vm/ByteCodeTranslator/src/javascript/parparvm_runtime.js
@@ -1461,6 +1461,19 @@ const jvm = {
             args: transferableArgs
           }]);
         }
+        if (jsoRetries > 0) {
+          // Direct evidence the transient-degradation retry fired (and whether
+          // it recovered the real object). Rate-limited.
+          if (!jvm._jsoRetryLogged) jvm._jsoRetryLogged = 0;
+          if (jvm._jsoRetryLogged < 8) {
+            jvm._jsoRetryLogged++;
+            try {
+              vmDiag('JSO_RETRY', 'member', String(bridge.member));
+              vmDiag('JSO_RETRY', 'retries', String(jsoRetries));
+              vmDiag('JSO_RETRY', 'recovered', isDegradedObject(hostResult) ? 'no' : 'yes');
+            } catch (_e) {}
+          }
+        }
         let workingHostResult = hostResult;
         if (isDegradedObject(hostResult) && typeof hostResult === 'number') {
           if (!jvm._numberForObjLogged) jvm._numberForObjLogged = 0;

--- a/vm/ByteCodeTranslator/src/javascript/parparvm_runtime.js
+++ b/vm/ByteCodeTranslator/src/javascript/parparvm_runtime.js
@@ -1399,29 +1399,70 @@ const jvm = {
         // previously-queued fire-and-forget ops first to keep
         // canvas state consistent.
         self.flushPendingFireAndForget();
-        const hostResult = yield self.invokeHostNative("__cn1_jso_bridge__", [{
+        // An object-returning bridge call (return class is a reference type)
+        // intermittently comes back as a NUMBER or an empty {} that lost its
+        // host-ref marker. Observed: ``getContext("2d")`` returning 375 and
+        // ``getDocument()`` returning 667/{} -- always the canvas/viewport
+        // width or height, i.e. a *transient* host-side race where the
+        // round-trip result is crossed with a concurrent getWidth/getHeight,
+        // not a permanent corruption (the same receiver resolves fine moments
+        // earlier and later in the run). Substituting null (the old recovery)
+        // turned that transient blip into a null/degraded receiver that the
+        // caller then busy-loops on (VIRTUAL_FAIL / NULL_RECEIVER), which is
+        // what hard-stalled the suite at ButtonTheme (#5145).
+        //
+        // For IDEMPOTENT reads -- any getter, plus getContext (returns the
+        // same context for a given canvas) -- we simply re-issue the call a
+        // few times. Each re-issue yields the scheduler (lets the crossed
+        // response and any queued ops drain), so the transient clears and we
+        // get the real object. We deliberately do NOT retry non-idempotent
+        // methods (createElement, appendChild, ...) where a re-issue could
+        // double-apply a side effect; those keep the substitute-null fallback.
+        const objectReturn = bridge.returnClass
+            && bridge.returnClass !== 'int' && bridge.returnClass !== 'byte'
+            && bridge.returnClass !== 'short' && bridge.returnClass !== 'char'
+            && bridge.returnClass !== 'long' && bridge.returnClass !== 'float'
+            && bridge.returnClass !== 'double' && bridge.returnClass !== 'boolean'
+            && bridge.returnClass !== 'void' && bridge.returnClass !== 'v';
+        // Idempotent reads (no host side effects, same result for same input)
+        // are safe to re-issue. Any getter qualifies; the listed methods are
+        // pure reads. Side-effecting methods (createElement, appendChild, ...)
+        // are intentionally excluded so a retry can never double-apply.
+        const idempotentRead = bridge.kind === 'getter'
+            || bridge.member === 'getContext'
+            || bridge.member === 'getBundledAssetAsDataURL'
+            || bridge.member === 'getImageData'
+            || bridge.member === 'measureText';
+        const isDegradedObject = function(r) {
+          if (!objectReturn) return false;
+          if (typeof r === 'number') return true;
+          return !!(r && typeof r === 'object' && !Array.isArray(r)
+              && r.__cn1HostRef == null
+              && Object.getOwnPropertyNames(r).length === 0);
+        };
+        let hostResult = yield self.invokeHostNative("__cn1_jso_bridge__", [{
           receiver: receiver,
           receiverClass: (receiver && receiver.__cn1HostClass) ? receiver.__cn1HostClass : className,
           kind: bridge.kind,
           member: bridge.member,
           args: transferableArgs
         }]);
-        // canvasContextWipe RECOVERY: when hostResult is a NUMBER but
-        // the expected return class is an object type, substitute null.
-        // The downstream code would otherwise treat the number as a
-        // receiver and busy-loop on VIRTUAL_FAIL / NULL_RECEIVER.
-        // Returning null lets the caller's standard null-check path
-        // throw a clean NPE instead.
-        //
-        // Host-side root cause TBD (browser_bridge.js:670
-        // ``receiver[member]`` returning a number when it shouldn't).
-        // The NUMBER_LEAK diag captures it at the bridge boundary.
+        let jsoRetries = 0;
+        while (isDegradedObject(hostResult) && idempotentRead && jsoRetries < 4) {
+          jsoRetries++;
+          // Re-issue with all queued fire-and-forget ops flushed first so the
+          // host sees consistent state. The yield drains the crossed response.
+          self.flushPendingFireAndForget();
+          hostResult = yield self.invokeHostNative("__cn1_jso_bridge__", [{
+            receiver: receiver,
+            receiverClass: (receiver && receiver.__cn1HostClass) ? receiver.__cn1HostClass : className,
+            kind: bridge.kind,
+            member: bridge.member,
+            args: transferableArgs
+          }]);
+        }
         let workingHostResult = hostResult;
-        if (typeof hostResult === 'number' && bridge.returnClass
-            && bridge.returnClass !== 'int' && bridge.returnClass !== 'byte'
-            && bridge.returnClass !== 'short' && bridge.returnClass !== 'char'
-            && bridge.returnClass !== 'long' && bridge.returnClass !== 'float'
-            && bridge.returnClass !== 'double' && bridge.returnClass !== 'boolean') {
+        if (isDegradedObject(hostResult) && typeof hostResult === 'number') {
           if (!jvm._numberForObjLogged) jvm._numberForObjLogged = 0;
           if (jvm._numberForObjLogged < 5) {
             jvm._numberForObjLogged++;
@@ -1432,7 +1473,9 @@ const jvm = {
               vmDiag('NUMBER_FOR_OBJECT', 'kind', String(bridge.kind));
               vmDiag('NUMBER_FOR_OBJECT', 'returnClass', String(bridge.returnClass));
               vmDiag('NUMBER_FOR_OBJECT', 'value', String(hostResult));
-              vmDiag('NUMBER_FOR_OBJECT', 'recovery', 'substituted-null');
+              vmDiag('NUMBER_FOR_OBJECT', 'retries', String(jsoRetries));
+              vmDiag('NUMBER_FOR_OBJECT', 'recovery',
+                  idempotentRead ? 'retries-exhausted-substituted-null' : 'substituted-null');
             } catch (_e) {}
           }
           workingHostResult = null;

--- a/vm/ByteCodeTranslator/src/javascript/parparvm_runtime.js
+++ b/vm/ByteCodeTranslator/src/javascript/parparvm_runtime.js
@@ -1466,6 +1466,13 @@ const jvm = {
           }
         };
         let attempt = yield* runBridgeOnce();
+        // Capture the FIRST-degraded attempt for clean host correlation: its
+        // call-id is the one that received the crossed response (the retry that
+        // eventually succeeds gets a fresh, clean id, so logging the last
+        // attempt's id was misleading).
+        const firstDegraded = isDegradedObject(attempt.value)
+          ? { callId: attempt.callId, value: attempt.value }
+          : null;
         let jsoRetries = 0;
         let jsoRetryThrew = false;
         while (idempotentRead && jsoRetries < 4
@@ -1492,7 +1499,10 @@ const jvm = {
             jvm._jsoRetryLogged++;
             try {
               vmDiag('JSO_RETRY', 'member', String(bridge.member));
-              vmDiag('JSO_RETRY', 'callId', String(attempt.callId));
+              vmDiag('JSO_RETRY', 'returnClass', String(bridge.returnClass));
+              vmDiag('JSO_RETRY', 'firstCallId', String(firstDegraded ? firstDegraded.callId : 'na'));
+              vmDiag('JSO_RETRY', 'firstValue', String(firstDegraded ? firstDegraded.value : 'na'));
+              vmDiag('JSO_RETRY', 'lastCallId', String(attempt.callId));
               vmDiag('JSO_RETRY', 'retries', String(jsoRetries));
               vmDiag('JSO_RETRY', 'via', jsoRetryThrew ? 'throw' : 'value');
               vmDiag('JSO_RETRY', 'recovered', isDegradedObject(hostResult) ? 'no' : 'yes');

--- a/vm/ByteCodeTranslator/src/javascript/parparvm_runtime.js
+++ b/vm/ByteCodeTranslator/src/javascript/parparvm_runtime.js
@@ -1440,36 +1440,61 @@ const jvm = {
               && r.__cn1HostRef == null
               && Object.getOwnPropertyNames(r).length === 0);
         };
-        let hostResult = yield self.invokeHostNative("__cn1_jso_bridge__", [{
-          receiver: receiver,
-          receiverClass: (receiver && receiver.__cn1HostClass) ? receiver.__cn1HostClass : className,
-          kind: bridge.kind,
-          member: bridge.member,
-          args: transferableArgs
-        }]);
-        let jsoRetries = 0;
-        while (isDegradedObject(hostResult) && idempotentRead && jsoRetries < 4) {
-          jsoRetries++;
-          // Re-issue with all queued fire-and-forget ops flushed first so the
-          // host sees consistent state. The yield drains the crossed response.
-          self.flushPendingFireAndForget();
-          hostResult = yield self.invokeHostNative("__cn1_jso_bridge__", [{
+        // The same transient degradation surfaces two ways: the host returns a
+        // degraded value (number / empty {}), OR -- when the degraded receiver
+        // doesn't even expose the member -- the host THROWS "Missing JS member"
+        // / "Missing host receiver". Both are recoverable on a re-issue for an
+        // idempotent read. ``runBridgeOnce`` does one round-trip and reports
+        // which (if any) transient condition occurred.
+        const transientErrorRe = /Missing JS member|Missing host receiver|Missing host object/;
+        const runBridgeOnce = function*() {
+          // Capture the host-call id so a degraded result can be correlated
+          // with the host-side HOSTCB trace (#5145 id-collision hunt).
+          const op = self.invokeHostNative("__cn1_jso_bridge__", [{
             receiver: receiver,
             receiverClass: (receiver && receiver.__cn1HostClass) ? receiver.__cn1HostClass : className,
             kind: bridge.kind,
             member: bridge.member,
             args: transferableArgs
           }]);
+          const callId = op && op.id;
+          try {
+            const r = yield op;
+            return { value: r, threw: false, err: null, callId: callId };
+          } catch (e) {
+            return { value: undefined, threw: true, err: e, callId: callId };
+          }
+        };
+        let attempt = yield* runBridgeOnce();
+        let jsoRetries = 0;
+        let jsoRetryThrew = false;
+        while (idempotentRead && jsoRetries < 4
+               && ((attempt.threw && transientErrorRe.test(String(attempt.err && attempt.err.message ? attempt.err.message : attempt.err)))
+                   || isDegradedObject(attempt.value))) {
+          jsoRetries++;
+          if (attempt.threw) { jsoRetryThrew = true; }
+          // Re-issue with all queued fire-and-forget ops flushed first so the
+          // host sees consistent state. The yield drains the crossed response.
+          self.flushPendingFireAndForget();
+          attempt = yield* runBridgeOnce();
         }
+        if (attempt.threw) {
+          // Not transient, or retries exhausted on a thrown error -- propagate
+          // the original error so the caller's normal catch/NPE path runs.
+          throw attempt.err;
+        }
+        let hostResult = attempt.value;
         if (jsoRetries > 0) {
           // Direct evidence the transient-degradation retry fired (and whether
-          // it recovered the real object). Rate-limited.
+          // it recovered). Rate-limited.
           if (!jvm._jsoRetryLogged) jvm._jsoRetryLogged = 0;
           if (jvm._jsoRetryLogged < 8) {
             jvm._jsoRetryLogged++;
             try {
               vmDiag('JSO_RETRY', 'member', String(bridge.member));
+              vmDiag('JSO_RETRY', 'callId', String(attempt.callId));
               vmDiag('JSO_RETRY', 'retries', String(jsoRetries));
+              vmDiag('JSO_RETRY', 'via', jsoRetryThrew ? 'throw' : 'value');
               vmDiag('JSO_RETRY', 'recovered', isDegradedObject(hostResult) ? 'no' : 'yes');
             } catch (_e) {}
           }


### PR DESCRIPTION
## Problem (follow-up to #5143)

After the host-ref canvas-leak fix landed, ~25% of JS screenshot CI runs still **hard-stall at `ButtonTheme`** (worker goes silent → 30-min timeout → red, regardless of `CN1SS_ALLOWED_MISSING`).

## Root-cause evidence

In a captured wedge run, `NUMBER_FOR_OBJECT` fired 35× with:
- `methodId = cn1_s_getContext_..._R_CanvasRenderingContext2D`, `member = getContext`, `className = HTMLCanvasElement`, **`value = 375`**.

i.e. `canvas.getContext("2d")` came back as the number **375** (the canvas/viewport *width*); `getDocument()` similarly returns 667/`{}` (the *height*). A real canvas/window can't do that — and the same receiver resolves fine moments before and after — so this is a **transient host-call race** (the round-trip result crossed with a concurrent `getWidth`/`getHeight`), not permanent corruption.

The old recovery substituted `null`, which turned the transient blip into a null/degraded receiver that the caller then **busy-looped** on (`VIRTUAL_FAIL`/`NULL_RECEIVER`) — the silent hard-stall.

## Fix

For **idempotent reads** (any getter, plus `getContext`/`getBundledAssetAsDataURL`/`getImageData`/`measureText`), re-issue the bridge call up to 4× when the result is degraded-for-object. Each re-issue yields the scheduler so the crossed response drains and the real object returns.

- Bounded (≤4) → no new hang.
- Only entered on the already-degraded path → zero impact on normal calls.
- Pixels unaffected → goldens stay valid.
- **Non-idempotent** methods (`createElement`, `appendChild`, …) keep the substitute-null fallback, so a retry can never double-apply a side effect.

## Validation note

The wedge is ~25% flaky, so confirming it's gone needs **several** green CI runs, not one. I'll run the suite multiple times on this branch.

Refs #5145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)