### PR TITLE
Fix blog mermaid diagrams: blank-render race + mobile legibility

### DIFF
--- a/docs/website/content/blog/developer-workflow-debug-and-junit.md
+++ b/docs/website/content/blog/developer-workflow-debug-and-junit.md
@@ -48,7 +48,7 @@ The same Debug tool window you use for any other Java project. Frames panel on t
 On iOS the IDE never talks to the device directly. The CN1 Debug Proxy is a small Java process you run on your developer machine. It binds two TCP ports: one for the iOS app to dial into using the CN1 wire protocol, and one that speaks standard JDWP for the IDE. The IDE sees a normal remote JVM. The iOS app sees a debug proxy. The proxy translates between the two and walks the ParparVM struct layout so Java fields, method calls, and values round-trip cleanly in both directions.
 
 {{< mermaid >}}
-flowchart LR
+flowchart TD
     IDE["IntelliJ IDEA<br/><i>any OS</i>"] -- "JDWP<br/>(localhost:8000)" --> Proxy["CN1 Debug Proxy<br/><i>your dev machine</i>"]
     Proxy -- "CN1 wire protocol<br/>(Wi-Fi or loopback)" --> App["Codename One iOS app<br/><i>real iPhone or iOS Simulator</i>"]
 {{< /mermaid >}}
@@ -56,7 +56,7 @@ flowchart LR
 On Android the proxy is unnecessary. Dalvik / ART implement JDWP themselves, so IntelliJ attaches directly to the device through `adb`'s built-in JDWP forwarder. The Maven plugin's new `cn1:android-on-device-debugging` goal does the `adb` orchestration and the port forwarding for you.
 
 {{< mermaid >}}
-flowchart LR
+flowchart TD
     IDE["IntelliJ IDEA<br/><i>macOS / Linux / Windows</i>"] -- "JDWP<br/>(localhost:5005)" --> ADB["adb forward<br/><i>your dev machine</i>"]
     ADB -- "JDWP over USB or Wi-Fi" --> Device["Android device<br/>or emulator<br/><i>Dalvik / ART</i>"]
 {{< /mermaid >}}

--- a/docs/website/content/blog/java-to-a-native-linux-app.md
+++ b/docs/website/content/blog/java-to-a-native-linux-app.md
@@ -45,7 +45,7 @@ Rendering was the easy part. The two genuinely hard parts of shipping a Linux de
 **glibc.** This is the single worst thing about shipping a Linux binary, and the only thing worse is the alternative. A binary linked against a new glibc refuses to start on a machine with an older one, and "older" can mean a distribution from last year. The fix is to build against an old glibc, so the resulting binary needs only an ancient, universally present version. We compile against roughly `GLIBC_2.17`, which dates to 2013, so the ELF starts on essentially any mainstream desktop. GTK3 is linked dynamically and resolved from the system at startup; it has shipped on every Linux desktop since 2011.
 
 {{< mermaid >}}
-flowchart LR
+flowchart TD
     A["Your Java / Kotlin"] --> B["ParparVM: bytecode to C"]
     B --> C["zig cc against an old glibc"]
     C --> D["Single self-contained ELF<br/>resources embedded"]

--- a/docs/website/content/blog/native-linux-apple-watch-game-builder-crash-protection.md
+++ b/docs/website/content/blog/native-linux-apple-watch-game-builder-crash-protection.md
@@ -51,7 +51,7 @@ Two more parts follow on the next Thursdays: a blackjack card game, then a first
 It is seamless in three senses. You do not wire up anything complex: the build servers do the heavy lifting. It connects to GitHub issues instead of sending a barrage of emails. And it symbolicates native crashes on every operating system we support, so a faulting address on iOS, Android, Windows or Linux comes back as a readable stack. On the device, reports are written to storage before they are sent and only deleted after the server confirms receipt, so nothing is lost to a flaky connection; a failed send is retried on the next launch and the server deduplicates it.
 
 {{< mermaid >}}
-flowchart LR
+flowchart TD
     A["App crashes on device"] --> B["Write report to Storage with eventId"]
     B --> C["POST to the crash endpoint"]
     C -->|2xx confirmed| D["Delete the stored report"]

--- a/docs/website/layouts/shortcodes/mermaid.html
+++ b/docs/website/layouts/shortcodes/mermaid.html
@@ -21,18 +21,35 @@
 (function () {
   if (window.__cn1MermaidLoaded) return;
   window.__cn1MermaidLoaded = true;
+
+  // Keep wide diagrams legible on phones: scale to the column, but never
+  // below a readable floor -- scroll horizontally past that instead of
+  // shrinking the labels into an illegible smudge.
+  var st = document.createElement("style");
+  st.textContent =
+    ".cn1-mermaid{overflow-x:auto;-webkit-overflow-scrolling:touch;margin:1.5rem 0}" +
+    ".cn1-mermaid svg{max-width:100%!important;height:auto;display:block;margin:0 auto}";
+  document.head.appendChild(st);
+
   var s = document.createElement("script");
   s.type = "module";
+  // Do NOT rely on mermaid's startOnLoad: it hooks the window "load" event
+  // when the module evaluates, but this module is imported dynamically -- on a
+  // cache hit / bfcache restore / non-Chromium browser "load" has already
+  // fired, the listener never runs, and the diagram silently stays blank.
+  // Calling mermaid.run() explicitly renders every .mermaid block regardless
+  // of load-event timing.
   s.textContent =
     'import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs";' +
     'var prefersDark = document.body.classList.contains("dark")' +
     ' || window.matchMedia("(prefers-color-scheme: dark)").matches;' +
     'mermaid.initialize({' +
-    '  startOnLoad: true,' +
+    '  startOnLoad: false,' +
     '  theme: prefersDark ? "dark" : "default",' +
     '  securityLevel: "loose",' +
     '  fontFamily: "Poppins, system-ui, sans-serif"' +
-    '});';
+    '});' +
+    'mermaid.run();';
   document.head.appendChild(s);
 })();
 </script>


### PR DESCRIPTION
## Problem

Mermaid diagrams in the blog were broken in two ways (reported via `java-to-a-native-linux-app`):

1. **Diagrams sometimes render blank.** The `mermaid.html` shortcode used `startOnLoad: true`. Mermaid v10's ESM build wires rendering to the `window` `load` event *at import time*, but the shortcode imports mermaid dynamically from a CDN — so the listener only catches `load` when the module happens to still be in-flight. On a cache hit, a bfcache restore, or a non-Chromium browser, `load` has already fired and the diagram silently stays blank.
2. **Wide diagrams are illegible on mobile.** mermaid shrinks the wide `flowchart LR` diagrams to fit the viewport, collapsing them into an unreadable smudge on phones.

## Fix

**`layouts/shortcodes/mermaid.html`**
- `startOnLoad: false` + an explicit `mermaid.run()` — renders every `.mermaid` block regardless of load-event timing.
- A one-time responsive `<style>` (`overflow-x:auto`, `svg { max-width:100%; height:auto }`) so a diagram never forces the page wider than the viewport.

**Converted wide `flowchart LR` → `flowchart TD`** so nodes stack full-width and stay legible on phones:
- `developer-workflow-debug-and-junit.md` (×2)
- `native-linux-apple-watch-game-builder-crash-protection.md`
- `java-to-a-native-linux-app.md`

The already-vertical `TD` chart (`native-apple-watch-and-wear.md`) and the `sequenceDiagram` (`seamless-crash-protection.md`) are unchanged.

## Verification

Rebuilt with Hugo and rendered every diagram over HTTP (real theme) at **390px** and **1100px**:
- All 6 diagrams render (`data-processed=true`), no syntax errors.
- Zero page-level horizontal overflow at either width.
- Converted flowcharts are full-width and legible on mobile (italics + edge labels intact).

Content/theme only — no Java or prose-gate surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)