### PR TITLE
Fix Game Builder Central publish: POM metadata + editor module inclusion

### DIFF
--- a/.github/workflows/release-on-maven-central.yml
+++ b/.github/workflows/release-on-maven-central.yml
@@ -122,7 +122,14 @@ jobs:
           # JUnit test deps are irrelevant to the published jar). -Pgamebuilder-
           # central adds the sources/javadoc jars, GPG signatures and the
           # central-publishing bundle; -Pexecutable-jar builds the fat jar.
+          # -Dcodename1.platform=javase is REQUIRED: it activates the parent's
+          # `javase` profile (which contributes the editor module) by property.
+          # That profile is activeByDefault, but any explicit -P activation
+          # suppresses activeByDefault, so without this property the editor
+          # (codenameone-gamebuilder) silently drops out of the reactor and only
+          # the parent + common modules would be published.
           xvfb-run -a mvn -Pexecutable-jar -Pgamebuilder-central deploy \
+            -Dcodename1.platform=javase \
             -Dgpg.passphrase=$MAVEN_GPG_PASSPHRASE \
             -Dcn1.version=$GITHUB_REF_NAME -Dcn1.plugin.version=$GITHUB_REF_NAME \
             -Dmaven.test.skip=true

--- a/scripts/gamebuilder/common/pom.xml
+++ b/scripts/gamebuilder/common/pom.xml
@@ -8,6 +8,10 @@
     </parent>
     <artifactId>cn1-gamebuilder-common</artifactId>
     <packaging>jar</packaging>
+    <!-- name + description are required by Maven Central and are not inherited
+         from the parent, so each module declares its own. -->
+    <name>cn1-gamebuilder-common</name>
+    <description>Shared editor/model code for the Codename One Game Builder.</description>
 
     <dependencies>
         <dependency>

--- a/scripts/gamebuilder/javase/pom.xml
+++ b/scripts/gamebuilder/javase/pom.xml
@@ -14,6 +14,8 @@
     <groupId>com.codenameone</groupId>
     <artifactId>codenameone-gamebuilder</artifactId>
     <name>codenameone-gamebuilder</name>
+    <!-- description is required by Maven Central and is not inherited. -->
+    <description>Standalone Codename One Game Builder editor (visual level/map editor).</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/scripts/gamebuilder/pom.xml
+++ b/scripts/gamebuilder/pom.xml
@@ -15,6 +15,32 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+    <!-- developers + scm are required by Maven Central's POM validation and are
+         inherited by the common + javase modules. Mirrors maven/pom.xml. -->
+    <developers>
+        <developer>
+            <id>shai</id>
+            <name>Shai Almog</name>
+            <email>shai.almog@codenameone.com</email>
+            <timezone>+4</timezone>
+        </developer>
+        <developer>
+            <id>chen</id>
+            <name>Chen Fishbein</name>
+            <email>chen.fishbein@codenameone.com</email>
+            <timezone>+4</timezone>
+        </developer>
+        <developer>
+            <id>shannah</id>
+            <name>Steve Hannah</name>
+            <email>steve.hannah@codenameone.com</email>
+            <timezone>-8</timezone>
+        </developer>
+    </developers>
+    <scm>
+        <url>https://github.com/codenameone/CodenameOne</url>
+        <connection>scm:git:git@github.com:codenameone/CodenameOne.git</connection>
+    </scm>
 
     <modules>
         <module>common</module>


### PR DESCRIPTION
Follow-up to #5293. The `7.0.254` release published the core/plugin/archetypes fine, but the **Game Builder deploy step failed**, so `com.codenameone:codenameone-gamebuilder` is still not on Maven Central. The release log surfaced two distinct problems — both only observable during a real signed Central deploy, which is why #5293 couldn't catch them locally.

## Problem 1 — Central rejected the bundle on POM validation

```
Deployment ... failed
 - Project name is missing
 - Developers information is missing
 - Developers information is missing
```

The gamebuilder reactor has its **own** parent, so it doesn't inherit `maven/pom.xml`'s metadata. Maven Central requires `name`, `description`, `url`, `licenses`, `developers`, and `scm` on every published POM.

- Added `developers` + `scm` to the gamebuilder **parent** (inherited by the children; mirrors `maven/pom.xml`).
- Added `name` + `description` to the **common** and **javase** modules (neither is inherited in Maven).

## Problem 2 — the editor module was excluded from the release reactor

The release reactor only built **2** modules:

```
Building Codename One Game Builder 7.0.254   [1/2]   (parent)
Building cn1-gamebuilder-common 7.0.254      [2/2]
```

The editor (`codenameone-gamebuilder`, the `javase` module) was missing. The parent's `javase` profile that contributes `<module>javase</module>` is `activeByDefault`, but **Maven suppresses `activeByDefault` whenever any profile is activated with `-P`** — and the release command activates `-Pexecutable-jar -Pgamebuilder-central`. So the editor module silently dropped out; only the parent + common would ever be published.

Fix: pass `-Dcodename1.platform=javase` in the release command. Property activation is **not** suppressed by `-P`, and it matches the documented dev command.

## Verification (JDK 17)

Release-equivalent build now resolves a **3-module reactor** and produces the editor jar plus sources/javadoc for every module:

```
Building Codename One Game Builder   [1/3]   (parent, pom)
Building cn1-gamebuilder-common      [2/3]   jar + sources + javadoc
Building codenameone-gamebuilder     [3/3]   jar + jar-with-dependencies + sources + javadoc
```

Without `-Dcodename1.platform=javase` the same command resolves only `[1/2]`/`[2/2]` (editor dropped) — confirming the cause. Each module's effective POM (`help:effective-pom`) now carries all six Central-required fields (name/description/url/licenses/developers/scm, the last two via inheritance).

The GPG signing and Central upload (creds-only) failed in `7.0.254` strictly on the two issues fixed here; everything up to the upload is verified locally. The release workflow's `Confirm Game Builder editor on Maven Central` step will give the definitive signal on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)