### PR TITLE
TextArea: grow by actual wrapped line count while editing (#4854)

### DIFF
--- a/CodenameOne/src/com/codename1/ui/TextArea.java
+++ b/CodenameOne/src/com/codename1/ui/TextArea.java
@@ -618,19 +618,21 @@ public class TextArea extends Component implements ActionSource, TextHolder {
     }
 
     private boolean textMightGrowByContent(String oldText, String newText) {
-        int oldNewLines = countNewLines(oldText);
-        int newNewLines = countNewLines(newText);
-        if (newNewLines > oldNewLines) {
+        if (newText == null || oldText == null) {
             return true;
         }
-        if (newText == null || oldText == null || newText.length() <= oldText.length()) {
-            return false;
+        // An added hard newline always adds a row.
+        if (countNewLines(newText) > countNewLines(oldText)) {
+            return true;
         }
-        int cols = getColumns();
-        if (cols > 1) {
-            return estimateLineCount(newText, cols) > estimateLineCount(oldText, cols);
-        }
-        return false;
+        // Any growth in length can push the content onto an extra wrapped row.
+        // We deliberately do NOT try to predict the wrap point here: the previous
+        // character-column estimate ignored the font and padding, so proportional
+        // text wrapped a row earlier than predicted and the field clipped the prior
+        // line while editing (#4854). revalidateLater() coalesces and the layout's
+        // getLines() (real font metrics, real width) determines the actual size, so
+        // erring toward an extra revalidate is cheap and never under-grows.
+        return newText.length() > oldText.length();
     }
 
     private int countNewLines(String value) {
@@ -644,24 +646,6 @@ public class TextArea extends Component implements ActionSource, TextHolder {
             }
         }
         return count;
-    }
-
-    private int estimateLineCount(String value, int cols) {
-        if (value == null || value.length() == 0) {
-            return 1;
-        }
-        int lines = 0;
-        int segmentLength = 0;
-        for (int i = 0; i < value.length(); i++) {
-            if (value.charAt(i) == '\n') {
-                lines += Math.max(1, (segmentLength + cols - 1) / cols);
-                segmentLength = 0;
-            } else {
-                segmentLength++;
-            }
-        }
-        lines += Math.max(1, (segmentLength + cols - 1) / cols);
-        return lines;
     }
 
     /// Convenience method for numeric text fields, returns the value as a number or invalid if the value in the


### PR DESCRIPTION
## Problem

Follow-up to #4859. As reported in the last comment on #4854, a `growByContent` multi-line `TextArea` clips the previous row while being edited: text wraps onto a new visual line but the field doesn't grow to follow it. Moving focus to another field corrects the size.

<img width="459" height="120" alt="reported screenshot" src="https://github.com/user-attachments/assets/55f2406e-df4e-432e-a7c6-9abadcc4ea5e" />

## Root cause

The during-editing grow gate added in #4741 (`textMightGrowByContent`) decided whether to `revalidateLater()` using `estimateLineCount` — a **character-column prediction** (string length vs `getColumns()`). The actual renderer (`initRowString` / `getLines()`) wraps using **real font metrics against `getWidth() - horizontalPadding`**. With a proportional font, text wraps onto a new row *before* the raw character count reaches `cols`, so the estimate undercounted, `revalidateLater()` never fired, and the field stayed a row short. Leaving the field runs a normal layout that uses the accurate `getLines()` — which is why it self-corrects (broken during editing, fine after).

## Fix

Drop the wrap prediction. The insight: **over-triggering `revalidateLater()` is harmless** — it coalesces into one layout per paint, and that layout already computes the true size via `getLines()` — while **under-triggering is the bug**. So `textMightGrowByContent` now triggers on any text-length increase (or an added hard newline) and lets the layout decide the real row count.

This is deliberately conservative and:
- stays **width- and EDT-independent** (no reliance on the component being laid out),
- does **not** call `getLines()` from inside `setText()`, so there's no layout re-entrancy / recursion risk,
- removes the bogus `estimateLineCount` helper.

## Testing

`mvn -Plocal-dev-javase -DunitTests -pl :codenameone-core-unittests test -Dtest=TextAreaTest` — all 42 pass locally under JDK 8, including `testGrowByContentRevalidatesParentWhenRowsGrowDuringEditing` (which fails on an earlier `getLines()`-based draft because its TextArea is never laid out, i.e. width 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)