### PR TITLE
Fix native-themes-sync commit-back: mark workspace safe.directory

### DIFF
--- a/.github/workflows/native-themes-sync.yml
+++ b/.github/workflows/native-themes-sync.yml
@@ -70,6 +70,13 @@ jobs:
       - name: Commit and push regenerated .res files
         run: |
           set -euo pipefail
+          # This job runs inside the pr-ci-container, where the checked-out
+          # tree is owned by a different UID than this shell step's user.
+          # git's dubious-ownership guard then rejects every command with
+          # "fatal: not in a git directory". actions/checkout writes a
+          # safe.directory entry, but into the action's HOME, which this
+          # bash step doesn't share -- so mark the workspace safe here too.
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           # Themes/ holds the single source of truth. Each downstream consumer


### PR DESCRIPTION
Follow-up to #5172. That PR's `packages: read` fix unblocked the container pull in `Native Themes Sync`, so the **`Commit and push regenerated .res files`** step ran for the first time ever — and immediately failed (exit 128):

```
fatal: not in a git directory
```

## Root cause
The job runs **inside** the `pr-ci-container`. The checked-out tree is owned by a different UID than the user executing the `run:` shell step, so git's dubious-ownership guard rejects every command. `actions/checkout` does write a `safe.directory` entry, but into the *action's* HOME, which the raw bash step doesn't share — so the guard still fires in the commit step.

This step had never executed before: prior to #5172 the job always died earlier at the container pull, so this was latent from day one.

## Fix
Add the workspace to `safe.directory` at the top of the commit step, before the `git config`/`commit`/`push` calls:

```bash
git config --global --add safe.directory "$GITHUB_WORKSPACE"
```

## Effect
This PR touches `native-themes-sync.yml`, which is in the workflow's own trigger `paths:`, so merging it re-fires the sync. It should now run end-to-end and commit the regenerated `Themes/*.res` files (stale since #5170 changed the theme CSS but the sync never managed to commit). Self-healing once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)