### PR TITLE
docs: versioned cloud builds (build.cn1Version) + master-snapshot publish workflow

### DIFF
--- a/.github/workflows/publish-master-snapshot.yml
+++ b/.github/workflows/publish-master-snapshot.yml
@@ -1,0 +1,64 @@
+# Publishes the framework artifacts for the current master to a fixed,
+# overwritten GitHub release ("master-snapshot"). The cloud build server grabs
+# these when a project sets the build hint `build.cn1Version=master`, letting
+# Pro/Enterprise users build against the development head. Only the release
+# ASSETS are overwritten each run; the daemon always downloads the latest.
+name: Publish master snapshot
+
+on:
+  push:
+    branches:
+      - master
+
+# Never let two master pushes publish at the same time.
+concurrency:
+  group: master-snapshot
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up JDK 8
+        uses: actions/setup-java@v5
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Build framework artifacts
+        run: |
+          cd maven
+          # Build only the four modules whose artifacts the daemon stages
+          # (core, ios bundle, parparvm bundle, android), plus their reactor
+          # dependencies (-am). Widen the -pl list if a needed module is missed.
+          xvfb-run -a mvn -B package -Plocal-dev-javase -DskipTests \
+            -Darchetype.test.skip=true \
+            -pl :codenameone-core,:codenameone-ios,:codenameone-parparvm,:codenameone-android -am
+
+      - name: Collect artifacts under fixed names
+        run: |
+          set -e
+          mkdir -p master-out
+          pick() { ls $1 2>/dev/null | grep -vE '\-(sources|javadoc|tests)\.jar$' | head -1; }
+          cp "$(pick 'maven/core/target/codenameone-core-*.jar')"            master-out/codenameone-core-master.jar
+          cp  maven/ios/target/codenameone-ios-*-bundle.jar                  master-out/codenameone-ios-master-bundle.jar
+          cp  maven/parparvm/target/codenameone-parparvm-*-bundle.jar        master-out/codenameone-parparvm-master-bundle.jar
+          cp "$(pick 'maven/android/target/codenameone-android-*.jar')"      master-out/codenameone-android-master.jar
+          ls -l master-out
+
+      - name: Publish to the master-snapshot release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Create the rolling release once; afterwards just overwrite its assets.
+          gh release create master-snapshot \
+            --prerelease \
+            --title "Codename One master snapshot" \
+            --notes "Rolling framework artifacts built from the latest master. Used by build.cn1Version=master." \
+            || true
+          gh release upload master-snapshot master-out/*.jar --clobber

--- a/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
+++ b/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
@@ -695,7 +695,7 @@ Only supported for App Store builds. See https://www.codenameone.com/developer-g
 
 === Versioned builds
 
-By default a cloud build always uses the current Codename One release. With a _versioned build_ you can instead pin the build to a specific previously released framework version, so you get reproducible output over time. This helps when stabilizing a release, supporting an older app, or isolating a regression: if an app that built correctly before suddenly fails, rebuilding against the last known good version tells you whether the change came from your code or from the framework and build server.
+By default a cloud build always uses the current Codename One release. With a _versioned build_ you can instead pin the build to a specific previously released framework version, so you get reproducible output over time. This helps when stabilizing a release, supporting an older app, or isolating a regression: if an app that built correctly in the past starts failing, rebuilding against the last known good version tells you whether the change came from your code or from the framework and build server.
 
 Set the `build.cn1Version` build hint to the version you want to target. Versions use the standard Maven release scheme published to Maven Central, for example `7.0.182`:
 
@@ -714,7 +714,7 @@ Versioned builds are a Pro and Enterprise feature, and how far back you can targ
 |Enterprise |Any version released within the last six months
 |===
 
-If you request a version older than your tier's window, a version that was never published, or you are not on a Pro or Enterprise plan, the build fails with an explanatory message instead of silently falling back to the current release.
+If you request a version older than your tier's window, a version that was never published, or you aren't on a Pro or Enterprise plan, the build fails with an explanatory message instead of falling back to the current release.
 
 ==== Building against master
 

--- a/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
+++ b/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
@@ -19,6 +19,9 @@ Here is the current list of supported arguments. Build hints change over time, s
 |===
 |Name	|Description
 
+|build.cn1Version
+|Pro/Enterprise only. Pins the cloud build to a specific released Codename One version using the Maven release scheme (for example `7.0.182`), or to `master` to build against the current development head. The build server fetches that version's framework artifacts. Pro accounts can target versions published within the last two months; Enterprise within the last six months. Requesting an older version, a version that was never published, or using this hint without a Pro/Enterprise subscription fails the build with an explanatory error. See <<Versioned builds>>.
+
 |android.debug
 |true/false defaults to true - indicates whether to include the debug version in the build
 
@@ -689,6 +692,39 @@ Only supported for App Store builds. See https://www.codenameone.com/developer-g
 |Native Windows port only. `true`/`false` (default `true`). Set `false` to force an unsigned build even when a certificate is available.
 
 |===
+
+=== Versioned builds
+
+By default a cloud build always uses the current Codename One release. With a _versioned build_ you can instead pin the build to a specific previously released framework version, so you get reproducible output over time. This helps when stabilizing a release, supporting an older app, or isolating a regression: if an app that built correctly before suddenly fails, rebuilding against the last known good version tells you whether the change came from your code or from the framework and build server.
+
+Set the `build.cn1Version` build hint to the version you want to target. Versions use the standard Maven release scheme published to Maven Central, for example `7.0.182`:
+
+----
+codename1.arg.build.cn1Version=7.0.182
+----
+
+The build server fetches that version's framework artifacts from Maven Central and builds against them. To keep your simulator and local compile classpath aligned with the same release, set the matching `cn1.version` in your project `pom.xml`.
+
+Versioned builds are a Pro and Enterprise feature, and how far back you can target depends on the subscription tier:
+
+[options="header"]
+|===
+|Tier |Versions you can target
+|Pro |Any version released within the last two months
+|Enterprise |Any version released within the last six months
+|===
+
+If you request a version older than your tier's window, a version that was never published, or you are not on a Pro or Enterprise plan, the build fails with an explanatory message instead of silently falling back to the current release.
+
+==== Building against master
+
+Set `build.cn1Version` to `master` to build against the current development head (the latest `master` of the Codename One repository) instead of a released version:
+
+----
+codename1.arg.build.cn1Version=master
+----
+
+Every push to `master` publishes a fresh set of framework artifacts and the build server always grabs the latest, so this is the quickest way to verify an unreleased fix or feature end to end on a device. Because `master` tracks active development it can be less stable than a release, so use it for verification rather than for shipping production builds. Building against `master` is available to Pro and Enterprise subscribers.
 
 === Android permissions
 

--- a/docs/website/content/comparison-chart.md
+++ b/docs/website/content/comparison-chart.md
@@ -45,7 +45,7 @@ $79/mo
 - Online Training
 - On Device Unit Tests
 - Concurrent Builds
-- Versioning
+- Versioning (2 months)
 - Live Preview
 - Crash Reporting
 - E-Mail Support
@@ -61,6 +61,7 @@ $399/mo
 
 - High Priority Builds
 - JavaScript App Generation
+- Versioning (6 months)
 - Continuous Integration
 - Office Hours/Phone Support
 - Optional SLA
@@ -73,7 +74,7 @@ We created videos detailing some of the benefits of a pro subscription. The bigg
 
 - Push notification
 - Codename One LIVE!
-- Versioning
+- Versioning (2 months)
 - Cloud storage/files
 - Crash protection
 - Use source download

--- a/docs/website/content/howdoi/how-do-i-get-repeatable-builds-build-against-a-consistent-version-of-codename-one-use-the-versioning-feature.md
+++ b/docs/website/content/howdoi/how-do-i-get-repeatable-builds-build-against-a-consistent-version-of-codename-one-use-the-versioning-feature.md
@@ -15,17 +15,52 @@ thumbnail: https://www.codenameone.com/wp-content/uploads/2020/09/hqdefault-4-1.
 {{< youtube "w7xvlw3rI6Y" >}}
 Repeatable builds matter when you are trying to stabilize a release, investigate a regression, or keep a production app on a known-good Codename One version instead of automatically moving with the latest server-side changes. Versioned builds are the feature designed for that job.
 
-The core idea is simple. Instead of always building against the current Codename One server release, you tell the build system to target a specific Codename One version. That means the native build is performed against the exact server logic and framework state associated with that release. If your application built and ran correctly against that version before, you now have a way to stay there while you validate later updates on your own schedule.
+The core idea is simple. Instead of always building against the current Codename One release, you tell the build server to target a specific published Codename One version. The native build is then performed using the framework artifacts for that exact release, which the build server fetches from Maven Central. If your application built and ran correctly against that version before, you have a way to stay there while you validate later updates on your own schedule.
 
-This is especially useful when a build suddenly starts failing or when behavior changes unexpectedly after a platform update. If you can rebuild against an older known-good Codename One version and the problem disappears, you have learned something important: the regression is probably tied to the framework or build-server changes rather than to a recent change in your own app. That turns versioned builds into both a stability feature and a debugging tool.
+## How to enable a versioned build
 
-The original video frames this as a Pro feature with longer retention in the Enterprise tier, and that is still the right way to think about availability. The exact retention window depends on the subscription tier, but the practical lesson is the same: if stable historical build targets matter to your team, versioned builds should be part of your release strategy.
+Set the `build.cn1Version` build hint to the Maven release version you want to target. Versions follow the standard Maven scheme published to Maven Central, for example `7.0.182`.
 
-When you use a versioned build, it is usually a good idea to keep your local simulator environment aligned with that same framework version as well. Otherwise you can end up testing one version locally and shipping another remotely. The older settings UI exposed this through the version selection and client library update flow. In current Maven-based projects, the broader goal is still consistency: keep the project, simulator, and native build path aligned so that local testing reflects what the build server is actually producing.
+In a Maven project, add the hint to `codenameone_settings.properties` using the `codename1.arg.` prefix:
 
-This is not something you need for every build during active day-to-day development. It becomes valuable when predictability matters more than immediately consuming the latest changes. Teams that ship production apps, support older releases, or operate in tightly controlled release windows tend to benefit the most from this feature.
+```
+codename1.arg.build.cn1Version=7.0.182
+```
 
-In practice, the healthiest workflow is to use the current Codename One version during normal development, then pin to a specific version when you need a reproducible release train or when you are isolating a regression. Once the newer version is validated, you can move forward deliberately instead of being surprised by it in the middle of a release.
+You can also set it from the IDE through the Codename One Settings dialog under Build Hints, using `build.cn1Version` as the key.
+
+To keep your local simulator and compile classpath aligned with the same release, set the matching version in your project `pom.xml`:
+
+```
+<cn1.version>7.0.182</cn1.version>
+```
+
+Otherwise you can end up testing one version locally and shipping another remotely.
+
+## Availability and the version window
+
+Versioned builds are a Pro and Enterprise feature, and how far back you can target depends on your subscription tier:
+
+- Pro can target any version released within the last two months.
+- Enterprise can target any version released within the last six months.
+
+If you request a version that is older than your tier's window, or you are not on a Pro or Enterprise plan, the build fails with a clear message instead of silently falling back to the current release. Requesting a version that was never published also returns an explicit error.
+
+## Building against master
+
+If you want to test an unreleased fix or feature, set the hint to `master` instead of a version number:
+
+```
+codename1.arg.build.cn1Version=master
+```
+
+Every push to the Codename One `master` branch publishes a fresh set of framework artifacts, and the build server always grabs the latest. This is the quickest way to verify an unreleased change end to end on a device. Because `master` tracks active development it can be less stable than a release, so use it for verification rather than for shipping production builds. Building against `master` is available to Pro and Enterprise subscribers.
+
+## When to use it
+
+This is especially useful when a build suddenly starts failing or when behavior changes after a platform update. If you can rebuild against an older known-good version and the problem disappears, the regression is probably tied to the framework or build server rather than to a recent change in your own app. That makes versioned builds both a stability feature and a debugging tool.
+
+You do not need this for every build during day-to-day development. It becomes valuable when predictability matters more than immediately consuming the latest changes: teams that ship production apps, support older releases, or operate in tightly controlled release windows benefit the most. The healthiest workflow is to develop against the current version, pin to a specific version when you need a reproducible release train or are isolating a regression, then move forward deliberately once the newer version is validated.
 
 ## Further Reading
 

--- a/docs/website/content/mobile-app-development-cost-codename-one.md
+++ b/docs/website/content/mobile-app-development-cost-codename-one.md
@@ -47,7 +47,7 @@ $79/mo
 - [Push Notification](#/)
 - [Crash Reporting](#/)
 - [Concurrent Builds](#/)
-- [Versioning (5 months)](#/)
+- [Versioning (2 months)](#/)
 - [E-Mail Support](#/)
 - [Native Desktop Apps](#/)
 
@@ -62,7 +62,7 @@ $399/mo
 - [in this tutorial](#/)." data-original-title="" title="">JavaScript App Generation
 - [Offline Builds](#/)
 - [High Priority Builds](#/)
-- [Versioning (18 months)](#/)
+- [Versioning (6 months)](#/)
 - [Continuous Integration](#/)
 - [On Device Unit Tests](#/)
 - [Office Hours/Phone Support](#/)

--- a/docs/website/layouts/_default/pricing.html
+++ b/docs/website/layouts/_default/pricing.html
@@ -69,7 +69,7 @@
       </header>
       <ul>
         <li>Everything in Basic</li>
-        <li>Versioning (5 months)</li>
+        <li>Versioning (2 months)</li>
         <li>Crash reporting</li>
         <li>Native desktop apps</li>
         <li>Push notifications (1M/month)</li>
@@ -97,7 +97,7 @@
         <li>Everything in Pro</li>
         <li>JavaScript app generation</li>
         <li>High priority builds</li>
-        <li>Versioning (18 months)</li>
+        <li>Versioning (6 months)</li>
         <li>Continuous integration</li>
         <li>On-device unit tests</li>
         <li>Push notifications (10M/month)</li>


### PR DESCRIPTION
## Summary
Documentation + publishing support for the new **versioned cloud builds** feature. The build-server logic lives in the BuildDaemon repo (separate PR); this PR is the docs and the master-publish workflow.

- **Developer guide** (`Advanced-Topics-Under-The-Hood.asciidoc`): new "Versioned builds" section covering the `build.cn1Version` hint, the Maven version scheme, the tier windows, failure behavior, and a "Building against master" subsection; the build-hints table gets a `build.cn1Version` row.
- **Website**: pricing / comparison-chart / cost pages updated so the advertised versioning windows are **2 months (Pro) / 6 months (Enterprise)**; the repeatable-builds how-to is rewritten for `build.cn1Version` (including `master`).
- **CI** (`publish-master-snapshot.yml`): on every push to `master`, builds the four framework modules (core, ios bundle, parparvm bundle, android) and uploads them to a fixed, overwritten `master-snapshot` GitHub Release. The BuildDaemon grabs these when a project sets `build.cn1Version=master`.

## Notes for review
- The advertised versioning windows are **reduced** (5 -> 2 months Pro, 18 -> 6 months Enterprise) to match the enforced policy.
- The publish workflow runs on every master push and creates/overwrites a public `master-snapshot` release; it uses the default `GITHUB_TOKEN` (no new secrets) and a targeted `-pl ... -am` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
