### PR TITLE
Windows port: tolerance for graphics-draw-arc x64/arm64 AA difference

### DIFF
--- a/scripts/windows/screenshots/graphics-draw-arc.tolerance
+++ b/scripts/windows/screenshots/graphics-draw-arc.tolerance
@@ -1,0 +1,10 @@
+# Arc antialiasing differs between the x64 and arm64 builds of Direct2D's
+# software rasterizer (screenshots render via a WIC bitmap render target, which
+# always uses the CPU rasterizer in d2d1.dll). This test strokes ~100 concentric
+# 1px arcs per cell, so nearly every painted pixel is an AA edge pixel and the
+# per-arch coverage rounding shows up here and nowhere else (124/125 tests match
+# bit-exactly across arches). Measured arm64-vs-baseline mismatch at channel
+# delta > 16 is 0.18%; a real arc regression (wrong sweep, missing arcs) blows
+# far past this.
+maxChannelDelta=16
+maxMismatchPercent=0.5


### PR DESCRIPTION
## Problem

The native arm64 leg of the Windows port screenshot suite consistently flags **graphics-draw-arc** as the lone mismatch out of 125 screenshots, while x64 (both native and cross-compiled) matches the stored baseline exactly — e.g. on #5209 the arm64 job reported "124 matched, 1 updated" with this test the only outlier.

## Root cause

Screenshots render through `CreateWicBitmapRenderTarget` (`cn1_windows_screenshot.cpp`), and WIC render targets always use Direct2D's **CPU software rasterizer**. Microsoft ships different per-architecture builds of that rasterizer in d2d1.dll (NEON on arm64, SSE on x64) which round antialiasing coverage slightly differently; UCRT `cos`/`sin` in `cn1WinArcPoint` add ulp-level drift to the arc tessellation as well.

Diffing the arm64 CI artifact against the committed baseline confirms it is pure AA edge noise, not a rendering bug: every differing pixel lies on the antialiased arc strokes across all four grid cells (no missing, shifted, or wrong-sweep arcs). This test is uniquely exposed because it strokes ~100 concentric 1px arcs per cell, so nearly every painted pixel is an AA edge pixel; the other 124 tests are dominated by fills/rects/text, which are arch-stable.

Measured arm64-vs-baseline numbers: 2.65% of pixels exceed the default channel-delta-4 tolerance (limit 0.30%), max channel delta 32, and 0.18% exceed delta 16.

## Fix

Add `scripts/windows/screenshots/graphics-draw-arc.tolerance` using the existing per-test tolerance mechanism (same as `Gpu3D*.tolerance`, which exist for the same x64-vs-arm64 reason):

```
maxChannelDelta=16
maxMismatchPercent=0.5
```

This passes the measured arm64 difference with ~3x headroom while staying far tighter than the Gpu3D files (8 / 3.0%) — a real arc regression would still fail loudly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)