### PR TITLE
Fix #5186: share ReceiptStore across Purchase instances

### DIFF
--- a/CodenameOne/src/com/codename1/payment/Purchase.java
+++ b/CodenameOne/src/com/codename1/payment/Purchase.java
@@ -71,7 +71,18 @@ public abstract class Purchase {
     /// race nor the field assignment need synchronization.
     private static final List<SuccessCallback<Boolean>> synchronizeReceiptsCallbacks =
             new ArrayList<SuccessCallback<Boolean>>();
-    private ReceiptStore receiptStore;
+    /// Static (shared across all `Purchase` instances) because
+    /// `Display#getInAppPurchase()` returns a fresh `Purchase` on every
+    /// call on every port (iOS `ZoozPurchase`, Android `ZoozPurchase`,
+    /// the JavaSE anonymous subclass).  A per-instance store would be
+    /// invisible to the native receipt path: StoreKit's
+    /// `paymentQueue:updatedTransactions:` enters via the static
+    /// `#postReceipt(...)` which calls `getInAppPurchase().postReceipt(r)`
+    /// on a brand-new instance whose store would be null, so the app's
+    /// `ReceiptStore` would never be invoked for auto-submitted receipts.
+    /// There is logically one IAP store per app, so a static field is the
+    /// correct scope.  Access is EDT-only by construction.
+    private static ReceiptStore receiptStore;
     private List<Receipt> receipts;
     private Date receiptsRefreshTime;
 


### PR DESCRIPTION
## Problem

`Display.getInAppPurchase()` returns a **fresh `Purchase` instance on every call** on every port:

- iOS — `IOSImplementation.getInAppPurchase()` → `new ZoozPurchase(...)`
- Android — `AndroidImplementation.getInAppPurchase()` → `ZoozPurchase.class.newInstance()`
- JavaSE — `JavaSEPort.getInAppPurchase()` → `new Purchase() { ... }`

But `receiptStore` was a **per-instance field**. The native receipt path on iOS enters through the static `Purchase.postReceipt(...)` (invoked from StoreKit's `paymentQueue:updatedTransactions:`), which calls `getInAppPurchase().postReceipt(r)` on a **brand-new instance whose `receiptStore` is `null`**.

So `synchronizeReceipts()` fell through to `loadReceipts()`, logged *"No receipt store is currently registered"*, and the app's `ReceiptStore.submitReceipt` / `fetchReceipts` were **never invoked** for auto-submitted receipts. Only an explicit `synchronizeReceipts(...)` call on the app's *own* configured instance worked — which is exactly the behavior reported in #5186 (receipts only submitted when the developer called `synchronizeReceiptsSync(...)` manually).

## Fix

Make `receiptStore` `static` so the store installed via `setReceiptStore(...)` is visible to the native auto-submit path regardless of which `Purchase` instance the callback arrives on. There is logically one IAP store per app, so static is the correct scope. Access remains EDT-only by construction, consistent with the existing `syncInProgress` / `loadInProgress` / `synchronizeReceiptsCallbacks` static state.

## Scope

This PR addresses only the confirmed, source-visible bug: the native auto-submit path never reaching the configured `ReceiptStore`. The separate "app crashes right after a successful purchase" symptom in #5186 is **not** addressed here and its root cause is still undetermined — it needs the device crash log to diagnose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)