### PR TITLE
Exclude com.codename1.impl from javadocs, add missing package-info, fix BX unboxing + CI gates

### DIFF
--- a/.github/scripts/build_javadocs.sh
+++ b/.github/scripts/build_javadocs.sh
@@ -63,8 +63,17 @@ EOF
 # split across multiple javadoc invocations, each regenerating the same output
 # directory. The last batch (the Ports/CLDC11 java.* sources) then clobbers the
 # full API docs, leaving only the CLDC packages. An @argfile has no length limit.
+#
+# The internal implementation package com.codename1.impl (and every sub package
+# such as com.codename1.impl.gpu) is never part of the published API. The
+# javadoc `-exclude` option only filters packages discovered through
+# `-subpackages`; with an explicit source @argfile it has no effect, so we drop
+# the impl sources from the list here. They remain reachable for symbol
+# resolution through `-sourcepath` below, so references from documented classes
+# still resolve without documenting impl itself.
 SOURCES_ARGFILE="$CN1_DIR/build/javadoc-sources.txt"
-find "$CN1_DIR/build/tempJavaSources" "$ROOT_DIR/Ports/CLDC11/src" -name "*.java" > "$SOURCES_ARGFILE"
+find "$CN1_DIR/build/tempJavaSources" "$ROOT_DIR/Ports/CLDC11/src" -name "*.java" \
+  | grep -v '/com/codename1/impl/' > "$SOURCES_ARGFILE"
 
 "$JAVADOC_CMD" \
   --allow-script-in-comments \
@@ -72,6 +81,7 @@ find "$CN1_DIR/build/tempJavaSources" "$ROOT_DIR/Ports/CLDC11/src" -name "*.java
   --add-script "$ROOT_DIR/maven/javadoc-resources/highlight.min.js" \
   --add-script "$ROOT_DIR/maven/javadoc-resources/javadoc-highlight-init.js" \
   --release 8 \
+  -sourcepath "$CN1_DIR/build/tempJavaSources:$ROOT_DIR/Ports/CLDC11/src" \
   -exclude com.codename1.impl \
   -Xdoclint:none \
   -quiet \
@@ -84,6 +94,14 @@ find "$CN1_DIR/build/tempJavaSources" "$ROOT_DIR/Ports/CLDC11/src" -name "*.java
 # build (e.g. only the CLDC java.* packages) ships silently to the website.
 if [ ! -f "$CN1_DIR/dist/javadoc/com/codename1/ui/Component.html" ]; then
   echo "JavaDoc generation produced no core com.codename1.ui output; aborting." >&2
+  exit 1
+fi
+
+# Guard: com.codename1.impl is an internal package and must never reach the
+# published API. If a regression documents it anyway, fail loudly here rather
+# than shipping internal classes to the website.
+if [ -e "$CN1_DIR/dist/javadoc/com/codename1/impl" ]; then
+  echo "JavaDoc generated com.codename1.impl output; the internal implementation package must stay excluded." >&2
   exit 1
 fi
 

--- a/.github/scripts/generate-quality-report.py
+++ b/.github/scripts/generate-quality-report.py
@@ -938,7 +938,8 @@ def main() -> None:
             "SA_FIELD_SELF_COMPARISON",
             "SR_NOT_CHECKED",
             "SWL_SLEEP_WITH_LOCK_HELD",
-            "UC_USELESS_CONDITION_TYPE"
+            "UC_USELESS_CONDITION_TYPE",
+            "BX_UNBOXING_IMMEDIATELY_REBOXED"
         }
 
         def _is_exempt(f: Finding) -> bool:

--- a/.github/workflows/javadocs.yml
+++ b/.github/workflows/javadocs.yml
@@ -7,6 +7,7 @@ on:
       - 'Ports/**/src/**/*.java'
       - 'maven/**/src/main/java/**/*.java'
       - '.github/scripts/build_javadocs.sh'
+      - 'scripts/check-package-info.sh'
       - '.github/workflows/javadocs.yml'
   push:
     branches:
@@ -34,6 +35,9 @@ jobs:
 
       - name: Capture Java 25 path
         run: echo "JDK_25_HOME=$JAVA_HOME" >> "$GITHUB_ENV"
+
+      - name: Verify every documented package has a package-info.java
+        run: scripts/check-package-info.sh
 
       - name: Build JavaDocs
         run: ./.github/scripts/build_javadocs.sh

--- a/CodenameOne/src/com/codename1/annotations/graphql/package-info.java
+++ b/CodenameOne/src/com/codename1/annotations/graphql/package-info.java
@@ -1,0 +1,8 @@
+/// Annotations for declaring type safe GraphQL clients.
+///
+/// A client interface is marked with `GraphQLClient` and its methods are mapped
+/// to GraphQL operations using `Query`, `Mutation` and `Subscription`, while
+/// `Var` binds method parameters to GraphQL variables. These annotations are
+/// consumed by the Codename One GraphQL client generator to produce the network
+/// implementation.
+package com.codename1.annotations.graphql;

--- a/CodenameOne/src/com/codename1/annotations/rest/package-info.java
+++ b/CodenameOne/src/com/codename1/annotations/rest/package-info.java
@@ -1,0 +1,8 @@
+/// Annotations for declaring type safe REST clients.
+///
+/// An interface is marked with `RestClient` and its methods describe HTTP
+/// requests using the verb annotations `GET`, `POST`, `PUT`, `PATCH` and
+/// `DELETE`. Request data is bound through `Path`, `Query`, `Header`, `Cookie`
+/// and `Body`. These annotations are processed to generate the concrete REST
+/// client implementation.
+package com.codename1.annotations.rest;

--- a/CodenameOne/src/com/codename1/camera/package-info.java
+++ b/CodenameOne/src/com/codename1/camera/package-info.java
@@ -1,0 +1,10 @@
+/// Session based camera API for live preview, photo capture and video recording.
+///
+/// A `CameraSession` is configured through `CameraSessionOptions` (selecting the
+/// `CameraFacing`, `FlashMode`, `FrameFormat` and so on) and rendered through a
+/// `CameraView` using a `ScaleType`. Individual `CameraFrame`s can be observed
+/// with a `FrameListener`, still images are returned as a `CapturedPhoto`
+/// according to `PhotoCaptureOptions`, and movies are produced as a
+/// `VideoRecording`. `CameraInfo` describes the devices available on the
+/// platform.
+package com.codename1.camera;

--- a/CodenameOne/src/com/codename1/crash/package-info.java
+++ b/CodenameOne/src/com/codename1/crash/package-info.java
@@ -1,0 +1,7 @@
+/// On device crash protection client for Codename One applications.
+///
+/// `CrashProtection` installs handlers that capture unexpected failures and
+/// assembles a `CrashReportPayload` describing the crash. A `PiiScrubber`
+/// removes personally identifiable information from the payload before it is
+/// delivered, so reports can be collected without leaking user data.
+package com.codename1.crash;

--- a/CodenameOne/src/com/codename1/gaming/physics/box2d/callbacks/package-info.java
+++ b/CodenameOne/src/com/codename1/gaming/physics/box2d/callbacks/package-info.java
@@ -1,0 +1,6 @@
+/// Listener and callback interfaces for the box2d physics engine (contact,
+/// query, ray cast and debug draw callbacks).
+///
+/// Part of the box2d simulation engine, a derived work of JBox2D used under the
+/// BSD 2-Clause license; see `com.codename1.gaming.physics` for attribution.
+package com.codename1.gaming.physics.box2d.callbacks;

--- a/CodenameOne/src/com/codename1/gaming/physics/box2d/collision/broadphase/package-info.java
+++ b/CodenameOne/src/com/codename1/gaming/physics/box2d/collision/broadphase/package-info.java
@@ -1,0 +1,6 @@
+/// Broad phase collision detection (dynamic tree and pair management) for the
+/// box2d physics engine.
+///
+/// Part of the box2d simulation engine, a derived work of JBox2D used under the
+/// BSD 2-Clause license; see `com.codename1.gaming.physics` for attribution.
+package com.codename1.gaming.physics.box2d.collision.broadphase;

--- a/CodenameOne/src/com/codename1/gaming/physics/box2d/collision/package-info.java
+++ b/CodenameOne/src/com/codename1/gaming/physics/box2d/collision/package-info.java
@@ -1,0 +1,6 @@
+/// Collision detection primitives (AABBs, manifolds, distance and
+/// time of impact queries) for the box2d physics engine.
+///
+/// Part of the box2d simulation engine, a derived work of JBox2D used under the
+/// BSD 2-Clause license; see `com.codename1.gaming.physics` for attribution.
+package com.codename1.gaming.physics.box2d.collision;

--- a/CodenameOne/src/com/codename1/gaming/physics/box2d/collision/shapes/package-info.java
+++ b/CodenameOne/src/com/codename1/gaming/physics/box2d/collision/shapes/package-info.java
@@ -1,0 +1,6 @@
+/// Collision shape definitions (circle, polygon, edge and chain) for the box2d
+/// physics engine.
+///
+/// Part of the box2d simulation engine, a derived work of JBox2D used under the
+/// BSD 2-Clause license; see `com.codename1.gaming.physics` for attribution.
+package com.codename1.gaming.physics.box2d.collision.shapes;

--- a/CodenameOne/src/com/codename1/gaming/physics/box2d/common/package-info.java
+++ b/CodenameOne/src/com/codename1/gaming/physics/box2d/common/package-info.java
@@ -1,0 +1,6 @@
+/// Math and utility types (vectors, matrices, transforms and engine settings)
+/// shared across the box2d physics engine.
+///
+/// Part of the box2d simulation engine, a derived work of JBox2D used under the
+/// BSD 2-Clause license; see `com.codename1.gaming.physics` for attribution.
+package com.codename1.gaming.physics.box2d.common;

--- a/CodenameOne/src/com/codename1/gaming/physics/box2d/dynamics/contacts/package-info.java
+++ b/CodenameOne/src/com/codename1/gaming/physics/box2d/dynamics/contacts/package-info.java
@@ -1,0 +1,5 @@
+/// Contact constraints and contact solving for the box2d physics engine.
+///
+/// Part of the box2d simulation engine, a derived work of JBox2D used under the
+/// BSD 2-Clause license; see `com.codename1.gaming.physics` for attribution.
+package com.codename1.gaming.physics.box2d.dynamics.contacts;

--- a/CodenameOne/src/com/codename1/gaming/physics/box2d/dynamics/joints/package-info.java
+++ b/CodenameOne/src/com/codename1/gaming/physics/box2d/dynamics/joints/package-info.java
@@ -1,0 +1,6 @@
+/// Joint constraints (revolute, prismatic, distance, weld and others) for the
+/// box2d physics engine.
+///
+/// Part of the box2d simulation engine, a derived work of JBox2D used under the
+/// BSD 2-Clause license; see `com.codename1.gaming.physics` for attribution.
+package com.codename1.gaming.physics.box2d.dynamics.joints;

--- a/CodenameOne/src/com/codename1/gaming/physics/box2d/dynamics/package-info.java
+++ b/CodenameOne/src/com/codename1/gaming/physics/box2d/dynamics/package-info.java
@@ -1,0 +1,6 @@
+/// Rigid body dynamics core (world, bodies, fixtures and the constraint solver)
+/// for the box2d physics engine.
+///
+/// Part of the box2d simulation engine, a derived work of JBox2D used under the
+/// BSD 2-Clause license; see `com.codename1.gaming.physics` for attribution.
+package com.codename1.gaming.physics.box2d.dynamics;

--- a/CodenameOne/src/com/codename1/gaming/physics/box2d/pooling/arrays/package-info.java
+++ b/CodenameOne/src/com/codename1/gaming/physics/box2d/pooling/arrays/package-info.java
@@ -1,0 +1,5 @@
+/// Pooled reusable arrays used by the box2d physics engine.
+///
+/// Part of the box2d simulation engine, a derived work of JBox2D used under the
+/// BSD 2-Clause license; see `com.codename1.gaming.physics` for attribution.
+package com.codename1.gaming.physics.box2d.pooling.arrays;

--- a/CodenameOne/src/com/codename1/gaming/physics/box2d/pooling/normal/package-info.java
+++ b/CodenameOne/src/com/codename1/gaming/physics/box2d/pooling/normal/package-info.java
@@ -1,0 +1,5 @@
+/// Default object pool implementations for the box2d physics engine.
+///
+/// Part of the box2d simulation engine, a derived work of JBox2D used under the
+/// BSD 2-Clause license; see `com.codename1.gaming.physics` for attribution.
+package com.codename1.gaming.physics.box2d.pooling.normal;

--- a/CodenameOne/src/com/codename1/gaming/physics/box2d/pooling/package-info.java
+++ b/CodenameOne/src/com/codename1/gaming/physics/box2d/pooling/package-info.java
@@ -1,0 +1,6 @@
+/// Object pooling abstractions used to avoid allocations in the box2d physics
+/// engine.
+///
+/// Part of the box2d simulation engine, a derived work of JBox2D used under the
+/// BSD 2-Clause license; see `com.codename1.gaming.physics` for attribution.
+package com.codename1.gaming.physics.box2d.pooling;

--- a/CodenameOne/src/com/codename1/gaming/physics/box2d/pooling/stacks/package-info.java
+++ b/CodenameOne/src/com/codename1/gaming/physics/box2d/pooling/stacks/package-info.java
@@ -1,0 +1,5 @@
+/// Stack based object pools used by the box2d physics engine.
+///
+/// Part of the box2d simulation engine, a derived work of JBox2D used under the
+/// BSD 2-Clause license; see `com.codename1.gaming.physics` for attribution.
+package com.codename1.gaming.physics.box2d.pooling.stacks;

--- a/CodenameOne/src/com/codename1/gpu/package-info.java
+++ b/CodenameOne/src/com/codename1/gpu/package-info.java
@@ -1,0 +1,10 @@
+/// Low level GPU accelerated graphics API for Codename One.
+///
+/// This package exposes a hardware rendering abstraction built around a
+/// `GraphicsDevice` and `Renderer` together with the resources they consume:
+/// `Mesh`, `VertexBuffer`, `IndexBuffer`, `VertexFormat`, `Texture`,
+/// `Material`, `Light` and `RenderState`. It supports drawing 3D
+/// `Primitives`, embedding output in a `RenderView` and loading models via the
+/// `GltfLoader`. Use `GpuCapabilities` to query what the underlying device
+/// supports at runtime.
+package com.codename1.gpu;

--- a/scripts/check-package-info.sh
+++ b/scripts/check-package-info.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Fail the build if any documented package under CodenameOne/src is missing a
+# package-info.java file.
+#
+# Background: packages without a package-info.java render in the published API
+# reference with no description, and new packages (e.g. com.codename1.gpu, the
+# box2d sub packages) repeatedly slipped in undocumented. This check makes that
+# a build failure so the gap is caught in review rather than on the website.
+#
+# A "package" here is any directory that directly contains at least one .java
+# file. The internal implementation package com.codename1.impl (and every sub
+# package such as com.codename1.impl.gpu) is exempt: it is deliberately
+# excluded from the published javadoc (see .github/scripts/build_javadocs.sh),
+# so it needs no package description.
+#
+# Exit codes:
+#   0 - every documented package has a package-info.java
+#   1 - one or more documented packages are missing package-info.java
+#   2 - misconfiguration (missing source directory)
+#
+# Usage:
+#   scripts/check-package-info.sh [source-dir]
+#
+# When no argument is given the script scans CodenameOne/src relative to the
+# repository root.
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)"
+SRC_DIR="${1:-$REPO_ROOT/CodenameOne/src}"
+
+if [[ ! -d "$SRC_DIR" ]]; then
+  echo "check-package-info: source directory not found: $SRC_DIR" >&2
+  exit 2
+fi
+
+missing=0
+
+# Enumerate every directory that directly contains a .java file. Sorting keeps
+# the failure output deterministic.
+while IFS= read -r dir; do
+  # Skip the internal implementation package and all of its sub packages.
+  case "$dir" in
+    */com/codename1/impl|*/com/codename1/impl/*) continue ;;
+  esac
+
+  # A directory holds a real package only if it contains a .java file other
+  # than package-info.java itself.
+  if ! find "$dir" -maxdepth 1 -name '*.java' ! -name 'package-info.java' \
+      -print -quit | grep -q .; then
+    continue
+  fi
+
+  if [[ ! -f "$dir/package-info.java" ]]; then
+    rel="${dir#"$REPO_ROOT"/}"
+    printf '%s: missing package-info.java\n' "$rel"
+    missing=$((missing + 1))
+  fi
+done < <(find "$SRC_DIR" -type d | sort)
+
+if (( missing > 0 )); then
+  echo "" >&2
+  echo "check-package-info: $missing documented package(s) have no" >&2
+  echo "  package-info.java. Add a package-info.java describing each package," >&2
+  echo "  or, for an internal package, exclude it from the published javadoc." >&2
+  exit 1
+fi
+
+echo "check-package-info: every documented package has a package-info.java."

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/JavascriptMethodGenerator.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/JavascriptMethodGenerator.java
@@ -3824,7 +3824,7 @@ final class JavascriptMethodGenerator {
                 }
                 for (Label l : swLabels) {
                     Integer t = l == null ? null : labelToIndex.get(l);
-                    Integer tb = t == null ? null : startToBlock.get((int) t);
+                    Integer tb = t == null ? null : startToBlock.get(t);
                     if (tb == null) {
                         return _sb(method, instructions, "L3116");
                     }
@@ -5847,7 +5847,7 @@ private static void appendJsBodyMethod(StringBuilder out, ByteCodeClass cls, Byt
                 if (sw.getLabels() != null) {
                     for (Label l : sw.getLabels()) {
                         Integer d = l == null ? null : labelToIndex.get(l);
-                        if (d != null && startToBlock.containsKey((int) d)) { b.succs.add(startToBlock.get((int) d)); }
+                        if (d != null && startToBlock.containsKey(d)) { b.succs.add(startToBlock.get(d)); }
                     }
                 }
                 addFallThrough = false;

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/JavascriptMethodGenerator.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/JavascriptMethodGenerator.java
@@ -4016,7 +4016,7 @@ final class JavascriptMethodGenerator {
                 if (instruction instanceof Jump) {
                     Jump jump = (Jump) instruction;
                     Integer t = labelToIndex.get(jump.getLabel());
-                    int tb = startToBlock.get((int) t);
+                    int tb = startToBlock.get(t);
                     String cond = structuredJumpCondition(jump.getOpcode(), ctx);
                     if (cond == null && jump.getOpcode() != Opcodes.GOTO) {
                         return _sb(method, instructions, "L3263");
@@ -4049,7 +4049,7 @@ final class JavascriptMethodGenerator {
                     Label[] swl = sw.getLabels();
                     for (int ki = 0; swl != null && ki < swl.length; ki++) {
                         Integer t = swl[ki] == null ? null : labelToIndex.get(swl[ki]);
-                        int tb = startToBlock.get((int) t);
+                        int tb = startToBlock.get(t);
                         if (entrySp[tb] < 0) {
                             entrySp[tb] = ctx.sp;
                         } else if (entrySp[tb] != ctx.sp) {
@@ -4060,7 +4060,7 @@ final class JavascriptMethodGenerator {
                                .append(structuredGoto(tb, b, loopEnd, tryStarts)).append(";\n");
                     }
                     Integer dT = sw.getDefaultLabel() == null ? null : labelToIndex.get(sw.getDefaultLabel());
-                    int db = startToBlock.get((int) dT);
+                    int db = startToBlock.get(dT);
                     if (entrySp[db] < 0) {
                         entrySp[db] = ctx.sp;
                     } else if (entrySp[db] != ctx.sp) {


### PR DESCRIPTION
## Summary

Three related documentation/quality fixes, each backed by a CI gate so the issue cannot quietly return to master.

### 1. `com.codename1.impl` excluded from javadocs
`javadoc`'s `-exclude` only filters packages discovered through `-subpackages`; this build passes an explicit `@argfile`, so `-exclude com.codename1.impl` was a **no-op** and the internal impl package (including `com.codename1.impl.gpu`) was leaking into the published API.

- `.github/scripts/build_javadocs.sh` now drops impl sources from the argfile, adds `-sourcepath` so documented classes still resolve references to impl, and **hard-fails** if `dist/javadoc/com/codename1/impl` is generated.
- Verified end-to-end on a full JDK-25 run: impl is **absent**, `com.codename1.gpu` and `box2d.*` are present with rendered descriptions, core (`Component`) intact.

### 2. Missing `package-info.java`
Added 17 ASCII-only `package-info.java` files for every documented (non-impl) package that lacked one: `com.codename1.gpu`, the 12 `box2d` sub packages, plus `camera`, `crash`, `annotations.graphql`, `annotations.rest`. The box2d files carry the JBox2D BSD attribution pointer.

- New `scripts/check-package-info.sh` fails the build if any documented (non-impl) package is missing its description. Wired into the JavaDocs workflow and tested positive **and** negative.

### 3. ByteCodeTranslator `BX_UNBOXING_IMMEDIATELY_REBOXED`
`JavascriptMethodGenerator` cast an `Integer` to `(int)` only to immediately rebox it for a `Map<Integer,Integer>` lookup at two sites:
- `startToBlock.get((int) t)` -> `startToBlock.get(t)`
- `startToBlock.containsKey((int) d)` / `get((int) d)` -> drop the casts

(The other `(int)` casts in the file operate on primitive `int` locals, which is why SpotBugs did not flag them.) Added `BX_UNBOXING_IMMEDIATELY_REBOXED` to the forbidden SpotBugs rules in `generate-quality-report.py` so a recurrence fails the PR gate.

## Verification
- ByteCodeTranslator clean-compiled with JDK 8.
- Full JavaDoc build (JDK 25) succeeds; impl excluded, gpu/box2d included.
- `scripts/check-package-info.sh` passes on the tree and fails when a package-info is removed.
- Python/bash syntax validated; no non-ASCII bytes in new sources.

## Note
The package-info gate is scoped to "every non-`impl` package must have one." That is why `camera`, `crash`, and the `annotations` packages were also given descriptions -- otherwise the gate would have gone red immediately on those pre-existing gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)