### PR TITLE
Fix iOS build of method refs needing unbox/box + add Objects.deepEquals

### DIFF
--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/Parser.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/Parser.java
@@ -1240,30 +1240,12 @@ public class Parser extends ClassVisitor {
                 // Invoke implMethod
                 // Return result
 
-                // Handle Constructor Reference (special case)
+                // Determine how the implementation method is invoked up front:
+                // we need to know whether it has an implicit receiver (an
+                // instance call consumes the first captured arg as `this`)
+                // before we can line captured/SAM args up against the target
+                // parameter types for adaptation.
                 boolean isCtorRef = (implMethod.getTag() == Opcodes.H_NEWINVOKESPECIAL);
-                if (isCtorRef) {
-                    interfaceMethod.addTypeInstruction(Opcodes.NEW, implMethod.getOwner());
-                    interfaceMethod.addInstruction(Opcodes.DUP);
-                }
-
-                // Load captured args
-                // Same caveat as the constructor: do not also emit addInstruction(Opcodes.ALOAD).
-                for (int i = 0; i < capturedArgs.length; i++) {
-                    interfaceMethod.addVariableOperation(Opcodes.ALOAD, 0);
-                    String fieldName = "arg$" + (i + 1);
-                    interfaceMethod.addField(lambdaClass, Opcodes.GETFIELD, lambdaClassName, fieldName, capturedArgs[i].getDescriptor());
-                }
-
-                // Load method args
-                Type[] samArgs = samMethodType.getArgumentTypes();
-                int localIndex = 1;
-                for (Type t : samArgs) {
-                    interfaceMethod.addVariableOperation(t.getOpcode(Opcodes.ILOAD), localIndex);
-                    localIndex += t.getSize();
-                }
-
-                // Invoke implMethod
                 int invokeOpcode;
                 switch (implMethod.getTag()) {
                     case Opcodes.H_INVOKESTATIC: invokeOpcode = Opcodes.INVOKESTATIC; break;
@@ -1276,15 +1258,79 @@ public class Parser extends ClassVisitor {
                         invokeOpcode = Opcodes.INVOKESTATIC;
                         break;// Fallback
                 }
+                boolean instanceCall = !isCtorRef &&
+                        (invokeOpcode == Opcodes.INVOKEVIRTUAL ||
+                         invokeOpcode == Opcodes.INVOKEINTERFACE ||
+                         invokeOpcode == Opcodes.INVOKESPECIAL);
 
+                // The values the implementation invocation consumes, in order:
+                // the receiver (for instance calls) followed by the declared
+                // parameter types. LambdaMetafactory adapts each captured/SAM
+                // argument to the matching target type (box, unbox, widen or
+                // cast) -- e.g. a SAM that hands us a Double bound to a method
+                // taking a primitive double must unbox via doubleValue(). We
+                // must replicate that here; loading the SAM args verbatim and
+                // invoking the impl method directly emits a C call that passes a
+                // JAVA_OBJECT where a primitive (or vice versa) is expected and
+                // fails to compile in the generated Xcode project.
+                Type[] implArgTypes = Type.getArgumentTypes(implMethod.getDesc());
+                Type[] targetTypes = new Type[(instanceCall ? 1 : 0) + implArgTypes.length];
+                int tIdx = 0;
+                if (instanceCall) {
+                    targetTypes[tIdx++] = Type.getObjectType(implMethod.getOwner());
+                }
+                for (Type t : implArgTypes) {
+                    targetTypes[tIdx++] = t;
+                }
+                Type[] samArgs = samMethodType.getArgumentTypes();
+                // Defensive: only adapt when our model of the consumed values
+                // matches the values we push (captured + SAM args). If it does
+                // not we fall back to the verbatim load/invoke below.
+                boolean adapt = targetTypes.length == capturedArgs.length + samArgs.length;
+
+                // Handle Constructor Reference (special case)
+                if (isCtorRef) {
+                    interfaceMethod.addTypeInstruction(Opcodes.NEW, implMethod.getOwner());
+                    interfaceMethod.addInstruction(Opcodes.DUP);
+                }
+
+                // Load captured args
+                // Same caveat as the constructor: do not also emit addInstruction(Opcodes.ALOAD).
+                int targetIndex = 0;
+                for (int i = 0; i < capturedArgs.length; i++) {
+                    interfaceMethod.addVariableOperation(Opcodes.ALOAD, 0);
+                    String fieldName = "arg$" + (i + 1);
+                    interfaceMethod.addField(lambdaClass, Opcodes.GETFIELD, lambdaClassName, fieldName, capturedArgs[i].getDescriptor());
+                    if (adapt) {
+                        adaptLambdaType(interfaceMethod, capturedArgs[i], targetTypes[targetIndex]);
+                    }
+                    targetIndex++;
+                }
+
+                // Load method args
+                int localIndex = 1;
+                for (Type t : samArgs) {
+                    interfaceMethod.addVariableOperation(t.getOpcode(Opcodes.ILOAD), localIndex);
+                    localIndex += t.getSize();
+                    if (adapt) {
+                        adaptLambdaType(interfaceMethod, t, targetTypes[targetIndex]);
+                    }
+                    targetIndex++;
+                }
+
+                // Invoke implMethod
                 if (isCtorRef) {
                     interfaceMethod.addInvoke(Opcodes.INVOKESPECIAL, implMethod.getOwner(), implMethod.getName(), implMethod.getDesc(), false);
                 } else {
                     interfaceMethod.addInvoke(invokeOpcode, implMethod.getOwner(), implMethod.getName(), implMethod.getDesc(), implMethod.isInterface());
                 }
 
-                // Return
+                // Adapt the value left on the stack by the implementation method
+                // to the SAM's return type (unbox/box/widen/cast, or pop for a
+                // void SAM), then return per the SAM descriptor.
                 Type returnType = samMethodType.getReturnType();
+                Type implReturnType = isCtorRef ? Type.getObjectType(implMethod.getOwner()) : Type.getReturnType(implMethod.getDesc());
+                adaptLambdaType(interfaceMethod, implReturnType, returnType);
                 interfaceMethod.addInstruction(returnType.getOpcode(Opcodes.IRETURN));
                 interfaceMethod.setMaxes(20, 20); // Approximation
 
@@ -1330,6 +1376,130 @@ public class Parser extends ClassVisitor {
             }
 
             super.visitInvokeDynamicInsn(name, desc, bsm, bsmArgs); 
+        }
+
+        /**
+         * Emits the box / unbox / widen / cast instructions LambdaMetafactory
+         * inserts when adapting a value of type {@code from} to type {@code to}
+         * (e.g. when a method reference's parameter or return type differs from
+         * the functional interface's). A no-op when the types already match.
+         */
+        private void adaptLambdaType(BytecodeMethod m, Type from, Type to) {
+            if (from.equals(to)) {
+                return;
+            }
+            int toSort = to.getSort();
+            int fromSort = from.getSort();
+            if (toSort == Type.VOID) {
+                if (fromSort != Type.VOID) {
+                    m.addInstruction(from.getSize() == 2 ? Opcodes.POP2 : Opcodes.POP);
+                }
+                return;
+            }
+            if (fromSort == Type.VOID) {
+                return; // nothing on the stack to adapt
+            }
+            boolean toRef = toSort == Type.OBJECT || toSort == Type.ARRAY;
+            boolean fromRef = fromSort == Type.OBJECT || fromSort == Type.ARRAY;
+
+            if (!toRef && fromRef) {
+                // unbox: cast to the wrapper (when the source is Object/Number
+                // rather than the exact wrapper) then invoke its xxxValue()
+                String wrapper = wrapperType(toSort);
+                if (wrapper == null) {
+                    return;
+                }
+                if (!wrapper.equals(from.getInternalName())) {
+                    m.addTypeInstruction(Opcodes.CHECKCAST, wrapper);
+                }
+                m.addInvoke(Opcodes.INVOKEVIRTUAL, wrapper, unboxMethod(toSort), "()" + to.getDescriptor(), false);
+                return;
+            }
+            if (toRef && !fromRef) {
+                // box via Wrapper.valueOf(primitive); the boxed wrapper is
+                // assignment compatible with the reference target by contract
+                String wrapper = wrapperType(fromSort);
+                if (wrapper == null) {
+                    return;
+                }
+                m.addInvoke(Opcodes.INVOKESTATIC, wrapper, "valueOf", "(" + from.getDescriptor() + ")L" + wrapper + ";", false);
+                return;
+            }
+            if (!toRef && !fromRef) {
+                emitPrimitiveConversion(m, from, to);
+                return;
+            }
+            // both references: narrow with a checkcast (generic erasure)
+            if (!"java/lang/Object".equals(to.getInternalName())) {
+                m.addTypeInstruction(Opcodes.CHECKCAST, to.getInternalName());
+            }
+        }
+
+        private void emitPrimitiveConversion(BytecodeMethod m, Type from, Type to) {
+            int t = to.getSort();
+            int f = from.getSort();
+            // byte/short/char/boolean live as int on the operand stack
+            int fc = (f == Type.BOOLEAN || f == Type.BYTE || f == Type.SHORT || f == Type.CHAR) ? Type.INT : f;
+            switch (t) {
+                case Type.LONG:
+                    if (fc == Type.INT) m.addInstruction(Opcodes.I2L);
+                    else if (fc == Type.FLOAT) m.addInstruction(Opcodes.F2L);
+                    else if (fc == Type.DOUBLE) m.addInstruction(Opcodes.D2L);
+                    return;
+                case Type.FLOAT:
+                    if (fc == Type.INT) m.addInstruction(Opcodes.I2F);
+                    else if (fc == Type.LONG) m.addInstruction(Opcodes.L2F);
+                    else if (fc == Type.DOUBLE) m.addInstruction(Opcodes.D2F);
+                    return;
+                case Type.DOUBLE:
+                    if (fc == Type.INT) m.addInstruction(Opcodes.I2D);
+                    else if (fc == Type.LONG) m.addInstruction(Opcodes.L2D);
+                    else if (fc == Type.FLOAT) m.addInstruction(Opcodes.F2D);
+                    return;
+                case Type.INT:
+                case Type.BYTE:
+                case Type.SHORT:
+                case Type.CHAR:
+                case Type.BOOLEAN:
+                    // bring the source down to int first, then narrow if needed
+                    if (fc == Type.LONG) m.addInstruction(Opcodes.L2I);
+                    else if (fc == Type.FLOAT) m.addInstruction(Opcodes.F2I);
+                    else if (fc == Type.DOUBLE) m.addInstruction(Opcodes.D2I);
+                    if (t == Type.BYTE) m.addInstruction(Opcodes.I2B);
+                    else if (t == Type.SHORT) m.addInstruction(Opcodes.I2S);
+                    else if (t == Type.CHAR) m.addInstruction(Opcodes.I2C);
+                    return;
+                default:
+                    return;
+            }
+        }
+
+        private String wrapperType(int sort) {
+            switch (sort) {
+                case Type.BOOLEAN: return "java/lang/Boolean";
+                case Type.BYTE: return "java/lang/Byte";
+                case Type.CHAR: return "java/lang/Character";
+                case Type.SHORT: return "java/lang/Short";
+                case Type.INT: return "java/lang/Integer";
+                case Type.LONG: return "java/lang/Long";
+                case Type.FLOAT: return "java/lang/Float";
+                case Type.DOUBLE: return "java/lang/Double";
+                default: return null;
+            }
+        }
+
+        private String unboxMethod(int sort) {
+            switch (sort) {
+                case Type.BOOLEAN: return "booleanValue";
+                case Type.BYTE: return "byteValue";
+                case Type.CHAR: return "charValue";
+                case Type.SHORT: return "shortValue";
+                case Type.INT: return "intValue";
+                case Type.LONG: return "longValue";
+                case Type.FLOAT: return "floatValue";
+                case Type.DOUBLE: return "doubleValue";
+                default: return null;
+            }
         }
 
         private void appendConcatLiteral(BytecodeMethod targetMethod, CharSequence literal) {

--- a/vm/JavaAPI/src/java/util/Objects.java
+++ b/vm/JavaAPI/src/java/util/Objects.java
@@ -40,6 +40,34 @@ public final class Objects {
         return (a == b) || (a != null && a.equals(b));
     }
 
+    public static boolean deepEquals(Object a, Object b) {
+        if (a == b) {
+            return true;
+        } else if (a == null || b == null) {
+            return false;
+        }
+        if (a instanceof Object[] && b instanceof Object[]) {
+            return Arrays.deepEquals((Object[]) a, (Object[]) b);
+        } else if (a instanceof byte[] && b instanceof byte[]) {
+            return Arrays.equals((byte[]) a, (byte[]) b);
+        } else if (a instanceof short[] && b instanceof short[]) {
+            return Arrays.equals((short[]) a, (short[]) b);
+        } else if (a instanceof int[] && b instanceof int[]) {
+            return Arrays.equals((int[]) a, (int[]) b);
+        } else if (a instanceof long[] && b instanceof long[]) {
+            return Arrays.equals((long[]) a, (long[]) b);
+        } else if (a instanceof char[] && b instanceof char[]) {
+            return Arrays.equals((char[]) a, (char[]) b);
+        } else if (a instanceof float[] && b instanceof float[]) {
+            return Arrays.equals((float[]) a, (float[]) b);
+        } else if (a instanceof double[] && b instanceof double[]) {
+            return Arrays.equals((double[]) a, (double[]) b);
+        } else if (a instanceof boolean[] && b instanceof boolean[]) {
+            return Arrays.equals((boolean[]) a, (boolean[]) b);
+        }
+        return a.equals(b);
+    }
+
     public static int hashCode(Object o) {
         return o != null ? o.hashCode() : 0;
     }

--- a/vm/tests/src/test/java/com/codename1/tools/translator/LambdaIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/LambdaIntegrationTest.java
@@ -54,24 +54,82 @@ class LambdaIntegrationTest {
                 "}\n";
     }
 
-    private String nativeReportSource() {
+    private String nativeReportSource(String className) {
         return "#include \"cn1_globals.h\"\n" +
                 "#include <stdio.h>\n" +
-                "void LambdaApp_report___int(CODENAME_ONE_THREAD_STATE, JAVA_INT value) {\n" +
+                "void " + className + "_report___int(CODENAME_ONE_THREAD_STATE, JAVA_INT value) {\n" +
                 "    printf(\"RESULT=%d\\n\", value);\n" +
+                "}\n";
+    }
+
+    /**
+     * Method references whose implementation parameter / return types differ
+     * from the functional interface's signature force LambdaMetafactory to
+     * insert box / unbox / widen / cast adaptation. The translator generates
+     * the adapter class itself, so it has to replicate that adaptation -- a
+     * regression here surfaced as iOS Xcode builds failing to compile (a
+     * Double object passed where a primitive double was expected).
+     */
+    private String unboxAppSource() {
+        return "public class UnboxApp {\n" +
+                "    interface DoubleSink { void accept(Double value); }\n" +   // explicit wrapper -> unbox to double
+                "    interface Sink<T> { void accept(T value); }\n" +           // erased Object -> checkcast Double + unbox
+                "    interface DoubleSource { Double get(); }\n" +              // primitive double return -> box to Double
+                "    interface IntToLong { long apply(int x); }\n" +           // widen int argument to long
+                "\n" +
+                "    static double accumulated;\n" +
+                "\n" +
+                "    void addValue(double v) { accumulated += v; }\n" +
+                "    static double produceHalf() { return 0.5; }\n" +
+                "    static long identityLong(long x) { return x; }\n" +
+                "\n" +
+                "    public static void main(String[] args) {\n" +
+                "        UnboxApp app = new UnboxApp();\n" +
+                "\n" +
+                "        // 1. unbox: accept(Double) bound to addValue(double)\n" +
+                "        DoubleSink sink = app::addValue;\n" +
+                "        sink.accept(Double.valueOf(2.5));            // accumulated = 2.5\n" +
+                "\n" +
+                "        // 2. unbox via erased generic SAM: accept(Object) bound to addValue(double)\n" +
+                "        Sink<Double> gsink = app::addValue;\n" +
+                "        gsink.accept(Double.valueOf(4.0));           // accumulated = 6.5\n" +
+                "\n" +
+                "        // 3. box: produceHalf() double return bound to get() Double return\n" +
+                "        DoubleSource src = UnboxApp::produceHalf;\n" +
+                "        Double boxed = src.get();                    // 0.5 boxed\n" +
+                "        app.addValue(boxed.doubleValue());           // accumulated = 7.0\n" +
+                "\n" +
+                "        // 4. widen: apply(int) bound to identityLong(long)\n" +
+                "        IntToLong widener = UnboxApp::identityLong;\n" +
+                "        long w = widener.apply(3);                   // 3\n" +
+                "\n" +
+                "        report((int)(accumulated * 10) + (int) w);   // 70 + 3 = 73\n" +
+                "    }\n" +
+                "\n" +
+                "    private static native void report(int value);\n" +
                 "}\n";
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"1.8"})
     void translatesLambdaBytecodeToLLVMExecutable(String targetVersion) throws Exception {
+        translateBuildAndRun(targetVersion, "LambdaApp", appSource(), "RESULT=145");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"1.8"})
+    void adaptsBoxingUnboxingInMethodReferences(String targetVersion) throws Exception {
+        translateBuildAndRun(targetVersion, "UnboxApp", unboxAppSource(), "RESULT=73");
+    }
+
+    private void translateBuildAndRun(String targetVersion, String className, String source, String expectedOutput) throws Exception {
         Parser.cleanup();
 
         Path sourceDir = Files.createTempDirectory("lambda-integration-sources");
         Path classesDir = Files.createTempDirectory("lambda-integration-classes");
         Path javaApiDir = Files.createTempDirectory("java-api-classes");
 
-        Files.write(sourceDir.resolve("LambdaApp.java"), appSource().getBytes(StandardCharsets.UTF_8));
+        Files.write(sourceDir.resolve(className + ".java"), source.getBytes(StandardCharsets.UTF_8));
 
         CompilerHelper.CompilerConfig config = selectCompiler(targetVersion);
         if (config == null) {
@@ -84,7 +142,7 @@ class LambdaIntegrationTest {
         CompilerHelper.compileJavaAPI(javaApiDir, config);
 
         Path nativeReport = sourceDir.resolve("native_report.c");
-        Files.write(nativeReport, nativeReportSource().getBytes(StandardCharsets.UTF_8));
+        Files.write(nativeReport, nativeReportSource(className).getBytes(StandardCharsets.UTF_8));
 
         // Compile App using JavaAPI as bootclasspath
         List<String> compileArgs = new ArrayList<>();
@@ -101,23 +159,23 @@ class LambdaIntegrationTest {
         }
         compileArgs.add("-d");
         compileArgs.add(classesDir.toString());
-        compileArgs.add(sourceDir.resolve("LambdaApp.java").toString());
+        compileArgs.add(sourceDir.resolve(className + ".java").toString());
 
         int compileResult = CompilerHelper.compile(config.jdkHome, compileArgs);
-        assertEquals(0, compileResult, "LambdaApp should compile");
+        assertEquals(0, compileResult, className + " should compile");
 
         CompilerHelper.copyDirectory(javaApiDir, classesDir);
 
         Files.copy(nativeReport, classesDir.resolve("native_report.c"));
 
         Path outputDir = Files.createTempDirectory("lambda-integration-output");
-        CleanTargetIntegrationTest.runTranslator(classesDir, outputDir, "LambdaApp");
+        CleanTargetIntegrationTest.runTranslator(classesDir, outputDir, className);
 
         Path distDir = outputDir.resolve("dist");
         Path cmakeLists = distDir.resolve("CMakeLists.txt");
         assertTrue(Files.exists(cmakeLists), "Translator should emit a CMake project");
 
-        Path srcRoot = distDir.resolve("LambdaApp-src");
+        Path srcRoot = distDir.resolve(className + "-src");
 
         CleanTargetIntegrationTest.replaceLibraryWithExecutableTarget(cmakeLists, srcRoot.getFileName().toString());
 
@@ -134,9 +192,9 @@ class LambdaIntegrationTest {
 
         CleanTargetIntegrationTest.runCommand(Arrays.asList("cmake", "--build", buildDir.toString()), distDir);
 
-        Path executable = buildDir.resolve("LambdaApp");
+        Path executable = buildDir.resolve(className);
         String output = CleanTargetIntegrationTest.runCommand(Arrays.asList(executable.toString()), buildDir);
-        assertTrue(output.contains("RESULT=145"), "Compiled program should print the expected result: " + output);
+        assertTrue(output.contains(expectedOutput), "Compiled program should print the expected result: " + output);
     }
 
     private CompilerHelper.CompilerConfig selectCompiler(String targetVersion) {


### PR DESCRIPTION
Fixes two issues reported building CodeRAD apps for iOS (r/cn1, 7.0.225+: *"Cannot build for iOS with CodeRAD on latest versions"*).

## 1. Method references needing box/unbox/widen/cast broke the Xcode build

A method reference whose implementation signature differs from the functional interface's failed to compile in the generated Xcode project. The reporter's case — `obj::setSomeValue` where `setSomeValue(double)` bound to a `Consumer<Double>`:

```
error: passing 'JAVA_OBJECT' to parameter of incompatible type 'JAVA_DOUBLE'
```

ParparVM consumes `invokedynamic` directly and synthesizes the lambda adapter class itself in `Parser.visitInvokeDynamicInsn`. It loaded each SAM argument verbatim and invoked the target method directly, **with no adaptation between the SAM signature and the implementation method signature**. The real `LambdaMetafactory` is required to box/unbox/widen/cast there, so a `Double` reached a primitive `double` parameter and the generated C did not compile.

The adapter now replicates that adaptation for every argument **and** the return value:
- **unbox** (with a `CHECKCAST` to the wrapper when the SAM type is erased to `Object`, e.g. generic functional interfaces),
- **box** via `valueOf`,
- primitive **widening/narrowing**,
- reference **checkcast** (generic erasure).

Lambdas and same-signature method references hit the identity path and are unchanged.

## 2. `Objects.deepEquals` missing from the iOS runtime

CodeRAD's `ButtonListPropertyView` calls `java.util.Objects.deepEquals`, which the iOS runtime (`vm/JavaAPI`) didn't provide, producing `call to undeclared function java_util_Objects_deepEquals___...`. Added it, faithful to the JDK's `deepEquals0` (dispatch to the matching `Arrays.equals`/`Arrays.deepEquals` overload by array element type, else `a.equals(b)`).

## Testing

`LambdaIntegrationTest` gains `adaptsBoxingUnboxingInMethodReferences`, which compiles Java → translates → builds the generated C with clang → runs it, covering unbox, erased-generic unbox, return boxing, and `int`→`long` widening.

- Pre-fix: reproduces `error: passing 'JAVA_OBJECT' ... incompatible type 'JAVA_DOUBLE'`.
- Post-fix: both lambda tests pass (`RESULT=73`, `RESULT=145`); `StreamApiIntegrationTest` (heavy generic-lambda boxing) still passes — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)