### PR TITLE
ci(cn1ss): fail when stored references produce no screenshot (mid-run hang)

### DIFF
--- a/scripts/lib/cn1ss.sh
+++ b/scripts/lib/cn1ss.sh
@@ -436,6 +436,38 @@ cn1ss_process_and_report() {
         return 17
       fi
       cn1ss_log "Missing-screenshot check passed: $missing_count missing <= $allowed_missing tolerated."
+
+      # Reference-coverage guard. The missing_actual check above only sees tests
+      # the runner *registered* an actual for. When the suite hangs and the app
+      # is killed (SIGTERM), the remaining tests are never registered at all, so
+      # they are invisible to that check -- which is exactly how the Metal suite
+      # reported "72/72 matched" while 51 of its 123 stored references never
+      # produced an image. Compare directly against the reference dir: every
+      # golden must have a corresponding actual. Tolerance reuses
+      # CN1SS_ALLOWED_MISSING (e.g. the iOS jobs allow 2 for OrientationLock +
+      # MutableImageReadback, which never render on either backend).
+      local ref_total=0 refs_without_actual=0 uncaptured=""
+      local ref_png ref_name a_name found
+      for ref_png in "$ref_dir"/*.png; do
+        [ -e "$ref_png" ] || continue
+        ref_total=$((ref_total + 1))
+        ref_name="$(basename "$ref_png" .png)"
+        found=0
+        for entry in "${actual_entries[@]}"; do
+          a_name="${entry%%=*}"
+          if [ "$a_name" = "$ref_name" ]; then found=1; break; fi
+        done
+        if [ "$found" -eq 0 ]; then
+          refs_without_actual=$((refs_without_actual + 1))
+          uncaptured="$uncaptured $ref_name"
+        fi
+      done
+      if [ "$refs_without_actual" -gt "$allowed_missing" ]; then
+        cn1ss_log "FATAL: $refs_without_actual of $ref_total stored reference(s) produced NO screenshot at all (only $allowed_missing tolerated)."
+        cn1ss_log "       The suite almost certainly hung or was killed before finishing -- these references were never captured:${uncaptured}"
+        return 17
+      fi
+      cn1ss_log "Reference-coverage check passed: $refs_without_actual of $ref_total reference(s) uncaptured <= $allowed_missing tolerated."
     fi
   fi
 


### PR DESCRIPTION
## Problem

The strict screenshot guard (`CN1SS_FAIL_ON_MISMATCH=1`) is supposed to fail when the suite produces fewer screenshots than there are stored references. In practice it only counted **`missing_actual`** entries in the comparison JSON — and those exist only for tests the runner *registered* an actual for.

When a suite **hangs and the app is killed mid-run** (SIGTERM), the remaining tests are never registered at all, so they're invisible to that check. The comparison only sees the actuals that were produced, all of which match, and the job reports green.

### Concrete failure this fixes
On the iOS **Metal** suite, the run hangs on `ChartRotatedScreenshotTest`, the app is terminated, and the ~51 tests after it are dropped. The job reported:

```
Compared 72 screenshots: 72 matched.
Missing-screenshot check passed: 0 missing <= 0 tolerated.
✅ Native iOS Metal screenshot tests passed.
```

…while the Metal golden set has **123** images. master captures all 123; a hang silently drops to 72 and still passes.

## Fix

Add a **reference-coverage guard**: every PNG in the reference dir must have a corresponding produced actual. References with no actual beyond `CN1SS_ALLOWED_MISSING` fail with exit `17` (the code/intent the surrounding comment already documented). Tolerance reuses `CN1SS_ALLOWED_MISSING` (e.g. iOS allows 2 for OrientationLock + MutableImageReadback); bypass with `CN1SS_SKIP_COUNT_CHECK=1` when intentionally seeding a new baseline.

Bash-3.2-safe (no associative arrays) for the macOS runners; `bash -n` clean and unit-tested locally.

## Effect
This will make any suite that hangs/crashes partway **fail loudly** instead of reporting a partial green. Expect it to immediately surface the existing Metal `ChartRotatedScreenshotTest` hang (tracked separately) rather than hide it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)