### PR TITLE
perf(parparvm-tests): diagonal JDK matrix + cached JavaAPI + parallel forks

### DIFF
--- a/vm/tests/pom.xml
+++ b/vm/tests/pom.xml
@@ -106,6 +106,15 @@
                 <version>3.2.5</version>
                 <configuration>
                     <useModulePath>false</useModulePath>
+                    <!-- Run test classes across parallel JVM forks. Parallelism MUST be
+                         process-level: the translator (Parser) keeps static mutable state,
+                         so in-JVM thread parallelism would corrupt it. Each test writes to
+                         unique createTempDirectory paths and the only shared path
+                         (target/benchmark-dependencies) is populated by maven-dependency-plugin
+                         before the test phase and only read here, so forks never collide.
+                         1C = one fork per available CPU core. -->
+                    <forkCount>1C</forkCount>
+                    <reuseForks>true</reuseForks>
                 </configuration>
             </plugin>
             <plugin>
@@ -117,6 +126,34 @@
                         <goals>
                             <goal>prepare-agent</goal>
                         </goals>
+                        <configuration>
+                            <!-- One exec file per surefire fork. surefire substitutes
+                                 ${surefire.forkNumber} in the agent argLine per forked JVM;
+                                 without this, parallel forks would clobber a single
+                                 jacoco.exec and the coverage report would be corrupt/empty. -->
+                            <destFile>${project.build.directory}/jacoco-fork-${surefire.forkNumber}.exec</destFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <!-- Merge the per-fork exec files back into one before the report.
+                             Declared before the report execution so it runs first in the
+                             test phase. -->
+                        <id>merge-forks</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>merge</goal>
+                        </goals>
+                        <configuration>
+                            <fileSets>
+                                <fileSet>
+                                    <directory>${project.build.directory}</directory>
+                                    <includes>
+                                        <include>jacoco-fork-*.exec</include>
+                                    </includes>
+                                </fileSet>
+                            </fileSets>
+                            <destFile>${project.build.directory}/jacoco.exec</destFile>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>report</id>

--- a/vm/tests/src/test/java/com/codename1/tools/translator/BytecodeInstructionIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/BytecodeInstructionIntegrationTest.java
@@ -39,14 +39,13 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class BytecodeInstructionIntegrationTest {
 
+    // Shared @MethodSource for the integration suites (RuntimeSemantics, Target,
+    // Bytecode, CleanTarget, Smoke, NativeAudit, FileClass, ...). Uses the
+    // diagonal compiler set -- each bytecode target compiled by its matching JDK
+    // (8->8 .. 25->25) -- rather than the full (compiler x target) cross-product,
+    // which re-tested the same bytecode shapes. See CompilerHelper.getDiagonalCompilers.
     static Stream<CompilerHelper.CompilerConfig> provideCompilerConfigs() {
-        List<CompilerHelper.CompilerConfig> configs = new ArrayList<>();
-        configs.addAll(CompilerHelper.getAvailableCompilers("1.8"));
-        configs.addAll(CompilerHelper.getAvailableCompilers("11"));
-        configs.addAll(CompilerHelper.getAvailableCompilers("17"));
-        configs.addAll(CompilerHelper.getAvailableCompilers("21"));
-        configs.addAll(CompilerHelper.getAvailableCompilers("25"));
-        return configs.stream();
+        return CompilerHelper.getDiagonalCompilers().stream();
     }
 
     @ParameterizedTest

--- a/vm/tests/src/test/java/com/codename1/tools/translator/CompilerHelper.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/CompilerHelper.java
@@ -190,6 +190,29 @@ public class CompilerHelper {
         return compilers;
     }
 
+    // Diagonal compiler set: each supported bytecode target compiled only by the
+    // JDK whose major version matches that target (8->8, 11->11, 17->17, 21->21,
+    // 25->25). The translator consumes bytecode, which is governed by the target
+    // level, so the full (compiler x target) cross-product mostly re-tests the
+    // same bytecode shapes. Restricting to the diagonal keeps every target level
+    // exercised while cutting the per-method parameter count from up to 15 to 5.
+    // A target whose matching JDK is not installed locally is simply skipped
+    // (CI installs all five). Pairs use {target, jdkMajor}; "1.8" maps to JDK 8.
+    public static List<CompilerConfig> getDiagonalCompilers() {
+        String[][] pairs = { {"1.8", "8"}, {"11", "11"}, {"17", "17"}, {"21", "21"}, {"25", "25"} };
+        List<CompilerConfig> out = new ArrayList<>();
+        for (String[] pair : pairs) {
+            int wantMajor = parseJavaMajor(pair[1]);
+            for (CompilerConfig config : getAvailableCompilers(pair[0])) {
+                if (getJdkMajor(config) == wantMajor) {
+                    out.add(config);
+                    break;
+                }
+            }
+        }
+        return out;
+    }
+
     private static boolean canCompile(String compilerVersion, String targetVersion) {
         int compilerMajor = parseJavaMajor(compilerVersion);
         int targetMajor = parseJavaMajor(targetVersion);
@@ -385,7 +408,35 @@ public class CompilerHelper {
         }
     }
 
+    // The compiled JavaAPI is identical for a given (jdkVersion, targetVersion),
+    // yet it was previously re-compiled (a ~259-source javac run) on every
+    // parameterized test invocation -- hundreds of times across the suite. Cache
+    // the compiled output per combo and copy it into each caller's outputDir
+    // instead. This removes the dominant repeated cost with zero change to what
+    // is tested. Within a surefire fork tests run sequentially, so the only
+    // contention is the compile-once guard below.
+    private static final java.util.Map<String, Path> JAVA_API_CACHE =
+            new java.util.concurrent.ConcurrentHashMap<>();
+
     public static void compileJavaAPI(Path outputDir, CompilerConfig config) throws IOException, InterruptedException {
+        Files.createDirectories(outputDir);
+        copyDirectory(getCachedJavaApi(config), outputDir);
+    }
+
+    private static synchronized Path getCachedJavaApi(CompilerConfig config) throws IOException, InterruptedException {
+        String key = config.jdkVersion + "->" + config.targetVersion;
+        Path cached = JAVA_API_CACHE.get(key);
+        if (cached != null && Files.isDirectory(cached)) {
+            return cached;
+        }
+        Path cacheDir = Files.createTempDirectory(
+                "java-api-cache-" + config.jdkVersion + "-" + config.targetVersion.replaceAll("[^A-Za-z0-9]", "_") + "-");
+        compileJavaApiInto(cacheDir, config);
+        JAVA_API_CACHE.put(key, cacheDir);
+        return cacheDir;
+    }
+
+    private static void compileJavaApiInto(Path outputDir, CompilerConfig config) throws IOException, InterruptedException {
         Files.createDirectories(outputDir);
         Path javaApiRoot = Paths.get("..", "JavaAPI", "src").normalize().toAbsolutePath();
         List<String> sources = new ArrayList<>();


### PR DESCRIPTION
## What
Cuts the ParparVM `vm/tests` job (≈60 min, fully serial) without losing test coverage, via three independent changes.

### Measured starting point (recent successful run)
| Class | Time | Tests |
|---|--:|--:|
| JavascriptRuntimeSemanticsTest | 23.6 min | 353 |
| JavascriptTargetIntegrationTest | 9.3 min | 143 |
| CleanTargetIntegrationTest | 6.7 min | 30 |
| BytecodeInstructionIntegrationTest | 5.0 min | 64 |
| Lock / RWLock / StampedLock / FileClass / StackOverflow | ~2.3 min ea | 11 ea |

### 1. Diagonal JDK matrix (redundant coverage)
The shared `@MethodSource` `provideCompilerConfigs` built the full triangular **(compiler-JDK × target-bytecode)** cross-product — **15 combos**, so every parameterized method ran 15×:
```
target 8→{8,11,17,21,25}  11→{11,17,21,25}  17→{17,21,25}  21→{21,25}  25→{25}
```
The translator consumes *bytecode*, governed by the **target level**, so compiling a target with five different JDKs mostly re-tests identical bytecode. New `CompilerHelper.getDiagonalCompilers()` keeps each target exercised by its matching JDK (**8→8, 11→11, 17→17, 21→21, 25→25 = 5 combos**). The biggest class scales directly with this. *(Matrix policy chosen deliberately: diagonal-only.)*

### 2. Cache the compiled JavaAPI (pure waste, coverage-neutral)
`compileJavaAPI()` re-ran a **259-source javac on every parameterized invocation** (hundreds of times); the result depends only on (jdk, target). Now compiled **once per combo** and copied into each caller's dir.

### 3. Parallel surefire forks
`forkCount=1C`, `reuseForks=true`. Parallelism is **process-level by necessity** — `Parser` holds static mutable translator state, so in-JVM threading would corrupt it; separate forks run classes sequentially. Tests use unique temp dirs and the only shared path (`target/benchmark-dependencies`) is populated by Maven before the test phase and only read, so forks don't collide. jacoco writes one exec per fork (`${surefire.forkNumber}`) and **merges before the report**, so the ByteCodeTranslator coverage/quality report is unchanged.

## Validation
- `mvn -pl tests test-compile` passes.
- Full 5-JDK matrix + native toolchain runs in CI (local box only has JDK 25, which exercises the `25→25` combo).
- The job's own `timeout-minutes: 90` (from #5196) bounds it; expect a large wall-clock drop once CI reports actuals.

## Coverage note
Every **target bytecode level** is still exercised; what's removed is re-compiling the *same* target with multiple JDKs and re-building the JavaAPI per test. No test logic or assertions changed.