### PR TITLE
ci: cancel superseded PR runs + cap runaway jobs

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -12,10 +12,19 @@ on:
     paths-ignore:
       - 'CodenameOneDesigner/**'
 
+concurrency:
+  # Cancel superseded runs of this workflow for the same PR branch
+  # (github.head_ref is set on pull_request events). On push to master
+  # head_ref is empty, so the group falls back to the unique run_id and
+  # every master commit is still tested in full -- no coverage lost.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build-linux-jdk8:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/archetype-smoke.yml
+++ b/.github/workflows/archetype-smoke.yml
@@ -34,9 +34,18 @@ on:
       - 'maven/integration-tests/inc/**'
       - '.github/workflows/archetype-smoke.yml'
 
+concurrency:
+  # Cancel superseded runs of this workflow for the same PR branch
+  # (github.head_ref is set on pull_request events). On push to master
+  # head_ref is empty, so the group falls back to the unique run_id and
+  # every master commit is still tested in full -- no coverage lost.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   archetype-smoke:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - name: Set up JDK 8

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,14 @@ on:
   schedule:
     - cron: '23 4 * * 1'
 
+concurrency:
+  # Cancel superseded runs of this workflow for the same PR branch
+  # (github.head_ref is set on pull_request events). On push to master
+  # head_ref is empty, so the group falls back to the unique run_id and
+  # every master commit is still tested in full -- no coverage lost.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/designer.yml
+++ b/.github/workflows/designer.yml
@@ -18,9 +18,18 @@ on:
       - 'maven/designer/**'
       - '.github/workflows/designer.yml'
 
+concurrency:
+  # Cancel superseded runs of this workflow for the same PR branch
+  # (github.head_ref is set on pull_request events). On push to master
+  # head_ref is empty, so the group falls back to the unique run_id and
+  # every master commit is still tested in full -- no coverage lost.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build-designer:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - name: Check out repository

--- a/.github/workflows/ios-packaging.yml
+++ b/.github/workflows/ios-packaging.yml
@@ -29,6 +29,14 @@ on:
       - 'scripts/hellocodenameone/**'
       - '!docs/**'
 
+concurrency:
+  # Cancel superseded runs of this workflow for the same PR branch
+  # (github.head_ref is set on pull_request events). On push to master
+  # head_ref is empty, so the group falls back to the unique run_id and
+  # every master commit is still tested in full -- no coverage lost.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build-port:
     uses: ./.github/workflows/_build-ios-port.yml

--- a/.github/workflows/parparvm-tests-windows.yml
+++ b/.github/workflows/parparvm-tests-windows.yml
@@ -39,6 +39,14 @@ on:
       - '!vm/**/readme.md'
       - '!vm/**/docs/**'
 
+concurrency:
+  # Cancel superseded runs of this workflow for the same PR branch
+  # (github.head_ref is set on pull_request events). On push to master
+  # head_ref is empty, so the group falls back to the unique run_id and
+  # every master commit is still tested in full -- no coverage lost.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   vm-tests-windows:
     name: clean-target (${{ matrix.name }})

--- a/.github/workflows/parparvm-tests.yml
+++ b/.github/workflows/parparvm-tests.yml
@@ -22,9 +22,18 @@ on:
     types:
       - published
 
+concurrency:
+  # Cancel superseded runs of this workflow for the same PR branch
+  # (github.head_ref is set on pull_request events). On push to master
+  # head_ref is empty, so the group falls back to the unique run_id and
+  # every master commit is still tested in full -- no coverage lost.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   vm-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -186,6 +195,7 @@ jobs:
   release-jars:
     if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: write
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,10 +39,19 @@ permissions:
   issues: write
   packages: read
 
+concurrency:
+  # Cancel superseded runs of this workflow for the same PR branch
+  # (github.head_ref is set on pull_request events). On push to master
+  # head_ref is empty, so the group falls back to the unique run_id and
+  # every master commit is still tested in full -- no coverage lost.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build-test:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     container: ghcr.io/codenameone/codenameone/pr-ci-container:latest
     defaults:
       run:

--- a/.github/workflows/scripts-android.yml
+++ b/.github/workflows/scripts-android.yml
@@ -74,6 +74,14 @@ name: Test Android build scripts
 #   5. Go to https://github.com/codenameone/CodenameOne/settings/secrets/actions
 #     and edit the CN1SS_GH_TOKEN to use the new token
 
+concurrency:
+  # Cancel superseded runs of this workflow for the same PR branch
+  # (github.head_ref is set on pull_request events). On push to master
+  # head_ref is empty, so the group falls back to the unique run_id and
+  # every master commit is still tested in full -- no coverage lost.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build-android:
     name: Build Android ${{ matrix.name }}
@@ -94,6 +102,7 @@ jobs:
       pull-requests: write
       issues: write
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       GITHUB_TOKEN: ${{ secrets.CN1SS_GH_TOKEN }}
       GH_TOKEN: ${{ secrets.CN1SS_GH_TOKEN }}

--- a/.github/workflows/scripts-javascript.yml
+++ b/.github/workflows/scripts-javascript.yml
@@ -41,6 +41,14 @@ on:
       - '!maven/core-unittests/**'
       - '!docs/**'
 
+concurrency:
+  # Cancel superseded runs of this workflow for the same PR branch
+  # (github.head_ref is set on pull_request events). On push to master
+  # head_ref is empty, so the group falls back to the unique run_id and
+  # every master commit is still tested in full -- no coverage lost.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   javascript-screenshots:
     permissions:


### PR DESCRIPTION
## What

Two pure waste-reduction changes to CI, both designed to preserve full coverage.

### 1. Cancel superseded PR runs (`concurrency`)
Adds a top-level `concurrency` group to the expensive workflows that had none: `parparvm-tests`, `parparvm-tests-windows`, `scripts-javascript`, `ios-packaging`, `scripts-android`, `ant`, `pr`, `designer`, `archetype-smoke`, `codeql`.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
  cancel-in-progress: true
```

- On a **PR**, `head_ref` is the source branch → re-pushing cancels the now-stale in-flight run.
- On **push to master**, `head_ref` is empty → the group falls back to the unique `run_id`, so **every master commit is still built and tested in full**. No coverage lost.

`scripts-ios` / `scripts-mac-native` already cancel via their job-level groups and are left as-is.

### 2. Cap runaway jobs (`timeout-minutes`)
Adds `timeout-minutes` to the long jobs that had none (`parparvm-tests`, `ant`, `pr`, `scripts-android`, `designer`, `archetype-smoke`). Previously a hung job ran to GitHub's **6h default**; the explicit caps (≈1.5–2× observed averages) fail fast.

## Why
Over the last ~200 runs (~3,194 machine-minutes), the priciest workflows lacked superseded-run cancellation, so stacked PR pushes ran 51–61 min jobs to completion needlessly. No job logic or test selection changes.