### PR TITLE
ByteCodeTranslator: add asm-analysis to compile classpath

### DIFF
--- a/vm/ByteCodeTranslator/nbproject/project.properties
+++ b/vm/ByteCodeTranslator/nbproject/project.properties
@@ -32,12 +32,14 @@ excludes=
 file.reference.asm-9.8.jar=../../../cn1-binaries/vm/asm-9.8.jar
 file.reference.asm-commons-9.8.jar=../../../cn1-binaries/vm/asm-commons-9.8.jar
 file.reference.asm-tree-9.8.jar=../../../cn1-binaries/vm/asm-tree-9.8.jar
+file.reference.asm-analysis-9.8.jar=../../../cn1-binaries/vm/asm-analysis-9.8.jar
 includes=**
 jar.compress=false
 javac.classpath=\
     ${file.reference.asm-9.8.jar}:\
     ${file.reference.asm-commons-9.8.jar}:\
-    ${file.reference.asm-tree-9.8.jar}
+    ${file.reference.asm-tree-9.8.jar}:\
+    ${file.reference.asm-analysis-9.8.jar}
 # Space-separated list of extra javac options
 javac.compilerargs=
 javac.deprecation=false


### PR DESCRIPTION
## Why

`vm/ByteCodeTranslator/src/com/codename1/tools/translator/Parser.java` imports `org.objectweb.asm.tree.analysis.{Analyzer, BasicInterpreter, BasicValue, Frame}`. Those ship in the **asm-analysis** module — a sibling of `asm-tree`, which is already on the classpath. `asm-analysis` was never added, so the translator fails to compile:

```
Parser.java: cannot find symbol — class Frame / BasicValue / Analyzer / BasicInterpreter (11 errors)
```

This breaks BuildDaemon CI, which fetches CodenameOne + cn1-binaries master fresh and runs `ant jar` in `ByteCodeTranslator` on every PR.

## What

- Add `file.reference.asm-analysis-9.8.jar` and append it to `javac.classpath`, matching the existing asm 9.8 jars.

**Depends on** codenameone/cn1-binaries#1, which vendors `vm/asm-analysis-9.8.jar`.

## Verification

With both changes in place: `ant clean jar` in `vm/ByteCodeTranslator` (JDK 1.8) → **BUILD SUCCESSFUL** (was 11 `cannot find symbol` errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)