### PR TITLE
fix(website-ci): mint a real Keycloak token from the password before cloud builds

### DIFF
--- a/scripts/website/build.sh
+++ b/scripts/website/build.sh
@@ -108,11 +108,32 @@ set_cn1_user_token() {
   local project_dir="$1"
 
   if [ -n "${CN1_USER}" ] && [ -n "${CN1_TOKEN}" ]; then
+    # CN1_TOKEN holds the account *password*, not a build token. The build
+    # sends whatever is stored in the prefs "token" slot as an
+    # "Authorization: Bearer" header; the cloud server parses that as a JWT,
+    # so seeding the raw password makes every cloud call 401 and the build
+    # falls back to an interactive browser login that hangs in CI
+    # ("Waiting for login..."). Exchange the password for a short-lived
+    # Keycloak access token (OAuth2 direct grant on the public cn1cloudapp
+    # client) and seed THAT instead.
+    local cn1_access_token=""
+    cn1_access_token="$(curl -fsS -m 20 \
+      -d 'grant_type=password' \
+      -d 'client_id=cn1cloudapp' \
+      --data-urlencode "username=${CN1_USER}" \
+      --data-urlencode "password=${CN1_TOKEN}" \
+      'https://auth.codenameone.com/auth/realms/Realm/protocol/openid-connect/token' \
+      | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')" || true
+    if [ -z "${cn1_access_token}" ]; then
+      echo "Failed to obtain a Codename One access token from CN1_USER/CN1_TOKEN — check the credentials (the secret must be the account password)." >&2
+      return 1
+    fi
+
     if ! sh ./mvnw -q -U -pl javascript -am \
       cn1:set-user-token \
       -Dcodename1.platform=javascript \
       -Duser="${CN1_USER}" \
-      -Dtoken="${CN1_TOKEN}"; then
+      -Dtoken="${cn1_access_token}"; then
       echo "cn1:set-user-token is unavailable in this plugin version for ${project_dir}; writing CN1 credentials directly to Java preferences." >&2
       local tmp_dir
       tmp_dir="$(mktemp -d)"
@@ -131,7 +152,7 @@ public class SetCn1Prefs {
 }
 JAVA
       javac "${tmp_dir}/SetCn1Prefs.java"
-      java -cp "${tmp_dir}" SetCn1Prefs "${CN1_USER}" "${CN1_TOKEN}"
+      java -cp "${tmp_dir}" SetCn1Prefs "${CN1_USER}" "${cn1_access_token}"
       rm -rf "${tmp_dir}"
     fi
   else


### PR DESCRIPTION
## Symptom
The "Build Hugo Website" workflow hangs the JS cloud builds at **`Waiting for login...`** — `CodeNameOneBuildTask` tries to open a browser no CI runner can answer.

## Root cause
`CN1_TOKEN` holds the account **password**, not a build token. `scripts/website/build.sh` fed it straight to `cn1:set-user-token` (and the `SetCn1Prefs` fallback), which writes it verbatim into the Java prefs `token` slot. The build then sends `Authorization: Bearer <password>` to the cloud server; the resource server tries to parse a password as a JWT, returns **401**, and the client falls back to the interactive browser login. A password can never be a bearer token, so it fails every time (the old App Engine username/password fallback that used to mask this is gone).

## Fix
In `set_cn1_user_token`, exchange the password for a short-lived **Keycloak access token** (OAuth2 direct access grant on the public `cn1cloudapp` client — Direct Access Grants is enabled) and seed *that* as the prefs token:

```sh
cn1_access_token="$(curl -fsS ... grant_type=password client_id=cn1cloudapp \
  username=$CN1_USER password=$CN1_TOKEN .../token | sed -n 's/..."access_token":"\([^"]*\)".*/\1/p')"
```

Minted per-build (this runs before each JS build), so it's fresh — no mid-build expiry for normal durations. **No `CodeNameOneBuildClient.jar` change needed** — the existing flow works once the prefs `token` is an actual token (alternative to the JAR-swap branch).

## Triggers the build
Touches `scripts/website/**`, which is in the `website-docs.yml` `pull_request` path filter — so this PR runs the website build and exercises the fix end-to-end.

## Note
If a cloud build ever exceeds the realm's access-token lifespan, bump **Access Token Lifespan** for the `Realm` realm in Keycloak. `CN1_TOKEN` secret stays as the password (no value change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)