### PR TITLE
Fix #5193: stackable mode for concurrent InteractionDialogs

### DIFF
--- a/CodenameOne/src/com/codename1/components/InteractionDialog.java
+++ b/CodenameOne/src/com/codename1/components/InteractionDialog.java
@@ -90,6 +90,17 @@ public class InteractionDialog extends Container implements AbstractDialog {
 
     /// Whether the interaction dialog uses the form layered pane of the regular layered pane
     private boolean formMode;
+
+    /// Opt-in "special mode" (see `#setStackable(boolean)`) that makes dispose remove
+    /// only this dialog's own component from the shared layered pane instead of clearing
+    /// the whole layer.
+    private static boolean stackable;
+
+    /// Records the `formMode` value used by the most recent `#show(int, int, int, int)`
+    /// so dispose cleans up the matching layered pane even if `formMode` is toggled in
+    /// between (e.g. by `#showPopupDialog(Component)`).
+    private boolean shownInFormMode;
+
     private boolean pressedOutOfBounds;
     private ActionListener pressedListener;
     private ActionListener releasedListener;
@@ -270,6 +281,22 @@ public class InteractionDialog extends Container implements AbstractDialog {
     }
 
     private void cleanupLayer(Form f) {
+        if (stackable) {
+            // Stackable mode: several InteractionDialogs can share the class
+            // layer at once (layered by show() order). Tearing the whole layer
+            // down here would wipe the sibling dialogs that are still showing
+            // (#5193). Remove the shared layer only once the last dialog has
+            // left it, so it neither nukes siblings nor lingers empty. Use the
+            // mode captured at show() time so we clean the pane the dialog was
+            // actually added to even if formMode changed in the meantime.
+            Container c = shownInFormMode
+                    ? f.getFormLayeredPane(InteractionDialog.class, true)
+                    : f.getLayeredPane(InteractionDialog.class, true);
+            if (c.getComponentCount() == 0) {
+                c.remove();
+            }
+            return;
+        }
         if (formMode) {
             Container c = f.getFormLayeredPane(InteractionDialog.class, true);
             c.removeAll();
@@ -363,6 +390,7 @@ public class InteractionDialog extends Container implements AbstractDialog {
         getUnselectedStyle().setOpacity(255);
         disposed = false;
         Form f = Display.getInstance().getCurrent();
+        shownInFormMode = formMode;
         Style unselectedStyle = getUnselectedStyle();
 
         unselectedStyle.setMargin(TOP, top);
@@ -563,7 +591,13 @@ public class InteractionDialog extends Container implements AbstractDialog {
                                 Container pp = getLayeredPane(f);
                                 remove();
                                 p.remove();
-                                pp.removeAll();
+                                if (!stackable) {
+                                    // In stackable mode removeAll() would wipe
+                                    // the other dialogs sharing this layer; the
+                                    // remove()/p.remove() above already detached
+                                    // just this dialog (#5193).
+                                    pp.removeAll();
+                                }
                                 pp.revalidate();
                                 cleanupLayer(f);
                             }
@@ -577,8 +611,19 @@ public class InteractionDialog extends Container implements AbstractDialog {
                     Container pp = getLayeredPane(f);
                     remove();
                     p.remove();
-                    pp.removeAll();
+                    if (!stackable) {
+                        // See the animated branch above: removeAll() would
+                        // discard sibling dialogs sharing this layer (#5193).
+                        pp.removeAll();
+                    }
                     pp.revalidate();
+                    if (stackable) {
+                        // Unlike the animated branch, this path never called
+                        // cleanupLayer(). With removeAll() now skipped we must
+                        // still tear the shared layer down once it is empty so
+                        // layers don't accumulate (#5193).
+                        cleanupLayer(f);
+                    }
                     if (onFinish != null) {
                         onFinish.run();
                     }
@@ -1208,6 +1253,41 @@ public class InteractionDialog extends Container implements AbstractDialog {
     /// - `formMode`: the formMode to set
     public void setFormMode(boolean formMode) {
         this.formMode = formMode;
+    }
+
+    /// Whether `InteractionDialog` is in the global "stackable" mode. See
+    /// `#setStackable(boolean)`.
+    ///
+    /// #### Returns
+    ///
+    /// true if stackable mode is enabled
+    public static boolean isStackable() {
+        return stackable;
+    }
+
+    /// Opt-in robustness mode for applications that show several
+    /// `InteractionDialog`s at the same time (for example a step-by-step
+    /// walkthrough that highlights different components).
+    ///
+    /// All `InteractionDialog` instances share a single layered pane keyed by
+    /// the class. In the default (historical) behavior, disposing one dialog
+    /// clears that whole layer (`removeAll()` / layer removal), which also wipes
+    /// any sibling dialog still showing in it -- so when dialogs overlap one of
+    /// them can silently fail to appear (#5193). When stackable mode is enabled
+    /// dispose removes only the disposed dialog's own component; remaining
+    /// dialogs stay visible, layered by the order in which `#show(int, int, int, int)`
+    /// was called (later shows render on top). The shared layer container is
+    /// removed only once it becomes empty, so layers do not accumulate as
+    /// dialogs come and go.
+    ///
+    /// This is a global, app-wide setting (it must be on for every dialog that
+    /// participates) and defaults to false to preserve backwards compatibility.
+    ///
+    /// #### Parameters
+    ///
+    /// - `stackable`: true to enable stackable/concurrent dialog support
+    public static void setStackable(boolean stackable) {
+        InteractionDialog.stackable = stackable;
     }
 
     /// {@inheritDoc}

--- a/maven/core-unittests/src/test/java/com/codename1/components/InteractionDialogTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/components/InteractionDialogTest.java
@@ -330,6 +330,166 @@ class InteractionDialogTest extends UITestBase {
         assertNull(dialog.getDisposeAnimationSetup(), "setDisposeAnimationSetup(null) clears the override");
     }
 
+    @FormTest
+    void stackableModeKeepsSiblingFormModeDialogOnDispose() {
+        // #5193: all InteractionDialogs share the InteractionDialog.class
+        // layer. In the default behavior, disposing one formMode dialog runs
+        // cleanupLayer() -> c.removeAll()/c.remove(), which also wipes any
+        // sibling dialog still showing in that layer ("sometimes nothing is
+        // shown"). With stackable mode on, dispose must remove only the
+        // disposed dialog.
+        boolean prev = InteractionDialog.isStackable();
+        InteractionDialog.setStackable(true);
+        try {
+            Form form = new Form(new BorderLayout());
+            form.show();
+
+            InteractionDialog first = new InteractionDialog("First");
+            first.setAnimateShow(false);
+            first.setFormMode(true);
+            first.show(0, 0, 0, 0);
+
+            InteractionDialog second = new InteractionDialog("Second");
+            second.setAnimateShow(false);
+            second.setFormMode(true);
+            second.show(0, 0, 0, 0);
+
+            Container formLayer = form.getFormLayeredPane(InteractionDialog.class, true);
+            assertTrue(first.isShowing(), "first dialog should be showing");
+            assertTrue(second.isShowing(), "second dialog should be showing");
+
+            first.dispose();
+
+            assertFalse(first.isShowing(), "disposed dialog must be removed");
+            assertTrue(second.isShowing(),
+                    "#5193: disposing one dialog must not remove its sibling sharing the layer");
+            assertTrue(formLayer.contains(second),
+                    "#5193: the sibling dialog must remain in the shared layer");
+
+            second.dispose();
+            assertFalse(second.isShowing(), "the last dialog should dispose normally");
+        } finally {
+            InteractionDialog.setStackable(prev);
+        }
+    }
+
+    @FormTest
+    void stackableModeKeepsSiblingDialogOnDisposeToTheLeft() {
+        // #5193: disposeTo*() additionally calls pp.removeAll() on the shared
+        // layered pane, which also discards siblings (independent of formMode).
+        // Stackable mode must guard that too.
+        boolean prev = InteractionDialog.isStackable();
+        InteractionDialog.setStackable(true);
+        try {
+            Form form = new Form(new BorderLayout());
+            form.show();
+
+            InteractionDialog first = new InteractionDialog("First");
+            first.setAnimateShow(false);
+            first.show(0, 0, 0, 0);
+
+            InteractionDialog second = new InteractionDialog("Second");
+            second.setAnimateShow(false);
+            second.show(0, 0, 0, 0);
+
+            Container layer = form.getLayeredPane(InteractionDialog.class, true);
+
+            first.disposeToTheLeft();
+
+            assertFalse(first.isShowing(), "disposed dialog must be removed");
+            assertTrue(second.isShowing(),
+                    "#5193: disposeTo* must not remove the sibling dialog");
+            assertTrue(layer.contains(second),
+                    "#5193: the sibling dialog must remain in the shared layer");
+
+            second.dispose();
+        } finally {
+            InteractionDialog.setStackable(prev);
+        }
+    }
+
+    @FormTest
+    void stackableModeLayersDialogsByShowOrder() {
+        // #5193: dialogs should stack by show() order -- a dialog shown later
+        // renders on top of one shown earlier (higher child index in the
+        // shared layered pane).
+        boolean prev = InteractionDialog.isStackable();
+        InteractionDialog.setStackable(true);
+        try {
+            Form form = new Form(new BorderLayout());
+            form.show();
+
+            InteractionDialog first = new InteractionDialog("First");
+            first.setAnimateShow(false);
+            first.show(0, 0, 0, 0);
+
+            InteractionDialog second = new InteractionDialog("Second");
+            second.setAnimateShow(false);
+            second.show(0, 0, 0, 0);
+
+            Container layer = form.getLayeredPane(InteractionDialog.class, true);
+            int firstIndex = layer.getComponentIndex(first.getParent());
+            int secondIndex = layer.getComponentIndex(second.getParent());
+            assertTrue(secondIndex > firstIndex,
+                    "#5193: the later-shown dialog must layer on top of the earlier one");
+
+            first.dispose();
+            second.dispose();
+        } finally {
+            InteractionDialog.setStackable(prev);
+        }
+    }
+
+    @FormTest
+    void stackableModeRemovesSharedLayerOnceEmpty() {
+        // #5193: layers must not accumulate -- once the last dialog leaves the
+        // shared layer it should be torn down rather than lingering empty.
+        boolean prev = InteractionDialog.isStackable();
+        InteractionDialog.setStackable(true);
+        try {
+            Form form = new Form(new BorderLayout());
+            form.show();
+
+            InteractionDialog dialog = new InteractionDialog("Only");
+            dialog.setAnimateShow(false);
+            dialog.show(0, 0, 0, 0);
+
+            Container layer = form.getLayeredPane(InteractionDialog.class, true);
+            assertNotNull(layer.getParent(), "layer should be attached while a dialog is showing");
+
+            dialog.dispose();
+
+            assertNull(layer.getParent(),
+                    "#5193: the shared layer must be removed once the last dialog disposes");
+        } finally {
+            InteractionDialog.setStackable(prev);
+        }
+    }
+
+    @FormTest
+    void defaultModeClearsFormLayerOnDispose() {
+        // Backward-compat: with stackable mode off (the default), disposing a
+        // formMode dialog still clears and removes the shared form layer as it
+        // historically did.
+        assertFalse(InteractionDialog.isStackable(), "stackable must default to false");
+        Form form = new Form(new BorderLayout());
+        form.show();
+
+        InteractionDialog dialog = new InteractionDialog("Only");
+        dialog.setAnimateShow(false);
+        dialog.setFormMode(true);
+        dialog.show(0, 0, 0, 0);
+
+        Container formLayer = form.getFormLayeredPane(InteractionDialog.class, true);
+        assertTrue(formLayer.contains(dialog), "dialog should be in the form layer before dispose");
+
+        dialog.dispose();
+
+        assertFalse(dialog.isShowing(), "dispose must remove the dialog");
+        assertNull(formLayer.getParent(),
+                "default behavior should remove the shared form layer on dispose");
+    }
+
     private <T> T getPrivateField(Object target, String name, Class<T> type) throws Exception {
         Field field = target.getClass().getDeclaredField(name);
         field.setAccessible(true);


### PR DESCRIPTION
## Problem (#5193)

All `InteractionDialog` instances share a **single** layered-pane container keyed by `InteractionDialog.class`. Disposing one dialog ran destructive teardown on that shared container:

- `cleanupLayer()` (formMode path): `c.removeAll(); c.remove();`
- `disposeTo*()`: `pp.removeAll();`

Both wipe out **every** dialog in the shared layer, not just the one being disposed. In a step-by-step walkthrough that overlaps dialogs (one shown before the previous finishes disposing), disposing one made the other silently vanish — the reporter's "I can't get them to appear consistently, sometimes nothing is shown." `cleanupLayer()` was also asymmetric (only ever cleaned the formMode pane), leaving orphaned layers behind.

## Fix

A small, **opt-in** robustness toggle — `InteractionDialog.setStackable(boolean)` (default `false`, fully gated for backwards compatibility). When enabled:

- **dispose / disposeTo remove only the disposed dialog** — siblings stay visible.
- **dialogs stack by `show()` order** — later shows render on top.
- **no layer accumulation** — the shared layer container is torn down only once it becomes empty, so it neither nukes siblings nor lingers/multiplies.
- **symmetric cleanup** — uses the `formMode` value captured at `show()` time, so the correct pane is cleaned even if `formMode` was toggled in between (e.g. by `showPopupDialog`).

Default behavior is byte-for-byte unchanged; existing single-dialog code is unaffected.

> Note: `stackable` is a global static, so it must be enabled for all dialogs that coexist (which fits the walkthrough use case). Easy to make per-instance later if preferred.

## Tests

Added to `InteractionDialogTest`:
- sibling survives `dispose()` (formMode) and `disposeToTheLeft()` (disposeTo path)
- dialogs layer by show() order
- shared layer is removed once empty
- backward-compat: default mode still clears the layer on dispose

Verified locally: `Tests run: 19, Failures: 0, Errors: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)