### PR TITLE
ParparVM: index native-symbol and class lookups in the dead-code cull (O(N^2) -> ~O(N))

### DIFF
--- a/vm/ByteCodeTranslator/spotbugs-exclude.xml
+++ b/vm/ByteCodeTranslator/spotbugs-exclude.xml
@@ -102,7 +102,12 @@
         <Bug pattern="EQ_GETCLASS_AND_CLASS_CONSTANT" />
     </Match>
 
-    <!-- Parser ingests input files and uses the same CLI-exit pattern. -->
+    <!--
+    Parser ingests input files and uses the same CLI-exit pattern. The native-symbol
+    and name->class indexes are lazily built static caches; they are safe here because
+    the translator runs single-threaded across one translation run (same rationale as
+    the ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD exclusions above).
+    -->
     <Match>
         <Class name="~com\.codename1\.tools\.translator\.Parser(\$.*)?" />
         <Or>
@@ -111,6 +116,8 @@
             <Bug pattern="OS_OPEN_STREAM_EXCEPTION_PATH" />
             <Bug pattern="OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE" />
             <Bug pattern="DLS_DEAD_LOCAL_STORE" />
+            <Bug pattern="LI_LAZY_INIT_STATIC" />
+            <Bug pattern="LI_LAZY_INIT_UPDATE_STATIC" />
         </Or>
     </Match>
 

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeClass.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeClass.java
@@ -411,12 +411,10 @@ public class ByteCodeClass {
     }
     
     private ByteCodeClass findClass(String s, List<ByteCodeClass> lst) {
-        for(ByteCodeClass c : lst) {
-            if(c.clsName.equals(s)) {
-                return c;
-            }
-        }
-        return null;
+        // lst is always Parser.classes here (markDependencies -> markDependent), so
+        // the shared name index gives the same first-match result in O(1) instead of
+        // the old O(N) scan that ran per dependency per class during marking.
+        return Parser.getClassObject(s);
     }
     
     public void updateAllDependencies() {

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
@@ -587,25 +587,21 @@ public class BytecodeMethod implements SignatureSet {
 
 
 
-        // check native code
+        // check native code: O(|symbol|) lookups against the inverted index instead
+        // of an O(native_bytes) substring scan per method. Semantics are identical --
+        // the index answers "is X a substring of the native source text".
         StringBuilder b = new StringBuilder();
         this.appendFunctionPointer(b);
         String str = b.toString();
-        boolean foundClassName = false;
-        for(String s : nativeSources) {
-            if (cls != null && !foundClassName && s.contains(clsName)) {
-                // For later we record whether the class is used.
-                foundClassName = true;
+        NativeSymbolIndex idx = Parser.getNativeSymbolIndex(nativeSources);
+        if (idx.contains(str)) {
+            usedByNative = true;
+            if (cls != null) {
+                cls.setUsedByNative(true);
             }
-            if(s.contains(str)) {
-                usedByNative = true;
-                if (cls != null) {
-                    cls.setUsedByNative(true);
-                }
-                return true;
-            }
+            return true;
         }
-        if (!foundClassName && cls != null) {
+        if (cls != null && !idx.contains(clsName)) {
             // We didn't find the class at all.
             // Let's record that as it will save us time
             // when looking up other methods in this class.

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/NativeSymbolIndex.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/NativeSymbolIndex.java
@@ -1,0 +1,125 @@
+package com.codename1.tools.translator;
+
+import java.util.HashMap;
+import java.util.HashSet;
+
+/**
+ * Inverts the "is this symbol referenced by native code" scan.
+ *
+ * The old code did, per Java method/class, a full substring scan of every
+ * native source string -- O(methods x native_bytes). Native symbols are CN1
+ * mangled identifiers ([A-Za-z0-9_]+), and a query string X matches the native
+ * text iff X is a substring of some maximal identifier token in it. So we:
+ *   1. tokenize all native sources into the DISTINCT set of identifier tokens
+ *      (this dedups repeated symbols across files, bounding the structure),
+ *   2. build a suffix automaton over those tokens (joined by '\n' so a query
+ *      can never span two tokens), giving O(|X|) substring membership.
+ *
+ * Result: native cost becomes O(native_bytes) once + O(|X|) per query, instead
+ * of O(methods x native_bytes). Semantics are identical to String.contains over
+ * the raw native text because queries are themselves delimiter-free identifiers.
+ */
+final class NativeSymbolIndex {
+    private int[] len;
+    private int[] link;
+    private HashMap<Character, Integer>[] next;
+    private int last;
+    private int sz;
+
+    @SuppressWarnings("unchecked")
+    NativeSymbolIndex(String[] nativeSources) {
+        HashSet<String> tokens = new HashSet<String>();
+        if (nativeSources != null) {
+            for (String s : nativeSources) {
+                if (s == null) {
+                    continue;
+                }
+                int n = s.length();
+                int i = 0;
+                while (i < n) {
+                    if (isIdent(s.charAt(i))) {
+                        int j = i + 1;
+                        while (j < n && isIdent(s.charAt(j))) {
+                            j++;
+                        }
+                        tokens.add(s.substring(i, j));
+                        i = j;
+                    } else {
+                        i++;
+                    }
+                }
+            }
+        }
+        StringBuilder sb = new StringBuilder();
+        for (String t : tokens) {
+            sb.append(t).append('\n');
+        }
+        String text = sb.toString();
+
+        int cap = 2 * Math.max(1, text.length()) + 5;
+        len = new int[cap];
+        link = new int[cap];
+        next = new HashMap[cap];
+        sz = 0;
+        last = newState(0, -1);
+        for (int i = 0; i < text.length(); i++) {
+            extend(text.charAt(i));
+        }
+    }
+
+    private int newState(int l, int lnk) {
+        len[sz] = l;
+        link[sz] = lnk;
+        next[sz] = new HashMap<Character, Integer>();
+        return sz++;
+    }
+
+    private void extend(char c) {
+        int cur = newState(len[last] + 1, -1);
+        int p = last;
+        while (p != -1 && !next[p].containsKey(c)) {
+            next[p].put(c, cur);
+            p = link[p];
+        }
+        if (p == -1) {
+            link[cur] = 0;
+        } else {
+            int q = next[p].get(c);
+            if (len[p] + 1 == len[q]) {
+                link[cur] = q;
+            } else {
+                int clone = newState(len[p] + 1, link[q]);
+                next[clone].putAll(next[q]);
+                while (p != -1) {
+                    Integer t = next[p].get(c);
+                    if (t == null || t != q) {
+                        break;
+                    }
+                    next[p].put(c, clone);
+                    p = link[p];
+                }
+                link[q] = clone;
+                link[cur] = clone;
+            }
+        }
+        last = cur;
+    }
+
+    /** True iff pat occurs as a substring of some native identifier token. */
+    boolean contains(String pat) {
+        int cur = 0;
+        for (int i = 0; i < pat.length(); i++) {
+            Integer nx = next[cur].get(pat.charAt(i));
+            if (nx == null) {
+                return false;
+            }
+            cur = nx;
+        }
+        return true;
+    }
+
+    private static boolean isIdent(char c) {
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+                || (c >= '0' && c <= '9') || c == '_';
+    }
+}

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/Parser.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/Parser.java
@@ -285,6 +285,20 @@ public class Parser extends ClassVisitor {
         }
     }
 
+    // Inverted index over the native sources for O(1) "is this symbol referenced
+    // by native code" queries (see NativeSymbolIndex). Built lazily and cached
+    // against the nativeSources array identity, mirroring the per-method memo in
+    // BytecodeMethod.isMethodUsedByNative.
+    private static NativeSymbolIndex nativeSymbolIndex;
+    private static String[] nativeSymbolIndexSources;
+    public static NativeSymbolIndex getNativeSymbolIndex(String[] nativeSources) {
+        if (nativeSymbolIndex == null || nativeSymbolIndexSources != nativeSources) {
+            nativeSymbolIndex = new NativeSymbolIndex(nativeSources);
+            nativeSymbolIndexSources = nativeSources;
+        }
+        return nativeSymbolIndex;
+    }
+
     private static final ArrayList<String> constantPool = new ArrayList<>();
     
     public static ByteCodeClass getClassObject(String name) {

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/Parser.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/Parser.java
@@ -86,13 +86,7 @@ public class Parser extends ClassVisitor {
     }
     
     private static ByteCodeClass getClassByName(String name) {
-        name = name.replace('/', '_').replace('$', '_');
-        for(ByteCodeClass bc : classes) {
-            if(bc.getClsName().equals(name)) {
-                return bc;
-            }
-        }
-        return null;
+        return classIndex().get(name.replace('/', '_').replace('$', '_'));
     }
 
     /**
@@ -301,13 +295,34 @@ public class Parser extends ClassVisitor {
 
     private static final ArrayList<String> constantPool = new ArrayList<>();
     
-    public static ByteCodeClass getClassObject(String name) {
-        for(ByteCodeClass cls : classes) {
-            if(cls.getClsName().equals(name)) {
-                return cls;
+    // Name -> class index, replacing the O(N) linear scans that getClassObject /
+    // getClassByName / ByteCodeClass.findClass used to do. Those run per dependency
+    // per class during the dead-code cull, so the scans were O(N^2) per pass.
+    // Rebuilt lazily when `classes` changes. `classes` is only ever reassigned (new
+    // reference) or grown in place via add()/cleared -- it is never mutated to a
+    // same-reference, same-size, different-content state -- so the (reference, size)
+    // pair uniquely identifies its state and makes this self-correcting.
+    private static HashMap<String, ByteCodeClass> classIndexMap;
+    private static List<ByteCodeClass> classIndexSource;
+    private static int classIndexSize;
+    private static HashMap<String, ByteCodeClass> classIndex() {
+        if (classIndexMap == null || classIndexSource != classes || classIndexSize != classes.size()) {
+            HashMap<String, ByteCodeClass> m = new HashMap<String, ByteCodeClass>(classes.size() * 2);
+            for (ByteCodeClass cls : classes) {
+                // first-wins, matching the old "return the first match" linear scan
+                if (!m.containsKey(cls.getClsName())) {
+                    m.put(cls.getClsName(), cls);
+                }
             }
+            classIndexMap = m;
+            classIndexSource = classes;
+            classIndexSize = classes.size();
         }
-        return null;
+        return classIndexMap;
+    }
+
+    public static ByteCodeClass getClassObject(String name) {
+        return classIndex().get(name);
     }
     
     /**

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/Parser.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/Parser.java
@@ -62,6 +62,12 @@ public class Parser extends ClassVisitor {
     public static void cleanup() {
         nativeSources = null;
         classes.clear();
+        // classes is cleared in place (same List reference), so the name index's
+        // (reference, size) guard cannot detect a subsequent same-size refill across
+        // translation runs in the same JVM (e.g. the unit tests). Invalidate it here.
+        classIndexMap = null;
+        classIndexSource = null;
+        classIndexSize = -1;
         dependencyGraph.clear();
         BytecodeMethod.setDependencyGraph(null);
         ByteCodeClass.cleanup();


### PR DESCRIPTION
## Problem

The ParparVM dead-code optimizer ("unused Method cull") had **two** quadratic "scan the same thing repeatedly" costs that made large / native-heavy iOS apps slow to translate (and on the build server, slow enough to hit the translator timeout):

1. **Native-symbol scan** — for every Java method/class it asked *"is this referenced by native code?"* by substring-scanning the **entire** native source corpus per query (`isMethodUsedByNative` -> `for each native source: s.contains(symbol)`): **O(methods × native_bytes)**. Apps pulling in many cn1libs with native code (camera, scanners, maps, ...) pay heavily.
2. **Class lookup** — `getClassObject` / `getClassByName` / `ByteCodeClass.findClass` each linear-scanned the whole class list, called per dependency per class during `markDependencies`/`updateAllDependencies` (run ~5× per build): **O(N²)**.

Found while investigating a real iOS cloud build hitting the translator timeout. (Heap was ruled out — the cost is deterministic/algorithmic, not GC.)

## Fix

Two indexes, each built once and queried in ~O(1):

- **`NativeSymbolIndex`** — a suffix automaton over the **distinct** native identifier tokens. Native symbols are CN1 mangled identifiers, and a query matches iff it's a substring of some token, so this is semantically identical to the old `String.contains`. Tokenizing into the distinct set dedups across files, bounding the structure. `O(methods × native_bytes)` -> `O(native_bytes)` once + `O(|symbol|)` per query.
- **Name → class `HashMap`** — replaces the three linear scans. Rebuilt lazily when `classes` changes (tracked by the `(reference, size)` pair, which is sufficient because `classes` is only ever reassigned / grown via `add()` / cleared). First-match semantics preserved.

Both run single-threaded across one translation run; the lazily-built static caches are excluded for `LI_LAZY_INIT_*` in `spotbugs-exclude.xml`, matching the file's existing convention.

## Measurements

Real failing iOS build's classes (5476, held fixed); native corpus scaled by duplicating `.m` files:

| native files | before | native index only | + class index | methods removed |
|---:|---:|---:|---:|---:|
| 62 | 15 s | 14 s | **7 s** | 6968 / 6968 |
| 462 | 24 s | 15.5 s | **7 s** | 6968 / 6968 |
| 1362 | 48 s | 16 s | **7 s** | 6968 / 6968 |

- **Correctness gate:** the cull removes the exact same **6968** methods at every size — the indexes change *what's scanned*, never *what's eliminated*.
- **Result:** cull time is now flat in both class count and native-file count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)