### PR TITLE
iOS: pin BrowserComponent appearance via setProperty("BrowserComponent.interfaceStyle")

### DIFF
--- a/CodenameOne/src/com/codename1/ui/BrowserComponent.java
+++ b/CodenameOne/src/com/codename1/ui/BrowserComponent.java
@@ -91,6 +91,14 @@ public class BrowserComponent extends Container {
     /// Browser property key to control whether links with `target="_blank"` or `target="_new"`
     /// should be followed in the current browser view. Defaults to `true`.
     public static final String BROWSER_PROPERTY_FOLLOW_TARGET_BLANK = "BrowserComponent.followTargetBlank";
+    /// Browser property key to pin the appearance (light/dark) of the native web widget regardless
+    /// of the device-wide setting. This drives the `prefers-color-scheme` CSS media query and the
+    /// user-agent rendering of form controls and default backgrounds inside the page. Accepted
+    /// values are `"light"`, `"dark"` and `"auto"` (follow the device, the default). Use it via
+    /// `browser.setProperty(BrowserComponent.BROWSER_PROPERTY_INTERFACE_STYLE, "light")`.
+    /// Currently honored on iOS (WKWebView); platforms that do not support pinning the web-view
+    /// appearance ignore it.
+    public static final String BROWSER_PROPERTY_INTERFACE_STYLE = "BrowserComponent.interfaceStyle";
     /// String constant for web event listener `com.codename1.ui.events.ActionListener)`
     public static final String onStart = "onStart";
     /// String constant for web event listener `com.codename1.ui.events.ActionListener)`

--- a/Ports/iOSPort/nativeSources/IOSNative.m
+++ b/Ports/iOSPort/nativeSources/IOSNative.m
@@ -3079,6 +3079,29 @@ void com_codename1_impl_ios_IOSNative_setBrowserFollowTargetBlank___long_boolean
     });
 }
 
+// Pin the appearance of the native web widget independently of the device-wide
+// setting. style: 0 = unspecified/auto (follow device), 1 = light, 2 = dark.
+// Setting overrideUserInterfaceStyle on the WKWebView feeds the trait collection
+// that drives the page's prefers-color-scheme media query and the UA rendering of
+// default backgrounds / form controls, so a page that adapts to dark mode can be
+// kept light (or dark) regardless of the user's system appearance.
+void com_codename1_impl_ios_IOSNative_setBrowserInterfaceStyle___long_int(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject, JAVA_LONG peer, JAVA_INT style) {
+    dispatch_sync(dispatch_get_main_queue(), ^{
+        POOL_BEGIN();
+        if (@available(iOS 13.0, *)) {
+            UIView* w = (BRIDGE_CAST UIView*)((void *)peer);
+            UIUserInterfaceStyle uiStyle = UIUserInterfaceStyleUnspecified;
+            if (style == 1) {
+                uiStyle = UIUserInterfaceStyleLight;
+            } else if (style == 2) {
+                uiStyle = UIUserInterfaceStyleDark;
+            }
+            w.overrideUserInterfaceStyle = uiStyle;
+        }
+        POOL_END();
+    });
+}
+
 
 void com_codename1_impl_ios_IOSNative_setPinchToZoomEnabled___long_boolean(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject, JAVA_LONG peer, JAVA_BOOLEAN enabled) {
     dispatch_sync(dispatch_get_main_queue(), ^{

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
@@ -7928,6 +7928,19 @@ public class IOSImplementation extends CodenameOneImplementation {
         if (BrowserComponent.BROWSER_PROPERTY_FOLLOW_TARGET_BLANK.equals(key)) {
             nativeInstance.setBrowserFollowTargetBlank(get(browserPeer), Boolean.TRUE.equals(value));
         }
+        if (BrowserComponent.BROWSER_PROPERTY_INTERFACE_STYLE.equals(key)) {
+            // Maps to UIUserInterfaceStyle: 0 = unspecified/auto, 1 = light, 2 = dark.
+            int style = 0;
+            if (value != null) {
+                String v = value.toString();
+                if ("light".equalsIgnoreCase(v)) {
+                    style = 1;
+                } else if ("dark".equalsIgnoreCase(v)) {
+                    style = 2;
+                }
+            }
+            nativeInstance.setBrowserInterfaceStyle(get(browserPeer), style);
+        }
     }
 
     /**

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSNative.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSNative.java
@@ -253,6 +253,8 @@ public final class IOSNative {
     
     native void setBrowserUserAgent(long browserPeer, String ua);
     native void setBrowserFollowTargetBlank(long browserPeer, boolean follow);
+    // style: 0 = unspecified/auto (follow device), 1 = light, 2 = dark
+    native void setBrowserInterfaceStyle(long browserPeer, int style);
     
     native void browserBack(long browserPeer);
     native void browserStop(long browserPeer);


### PR DESCRIPTION
## Problem

Embedded web views on iOS started rendering in dark mode (following the device) with no per-component way to override it. Reported by a customer whose `BrowserComponent` was light in a January build and went dark in recent builds; `ios.plistInject=<key>UIUserInterfaceStyle</key><string>Light</string>` no longer helped.

## Root cause

`WKWebView` feeds the device's light/dark trait into the page's `prefers-color-scheme` media query and the UA rendering of default backgrounds / form controls. Since **#4786 "Enable UIScene by default"** the window is created programmatically via `-initWithWindowScene:`, and the `UIUserInterfaceStyle` Info.plist key is no longer reliably applied to it — so web views began following the device appearance and the app-wide plist override appeared to do nothing.

## Fix

Rather than reapply an app-wide window hack under UIScene, this exposes the knob where it belongs — on the browser widget — via the existing `setProperty` vertical:

```java
browser.setProperty(BrowserComponent.BROWSER_PROPERTY_INTERFACE_STYLE, "light"); // "light" / "dark" / "auto"
```

The value is routed through `setBrowserProperty` to a new native method that sets the web view's `overrideUserInterfaceStyle`. Because that's a `UIView` property, the single cast covers both `WKWebView` and the legacy `UIWebView`. Platforms that don't support pinning web-view appearance ignore the unknown property as usual.

| Layer | File |
|---|---|
| Public API + constant/doc | `CodenameOne/src/com/codename1/ui/BrowserComponent.java` |
| iOS impl: property → native | `Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java` |
| Native interface decl | `Ports/iOSPort/src/com/codename1/impl/ios/IOSNative.java` |
| Native impl | `Ports/iOSPort/nativeSources/IOSNative.m` |

`setProperty` already defers via `onReady` until the peer exists, so calling it in the component constructor is safe.

## Notes

- iOS-only for now; the same property can later drive Android's `WebSettingsCompat.setAlgorithmicDarkeningAllowed` / `setForceDark`.
- Native ObjC isn't built locally; the change mirrors the existing `setBrowserFollowTargetBlank` vertical exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)