### PR TITLE
scripts/website: bump Codename One versions to 7.0.251

### DIFF
--- a/scripts/cn1playground/pom.xml
+++ b/scripts/cn1playground/pom.xml
@@ -20,7 +20,7 @@
 </modules>
   <properties>
     <cn1.plugin.version>${cn1.version}</cn1.plugin.version>
-    <cn1.version>7.0.250</cn1.version>
+    <cn1.version>7.0.251</cn1.version>
     <!-- cn1.registry.version pins the bean-shell access registry one
          release behind cn1.version. The registry is consumed by the
          deployed JavaScript cloud build, which lags the release

--- a/scripts/initializr/common/src/main/java/com/codename1/initializr/model/GeneratorModel.java
+++ b/scripts/initializr/common/src/main/java/com/codename1/initializr/model/GeneratorModel.java
@@ -18,7 +18,7 @@ import java.util.Map;
 import static com.codename1.ui.CN.*;
 
 public class GeneratorModel {
-    private static final String CN1_PLUGIN_VERSION = "7.0.250";
+    private static final String CN1_PLUGIN_VERSION = "7.0.251";
     private static final String PREVIEW_BUTTON_SELECTOR =
             "Button, InitializrLiveButtonDarkClean, "
                     + "InitializrLiveButtonLightTealRound, InitializrLiveButtonLightTealSquare, "

--- a/scripts/initializr/common/src/test/java/com/codename1/initializr/model/GeneratorModelMatrixTest.java
+++ b/scripts/initializr/common/src/test/java/com/codename1/initializr/model/GeneratorModelMatrixTest.java
@@ -355,8 +355,8 @@ public class GeneratorModelMatrixTest extends AbstractTest {
         String pom = getText(entries, "pom.xml");
         assertContains(pom, packageName, "Root pom should include package as groupId");
         assertContains(pom, mainClassName.toLowerCase(), "Root pom should include app artifact/name");
-        assertContains(pom, "<cn1.plugin.version>7.0.250</cn1.plugin.version>", "Root pom should use current CN1 plugin version");
-        assertContains(pom, "<cn1.version>7.0.250</cn1.version>", "Root pom should align CN1 runtime version with plugin version");
+        assertContains(pom, "<cn1.plugin.version>7.0.251</cn1.plugin.version>", "Root pom should use current CN1 plugin version");
+        assertContains(pom, "<cn1.version>7.0.251</cn1.version>", "Root pom should align CN1 runtime version with plugin version");
         assertFalse(pom.indexOf("com.example.myapp") >= 0, "Root pom still contains placeholder package");
         assertFalse(pom.indexOf("myappname") >= 0, "Root pom still contains placeholder app name");
     }

--- a/scripts/initializr/pom.xml
+++ b/scripts/initializr/pom.xml
@@ -19,8 +19,8 @@
 <module>common</module>
 </modules>
   <properties>
-    <cn1.version>7.0.250</cn1.version>
-    <cn1.plugin.version>7.0.250</cn1.plugin.version>
+    <cn1.version>7.0.251</cn1.version>
+    <cn1.plugin.version>7.0.251</cn1.plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
     <java-tests.version>11</java-tests.version>
@@ -118,7 +118,7 @@
         </property>
       </activation>
       <properties>
-        <cn1.version>7.0.250</cn1.version>
+        <cn1.version>7.0.251</cn1.version>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
Automated update of website Codename One versions after release `7.0.251`.

Updated:
- All `scripts/initializr/**/pom.xml` files containing `cn1.plugin.version`
- `scripts/initializr/common/src/main/java/com/codename1/initializr/model/GeneratorModel.java`
- `scripts/initializr/common/src/test/java/com/codename1/initializr/model/GeneratorModelMatrixTest.java`
- Embedded root `pom.xml` in `scripts/initializr/common/src/main/resources/common.zip`
- `scripts/cn1playground/pom.xml`