### PR TITLE
ByteCodeTranslator: fat-pack asm-analysis into the runtime jar (fixes iOS NoClassDefFoundError)

### DIFF
--- a/vm/ByteCodeTranslator/build.xml
+++ b/vm/ByteCodeTranslator/build.xml
@@ -80,6 +80,12 @@
         <unzip src="../../../cn1-binaries/vm/asm-9.8.jar" dest="build/classes"  />
         <unzip src="../../../cn1-binaries/vm/asm-commons-9.8.jar" dest="build/classes"  />
         <unzip src="../../../cn1-binaries/vm/asm-tree-9.8.jar" dest="build/classes"  />
+        <!-- asm-analysis (org.objectweb.asm.tree.analysis.*) — Parser.java now uses
+             Analyzer/BasicInterpreter/BasicValue/Frame. It must be fat-packed into the
+             jar here too (not just on the compile classpath): the translator is launched
+             as `java -jar ByteCodeTranslator.jar` which ignores -cp, so a missing class
+             here is a runtime NoClassDefFoundError: .../tree/analysis/Interpreter. -->
+        <unzip src="../../../cn1-binaries/vm/asm-analysis-9.8.jar" dest="build/classes"  />
     </target>
             
         <!-- /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project TestApp.xcodeproj/ -target TestApp -configuration release -sdk iphoneos7.0 build -->


### PR DESCRIPTION
## Problem (prod iOS builds failing)

iOS App Store + Debug builds die at the translate step:
```
Exception in thread "main" java.lang.NoClassDefFoundError: org/objectweb/asm/tree/analysis/Interpreter
  at com.codename1.tools.translator.ByteCodeTranslator...
```

`Parser.java` uses `org.objectweb.asm.tree.analysis.*` (Analyzer / BasicInterpreter / BasicValue / Frame). The translator is launched as **`java -jar ByteCodeTranslator.jar`**, which **ignores `-cp`** — so every dependency must be **bundled inside the jar**. The `-pre-jar` target unzips `asm` / `asm-commons` / `asm-tree` into `build/classes` but **not `asm-analysis`**, so the shipped jar lacks those classes → runtime `NoClassDefFoundError`.

This is the **runtime** half of the asm-analysis migration. The earlier fixes (cn1-binaries `asm-analysis-9.8.jar`; `project.properties` compile classpath) made it **compile**; this makes it **run**.

## Fix

Add `asm-analysis-9.8.jar` to the `-pre-jar` fat-pack in `vm/ByteCodeTranslator/build.xml`.

## Verification

`ant clean jar` (JDK 1.8) → BUILD SUCCESSFUL, and `dist/ByteCodeTranslator.jar` now contains `org/objectweb/asm/tree/analysis/Interpreter.class` (15 analysis classes) — previously 0.

## Rollout

Merge → BuildDaemon rebuilds `CodeNameOneBuildDaemon.jar` (bundles the fixed translator) → deploy to the Mac build servers. The currently-deployed release (built after the compile fix but before this) ships the broken translator, so **new-system Mac servers are failing iOS builds until redeployed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)