### PR TITLE
Fix black screen at iOS app launch under UIScene

### DIFF
--- a/Ports/iOSPort/nativeSources/CodenameOne_GLAppDelegate.m
+++ b/Ports/iOSPort/nativeSources/CodenameOne_GLAppDelegate.m
@@ -190,6 +190,12 @@ static void installSignalHandlers() {
     self.window = window;
     self.window.rootViewController = [self cn1EnsureViewController];
     [self.window makeKeyAndVisible];
+    // The GL/Metal surface is still empty at the window's first Core
+    // Animation commit -- the EDT paints the first form much later -- so the
+    // system launch screen would be replaced by a black frame (issue #5210).
+    // Cover the window with a placeholder (light/dark system background +
+    // launch icon) that drawFrame fades out on the first content frame.
+    CN1ShowLaunchPlaceholder(self.window);
     [self cn1InstallTapGestureRecognizerIfNeeded];
 }
 

--- a/Ports/iOSPort/nativeSources/CodenameOne_GLViewController.h
+++ b/Ports/iOSPort/nativeSources/CodenameOne_GLViewController.h
@@ -198,6 +198,11 @@
 
 #define EAGLVIEW [[CodenameOne_GLViewController instance] eaglView]
 
+// Launch placeholder shown over the GL/Metal view between makeKeyAndVisible
+// and the first EDT-painted frame; see CodenameOne_GLViewController.m
+void CN1ShowLaunchPlaceholder(UIWindow *window);
+void CN1DismissLaunchPlaceholder(void);
+
 //ADD_INCLUDE
 
 @interface CodenameOne_GLViewController : UIViewController<UIImagePickerControllerDelegate, MFMailComposeViewControllerDelegate, UIScrollViewDelegate,

--- a/Ports/iOSPort/nativeSources/CodenameOne_GLViewController.m
+++ b/Ports/iOSPort/nativeSources/CodenameOne_GLViewController.m
@@ -81,6 +81,101 @@
 
 
 //#define CN1_USE_SPLASH_SCREEN
+//#define CN1_DISABLE_LAUNCH_PLACEHOLDER
+
+// Launch placeholder: covers the GL/Metal layer from the moment the window
+// becomes key until the EDT presents its first content frame. The window's
+// first Core Animation commit happens long before Display.init and the first
+// form paint, so without this the system launch screen is replaced by a black
+// surface for a noticeable moment (issue #5210). The placeholder mirrors the
+// default launch storyboard -- Launch.Foreground.png centered at natural
+// size -- over a background that tracks light/dark mode, then fades out when
+// drawFrame presents the first frame that actually executed draw ops.
+// Opt out with the ios.launchPlaceholder=false build hint.
+static UIView *cn1LaunchPlaceholderView = nil;
+static BOOL cn1LaunchPlaceholderDone = NO;
+
+void CN1DismissLaunchPlaceholder(void) {
+    cn1LaunchPlaceholderDone = YES;
+    if (cn1LaunchPlaceholderView == nil) {
+        return;
+    }
+    UIView *placeholder = cn1LaunchPlaceholderView;
+    cn1LaunchPlaceholderView = nil;
+    [UIView animateWithDuration:0.15 animations:^{
+        placeholder.alpha = 0;
+    } completion:^(BOOL finished) {
+        [placeholder removeFromSuperview];
+#ifndef CN1_USE_ARC
+        [placeholder release];
+#endif
+    }];
+}
+
+void CN1ShowLaunchPlaceholder(UIWindow *window) {
+#if defined(CN1_DISABLE_LAUNCH_PLACEHOLDER) || defined(CN1_USE_SPLASH_SCREEN) || TARGET_OS_MACCATALYST
+    // A Mac window appears instantly, and CN1_USE_SPLASH_SCREEN draws its own
+    // splash directly into the GL surface; in both cases the placeholder
+    // would only hide content.
+#else
+    if (cn1LaunchPlaceholderDone || cn1LaunchPlaceholderView != nil || window == nil) {
+        return;
+    }
+    UIView *placeholder = [[UIView alloc] initWithFrame:window.bounds];
+    placeholder.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    placeholder.userInteractionEnabled = NO;
+    if (@available(iOS 13.0, *)) {
+        placeholder.backgroundColor = [UIColor systemBackgroundColor];
+    } else {
+        placeholder.backgroundColor = [UIColor whiteColor];
+    }
+    // Prefer the image the launch storyboard shows, rendered the same way
+    // (centered at natural size, matching its contentMode=center image view)
+    // so the handoff from the system launch screen is seamless. Fall back to
+    // the primary app icon when it isn't bundled, e.g. a custom storyboard.
+    UIImage *icon = [UIImage imageNamed:@"Launch.Foreground.png"];
+    BOOL isRawIcon = NO;
+    if (icon == nil) {
+        NSDictionary *icons = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleIcons"];
+        NSArray *iconFiles = [[icons objectForKey:@"CFBundlePrimaryIcon"] objectForKey:@"CFBundleIconFiles"];
+        if ([iconFiles isKindOfClass:[NSArray class]] && [iconFiles count] > 0) {
+            icon = [UIImage imageNamed:(NSString*)[iconFiles lastObject]];
+        }
+        isRawIcon = YES;
+    }
+    if (icon != nil) {
+        UIImageView *iconView = [[UIImageView alloc] initWithImage:icon];
+        if (isRawIcon) {
+            // Bundle icons are square PNGs without the home-screen mask;
+            // round them so the placeholder reads as "the app icon".
+            CGFloat side = MIN(icon.size.width, icon.size.height);
+            side = MIN(side, (CGFloat)152);
+            iconView.frame = CGRectMake(0, 0, side, side);
+            iconView.contentMode = UIViewContentModeScaleAspectFill;
+            iconView.layer.cornerRadius = side * 0.2237f;
+            iconView.layer.masksToBounds = YES;
+            if (@available(iOS 13.0, *)) {
+                iconView.layer.cornerCurve = kCACornerCurveContinuous;
+            }
+        }
+        iconView.center = CGPointMake(CGRectGetMidX(placeholder.bounds), CGRectGetMidY(placeholder.bounds));
+        iconView.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin
+                | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
+        [placeholder addSubview:iconView];
+#ifndef CN1_USE_ARC
+        [iconView release];
+#endif
+    }
+    [window addSubview:placeholder];
+    // the static keeps ownership; released when the dismissal fade completes
+    cn1LaunchPlaceholderView = placeholder;
+    // Safety net: if the first frame never presents (EDT wedged before the
+    // first paint) drop the placeholder rather than masking the app forever.
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(10 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        CN1DismissLaunchPlaceholder();
+    });
+#endif
+}
 
 // Last touch positions.  Helpful to know on the iPad when some popover stuff
 // needs a source rect that the java API doesn't pass through.
@@ -3782,6 +3877,7 @@ BOOL prefersStatusBarHidden = NO;
 #endif
     [[self eaglView] setFramebuffer];
     GLErrorLog;
+    BOOL drewContentOps = NO;
     if(currentTarget != nil) {
         if([currentTarget count] > 0) {
             [ClipRect setDrawRect:rect];
@@ -3838,11 +3934,17 @@ BOOL prefersStatusBarHidden = NO;
                 if (opTarget != nil && !mutableEncoderOpen) continue;
                 [ex executeWithClipping];
                 GLErrorLog;
+                if (opTarget == nil) {
+                    // Screen-targeted op: this present puts real content on
+                    // the GL layer (a drain of only mutable-image ops doesn't).
+                    drewContentOps = YES;
+                }
             }
             if (mutableEncoderOpen) {
                 CN1MetalEndMutableImageDraw(currentDrainTarget);
             }
 #else
+            drewContentOps = YES;
             for(ExecutableOp* ex in cp) {
                 [ex executeWithClipping];
                 //[ex executeWithLog];
@@ -3919,9 +4021,14 @@ BOOL prefersStatusBarHidden = NO;
         }
     }
     GLErrorLog;
-    
+
     [[self eaglView] presentFramebuffer];
     GLErrorLog;
+    if (drewContentOps && !cn1LaunchPlaceholderDone) {
+        // First frame with real content is on screen -- fade out the launch
+        // placeholder installed by cn1InstallRootViewControllerIntoWindow.
+        CN1DismissLaunchPlaceholder();
+    }
 }
 
 

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
@@ -1201,6 +1201,11 @@ public class IPhoneBuilder extends Executor {
                 replaceInFile(CodenameOne_GLViewController, "//#define LOW_MEM_CAMERA", "#define LOW_MEM_CAMERA");
             }
 
+            if (request.getArg("ios.launchPlaceholder", "true").equals("false")) {
+                File glViewControllerM = new File(buildinRes, "CodenameOne_GLViewController.m");
+                replaceInFile(glViewControllerM, "//#define CN1_DISABLE_LAUNCH_PLACEHOLDER", "#define CN1_DISABLE_LAUNCH_PLACEHOLDER");
+            }
+
             if (request.getArg("ios.enableStatusBar7", "true").equals("false")) {
                 File CodenameOne_GLViewController = new File(buildinRes, "CodenameOne_GLViewController.m");
                 replaceInFile(CodenameOne_GLViewController, "int statusbarHeight = 20;", "int statusbarHeight = 0;");
@@ -3456,7 +3461,32 @@ public class IPhoneBuilder extends Executor {
             }
         }
         if (!"true".equals(request.getArg("ios.generateSplashScreens", "false"))) {
-            if (!inject.contains("UILaunchStoryboardName")) {
+            if ("true".equalsIgnoreCase(request.getArg("ios.uiscene", "true"))) {
+                // SplashBoard never renders the launch storyboard for scene-based
+                // CN1 apps -- the system animates from a black frame instead
+                // (issue #5210). The iOS 14+ UILaunchScreen generated launch
+                // screen does work under UIScene: system background color
+                // (light/dark aware) with the launch icon centered, matching the
+                // native launch placeholder the app shows until the first EDT
+                // frame. UILaunchStoryboardName must be OMITTED here: when both
+                // keys are present iOS prefers the storyboard, which is exactly
+                // the broken path (verified on the iOS 26 simulator with a cold
+                // SplashBoard cache). The ios.launchStoryboardName hint is
+                // therefore only honored with ios.uiscene=false; injecting
+                // either key via ios.plistInject overrides this default.
+                // UIImageName points at the loose Launch.Foreground.png in the
+                // bundle root (guaranteed by generateLaunchScreen); SplashBoard
+                // resolves it there but fails to render the same image from an
+                // actool compiled imageset, so do NOT move it into
+                // Images.xcassets.
+                if (!inject.contains("UILaunchScreen") && !inject.contains("UILaunchStoryboardName")) {
+                    inject += "\n<key>UILaunchScreen</key>\n"
+                            + "<dict>\n"
+                            + "    <key>UIImageName</key>\n"
+                            + "    <string>Launch.Foreground</string>\n"
+                            + "</dict>";
+                }
+            } else if (!inject.contains("UILaunchStoryboardName")) {
                 inject += "\n<key>UILaunchStoryboardName</key><string>"+request.getArg("ios.launchStoryboardName", "LaunchScreen")+"</string>";
             }
         }
@@ -4324,6 +4354,7 @@ public class IPhoneBuilder extends Executor {
             if (legacyLaunchImages.exists()) {
                 delTree(legacyLaunchImages);
             }
+
         }
         return true;
     }


### PR DESCRIPTION
Fixes #5210.

## Problem

Since UIScene became the default (`ios.uiscene=true`), iOS apps launch with no splash at all — the app-open zoom animates from a black frame, followed by more black until the first form paints. With `ios.uiscene=false` the storyboard splash shows briefly, but there is still a black gap between its dismissal and the first EDT frame.

Investigation on the iOS 26 simulator (cold `SplashBoard` caches, contact sheets from 10fps launch recordings) found **two independent black-screen sources**:

1. **SplashBoard never renders `LaunchScreen.storyboard` for scene-based apps.** The app's launch snapshot cache stays empty (a uiscene=false control app on the same simulator has cached snapshots and shows its splash instantly under the identical launch path), so the system animates from black.
2. **The GL/Metal surface is empty at the window's first Core Animation commit.** The EDT paints the first form much later (`Display.init`, theme load, `form.show()`), so whatever the system shows hands off to a black surface until then.

## Fix

**Builder (`IPhoneBuilder`)** — when `ios.uiscene=true`, inject the iOS 14+ `UILaunchScreen` generated launch screen (system background color, light/dark aware, with the launch icon centered) and **omit `UILaunchStoryboardName`**. Two empirically-hard-won constraints, documented in the code:
- iOS prefers the storyboard when both keys are present — which is exactly the broken path, so the storyboard key must not be injected alongside.
- `UIImageName` must reference the loose `Launch.Foreground.png` in the bundle root; SplashBoard fails (black) when the same image comes from an actool-compiled imageset.

`ios.launchStoryboardName` remains honored with `ios.uiscene=false` (where storyboards work), and plist-injecting either key overrides the default.

**Native (`CodenameOne_GLAppDelegate.m` / `CodenameOne_GLViewController.m/.h`)** — `cn1InstallRootViewControllerIntoWindow:` (both UIScene and legacy paths) covers the window with a placeholder: system background + the same launch image rendered exactly the way the launch screen renders it, so the hand-off is invisible. `drawFrame:` fades it out after the first present that executed *screen-targeted* draw ops — on Metal, `drawFrame` also drains mutable-image-targeted ops (theme images created during init), so a present only counts as content when an op with a nil target ran. A 10s safety timer drops the placeholder if the EDT wedges before the first paint, and it never intercepts touches. Disabled under Mac Catalyst and the legacy `CN1_USE_SPLASH_SCREEN` flag; opt out with the new `ios.launchPlaceholder=false` build hint.

## Resulting launch sequence

icon tap → launch screen (background + icon) visible inside the zoom animation → placeholder (visually identical) while the VM/EDT initializes → cross-fade to the first form. No black at any point.

## Testing

- Full local pipeline on the iOS 26.3 simulator: rebuilt port + plugin, generated `scripts/hellocodenameone` via `-Dcodename1.buildTarget=ios-source`, compiled with Xcode 26.3.
- Verified on **pristine** simulators (the SplashBoard snapshot cache survives uninstall/reinstall, which contaminated earlier runs): very first cold launch shows zero black frames on 10fps recordings, with a deliberate 2s EDT delay making the placeholder phase observable.
- A/B confirmed both constraints above (both-keys → black; imageset reference → black).
- uiscene=false control app confirms the storyboard path is unchanged.
- Placeholder ObjC syntax-checked under MRC, ARC, hint-disabled, and Mac Catalyst configurations.

Simulator-verified only — a confirmation on a physical device from the issue reporter would be a welcome final check, particularly that `UILaunchScreen`+loose-PNG renders on device the way it does on the simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)