### PR TITLE
Fix #5184: remove docs reference to non-existent synchronizeReceiptsSync()

### DIFF
--- a/docs/developer-guide/Monetization.asciidoc
+++ b/docs/developer-guide/Monetization.asciidoc
@@ -427,9 +427,8 @@ In order for your app to provide you with current data about the user's subscrip
 The following methods can be used for synchronization:
 
 . `synchronizeReceipts()` - Asynchronously synchronizes receipts in the background. You won't be notified when it's complete.
-. `synchronizeReceiptsSync()` - Synchronously synchronizes receipts, and blocks until it's complete. This is safe to use on the EDT as it employs `invokeAndBlock` under the covers.
 . `synchronizeReceipts(final long ifOlderThanMs, final SuccessCallback<Boolean> callback)` - Asynchronously synchronizes receipts, but only if they haven't been synchronized in the specified time. For example, In your start() method you might decide that you only want to synchronize receipts once per day. This also includes a callback that will be called when synchronization is complete.
-. `synchronizeReceiptsSync(long ifOlderThanMs)` - A synchronous version that will only refetch if data is older than given time.
+. `synchronizeReceiptsSync(long ifOlderThanMs)` - Synchronously synchronizes receipts, blocking until it's complete, and will only refetch if data is older than the given time (pass `0` to always refetch). This is safe to use on the EDT as it employs `invokeAndBlock` under the covers.
 
 In your hello world app you synchronize the subscriptions in a few places.
 
@@ -578,7 +577,7 @@ public void itemPurchaseError(String sku, String errorMessage) {
 }
 ----
 
-Notice that, in `itemPurchased()` you don't need to explicitly create any receipts or submit anything to the receipt store. This is handled for you automatically. You do make a call to `synchronizeReceiptsSync()` but this is just to ensure that your toast message has the new expiry date loaded already.
+Notice that, in `itemPurchased()` you don't need to explicitly create any receipts or submit anything to the receipt store. This is handled for you automatically. You do make a call to `synchronizeReceiptsSync(0)` but this is just to ensure that your toast message has the new expiry date loaded already.
 
 ==== Screenshots
 

--- a/docs/website/content/blog/in-app-purchase-non-renewable-subscriptions.md
+++ b/docs/website/content/blog/in-app-purchase-non-renewable-subscriptions.md
@@ -229,11 +229,9 @@ The following methods can be used for synchronization:
 
   1. `synchronizeReceipts()` – Asynchronously synchronizes receipts in the background. You won’t be notified when it is complete.
 
-  2. `synchronizeReceiptsSync()` – Synchronously synchronizes receipts, and blocks until it is complete. This is safe to use on the EDT as it employs `invokeAndBlock` under the covers.
+  2. `synchronizeReceipts(final long ifOlderThanMs, final SuccessCallback<Boolean> callback)` – Asynchronously synchronizes receipts, but only if they haven’t been synchronized in the specified time period. E.g. In your start() method you might decide that you only want to synchronize receipts once per day. This also includes a callback that will be called when synchronization is complete.
 
-  3. `synchronizeReceipts(final long ifOlderThanMs, final SuccessCallback<Boolean> callback)` – Asynchronously synchronizes receipts, but only if they haven’t been synchronized in the specified time period. E.g. In your start() method you might decide that you only want to synchronize receipts once per day. This also includes a callback that will be called when synchronization is complete.
-
-  4. `synchronizeReceiptsSync(long ifOlderThanMs)` – A synchronous version that will only refetch if data is older than given time.
+  3. `synchronizeReceiptsSync(long ifOlderThanMs)` – Synchronously synchronizes receipts, blocking until it is complete, and will only refetch if data is older than the given time (pass `0` to always refetch). This is safe to use on the EDT as it employs `invokeAndBlock` under the covers.
 
 In our hello world app we synchronize the subscriptions in a few places.
 
@@ -368,7 +366,7 @@ The purchase callbacks are very similar to the ones that we implemented in the r
             ToastBar.showErrorMessage("Failure occurred: "+errorMessage);
         }
 
-Notice that, in `itemPurchased()` we don’t need to explicitly create any receipts or submit anything to the receipt store. This is handled for you automatically. We do make a call to `synchronizeReceiptsSync()` but this is just to ensure that our toast message has the new expiry date loaded already.
+Notice that, in `itemPurchased()` we don’t need to explicitly create any receipts or submit anything to the receipt store. This is handled for you automatically. We do make a call to `synchronizeReceiptsSync(0)` but this is just to ensure that our toast message has the new expiry date loaded already.
 
 ## Full Source
 


### PR DESCRIPTION
Fixes #5184.

The Monetization chapter referenced a no-argument `Purchase.synchronizeReceiptsSync()` method. That overload **never existed** in the API — I confirmed this all the way back to the commit that first introduced the receipts/subscriptions API (`505edec91`). The only synchronous variant has always been `synchronizeReceiptsSync(long ifOlderThanMs)`.

So this is a documentation-only bug (no API was removed, no compatibility broken — there is nothing to deprecate).

## Changes

- **`docs/developer-guide/Monetization.asciidoc`**
  - Removed the phantom no-arg `synchronizeReceiptsSync()` bullet and folded its useful "blocks until complete / safe on the EDT via `invokeAndBlock`" description into the real `synchronizeReceiptsSync(long ifOlderThanMs)` entry.
  - Corrected the inline prose to `synchronizeReceiptsSync(0)` to match the code sample directly above it.
- **`docs/website/content/blog/in-app-purchase-non-renewable-subscriptions.md`** — same two corrections, preserving the blog's existing em-dash/smart-quote style.

The legitimate `synchronizeReceipts()` (void, no-arg) method remains documented; only the non-existent `*Sync()` no-arg reference was removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)