### PR TITLE
Fix #5069: NPE in spinner setValue when Picker.setDate(null) called while popup showing

### DIFF
--- a/CodenameOne/src/com/codename1/ui/spinner/CalendarPicker.java
+++ b/CodenameOne/src/com/codename1/ui/spinner/CalendarPicker.java
@@ -51,6 +51,13 @@ class CalendarPicker extends Container implements InternalPickerWidget {
 
     @Override
     public void setValue(Object value) {
+        if (value == null) {
+            // A null value (e.g. Picker.setDate(null) while the popup is on
+            // screen) has no meaningful representation; leave the current
+            // selection untouched instead of NPE'ing. Mirrors TimeSpinner3D's
+            // null tolerance. #5069
+            return;
+        }
         Date dt = (Date) value;
         calendar.setDate(dt);
 

--- a/CodenameOne/src/com/codename1/ui/spinner/DateSpinner3D.java
+++ b/CodenameOne/src/com/codename1/ui/spinner/DateSpinner3D.java
@@ -578,6 +578,13 @@ class DateSpinner3D extends Container implements InternalPickerWidget {
 
     @Override
     public void setValue(Object value) {
+        if (value == null) {
+            // A null value (e.g. Picker.setDate(null) while the popup is on
+            // screen) has no meaningful representation on the date wheels, so
+            // leave the current selection untouched rather than NPE'ing on the
+            // cast/setTime below. Mirrors TimeSpinner3D's null tolerance. #5069
+            return;
+        }
         Date dt = (Date) value;
         Calendar cld = Calendar.getInstance();
         cld.setTime(dt);

--- a/CodenameOne/src/com/codename1/ui/spinner/DateTimeSpinner3D.java
+++ b/CodenameOne/src/com/codename1/ui/spinner/DateTimeSpinner3D.java
@@ -408,6 +408,13 @@ class DateTimeSpinner3D extends Container implements InternalPickerWidget {
 
     @Override
     public void setValue(Object value) {
+        if (value == null) {
+            // A null value (e.g. Picker.setDate(null) while the popup is on
+            // screen) has no meaningful representation on the wheels; leave the
+            // current selection untouched instead of NPE'ing. Mirrors
+            // TimeSpinner3D's null tolerance. #5069
+            return;
+        }
         setCurrentDate((Date) value);
     }
 

--- a/CodenameOne/src/com/codename1/ui/spinner/DurationSpinner3D.java
+++ b/CodenameOne/src/com/codename1/ui/spinner/DurationSpinner3D.java
@@ -161,6 +161,13 @@ class DurationSpinner3D extends Container implements InternalPickerWidget {
 
     @Override
     public void setValue(Object value) {
+        if (value == null) {
+            // A null value (e.g. Picker.setDate(null) while the popup is on
+            // screen) has no meaningful representation on the duration wheels;
+            // leave the current selection untouched instead of NPE'ing while
+            // unboxing. Mirrors TimeSpinner3D's null tolerance. #5069
+            return;
+        }
         long l = (Long) value;
         if (days != null) {
             long numDays = l / DAY;

--- a/CodenameOne/src/com/codename1/ui/spinner/Spinner3D.java
+++ b/CodenameOne/src/com/codename1/ui/spinner/Spinner3D.java
@@ -217,6 +217,13 @@ class Spinner3D extends Container implements InternalPickerWidget {
 
     @Override
     public void setValue(Object value) {
+        if (value == null) {
+            // A null value (e.g. Picker.setSelectedString(null) / setDate(null)
+            // while the popup is on screen) has no row to select; leave the
+            // current selection untouched instead of NPE'ing in the model
+            // adapters. Mirrors TimeSpinner3D's null tolerance. #5069
+            return;
+        }
         ListModel lm = root.getListModel();
         if (lm instanceof NumberModelAdapter) {
             NumberModelAdapter adapter = (NumberModelAdapter) lm;

--- a/tests/core/test/com/codename1/ui/spinner/TestSpinnerNullValue.java
+++ b/tests/core/test/com/codename1/ui/spinner/TestSpinnerNullValue.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.ui.spinner;
+
+import com.codename1.testing.AbstractTest;
+import com.codename1.ui.list.DefaultListModel;
+
+/// Regression test for issue #5069: calling `Picker.setDate(null)` while the
+/// lightweight popup is on screen forwards the `null` straight to the live
+/// `InternalPickerWidget#setValue`, which used to NPE in every date-type
+/// spinner (unchecked cast / unboxing). `TimeSpinner3D` already tolerated
+/// `null`, which is why only some picker types crashed. The spinner widgets now
+/// uniformly treat a `null` value as a no-op (leave the wheels untouched). This
+/// lives in the `com.codename1.ui.spinner` package so it can reach the
+/// package-private widget classes directly.
+public class TestSpinnerNullValue extends AbstractTest {
+
+    @Override
+    public boolean runTest() throws Exception {
+        // Each setValue(null) must not throw; previously these NPE'd while
+        // casting/unboxing the null value (#5069).
+        new DateSpinner3D().setValue(null);
+        new DateTimeSpinner3D().setValue(null);
+        new CalendarPicker().setValue(null);
+        new DurationSpinner3D(DurationSpinner3D.FIELD_HOUR | DurationSpinner3D.FIELD_MINUTE).setValue(null);
+        new Spinner3D(new DefaultListModel<String>("a", "b", "c")).setValue(null);
+        return true;
+    }
+
+    @Override
+    public boolean shouldExecuteOnEDT() {
+        return true;
+    }
+}


### PR DESCRIPTION
## Problem

Follow-up to the secondary NPE reported in the [last comment of #5069](https://github.com/codenameone/CodenameOne/issues/5069). The original layered-pane NPE was already fixed in #5070; the reporter then hit a *different* NPE:

> When setting the Date to null while the Picker is showing, there was another NPE somewhere in the Spinners.

## Root cause

`Picker.setDate(d)` forwards the value to the live spinner while the popup is open:

```java
if (currentSpinner != null) {
    currentSpinner.setValue(d);   // d == null here
}
```

The date-type spinners cast/unbox without a null check, so `setValue(null)` threw NPE:

- `DateSpinner3D` → `cld.setTime((Date) null)`
- `DateTimeSpinner3D` → `setCurrentDate((Date) null)`
- `DurationSpinner3D` → `long l = (Long) null` (unboxing NPE)
- `CalendarPicker` → `calendar.setDate(null)`
- `Spinner3D` → null forwarded into the number/date model adapters

`TimeSpinner3D` already tolerated `null` (treats it as `0`), which is why only *some* picker types crashed. The picker's creation path also never passes null — it substitutes a default (`new Date()`, `0`). Only `setDate(null)` / `setSelectedString(null)` *while the popup is showing* bypassed that.

## Fix

A `null` value has no meaningful representation on a date/time/duration wheel, so the widgets now treat `null` as a no-op (leave the current selection untouched) — matching `TimeSpinner3D`'s existing behavior. `getDate()` still returns the explicitly-set `null`.

Adds `TestSpinnerNullValue` (placed in the `com.codename1.ui.spinner` package so it can reach the package-private widget classes) asserting `setValue(null)` no longer throws across all five widgets.

## Verification

- Core + Factory recompile cleanly with JDK 8 (no errors in the spinner package).
- New test compiles against the built classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)