### PR TITLE
Screenshot suite: retry once + stage logging for silent capture timeouts

### DIFF
--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/AbstractAnimationScreenshotTest.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/AbstractAnimationScreenshotTest.java
@@ -62,6 +62,7 @@ public abstract class AbstractAnimationScreenshotTest extends BaseTest {
         } finally {
             AnimationTime.reset();
         }
+        markCaptureStarted();
         Cn1ssDeviceRunnerHelper.emitImage(grid, getImageName(), this::done);
     }
 

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/BaseTest.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/BaseTest.java
@@ -12,6 +12,18 @@ public abstract class BaseTest extends AbstractTest {
     private volatile boolean done;
     private volatile boolean failed;
     private volatile String failMessage;
+    /// Set the moment the capture pipeline hands off to
+    /// Cn1ssDeviceRunnerHelper.emitCurrentFormScreenshot. The runner consults
+    /// it on a timeout: false means the test died silently BEFORE any capture
+    /// was requested (the iOS Metal flake where a transient render-pipeline
+    /// stall swallows the whole show -> UITimer -> screenshot chain without a
+    /// single error line) and a one-shot retry is safe; true means a capture
+    /// is in flight and re-running would risk a duplicate/mislabelled emit.
+    private volatile boolean captureStarted;
+    /// Last stage the screenshot pipeline reached, logged by the runner when
+    /// a test times out so a silent stall pinpoints itself: created ->
+    /// show-completed -> settle-timer-fired -> capture-requested.
+    private volatile String captureStage = "created";
 
     public boolean shouldTakeScreenshot() {
         return true;
@@ -35,6 +47,7 @@ public abstract class BaseTest extends AbstractTest {
         return new Form(title, layout) {
             @Override
             protected void onShowCompleted() {
+                captureStage = "show-completed";
                 registerReadyCallback(this, () -> awaitAnimationsThenScreenshot(this, imageName));
             }
         };
@@ -53,10 +66,14 @@ public abstract class BaseTest extends AbstractTest {
     }
 
     private void awaitAnimationsThenScreenshot(final Form form, final String imageName, final int waitedMs) {
+        if (waitedMs == 0) {
+            captureStage = "settle-timer-fired";
+        }
         AnimationManager am = form.getAnimationManager();
         boolean animating = (am != null && am.isAnimating())
                 || Display.getInstance().isInTransition();
         if (!animating || waitedMs >= 5000) {
+            markCaptureStarted();
             Cn1ssDeviceRunnerHelper.emitCurrentFormScreenshot(imageName, BaseTest.this::done);
             return;
         }
@@ -69,5 +86,35 @@ public abstract class BaseTest extends AbstractTest {
 
     public synchronized boolean isDone() {
         return done;
+    }
+
+    public boolean isCaptureStarted() {
+        return captureStarted;
+    }
+
+    /// Tests that bypass createForm()'s capture chain and invoke
+    /// Cn1ssDeviceRunnerHelper.emit* directly must call this right before the
+    /// emit so the runner's silent-timeout retry never re-runs a test whose
+    /// capture is already in flight (a late emit after the rerun's form is up
+    /// would ship the wrong pixels under this test's name).
+    protected void markCaptureStarted() {
+        captureStarted = true;
+        captureStage = "capture-requested";
+    }
+
+    public String getCaptureStage() {
+        return captureStage;
+    }
+
+    /// Re-arms the instance so the runner can re-invoke prepare()/runTest()
+    /// after a silent timeout (timeout with no capture started). Only the
+    /// harness flags are reset; subclasses create a fresh Form per runTest()
+    /// call so no UI state needs unwinding here.
+    public synchronized void resetForRetry() {
+        done = false;
+        failed = false;
+        failMessage = null;
+        captureStarted = false;
+        captureStage = "retry-created";
     }
 }

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/Cn1ssDeviceRunner.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/Cn1ssDeviceRunner.java
@@ -301,6 +301,12 @@ public final class Cn1ssDeviceRunner extends DeviceRunner {
 
     private static BaseTest prependedTest;
 
+    /// Index of the test that has consumed its one-shot silent-timeout retry
+    /// (see finalizeTest). -1 until the first retry fires; comparing against
+    /// the index guarantees at most one retry per test so a genuinely broken
+    /// test still fails after ~2x its timeout instead of looping.
+    private int retriedTestIndex = -1;
+
     public static void addTest(BaseTest test) {
         prependedTest = test;
     }
@@ -474,7 +480,26 @@ public final class Cn1ssDeviceRunner extends DeviceRunner {
         try {
             testClass.cleanup();
             if (timedOut) {
-                log("CN1SS:ERR:suite test=" + testName + " failed due to timeout waiting for DONE");
+                log("CN1SS:ERR:suite test=" + testName + " failed due to timeout waiting for DONE stage="
+                        + testClass.getCaptureStage());
+                if (shouldRetryAfterSilentTimeout(index, testClass)) {
+                    // The test timed out without EVER requesting a capture and
+                    // without reporting a failure: the show -> settle-timer ->
+                    // screenshot chain was silently swallowed. Observed on the
+                    // iOS Metal CI job (graphics-fill-shape produced no PNG, no
+                    // error, while the very next test rendered fine ~2s later),
+                    // i.e. a transient render-pipeline stall rather than a bug
+                    // in the test itself. The pipeline is healthy again by the
+                    // time the timeout poll fires, so one re-run reliably
+                    // recovers the screenshot instead of failing the whole job
+                    // on a missing tile.
+                    retriedTestIndex = index;
+                    log("CN1SS:WARN:suite test=" + testName
+                            + " retrying once: timed out before any capture started");
+                    testClass.resetForRetry();
+                    runNextTest(index);
+                    return;
+                }
             } else if (testClass.isFailed()) {
                 log("CN1SS:ERR:suite test=" + testName + " failed: " + testClass.getFailMessage());
             } else if (!testClass.shouldTakeScreenshot()) {
@@ -490,6 +515,26 @@ public final class Cn1ssDeviceRunner extends DeviceRunner {
         // doesn't match the reference screenshot name (e.g. "graphics-affine-scale")
         // and breaks iOS/Android comparison results.
         continueToNext.run();
+    }
+
+    /// A retry is only safe when the timeout was truly silent. Gates:
+    /// - one retry per test (retriedTestIndex);
+    /// - native ports only: on HTML5 the suite advancement is co-driven by
+    ///   port.js (runCn1ssResolvedTest dispatches per index) and known-bad
+    ///   tests are parked via its forced-timeout lists, so a Java-side rerun
+    ///   would fight that machinery;
+    /// - no failure was reported (a real failure should surface, not retry);
+    /// - no capture was started (an in-flight capture could emit after the
+    ///   rerun's form is up and ship the wrong pixels under this test's name);
+    /// - the test actually takes a screenshot (non-screenshot tests may have
+    ///   side effects that aren't safe to repeat, and a missing tile is the
+    ///   only failure mode this retry exists to prevent).
+    private boolean shouldRetryAfterSilentTimeout(int index, BaseTest testClass) {
+        return retriedTestIndex != index
+                && !"HTML5".equals(Display.getInstance().getPlatformName())
+                && !testClass.isFailed()
+                && !testClass.isCaptureStarted()
+                && testClass.shouldTakeScreenshot();
     }
 
     private void finishSuite() {

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/DualAppearanceBaseTest.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/DualAppearanceBaseTest.java
@@ -196,8 +196,10 @@ public abstract class DualAppearanceBaseTest extends BaseTest {
                     // time to reach the front buffer.
                     Display.getInstance().callSerially(() ->
                         Display.getInstance().callSerially(() ->
-                            Display.getInstance().callSerially(() ->
-                                Cn1ssDeviceRunnerHelper.emitCurrentFormScreenshot(imageName, next))));
+                            Display.getInstance().callSerially(() -> {
+                                markCaptureStarted();
+                                Cn1ssDeviceRunnerHelper.emitCurrentFormScreenshot(imageName, next);
+                            })));
                 });
             }
         };

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/LightweightPickerButtonsScreenshotTest.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/LightweightPickerButtonsScreenshotTest.java
@@ -192,6 +192,7 @@ public class LightweightPickerButtonsScreenshotTest extends BaseTest {
                                         Display.getInstance().callSerially(new Runnable() {
                                             @Override
                                             public void run() {
+                                                markCaptureStarted();
                                                 Cn1ssDeviceRunnerHelper.emitCurrentFormScreenshot(variant.imageName, new Runnable() {
                                                     @Override
                                                     public void run() {

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/OrientationLockScreenshotTest.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/OrientationLockScreenshotTest.java
@@ -34,6 +34,7 @@ public class OrientationLockScreenshotTest extends BaseTest {
                     revalidate();
                     UITimer.timer(1500, false, this, () -> {
                         revalidate();
+                        markCaptureStarted();
                         Cn1ssDeviceRunnerHelper.emitCurrentFormScreenshot("landscape", () -> {
                             CN.lockOrientation(true);
                             waitForOrientation(this, true, OrientationLockScreenshotTest.this::done);

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/StatusBarTapDiagnosticScreenshotTest.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/StatusBarTapDiagnosticScreenshotTest.java
@@ -120,6 +120,7 @@ public class StatusBarTapDiagnosticScreenshotTest extends BaseTest {
         beforeFrame.dispose();
         afterFrame.dispose();
 
+        markCaptureStarted();
         Cn1ssDeviceRunnerHelper.emitImage(composite, "StatusBarTapDiagnosticScreenshotTest", this::done);
         return true;
     }


### PR DESCRIPTION
## The flake

`build-ios-metal` intermittently fails with a single missing golden tile. In run [27266425884](https://github.com/codenameone/CodenameOne/actions/runs/27266425884) (job 80525163580) all **127 produced tiles matched their references exactly**, but `graphics-fill-shape` never emitted, so the coverage guard failed the whole job:

```
FATAL: 1 of 128 expected screenshot(s) were not produced and compared (only 127 covered)
```

The device log shows the failure is completely silent:

```
09:35:49.384 CN1SS:INFO:suite starting test=FillShape
09:36:19.409 CN1SS:ERR:suite test=FillShape failed due to timeout waiting for DONE
09:36:19.430 CN1SS:INFO:suite starting test=InscribedTriangleGrid   <- renders fine 2s later
```

No screenshot, no `CN1SS:ERR` from the capture helper, no EDT exception. The show → 1500ms settle timer → `Display.screenshot()` chain was swallowed whole by a transient render-pipeline stall (the timeout poll fired at exactly +30.025s — 600 × 50ms polls — so the EDT serial-call loop itself stayed healthy), and the pipeline was demonstrably healthy again when the next test ran ~2s later. The same silent mode can land on any test; it just happened to hit `FillShape` (which exercises the iOS `fillShape`/`drawShape` alpha-mask path) in this run.

## The fix (test harness only, no framework changes)

1. **Stage instrumentation** — `BaseTest` tracks the last stage the capture pipeline reached (`created → show-completed → settle-timer-fired → capture-requested`) and the runner appends it to the timeout line. The next occurrence tells us exactly where the chain died instead of logging nothing.

2. **One-shot retry on silent timeout** — `Cn1ssDeviceRunner.finalizeTest` re-runs a test once when it timed out **silently**: no failure reported, no capture ever requested, screenshot expected. Since the pipeline recovers within seconds, the rerun reliably produces the tile instead of failing a 30-minute job over it. Guards:
   - at most one retry per test (a genuinely broken test still fails, after ~2× its timeout);
   - native ports only — on HTML5 suite advancement is co-driven by port.js and its forced-timeout park lists;
   - never when a capture is already in flight: tests that bypass `BaseTest`'s chain (DualAppearance, OrientationLock, LightweightPickerButtons, StatusBarTapDiagnostic, animation grids) mark capture-started before their direct emits, so a late emit can never ship the wrong pixels under a retried test's name.

No host-side script changes needed: nothing machine-parses the timeout line's tail, and `suite starting`/`suite finished` lines aren't paired anywhere.

Verified: `mvn -pl common compile` passes (JDK 17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)