### PR TITLE
Fix App Store rejection: UILaunchScreen requires MinimumOSVersion 14+

### DIFF
--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
@@ -293,6 +293,14 @@ public class IPhoneBuilder extends Executor {
     public boolean build(File sourceZip, BuildRequest request) throws BuildException {
         Stopwatch stopwatch = new Stopwatch();
         addMinDeploymentTarget(DEFAULT_MIN_DEPLOYMENT_VERSION);
+        if (request.getArg("ios.deployment_target", null) == null) {
+            // No explicit deployment target. Default to iOS 14 so the
+            // UILaunchScreen-based launch screen injected for UIScene builds
+            // satisfies App Store validation: apps supporting iPad
+            // multitasking must provide a launch storyboard, or UILaunchScreen
+            // when MinimumOSVersion is 14 or higher.
+            addMinDeploymentTarget("14.0");
+        }
         detectJailbreak = request.getArg("ios.detectJailbreak", "false").equals("true");
         defaultEnvironment.put("LANG", "en_US.UTF-8");
         tmpFile = tmpDir = getBuildDirectory();
@@ -3600,8 +3608,17 @@ public class IPhoneBuilder extends Executor {
             "true")) {
             multitasking = false;
         }
-        
-        
+        if (multitasking && useMetal && getDeploymentTargetInt(request) < 14) {
+            // An explicit ios.deployment_target below 14 cannot satisfy the
+            // App Store launch screen rule for iPad multitasking apps via the
+            // UILaunchScreen key (it only counts when MinimumOSVersion is 14
+            // or higher), so opt out of multitasking instead of producing a
+            // bundle that fails upload validation.
+            log("ios.deployment_target is below 14; implicitly disabling iPad multitasking (UIRequiresFullScreen) so the launch screen passes App Store validation. Set ios.deployment_target=14.0 or higher to keep multitasking support.");
+            multitasking = false;
+        }
+
+
         if (!multitasking || xcodeVersion < 9) {
             if (inject.indexOf("UIRequiresFullScreen") < 0) {
                 // Temporary workaround to disable iPad multitasking support.


### PR DESCRIPTION
## Problem

Since the UIScene launch screen fix (#5218, shipped in 7.0.251), scene-based builds inject the `UILaunchScreen` plist key instead of `UILaunchStoryboardName`. Apple only accepts `UILaunchScreen` as the launch screen for apps that support iPad multitasking when the bundle's `MinimumOSVersion` is **14 or higher**. The default deployment target floor was 13.0, so default builds were rejected at upload with:

> Invalid bundle. Apps that support Multitasking on iPad must provide the app's launch screen using an Xcode storyboard, or using UILaunchScreen if the app's MinimumOSVersion is 14 or higher.

## Fix

- When no explicit `ios.deployment_target` is supplied, the deployment target floor is now 14.0 (every device that ran iOS 13 also got iOS 14, so this excludes no devices).
- When an explicitly supplied target resolves below 14 on a Metal build, iPad multitasking is implicitly disabled via the existing `UIRequiresFullScreen` injection, with a build log line explaining how to keep multitasking (`ios.deployment_target=14.0`).

The check uses the effective resolved target, so `ios.minDeploymentTarget` / `ios.pods.platform` values that already push the target to 14+ keep multitasking enabled.

Mirrored in the BuildDaemon repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)