### PR TITLE
Release: stop importing the GPG key twice (fixes red-on-success release)

### DIFF
--- a/.github/workflows/release-on-maven-central.yml
+++ b/.github/workflows/release-on-maven-central.yml
@@ -98,6 +98,12 @@ jobs:
       # core/javase/plugin published above, so it is built and deployed in a
       # second pass here. These steps run only when the core release succeeded;
       # update-version.sh already synced the gamebuilder poms to GITHUB_REF_NAME.
+      # Deliberately does NOT import the GPG key: it was already imported by the
+      # Java 8 "Set up Maven Central Repository" step above and persists in the
+      # runner keyring (gpg signing in the editor deploy below uses it fine). If
+      # both setup-java steps import the key, both of their cleanup post-steps
+      # try to delete it; the second deletion fails ("gpg ... exit code 2") and
+      # marks the whole release red even though every artifact published.
       - name: Set up JDK 17 for the Game Builder editor
         if: steps.deploy.outcome == 'success' || steps.confirm.outcome == 'success'
         uses: actions/setup-java@v5
@@ -107,8 +113,6 @@ jobs:
           server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
-          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Deploy Game Builder editor to Maven Central
         if: steps.deploy.outcome == 'success' || steps.confirm.outcome == 'success'


### PR DESCRIPTION
## Result of 7.0.255

The Game Builder publish fix (#5296) **worked** — for the first time the editor is on Maven Central:

| artifact | status |
|---|---|
| `codenameone-gamebuilder/maven-metadata.xml` | 200 |
| `codenameone-gamebuilder-7.0.255.pom` | 200 |
| **`codenameone-gamebuilder-7.0.255-jar-with-dependencies.jar`** (what `cn1:gamebuilder` resolves) | 200 |
| `cn1-gamebuilder-common-7.0.255.jar` | 200 |

`mvn cn1:gamebuilder` now resolves the editor for 7.0.255+.

## But the workflow still reported failure

The only failing step was the post-job cleanup:

```
##[error]Failed to remove private key due to: The process '/usr/bin/gpg' failed with exit code 2
```

**Cause (a bug I introduced in #5293):** the JDK-17 setup step added for the editor deploy *also* imported the GPG private key via `setup-java`, on top of the Java 8 "Set up Maven Central Repository" step. Each `setup-java` that imports a key registers a cleanup post-step that deletes it. Post-steps run in reverse order, so the first deletion succeeds and the **second fails** (key already gone) — marking the whole release red even though every artifact published.

## Fix

Drop `gpg-private-key`/`gpg-passphrase` from the **second** `setup-java`. The key only needs importing once — it persists in the runner's GPG keyring for the job, and the editor deploy's `gpg:sign` used it successfully in 7.0.255. Server credentials and the JDK-17 switch are kept; the deploy still passes the passphrase via `-Dgpg.passphrase`.

This is the last loose end — the release pipeline now both publishes the editor **and** reports success. (Heavy build jobs are path-filtered and won't run on this release-workflow-only change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)