### PR TITLE
Fix javadoc website build: only CLDC packages were being generated

### DIFF
--- a/.github/scripts/build_javadocs.sh
+++ b/.github/scripts/build_javadocs.sh
@@ -57,19 +57,35 @@ public class ImplementationFactory {
 }
 EOF
 
-find "$CN1_DIR/build/tempJavaSources" "$ROOT_DIR/Ports/CLDC11/src" -name "*.java" \
-  | /usr/bin/xargs "$JAVADOC_CMD" \
-    --allow-script-in-comments \
-    --add-stylesheet "$ROOT_DIR/maven/javadoc-resources/highlight.css" \
-    --add-script "$ROOT_DIR/maven/javadoc-resources/highlight.min.js" \
-    --add-script "$ROOT_DIR/maven/javadoc-resources/javadoc-highlight-init.js" \
-    --release 8 \
-    -exclude com.codename1.impl \
-    -Xdoclint:none \
-    -quiet \
-    -protected \
-    -d "$CN1_DIR/dist/javadoc" \
-    -windowtitle "Codename One API" || true
+# Collect every source file into a javadoc @argfile and run javadoc exactly
+# once. Piping the list through `xargs javadoc -d <dir>` is unsafe: once the
+# command line exceeds the shell/xargs limit (~128 KiB on GNU xargs) the list is
+# split across multiple javadoc invocations, each regenerating the same output
+# directory. The last batch (the Ports/CLDC11 java.* sources) then clobbers the
+# full API docs, leaving only the CLDC packages. An @argfile has no length limit.
+SOURCES_ARGFILE="$CN1_DIR/build/javadoc-sources.txt"
+find "$CN1_DIR/build/tempJavaSources" "$ROOT_DIR/Ports/CLDC11/src" -name "*.java" > "$SOURCES_ARGFILE"
+
+"$JAVADOC_CMD" \
+  --allow-script-in-comments \
+  --add-stylesheet "$ROOT_DIR/maven/javadoc-resources/highlight.css" \
+  --add-script "$ROOT_DIR/maven/javadoc-resources/highlight.min.js" \
+  --add-script "$ROOT_DIR/maven/javadoc-resources/javadoc-highlight-init.js" \
+  --release 8 \
+  -exclude com.codename1.impl \
+  -Xdoclint:none \
+  -quiet \
+  -protected \
+  -d "$CN1_DIR/dist/javadoc" \
+  -windowtitle "Codename One API" \
+  "@$SOURCES_ARGFILE" || true
+
+# Fail loudly if the core API failed to generate. Without this guard a partial
+# build (e.g. only the CLDC java.* packages) ships silently to the website.
+if [ ! -f "$CN1_DIR/dist/javadoc/com/codename1/ui/Component.html" ]; then
+  echo "JavaDoc generation produced no core com.codename1.ui output; aborting." >&2
+  exit 1
+fi
 
 (
   cd "$CN1_DIR/dist/javadoc"

--- a/.github/workflows/website-docs.yml
+++ b/.github/workflows/website-docs.yml
@@ -20,6 +20,9 @@ on:
       - 'vm/ByteCodeTranslator/**'
       - 'vm/JavaAPI/**'
       - 'CodenameOne/src/**'
+      # The Hugo build embeds JavaDocs produced by this script, so a change
+      # to how the docs are generated must redeploy the website too.
+      - '.github/scripts/build_javadocs.sh'
       - '.github/workflows/website-docs.yml'
   push:
     branches: [main, master]
@@ -34,6 +37,9 @@ on:
       - 'vm/ByteCodeTranslator/**'
       - 'vm/JavaAPI/**'
       - 'CodenameOne/src/**'
+      # The Hugo build embeds JavaDocs produced by this script, so a change
+      # to how the docs are generated must redeploy the website too.
+      - '.github/scripts/build_javadocs.sh'
       - '.github/workflows/website-docs.yml'
   workflow_dispatch:
 


### PR DESCRIPTION
## Problem

The website javadoc was only showing the CLDC `java.*` packages (`java/io`, `java/lang`, `java/util`, …) — the entire `com.codename1.*` API was missing.

## Root cause

`.github/scripts/build_javadocs.sh` piped the full source list into:

```sh
find …/tempJavaSources …/Ports/CLDC11/src -name "*.java" | xargs javadoc … -d dist/javadoc
```

GNU `xargs` on the CI runner caps a single command line at ~128 KiB. Once the source list exceeds that, `xargs` runs `javadoc` **multiple times**, and every invocation regenerates the *same* `-d dist/javadoc` directory. Because `Ports/CLDC11/src` is last in the `find`, the final batch — only the CLDC `java.*` sources — overwrote the full API docs. The trailing `|| true` hid the failure.

### Why it surfaced now

CLDC sources were folded into this build in March (`451c1f08b`) at ~897 files, comfortably under the cap. Recent package additions (`com.codename1.ads`, `com.codename1.ai`, GraphQL, declarative router, JSON/XML/ORM mappers) grew it to **1201 files** (~116 KB of args on the runner), tipping it past the limit.

## Fix

1. Run `javadoc` **once** via an `@argfile` — argfiles have no command-line length limit, so the source list can never be split/clobbered no matter how many packages are added later.
2. Add a guard that aborts if the core `com/codename1/ui/Component.html` is missing, so a partial build fails the CI job loudly instead of silently publishing only CLDC.

## Verification

Locally (JDK 21, `--release 8`, all 1202 sources): the single invocation exits 0 and emits **both** `com/codename1/ui/Component.html` and `java/util/HashMap.html`. The old failure was reproduced by forcing an `xargs` split, which leaves a clobbered/partial tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)