### PR TITLE
sim: warn when Larger Text menu is used without the app opting in (#4963)

### DIFF
--- a/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
@@ -216,6 +216,9 @@ public class JavaSEPort extends CodenameOneImplementation {
     private boolean autoUpdateDefaultResourceBundle;
     private float largerTextScale = 1.0f;
     private boolean largerTextEnabled = false;
+    // Set once we've warned the developer that the running app hasn't opted into
+    // font scaling, so the Larger Text menu only nags them a single time per session.
+    private boolean largerTextOptInWarningShown = false;
     private static final String PREF_LARGER_TEXT_SCALE = "cn1.simulator.largerTextScale";
 
     // Floor below which any persisted window dimension is treated as the
@@ -7014,12 +7017,40 @@ public class JavaSEPort extends CodenameOneImplementation {
                     // Theme-only refresh so the app's CSS-compiled theme survives; see
                     // refreshThemeOnly() for why refreshSkin breaks the app theme + canvas size.
                     refreshThemeOnly();
+                    warnIfLargerTextScaleIgnored(frm);
                 }
             });
             group.add(item);
             largerTextMenu.add(item);
         }
         parent.add(largerTextMenu);
+    }
+
+    /// The Larger Text menu only changes the on-screen fonts when the running app
+    /// has opted into font scaling -- either through the `useLargerTextScaleBool`
+    /// theme constant or a `UIManager.setUseLargerTextScale(true)` call at startup.
+    /// Without that opt-in, `UIManager`'s effective scale clamps back to 1.0 and the
+    /// menu selection has no visible effect, which historically read as "the
+    /// simulator doesn't refresh" (issue #4963). Surface a one-time explanation so
+    /// the developer understands why the text didn't grow and how to enable it,
+    /// instead of being left to guess that the refresh is broken.
+    private void warnIfLargerTextScaleIgnored(JFrame frm) {
+        if (largerTextOptInWarningShown || !largerTextEnabled) {
+            return;
+        }
+        if (UIManager.getInstance().isUseLargerTextScale()) {
+            return;
+        }
+        largerTextOptInWarningShown = true;
+        JOptionPane.showMessageDialog(frm,
+                "This app has not enabled larger text scaling, so the size you picked\n"
+                + "won't change the on-screen fonts.\n\n"
+                + "To preview Dynamic Type sizing, enable scaling in your app by either:\n"
+                + "  - adding the theme constant  useLargerTextScaleBool = true,  or\n"
+                + "  - calling  UIManager.getInstance().setUseLargerTextScale(true)\n"
+                + "    during app startup.",
+                "Larger Text scaling not enabled",
+                JOptionPane.WARNING_MESSAGE);
     }
 
     /**


### PR DESCRIPTION
## Summary

Closes the loose end on [#4963](https://github.com/codenameone/CodenameOne/issues/4963) (*"The Simulator does not refresh when changing font size using Simulate -> Larger Text"*).

The live-refresh half of this is already on `master`: the **Simulate -> Larger Text** menu calls `refreshThemeOnly()` -> `applyThemeOnlyRefresh()` (`UIManager.refreshTheme()` + `Form.refreshTheme(true)` + revalidate/repaint), so **no restart is required** anymore.

The remaining gotcha is that the scale only has a *visible* effect when the app opts into font scaling — via the `useLargerTextScaleBool` theme constant or `UIManager.getInstance().setUseLargerTextScale(true)`. For an app that never opts in, `UIManager`'s effective scale clamps back to `1.0`, so picking "Extra Large" silently changes nothing on screen — which looks identical to the original "doesn't refresh" complaint.

This PR makes that case self-explanatory: when a developer selects a larger size while the running app hasn't enabled scaling, the simulator shows a **one-time** dialog explaining why the fonts didn't grow and how to turn scaling on.

## Change

- `JavaSEPort.warnIfLargerTextScaleIgnored(JFrame)` — fired from the Larger Text menu action after the theme refresh. Guards:
  - only when a *larger-than-default* size was picked (`largerTextEnabled`),
  - only when `UIManager.isUseLargerTextScale()` is `false`,
  - at most once per simulator session (`largerTextOptInWarningShown`).

When the app *has* opted in, behavior is unchanged — the menu rescales fonts live.

## Testing

Built the JavaSE port (`mvn install -pl javase -Plocal-dev-javase`) and ran the simulator against a minimal static demo:

- **Opted in** (`setUseLargerTextScale(true)`): selecting each Dynamic Type stop rescales the labels/buttons live, no restart — confirming the existing #4963 refresh path works.
- **Not opted in**: selecting a larger size pops the new explanatory warning once, and stays quiet afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)