### PR TITLE
ParparVM: bundle ASM 9.8 in the translator jar (was asm-5.0.3)

### DIFF
--- a/vm/ByteCodeTranslator/build.xml
+++ b/vm/ByteCodeTranslator/build.xml
@@ -71,10 +71,15 @@
 
     -->
 
+    <!-- Bundle ASM 9.8 (matching nbproject/project.properties' compile classpath
+         and Parser.java's Opcodes.ASM9). The old asm-5.0.3 here shipped a runtime
+         ASM that only reads class file version <= 52 (Java 8); modern app bytecode
+         (Java 9+, e.g. version 61) made ClassReader throw a bare
+         IllegalArgumentException. 9.8 reads current bytecode. -->
     <target name="-pre-jar">
-        <unzip src="../../../cn1-binaries/vm/asm-5.0.3.jar" dest="build/classes"  />
-        <unzip src="../../../cn1-binaries/vm/asm-commons-5.0.3.jar" dest="build/classes"  />
-        <unzip src="../../../cn1-binaries/vm/asm-tree-5.0.3.jar" dest="build/classes"  />
+        <unzip src="../../../cn1-binaries/vm/asm-9.8.jar" dest="build/classes"  />
+        <unzip src="../../../cn1-binaries/vm/asm-commons-9.8.jar" dest="build/classes"  />
+        <unzip src="../../../cn1-binaries/vm/asm-tree-9.8.jar" dest="build/classes"  />
     </target>
             
         <!-- /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project TestApp.xcodeproj/ -target TestApp -configuration release -sdk iphoneos7.0 build -->


### PR DESCRIPTION
The ByteCodeTranslator is compiled against **ASM 9.8** (`vm/ByteCodeTranslator/nbproject/project.properties`) and its `Parser` uses `Opcodes.ASM9`, but the `-pre-jar` step in `build.xml` bundles the **runtime `asm-5.0.3`** into the output jar. ASM 5.0 only reads class-file version ≤ 52 (Java 8), so any Java 9+ app class (e.g. version 61 / JDK 17) makes `ClassReader.<init>` throw a bare `IllegalArgumentException` during translation.

Found while bringing up the containerized **win32** target against Java-17 app bytecode — the translator aborted before generating any C. Bundling ASM 9.8 (already in `cn1-binaries` and already on the compile classpath) lets the shipped translator read current bytecode. One-line swap; no source changes.

After this, a full win32 cross-compile of a Java-17 app translated and linked cleanly (`MyAppName-x64.exe`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)