### PR TITLE
Fix two release-pipeline workflow failures (native-themes-sync + version-bump PR)

### DIFF
--- a/.github/workflows/initializr-cn1-version-pr.yml
+++ b/.github/workflows/initializr-cn1-version-pr.yml
@@ -21,6 +21,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # The Create-pull-request step below authenticates with a PAT
+          # (CN1SS_GH_TOKEN) that differs from the GITHUB_TOKEN checkout
+          # would otherwise persist as an http.extraheader. Two different
+          # credentials on the same remote make git emit two Authorization
+          # headers, which GitHub rejects with "Duplicate header:
+          # Authorization" / HTTP 400. Not persisting the checkout
+          # credential leaves only the PAT, so the push succeeds.
+          persist-credentials: false
 
       - name: Wait for developer-guide.pdf on the release
         env:
@@ -79,7 +88,7 @@ jobs:
         run: ./scripts/cn1playground/update-cn1-version.sh "${{ github.event.release.tag_name || github.ref_name }}"
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7
         with:
           # PRs created with the default GITHUB_TOKEN do not trigger pull_request
           # workflows (GitHub's anti-recursion rule), so the bump PR ships with no

--- a/.github/workflows/native-themes-sync.yml
+++ b/.github/workflows/native-themes-sync.yml
@@ -23,6 +23,11 @@ on:
 
 permissions:
   contents: write
+  # The job runs inside the private ghcr.io/codenameone pr-ci-container
+  # image; pulling it needs the GITHUB_TOKEN to carry packages:read.
+  # Declaring any permissions block resets every unlisted scope to none,
+  # so packages:read must be spelled out or the container pull is denied.
+  packages: read
 
 concurrency:
   group: native-themes-sync


### PR DESCRIPTION
The 7.0.248 release exposed two independent CI failures in the release pipeline. Both are fixed here so the next tag (7.0.249) runs cleanly.

## 1. `Native Themes Sync` — container pull denied
The run died in ~25s at container init:

```
docker pull ghcr.io/codenameone/codenameone/pr-ci-container:latest
Error response from daemon: denied
```

The job runs **inside** the private `pr-ci-container` GHCR image, so the auto ghcr.io login needs the `GITHUB_TOKEN` to carry `packages: read`. The workflow declared `permissions: { contents: write }`, and specifying *any* `permissions:` block resets every unlisted scope to `none` — silently dropping the implicit `packages: read`. Sibling container workflows (`pr.yml`, `identity-stack.yml`) spell it out; this one didn't.

**Fix:** add `packages: read` to the permissions block.

## 2. `Website CN1 Version PR` — duplicate Authorization header
The PR-creation step died with:

```
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/codenameone/CodenameOne/': The requested URL returned error: 400
```

`actions/checkout@v6` defaults to `persist-credentials: true`, persisting the `GITHUB_TOKEN` as an `http.https://github.com/.extraheader`. `peter-evans/create-pull-request` then runs with a **different** token (`CN1SS_GH_TOKEN`, used so the bump PR triggers downstream CI) and adds its **own** extraheader — so git emits two `Authorization` headers and GitHub returns 400. The workflow file is unchanged since 7.0.247 (which passed); a runner-side git/checkout update made git strict about the always-latent duplicate.

**Fix:** set `persist-credentials: false` on checkout (the action's documented fix for this error — only the PAT header remains), and bump `create-pull-request@v6 → @v7` to match the repo's other two PR workflows and clear the Node 20 deprecation warning.

## Not a bug
`codenameone-maven-plugin 7.0.248` briefly 404'd on Maven Central — just slow Sonatype → repo1 propagation (cleared after ~44 retries). The Maven Central release itself succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)