### PR TITLE
Add mockup-comparison and design-import tooling to the CN1 agent skill

### DIFF
--- a/scripts/initializr/common/src/main/resources/skill/SKILL.md
+++ b/scripts/initializr/common/src/main/resources/skill/SKILL.md
@@ -31,6 +31,7 @@ This skill teaches you how to write code for a Codename One (CN1) cross-platform
 - `references/html-css-cheatsheet.md` — Converting common HTML/CSS snippets to CN1 components + CSS.
 - `references/android-to-cn1.md` — Porting Android (XML + Kotlin/Java) screens to Codename One.
 - `references/testing-and-screenshots.md` — `AbstractTest`, `TestUtils`, `screenshotTest`, the `cn1:test` Maven goal, the screenshot tolerance algorithm.
+- `references/mockup-comparison.md` — Building a screen to **match a designer mockup**: `tools/CompareToMockup.java` scores a render against a mockup image and prints a similarity % (with partial/region masking so device chrome doesn't sabotage the score), and `tools/DesignImport.java` turns a Figma/Sketch/Adobe XD file into a starter `theme.css` + tokens + layout map. Read this when the user gives you a mockup, a Figma/Sketch/XD file, or asks "how close is this screen to the design".
 - `references/junit-testing.md` — Standard JUnit 5 tests against the simulator via `@CodenameOneTest`. Annotations (`@RunOnEdt`, `@Theme`, `@DarkMode`, `@LargerText`, `@Orientation`, `@RTL`, `@SimulatorProperty`), how it coexists with `cn1:test`, and why a headless CI runner has to be configured with Xvfb (or accepts that JUnit test classes will be skipped).
 - `references/mobile-adaptability.md` — Density-independent units (mm), `convertToPixels`, `LayeredLayout` for responsive design, `Display.isTablet()`, font scaling.
 - `references/native-interfaces.md` — Authoring native interfaces for iOS/Android/JavaScript/Desktop with `cn1:generate-native-interfaces` and platform callbacks.
@@ -38,7 +39,7 @@ This skill teaches you how to write code for a Codename One (CN1) cross-platform
 - `references/ai-and-speech.md` — LLM client (`com.codename1.ai`), `ChatView`, `SpeechRecognizer`, `TextToSpeech`, non-prompting `SecureStorage` overloads, the ML Kit cn1libs, and the simulator's offline Ollama redirect. Read this when the user asks for chat, voice, embeddings, image generation, barcode/document/face detection, or wants to store an LLM API key.
 - `references/snapshot-builds.md` — Edge case: compiling against a Codename One SNAPSHOT from git.
 - `references/debugging.md` — `jdb`-attach workflow for an agent: start the simulator paused, set breakpoints, dump locals, drive the session non-interactively from a script.
-- `tools/` — runnable Java 17 single-file utilities. `tools/IsApiSupported.java` answers "is this `java.*` class in the CN1 subset?"; `tools/IsCssValid.java` answers "does this `theme.css` compile?". Run with `java tools/<Name>.java <args>`.
+- `tools/` — runnable Java 17 single-file utilities. `tools/IsApiSupported.java` answers "is this `java.*` class in the CN1 subset?"; `tools/IsCssValid.java` answers "does this `theme.css` compile?"; `tools/CompareToMockup.java` scores a rendered screenshot against a designer mockup (similarity %, with region masking); `tools/DesignImport.java` turns a Figma/Sketch/Adobe XD design into starter CN1 CSS + tokens + a layout map. Run with `java tools/<Name>.java <args>`.
 
 When the user's task hits any one of those topics, **read the matching reference before generating code**. Do not paste large snippets without checking.
 
@@ -291,6 +292,7 @@ If you cannot run the simulator (e.g. headless environment), **say so explicitly
 | "I have Android XML/Kotlin/Java, convert it" | `references/android-to-cn1.md` |
 | "Generate a client for this OpenAPI spec / `.proto` / GraphQL schema" / `@RestClient`, `@GrpcClient`, `@GraphQLClient` | `references/api-clients.md` |
 | "Write a test for this screen" / "Compare to a baseline" | `references/testing-and-screenshots.md` |
+| "Match this mockup" / "Compare to a Figma/Sketch/XD design" / "How close is this screen to the design" | `references/mockup-comparison.md` |
 | "Make it look right on tablet/landscape" | `references/mobile-adaptability.md` |
 | "How do I run/build/deploy" | `references/build-and-run.md` |
 | "What's the right `codename1.arg.*` for X" / native config | `references/build-hints.md` |
@@ -304,3 +306,4 @@ If you cannot run the simulator (e.g. headless environment), **say so explicitly
 | "Build against a Codename One SNAPSHOT from git" | `references/snapshot-builds.md` |
 | "Debug a faulty screen — attach `jdb` to the simulator" | `references/debugging.md` |
 | Quick yes/no check: "is this `java.*` class supported", "does my `theme.css` compile" | `tools/` directory — `java tools/IsApiSupported.java <class>` / `java tools/IsCssValid.java <file>` |
+| "Score this screen against a mockup" / "Import a Figma/Sketch/XD design" | `tools/` directory — `java tools/CompareToMockup.java <render> <mockup>` / `java tools/DesignImport.java <design>` (see `references/mockup-comparison.md`) |

--- a/scripts/initializr/common/src/main/resources/skill/references/mockup-comparison.md
+++ b/scripts/initializr/common/src/main/resources/skill/references/mockup-comparison.md
@@ -1,0 +1,139 @@
+# Mockup Comparison Reference
+
+Building a screen to match a designer mockup is hard to do "by eye": you cannot tell *how close*
+the render is to the target, so you cannot converge reliably. This skill ships two tools that turn
+that into a measurable loop:
+
+- `tools/CompareToMockup.java` - scores a rendered screenshot against a mockup image and prints a
+  similarity percentage. Supports a **partial/region mode** so device chrome in the mockup (a
+  status-bar mock, a home indicator) does not sabotage the score.
+- `tools/DesignImport.java` - parses a Figma / Sketch / Adobe XD design into a **starter**
+  `theme.css` + `tokens.json` + `layout.md`, so you begin near the target instead of from scratch.
+
+Plus `templates/MockupComparisonTest.java`, a copy-paste test that renders a screen and saves a PNG
+to a predictable path for the comparison tool to read.
+
+> This is the *correctness* counterpart to `screenshotTest` (see
+> `references/testing-and-screenshots.md`). `screenshotTest` compares a render to a baseline the
+> system produced itself - that proves **consistency**, not correctness. A designer mockup is an
+> **independent reference**, so comparing against it actually measures whether you built the right
+> thing.
+
+## The loop
+
+1. **(Optional) Import the design** to seed your styling:
+   ```bash
+   # Figma (needs a personal access token + the file key from the file URL)
+   java .claude/skills/codename-one/tools/DesignImport.java figma \
+        --token "$FIGMA_TOKEN" --file ABC123 --out target/design-import
+   # Sketch / Adobe XD (local files, no token, no network)
+   java .claude/skills/codename-one/tools/DesignImport.java design.sketch --out target/design-import
+   ```
+   Then validate the emitted CSS before using it:
+   ```bash
+   java .claude/skills/codename-one/tools/IsCssValid.java target/design-import/theme.css
+   ```
+   Fold the useful colors/sizes from `theme.css` into `common/src/main/css/theme.css`, and use
+   `layout.md` as the structure to build (it suggests the CN1 layout per container).
+
+2. **Build the screen** from the layout map.
+
+3. **Capture the render.** Either drive the simulator and use *Simulator menu -> Save Screenshot*,
+   or copy `templates/MockupComparisonTest.java` into `common/src/test/java/<pkg>/`, point it at
+   your screen, and run it:
+   ```bash
+   mvn -pl common test -Dtest=MockupComparisonTest
+   # writes target/mockup-compare/home.png
+   ```
+
+4. **Score against the mockup.** Put mockups in `common/src/test/resources/mockups/`:
+   ```bash
+   java .claude/skills/codename-one/tools/CompareToMockup.java \
+        target/mockup-compare/home.png \
+        common/src/test/resources/mockups/home.png \
+        --ignore-top 8% \
+        --diff target/mockup-compare/home-diff.png
+   # STRUCTURAL 0.912  PIXEL 0.874   (compared ... , ignored top 96px)
+   ```
+
+5. **Read the numbers, inspect `home-diff.png`** (green = match, red = large difference), adjust the
+   CSS/layout, and repeat until the **STRUCTURAL** score reaches your target.
+
+## Reading the two scores
+
+| Score | What it is | Use it for |
+| --- | --- | --- |
+| `STRUCTURAL` | SSIM-style structural similarity (the headline number). Robust to the small pixel noise that always exists between a live render and a vector mockup. | The convergence metric you optimise. |
+| `PIXEL` | Fraction of pixels whose max ARGB channel delta is <= 3 - the framework's "same pixel" rule. | Spotting exact-match regions; will read low against a non-render mockup. |
+
+The render is auto-resized to the mockup's pixel dimensions first (`--resize fit`, the default), so
+you can capture at any simulator skin size.
+
+## Partial / region mode (the important part)
+
+Mockups routinely include things your app does not render: an iOS status-bar mock, a notch, a home
+indicator, a watermark. Comparing those regions tanks the score for no reason. Mask them:
+
+```bash
+# Ignore a status bar at the top (pixels or percent of height):
+... --ignore-top 96            # drop the top 96 px
+... --ignore-top 8%            # drop the top 8% of the height
+
+# Ignore a bottom tab-bar / home indicator:
+... --ignore-bottom 5%
+
+# Exclude an arbitrary rectangle (repeatable) - e.g. a logo the mockup mocks but you load remotely:
+... --ignore 24,700,300,80 --ignore 0,0,375,44
+
+# Compare ONLY one region - e.g. evaluate just the product card:
+... --region 24,120,327,180
+```
+
+All rectangle coordinates are in the **mockup's** pixel space (`X,Y,W,H`).
+
+## Calibrate the target - don't chase 1.000
+
+A live render will **never** hit `STRUCTURAL 1.000` against a *vector* mockup: fonts render with
+different hinting, anti-aliasing differs, sub-pixel positions shift. A good match against a real
+design typically lands in the **0.88-0.96** range once chrome is masked. Establish what "good"
+looks like for your project on a screen you have visually confirmed, then use that as the bar for
+the rest. If your "mockup" is itself a screenshot from the same renderer, you can expect higher.
+
+Use `--min` to turn the score into a gate once you have a target:
+```bash
+java .claude/skills/codename-one/tools/CompareToMockup.java render.png mockup.png \
+     --ignore-top 8% --min 0.9      # exit code 1 if structural < 0.9
+```
+
+## Design import notes
+
+`DesignImport` output is a **starting point**, extracted mechanically:
+
+- `tokens.json` - the palette (hex + usage count), the type scale, and spacing values found.
+- `theme.css` - `Form`/`Title`/`Label`/`Button` seeded from the dominant colors/sizes, plus a UIID
+  block per named layer. Sizes are converted to `mm` at `--px-per-mm` (default `11.8`, about a 3x
+  retina export); each value carries the source px in a comment. **Always run it through
+  `IsCssValid.java`** and tune `--px-per-mm` if sizes look off.
+- `layout.md` - the component tree with frames and text, plus a design-layout -> CN1-layout table.
+
+Format support:
+
+| Format | How it is read | Needs |
+| --- | --- | --- |
+| Figma | `api.figma.com` REST API | a personal access token (`--token`) + file key (`--file`); network |
+| Sketch (`.sketch`) | unzipped JSON (`pages/*.json`) | nothing - fully local |
+| Adobe XD (`.xd`) | unzipped JSON (`graphicContent.agc`) | nothing - fully local |
+
+Photoshop PSD is **not** supported (opaque layered binary). Flatten-export it to PNG and use the
+`CompareToMockup` path instead.
+
+## Common pitfalls
+
+| Symptom | Cause / fix |
+| --- | --- |
+| Score is low but the screen looks right | The mockup includes chrome you do not render. Mask it with `--ignore-top` / `--ignore`. |
+| `STRUCTURAL` never approaches 1.0 | Expected against a vector mockup. Calibrate a per-project target (~0.9), don't chase 1.0. |
+| "The mask excludes every pixel" | Your `--region` is outside the image, or `--ignore` rects cover everything. Coords are in mockup px. |
+| `Unsupported or corrupt image` | Mockup is not a raster PNG/JPG (e.g. an SVG). Export it to PNG first. |
+| Imported CSS sizes are all tiny/huge | Wrong `--px-per-mm` for the export scale. A 1x export is ~3.9 px/mm; a 3x export ~11.8. |
+| Figma call returns HTTP 403 | Bad/expired token, or the token lacks access to that file. |

--- a/scripts/initializr/common/src/main/resources/skill/references/testing-and-screenshots.md
+++ b/scripts/initializr/common/src/main/resources/skill/references/testing-and-screenshots.md
@@ -141,6 +141,21 @@ The right loop:
 
 A screenshot test where the baseline was never visually inspected is theatrical. Don't ship it as "validated".
 
+### Self-baseline regression vs. mockup comparison
+
+`screenshotTest` compares a render to a baseline **the system produced itself** — it measures
+*consistency over time* (did this screen change?), not *correctness* (does it match the design?).
+When you have an **independent reference** — a designer's mockup — use the mockup-comparison tools
+instead, which is the actual correctness signal:
+
+| Goal | Use | Reference |
+| --- | --- | --- |
+| "Did this screen change vs. last run?" (regression) | `TestUtils.screenshotTest(name)` | this doc |
+| "How close is this screen to the designer's mockup?" (correctness) | `tools/CompareToMockup.java` (+ `tools/DesignImport.java`) | `references/mockup-comparison.md` |
+
+The comparison tool prints a similarity percentage and supports region masking so device chrome in
+the mockup doesn't sabotage the score. See `references/mockup-comparison.md` for the full loop.
+
 ## Tests that don't need UI
 
 For pure-logic tests (parsers, models, business rules), set `shouldExecuteOnEDT()` to `false` and skip the UI helpers:

--- a/scripts/initializr/common/src/main/resources/skill/templates/MockupComparisonTest.java
+++ b/scripts/initializr/common/src/main/resources/skill/templates/MockupComparisonTest.java
@@ -1,0 +1,75 @@
+// ===========================================================================
+// COPY-PASTE TEMPLATE - not compiled where it ships.
+//
+// To use it:
+//   1. Copy this file into  common/src/test/java/<your-package>/
+//   2. Replace the package below with your app's package.
+//   3. Replace `YourMainClass` with your Lifecycle main class and adjust the
+//      navigation in each capture method to reach the screen you want.
+//
+// What it does:
+//   Renders a screen in the simulator and writes a PNG to
+//   `target/mockup-compare/<name>.png`. It does NOT score anything - scoring
+//   lives in tools/CompareToMockup.java so there is a single definition of the
+//   similarity metric. After running this test, compare the capture to your
+//   designer mockup:
+//
+//     java .claude/skills/codename-one/tools/CompareToMockup.java \
+//          target/mockup-compare/home.png \
+//          common/src/test/resources/mockups/home.png \
+//          --ignore-top 8% --diff target/mockup-compare/home-diff.png
+//
+// This is a JUnit 5 @CodenameOneTest, so it runs only in the simulator JVM
+// (which is exactly where you compare against a mockup during development).
+// See references/mockup-comparison.md for the full loop.
+// ===========================================================================
+package com.example.myapp; // <-- CHANGE to your app package
+
+import com.codename1.testing.junit.CodenameOneTest;
+import com.codename1.testing.junit.RunOnEdt;
+import com.codename1.ui.Display;
+import com.codename1.ui.Image;
+import com.codename1.ui.util.ImageIO;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import org.junit.jupiter.api.Test;
+
+@CodenameOneTest
+class MockupComparisonTest {
+
+    @Test
+    @RunOnEdt
+    void captureHome() throws Exception {
+        // Build and show the screen you want to compare against the mockup.
+        new YourMainClass().runApp(); // <-- CHANGE to your Lifecycle main class
+        // Pump the EDT so the form is laid out and painted before capture.
+        Display.getInstance().getCurrent().revalidate();
+
+        captureCurrentScreen("home");
+    }
+
+    /// Captures the current form to target/mockup-compare/<name>.png.
+    /// Mirrors the capture idiom used by TestUtils.screenshotTest
+    /// (captureScreen + paintComponent), but writes to a predictable project
+    /// path instead of CN1 Storage so the comparison tool can find it.
+    private static void captureCurrentScreen(String name) throws Exception {
+        ImageIO io = ImageIO.getImageIO();
+        if (io == null || !io.isFormatSupported(ImageIO.FORMAT_PNG)) {
+            throw new IllegalStateException("PNG ImageIO not available in this environment");
+        }
+
+        Image shot = Display.getInstance().captureScreen();
+        Display.getInstance().getCurrent().paintComponent(shot.getGraphics(), true);
+
+        File outDir = new File("target/mockup-compare");
+        outDir.mkdirs();
+        File outFile = new File(outDir, name + ".png");
+        try (OutputStream out = new FileOutputStream(outFile)) {
+            io.save(shot, out, ImageIO.FORMAT_PNG, 1);
+        }
+        // Surfaced in the test log so the agent can locate the artifact.
+        System.out.println("[MockupComparisonTest] wrote " + outFile.getAbsolutePath()
+                + " (" + shot.getWidth() + "x" + shot.getHeight() + ")");
+    }
+}

--- a/scripts/initializr/common/src/main/resources/skill/tools/CompareToMockup.java
+++ b/scripts/initializr/common/src/main/resources/skill/tools/CompareToMockup.java
@@ -1,0 +1,476 @@
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.imageio.ImageIO;
+
+/// Scores how closely a rendered Codename One screen matches a designer mockup
+/// and prints a similarity percentage. This is the deterministic convergence
+/// signal an agent needs when building a UI from a mockup: instead of eyeballing
+/// the result, run this tool, read the number, adjust the CSS/layout, repeat.
+///
+/// It reports two complementary scores (both 0..1):
+///
+///   STRUCTURAL - an SSIM-style perceptual/structural similarity. This is the
+///                headline number. It is robust to the small pixel differences
+///                that always exist between a live render and a vector mockup
+///                (font hinting, anti-aliasing, sub-pixel positioning).
+///   PIXEL      - the fraction of pixels whose max ARGB channel delta is <= 3,
+///                using the same "same pixel" definition as the framework's
+///                TestUtils.imagesWithinTolerance. A stricter, lower number that
+///                is useful for spotting exact-match regions.
+///
+/// The render is auto-resized to the mockup's pixel dimensions before comparing
+/// (both depict the same full screen at different scales), so you can capture at
+/// any simulator skin size.
+///
+/// PARTIAL / REGION MODE - mockups frequently include device chrome (a status-bar
+/// mock at the top, a home indicator at the bottom, a watermark). Compare only
+/// what matters:
+///
+///   --region X,Y,W,H     compare ONLY this rectangle (mockup pixel coords)
+///   --ignore X,Y,W,H     exclude a rectangle; may be repeated
+///   --ignore-top N       exclude a band N pixels (or N%) tall from the top edge
+///   --ignore-bottom N    exclude a band N pixels (or N%) tall from the bottom edge
+///
+/// Usage:
+///
+///     java tools/CompareToMockup.java <render.png> <mockup.png> [options]
+///
+/// Options:
+///
+///     --region X,Y,W,H      restrict comparison to this rectangle
+///     --ignore X,Y,W,H      exclude this rectangle (repeatable)
+///     --ignore-top N[%]     exclude a top band (e.g. a status bar): 96 or 8%
+///     --ignore-bottom N[%]  exclude a bottom band (home indicator / tab bar)
+///     --resize fit|none     fit (default) scales the render to the mockup size;
+///                           none requires the two images to already match
+///     --diff <out.png>      write a heatmap diff image (masked areas dimmed)
+///     --min <0..1>          fail (exit 1) if the STRUCTURAL score is below this
+///     --json                print a single-line JSON result instead of text
+///
+/// Exit codes:
+///
+///   0 - compared successfully (and, if --min given, structural score >= min)
+///   1 - structural score below --min
+///   2 - usage / IO error (bad args, unreadable image, size mismatch with --resize none)
+public class CompareToMockup {
+    // Mirrors TestUtils.imagesWithinTolerance: a per-channel delta of <= 3 is
+    // treated as "the same pixel".
+    private static final int TOLERATED_CHANNEL_DELTA = 3;
+
+    // Standard SSIM stabilising constants for an 8-bit dynamic range (L = 255).
+    private static final double C1 = (0.01 * 255) * (0.01 * 255);
+    private static final double C2 = (0.03 * 255) * (0.03 * 255);
+    private static final int SSIM_WINDOW = 8;
+    private static final int SSIM_STEP = 4;
+
+    public static void main(String[] args) {
+        if (args.length < 2) {
+            usage();
+            System.exit(2);
+        }
+
+        String renderPath = null;
+        String mockupPath = null;
+        int[] region = null;                       // {x,y,w,h} or null
+        List<int[]> ignores = new ArrayList<>();    // list of {x,y,w,h}
+        String ignoreTop = null;
+        String ignoreBottom = null;
+        boolean resizeFit = true;
+        String diffPath = null;
+        Double min = null;
+        boolean json = false;
+
+        try {
+            for (int i = 0; i < args.length; i++) {
+                String a = args[i];
+                switch (a) {
+                    case "--region":      region = parseRect(args[++i]); break;
+                    case "--ignore":      ignores.add(parseRect(args[++i])); break;
+                    case "--ignore-top":  ignoreTop = args[++i]; break;
+                    case "--ignore-bottom": ignoreBottom = args[++i]; break;
+                    case "--resize":      resizeFit = !"none".equals(args[++i]); break;
+                    case "--diff":        diffPath = args[++i]; break;
+                    case "--min":         min = Double.valueOf(args[++i]); break;
+                    case "--json":        json = true; break;
+                    default:
+                        if (a.startsWith("--")) {
+                            System.err.println("Unknown option: " + a);
+                            usage();
+                            System.exit(2);
+                        } else if (renderPath == null) {
+                            renderPath = a;
+                        } else if (mockupPath == null) {
+                            mockupPath = a;
+                        } else {
+                            System.err.println("Unexpected argument: " + a);
+                            usage();
+                            System.exit(2);
+                        }
+                }
+            }
+        } catch (ArrayIndexOutOfBoundsException ex) {
+            System.err.println("Missing value for the final option.");
+            usage();
+            System.exit(2);
+            return;
+        } catch (NumberFormatException ex) {
+            System.err.println("Bad numeric argument: " + ex.getMessage());
+            System.exit(2);
+            return;
+        }
+
+        if (renderPath == null || mockupPath == null) {
+            usage();
+            System.exit(2);
+        }
+
+        try {
+            BufferedImage render = readImage(renderPath, "render");
+            BufferedImage mockup = readImage(mockupPath, "mockup");
+
+            int w = mockup.getWidth();
+            int h = mockup.getHeight();
+
+            if (render.getWidth() != w || render.getHeight() != h) {
+                if (!resizeFit) {
+                    System.err.println("Size mismatch: render is "
+                            + render.getWidth() + "x" + render.getHeight()
+                            + " but mockup is " + w + "x" + h
+                            + " and --resize none was set.");
+                    System.exit(2);
+                }
+                render = scaleTo(render, w, h);
+                System.err.println("[CompareToMockup] resized render to mockup dimensions "
+                        + w + "x" + h);
+            }
+
+            int topBand = ignoreTop == null ? 0 : resolveBand(ignoreTop, h);
+            int bottomBand = ignoreBottom == null ? 0 : resolveBand(ignoreBottom, h);
+
+            boolean[] mask = buildMask(w, h, region, ignores, topBand, bottomBand);
+            int comparedPixels = 0;
+            for (boolean m : mask) {
+                if (m) comparedPixels++;
+            }
+            if (comparedPixels == 0) {
+                System.err.println("The mask excludes every pixel - nothing to compare.");
+                System.exit(2);
+            }
+
+            int[] renderArgb = argb(render);
+            int[] mockupArgb = argb(mockup);
+
+            double pixel = pixelScore(renderArgb, mockupArgb, mask);
+            double structural = ssimScore(renderArgb, mockupArgb, mask, w, h);
+
+            if (diffPath != null) {
+                writeDiff(renderArgb, mockupArgb, mask, w, h, diffPath);
+                System.err.println("[CompareToMockup] wrote diff heatmap to " + diffPath);
+            }
+
+            String ignoredNote = describeIgnored(region, ignores, topBand, bottomBand);
+            if (json) {
+                System.out.println("{\"structural\":" + round(structural)
+                        + ",\"pixel\":" + round(pixel)
+                        + ",\"width\":" + w + ",\"height\":" + h
+                        + ",\"comparedPixels\":" + comparedPixels
+                        + ",\"totalPixels\":" + (w * h) + "}");
+            } else {
+                System.out.println("STRUCTURAL " + fmt(structural)
+                        + "  PIXEL " + fmt(pixel)
+                        + "   (compared " + comparedPixels + " of " + (w * h)
+                        + " px at " + w + "x" + h + ignoredNote + ")");
+            }
+
+            if (min != null && structural < min) {
+                System.err.println("[CompareToMockup] structural score " + fmt(structural)
+                        + " is below --min " + min);
+                System.exit(1);
+            }
+        } catch (IOException ex) {
+            System.err.println("IO error: " + ex.getMessage());
+            System.exit(2);
+        }
+    }
+
+    private static void usage() {
+        System.err.println("Usage: java CompareToMockup.java <render.png> <mockup.png> "
+                + "[--region X,Y,W,H] [--ignore X,Y,W,H]... "
+                + "[--ignore-top N[%]] [--ignore-bottom N[%]] "
+                + "[--resize fit|none] [--diff out.png] [--min 0..1] [--json]");
+    }
+
+    private static BufferedImage readImage(String path, String label) throws IOException {
+        File f = new File(path);
+        if (!f.isFile()) {
+            throw new IOException("Cannot read " + label + " image: " + path);
+        }
+        BufferedImage img = ImageIO.read(f);
+        if (img == null) {
+            throw new IOException("Unsupported or corrupt " + label + " image: " + path);
+        }
+        return img;
+    }
+
+    private static int[] parseRect(String s) {
+        String[] parts = s.split(",");
+        if (parts.length != 4) {
+            throw new NumberFormatException("expected X,Y,W,H but got '" + s + "'");
+        }
+        int[] r = new int[4];
+        for (int i = 0; i < 4; i++) {
+            r[i] = Integer.parseInt(parts[i].trim());
+        }
+        return r;
+    }
+
+    /// Resolves an N or N% band height against the image height.
+    private static int resolveBand(String spec, int height) {
+        spec = spec.trim();
+        if (spec.endsWith("%")) {
+            double pct = Double.parseDouble(spec.substring(0, spec.length() - 1).trim());
+            return (int) Math.round(height * pct / 100.0);
+        }
+        return Integer.parseInt(spec);
+    }
+
+    private static BufferedImage scaleTo(BufferedImage src, int w, int h) {
+        BufferedImage dst = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g = dst.createGraphics();
+        g.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+                RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+        g.setRenderingHint(RenderingHints.KEY_RENDERING,
+                RenderingHints.VALUE_RENDER_QUALITY);
+        g.drawImage(src, 0, 0, w, h, null);
+        g.dispose();
+        return dst;
+    }
+
+    private static int[] argb(BufferedImage img) {
+        int w = img.getWidth();
+        int h = img.getHeight();
+        int[] out = new int[w * h];
+        img.getRGB(0, 0, w, h, out, 0, w);
+        return out;
+    }
+
+    private static boolean[] buildMask(int w, int h, int[] region, List<int[]> ignores,
+                                       int topBand, int bottomBand) {
+        boolean[] mask = new boolean[w * h];
+        if (region == null) {
+            java.util.Arrays.fill(mask, true);
+        } else {
+            paintRect(mask, w, h, region, true);
+        }
+        for (int[] ig : ignores) {
+            paintRect(mask, w, h, ig, false);
+        }
+        if (topBand > 0) {
+            paintRect(mask, w, h, new int[]{0, 0, w, Math.min(topBand, h)}, false);
+        }
+        if (bottomBand > 0) {
+            int band = Math.min(bottomBand, h);
+            paintRect(mask, w, h, new int[]{0, h - band, w, band}, false);
+        }
+        return mask;
+    }
+
+    private static void paintRect(boolean[] mask, int w, int h, int[] r, boolean value) {
+        int x0 = Math.max(0, r[0]);
+        int y0 = Math.max(0, r[1]);
+        int x1 = Math.min(w, r[0] + r[2]);
+        int y1 = Math.min(h, r[1] + r[3]);
+        for (int y = y0; y < y1; y++) {
+            int row = y * w;
+            for (int x = x0; x < x1; x++) {
+                mask[row + x] = value;
+            }
+        }
+    }
+
+    /// Fraction of masked pixels whose maximum ARGB channel delta is within
+    /// TOLERATED_CHANNEL_DELTA. Same "same pixel" rule as the framework.
+    private static double pixelScore(int[] a, int[] b, boolean[] mask) {
+        long same = 0;
+        long total = 0;
+        for (int i = 0; i < a.length; i++) {
+            if (!mask[i]) continue;
+            total++;
+            int pa = a[i];
+            int pb = b[i];
+            int dA = Math.abs(((pa >> 24) & 0xff) - ((pb >> 24) & 0xff));
+            int dR = Math.abs(((pa >> 16) & 0xff) - ((pb >> 16) & 0xff));
+            int dG = Math.abs(((pa >> 8) & 0xff) - ((pb >> 8) & 0xff));
+            int dB = Math.abs((pa & 0xff) - (pb & 0xff));
+            int max = Math.max(Math.max(dA, dR), Math.max(dG, dB));
+            if (max <= TOLERATED_CHANNEL_DELTA) {
+                same++;
+            }
+        }
+        return total == 0 ? 0.0 : same / (double) total;
+    }
+
+    /// Mean SSIM over sliding windows whose pixels are all inside the mask.
+    /// Returns the mean clamped to [0,1].
+    private static double ssimScore(int[] a, int[] b, boolean[] mask, int w, int h) {
+        double[] lumA = luminance(a);
+        double[] lumB = luminance(b);
+
+        double sum = 0.0;
+        long windows = 0;
+
+        for (int y = 0; y + SSIM_WINDOW <= h; y += SSIM_STEP) {
+            for (int x = 0; x + SSIM_WINDOW <= w; x += SSIM_STEP) {
+                if (!windowFullyMasked(mask, w, x, y)) continue;
+
+                double sumA = 0, sumB = 0, sumAA = 0, sumBB = 0, sumAB = 0;
+                int n = SSIM_WINDOW * SSIM_WINDOW;
+                for (int wy = 0; wy < SSIM_WINDOW; wy++) {
+                    int row = (y + wy) * w + x;
+                    for (int wx = 0; wx < SSIM_WINDOW; wx++) {
+                        double va = lumA[row + wx];
+                        double vb = lumB[row + wx];
+                        sumA += va;
+                        sumB += vb;
+                        sumAA += va * va;
+                        sumBB += vb * vb;
+                        sumAB += va * vb;
+                    }
+                }
+                double muA = sumA / n;
+                double muB = sumB / n;
+                double varA = sumAA / n - muA * muA;
+                double varB = sumBB / n - muB * muB;
+                double cov = sumAB / n - muA * muB;
+
+                double ssim = ((2 * muA * muB + C1) * (2 * cov + C2))
+                        / ((muA * muA + muB * muB + C1) * (varA + varB + C2));
+                sum += ssim;
+                windows++;
+            }
+        }
+        if (windows == 0) {
+            // Mask too small for a full window: fall back to a global single-window
+            // estimate over the masked pixels so we still return a meaningful score.
+            return globalSsim(lumA, lumB, mask);
+        }
+        double mean = sum / windows;
+        return Math.max(0.0, Math.min(1.0, mean));
+    }
+
+    private static double globalSsim(double[] a, double[] b, boolean[] mask) {
+        double sumA = 0, sumB = 0, sumAA = 0, sumBB = 0, sumAB = 0;
+        long n = 0;
+        for (int i = 0; i < a.length; i++) {
+            if (!mask[i]) continue;
+            double va = a[i];
+            double vb = b[i];
+            sumA += va;
+            sumB += vb;
+            sumAA += va * va;
+            sumBB += vb * vb;
+            sumAB += va * vb;
+            n++;
+        }
+        if (n == 0) return 0.0;
+        double muA = sumA / n;
+        double muB = sumB / n;
+        double varA = sumAA / n - muA * muA;
+        double varB = sumBB / n - muB * muB;
+        double cov = sumAB / n - muA * muB;
+        double ssim = ((2 * muA * muB + C1) * (2 * cov + C2))
+                / ((muA * muA + muB * muB + C1) * (varA + varB + C2));
+        return Math.max(0.0, Math.min(1.0, ssim));
+    }
+
+    private static boolean windowFullyMasked(boolean[] mask, int w, int x, int y) {
+        for (int wy = 0; wy < SSIM_WINDOW; wy++) {
+            int row = (y + wy) * w + x;
+            for (int wx = 0; wx < SSIM_WINDOW; wx++) {
+                if (!mask[row + wx]) return false;
+            }
+        }
+        return true;
+    }
+
+    private static double[] luminance(int[] argb) {
+        double[] lum = new double[argb.length];
+        for (int i = 0; i < argb.length; i++) {
+            int p = argb[i];
+            int r = (p >> 16) & 0xff;
+            int g = (p >> 8) & 0xff;
+            int b = p & 0xff;
+            lum[i] = 0.299 * r + 0.587 * g + 0.114 * b;
+        }
+        return lum;
+    }
+
+    /// Writes a heatmap: green=match, yellow/red=large luminance delta. Masked-out
+    /// pixels are shown as a dimmed grayscale of the mockup for orientation.
+    private static void writeDiff(int[] render, int[] mockup, boolean[] mask,
+                                  int w, int h, String path) throws IOException {
+        BufferedImage diff = new BufferedImage(w, h, BufferedImage.TYPE_INT_RGB);
+        int[] out = new int[w * h];
+        for (int i = 0; i < out.length; i++) {
+            if (!mask[i]) {
+                int p = mockup[i];
+                int gray = (int) (0.299 * ((p >> 16) & 0xff)
+                        + 0.587 * ((p >> 8) & 0xff)
+                        + 0.114 * (p & 0xff));
+                gray = gray / 3 + 40; // dim
+                out[i] = (gray << 16) | (gray << 8) | gray;
+            } else {
+                int pa = render[i];
+                int pb = mockup[i];
+                double la = 0.299 * ((pa >> 16) & 0xff) + 0.587 * ((pa >> 8) & 0xff) + 0.114 * (pa & 0xff);
+                double lb = 0.299 * ((pb >> 16) & 0xff) + 0.587 * ((pb >> 8) & 0xff) + 0.114 * (pb & 0xff);
+                double d = Math.abs(la - lb) / 255.0; // 0..1
+                out[i] = heat(d);
+            }
+        }
+        diff.setRGB(0, 0, w, h, out, 0, w);
+        String fmt = path.toLowerCase().endsWith(".jpg") || path.toLowerCase().endsWith(".jpeg")
+                ? "jpg" : "png";
+        ImageIO.write(diff, fmt, new File(path));
+    }
+
+    /// Maps 0..1 onto green -> yellow -> red.
+    private static int heat(double d) {
+        d = Math.max(0.0, Math.min(1.0, d));
+        int r, g;
+        if (d < 0.5) {
+            r = (int) (510 * d);   // 0 -> 255 across first half
+            g = 255;
+        } else {
+            r = 255;
+            g = (int) (510 * (1.0 - d)); // 255 -> 0 across second half
+        }
+        return (r << 16) | (g << 8);
+    }
+
+    private static String describeIgnored(int[] region, List<int[]> ignores,
+                                          int topBand, int bottomBand) {
+        StringBuilder sb = new StringBuilder();
+        if (region != null) {
+            sb.append(", region ").append(region[0]).append(',').append(region[1])
+              .append(',').append(region[2]).append(',').append(region[3]);
+        }
+        if (topBand > 0) sb.append(", ignored top ").append(topBand).append("px");
+        if (bottomBand > 0) sb.append(", ignored bottom ").append(bottomBand).append("px");
+        if (!ignores.isEmpty()) sb.append(", ").append(ignores.size()).append(" ignore rect(s)");
+        return sb.toString();
+    }
+
+    private static String fmt(double v) {
+        return String.format(java.util.Locale.US, "%.3f", v);
+    }
+
+    private static double round(double v) {
+        return Math.round(v * 1000.0) / 1000.0;
+    }
+}

--- a/scripts/initializr/common/src/main/resources/skill/tools/DesignImport.java
+++ b/scripts/initializr/common/src/main/resources/skill/tools/DesignImport.java
@@ -1,0 +1,869 @@
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+/// Parses a designer file (Figma, Sketch, or Adobe XD) into a STARTER Codename One
+/// style so an agent building a screen from a mockup starts near the target instead
+/// of from scratch. It emits three files into the output directory:
+///
+///   theme.css   - seeded CN1 CSS (Form/Title/Label/Button + per-named-layer UIIDs)
+///   tokens.json - the extracted palette, type scale and spacing scale
+///   layout.md   - the component tree with frames, text and a suggested CN1 layout
+///
+/// The output is a STARTING POINT, extracted mechanically. Refine it by hand and
+/// measure how close you are with tools/CompareToMockup.java. Validate the emitted
+/// CSS with tools/IsCssValid.java before wiring it in.
+///
+/// This tool is fully self-contained: it includes a small JSON parser and uses
+/// only the JDK (java.net.http for the Figma REST call). It does NOT need the CN1
+/// jars in ~/.m2.
+///
+/// Usage:
+///
+///   # Local ZIP+JSON formats
+///   java tools/DesignImport.java path/to/design.sketch [--out DIR] [--px-per-mm N]
+///   java tools/DesignImport.java path/to/design.xd     [--out DIR] [--px-per-mm N]
+///
+///   # Figma over its REST API (needs a personal access token + the file key)
+///   java tools/DesignImport.java figma --token <PAT> --file <FILE_KEY> \
+///        [--node <NODE_ID>] [--out DIR] [--px-per-mm N]
+///
+/// Options:
+///
+///   --out DIR        output directory (default: cn1-design-import)
+///   --px-per-mm N    pixels-per-millimetre used to convert sizes to CN1 mm units
+///                    (default 11.8, roughly a 3x retina mockup). Tune to taste.
+///   --token TOKEN    Figma personal access token (figma mode only)
+///   --file KEY       Figma file key from the file URL (figma mode only)
+///   --node ID        restrict to a single Figma node/frame id (figma mode only)
+///
+/// Exit codes:
+///
+///   0 - imported successfully
+///   1 - parsed but produced nothing useful (no recognisable layers)
+///   2 - usage / IO / network error
+public class DesignImport {
+    public static void main(String[] args) {
+        if (args.length < 1) {
+            usage();
+            System.exit(2);
+        }
+
+        String source = args[0];
+        String out = "cn1-design-import";
+        double pxPerMm = 11.8;
+        String token = null;
+        String fileKey = null;
+        String nodeId = null;
+
+        try {
+            for (int i = 1; i < args.length; i++) {
+                switch (args[i]) {
+                    case "--out":       out = args[++i]; break;
+                    case "--px-per-mm": pxPerMm = Double.parseDouble(args[++i]); break;
+                    case "--token":     token = args[++i]; break;
+                    case "--file":      fileKey = args[++i]; break;
+                    case "--node":      nodeId = args[++i]; break;
+                    default:
+                        System.err.println("Unknown option: " + args[i]);
+                        usage();
+                        System.exit(2);
+                }
+            }
+        } catch (ArrayIndexOutOfBoundsException ex) {
+            System.err.println("Missing value for the final option.");
+            usage();
+            System.exit(2);
+        }
+
+        try {
+            Node root;
+            String label;
+            String lower = source.toLowerCase(Locale.US);
+            if (source.equals("figma")) {
+                if (token == null || fileKey == null) {
+                    System.err.println("figma mode requires --token and --file");
+                    System.exit(2);
+                }
+                root = parseFigma(token, fileKey, nodeId);
+                label = "Figma file " + fileKey;
+            } else if (lower.endsWith(".sketch")) {
+                root = parseSketch(Paths.get(source));
+                label = "Sketch file " + source;
+            } else if (lower.endsWith(".xd")) {
+                root = parseXd(Paths.get(source));
+                label = "Adobe XD file " + source;
+            } else {
+                System.err.println("Unrecognised source. Expected a .sketch / .xd file or the literal 'figma'.");
+                usage();
+                System.exit(2);
+                return;
+            }
+
+            Extracted ex = new Extracted();
+            collect(root, ex);
+
+            if (ex.nodeCount == 0) {
+                System.err.println("No recognisable layers were found in " + label + ".");
+                System.exit(1);
+            }
+
+            Path outDir = Paths.get(out);
+            Files.createDirectories(outDir);
+            Files.writeString(outDir.resolve("tokens.json"), renderTokens(ex));
+            Files.writeString(outDir.resolve("theme.css"), renderCss(ex, pxPerMm, label));
+            Files.writeString(outDir.resolve("layout.md"), renderLayout(root, ex, pxPerMm, label));
+
+            System.out.println("IMPORTED " + ex.nodeCount + " layers, "
+                    + ex.colorCounts.size() + " colors, "
+                    + ex.fontSizes.size() + " text sizes -> " + outDir.toAbsolutePath());
+            System.err.println("[DesignImport] next: validate CSS with "
+                    + "`java tools/IsCssValid.java " + outDir.resolve("theme.css") + "`, "
+                    + "then iterate with tools/CompareToMockup.java");
+        } catch (IOException | InterruptedException ex) {
+            System.err.println("Error: " + ex.getMessage());
+            System.exit(2);
+        }
+    }
+
+    private static void usage() {
+        System.err.println("Usage:");
+        System.err.println("  java DesignImport.java design.sketch [--out DIR] [--px-per-mm N]");
+        System.err.println("  java DesignImport.java design.xd     [--out DIR] [--px-per-mm N]");
+        System.err.println("  java DesignImport.java figma --token PAT --file KEY [--node ID] [--out DIR]");
+    }
+
+    // ===================================================================
+    // Intermediate model
+    // ===================================================================
+
+    private static final class Node {
+        String name = "";
+        String type = "";
+        double x, y, w, h;
+        boolean hasFrame;
+        Integer fill;           // 0xRRGGBB or null
+        Integer stroke;
+        double cornerRadius;
+        String text;            // text content if this is a text layer
+        String fontFamily;
+        Double fontSize;        // px
+        String layoutMode;      // VERTICAL / HORIZONTAL / null
+        double gap;
+        final List<Node> children = new ArrayList<>();
+    }
+
+    private static final class Extracted {
+        int nodeCount;
+        final Map<String, Integer> colorCounts = new LinkedHashMap<>();
+        final List<Double> fontSizes = new ArrayList<>();
+        final List<Double> spacings = new ArrayList<>();
+        Integer dominantBackground;
+        final List<Node> namedComponents = new ArrayList<>();
+    }
+
+    private static void collect(Node n, Extracted ex) {
+        ex.nodeCount++;
+        if (n.fill != null) {
+            String hex = hex(n.fill);
+            ex.colorCounts.merge(hex, 1, Integer::sum);
+        }
+        if (n.stroke != null) {
+            ex.colorCounts.merge(hex(n.stroke), 1, Integer::sum);
+        }
+        if (n.fontSize != null && n.fontSize > 0 && !ex.fontSizes.contains(n.fontSize)) {
+            ex.fontSizes.add(n.fontSize);
+        }
+        if (n.gap > 0 && !ex.spacings.contains(n.gap)) {
+            ex.spacings.add(n.gap);
+        }
+        // A large filled rectangle that contains other layers is a likely background.
+        if (n.fill != null && n.hasFrame && n.w * n.h > 100000 && !n.children.isEmpty()) {
+            ex.dominantBackground = n.fill;
+        }
+        if (isComponentName(n.name) && (n.fill != null || n.text != null)) {
+            ex.namedComponents.add(n);
+        }
+        for (Node c : n.children) {
+            collect(c, ex);
+        }
+        Collections.sort(ex.fontSizes);
+        Collections.sort(ex.spacings);
+    }
+
+    private static boolean isComponentName(String name) {
+        if (name == null || name.isEmpty()) return false;
+        // Skip Sketch/Figma symbol-path names and auto-generated names.
+        if (name.contains("/")) return false;
+        String l = name.toLowerCase(Locale.US);
+        return !l.equals("rectangle") && !l.equals("group") && !l.equals("frame")
+                && !l.startsWith("vector") && !l.startsWith("ellipse") && !l.startsWith("line");
+    }
+
+    // ===================================================================
+    // Figma
+    // ===================================================================
+
+    @SuppressWarnings("unchecked")
+    private static Node parseFigma(String token, String fileKey, String nodeId)
+            throws IOException, InterruptedException {
+        String url = nodeId == null
+                ? "https://api.figma.com/v1/files/" + fileKey
+                : "https://api.figma.com/v1/files/" + fileKey + "/nodes?ids=" + enc(nodeId);
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest req = HttpRequest.newBuilder(URI.create(url))
+                .header("X-Figma-Token", token)
+                .GET()
+                .build();
+        HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+        if (resp.statusCode() != 200) {
+            throw new IOException("Figma API returned HTTP " + resp.statusCode()
+                    + ": " + truncate(resp.body(), 300));
+        }
+        Object json = Json.parse(resp.body());
+        Map<String, Object> top = asMap(json);
+        Object document;
+        if (nodeId == null) {
+            document = top.get("document");
+        } else {
+            Map<String, Object> nodes = asMap(top.get("nodes"));
+            Map<String, Object> first = nodes.isEmpty() ? null
+                    : asMap(nodes.values().iterator().next());
+            document = first == null ? null : first.get("document");
+        }
+        Node root = new Node();
+        root.name = stringOr(top.get("name"), "Figma");
+        root.type = "DOCUMENT";
+        if (document != null) {
+            root.children.add(figmaNode(asMap(document)));
+        }
+        return root;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Node figmaNode(Map<String, Object> m) {
+        Node n = new Node();
+        n.name = stringOr(m.get("name"), "");
+        n.type = stringOr(m.get("type"), "");
+
+        Map<String, Object> box = asMap(m.get("absoluteBoundingBox"));
+        if (!box.isEmpty()) {
+            n.x = num(box.get("x"));
+            n.y = num(box.get("y"));
+            n.w = num(box.get("width"));
+            n.h = num(box.get("height"));
+            n.hasFrame = true;
+        }
+        n.cornerRadius = num(m.get("cornerRadius"));
+
+        List<Object> fills = asList(m.get("fills"));
+        for (Object f : fills) {
+            Map<String, Object> fill = asMap(f);
+            if ("SOLID".equals(fill.get("type")) && enabled(fill)) {
+                n.fill = figmaColor(asMap(fill.get("color")));
+                break;
+            }
+        }
+        List<Object> strokes = asList(m.get("strokes"));
+        for (Object s : strokes) {
+            Map<String, Object> st = asMap(s);
+            if ("SOLID".equals(st.get("type"))) {
+                n.stroke = figmaColor(asMap(st.get("color")));
+                break;
+            }
+        }
+
+        if ("TEXT".equals(n.type)) {
+            n.text = stringOr(m.get("characters"), null);
+            Map<String, Object> style = asMap(m.get("style"));
+            n.fontFamily = stringOr(style.get("fontFamily"), null);
+            double fs = num(style.get("fontSize"));
+            if (fs > 0) n.fontSize = fs;
+        }
+
+        String lm = stringOr(m.get("layoutMode"), null);
+        if ("VERTICAL".equals(lm) || "HORIZONTAL".equals(lm)) {
+            n.layoutMode = lm;
+            n.gap = num(m.get("itemSpacing"));
+        }
+
+        for (Object c : asList(m.get("children"))) {
+            n.children.add(figmaNode(asMap(c)));
+        }
+        return n;
+    }
+
+    private static boolean enabled(Map<String, Object> fill) {
+        Object v = fill.get("visible");
+        return !(v instanceof Boolean) || (Boolean) v;
+    }
+
+    private static Integer figmaColor(Map<String, Object> c) {
+        if (c.isEmpty()) return null;
+        return rgb(num(c.get("r")), num(c.get("g")), num(c.get("b")), true);
+    }
+
+    // ===================================================================
+    // Sketch (.sketch is a ZIP of JSON)
+    // ===================================================================
+
+    private static Node parseSketch(Path file) throws IOException {
+        Node root = new Node();
+        root.name = "Sketch";
+        root.type = "DOCUMENT";
+        try (ZipFile zip = new ZipFile(file.toFile())) {
+            var entries = zip.entries();
+            List<String> pageEntries = new ArrayList<>();
+            while (entries.hasMoreElements()) {
+                ZipEntry e = entries.nextElement();
+                if (e.getName().startsWith("pages/") && e.getName().endsWith(".json")) {
+                    pageEntries.add(e.getName());
+                }
+            }
+            Collections.sort(pageEntries);
+            for (String name : pageEntries) {
+                ZipEntry e = zip.getEntry(name);
+                try (InputStream in = zip.getInputStream(e)) {
+                    Object json = Json.parse(new String(in.readAllBytes(), StandardCharsets.UTF_8));
+                    root.children.add(sketchLayer(asMap(json)));
+                }
+            }
+        }
+        return root;
+    }
+
+    private static Node sketchLayer(Map<String, Object> m) {
+        Node n = new Node();
+        n.name = stringOr(m.get("name"), "");
+        n.type = stringOr(m.get("_class"), "");
+
+        Map<String, Object> frame = asMap(m.get("frame"));
+        if (!frame.isEmpty()) {
+            n.x = num(frame.get("x"));
+            n.y = num(frame.get("y"));
+            n.w = num(frame.get("width"));
+            n.h = num(frame.get("height"));
+            n.hasFrame = true;
+        }
+        n.cornerRadius = num(m.get("fixedRadius"));
+
+        Map<String, Object> style = asMap(m.get("style"));
+        for (Object f : asList(style.get("fills"))) {
+            Map<String, Object> fill = asMap(f);
+            Object on = fill.get("isEnabled");
+            if (on instanceof Boolean && !((Boolean) on)) continue;
+            n.fill = sketchColor(asMap(fill.get("color")));
+            if (n.fill != null) break;
+        }
+        for (Object b : asList(style.get("borders"))) {
+            Map<String, Object> border = asMap(b);
+            n.stroke = sketchColor(asMap(border.get("color")));
+            if (n.stroke != null) break;
+        }
+
+        if ("text".equals(n.type)) {
+            Map<String, Object> attr = asMap(m.get("attributedString"));
+            n.text = stringOr(attr.get("string"), null);
+            Map<String, Object> textStyle = asMap(asMap(style.get("textStyle"))
+                    .getOrDefault("encodedAttributes", Collections.emptyMap()));
+            double fs = num(asMap(textStyle.get("MSAttributedStringFontAttribute")).get("size"));
+            if (fs == 0) {
+                // Newer Sketch nests the size under attributes.font / a number directly.
+                fs = num(textStyle.get("size"));
+            }
+            if (fs > 0) n.fontSize = fs;
+        }
+
+        for (Object c : asList(m.get("layers"))) {
+            n.children.add(sketchLayer(asMap(c)));
+        }
+        return n;
+    }
+
+    private static Integer sketchColor(Map<String, Object> c) {
+        if (c.isEmpty()) return null;
+        return rgb(num(c.get("red")), num(c.get("green")), num(c.get("blue")), true);
+    }
+
+    // ===================================================================
+    // Adobe XD (.xd is a ZIP; artboards live in graphicContent.agc JSON)
+    // ===================================================================
+
+    private static Node parseXd(Path file) throws IOException {
+        Node root = new Node();
+        root.name = "AdobeXD";
+        root.type = "DOCUMENT";
+        try (ZipFile zip = new ZipFile(file.toFile())) {
+            var entries = zip.entries();
+            List<String> agc = new ArrayList<>();
+            while (entries.hasMoreElements()) {
+                ZipEntry e = entries.nextElement();
+                if (e.getName().endsWith("graphicContent.agc")) {
+                    agc.add(e.getName());
+                }
+            }
+            Collections.sort(agc);
+            for (String name : agc) {
+                ZipEntry e = zip.getEntry(name);
+                try (InputStream in = zip.getInputStream(e)) {
+                    Object json = Json.parse(new String(in.readAllBytes(), StandardCharsets.UTF_8));
+                    Map<String, Object> m = asMap(json);
+                    Map<String, Object> artboard = asMap(m.get("artboard"));
+                    Object children = artboard.isEmpty() ? m.get("children") : artboard.get("children");
+                    Node board = new Node();
+                    board.name = name;
+                    board.type = "artboard";
+                    for (Object c : asList(children)) {
+                        board.children.add(xdNode(asMap(c)));
+                    }
+                    root.children.add(board);
+                }
+            }
+        }
+        return root;
+    }
+
+    private static Node xdNode(Map<String, Object> m) {
+        Node n = new Node();
+        n.name = stringOr(m.get("name"), "");
+        n.type = stringOr(m.get("type"), "");
+
+        Map<String, Object> transform = asMap(m.get("transform"));
+        Map<String, Object> shape = asMap(m.get("shape"));
+        if (!shape.isEmpty()) {
+            n.w = num(shape.get("width"));
+            n.h = num(shape.get("height"));
+            n.x = num(transform.get("tx"));
+            n.y = num(transform.get("ty"));
+            n.hasFrame = n.w > 0 || n.h > 0;
+            n.cornerRadius = num(shape.get("r"));
+        }
+
+        Map<String, Object> style = asMap(m.get("style"));
+        Map<String, Object> fill = asMap(style.get("fill"));
+        if (!fill.isEmpty()) {
+            n.fill = xdColor(asMap(fill.get("color")));
+        }
+        Map<String, Object> stroke = asMap(style.get("stroke"));
+        if (!stroke.isEmpty()) {
+            n.stroke = xdColor(asMap(stroke.get("color")));
+        }
+
+        Map<String, Object> text = asMap(m.get("text"));
+        if (!text.isEmpty()) {
+            n.text = stringOr(text.get("rawText"), null);
+            Map<String, Object> font = asMap(asMap(style.get("font")).isEmpty()
+                    ? text.get("font") : style.get("font"));
+            double fs = num(font.get("size"));
+            if (fs > 0) n.fontSize = fs;
+            n.fontFamily = stringOr(font.get("postscriptName"), stringOr(font.get("family"), null));
+        }
+
+        for (Object c : asList(m.get("children"))) {
+            n.children.add(xdNode(asMap(c)));
+        }
+        return n;
+    }
+
+    private static Integer xdColor(Map<String, Object> c) {
+        if (c.isEmpty()) return null;
+        Map<String, Object> v = asMap(c.get("value"));
+        if (v.isEmpty()) return null;
+        return rgb(num(v.get("r")), num(v.get("g")), num(v.get("b")), false);
+    }
+
+    // ===================================================================
+    // Output rendering
+    // ===================================================================
+
+    private static String renderTokens(Extracted ex) {
+        List<Map.Entry<String, Integer>> colors = new ArrayList<>(ex.colorCounts.entrySet());
+        colors.sort((a, b) -> b.getValue() - a.getValue());
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\n  \"colors\": [\n");
+        for (int i = 0; i < colors.size(); i++) {
+            Map.Entry<String, Integer> e = colors.get(i);
+            sb.append("    {\"hex\": \"").append(e.getKey())
+              .append("\", \"count\": ").append(e.getValue()).append("}");
+            sb.append(i < colors.size() - 1 ? ",\n" : "\n");
+        }
+        sb.append("  ],\n  \"fontSizesPx\": ").append(numberList(ex.fontSizes)).append(",\n");
+        sb.append("  \"spacingPx\": ").append(numberList(ex.spacings)).append("\n}\n");
+        return sb.toString();
+    }
+
+    private static String renderCss(Extracted ex, double pxPerMm, String label) {
+        List<Map.Entry<String, Integer>> colors = new ArrayList<>(ex.colorCounts.entrySet());
+        colors.sort((a, b) -> b.getValue() - a.getValue());
+        String bg = ex.dominantBackground != null ? hex(ex.dominantBackground)
+                : (colors.isEmpty() ? "#ffffff" : colors.get(0).getKey());
+        String accent = colors.size() > 1 ? colors.get(1).getKey()
+                : (colors.isEmpty() ? "#1d4ed8" : colors.get(0).getKey());
+        String onAccent = contrastColor(accent);
+        double bodyPx = ex.fontSizes.isEmpty() ? 0 : median(ex.fontSizes);
+        double titlePx = ex.fontSizes.isEmpty() ? 0 : ex.fontSizes.get(ex.fontSizes.size() - 1);
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("/*\n * STARTER theme.css generated by tools/DesignImport.java from ")
+          .append(label).append(".\n")
+          .append(" * Colors are extracted by frequency; sizes converted at ")
+          .append(trim(pxPerMm)).append(" px/mm.\n")
+          .append(" * This is a starting point - refine it, validate with tools/IsCssValid.java,\n")
+          .append(" * and measure convergence with tools/CompareToMockup.java.\n */\n\n");
+
+        sb.append("Form {\n    background-color: ").append(bg).append(";\n}\n\n");
+
+        sb.append("Title {\n    color: ").append(contrastColor(bg)).append(";\n");
+        if (titlePx > 0) sb.append("    font-size: ").append(mm(titlePx, pxPerMm)).append(";\n");
+        sb.append("}\n\n");
+
+        sb.append("Label {\n    color: ").append(contrastColor(bg)).append(";\n");
+        if (bodyPx > 0) sb.append("    font-size: ").append(mm(bodyPx, pxPerMm)).append(";\n");
+        sb.append("}\n\n");
+
+        sb.append("Button {\n    background-color: ").append(accent).append(";\n")
+          .append("    color: ").append(onAccent).append(";\n")
+          .append("    border-radius: 2mm;\n")
+          .append("    padding: 2mm 4mm;\n");
+        if (bodyPx > 0) sb.append("    font-size: ").append(mm(bodyPx, pxPerMm)).append(";\n");
+        sb.append("}\n");
+
+        int emitted = 0;
+        for (Node c : ex.namedComponents) {
+            if (emitted >= 24) break; // keep the starter readable
+            String uiid = toUiid(c.name);
+            if (uiid.isEmpty()) continue;
+            sb.append('\n').append(uiid).append(" {\n");
+            if (c.fill != null) {
+                sb.append("    background-color: ").append(hex(c.fill)).append(";\n");
+                sb.append("    color: ").append(contrastColor(c.fill)).append(";\n");
+            }
+            if (c.cornerRadius > 0) {
+                sb.append("    border-radius: ").append(mm(c.cornerRadius, pxPerMm)).append(";\n");
+            }
+            if (c.fontSize != null && c.fontSize > 0) {
+                sb.append("    font-size: ").append(mm(c.fontSize, pxPerMm)).append(";\n");
+            }
+            sb.append("}\n");
+            emitted++;
+        }
+        return sb.toString();
+    }
+
+    private static String renderLayout(Node root, Extracted ex, double pxPerMm, String label) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("# Layout map - ").append(label).append("\n\n");
+        sb.append("Generated by tools/DesignImport.java. Use this as the structure to build, then ")
+          .append("measure with tools/CompareToMockup.java.\n\n");
+        sb.append("Sizes are shown as `WxH px` (design pixels). Convert to CN1 `mm` at ")
+          .append(trim(pxPerMm)).append(" px/mm.\n\n");
+        sb.append("## Component tree\n\n```\n");
+        for (Node c : root.children) {
+            printTree(c, 0, sb);
+        }
+        sb.append("```\n\n");
+
+        sb.append("## Suggested CN1 layouts\n\n");
+        sb.append("| Design container layout | Codename One equivalent |\n");
+        sb.append("| --- | --- |\n");
+        sb.append("| Vertical auto-layout / stack | `BoxLayout.y()` |\n");
+        sb.append("| Horizontal auto-layout / row | `BoxLayout.x()` |\n");
+        sb.append("| Absolute / free positioning | `LayeredLayout` with percentage insets |\n");
+        sb.append("| Header / body / footer split | `BorderLayout` (NORTH/CENTER/SOUTH) |\n\n");
+
+        List<String> texts = new ArrayList<>();
+        collectText(root, texts);
+        if (!texts.isEmpty()) {
+            sb.append("## Text strings\n\n");
+            for (String t : texts) {
+                sb.append("- ").append(t.replace("\n", " ")).append('\n');
+            }
+        }
+        return sb.toString();
+    }
+
+    private static void printTree(Node n, int depth, StringBuilder sb) {
+        for (int i = 0; i < depth; i++) sb.append("  ");
+        sb.append(n.name.isEmpty() ? "(" + n.type + ")" : n.name);
+        if (!n.type.isEmpty()) sb.append(" [").append(n.type).append(']');
+        if (n.hasFrame) {
+            sb.append("  ").append(Math.round(n.w)).append('x').append(Math.round(n.h)).append("px");
+        }
+        if (n.fill != null) sb.append("  fill=").append(hex(n.fill));
+        if (n.layoutMode != null) sb.append("  layout=").append(n.layoutMode);
+        if (n.text != null) sb.append("  text=\"").append(truncate(n.text.replace("\n", " "), 40)).append('"');
+        sb.append('\n');
+        for (Node c : n.children) {
+            printTree(c, depth + 1, sb);
+        }
+    }
+
+    private static void collectText(Node n, List<String> out) {
+        if (n.text != null && !n.text.isBlank()) out.add(n.text);
+        for (Node c : n.children) collectText(c, out);
+    }
+
+    // ===================================================================
+    // Helpers
+    // ===================================================================
+
+    /// Builds a 0xRRGGBB int from channel values. floatScale=true means the
+    /// inputs are 0..1 (Figma/Sketch); false means they may already be 0..255 (XD),
+    /// although XD sometimes uses 0..1 too, so we detect.
+    private static Integer rgb(double r, double g, double b, boolean floatScale) {
+        boolean looksFloat = floatScale || (r <= 1.0 && g <= 1.0 && b <= 1.0);
+        int ri = clampByte(looksFloat ? r * 255.0 : r);
+        int gi = clampByte(looksFloat ? g * 255.0 : g);
+        int bi = clampByte(looksFloat ? b * 255.0 : b);
+        return (ri << 16) | (gi << 8) | bi;
+    }
+
+    private static int clampByte(double v) {
+        return (int) Math.round(Math.max(0, Math.min(255, v)));
+    }
+
+    private static String hex(int rgb) {
+        return String.format("#%06x", rgb & 0xffffff);
+    }
+
+    /// Chooses black or white text for readability against a background color.
+    private static String contrastColor(int rgb) {
+        int r = (rgb >> 16) & 0xff;
+        int g = (rgb >> 8) & 0xff;
+        int b = rgb & 0xff;
+        double lum = 0.299 * r + 0.587 * g + 0.114 * b;
+        return lum > 140 ? "#000000" : "#ffffff";
+    }
+
+    private static String contrastColor(String hex) {
+        return contrastColor(Integer.parseInt(hex.substring(1), 16));
+    }
+
+    private static String mm(double px, double pxPerMm) {
+        double v = px / pxPerMm;
+        return trim(Math.round(v * 10.0) / 10.0) + "mm /* " + trim(px) + "px */";
+    }
+
+    private static String toUiid(String name) {
+        StringBuilder sb = new StringBuilder();
+        boolean upper = true;
+        for (int i = 0; i < name.length(); i++) {
+            char ch = name.charAt(i);
+            if (Character.isLetterOrDigit(ch)) {
+                sb.append(upper ? Character.toUpperCase(ch) : ch);
+                upper = false;
+            } else {
+                upper = true;
+            }
+        }
+        String s = sb.toString();
+        if (!s.isEmpty() && Character.isDigit(s.charAt(0))) s = "C" + s;
+        return s;
+    }
+
+    private static double median(List<Double> sorted) {
+        if (sorted.isEmpty()) return 0;
+        return sorted.get(sorted.size() / 2);
+    }
+
+    private static String numberList(List<Double> values) {
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < values.size(); i++) {
+            sb.append(trim(values.get(i)));
+            if (i < values.size() - 1) sb.append(", ");
+        }
+        return sb.append("]").toString();
+    }
+
+    private static String trim(double v) {
+        if (v == Math.rint(v)) return Long.toString((long) v);
+        return String.valueOf(v);
+    }
+
+    private static String truncate(String s, int max) {
+        if (s == null) return "";
+        return s.length() <= max ? s : s.substring(0, max) + "...";
+    }
+
+    private static String enc(String s) {
+        return java.net.URLEncoder.encode(s, StandardCharsets.UTF_8);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> asMap(Object o) {
+        return o instanceof Map ? (Map<String, Object>) o : Collections.emptyMap();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Object> asList(Object o) {
+        return o instanceof List ? (List<Object>) o : Collections.emptyList();
+    }
+
+    private static double num(Object o) {
+        return o instanceof Number ? ((Number) o).doubleValue() : 0.0;
+    }
+
+    private static String stringOr(Object o, String dflt) {
+        return o instanceof String ? (String) o : dflt;
+    }
+
+    // ===================================================================
+    // Minimal dependency-free JSON parser
+    // ===================================================================
+
+    private static final class Json {
+        private final String s;
+        private int i;
+
+        private Json(String s) { this.s = s; }
+
+        static Object parse(String text) throws IOException {
+            Json j = new Json(text);
+            j.ws();
+            Object v = j.value();
+            j.ws();
+            if (j.i < j.s.length()) {
+                throw new IOException("Trailing JSON content at offset " + j.i);
+            }
+            return v;
+        }
+
+        private Object value() throws IOException {
+            char c = peek();
+            switch (c) {
+                case '{': return object();
+                case '[': return array();
+                case '"': return string();
+                case 't': case 'f': return bool();
+                case 'n': literal("null"); return null;
+                default:  return number();
+            }
+        }
+
+        private Map<String, Object> object() throws IOException {
+            Map<String, Object> m = new LinkedHashMap<>();
+            expect('{');
+            ws();
+            if (peek() == '}') { i++; return m; }
+            while (true) {
+                ws();
+                String key = string();
+                ws();
+                expect(':');
+                ws();
+                m.put(key, value());
+                ws();
+                char c = next();
+                if (c == '}') break;
+                if (c != ',') throw err("expected , or } in object");
+            }
+            return m;
+        }
+
+        private List<Object> array() throws IOException {
+            List<Object> list = new ArrayList<>();
+            expect('[');
+            ws();
+            if (peek() == ']') { i++; return list; }
+            while (true) {
+                ws();
+                list.add(value());
+                ws();
+                char c = next();
+                if (c == ']') break;
+                if (c != ',') throw err("expected , or ] in array");
+            }
+            return list;
+        }
+
+        private String string() throws IOException {
+            expect('"');
+            StringBuilder sb = new StringBuilder();
+            while (true) {
+                char c = next();
+                if (c == '"') break;
+                if (c == '\\') {
+                    char e = next();
+                    switch (e) {
+                        case '"': sb.append('"'); break;
+                        case '\\': sb.append('\\'); break;
+                        case '/': sb.append('/'); break;
+                        case 'b': sb.append('\b'); break;
+                        case 'f': sb.append('\f'); break;
+                        case 'n': sb.append('\n'); break;
+                        case 'r': sb.append('\r'); break;
+                        case 't': sb.append('\t'); break;
+                        case 'u':
+                            sb.append((char) Integer.parseInt(s.substring(i, i + 4), 16));
+                            i += 4;
+                            break;
+                        default: throw err("bad escape \\" + e);
+                    }
+                } else {
+                    sb.append(c);
+                }
+            }
+            return sb.toString();
+        }
+
+        private Object number() throws IOException {
+            int start = i;
+            while (i < s.length() && "+-0123456789.eE".indexOf(s.charAt(i)) >= 0) i++;
+            String n = s.substring(start, i);
+            if (n.isEmpty()) throw err("unexpected character '" + peek() + "'");
+            return Double.parseDouble(n);
+        }
+
+        private Boolean bool() throws IOException {
+            if (peek() == 't') { literal("true"); return Boolean.TRUE; }
+            literal("false");
+            return Boolean.FALSE;
+        }
+
+        private void literal(String lit) throws IOException {
+            if (!s.startsWith(lit, i)) throw err("expected '" + lit + "'");
+            i += lit.length();
+        }
+
+        private void ws() {
+            while (i < s.length()) {
+                char c = s.charAt(i);
+                if (c == ' ' || c == '\t' || c == '\n' || c == '\r') i++;
+                else break;
+            }
+        }
+
+        private char peek() throws IOException {
+            if (i >= s.length()) throw err("unexpected end of JSON");
+            return s.charAt(i);
+        }
+
+        private char next() throws IOException {
+            if (i >= s.length()) throw err("unexpected end of JSON");
+            return s.charAt(i++);
+        }
+
+        private void expect(char c) throws IOException {
+            if (next() != c) throw err("expected '" + c + "'");
+        }
+
+        private IOException err(String msg) {
+            return new IOException("JSON parse error at offset " + i + ": " + msg);
+        }
+    }
+}

--- a/scripts/initializr/common/src/main/resources/skill/tools/README.md
+++ b/scripts/initializr/common/src/main/resources/skill/tools/README.md
@@ -44,6 +44,45 @@ The tool loads the latest `codenameone-core` jar from `~/.m2` and invokes the co
 
 This is **not** a substitute for running the simulator and looking at the result; it catches CSS *syntax* errors and unsupported properties, but a syntactically-valid file that styles the wrong UIID will still pass. Use it as a fast pre-flight before `mvn -pl common cn1:run`.
 
+### `CompareToMockup.java`
+
+Scores how closely a rendered screen matches a designer mockup and prints a similarity percentage.
+Reports two numbers: `STRUCTURAL` (an SSIM-style perceptual score — the headline) and `PIXEL` (the
+fraction of pixels within the framework's channel-delta tolerance). The render is auto-resized to
+the mockup's dimensions first. Pure JDK — it does **not** need the CN1 jars in `~/.m2`.
+
+```bash
+java tools/CompareToMockup.java render.png mockup.png
+# STRUCTURAL 0.912  PIXEL 0.874   (compared ... )
+
+# Partial mode — mask device chrome the mockup includes but you don't render:
+java tools/CompareToMockup.java render.png mockup.png --ignore-top 8% --diff diff.png
+java tools/CompareToMockup.java render.png mockup.png --region 24,120,327,180
+```
+
+Options: `--region X,Y,W,H`, `--ignore X,Y,W,H` (repeatable), `--ignore-top N[%]`,
+`--ignore-bottom N[%]`, `--resize fit|none`, `--diff out.png`, `--min 0..1` (exit 1 if structural
+score is below it), `--json`. Exit codes: `0` compared (and above `--min`), `1` below `--min`,
+`2` usage/IO error. See `references/mockup-comparison.md` for the full loop.
+
+### `DesignImport.java`
+
+Parses a Figma / Sketch / Adobe XD design into a **starter** CN1 style: `theme.css`, `tokens.json`,
+and `layout.md`. Fully self-contained (embedded JSON parser, JDK only); Figma mode needs a token +
+network, the local formats need neither.
+
+```bash
+# Local ZIP+JSON formats
+java tools/DesignImport.java design.sketch --out target/design-import
+java tools/DesignImport.java design.xd     --out target/design-import
+# Figma over its REST API
+java tools/DesignImport.java figma --token "$FIGMA_TOKEN" --file FILE_KEY --out target/design-import
+```
+
+The output is a starting point — refine it, validate the CSS with `java tools/IsCssValid.java
+target/design-import/theme.css`, and measure convergence with `CompareToMockup.java`. Exit codes:
+`0` imported, `1` nothing recognisable found, `2` usage/IO/network error.
+
 ## Adding more tools
 
 The pattern is intentionally minimal — drop a new `.java` file into this directory and document it in this README. Constraints:


### PR DESCRIPTION
## Why

A common task developers hand an AI agent is *"build this screen to match this designer mockup."* Until now the agent had to eyeball the result with computer vision — there was no deterministic measure of *how close* the render was to the target, so it couldn't converge reliably. The existing `screenshotTest` only compares a render to a baseline the system produced itself, which measures **consistency, not correctness**.

This adds a measurable mockup-comparison loop to the `codename-one` skill that ships inside generated apps (`.claude/skills/codename-one/`, source of truth under `scripts/initializr/common/src/main/resources/skill/`, copied in by `maven/cn1app-archetype`).

## What

- **`tools/CompareToMockup.java`** — pure-JDK single-file CLI. Scores a rendered screenshot against a mockup image and prints a similarity %:
  - `STRUCTURAL` — SSIM-style perceptual score (the headline, robust to font/AA noise vs a vector mockup).
  - `PIXEL` — fraction of pixels within the framework's `<= 3` channel-delta "same pixel" rule (mirrors `TestUtils.imagesWithinTolerance`).
  - **Partial/region mode** so device chrome doesn't sabotage the score: `--region X,Y,W,H`, repeatable `--ignore X,Y,W,H`, `--ignore-top N[%]`, `--ignore-bottom N[%]`. Plus `--resize fit|none`, `--diff heatmap.png`, `--min` gate, `--json`.
- **`tools/DesignImport.java`** — self-contained CLI (embedded JSON parser, no deps). Parses **Figma** (REST API + token), **Sketch** (`.sketch`) and **Adobe XD** (`.xd`) into a *starter* `theme.css` + `tokens.json` + `layout.md`. (PSD is intentionally out of scope — flatten to PNG and use the comparison path.)
- **`templates/MockupComparisonTest.java`** — copy-paste `@CodenameOneTest` that renders a screen to `target/mockup-compare/<name>.png` for the comparison tool to read. Scoring lives only in the CLI tool (single metric definition).
- **`references/mockup-comparison.md`** + wiring in `SKILL.md`, `tools/README.md`, and `testing-and-screenshots.md` (distinguishes self-baseline regression from independent-reference correctness).

## Verification (local)

- `CompareToMockup`: identical PNGs → `1.000/1.000`; different-size render auto-resizes; shifted copy scores lower; `--ignore-top 10%` recovers the score when only the top band differs; `--region`, `--diff`, `--min` (exit 1), `--json`, and `--resize none` mismatch (exit 2) all behave.
- `DesignImport`: synthetic `.sketch` and `.xd` fixtures parse; emitted `theme.css` passes `java tools/IsCssValid.java`; `tokens.json` is valid JSON; `layout.md` lists frames/text. Figma shares the same parser/model.
- Archetype `process-resources` confirms all four new files package into `.claude/skills/codename-one/`.
- New `.java` tools are ASCII-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)