### PR TITLE
blog: restructure weekly post with per-item deep-dive sections

### DIFF
--- a/docs/website/content/blog/mac-native-grpc-graphql-and-fewer-open-issues.md
+++ b/docs/website/content/blog/mac-native-grpc-graphql-and-fewer-open-issues.md
@@ -20,27 +20,67 @@ The open issue count is now below 350 (332 at the moment of this writing). That 
 
 We went over the issue tracker starting with the oldest issues and working our way back. You may recall that when we started tracking this, going under the 500-issue mark was a major milestone and that was just a few weeks back!
 
-## A note on contributions
-
-We stopped accepting community pull requests. We want to be precise about why, because it would be easy to read more into this than is there.
-
-This is **not** about AI-generated PRs. We are not policing how a contribution was written. 
-
-The real reason is mechanical: our CI does not run correctly against pull requests from forks. The screenshot pipeline, the device runners, and the protocol tests all need credentials and a setup that a forked PR cannot get, so a community PR cannot actually be validated by the same gates we hold our own work to. This isn't something we can easily solve without introducing major security vulnerabilities to our process. Recently, a change that looked completely safe slipped through and triggered a CI regression that took the builds down. That was on us, not on the contributor, but it convinced us that merging code we cannot fully run is the wrong trade.
-
-So the door is open the other way. **Please keep filing issues.** A clear issue with a test case is genuinely no trouble for us to pick up, and as the number above shows, we are actively working the tracker. If you have a fix in mind, describe it in the issue, attach the failing case, and we will carry it through CI ourselves.
-
-To everyone who has sent us patches over the years, and especially the people who contributed recently: thank you. The effort was real and appreciated, and this decision is about our pipeline, not your work. 
-
 ## What shipped this week
 
-The bigger items get their own deep-dive tutorials over the coming week. Short version:
+Every one of the bigger items has its own deep-dive tutorial. Here is the tour, with the links to the full posts.
 
-- **Native Mac builds.** The `macNative.enabled=true` build hint takes the same project through the iOS pipeline and emits a native Mac app. It pairs with a deeper desktop integration layer (native title bar, native menu bar, interactive scrollbars, desktop notifications), so a desktop target stops feeling like a phone in a window.
-- **WebSockets, gRPC, and GraphQL.** `com.codename1.io.WebSocket` is now in the core with no `cn1lib` required, and `cn1:generate-grpc` and `cn1:generate-graphql` join `cn1:generate-openapi` to turn a proto file or a GraphQL schema into a typed client. GraphQL subscriptions ride the new core WebSocket support, and enum binding landed in the JSON/XML mapper alongside them.
-- **A new advertising API.** A pluggable, format-complete `com.codename1.ads` subsystem replaces a pile of dead-end legacy mechanisms, with a modern AdMob reference provider.
-- **Background execution and push.** Constraint-based background work, foreground services, push topics, and much richer local notifications, all with full simulator support.
-- **Agent skills and a simpler Initializr.** Covered in this post below, since it is more about the tooling around your project than the framework inside it.
+### Your app is now a native Mac app
+
+One build hint, `macNative.enabled=true`, takes the exact same project through the iOS pipeline and emits a **real** native Mac app: no bundled JVM, the same Metal renderer and battle-tested ParparVM output as the iOS target. It pairs with a deeper desktop integration layer (native title bar, native menu bar, interactive scrollbars, desktop notifications), so a desktop target finally stops feeling like a phone in a window. This is the same Java code that produces the iOS and Android builds, running as a native Mac app:
+
+![A Codename One app running as a native Mac app](/blog/mac-native-builds-and-desktop-integration/mac-app.png)
+
+The full tutorial, including the new desktop menu and shortcut APIs and the Mac signing hints, is in [Your Codename One App, Now A Native Mac App](/blog/mac-native-builds-and-desktop-integration/).
+
+### WebSockets, gRPC, and GraphQL in the core
+
+`com.codename1.io.WebSocket` is now part of the framework with no `cn1lib` required, implemented natively on every port. A live connection is a fluent one-liner:
+
+```java
+WebSocket ws = WebSocket.build("wss://chat.example.com/room/general")
+    .onConnect(() -> Log.p("connected"))
+    .onTextMessage(text -> Display.getInstance()
+        .callSerially(() -> addBubble(text, false)))
+    .connect();
+```
+
+On top of that, `cn1:generate-grpc` and `cn1:generate-graphql` join `cn1:generate-openapi`, turning a proto file or a GraphQL schema into a typed client with no `protoc` and no HTTP plumbing. GraphQL subscriptions ride the new core WebSocket support, and enum binding landed in the JSON/XML mapper alongside them. The hands-on tutorial that builds a live chat and both typed clients is [WebSockets, gRPC, And GraphQL In The Core](/blog/websockets-grpc-and-graphql/).
+
+### A new advertising API
+
+Advertising support had quietly rotted across three dead-end legacy mechanisms. A pluggable, format-complete `com.codename1.ads` subsystem replaces all of them, with a modern AdMob reference provider, GDPR consent and iOS App Tracking Transparency built in, and a simulator placeholder provider so you can exercise every format without a device. A rewarded ad, the format people most often ask about, is now this short:
+
+```java
+RewardedAd ad = new RewardedAd("your-rewarded-ad-unit-id");
+ad.setAdListener(new AdListener() {
+    public void onLoaded() {
+        ad.show(reward ->
+            grantCoins(reward.getType(), reward.getAmount()));
+    }
+});
+ad.load();
+```
+
+The full story, including banners, native ads, app-open ads, and the provider SPI, is in [A New Advertising API, Built From The Ground Up](/blog/modern-advertising-api/).
+
+### Background execution and push
+
+Constraint-based background work, foreground services, push topics, shared-content handling, and a much richer local notification API, all of it usable in the simulator so you can debug these flows on your desktop. You describe what the work needs, not when to poll:
+
+```java
+WorkRequest req = WorkRequest.builder("daily-sync", SyncWorker.class)
+    .setRequiresNetwork(true)
+    .setRequiresCharging(true)
+    .setPeriodic(6 * 60 * 60 * 1000L)
+    .build();
+BackgroundWork.schedule(req);
+```
+
+The walkthrough, from progress notifications and inline replies to push topics and shared content, is [Background Work, Push Topics, And Richer Notifications](/blog/background-execution-and-push/).
+
+### Agent skills and a simpler Initializr
+
+Covered in this post right below, since it is more about the tooling around your project than the framework inside it.
 
 ## Building screens from screenshots, and a simpler Initializr
 
@@ -67,6 +107,18 @@ Several of these came straight out of the issue-tracker pass:
 - **Graphics.isVisible().** [PR #5129](https://github.com/codenameone/CodenameOne/pull/5129) adds a clip-intersection primitive so a zoomed canvas can cull off-screen content and skip the decode/scale. Closes [#3846](https://github.com/codenameone/CodenameOne/issues/3846).
 - **Screenshot block now covers peers.** [PR #5107](https://github.com/codenameone/CodenameOne/pull/5107): `ios.blockScreenshotsOnEnterBackground=true` was hiding the render surface but leaving peer components (such as a `BrowserComponent`'s `WKWebView`) visible in the app-switcher snapshot. Fixed.
 - **Better site search.** [PR #5090](https://github.com/codenameone/CodenameOne/pull/5090) sorts the on-site search index newest-first and stops the giant developer-guide page from crowding out every result. We also have dates visible next to blog post results in the search and a new highlight explaining we don't search the developer guide/Javadoc. 
+
+## A note on contributions
+
+We stopped accepting community pull requests. We want to be precise about why, because it would be easy to read more into this than is there.
+
+This is **not** about AI-generated PRs. We are not policing how a contribution was written. 
+
+The real reason is mechanical: our CI does not run correctly against pull requests from forks. The screenshot pipeline, the device runners, and the protocol tests all need credentials and a setup that a forked PR cannot get, so a community PR cannot actually be validated by the same gates we hold our own work to. This isn't something we can easily solve without introducing major security vulnerabilities to our process. Recently, a change that looked completely safe slipped through and triggered a CI regression that took the builds down. That was on us, not on the contributor, but it convinced us that merging code we cannot fully run is the wrong trade.
+
+So the door is open the other way. **Please keep filing issues.** A clear issue with a test case is genuinely no trouble for us to pick up, and as the number above shows, we are actively working the tracker. If you have a fix in mind, describe it in the issue, attach the failing case, and we will carry it through CI ourselves.
+
+To everyone who has sent us patches over the years, and especially the people who contributed recently: thank you. The effort was real and appreciated, and this decision is about our pipeline, not your work. 
 
 ## Upcoming attractions
 

--- a/docs/website/content/blog/mac-native-grpc-graphql-and-fewer-open-issues.md
+++ b/docs/website/content/blog/mac-native-grpc-graphql-and-fewer-open-issues.md
@@ -26,9 +26,9 @@ Every one of the bigger items has its own deep-dive tutorial. Here is the tour, 
 
 ### Your app is now a native Mac app
 
-Your existing Codename One app can ship as a **100% native Mac app today, with zero porting effort**. No rewrite, no bundled JVM, no Electron shell: the project you already have produces a lean native Mac binary the same way it produces your iPhone app, on the same Metal renderer and battle-tested native pipeline. And it arrives feeling like a real Mac app, not a phone in a window: native title bar, native menu bar, interactive scrollbars, and desktop notifications come with it. This is the same Java code that produces the iOS and Android builds, running as a native Mac app:
+Your existing Codename One app can ship as a **100% native Mac app today, with zero porting effort**. No rewrite, no bundled JVM, no Electron shell: the project you already have produces a lean native Mac binary the same way it produces your iPhone app, on the same Metal renderer and battle-tested native pipeline. And it arrives feeling like a real Mac app, not a phone in a window: native title bar, native menu bar, interactive scrollbars, and desktop notifications come with it. Two of this week's features in one shot: the sample below uses the new advertising API covered later in this post, running as a native Mac app from the same Java code that produces the iOS and Android builds:
 
-![A Codename One app running as a native Mac app](/blog/mac-native-builds-and-desktop-integration/mac-app.png)
+![The advertising API sample running as a native Mac app](/blog/mac-native-builds-and-desktop-integration/mac-app.png)
 
 The full tutorial, including the new desktop menu and shortcut APIs and the Mac signing hints, is in [Your Codename One App, Now A Native Mac App](/blog/mac-native-builds-and-desktop-integration/).
 

--- a/docs/website/content/blog/mac-native-grpc-graphql-and-fewer-open-issues.md
+++ b/docs/website/content/blog/mac-native-grpc-graphql-and-fewer-open-issues.md
@@ -26,13 +26,13 @@ Every one of the bigger items has its own deep-dive tutorial. Here is the tour, 
 
 ### Your app is now a native Mac app
 
-One build hint, `macNative.enabled=true`, takes the exact same project through the iOS pipeline and emits a **real** native Mac app: no bundled JVM, the same Metal renderer and battle-tested ParparVM output as the iOS target. It pairs with a deeper desktop integration layer (native title bar, native menu bar, interactive scrollbars, desktop notifications), so a desktop target finally stops feeling like a phone in a window. This is the same Java code that produces the iOS and Android builds, running as a native Mac app:
+Your existing Codename One app can ship as a **100% native Mac app today, with zero porting effort**. No rewrite, no bundled JVM, no Electron shell: the project you already have produces a lean native Mac binary the same way it produces your iPhone app, on the same Metal renderer and battle-tested native pipeline. And it arrives feeling like a real Mac app, not a phone in a window: native title bar, native menu bar, interactive scrollbars, and desktop notifications come with it. This is the same Java code that produces the iOS and Android builds, running as a native Mac app:
 
 ![A Codename One app running as a native Mac app](/blog/mac-native-builds-and-desktop-integration/mac-app.png)
 
 The full tutorial, including the new desktop menu and shortcut APIs and the Mac signing hints, is in [Your Codename One App, Now A Native Mac App](/blog/mac-native-builds-and-desktop-integration/).
 
-### WebSockets, gRPC, and GraphQL in the core
+### WebSockets in the core
 
 `com.codename1.io.WebSocket` is now part of the framework with no `cn1lib` required, implemented natively on every port. A live connection is a fluent one-liner:
 
@@ -44,7 +44,43 @@ WebSocket ws = WebSocket.build("wss://chat.example.com/room/general")
     .connect();
 ```
 
-On top of that, `cn1:generate-grpc` and `cn1:generate-graphql` join `cn1:generate-openapi`, turning a proto file or a GraphQL schema into a typed client with no `protoc` and no HTTP plumbing. GraphQL subscriptions ride the new core WebSocket support, and enum binding landed in the JSON/XML mapper alongside them. The hands-on tutorial that builds a live chat and both typed clients is [WebSockets, gRPC, And GraphQL In The Core](/blog/websockets-grpc-and-graphql/).
+This is the foundation the GraphQL subscriptions below ride on, and it is trusted enough that our own screenshot CI uses it as the transport for device renders. The hands-on tutorial that builds a live chat with it is [WebSockets, gRPC, And GraphQL In The Core](/blog/websockets-grpc-and-graphql/).
+
+### A typed GraphQL client from your schema
+
+`cn1:generate-graphql` turns a GraphQL schema into a typed client: you declare an interface against your operations and the build emits the implementation, with zero HTTP plumbing on your side. A `@Subscription` gets you live server-pushed updates over the new core WebSocket:
+
+```java
+@GraphQLClient("https://swapi.example.com/graphql")
+public interface StarWarsApi {
+    @Query("query HeroName($episode: Episode) { hero(episode: $episode) { name } }")
+    void hero(@Var("episode") Episode episode,
+              OnComplete<GraphQLResponse<HeroData>> callback);
+
+    @Subscription("subscription OnReview($ep: Episode!) { reviewAdded(episode: $ep) { stars } }")
+    GraphQLSubscription onReview(@Var("ep") Episode ep,
+                                 GraphQLSubscription.Handler<ReviewData> handler);
+}
+```
+
+Note that `Episode` is a real enum: enum binding landed in the JSON/XML mapper alongside this work, fixing a long-standing gap for `@Mapped` users too. The full tutorial is in [WebSockets, gRPC, And GraphQL In The Core](/blog/websockets-grpc-and-graphql/).
+
+### gRPC clients with no protoc
+
+`cn1:generate-grpc` does the same for proto3. Point it at your `.proto` files and it generates the messages, the binary protobuf codecs, and the client, speaking the standard gRPC-Web wire protocol that works with Envoy and modern gRPC servers. There is no `protoc` to install and no native dependency; calling a service looks like this:
+
+```java
+GreeterGrpc g = GreeterGrpc.of("https://api.example.com");
+HelloRequest req = new HelloRequest();
+req.name = "world";
+g.sayHello(req, "Bearer " + token, response -> {
+    if (response.isOk()) {
+        renderGreeting(response.getResponseData().message);
+    }
+});
+```
+
+Together with `cn1:generate-openapi` and `cn1:generate-graphql`, this means a typed client for practically any backend is one Maven goal away. The walkthrough from proto file to running call is in [WebSockets, gRPC, And GraphQL In The Core](/blog/websockets-grpc-and-graphql/).
 
 ### A new advertising API
 
@@ -77,10 +113,6 @@ BackgroundWork.schedule(req);
 ```
 
 The walkthrough, from progress notifications and inline replies to push topics and shared content, is [Background Work, Push Topics, And Richer Notifications](/blog/background-execution-and-push/).
-
-### Agent skills and a simpler Initializr
-
-Covered in this post right below, since it is more about the tooling around your project than the framework inside it.
 
 ## Building screens from screenshots, and a simpler Initializr
 


### PR DESCRIPTION
## Summary
- Turn the **What shipped this week** bullet list in the `mac-native-grpc-graphql-and-fewer-open-issues` post into a parent section with one subsection per shipped item
- Each subsection leads with a stronger hook, links to its now-published deep-dive tutorial, and includes an image or code snippet pulled from that post (Mac app screenshot, `WebSocket.build` snippet, rewarded-ad snippet, `WorkRequest` snippet)
- Move **A note on contributions** to just before **Upcoming attractions**

All referenced images already exist under `docs/website/static/blog/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)