### PR TITLE
ParparVM: fix double-checked-locking race in monitorEnter that deadlocks the VM

### DIFF
--- a/vm/ByteCodeTranslator/src/nativeMethods.m
+++ b/vm/ByteCodeTranslator/src/nativeMethods.m
@@ -1444,38 +1444,47 @@ JAVA_VOID java_lang_System_exit___int(CODENAME_ONE_THREAD_STATE, JAVA_INT i) {
 
 JAVA_VOID monitorEnter(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT obj) {
     int err = 0;
-    // we need to synchronize the mutex initialization since there might be a race condition here
-    if(!obj->__codenameOneThreadData) {
-        // double locking to avoid race condition and improve performance
+    // Double-checked locking for the lazily allocated per-object monitor. The fast-path
+    // read MUST be an acquire load and the publishing store (inside the critical section)
+    // MUST be a release store: otherwise a second thread can observe the
+    // __codenameOneThreadData pointer the instant malloc() returns -- before
+    // pthread_mutex_init() has run on it -- and then pthread_mutex_lock() an
+    // uninitialized mutex. On ARM's weak memory model that hangs forever (observed as the
+    // EDT wedged in monitorEnter while logging an exception, which freezes the whole app).
+    // Build the struct fully, init its mutex/condition, and only then publish the pointer.
+    struct CN1ThreadData* data = (struct CN1ThreadData*)__atomic_load_n(&obj->__codenameOneThreadData, __ATOMIC_ACQUIRE);
+    if(!data) {
         lockCriticalSection();
-        if(!obj->__codenameOneThreadData) {
-            obj->__codenameOneThreadData = malloc(sizeof(struct CN1ThreadData));
-            memset(obj->__codenameOneThreadData, 0, sizeof(struct CN1ThreadData));
-            pthread_mutex_init(&((struct CN1ThreadData*)obj->__codenameOneThreadData)->__codenameOneMutex, NULL);
-            pthread_cond_init(&((struct CN1ThreadData*)obj->__codenameOneThreadData)->__codenameOneCondition, NULL);
+        data = (struct CN1ThreadData*)obj->__codenameOneThreadData;
+        if(!data) {
+            data = malloc(sizeof(struct CN1ThreadData));
+            memset(data, 0, sizeof(struct CN1ThreadData));
+            pthread_mutex_init(&data->__codenameOneMutex, NULL);
+            pthread_cond_init(&data->__codenameOneCondition, NULL);
+            __atomic_store_n(&obj->__codenameOneThreadData, data, __ATOMIC_RELEASE);
         }
         unlockCriticalSection();
-        err = pthread_mutex_lock(&((struct CN1ThreadData*)obj->__codenameOneThreadData)->__codenameOneMutex);
-        ((struct CN1ThreadData*)obj->__codenameOneThreadData)->ownerThread = threadStateData->threadId;
-        ((struct CN1ThreadData*)obj->__codenameOneThreadData)->counter++;
+        err = pthread_mutex_lock(&data->__codenameOneMutex);
+        data->ownerThread = threadStateData->threadId;
+        data->counter++;
     } else {
         JAVA_LONG own = threadStateData->threadId;
-        JAVA_LONG currentlyHeldBy = ((struct CN1ThreadData*)obj->__codenameOneThreadData)->ownerThread;
-        
+        JAVA_LONG currentlyHeldBy = data->ownerThread;
+
         // we already own the lock...
         if(currentlyHeldBy == own) {
-            ((struct CN1ThreadData*)obj->__codenameOneThreadData)->counter++;
+            data->counter++;
             return;
         }
         threadStateData->threadActive = JAVA_FALSE;
-        err = pthread_mutex_lock(&((struct CN1ThreadData*)obj->__codenameOneThreadData)->__codenameOneMutex);
-        ((struct CN1ThreadData*)obj->__codenameOneThreadData)->counter++;
-        ((struct CN1ThreadData*)obj->__codenameOneThreadData)->ownerThread = own;
+        err = pthread_mutex_lock(&data->__codenameOneMutex);
+        data->counter++;
+        data->ownerThread = own;
         while (threadStateData->threadBlockedByGC) {
             usleep(100);
         }
         threadStateData->threadActive = JAVA_TRUE;
-        
+
 
     }
     //printf("Locking mutex %i started from %@", (int)obj->__codenameOneMutex, [NSThread callStackSymbols]);


### PR DESCRIPTION
## Symptom

`build-ios-metal` (and intermittently `build-mac-native`) goes red with *"N of 128 expected screenshot(s) were not produced"*, at a **varying** count run-to-run (seen at 31 / 63 / 69 / 92) — the classic signature of a race rather than a bad test or a pixel diff. The same branch passes 128/128 on a re-run, so it has read as a "known flake."

## Root cause (from the hang sample)

The run uploads an `app-hang-sample.txt`. It is a clean **deadlock**, not a crash. The EDT is wedged for the entire sample while *logging an exception*:

```
Display.mainEDTLoop
 -> Log.e(Throwable) -> Log.logThrowable -> Log.print -> Log.getWriter -> Log.createWriter
  -> Storage.createOutputStream -> IOSImplementation.createStorageOutputStream
   -> __NEW_com_codename1_io_BufferedOutputStream
    -> __STATIC_INITIALIZER_com_codename1_io_BufferedOutputStream
     -> monitorEnter -> _pthread_mutex_firstfit_lock_slow -> __psynch_mutexwait   (2389/2389 samples)
```

Once the EDT is stuck, the screenshot suite stops emitting and the job dies at whatever count it reached.

`monitorEnter` lazily allocates the per-object monitor with **double-checked locking**, but without the required memory ordering:

```c
if(!obj->__codenameOneThreadData) {            // plain (relaxed) load
    lockCriticalSection();
    if(!obj->__codenameOneThreadData) {
        obj->__codenameOneThreadData = malloc(...);   // pointer PUBLISHED here...
        memset(...);
        pthread_mutex_init(...);                       // ...mutex initialized AFTER
    }
    unlockCriticalSection();
    ...
} else {
    ...
    pthread_mutex_lock(&((CN1ThreadData*)obj->__codenameOneThreadData)->__codenameOneMutex);
}
```

A second thread (logging concurrently — the sample shows two `NetworkManager` threads alongside the EDT) can observe the pointer the instant `malloc()` returns, **before** `pthread_mutex_init()` has run, take the `else` branch, and `pthread_mutex_lock()` an uninitialized mutex. On ARM's weak memory model the store of the pointer and the stores that initialize the mutex are not ordered, so this hangs forever.

## Fix

Standard acquire/release double-checked locking:

- fast-path read is an `__ATOMIC_ACQUIRE` load,
- the struct is fully built (`memset` + `pthread_mutex_init` + `pthread_cond_init`) into a local,
- the pointer is published with an `__ATOMIC_RELEASE` store **only after** it is completely initialized.

The already-initialized happy path is semantically unchanged (same `threadActive`/GC-park dance, same recursion counter). Atomics/casts verified to compile clean with clang.

## Validation

The deadlock is rare per run, so this can't be proven green in a single CI pass — it needs to survive several `build-ios-metal` runs without a "not produced" failure. The fix is a correctness fix at the exact wedge point in the sample; it cannot regress the happy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)