### PR TITLE
Publish the Game Builder editor to Maven Central during release (fixes #5292)

### DIFF
--- a/.github/workflows/release-on-maven-central.yml
+++ b/.github/workflows/release-on-maven-central.yml
@@ -89,3 +89,65 @@ jobs:
         run: |
           echo "Release failed: deploy reported failure and the artifacts never appeared on Maven Central."
           exit 1
+
+      # --- Game Builder editor -------------------------------------------------
+      # The cn1:gamebuilder goal resolves
+      # com.codenameone:codenameone-gamebuilder:<version>:jar-with-dependencies
+      # from Maven Central. That editor lives outside the maven/ reactor
+      # (scripts/gamebuilder), compiles at Java 17, and depends on the
+      # core/javase/plugin published above, so it is built and deployed in a
+      # second pass here. These steps run only when the core release succeeded;
+      # update-version.sh already synced the gamebuilder poms to GITHUB_REF_NAME.
+      - name: Set up JDK 17 for the Game Builder editor
+        if: steps.deploy.outcome == 'success' || steps.confirm.outcome == 'success'
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Deploy Game Builder editor to Maven Central
+        if: steps.deploy.outcome == 'success' || steps.confirm.outcome == 'success'
+        run: |
+          export GPG_TTY=$(tty)
+          cd scripts/gamebuilder
+          # The core/javase/plugin just released are already in the local repo
+          # from the deploy above (install runs before the Central upload).
+          # -Dcn1.version/-Dcn1.plugin.version pin the build to that version.
+          # -Dmaven.test.skip=true also skips test *compilation* (the editor's
+          # JUnit test deps are irrelevant to the published jar). -Pgamebuilder-
+          # central adds the sources/javadoc jars, GPG signatures and the
+          # central-publishing bundle; -Pexecutable-jar builds the fat jar.
+          xvfb-run -a mvn -Pexecutable-jar -Pgamebuilder-central deploy \
+            -Dgpg.passphrase=$MAVEN_GPG_PASSPHRASE \
+            -Dcn1.version=$GITHUB_REF_NAME -Dcn1.plugin.version=$GITHUB_REF_NAME \
+            -Dmaven.test.skip=true
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+
+      - name: Confirm Game Builder editor on Maven Central
+        if: steps.deploy.outcome == 'success' || steps.confirm.outcome == 'success'
+        continue-on-error: true
+        run: |
+          # Informational only: the editor bundle was accepted by Sonatype
+          # Central in the step above (which would have failed otherwise).
+          # Propagation to repo1 can take 30+ minutes, so this is a best-effort
+          # sanity poll, not a gate.
+          set +e
+          url="https://repo1.maven.org/maven2/com/codenameone/codenameone-gamebuilder/${GITHUB_REF_NAME}/codenameone-gamebuilder-${GITHUB_REF_NAME}-jar-with-dependencies.jar"
+          for i in $(seq 1 15); do
+            code=$(curl -s -o /dev/null -w "%{http_code}" "$url")
+            if [ "$code" = "200" ]; then
+              echo "Confirmed codenameone-gamebuilder ${GITHUB_REF_NAME} (jar-with-dependencies) on Maven Central"
+              exit 0
+            fi
+            echo "[$i/15] Waiting on Maven Central for codenameone-gamebuilder (code=$code)"
+            sleep 20
+          done
+          echo "codenameone-gamebuilder ${GITHUB_REF_NAME} not visible on repo1 yet; it may still be propagating from Sonatype Central."

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -666,18 +666,12 @@
                 <module>errorprone-checks</module>
             </modules>
         </profile>
-        <!-- Release lane for the Game Builder editor jar. Off by default (the editor is a CN1
-             app that depends on the just-built plugin/core/javase, so it must build AFTER them).
-             Activate during the release to build + deploy com.codenameone:codenameone-gamebuilder
-             at the CN1 version, so cn1:gamebuilder resolves it from Central like the Designer jar:
-                 mvn -Pgamebuilder-release -Pexecutable-jar deploy
-             The module lives outside maven/ (scripts/gamebuilder); it is version-synced to the
-             reactor (8.0-SNAPSHOT) and pulls codenameone-core/javase/maven-plugin from it. -->
-        <profile>
-            <id>gamebuilder-release</id>
-            <modules>
-                <module>../scripts/gamebuilder</module>
-            </modules>
-        </profile>
+        <!-- The Game Builder editor is published to Maven Central by the release
+             workflow as a separate Java-17 pass over scripts/gamebuilder (its
+             gamebuilder-central profile), not from this reactor: it is a CN1 app
+             that depends on the core/javase/plugin built here and compiles at
+             Java 17, while this reactor builds at Java 8. See
+             .github/workflows/release-on-maven-central.yml and
+             scripts/gamebuilder/pom.xml. -->
     </profiles>
 </project>

--- a/maven/update-version.sh
+++ b/maven/update-version.sh
@@ -63,10 +63,30 @@ for a in cn1app-archetype cn1lib-archetype; do
   done
 done
 
+# Game Builder editor (scripts/gamebuilder) lives outside the maven/ reactor
+# with its own coordinates, so the mvn versions:set above does not reach it.
+# Rewrite its module version and the cn1.version/cn1.plugin.version it builds
+# against (kept in lock-step with the reactor) so the published
+# com.codenameone:codenameone-gamebuilder matches the plugin version that the
+# cn1:gamebuilder goal resolves from Maven Central. Done with perl rather than
+# versions:set because at release time the old SNAPSHOT plugin it references is
+# not yet resolvable in a clean .m2, which would make versions:set fail.
+for f in ../scripts/gamebuilder/pom.xml \
+         ../scripts/gamebuilder/common/pom.xml \
+         ../scripts/gamebuilder/javase/pom.xml; do
+  [ -f "$f" ] && perl -pi -e "s{<version>\Q$oldVersion\E</version>}{<version>$version</version>}g" "$f"
+done
+gbParent=../scripts/gamebuilder/pom.xml
+if [ -f "$gbParent" ]; then
+  perl -pi -e "s{<cn1\.version>\Q$oldVersion\E</cn1\.version>}{<cn1.version>$version</cn1.version>}g" "$gbParent"
+  perl -pi -e "s{<cn1\.plugin\.version>\Q$oldVersion\E</cn1\.plugin\.version>}{<cn1.plugin.version>$version</cn1.plugin.version>}g" "$gbParent"
+fi
+
 echo "Committing version change in git"
 git add -u .
 # Note: the -u is to prevent adding files that aren't added to git yet.  Only changed
 # files.  This is to help avoid accidents.
+git add -u ../scripts/gamebuilder
 git commit -m "Updated version to $version"
 if [[ "$version" == *-SNAPSHOT ]]; then
   echo "This is a snapshot version so not adding a tag"

--- a/scripts/gamebuilder/javase/pom.xml
+++ b/scripts/gamebuilder/javase/pom.xml
@@ -6,9 +6,11 @@
         <artifactId>cn1-gamebuilder</artifactId>
         <version>8.0-SNAPSHOT</version>
     </parent>
-    <!-- The distributable editor coordinates. In a Codename One release this module is
-         built in the maven/ reactor at the CN1 version and published to Maven Central;
-         the cn1:gamebuilder goal then resolves it like the Designer jar. -->
+    <!-- The distributable editor coordinates. In a Codename One release the release
+         workflow builds this module at the CN1 version (a Java-17 pass over
+         scripts/gamebuilder with -Pexecutable-jar -Pgamebuilder-central) and publishes
+         it to Maven Central; the cn1:gamebuilder goal then resolves it like the
+         Designer jar. -->
     <groupId>com.codenameone</groupId>
     <artifactId>codenameone-gamebuilder</artifactId>
     <name>codenameone-gamebuilder</name>

--- a/scripts/gamebuilder/pom.xml
+++ b/scripts/gamebuilder/pom.xml
@@ -95,5 +95,87 @@
                 <module>javase</module>
             </modules>
         </profile>
+        <!-- Release lane: makes the whole Game Builder reactor publishable to Maven
+             Central. This reactor has its own parent, so it does not inherit the
+             release plumbing in maven/pom.xml; this profile reproduces it (sources +
+             javadoc jars, GPG signatures and the central-publishing bundle). Off by
+             default so ordinary dev builds are unaffected. The release workflow
+             activates it together with -Pexecutable-jar so the editor is published as
+             com.codenameone:codenameone-gamebuilder:<version> (plus its
+             jar-with-dependencies classifier) and cn1:gamebuilder resolves it from
+             Central the same way it resolves the Designer jar. The parent pom and the
+             cn1-gamebuilder-common jar are published alongside it because the editor's
+             pom references them, so they must resolve for the classifier lookup. -->
+        <profile>
+            <id>gamebuilder-central</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.3.0</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.6.3</version>
+                        <configuration>
+                            <doclint>none</doclint>
+                            <failOnError>false</failOnError>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.5</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <passphrase>${gpg.passphrase}</passphrase>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <!-- Prevent gpg from using pinentry programs -->
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.8.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
## Problem

`mvn cn1:gamebuilder` fails for everyone with:

> Could not resolve the game builder editor (com.codenameone:codenameone-gamebuilder:<version>:jar-with-dependencies)

The `cn1:gamebuilder` goal resolves the editor as `com.codenameone:codenameone-gamebuilder:<pluginVersion>:jar-with-dependencies` from Maven Central, but **that artifact was never published** (its `maven-metadata.xml` is a 404). It fails on every released plugin version, not just the one in the issue.

The general Maven Central release is healthy — `codenameone-maven-plugin` `7.0.253` published normally. This is specific to the editor jar.

Fixes #5292.

## Why it was never published

The editor lives outside the `maven/` reactor (`scripts/gamebuilder`), compiles at **Java 17**, and depends on the core/javase/plugin built in the reactor — so it can't just be a reactor module built with the Java 8 release job. Four gaps all had to be closed:

1. The release workflow never built it.
2. `update-version.sh` never version-synced it (so it would publish as `8.0-SNAPSHOT`, not the release version the goal looks for).
3. Its poms had none of the Central plumbing (signatures / sources / javadoc / publishing), so Central would reject them.
4. JDK mismatch (editor needs 17, release job runs 8).

The previously-documented `mvn -Pgamebuilder-release -Pexecutable-jar deploy` recipe never actually worked — it would re-deploy the whole already-released reactor and ship unsigned gamebuilder artifacts.

## The fix

- **`scripts/gamebuilder/pom.xml`** — new `gamebuilder-central` profile (inherited by the `common` + `javase` modules) reproducing `maven/pom.xml`'s release plumbing: `maven-source-plugin`, `maven-javadoc-plugin` (doclint none / failOnError false), `maven-gpg-plugin` (same loopback config as the main reactor), and `central-publishing-maven-plugin` (autoPublish). Off by default, so dev builds are unaffected.
- **`maven/update-version.sh`** — version-syncs the gamebuilder module + its `cn1.version`/`cn1.plugin.version` to the release version and stages the poms. Uses `perl` rather than `versions:set` because the old SNAPSHOT plugin isn't resolvable in a clean CI `.m2` at that point.
- **`.github/workflows/release-on-maven-central.yml`** — after the core release succeeds, a JDK-17 setup + `cd scripts/gamebuilder; mvn -Pexecutable-jar -Pgamebuilder-central deploy … -Dmaven.test.skip=true`, plus an informational Central-confirm poll. Gated to run only when the core release succeeded.
- **`maven/pom.xml`** — removed the dead/misleading `gamebuilder-release` profile, replaced with a pointer comment.
- **`scripts/gamebuilder/javase/pom.xml`** — corrected a comment that falsely claimed the module builds in the `maven/` reactor.

## Verification

Verified locally on JDK 17 (`-Pexecutable-jar -Pgamebuilder-central package`, clean): produces exactly the Central-required set for both modules — main jar, **sources**, **javadoc**, and the editor's **jar-with-dependencies**. This also confirmed the parent-defined profile is correctly inherited by the child modules. Dry-ran the `update-version.sh` perl (`8.0-SNAPSHOT → 7.0.254`) across all three poms: no stray versions, still well-formed XML. Workflow YAML validates.

**Not verifiable locally** (no signing key / Central credentials): the GPG signing and the Central upload themselves. These mirror the main reactor's proven config exactly and are exercised by the first tagged release after merge; the new confirm step gives a clear pass/fail signal.

> [!NOTE]
> Already-published versions (7.0.252/7.0.253) can't get the editor retroactively — this takes effect on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)