### PR TITLE
Add cross-platform printing API (com.codename1.printing)

### DIFF
--- a/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
+++ b/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
@@ -59,6 +59,8 @@ import com.codename1.notifications.NotificationPermissionRequest;
 import com.codename1.notifications.NotificationPermissionResult;
 import com.codename1.background.ForegroundService;
 import com.codename1.background.WorkRequest;
+import com.codename1.printing.PrintResult;
+import com.codename1.printing.PrintResultListener;
 import com.codename1.share.SharedContent;
 import com.codename1.share.ShareResult;
 import com.codename1.share.ShareResultListener;
@@ -7440,6 +7442,34 @@ public abstract class CodenameOneImplementation {
         share(text, image, mimeType, sourceRect);
         if (listener != null) {
             listener.onResult(ShareResult.sharedTo(null));
+        }
+    }
+
+    /// Indicates if the underlying platform can print documents through
+    /// [#print(String,String,PrintResultListener)].
+    ///
+    /// #### Returns
+    ///
+    /// true if the underlying platform handles printing.
+    public boolean isPrintingSupported() {
+        return false;
+    }
+
+    /// Print a document file through the platform printing system,
+    /// typically showing the native print dialog. The default
+    /// implementation reports failure since this base class has no
+    /// printing capability. Ports that can print override this method.
+    ///
+    /// #### Parameters
+    ///
+    /// - `filePath`: path of the document in file system storage
+    ///
+    /// - `mimeType`: the document type, e.g. `application/pdf`, `image/png`
+    ///
+    /// - `listener`: callback for the print outcome. May be null.
+    public void print(String filePath, String mimeType, PrintResultListener listener) {
+        if (listener != null) {
+            listener.onResult(PrintResult.failed("Printing is not supported on this platform"));
         }
     }
 

--- a/CodenameOne/src/com/codename1/printing/PrintResult.java
+++ b/CodenameOne/src/com/codename1/printing/PrintResult.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.printing;
+
+/// Outcome of a print request initiated through [Printer] or
+/// [com.codename1.ui.Display#print].
+///
+/// Status semantics:
+///
+/// - `COMPLETED`: the print flow finished and the job was handed to the
+///   printing system. Platforms generally can't observe the physical
+///   printer, so this means "queued/sent", not "paper came out".
+/// - `CANCELLED`: the user dismissed the print dialog without printing.
+/// - `FAILED`: the job could not be started or the printing system
+///   reported an error. `getError()` may carry a short, platform-supplied
+///   description.
+///
+/// Some platforms cannot distinguish cancellation from completion once the
+/// native dialog takes over; those report `COMPLETED` on a best-effort
+/// basis.
+///
+/// Instances are immutable. Construct through the static factories.
+public final class PrintResult {
+
+    /// The print job was handed to the platform printing system.
+    public static final int STATUS_COMPLETED = 1;
+
+    /// User dismissed/cancelled the print dialog.
+    public static final int STATUS_CANCELLED = 2;
+
+    /// The print job could not be completed.
+    public static final int STATUS_FAILED = 3;
+
+    private final int status;
+    private final String error;
+
+    private PrintResult(int status, String error) {
+        this.status = status;
+        this.error = error;
+    }
+
+    /// Build a `COMPLETED` result.
+    public static PrintResult completed() {
+        return new PrintResult(STATUS_COMPLETED, null);
+    }
+
+    /// Build a `CANCELLED` result.
+    public static PrintResult cancelled() {
+        return new PrintResult(STATUS_CANCELLED, null);
+    }
+
+    /// Build a `FAILED` result with an optional platform message.
+    public static PrintResult failed(String message) {
+        return new PrintResult(STATUS_FAILED, message);
+    }
+
+    /// Numeric status: one of [#STATUS_COMPLETED], [#STATUS_CANCELLED], [#STATUS_FAILED].
+    public int getStatus() {
+        return status;
+    }
+
+    /// True iff status == [#STATUS_COMPLETED].
+    public boolean isCompleted() {
+        return status == STATUS_COMPLETED;
+    }
+
+    /// True iff status == [#STATUS_CANCELLED].
+    public boolean isCancelled() {
+        return status == STATUS_CANCELLED;
+    }
+
+    /// True iff status == [#STATUS_FAILED].
+    public boolean isFailed() {
+        return status == STATUS_FAILED;
+    }
+
+    /// Platform-supplied message when [#isFailed] is true, otherwise null.
+    public String getError() {
+        return error;
+    }
+
+    @Override
+    public String toString() {
+        switch (status) {
+            case STATUS_COMPLETED:
+                return "PrintResult{COMPLETED}";
+            case STATUS_CANCELLED:
+                return "PrintResult{CANCELLED}";
+            case STATUS_FAILED:
+                return "PrintResult{FAILED " + error + "}";
+            default:
+                return "PrintResult{?}";
+        }
+    }
+}

--- a/CodenameOne/src/com/codename1/printing/PrintResultListener.java
+++ b/CodenameOne/src/com/codename1/printing/PrintResultListener.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.printing;
+
+/// Receives the outcome of a print request. Always invoked on the EDT.
+///
+/// Pass into [Printer#print] or [com.codename1.ui.Display#print].
+public interface PrintResultListener {
+
+    /// Called once when the print flow finishes (job queued, dialog
+    /// dismissed, or failure). Never invoked more than once for the same
+    /// print request.
+    void onResult(PrintResult result);
+}

--- a/CodenameOne/src/com/codename1/printing/Printer.java
+++ b/CodenameOne/src/com/codename1/printing/Printer.java
@@ -52,7 +52,7 @@ import java.io.OutputStream;
 ///     });
 /// }
 /// ```
-public class Printer {
+public final class Printer {
 
     private Printer() {
     }
@@ -98,8 +98,11 @@ public class Printer {
         final String path = fs.getAppHomePath() + "cn1-print-image-temp.png";
         try {
             OutputStream os = fs.openOutputStream(path);
-            ImageIO.getImageIO().save(image, os, ImageIO.FORMAT_PNG, 1);
-            os.close();
+            try {
+                ImageIO.getImageIO().save(image, os, ImageIO.FORMAT_PNG, 1);
+            } finally {
+                os.close();
+            }
         } catch (IOException err) {
             if (listener != null) {
                 listener.onResult(PrintResult.failed(err.toString()));
@@ -107,6 +110,7 @@ public class Printer {
             return;
         }
         print(path, "image/png", new PrintResultListener() {
+            @Override
             public void onResult(PrintResult result) {
                 fs.delete(path);
                 if (listener != null) {

--- a/CodenameOne/src/com/codename1/printing/Printer.java
+++ b/CodenameOne/src/com/codename1/printing/Printer.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.printing;
+
+import com.codename1.io.FileSystemStorage;
+import com.codename1.ui.Display;
+import com.codename1.ui.Image;
+import com.codename1.ui.util.ImageIO;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/// Cross platform printing API that hands a document to the platform
+/// printing system, typically by popping up the native print dialog where
+/// the user picks a printer and options.
+///
+/// The document is a file in [com.codename1.io.FileSystemStorage]
+/// identified by its path and mime type. All platforms accept PDF
+/// (`application/pdf`) and common image types (`image/png`, `image/jpeg`);
+/// other mime types fail with [PrintResult#STATUS_FAILED] on platforms that
+/// can't render them.
+///
+/// Sample usage:
+///
+/// ```java
+/// if (Printer.isPrintingSupported()) {
+///     Printer.print(reportPath, "application/pdf", new PrintResultListener() {
+///         public void onResult(PrintResult result) {
+///             if (result.isFailed()) {
+///                 ToastBar.showErrorMessage("Print failed: " + result.getError());
+///             }
+///         }
+///     });
+/// }
+/// ```
+public class Printer {
+
+    private Printer() {
+    }
+
+    /// Returns true if the underlying platform can print documents. When
+    /// this returns false [#print] reports [PrintResult#STATUS_FAILED] to
+    /// its listener without showing any UI.
+    public static boolean isPrintingSupported() {
+        return Display.getInstance().isPrintingSupported();
+    }
+
+    /// Print a document file through the platform printing system,
+    /// typically showing the native print dialog.
+    ///
+    /// #### Parameters
+    ///
+    /// - `filePath`: path of the document in [com.codename1.io.FileSystemStorage]
+    ///
+    /// - `mimeType`: the document type, e.g. `application/pdf`, `image/png`
+    ///
+    /// - `listener`: callback for the print outcome, invoked on the EDT. May be null.
+    public static void print(String filePath, String mimeType, PrintResultListener listener) {
+        Display.getInstance().print(filePath, mimeType, listener);
+    }
+
+    /// Convenience variant of [#print(String,String,PrintResultListener)]
+    /// for PDF documents.
+    public static void printPDF(String filePath, PrintResultListener listener) {
+        print(filePath, "application/pdf", listener);
+    }
+
+    /// Print an image through the platform printing system. The image is
+    /// encoded to a temporary PNG file that is deleted once the print flow
+    /// finishes.
+    ///
+    /// #### Parameters
+    ///
+    /// - `image`: the image to print
+    ///
+    /// - `listener`: callback for the print outcome, invoked on the EDT. May be null.
+    public static void printImage(Image image, final PrintResultListener listener) {
+        final FileSystemStorage fs = FileSystemStorage.getInstance();
+        final String path = fs.getAppHomePath() + "cn1-print-image-temp.png";
+        try {
+            OutputStream os = fs.openOutputStream(path);
+            ImageIO.getImageIO().save(image, os, ImageIO.FORMAT_PNG, 1);
+            os.close();
+        } catch (IOException err) {
+            if (listener != null) {
+                listener.onResult(PrintResult.failed(err.toString()));
+            }
+            return;
+        }
+        print(path, "image/png", new PrintResultListener() {
+            public void onResult(PrintResult result) {
+                fs.delete(path);
+                if (listener != null) {
+                    listener.onResult(result);
+                }
+            }
+        });
+    }
+}

--- a/CodenameOne/src/com/codename1/printing/package-info.java
+++ b/CodenameOne/src/com/codename1/printing/package-info.java
@@ -1,0 +1,60 @@
+/*
+    Document   : package
+    Created on : June 11, 2026
+    Author     : Shai Almog
+*/
+
+/// Cross platform printing: hand a PDF or image file to the platform
+/// printing system, which shows the native print dialog where the user
+/// picks a printer and confirms the job.
+///
+/// [Printer] is the entry point. The document is a file in
+/// [com.codename1.io.FileSystemStorage] identified by path and mime
+/// type; every printing platform accepts PDF (`application/pdf`) and
+/// common image types (`image/png`, `image/jpeg`):
+///
+/// ```java
+/// if (Printer.isPrintingSupported()) {
+///     Printer.printPDF(reportPath, new PrintResultListener() {
+///         public void onResult(PrintResult result) {
+///             if (result.isFailed()) {
+///                 ToastBar.showErrorMessage("Print failed: " + result.getError());
+///             }
+///         }
+///     });
+/// }
+/// ```
+///
+/// [Printer#printImage] prints a [com.codename1.ui.Image] directly by
+/// encoding it to a temporary PNG behind the scenes.
+///
+/// #### Results
+///
+/// The outcome arrives as a [PrintResult] on the EDT, exactly once per
+/// request. `COMPLETED` means the job was handed to the platform
+/// printing system - platforms generally can't observe the physical
+/// printer, so it means "queued/sent", not "paper came out".
+/// `CANCELLED` means the user dismissed the print dialog, where the
+/// platform can observe that; platforms that can't (image printing on
+/// Android, PDF hand-off on the desktop, browsers) report `COMPLETED`
+/// on a best-effort basis. `FAILED` carries a short platform message
+/// in [PrintResult#getError].
+///
+/// #### Permissions and the user gate
+///
+/// No platform permission, entitlement, or manifest entry is required.
+/// Printing is always user-confirmed: the API can only pose the native
+/// print dialog, and nothing reaches a printer until the user approves
+/// the job there. Silent printing is deliberately not supported. Device
+/// policy (managed Android profiles, MDM restrictions on iOS) can
+/// disable printing entirely; that surfaces through
+/// [Printer#isPrintingSupported] returning false or a `FAILED` result.
+///
+/// #### Platform mechanisms
+///
+/// iOS uses `UIPrintInteractionController` (AirPrint), Android the
+/// `android.print` framework, desktop builds and the simulator use the
+/// Java print services, Windows uses the Win32 print dialog with GDI
+/// rendering, and the JavaScript port prints through the browser's
+/// print dialog via a hidden frame.
+package com.codename1.printing;

--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -37,6 +37,8 @@ import com.codename1.io.Preferences;
 import com.codename1.io.Util;
 import com.codename1.l10n.L10NManager;
 import com.codename1.location.LocationManager;
+import com.codename1.printing.PrintResult;
+import com.codename1.printing.PrintResultListener;
 import com.codename1.security.Biometrics;
 import com.codename1.security.SecureStorage;
 import com.codename1.share.ShareResult;
@@ -5272,6 +5274,53 @@ public final class Display extends CN1Constants {
             @Override
             public void onResult(final ShareResult result) {
                 final ShareResult r = result != null ? result : ShareResult.sharedTo(null);
+                callSerially(new Runnable() {
+                    @Override
+                    public void run() {
+                        finalListener.onResult(r);
+                    }
+                });
+            }
+        });
+    }
+
+    /// Indicates if the underlying platform can print documents through
+    /// [#print(String,String,PrintResultListener)].
+    ///
+    /// #### Returns
+    ///
+    /// true if the underlying platform handles printing.
+    public boolean isPrintingSupported() {
+        return impl.isPrintingSupported();
+    }
+
+    /// Print a document file through the platform printing system,
+    /// typically showing the native print dialog where the user picks a
+    /// printer and options. The outcome is reported through `listener` on
+    /// the EDT.
+    ///
+    /// All printing platforms accept PDF (`application/pdf`) and common
+    /// image types (`image/png`, `image/jpeg`); other mime types fail with
+    /// [PrintResult#STATUS_FAILED] on platforms that can't render them.
+    /// See [com.codename1.printing.Printer] for a friendlier facade.
+    ///
+    /// #### Parameters
+    ///
+    /// - `filePath`: path of the document in [com.codename1.io.FileSystemStorage]
+    ///
+    /// - `mimeType`: the document type, e.g. `application/pdf`, `image/png`
+    ///
+    /// - `listener`: callback for the print outcome. May be null.
+    public void print(String filePath, String mimeType, PrintResultListener listener) {
+        if (listener == null) {
+            impl.print(filePath, mimeType, null);
+            return;
+        }
+        final PrintResultListener finalListener = listener;
+        impl.print(filePath, mimeType, new PrintResultListener() {
+            @Override
+            public void onResult(final PrintResult result) {
+                final PrintResult r = result != null ? result : PrintResult.completed();
                 callSerially(new Runnable() {
                     @Override
                     public void run() {

--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -7928,6 +7928,295 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
         return Intent.createChooser(shareIntent, "Share with...", pendingIntent.getIntentSender());
     }
 
+    /// Printing uses the Android print framework which requires API 19
+    /// and a foreground activity to host the print dialog.
+    @Override
+    public boolean isPrintingSupported() {
+        return android.os.Build.VERSION.SDK_INT >= 19 && getActivity() != null;
+    }
+
+    /// Print through the Android print framework. PDF files are streamed
+    /// verbatim into a `android.print.PrintDocumentAdapter`; images go
+    /// through the support library `PrintHelper` which scales them to the
+    /// page.
+    ///
+    /// Outcome reporting is best effort: the PDF path polls the returned
+    /// `android.print.PrintJob` and treats a queued/started job as
+    /// completed since Android offers no callback for the terminal job
+    /// state once it was handed to the print service. The image path
+    /// reports completed when `PrintHelper` finishes because it can't
+    /// distinguish a dismissed dialog from a printed page.
+    @Override
+    public void print(final String filePath, final String mimeType, final com.codename1.printing.PrintResultListener listener) {
+        final PrintResultDispatcher dispatcher = new PrintResultDispatcher(listener);
+        if (!isPrintingSupported()) {
+            dispatcher.fire(com.codename1.printing.PrintResult.failed(
+                    "Printing requires Android 4.4 or newer and a foreground activity"));
+            return;
+        }
+        if (filePath == null) {
+            dispatcher.fire(com.codename1.printing.PrintResult.failed("No file to print"));
+            return;
+        }
+        final File file = new File(removeFilePrefix(filePath));
+        if (!file.exists()) {
+            dispatcher.fire(com.codename1.printing.PrintResult.failed("File not found: " + filePath));
+            return;
+        }
+        getActivity().runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    // PrintSupport touches android.print which only exists
+                    // on API 19+; the isPrintingSupported() gate above keeps
+                    // the class from loading on older devices.
+                    PrintSupport.startPrint(getActivity(), file, mimeType, dispatcher);
+                } catch (Throwable t) {
+                    dispatcher.fire(com.codename1.printing.PrintResult.failed(
+                            "Failed to start print job: " + t));
+                }
+            }
+        });
+    }
+
+    /// Delivers a [com.codename1.printing.PrintResult] to the listener at
+    /// most once. The listener may be null and results may arrive from any
+    /// thread; `Display` moves the callback onto the EDT.
+    private static final class PrintResultDispatcher {
+        private final com.codename1.printing.PrintResultListener listener;
+        private boolean fired;
+
+        PrintResultDispatcher(com.codename1.printing.PrintResultListener listener) {
+            this.listener = listener;
+        }
+
+        void fire(com.codename1.printing.PrintResult result) {
+            synchronized (this) {
+                if (fired) {
+                    return;
+                }
+                fired = true;
+            }
+            if (listener != null) {
+                listener.onResult(result);
+            }
+        }
+    }
+
+    /// All android.print framework access lives in this class so the
+    /// classes it references are only loaded behind the API 19 check in
+    /// [#print].
+    @TargetApi(19)
+    private static final class PrintSupport {
+
+        private static final int JOB_PENDING = 0;
+        private static final int JOB_COMPLETED = 1;
+        private static final int JOB_CANCELLED = 2;
+        private static final int JOB_FAILED = 3;
+
+        /// How long the poller waits for the print dialog/job to reach a
+        /// terminal state before giving up.
+        private static final long POLL_TIMEOUT = 15 * 60 * 1000L;
+        private static final long POLL_INTERVAL = 500;
+
+        /// Must run on the UI thread: `PrintManager.print` and
+        /// `PrintHelper.printBitmap` both require it.
+        static void startPrint(Activity activity, File file, String mimeType, PrintResultDispatcher dispatcher) {
+            String jobName = file.getName();
+            if ("application/pdf".equalsIgnoreCase(mimeType)) {
+                android.print.PrintManager printManager =
+                        (android.print.PrintManager) activity.getSystemService(Context.PRINT_SERVICE);
+                if (printManager == null) {
+                    dispatcher.fire(com.codename1.printing.PrintResult.failed("Print service unavailable"));
+                    return;
+                }
+                android.print.PrintJob job = printManager.print(jobName,
+                        new PdfFilePrintAdapter(jobName, file), null);
+                pollPrintJob(activity, job, dispatcher);
+            } else if (mimeType != null && mimeType.startsWith("image/")) {
+                printImage(activity, file, jobName, dispatcher);
+            } else {
+                dispatcher.fire(com.codename1.printing.PrintResult.failed(
+                        "Unsupported print document type: " + mimeType));
+            }
+        }
+
+        private static void printImage(Activity activity, File file, String jobName,
+                final PrintResultDispatcher dispatcher) {
+            Bitmap bitmap = BitmapFactory.decodeFile(file.getAbsolutePath());
+            if (bitmap == null) {
+                dispatcher.fire(com.codename1.printing.PrintResult.failed(
+                        "Unable to decode image for printing"));
+                return;
+            }
+            android.support.v4.print.PrintHelper helper = new android.support.v4.print.PrintHelper(activity);
+            helper.setScaleMode(android.support.v4.print.PrintHelper.SCALE_MODE_FIT);
+            helper.printBitmap(jobName, bitmap, new android.support.v4.print.PrintHelper.OnPrintFinishCallback() {
+                @Override
+                public void onFinish() {
+                    // PrintHelper fires onFinish when the print flow ends
+                    // without exposing whether the user printed or
+                    // dismissed the dialog; report completed best effort.
+                    dispatcher.fire(com.codename1.printing.PrintResult.completed());
+                }
+            });
+        }
+
+        /// Watches the print job from a background thread and reports the
+        /// first terminal state. The job object must only be queried on
+        /// the UI thread, so every tick bounces through `runOnUiThread`.
+        private static void pollPrintJob(final Activity activity, final android.print.PrintJob job,
+                final PrintResultDispatcher dispatcher) {
+            Thread poller = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    long deadline = System.currentTimeMillis() + POLL_TIMEOUT;
+                    while (System.currentTimeMillis() < deadline) {
+                        try {
+                            Thread.sleep(POLL_INTERVAL);
+                        } catch (InterruptedException ignore) {
+                        }
+                        final int[] state = new int[]{JOB_PENDING};
+                        final boolean[] done = new boolean[1];
+                        final Object lock = new Object();
+                        activity.runOnUiThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                int s = JOB_PENDING;
+                                try {
+                                    if (job.isCancelled()) {
+                                        s = JOB_CANCELLED;
+                                    } else if (job.isFailed()) {
+                                        s = JOB_FAILED;
+                                    } else if (job.isCompleted()) {
+                                        s = JOB_COMPLETED;
+                                    } else if (job.isQueued() || job.isStarted() || job.isBlocked()) {
+                                        // The dialog phase is over and the
+                                        // job belongs to the print service;
+                                        // that is as "completed" as Android
+                                        // lets us observe reliably.
+                                        s = JOB_COMPLETED;
+                                    }
+                                } catch (Throwable t) {
+                                    s = JOB_FAILED;
+                                }
+                                synchronized (lock) {
+                                    state[0] = s;
+                                    done[0] = true;
+                                    lock.notifyAll();
+                                }
+                            }
+                        });
+                        synchronized (lock) {
+                            long waitUntil = System.currentTimeMillis() + 5000;
+                            while (!done[0] && System.currentTimeMillis() < waitUntil) {
+                                try {
+                                    lock.wait(POLL_INTERVAL);
+                                } catch (InterruptedException ignore) {
+                                }
+                            }
+                            if (!done[0]) {
+                                // UI thread didn't get to us; try again on
+                                // the next tick until the deadline passes.
+                                continue;
+                            }
+                        }
+                        switch (state[0]) {
+                            case JOB_COMPLETED:
+                                dispatcher.fire(com.codename1.printing.PrintResult.completed());
+                                return;
+                            case JOB_CANCELLED:
+                                dispatcher.fire(com.codename1.printing.PrintResult.cancelled());
+                                return;
+                            case JOB_FAILED:
+                                dispatcher.fire(com.codename1.printing.PrintResult.failed("Print job failed"));
+                                return;
+                            default:
+                                // still in the dialog phase, keep polling
+                        }
+                    }
+                    dispatcher.fire(com.codename1.printing.PrintResult.failed(
+                            "Timed out waiting for the print job status"));
+                }
+            }, "CN1PrintJobPoller");
+            poller.setDaemon(true);
+            poller.start();
+        }
+
+        /// Streams an existing PDF file into the print system unchanged.
+        /// Layout/write failures are routed through the framework
+        /// callbacks which fail the print job; the poller in
+        /// [#pollPrintJob] then reports the failure to the listener, so
+        /// the dispatcher still fires exactly once.
+        private static final class PdfFilePrintAdapter extends android.print.PrintDocumentAdapter {
+            private final String jobName;
+            private final File file;
+
+            PdfFilePrintAdapter(String jobName, File file) {
+                this.jobName = jobName;
+                this.file = file;
+            }
+
+            @Override
+            public void onLayout(android.print.PrintAttributes oldAttributes,
+                    android.print.PrintAttributes newAttributes,
+                    android.os.CancellationSignal cancellationSignal,
+                    LayoutResultCallback callback, Bundle extras) {
+                if (cancellationSignal != null && cancellationSignal.isCanceled()) {
+                    callback.onLayoutCancelled();
+                    return;
+                }
+                try {
+                    android.print.PrintDocumentInfo info = new android.print.PrintDocumentInfo.Builder(jobName)
+                            .setContentType(android.print.PrintDocumentInfo.CONTENT_TYPE_DOCUMENT)
+                            .setPageCount(android.print.PrintDocumentInfo.PAGE_COUNT_UNKNOWN)
+                            .build();
+                    callback.onLayoutFinished(info, !newAttributes.equals(oldAttributes));
+                } catch (Throwable t) {
+                    callback.onLayoutFailed(t.toString());
+                }
+            }
+
+            @Override
+            public void onWrite(android.print.PageRange[] pages,
+                    android.os.ParcelFileDescriptor destination,
+                    android.os.CancellationSignal cancellationSignal,
+                    WriteResultCallback callback) {
+                FileInputStream in = null;
+                FileOutputStream out = null;
+                try {
+                    in = new FileInputStream(file);
+                    out = new FileOutputStream(destination.getFileDescriptor());
+                    byte[] buffer = new byte[8192];
+                    int count;
+                    while ((count = in.read(buffer)) > -1) {
+                        if (cancellationSignal != null && cancellationSignal.isCanceled()) {
+                            callback.onWriteCancelled();
+                            return;
+                        }
+                        out.write(buffer, 0, count);
+                    }
+                    callback.onWriteFinished(new android.print.PageRange[]{android.print.PageRange.ALL_PAGES});
+                } catch (Throwable t) {
+                    callback.onWriteFailed(t.toString());
+                } finally {
+                    if (in != null) {
+                        try {
+                            in.close();
+                        } catch (Throwable ignore) {
+                        }
+                    }
+                    if (out != null) {
+                        try {
+                            out.close();
+                        } catch (Throwable ignore) {
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     /**
      * @inheritDoc
      */

--- a/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
@@ -36,6 +36,8 @@ import com.codename1.impl.javase.util.MavenUtils;
 import com.codename1.impl.javase.util.SwingUtils;
 import com.codename1.messaging.Message;
 import com.codename1.payment.PromotionalOffer;
+import com.codename1.printing.PrintResult;
+import com.codename1.printing.PrintResultListener;
 import com.codename1.ui.Component;
 import com.codename1.ui.Display;
 import com.codename1.ui.Font;
@@ -67,6 +69,10 @@ import java.awt.event.*;
 import java.awt.font.FontRenderContext;
 import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.awt.print.PrinterJob;
 import java.io.ByteArrayInputStream;
 import java.io.EOFException;
 import java.io.FilenameFilter;
@@ -166,6 +172,12 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javax.net.ssl.HttpsURLConnection;
+import javax.print.DocFlavor;
+import javax.print.DocPrintJob;
+import javax.print.PrintService;
+import javax.print.PrintServiceLookup;
+import javax.print.SimpleDoc;
+import javax.print.attribute.HashPrintRequestAttributeSet;
 import javax.sound.sampled.AudioFileFormat;
 import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.AudioInputStream;
@@ -11951,6 +11963,143 @@ public class JavaSEPort extends CodenameOneImplementation {
 
         } catch (Exception ex) {
             ex.printStackTrace();
+        }
+    }
+
+    /// Printing is available in the simulator whenever a display is attached;
+    /// the actual job goes through the desktop printing system via
+    /// [#print(String,String,PrintResultListener)].
+    public boolean isPrintingSupported() {
+        return !GraphicsEnvironment.isHeadless();
+    }
+
+    /// Prints a document file through the desktop printing system.
+    ///
+    /// Image files (`image/png`, `image/jpeg`, ...) are rendered with
+    /// `java.awt.print.PrinterJob` behind the native print dialog; the image
+    /// is scaled to fit the imageable page area while preserving its aspect
+    /// ratio. PDF files are handed to the OS through `Desktop.print` when
+    /// the desktop supports it, falling back to a `javax.print` service
+    /// that accepts PDF input streams. Since the OS owns the PDF flow,
+    /// `COMPLETED` for PDFs means "handed off" on a best-effort basis and
+    /// user cancellation cannot be observed.
+    ///
+    /// The flow runs on a background thread; the listener is invoked
+    /// exactly once from that thread and `Display` marshals it back to
+    /// the EDT.
+    public void print(final String filePath, final String mimeType, final PrintResultListener listener) {
+        new Thread(new Runnable() {
+            public void run() {
+                PrintResult result;
+                try {
+                    result = printImpl(filePath, mimeType);
+                } catch (Throwable t) {
+                    Log.e(t);
+                    result = PrintResult.failed("Print failed: " + t);
+                }
+                if (listener != null) {
+                    listener.onResult(result);
+                }
+            }
+        }, "CN1 Print Thread").start();
+    }
+
+    private PrintResult printImpl(String filePath, String mimeType) {
+        if (filePath == null) {
+            return PrintResult.failed("Print file path is null");
+        }
+        File file = new File(unfile(filePath));
+        if (!file.isFile()) {
+            return PrintResult.failed("Print file not found: " + filePath);
+        }
+        if (mimeType != null && mimeType.startsWith("image/")) {
+            return printImage(file);
+        }
+        if ("application/pdf".equals(mimeType)) {
+            return printPdf(file);
+        }
+        return PrintResult.failed("Unsupported print mime type: " + mimeType);
+    }
+
+    private PrintResult printImage(File file) {
+        final BufferedImage img;
+        try {
+            img = ImageIO.read(file);
+        } catch (IOException err) {
+            Log.e(err);
+            return PrintResult.failed("Failed to read image: " + err);
+        }
+        if (img == null) {
+            return PrintResult.failed("Unsupported image format: " + file.getName());
+        }
+        PrinterJob job = PrinterJob.getPrinterJob();
+        job.setJobName(file.getName());
+        job.setPrintable(new Printable() {
+            public int print(java.awt.Graphics graphics, PageFormat pageFormat, int pageIndex) {
+                if (pageIndex > 0) {
+                    return NO_SUCH_PAGE;
+                }
+                Graphics2D g2d = (Graphics2D) graphics;
+                g2d.translate(pageFormat.getImageableX(), pageFormat.getImageableY());
+                double scale = Math.min(pageFormat.getImageableWidth() / img.getWidth(),
+                        pageFormat.getImageableHeight() / img.getHeight());
+                int w = Math.max(1, (int) Math.round(img.getWidth() * scale));
+                int h = Math.max(1, (int) Math.round(img.getHeight() * scale));
+                g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+                g2d.drawImage(img, 0, 0, w, h, null);
+                return PAGE_EXISTS;
+            }
+        });
+        if (!job.printDialog()) {
+            return PrintResult.cancelled();
+        }
+        try {
+            job.print();
+            return PrintResult.completed();
+        } catch (PrinterException err) {
+            Log.e(err);
+            return PrintResult.failed("Print job failed: " + err.getMessage());
+        }
+    }
+
+    private PrintResult printPdf(File file) {
+        if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.PRINT)) {
+            try {
+                Desktop.getDesktop().print(file);
+                return PrintResult.completed();
+            } catch (IOException err) {
+                Log.e(err);
+                // fall through to the javax.print path below
+            }
+        }
+        DocFlavor flavor = DocFlavor.INPUT_STREAM.PDF;
+        PrintService service = PrintServiceLookup.lookupDefaultPrintService();
+        if (service == null || !service.isDocFlavorSupported(flavor)) {
+            service = null;
+            PrintService[] services = PrintServiceLookup.lookupPrintServices(flavor, null);
+            if (services.length > 0) {
+                service = services[0];
+            }
+        }
+        if (service == null) {
+            return PrintResult.failed("No print service on this system accepts PDF documents");
+        }
+        InputStream in = null;
+        try {
+            in = new FileInputStream(file);
+            DocPrintJob printJob = service.createPrintJob();
+            printJob.print(new SimpleDoc(in, flavor, null), new HashPrintRequestAttributeSet());
+            return PrintResult.completed();
+        } catch (Exception err) {
+            Log.e(err);
+            return PrintResult.failed("Failed to print PDF: " + err.getMessage());
+        } finally {
+            if (in != null) {
+                try {
+                    in.close();
+                } catch (IOException ignore) {
+                }
+            }
         }
     }
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -43,6 +43,8 @@ import com.codename1.location.LocationManager;
 import com.codename1.media.Media;
 import com.codename1.media.MediaRecorderBuilder;
 import com.codename1.messaging.Message;
+import com.codename1.printing.PrintResult;
+import com.codename1.printing.PrintResultListener;
 import com.codename1.push.PushCallback;
 import com.codename1.teavm.ext.localforage.LocalForage;
 import com.codename1.teavm.ext.localforage.LocalForage.ItemSavedListener;
@@ -9779,8 +9781,133 @@ public class HTML5Implementation extends CodenameOneImplementation {
             super.share(text, image, mimeType, sourceRect);
         }
     }
-    
-    
+
+    /// Printing works by loading the document into a hidden iframe and
+    /// invoking the browser print dialog, so it is always available.
+    @Override
+    public boolean isPrintingSupported() {
+        return true;
+    }
+
+    /// Print a document by loading it into a hidden iframe as a blob
+    /// object URL and invoking the browser print dialog on the iframe's
+    /// content window.
+    ///
+    /// Browsers don't reliably expose whether the user printed or
+    /// dismissed the dialog: where the iframe fires `afterprint` the
+    /// result is reported as completed when the dialog closes, otherwise
+    /// completed is reported on a best-effort basis shortly after
+    /// `print()` is invoked. Cancellation is therefore reported as
+    /// completed on this port.
+    ///
+    /// PDF documents print through the browser's built-in PDF viewer and
+    /// behavior varies between browsers; Firefox may print a blank or
+    /// placeholder page for PDF iframes.
+    ///
+    /// #### Parameters
+    ///
+    /// - `filePath`: path of the document in file system storage
+    ///
+    /// - `mimeType`: the document type, e.g. `application/pdf`, `image/png`
+    ///
+    /// - `listener`: callback for the print outcome. May be null.
+    @Override
+    public void print(final String filePath, final String mimeType, final PrintResultListener listener) {
+        final boolean[] fired = new boolean[1];
+        new Thread(new Runnable() {
+            public void run() {
+                String url;
+                try {
+                    Blob blob = openFileAsBlob(filePath);
+                    if (mimeType != null && !Objects.equals(blob.getType(), mimeType)) {
+                        blob = BlobUtil.toType(blob, mimeType);
+                    }
+                    url = BlobUtil.createObjectURL(blob);
+                    if (url == null) {
+                        firePrintResult(listener, PrintResult.failed("Object URLs are not supported in this browser"), fired);
+                        return;
+                    }
+                } catch (Exception ex) {
+                    Log.e(ex);
+                    firePrintResult(listener, PrintResult.failed(ex.getMessage()), fired);
+                    return;
+                }
+                printObjectURL_(url, new PrintFrameCallback() {
+                    public void onResult(final boolean completed, final String error) {
+                        // Hop off the JS callback context before touching
+                        // Codename One code, matching the other JSFunctor
+                        // callbacks in this class.
+                        new Thread(new Runnable() {
+                            public void run() {
+                                if (completed) {
+                                    firePrintResult(listener, PrintResult.completed(), fired);
+                                } else {
+                                    firePrintResult(listener, PrintResult.failed(error), fired);
+                                }
+                            }
+                        }).start();
+                    }
+                });
+            }
+        }).start();
+    }
+
+    /// Reports a print result exactly once. The native print script fires
+    /// its callback at most once, but the load/afterprint/fallback paths
+    /// plus the Java-side error paths share this guard so the listener
+    /// can never be invoked twice.
+    private static void firePrintResult(PrintResultListener listener, PrintResult result, boolean[] fired) {
+        synchronized (fired) {
+            if (fired[0]) {
+                return;
+            }
+            fired[0] = true;
+        }
+        if (listener != null) {
+            listener.onResult(result);
+        }
+    }
+
+    @JSFunctor
+    private static interface PrintFrameCallback extends JSObject {
+        public void onResult(boolean completed, String error);
+    }
+
+    // Loads the object URL into a hidden iframe, prints it and reports the
+    // outcome through the callback. The iframe and the object URL are kept
+    // alive for 60 seconds (or until afterprint) because print dialogs read
+    // the frame content lazily.
+    @JSBody(params = {"url", "callback"}, script =
+            "var done = false;\n"
+            + "var cleaned = false;\n"
+            + "var iframe = null;\n"
+            + "var finish = function(ok, msg) { if (done) return; done = true; callback(ok, msg); };\n"
+            + "var cleanup = function() {\n"
+            + "    if (cleaned) return; cleaned = true;\n"
+            + "    try { var u = (typeof URL !== 'undefined' && URL) ? URL : ((typeof window !== 'undefined' && window.webkitURL) ? window.webkitURL : null); if (u) u.revokeObjectURL(url); } catch (e) {}\n"
+            + "    try { if (iframe && iframe.parentNode) iframe.parentNode.removeChild(iframe); } catch (e) {}\n"
+            + "};\n"
+            + "if (typeof document === 'undefined' || !document.body) { finish(false, 'Printing requires a browser document context'); return; }\n"
+            + "iframe = document.createElement('iframe');\n"
+            + "iframe.style.cssText = 'position:fixed;visibility:hidden;right:0;bottom:0;width:0;height:0;border:0';\n"
+            + "iframe.onload = function() {\n"
+            + "    try {\n"
+            + "        var win = iframe.contentWindow;\n"
+            + "        try { win.addEventListener('afterprint', function() { finish(true, null); setTimeout(cleanup, 0); }); } catch (e) {}\n"
+            + "        win.focus();\n"
+            + "        win.print();\n"
+            + "        setTimeout(function() { finish(true, null); }, 1000);\n"
+            + "    } catch (e) {\n"
+            + "        finish(false, '' + e);\n"
+            + "        cleanup();\n"
+            + "    }\n"
+            + "};\n"
+            + "iframe.onerror = function() { finish(false, 'Failed to load document for printing'); cleanup(); };\n"
+            + "iframe.src = url;\n"
+            + "document.body.appendChild(iframe);\n"
+            + "setTimeout(cleanup, 60000);")
+    private native static void printObjectURL_(String url, PrintFrameCallback callback);
+
     private static interface CancelableEvent extends Event {
         @JSProperty
         public boolean isDefaultPrevented();

--- a/Ports/WindowsPort/nativeSources/cn1_windows.h
+++ b/Ports/WindowsPort/nativeSources/cn1_windows.h
@@ -251,6 +251,14 @@ void cn1WinTrayHandleMessage(WPARAM wParam, LPARAM lParam);
 #define WM_CN1_SHARE (WM_APP + 22)
 void cn1WinShareHandleMessage(WPARAM wParam);
 
+/* System print dialog (cn1_windows_print.cpp). PrintDlgW is modal and must run
+ * on the window-owning pump thread, so the printing worker thread sends (not
+ * posts) WM_CN1_PRINTDLG to cn1Win.hwnd -- a blocking SendMessage that returns
+ * once the user has chosen a printer -- and cn1WinWndProc forwards it here. The
+ * document is then rasterized and spooled on the worker thread. */
+#define WM_CN1_PRINTDLG (WM_APP + 23)
+LRESULT cn1WinPrintDialogHandleMessage(WPARAM wParam);
+
 /* graphics (cn1_windows_graphics.c) */
 CN1Graphics* cn1WinCreateGraphics(ID2D1RenderTarget* target);
 void cn1WinBeginFrame(CN1Graphics* g);

--- a/Ports/WindowsPort/nativeSources/cn1_windows_print.cpp
+++ b/Ports/WindowsPort/nativeSources/cn1_windows_print.cpp
@@ -1,0 +1,709 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+/*
+ * Printing translation unit for the native Codename One Windows port: backs
+ * com.codename1.printing (Printer / PrintResult) with the real Win32 print
+ * pipeline.
+ *
+ * Flow: the CN1 printing worker thread calls printDocument, which hands the
+ * modal system print dialog (PrintDlgW) to the window-owning pump thread with a
+ * blocking SendMessage(WM_CN1_PRINTDLG) -- the same cross-thread handover the
+ * file dialog uses (cn1_windows_io.c). The dialog yields the printer HDC; the
+ * worker thread then rasterizes the document and spools it through GDI
+ * (StartDocW / StartPage / StretchDIBits / EndPage / EndDoc):
+ *
+ *   - images (image/png, image/jpeg, ...): decoded with the shared WIC helper
+ *     (cn1WinDecodeImage in cn1_windows_image.cpp) and printed as a single
+ *     page scaled to fit the printable area, preserving aspect ratio.
+ *   - application/pdf: each page is rasterized by the WinRT Windows.Data.Pdf
+ *     renderer at the printer's DPI into an in-memory PNG stream, decoded with
+ *     the same WIC helper and printed like an image page. WinRT is consumed
+ *     through the raw WRL ABI projection exactly like cn1_windows_winrt.cpp --
+ *     no C++/WinRT, no C++ STL (the cross-compile toolchain may predate the
+ *     MSVC STL's clang requirement), manual COM lifetime management.
+ *
+ * Outcomes are honest: 0 only after EndDoc handed the job to the spooler, 1
+ * when the user dismissed the dialog, 2 with a short message (printLastError)
+ * for everything else. Nothing is fabricated in headless mode -- with no host
+ * window there is no dialog, so the request fails.
+ */
+
+#ifdef _WIN32
+
+#include "cn1_windows.h"
+
+#include <cderr.h>
+#include <commdlg.h>
+#include <roapi.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wrl.h>
+#include <wrl/event.h>
+#include <wrl/wrappers/corewrappers.h>
+#include <windows.foundation.h>
+#include <windows.data.pdf.h>
+#include <windows.storage.h>
+#include <windows.storage.streams.h>
+
+using namespace ABI::Windows::Foundation;
+using namespace ABI::Windows::Data::Pdf;
+using namespace ABI::Windows::Storage;
+using namespace ABI::Windows::Storage::Streams;
+using namespace Microsoft::WRL;
+using namespace Microsoft::WRL::Wrappers;
+
+/* Largest page-raster dimension for PDF rendering. Bounds the per-page pixel
+ * buffer (4096^2 * 4 bytes = 64MB) while still exceeding 400 DPI on letter /
+ * A4 paper -- visually lossless for a desktop print. */
+#define CN1_PRINT_MAX_RENDER_DIM 4096
+
+/* Last failure description for the Java side (printLastError). Printing is
+ * serialized by the modal dialog -- one job at a time -- so a single static
+ * buffer is sufficient. ASCII/UTF-8. */
+static char g_printError[512];
+
+static void cn1PrintSetError(const char* msg) {
+    snprintf(g_printError, sizeof(g_printError), "%s", msg != NULL ? msg : "");
+}
+
+static void cn1PrintSetErrorHr(const char* what, HRESULT hr) {
+    snprintf(g_printError, sizeof(g_printError), "%s (HRESULT 0x%08lX)",
+            what, (unsigned long) hr);
+}
+
+/* Blocks the calling (CN1 worker) thread until a WinRT IAsyncOperation<T>
+ * completes, then fetches its result -- same shape as the helper in
+ * cn1_windows_winrt.cpp (which is private to that unit). TOp is the operation's
+ * logical result type; TResultPtr the GetResults out-pointer type. */
+template <typename TOp, typename TResultPtr>
+static HRESULT cn1PrintAwaitOp(IAsyncOperation<TOp>* op, TResultPtr result) {
+    Event done(CreateEventExW(nullptr, nullptr, 0, EVENT_ALL_ACCESS));
+    if (!done.IsValid()) {
+        return E_FAIL;
+    }
+    HRESULT hr = op->put_Completed(Callback<IAsyncOperationCompletedHandler<TOp>>(
+            [&done](IAsyncOperation<TOp>*, AsyncStatus) {
+                SetEvent(done.Get());
+                return S_OK;
+            }).Get());
+    if (FAILED(hr)) {
+        return hr;
+    }
+    WaitForSingleObject(done.Get(), 120000);
+    return op->GetResults(result);
+}
+
+/* IAsyncAction variant of the above (RenderWithOptionsToStreamAsync returns an
+ * action, not an operation). */
+static HRESULT cn1PrintAwaitAction(IAsyncAction* action) {
+    Event done(CreateEventExW(nullptr, nullptr, 0, EVENT_ALL_ACCESS));
+    if (!done.IsValid()) {
+        return E_FAIL;
+    }
+    HRESULT hr = action->put_Completed(Callback<IAsyncActionCompletedHandler>(
+            [&done](IAsyncAction*, AsyncStatus) {
+                SetEvent(done.Get());
+                return S_OK;
+            }).Get());
+    if (FAILED(hr)) {
+        return hr;
+    }
+    WaitForSingleObject(done.Get(), 120000);
+    return action->GetResults();
+}
+
+/* Frees a CN1Image produced by cn1WinDecodeImage. Decode-only images carry just
+ * the CPU pixel copy -- no GPU bitmap (lazy) and no mutable graphics. */
+static void cn1PrintFreeImage(CN1Image* img) {
+    if (img == NULL) {
+        return;
+    }
+    if (img->argb != NULL) {
+        free(img->argb);
+    }
+    free(img);
+}
+
+/*
+ * Spools one page of straight-alpha 0xAARRGGBB pixels: composites over white
+ * (paper), scales to fit the printable area preserving aspect ratio, centers,
+ * and emits it between StartPage/EndPage with StretchDIBits. Returns 1 on
+ * success, 0 on failure with g_printError set.
+ */
+static int cn1PrintArgbPage(HDC hdc, const uint32_t* argb, int w, int h) {
+    int printW = GetDeviceCaps(hdc, HORZRES);
+    int printH = GetDeviceCaps(hdc, VERTRES);
+    long long destW, destH;
+    int destX, destY;
+    uint32_t* dib;
+    size_t pixels;
+    size_t i;
+    BITMAPINFO bmi;
+    int scanned;
+    int ok = 1;
+
+    if (argb == NULL || w <= 0 || h <= 0) {
+        cn1PrintSetError("Nothing to print on this page");
+        return 0;
+    }
+    if (printW <= 0 || printH <= 0) {
+        cn1PrintSetError("The printer reports an empty printable area");
+        return 0;
+    }
+
+    /* Fit within the printable area, preserving aspect ratio; center within it.
+     * (0,0) of a printer DC is the top-left of the printable area -- the
+     * physical margin offsets (PHYSICALOFFSETX/Y) are already outside it. */
+    destW = printW;
+    destH = ((long long) h * printW) / w;
+    if (destH > printH) {
+        destH = printH;
+        destW = ((long long) w * printH) / h;
+    }
+    if (destW < 1) {
+        destW = 1;
+    }
+    if (destH < 1) {
+        destH = 1;
+    }
+    destX = (int) ((printW - destW) / 2);
+    destY = (int) ((printH - destH) / 2);
+
+    /* Composite over white into a 32bpp BI_RGB top-down DIB. A DIB pixel's
+     * little-endian memory bytes are {B,G,R,x}, i.e. the uint32 0x00RRGGBB --
+     * the same layout as our ARGB once alpha has been blended away. */
+    pixels = (size_t) w * (size_t) h;
+    dib = (uint32_t*) malloc(pixels * sizeof(uint32_t));
+    if (dib == NULL) {
+        cn1PrintSetError("Out of memory preparing the print page");
+        return 0;
+    }
+    for (i = 0; i < pixels; i++) {
+        uint32_t p = argb[i];
+        uint32_t a = (p >> 24) & 0xFF;
+        uint32_t r = (p >> 16) & 0xFF;
+        uint32_t g = (p >> 8) & 0xFF;
+        uint32_t b = p & 0xFF;
+        if (a != 255) {
+            uint32_t inv = 255 - a;
+            r = (r * a + 255 * inv + 127) / 255;
+            g = (g * a + 255 * inv + 127) / 255;
+            b = (b * a + 255 * inv + 127) / 255;
+        }
+        dib[i] = (r << 16) | (g << 8) | b;
+    }
+
+    ZeroMemory(&bmi, sizeof(bmi));
+    bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+    bmi.bmiHeader.biWidth = w;
+    bmi.bmiHeader.biHeight = -h; /* negative = top-down rows */
+    bmi.bmiHeader.biPlanes = 1;
+    bmi.bmiHeader.biBitCount = 32;
+    bmi.bmiHeader.biCompression = BI_RGB;
+
+    if (StartPage(hdc) <= 0) {
+        cn1PrintSetError("StartPage failed");
+        free(dib);
+        return 0;
+    }
+    /* HALFTONE averages source pixels when shrinking -- the quality mode for
+     * scaling a raster onto a high-DPI printer page. */
+    SetStretchBltMode(hdc, HALFTONE);
+    SetBrushOrgEx(hdc, 0, 0, NULL);
+    /* StretchDIBits returns the scanned line count, 0 / GDI_ERROR (-1 as int)
+     * on failure. */
+    scanned = StretchDIBits(hdc, destX, destY, (int) destW, (int) destH,
+            0, 0, w, h, dib, &bmi, DIB_RGB_COLORS, SRCCOPY);
+    if (scanned <= 0) {
+        cn1PrintSetError("StretchDIBits failed to spool the page");
+        ok = 0;
+    }
+    if (EndPage(hdc) <= 0 && ok) {
+        cn1PrintSetError("EndPage failed");
+        ok = 0;
+    }
+    free(dib);
+    return ok;
+}
+
+/*
+ * Prints an image file (PNG/JPEG/... -- anything the shared WIC decoder
+ * handles) as a single-page document. Returns 1 on success, 0 on failure with
+ * g_printError set. The document (StartDocW/EndDoc) is managed by the caller.
+ */
+static int cn1PrintImagePages(HDC hdc, const WCHAR* path) {
+    FILE* fp;
+    long size;
+    BYTE* data;
+    size_t readCount;
+    CN1Image* img;
+    int ok;
+
+    fp = _wfopen(path, L"rb");
+    if (fp == NULL) {
+        cn1PrintSetError("Could not open the image file");
+        return 0;
+    }
+    if (fseek(fp, 0, SEEK_END) != 0 || (size = ftell(fp)) <= 0
+            || fseek(fp, 0, SEEK_SET) != 0) {
+        fclose(fp);
+        cn1PrintSetError("Could not read the image file");
+        return 0;
+    }
+    data = (BYTE*) malloc((size_t) size);
+    if (data == NULL) {
+        fclose(fp);
+        cn1PrintSetError("Out of memory reading the image file");
+        return 0;
+    }
+    readCount = fread(data, 1, (size_t) size, fp);
+    fclose(fp);
+    if (readCount != (size_t) size) {
+        free(data);
+        cn1PrintSetError("Could not read the image file");
+        return 0;
+    }
+    img = cn1WinDecodeImage(data, (UINT32) size);
+    free(data);
+    if (img == NULL || img->argb == NULL) {
+        cn1PrintFreeImage(img);
+        cn1PrintSetError("Could not decode the image");
+        return 0;
+    }
+    ok = cn1PrintArgbPage(hdc, img->argb, img->width, img->height);
+    cn1PrintFreeImage(img);
+    return ok;
+}
+
+/*
+ * Prints a PDF file: loads it with the WinRT Windows.Data.Pdf renderer and
+ * rasterizes each page at the printer's DPI (capped at
+ * CN1_PRINT_MAX_RENDER_DIM) into an in-memory PNG, which is then decoded with
+ * the shared WIC helper and spooled like an image page. Returns 1 on success,
+ * 0 on failure with g_printError set. The document (StartDocW/EndDoc) is
+ * managed by the caller.
+ */
+static int cn1PrintPdfPages(HDC hdc, const WCHAR* path) {
+    HRESULT hr;
+    UINT32 pageCount = 0;
+    UINT32 pageIndex;
+    int dpiX = GetDeviceCaps(hdc, LOGPIXELSX);
+    int dpiY = GetDeviceCaps(hdc, LOGPIXELSY);
+
+    if (dpiX <= 0) {
+        dpiX = 600;
+    }
+    if (dpiY <= 0) {
+        dpiY = 600;
+    }
+
+    RoInitialize(RO_INIT_MULTITHREADED);
+
+    /* StorageFile from the Win32 path (the unpackaged-app entry point into
+     * Windows.Storage; the caller already normalized to backslashes). */
+    ComPtr<IStorageFileStatics> fileStatics;
+    hr = RoGetActivationFactory(
+            HStringReference(RuntimeClass_Windows_Storage_StorageFile).Get(),
+            IID_PPV_ARGS(&fileStatics));
+    if (FAILED(hr)) {
+        cn1PrintSetErrorHr("The PDF renderer is unavailable", hr);
+        return 0;
+    }
+    ComPtr<IAsyncOperation<StorageFile*>> fileOp;
+    hr = fileStatics->GetFileFromPathAsync(
+            HStringReference(path).Get(), &fileOp);
+    if (FAILED(hr)) {
+        cn1PrintSetErrorHr("Could not open the PDF file", hr);
+        return 0;
+    }
+    ComPtr<IStorageFile> file;
+    hr = cn1PrintAwaitOp(fileOp.Get(), file.GetAddressOf());
+    if (FAILED(hr) || !file) {
+        cn1PrintSetErrorHr("Could not open the PDF file", hr);
+        return 0;
+    }
+
+    ComPtr<IPdfDocumentStatics> pdfStatics;
+    hr = RoGetActivationFactory(
+            HStringReference(RuntimeClass_Windows_Data_Pdf_PdfDocument).Get(),
+            IID_PPV_ARGS(&pdfStatics));
+    if (FAILED(hr)) {
+        cn1PrintSetErrorHr("The PDF renderer is unavailable", hr);
+        return 0;
+    }
+    ComPtr<IAsyncOperation<PdfDocument*>> docOp;
+    hr = pdfStatics->LoadFromFileAsync(file.Get(), &docOp);
+    if (FAILED(hr)) {
+        cn1PrintSetErrorHr("Could not load the PDF document", hr);
+        return 0;
+    }
+    ComPtr<IPdfDocument> doc;
+    hr = cn1PrintAwaitOp(docOp.Get(), doc.GetAddressOf());
+    if (FAILED(hr) || !doc) {
+        /* A password-protected or corrupt PDF lands here. */
+        cn1PrintSetErrorHr("Could not load the PDF document", hr);
+        return 0;
+    }
+    doc->get_PageCount(&pageCount);
+    if (pageCount == 0) {
+        cn1PrintSetError("The PDF document has no pages");
+        return 0;
+    }
+
+    for (pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+        ComPtr<IPdfPage> page;
+        hr = doc->GetPage(pageIndex, &page);
+        if (FAILED(hr) || !page) {
+            cn1PrintSetErrorHr("Could not read a PDF page", hr);
+            return 0;
+        }
+        /* Page size is in DIPs (1/96"); scale uniformly to the printer DPI,
+         * bounded so one rasterized page cannot exhaust memory. */
+        Size pageSize;
+        pageSize.Width = 0;
+        pageSize.Height = 0;
+        page->get_Size(&pageSize);
+        if (pageSize.Width <= 0 || pageSize.Height <= 0) {
+            cn1PrintSetError("A PDF page reports an empty size");
+            return 0;
+        }
+        double scale = dpiX / 96.0;
+        double scaleY = dpiY / 96.0;
+        if (scaleY < scale) {
+            scale = scaleY;
+        }
+        if (pageSize.Width * scale > CN1_PRINT_MAX_RENDER_DIM) {
+            scale = CN1_PRINT_MAX_RENDER_DIM / pageSize.Width;
+        }
+        if (pageSize.Height * scale > CN1_PRINT_MAX_RENDER_DIM) {
+            scale = CN1_PRINT_MAX_RENDER_DIM / pageSize.Height;
+        }
+        UINT32 destW = (UINT32) (pageSize.Width * scale + 0.5);
+        UINT32 destH = (UINT32) (pageSize.Height * scale + 0.5);
+        if (destW < 1) {
+            destW = 1;
+        }
+        if (destH < 1) {
+            destH = 1;
+        }
+
+        ComPtr<IInspectable> streamInsp;
+        hr = RoActivateInstance(
+                HStringReference(RuntimeClass_Windows_Storage_Streams_InMemoryRandomAccessStream).Get(),
+                &streamInsp);
+        if (FAILED(hr)) {
+            cn1PrintSetErrorHr("Could not create the page render stream", hr);
+            return 0;
+        }
+        ComPtr<IRandomAccessStream> stream;
+        if (FAILED(streamInsp.As(&stream)) || !stream) {
+            cn1PrintSetError("Could not create the page render stream");
+            return 0;
+        }
+        ComPtr<IInspectable> optionsInsp;
+        hr = RoActivateInstance(
+                HStringReference(RuntimeClass_Windows_Data_Pdf_PdfPageRenderOptions).Get(),
+                &optionsInsp);
+        if (FAILED(hr)) {
+            cn1PrintSetErrorHr("Could not create the page render options", hr);
+            return 0;
+        }
+        ComPtr<IPdfPageRenderOptions> options;
+        if (FAILED(optionsInsp.As(&options)) || !options) {
+            cn1PrintSetError("Could not create the page render options");
+            return 0;
+        }
+        options->put_DestinationWidth(destW);
+        options->put_DestinationHeight(destH);
+
+        /* Rasterize the page (PNG, the renderer's default encoder). */
+        ComPtr<IAsyncAction> renderAction;
+        hr = page->RenderWithOptionsToStreamAsync(stream.Get(), options.Get(), &renderAction);
+        if (FAILED(hr)) {
+            cn1PrintSetErrorHr("Could not render a PDF page", hr);
+            return 0;
+        }
+        hr = cn1PrintAwaitAction(renderAction.Get());
+        if (FAILED(hr)) {
+            cn1PrintSetErrorHr("Could not render a PDF page", hr);
+            return 0;
+        }
+
+        /* Pull the encoded bytes back out of the in-memory stream through a
+         * DataReader -- pure ABI, no shcore IStream bridge needed. */
+        UINT64 streamSize = 0;
+        stream->get_Size(&streamSize);
+        if (streamSize == 0 || streamSize > 0x7FFFFFFF) {
+            cn1PrintSetError("A rendered PDF page is empty or too large");
+            return 0;
+        }
+        ComPtr<IInputStream> input;
+        hr = stream->GetInputStreamAt(0, &input);
+        if (FAILED(hr) || !input) {
+            cn1PrintSetErrorHr("Could not read back a rendered PDF page", hr);
+            return 0;
+        }
+        ComPtr<IDataReaderFactory> readerFactory;
+        hr = RoGetActivationFactory(
+                HStringReference(RuntimeClass_Windows_Storage_Streams_DataReader).Get(),
+                IID_PPV_ARGS(&readerFactory));
+        if (FAILED(hr)) {
+            cn1PrintSetErrorHr("Could not read back a rendered PDF page", hr);
+            return 0;
+        }
+        ComPtr<IDataReader> reader;
+        hr = readerFactory->CreateDataReader(input.Get(), &reader);
+        if (FAILED(hr) || !reader) {
+            cn1PrintSetErrorHr("Could not read back a rendered PDF page", hr);
+            return 0;
+        }
+        ComPtr<IAsyncOperation<UINT32>> loadOp;
+        hr = reader->LoadAsync((UINT32) streamSize, &loadOp);
+        if (FAILED(hr)) {
+            cn1PrintSetErrorHr("Could not read back a rendered PDF page", hr);
+            return 0;
+        }
+        UINT32 loaded = 0;
+        hr = cn1PrintAwaitOp(loadOp.Get(), &loaded);
+        if (FAILED(hr) || loaded == 0) {
+            cn1PrintSetErrorHr("Could not read back a rendered PDF page", hr);
+            return 0;
+        }
+        BYTE* png = (BYTE*) malloc(loaded);
+        if (png == NULL) {
+            cn1PrintSetError("Out of memory reading a rendered PDF page");
+            return 0;
+        }
+        hr = reader->ReadBytes(loaded, png);
+        if (FAILED(hr)) {
+            free(png);
+            cn1PrintSetErrorHr("Could not read back a rendered PDF page", hr);
+            return 0;
+        }
+
+        CN1Image* img = cn1WinDecodeImage(png, loaded);
+        free(png);
+        if (img == NULL || img->argb == NULL) {
+            cn1PrintFreeImage(img);
+            cn1PrintSetError("Could not decode a rendered PDF page");
+            return 0;
+        }
+        int ok = cn1PrintArgbPage(hdc, img->argb, img->width, img->height);
+        cn1PrintFreeImage(img);
+        if (!ok) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+extern "C" {
+
+/* ----------------------------------------------------- system print dialog
+ *
+ * Cross-thread request for the modal print dialog. The printing worker fills
+ * it, sends it to the pump thread (which owns the window) via WM_CN1_PRINTDLG,
+ * and reads the results back once SendMessage returns. The struct lives on the
+ * worker's stack, valid for the whole blocking call. */
+typedef struct CN1PrintDlgReq {
+    HDC hdc;        /* out: printer DC on success; the worker owns it (DeleteDC) */
+    int cancelled;  /* out: 1 when the user dismissed the dialog                 */
+    DWORD dlgError; /* out: CommDlgExtendedError code when the dialog failed     */
+} CN1PrintDlgReq;
+
+/* Runs on the pump thread (dispatched from cn1WinWndProc on WM_CN1_PRINTDLG).
+ * Shows the modal system print dialog owned by the main window and hands the
+ * chosen printer's DC back to the worker. The driver handles copies/collation
+ * (PD_USEDEVMODECOPIESANDCOLLATE), so the worker spools each page exactly once. */
+LRESULT cn1WinPrintDialogHandleMessage(WPARAM wp) {
+    CN1PrintDlgReq* req = (CN1PrintDlgReq*) wp;
+    PRINTDLGW pd;
+    if (req == NULL) {
+        return 0;
+    }
+    req->hdc = NULL;
+    req->cancelled = 0;
+    req->dlgError = 0;
+    ZeroMemory(&pd, sizeof(pd));
+    pd.lStructSize = sizeof(pd);
+    pd.hwndOwner = cn1Win.hwnd;
+    pd.Flags = PD_RETURNDC | PD_USEDEVMODECOPIESANDCOLLATE | PD_NOPAGENUMS
+            | PD_NOSELECTION | PD_HIDEPRINTTOFILE;
+    pd.nCopies = 1;
+    if (PrintDlgW(&pd)) {
+        req->hdc = pd.hDC;
+    } else {
+        DWORD err = CommDlgExtendedError();
+        if (err == 0) {
+            req->cancelled = 1; /* user dismissed the dialog */
+        } else {
+            req->dlgError = err;
+        }
+    }
+    /* PrintDlgW allocates these global handles even when the caller passed
+     * NULL; they are not needed once the DC exists. */
+    if (pd.hDevMode != NULL) {
+        GlobalFree(pd.hDevMode);
+    }
+    if (pd.hDevNames != NULL) {
+        GlobalFree(pd.hDevNames);
+    }
+    return 0;
+}
+
+/* --------------------------------------------------------------- Java bridge
+ *
+ * Prints the document at `path` (already stripped of the file:// prefix by the
+ * Java side). Returns 0 once EndDoc handed the job to the print spooler, 1 when
+ * the user cancelled the print dialog, 2 on failure (printLastError carries the
+ * description). Blocks for the whole flow -- the Java side calls it from a
+ * dedicated worker thread, and the thread state is yielded around the blocking
+ * native section so the GC is never held up (same discipline as fileDialog). */
+JAVA_INT com_codename1_impl_windows_WindowsNative_printDocument___java_lang_String_java_lang_String_java_lang_String_R_int(
+        CODENAME_ONE_THREAD_STATE, JAVA_OBJECT pathObj, JAVA_OBJECT mimeObj, JAVA_OBJECT jobNameObj) {
+    WCHAR* path;
+    WCHAR* mime;
+    WCHAR* jobName;
+    WCHAR* p;
+    CN1PrintDlgReq req;
+    DOCINFOW di;
+    int isPdf;
+    int isImage;
+    int ok;
+    JAVA_INT status = 2;
+
+    g_printError[0] = 0;
+    /* Headless screenshot mode has no window to own the print dialog. */
+    if (cn1Win.hwnd == NULL) {
+        cn1PrintSetError("Printing requires a display window");
+        return 2;
+    }
+    if (pathObj == JAVA_NULL) {
+        cn1PrintSetError("Print file path is null");
+        return 2;
+    }
+    path = cn1WinJavaStringToWide(threadStateData, pathObj, NULL);
+    mime = mimeObj != JAVA_NULL ? cn1WinJavaStringToWide(threadStateData, mimeObj, NULL) : NULL;
+    jobName = jobNameObj != JAVA_NULL ? cn1WinJavaStringToWide(threadStateData, jobNameObj, NULL) : NULL;
+    if (path == NULL) {
+        if (mime != NULL) {
+            free(mime);
+        }
+        if (jobName != NULL) {
+            free(jobName);
+        }
+        cn1PrintSetError("Print file path is invalid");
+        return 2;
+    }
+    /* WinRT's GetFileFromPathAsync insists on backslashes; CN1 paths arrive
+     * with forward slashes (the Win32 file APIs accept both). */
+    for (p = path; *p != 0; p++) {
+        if (*p == L'/') {
+            *p = L'\\';
+        }
+    }
+    isPdf = mime != NULL && wcscmp(mime, L"application/pdf") == 0;
+    isImage = mime != NULL && wcsncmp(mime, L"image/", 6) == 0;
+
+    if (!isPdf && !isImage) {
+        cn1PrintSetError("Unsupported print document type");
+        free(path);
+        if (mime != NULL) {
+            free(mime);
+        }
+        if (jobName != NULL) {
+            free(jobName);
+        }
+        return 2;
+    }
+
+    /* Everything from the modal dialog to the spooler hand-off blocks with no
+     * Java object access, so yield the thread state for the duration. */
+    CN1_YIELD_THREAD;
+
+    req.hdc = NULL;
+    req.cancelled = 0;
+    req.dlgError = 0;
+    SendMessageW(cn1Win.hwnd, WM_CN1_PRINTDLG, (WPARAM) &req, 0);
+
+    if (req.cancelled) {
+        status = 1;
+    } else if (req.hdc == NULL) {
+        if (req.dlgError == PDERR_NODEFAULTPRN) {
+            cn1PrintSetError("No printer is installed");
+        } else {
+            cn1PrintSetError("The print dialog could not be shown");
+        }
+        status = 2;
+    } else {
+        ZeroMemory(&di, sizeof(di));
+        di.cbSize = sizeof(di);
+        di.lpszDocName = (jobName != NULL && jobName[0] != 0) ? jobName : L"Codename One";
+        if (StartDocW(req.hdc, &di) <= 0) {
+            cn1PrintSetError("The print job could not be started");
+            status = 2;
+        } else {
+            ok = isPdf ? cn1PrintPdfPages(req.hdc, path)
+                       : cn1PrintImagePages(req.hdc, path);
+            if (ok) {
+                if (EndDoc(req.hdc) > 0) {
+                    status = 0;
+                } else {
+                    cn1PrintSetError("The print job could not be handed to the spooler");
+                    status = 2;
+                }
+            } else {
+                /* g_printError was set by the page renderer; discard the job. */
+                AbortDoc(req.hdc);
+                status = 2;
+            }
+        }
+        DeleteDC(req.hdc);
+    }
+
+    CN1_RESUME_THREAD;
+
+    free(path);
+    if (mime != NULL) {
+        free(mime);
+    }
+    if (jobName != NULL) {
+        free(jobName);
+    }
+    return status;
+}
+
+/* Short description of the most recent printDocument failure, or null when the
+ * last request did not fail. */
+JAVA_OBJECT com_codename1_impl_windows_WindowsNative_printLastError___R_java_lang_String(CODENAME_ONE_THREAD_STATE) {
+    if (g_printError[0] == 0) {
+        return JAVA_NULL;
+    }
+    return newStringFromCString(threadStateData, g_printError);
+}
+
+} /* extern "C" */
+
+#endif /* _WIN32 */

--- a/Ports/WindowsPort/nativeSources/cn1_windows_window.cpp
+++ b/Ports/WindowsPort/nativeSources/cn1_windows_window.cpp
@@ -415,6 +415,11 @@ LRESULT CALLBACK cn1WinWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam
              * (cn1_windows_winrt.cpp). */
             cn1WinShareHandleMessage(wParam);
             return 0;
+        case WM_CN1_PRINTDLG:
+            /* Modal system print dialog, run synchronously on this (pump) thread
+             * while the printing worker blocks in SendMessage
+             * (cn1_windows_print.cpp). */
+            return cn1WinPrintDialogHandleMessage(wParam);
         case WM_CTLCOLOREDIT: {
             /* Colour the native edit overlay to match the CN1 field it stands in
              * for; fall through to default when it is not our control. */

--- a/Ports/WindowsPort/src/com/codename1/impl/windows/WindowsImplementation.java
+++ b/Ports/WindowsPort/src/com/codename1/impl/windows/WindowsImplementation.java
@@ -27,6 +27,8 @@ import com.codename1.impl.WebSocketImpl;
 import com.codename1.io.Util;
 import com.codename1.l10n.L10NManager;
 import com.codename1.media.Media;
+import com.codename1.printing.PrintResult;
+import com.codename1.printing.PrintResultListener;
 import com.codename1.ui.Component;
 import com.codename1.ui.Display;
 import com.codename1.ui.Image;
@@ -1882,6 +1884,75 @@ public class WindowsImplementation extends CodenameOneImplementation {
             uri.append(sep).append("body=").append(com.codename1.io.Util.encodeUrl(body));
         }
         WindowsNative.shellOpen(uri.toString());
+    }
+
+    /* --------------------------------------------------------------- printing
+     * Win32 printing (cn1_windows_print.cpp): the modal system print dialog
+     * (PrintDlgW) picks the printer, then the native layer rasterizes the
+     * document onto the printer DC -- WIC for images, the WinRT
+     * Windows.Data.Pdf renderer for PDFs. The blocking native call runs on a
+     * dedicated worker thread; Display marshals the listener onto the EDT. */
+
+    @Override
+    public boolean isPrintingSupported() {
+        // The Win32 print pipeline is always compiled in. A missing printer or
+        // host window (headless screenshot mode) surfaces honestly as a FAILED
+        // result with a message, exactly like a spooler error would.
+        return true;
+    }
+
+    /**
+     * Prints a document file through the Windows printing system behind the
+     * native print dialog. {@code COMPLETED} means the job was handed to the
+     * print spooler, {@code CANCELLED} that the user dismissed the dialog. The
+     * listener fires exactly once, from the worker thread; {@code Display}
+     * wraps it onto the EDT.
+     */
+    @Override
+    public void print(final String filePath, final String mimeType, final PrintResultListener listener) {
+        Thread t = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                PrintResult result;
+                try {
+                    result = printImpl(filePath, mimeType);
+                } catch (Throwable err) {
+                    err.printStackTrace();
+                    result = PrintResult.failed("Print failed: " + err);
+                }
+                if (listener != null) {
+                    listener.onResult(result);
+                }
+            }
+        }, "cn1-windows-print");
+        t.setDaemon(true);
+        t.start();
+    }
+
+    private PrintResult printImpl(String filePath, String mimeType) {
+        if (filePath == null) {
+            return PrintResult.failed("Print file path is null");
+        }
+        String path = stripFileUrl(filePath);
+        if (!WindowsNative.fileExists(path) || WindowsNative.fileIsDirectory(path)) {
+            return PrintResult.failed("Print file not found: " + filePath);
+        }
+        boolean pdf = "application/pdf".equals(mimeType);
+        if (!pdf && (mimeType == null || !mimeType.startsWith("image/"))) {
+            // Reject before any UI: showing the print dialog for a document we
+            // can't render would waste the user's choice.
+            return PrintResult.failed("Unsupported print mime type: " + mimeType);
+        }
+        String jobName = Display.getInstance().getProperty("AppName", "Codename One");
+        int status = WindowsNative.printDocument(path, mimeType, jobName);
+        if (status == 0) {
+            return PrintResult.completed();
+        }
+        if (status == 1) {
+            return PrintResult.cancelled();
+        }
+        String error = WindowsNative.printLastError();
+        return PrintResult.failed(error != null ? error : "Print failed");
     }
 
     /* -------------------------------------------------- native file picker

--- a/Ports/WindowsPort/src/com/codename1/impl/windows/WindowsNative.java
+++ b/Ports/WindowsPort/src/com/codename1/impl/windows/WindowsNative.java
@@ -546,6 +546,28 @@ public final class WindowsNative {
      */
     public static native boolean shareText(String text, String title);
 
+    /* --------------------------------------------------------------- printing */
+
+    /**
+     * Prints a document file through the Win32 printing system: shows the modal
+     * system print dialog ({@code PrintDlgW}, run on the window-owning pump
+     * thread like {@link #fileDialog}), then rasterizes the document and spools
+     * it to the chosen printer's device context. {@code mimeType} selects the
+     * renderer -- {@code image/*} decodes through the port's WIC helper,
+     * {@code application/pdf} rasterizes each page via WinRT Windows.Data.Pdf
+     * at the printer's DPI. Blocks for the whole flow (call off the EDT).
+     * Returns 0 once the job was handed to the print spooler, 1 when the user
+     * cancelled the dialog, 2 on failure ({@link #printLastError()} carries a
+     * short description).
+     */
+    public static native int printDocument(String path, String mimeType, String jobName);
+
+    /**
+     * Short description of the most recent {@link #printDocument} failure, or
+     * {@code null} when the last request did not fail.
+     */
+    public static native String printLastError();
+
     /* ----------------------------------------------------------- camera */
 
     /**

--- a/Ports/iOSPort/nativeSources/IOSNative.m
+++ b/Ports/iOSPort/nativeSources/IOSNative.m
@@ -9302,6 +9302,60 @@ void com_codename1_impl_ios_IOSNative_socialShareWithCallback___java_lang_String
     });
 }
 
+JAVA_BOOLEAN com_codename1_impl_ios_IOSNative_isPrintingAvailable__(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject) {
+    return [UIPrintInteractionController isPrintingAvailable];
+}
+
+// Prints the file at path through UIPrintInteractionController and reports
+// the outcome to IOSImplementation.printDocumentCallback using the supplied
+// callbackId. Status codes mirror com.codename1.printing.PrintResult:
+// 1=COMPLETED, 2=CANCELLED, 3=FAILED.
+void com_codename1_impl_ios_IOSNative_printDocument___java_lang_String_java_lang_String_int(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT me, JAVA_OBJECT path, JAVA_OBJECT mimeType, JAVA_INT callbackId) {
+    NSString* filePath = toNSString(CN1_THREAD_STATE_PASS_ARG path);
+    NSString* mime = toNSString(CN1_THREAD_STATE_PASS_ARG mimeType);
+    int cbId = (int)callbackId;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        POOL_BEGIN();
+        NSString* ns = fixFilePath(filePath);
+        NSURL* fileURL = [NSURL fileURLWithPath:ns];
+        if (![[NSFileManager defaultManager] fileExistsAtPath:ns] || ![UIPrintInteractionController canPrintURL:fileURL]) {
+            JAVA_OBJECT jErrMsg = fromNSString(CN1_THREAD_GET_STATE_PASS_ARG @"The document cannot be printed");
+            com_codename1_impl_ios_IOSImplementation_printDocumentCallback___int_int_java_lang_String(CN1_THREAD_GET_STATE_PASS_ARG (JAVA_INT)cbId, 3, jErrMsg);
+            POOL_END();
+            return;
+        }
+        UIPrintInteractionController* printController = [UIPrintInteractionController sharedPrintController];
+        UIPrintInfo* printInfo = [UIPrintInfo printInfo];
+        printInfo.outputType = (mime != nil && [mime hasPrefix:@"image/"]) ? UIPrintInfoOutputPhoto : UIPrintInfoOutputGeneral;
+        printInfo.jobName = [ns lastPathComponent];
+        printController.printInfo = printInfo;
+        printController.printingItem = fileURL;
+        UIPrintInteractionCompletionHandler completionHandler = ^(UIPrintInteractionController *controller, BOOL completed, NSError *error) {
+            JAVA_INT status;
+            NSString* errMsg = nil;
+            if (error != nil) {
+                status = 3;
+                errMsg = [error localizedDescription];
+            } else if (completed) {
+                status = 1;
+            } else {
+                status = 2;
+            }
+            JAVA_OBJECT jErrMsg = errMsg != nil ? fromNSString(CN1_THREAD_GET_STATE_PASS_ARG errMsg) : JAVA_NULL;
+            com_codename1_impl_ios_IOSImplementation_printDocumentCallback___int_int_java_lang_String(CN1_THREAD_GET_STATE_PASS_ARG (JAVA_INT)cbId, status, jErrMsg);
+        };
+        if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+            UIView* view = [CodenameOne_GLViewController instance].view;
+            CGRect sourceRect = CGRectMake(view.bounds.size.width / 2, view.bounds.size.height / 2, 1, 1);
+            [printController presentFromRect:sourceRect inView:view animated:YES completionHandler:completionHandler];
+        } else {
+            [printController presentAnimated:YES completionHandler:completionHandler];
+        }
+        POOL_END();
+        repaintUI();
+    });
+}
+
 
 extern BOOL isVKBAlwaysOpen();
 extern BOOL vkbAlwaysOpen;

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
@@ -10095,6 +10095,54 @@ public class IOSImplementation extends CodenameOneImplementation {
         listener.onResult(result);
     }
 
+    @Override
+    public boolean isPrintingSupported() {
+        return nativeInstance.isPrintingAvailable();
+    }
+
+    @Override
+    public void print(String filePath, String mimeType, com.codename1.printing.PrintResultListener listener) {
+        int callbackId = registerPrintCallback(listener);
+        nativeInstance.printDocument(filePath, mimeType, callbackId);
+    }
+
+    // Pending print-result callbacks. Native code invokes
+    // printDocumentCallback(...) once per id.
+    private static final java.util.HashMap<Integer, com.codename1.printing.PrintResultListener> pendingPrintCallbacks = new java.util.HashMap<Integer, com.codename1.printing.PrintResultListener>();
+    private static int nextPrintCallbackId = 1;
+
+    private static synchronized int registerPrintCallback(com.codename1.printing.PrintResultListener l) {
+        int id = nextPrintCallbackId++;
+        pendingPrintCallbacks.put(Integer.valueOf(id), l);
+        return id;
+    }
+
+    /// Invoked from native code with the outcome of a print job. Public so
+    /// the VM-emitted symbol stays stable. `status` matches
+    /// [com.codename1.printing.PrintResult]: 1=COMPLETED, 2=CANCELLED, 3=FAILED.
+    public static void printDocumentCallback(int callbackId, int status, String errorMessage) {
+        com.codename1.printing.PrintResultListener listener;
+        synchronized (IOSImplementation.class) {
+            listener = pendingPrintCallbacks.remove(Integer.valueOf(callbackId));
+        }
+        if (listener == null) {
+            return;
+        }
+        com.codename1.printing.PrintResult result;
+        switch (status) {
+            case 1:
+                result = com.codename1.printing.PrintResult.completed();
+                break;
+            case 2:
+                result = com.codename1.printing.PrintResult.cancelled();
+                break;
+            default:
+                result = com.codename1.printing.PrintResult.failed(errorMessage);
+                break;
+        }
+        listener.onResult(result);
+    }
+
     private Purchase pur;
     private Vector purchasedItems;
 

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSNative.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSNative.java
@@ -624,7 +624,15 @@ public final class IOSNative {
     // IOSImplementation.socialShareCallback(int, String, String) using
     // the supplied callbackId. Status: 1=SHARED_TO, 2=DISMISSED, 3=FAILED.
     native void socialShareWithCallback(String text, long imagePeer, Rectangle sourceRect, int callbackId);
-    
+
+    // Printing via UIPrintInteractionController
+    native boolean isPrintingAvailable();
+
+    // Prints the document at path and reports the outcome via
+    // IOSImplementation.printDocumentCallback(int, int, String) using
+    // the supplied callbackId. Status: 1=COMPLETED, 2=CANCELLED, 3=FAILED.
+    native void printDocument(String path, String mimeType, int callbackId);
+
     // facebook connect
     public native void facebookLogin(Object callback);
     public native boolean isFacebookLoggedIn();

--- a/Samples/samples/PrinterSample/PrinterSample.java
+++ b/Samples/samples/PrinterSample/PrinterSample.java
@@ -1,0 +1,119 @@
+package com.codename1.samples;
+
+import com.codename1.components.SpanLabel;
+import com.codename1.components.ToastBar;
+import com.codename1.io.FileSystemStorage;
+import com.codename1.io.Log;
+import com.codename1.io.Util;
+import com.codename1.printing.PrintResult;
+import com.codename1.printing.PrintResultListener;
+import com.codename1.printing.Printer;
+import static com.codename1.ui.CN.*;
+import com.codename1.ui.Button;
+import com.codename1.ui.Dialog;
+import com.codename1.ui.Font;
+import com.codename1.ui.FontImage;
+import com.codename1.ui.Form;
+import com.codename1.ui.Graphics;
+import com.codename1.ui.Image;
+import com.codename1.ui.Toolbar;
+import com.codename1.ui.events.ActionEvent;
+import com.codename1.ui.events.ActionListener;
+import com.codename1.ui.layouts.BoxLayout;
+import com.codename1.ui.plaf.UIManager;
+import com.codename1.ui.util.Resources;
+
+/**
+ * Demonstrates the printing API: prints a generated image and a downloaded
+ * PDF through the platform print dialog.
+ */
+public class PrinterSample {
+
+    private static final String SAMPLE_PDF_URL = "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf";
+
+    private Form current;
+    private Resources theme;
+
+    public void init(Object context) {
+        theme = UIManager.initFirstTheme("/theme");
+        Toolbar.setGlobalToolbar(true);
+        Log.bindCrashProtection(true);
+    }
+
+    public void start() {
+        if (current != null) {
+            current.show();
+            return;
+        }
+        Form hi = new Form("Printing", BoxLayout.y());
+        hi.add(new SpanLabel("Printing supported: " + Printer.isPrintingSupported()));
+
+        Button printImage = new Button("Print Image");
+        printImage.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent evt) {
+                Printer.printImage(createSampleImage(), new PrintResultListener() {
+                    public void onResult(PrintResult result) {
+                        showResult(result);
+                    }
+                });
+            }
+        });
+        hi.add(printImage);
+
+        Button printPdf = new Button("Print PDF");
+        printPdf.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent evt) {
+                final String path = FileSystemStorage.getInstance().getAppHomePath() + "sample.pdf";
+                Util.downloadUrlToFileSystemInBackground(SAMPLE_PDF_URL, path, new ActionListener() {
+                    public void actionPerformed(ActionEvent downloadEvent) {
+                        if (!FileSystemStorage.getInstance().exists(path)) {
+                            ToastBar.showErrorMessage("Failed to download the sample PDF");
+                            return;
+                        }
+                        Printer.printPDF(path, new PrintResultListener() {
+                            public void onResult(PrintResult result) {
+                                showResult(result);
+                            }
+                        });
+                    }
+                });
+            }
+        });
+        hi.add(printPdf);
+
+        hi.show();
+    }
+
+    private void showResult(PrintResult result) {
+        if (result.isFailed()) {
+            ToastBar.showErrorMessage("Print failed: " + result.getError());
+        } else {
+            ToastBar.showMessage("Print result: " + result, FontImage.MATERIAL_PRINT);
+        }
+    }
+
+    private Image createSampleImage() {
+        int size = convertToPixels(60);
+        Image img = Image.createImage(size, size, 0xffffffff);
+        Graphics g = img.getGraphics();
+        g.setAntiAliased(true);
+        g.setColor(0x4986e7);
+        g.fillArc(size / 8, size / 8, size * 3 / 4, size * 3 / 4, 0, 360);
+        g.setColor(0xffffff);
+        g.setFont(Font.createSystemFont(Font.FACE_SYSTEM, Font.STYLE_BOLD, Font.SIZE_LARGE));
+        g.drawString("Codename One", size / 2 - g.getFont().stringWidth("Codename One") / 2,
+                size / 2 - g.getFont().getHeight() / 2);
+        return img;
+    }
+
+    public void stop() {
+        current = getCurrentForm();
+        if (current instanceof Dialog) {
+            ((Dialog) current).dispose();
+            current = getCurrentForm();
+        }
+    }
+
+    public void destroy() {
+    }
+}

--- a/docs/developer-guide/Printing.asciidoc
+++ b/docs/developer-guide/Printing.asciidoc
@@ -22,7 +22,7 @@ if (Printer.isPrintingSupported()) {
 
 `Printer.printPDF(path, listener)` is shorthand for `Printer.print(path, "application/pdf", listener)`. Use the general `print` variant for other document types, for example `Printer.print(photoPath, "image/jpeg", listener)`.
 
-Gate the call on `isPrintingSupported()`. When it returns `false` the listener receives a `FAILED` result without any UI appearing, so an unguarded call does no harm, but a well behaved app hides or disables its print button instead.
+Gate the call on `isPrintingSupported()`. When it returns `false` the listener receives a `FAILED` result without any UI appearing, so an unguarded call does no harm, but a well-behaved app hides or disables its print button instead.
 
 === Printing images
 

--- a/docs/developer-guide/Printing.asciidoc
+++ b/docs/developer-guide/Printing.asciidoc
@@ -1,0 +1,71 @@
+== Printing
+
+Codename One can hand a document to the platform printing system through the `com.codename1.printing` package. The API shows the native print dialog where the user picks a printer, adjusts options and confirms the job. It works on iOS (AirPrint), Android, desktop builds, the simulator, Windows and the JavaScript port.
+
+The document is a file in `FileSystemStorage` identified by its path and mime type. Every printing platform accepts PDF (`application/pdf`) and common image types (`image/png`, `image/jpeg`).
+
+=== Quick start: Print a PDF
+
+[source,java]
+----
+import com.codename1.printing.Printer;
+import com.codename1.printing.PrintResult;
+
+if (Printer.isPrintingSupported()) {
+    Printer.printPDF(reportPath, result -> {
+        if (result.isFailed()) {
+            ToastBar.showErrorMessage("Print failed: " + result.getError());
+        }
+    });
+}
+----
+
+`Printer.printPDF(path, listener)` is shorthand for `Printer.print(path, "application/pdf", listener)`. Use the general `print` variant for other document types, for example `Printer.print(photoPath, "image/jpeg", listener)`.
+
+Gate the call on `isPrintingSupported()`. When it returns `false` the listener receives a `FAILED` result without any UI appearing, so an unguarded call does no harm, but a well behaved app hides or disables its print button instead.
+
+=== Printing images
+
+`Printer.printImage(image, listener)` prints a `com.codename1.ui.Image` directly. The image is encoded to a temporary PNG file behind the scenes and the file is deleted once the print flow finishes:
+
+[source,java]
+----
+Image chart = renderChart();
+Printer.printImage(chart, result -> {
+    if (result.isFailed()) {
+        ToastBar.showErrorMessage("Print failed: " + result.getError());
+    }
+});
+----
+
+This pairs well with drawing on a mutable image, so you can compose a printable page (a receipt, a ticket, a chart) with the standard `Graphics` API and send it to paper without generating a PDF.
+
+=== Handling the result
+
+The listener receives a `PrintResult` on the EDT, exactly once per request. The listener may be `null` for fire-and-forget printing. There are three statuses:
+
+* `COMPLETED` – the job was handed to the platform printing system. Most platforms can't observe the physical printer, so this means "queued/sent," not "paper came out."
+* `CANCELLED` – the user dismissed the print dialog without printing, on platforms that can observe the dialog outcome.
+* `FAILED` – the job couldn't start or the printing system reported an error. `getError()` may carry a short platform message.
+
+Cancel detection is best-effort. iOS, Windows, PDF printing on Android and image printing in the simulator report `CANCELLED` reliably. Image printing on Android, PDF hand-off on the desktop and the browsers report `COMPLETED` once the job is posed, since their printing pipelines don't expose the user's choice.
+
+=== Permissions and the user gate
+
+Printing requires no permission, entitlement, manifest entry or build hint on any platform. This is safe because printing is always user-confirmed: the API can only pose the native print dialog, and nothing reaches a printer until the user approves the job there. In that sense it follows the same trust model as the share API.
+
+Silent printing - sending a job to a preselected printer without showing a dialog - isn't supported by design.
+
+Device policy can disable printing entirely, for example a managed Android work profile with the printing restriction or an iOS MDM profile that blocks AirPrint. Those cases surface as `isPrintingSupported()` returning `false` or as a `FAILED` result, so the result-handling code above covers them.
+
+=== Platform notes
+
+* iOS – `UIPrintInteractionController` presents the AirPrint sheet; on the iPad it appears as a popover. The completion handler reports completed, cancelled or failed.
+* Android – the `android.print` framework. PDFs stream through a `PrintDocumentAdapter`; images go through the support library `PrintHelper`, which reports completion but can't observe cancellation. Printing requires a foreground activity, so calls from background mode fail.
+* Desktop / simulator – images print through `java.awt.print.PrinterJob` with the native dialog; PDFs are handed to the operating system's default PDF print flow.
+* Windows (native port) – the Win32 print dialog with GDI rendering; PDF pages render through the `Windows.Data.Pdf` API at the printer's resolution.
+* JavaScript – the document loads into a hidden frame and prints through the browser's print dialog. Browsers don't report whether the user printed or cancelled, and PDF behavior varies with the browser's built-in viewer.
+
+=== Trying it in the simulator
+
+The `PrinterSample` in the samples project demonstrates both flows: it prints a generated image and downloads a small PDF to print. On the desktop the native print dialog of your operating system appears, which makes it a convenient way to test result handling - print to a file or preview instead of paper.

--- a/docs/developer-guide/developer-guide.asciidoc
+++ b/docs/developer-guide/developer-guide.asciidoc
@@ -108,6 +108,8 @@ include::Ai-And-Speech.asciidoc[]
 
 include::Near-Field-Communication.asciidoc[]
 
+include::Printing.asciidoc[]
+
 include::Network-Connectivity.asciidoc[]
 
 include::signing.asciidoc[]

--- a/docs/developer-guide/languagetool-accept.txt
+++ b/docs/developer-guide/languagetool-accept.txt
@@ -105,6 +105,8 @@ andlib
 dumbing
 handcoded
 navigatable
+popover
+popovers
 
 # -----------------------------------------------------------------------------
 # Acronyms and product / framework names

--- a/vm/tests/src/test/java/com/codename1/tools/translator/CleanTargetIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/CleanTargetIntegrationTest.java
@@ -247,7 +247,7 @@ class CleanTargetIntegrationTest {
                 "cn1_windows_image.cpp", "cn1_windows_io.c", "cn1_windows_net.c",
                 "cn1_windows_dwrite.cpp", "cn1_windows_screenshot.cpp", "cn1_windows_simd.c",
                 "cn1_windows_notify.c", "cn1_windows_audiorec.c", "cn1_windows_winrt.cpp",
-                "cn1_windows_camera.cpp", "cn1_windows_peer.cpp"
+                "cn1_windows_camera.cpp", "cn1_windows_peer.cpp", "cn1_windows_print.cpp"
         };
         for (String f : files) {
             Files.copy(nativeDir.resolve(f), srcRoot.resolve(f), StandardCopyOption.REPLACE_EXISTING);


### PR DESCRIPTION
## Summary

New cross-platform printing API that hands a document (PDF or image file in `FileSystemStorage`) to the platform printing system, typically through the native print dialog.

```java
if (Printer.isPrintingSupported()) {
    Printer.printPDF(reportPath, result -> {
        if (result.isFailed()) {
            ToastBar.showErrorMessage("Print failed: " + result.getError());
        }
    });
}
```

**Core** — `com.codename1.printing`: `Printer` static facade (`print(filePath, mimeType, listener)`, `printPDF`, `printImage` which encodes to a temp PNG), immutable `PrintResult` (COMPLETED / CANCELLED / FAILED factories, mirroring `ShareResult`), `PrintResultListener` (invoked exactly once, on the EDT). Plumbed through `Display.print(...)` (EDT-wrapping, same pattern as `share`) with overridable defaults in `CodenameOneImplementation`.

COMPLETED means "handed to the printing system"; platforms that can't observe the native dialog's outcome report it best-effort, documented per method.

## Port implementations

| Port | Mechanism |
|---|---|
| JavaSE | Images via `PrinterJob` + native dialog (real cancel detection, aspect-fit); PDFs via `Desktop.print` with a `javax.print` PDF-flavor fallback |
| Android | `android.print.PrintManager`: PDFs through a streaming `PrintDocumentAdapter`, images through support-v4 `PrintHelper`; job outcome via `PrintJob` state polling; all API-19+ types isolated in a `@TargetApi(19)` inner class |
| iOS | `UIPrintInteractionController` via the `IOSNative` bridge, following the `socialShareWithCallback` callback-id pattern; iPad presents from a rect |
| JavaScript | Blob object URL (reusing `openFileAsBlob`/`BlobUtil`) + hidden iframe + `contentWindow.print()`, `afterprint` + fallback completion |
| Windows | New `cn1_windows_print.cpp`: `PrintDlgW` on the pump thread (same `SendMessage` handover as the file dialog, `WM_APP+23`), images via the shared WIC decoder + GDI `StretchDIBits`, PDFs via raw-ABI `Windows.Data.Pdf` page rendering at printer DPI — no STL, no new link libraries |

Also adds `Samples/samples/PrinterSample` (prints a generated image and a downloaded PDF).

## Verification

- `mvn compile` clean for core, javase, android, ios and windows modules; JS port compiles via the same `javac` step its build script uses; sample compiles against core.
- Windows: `CleanTargetIntegrationTest#crossCompilesWindowsExeWithXwin` passes on this branch — full translate + clang-cl compile + lld-link of a Form app **including the print code** into a Windows PE (x64), against the current master port (no `WM_APP` message collision with the new file picker). `cn1_windows_print.cpp` is also registered in the per-file clang-cl compile check.
- JavaSE path tested interactively in the simulator via `PrinterSample` (native macOS print dialog, image print + cancel reporting).

## Not yet runtime-tested

iOS (ObjC mirrors the share pattern; needs a device build), Android dialog flow, Windows dialog→spool/PDF rendering on real hardware, and browser printing. `PrinterSample` is the quickest smoke test on each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)