### PR TITLE
Fix initializr projects: keep win32 module, dual-mode default theme, Linux/win32 IDE targets

### DIFF
--- a/maven/cn1app-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/maven/cn1app-archetype/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -118,28 +118,22 @@ def pickJavaVersionFromCurrentJvm() {
 }
 
 /**
- * Apply the Java-17-only transforms that the initializr does on its
+ * Apply the Java-version-specific transforms that the initializr does on its
  * server-rendered templates:
- *   - drop the win/ native source tree and the matching <profile id="win"> block
- *     from the root pom (the legacy Windows device cloud target is retired for
- *     Java 17 builds)
- *   - keep .claude/skills/codename-one/** (the Codename One authoring skill)
+ *   - Java 17 keeps .claude/skills/codename-one/** (the Codename One authoring skill)
+ *   - Java 8 strips .claude/ so older projects don't suddenly grow an AI-agent
+ *     skill they never opted into.
  *
- * For Java 8 projects we do the inverse: keep win/, strip .claude/ so older
- * projects don't suddenly grow an AI-agent skill they never opted into.
+ * The win/ module is the native win32 target and ships for every Java version
+ * (only the long-retired UWP module that previously lived under win/ used to be
+ * dropped for Java 17).
  *
  * Also rewrites the IntelliJ misc.xml languageLevel attribute to match the
  * resolved JDK (universal cleanup: the project-jdk-name/-type attributes
  * are already stripped in the archetype template itself).
  */
 def applyJavaVersionTransforms(rootDir, rootPom, resolvedJava) {
-    if (resolvedJava == "17") {
-        def winDir = new java.io.File(rootDir, "win")
-        if (winDir.exists()) {
-            deleteRecursively(winDir)
-        }
-        stripWindowsModuleProfile(rootPom)
-    } else {
+    if (resolvedJava != "17") {
         def claudeDir = new java.io.File(rootDir, ".claude")
         if (claudeDir.exists()) {
             deleteRecursively(claudeDir)
@@ -173,40 +167,6 @@ def setIntellijLanguageLevel(rootDir, resolvedJava) {
     }
     def rewritten = content.substring(0, valueStart) + desired + content.substring(valueEnd)
     miscXml.newWriter("UTF-8").withWriter { w -> w << rewritten }
-}
-
-/**
- * Mirror of initializr's GeneratorModel.stripWindowsModuleProfile: locate the
- * <profile> block whose <id>win</id> identifies the Windows device profile and
- * remove the whole block (and trailing newline) from the root pom. Tolerant of
- * indentation. No-op if the profile is not present.
- */
-def stripWindowsModuleProfile(pomFile) {
-    if (!pomFile.exists()) {
-        return
-    }
-    def pom = pomFile.text
-    def idIdx = pom.indexOf("<id>win</id>")
-    if (idIdx < 0) {
-        return
-    }
-    def profileStart = pom.lastIndexOf("<profile>", idIdx)
-    if (profileStart < 0) {
-        return
-    }
-    def profileEnd = pom.indexOf("</profile>", idIdx)
-    if (profileEnd < 0) {
-        return
-    }
-    profileEnd += "</profile>".length()
-    while (profileEnd < pom.length() && (pom.charAt(profileEnd) == (char) '\n' || pom.charAt(profileEnd) == (char) '\r')) {
-        profileEnd++
-    }
-    while (profileStart > 0 && (pom.charAt(profileStart - 1) == (char) ' ' || pom.charAt(profileStart - 1) == (char) '\t')) {
-        profileStart--
-    }
-    def rewritten = pom.substring(0, profileStart) + pom.substring(profileEnd)
-    pomFile.newWriter("UTF-8").withWriter { w -> w << rewritten }
 }
 
 def deleteRecursively(file) {

--- a/maven/cn1app-archetype/src/main/resources/archetype-resources/common/src/main/css/theme.css
+++ b/maven/cn1app-archetype/src/main/resources/archetype-resources/common/src/main/css/theme.css
@@ -53,17 +53,40 @@ SideCommand {
     border-bottom: 2px solid #cccccc;
 }
 
-/* Dark mode example - uncomment to override styles when the
- * device is in dark mode:
- *
- * @media (prefers-color-scheme: dark) {
- *     SideNavigationPanel {
- *         background: #0f172a;
- *     }
- *     SideCommand {
- *         color: #e2e8f0;
- *         background: #0f172a;
- *         border-bottom: 2px solid #334155;
- *     }
- * }
- */
+/* Dark mode: the default theme adapts automatically when the device
+ * (or simulator) is switched to dark mode. Tweak the colors below or
+ * delete this block entirely if you only want a light theme. */
+@media (prefers-color-scheme: dark) {
+    Form {
+        background-color: #0f172a;
+        color: #e2e8f0;
+    }
+    Toolbar {
+        background-color: #0f172a;
+        border: none;
+    }
+    Title, TitleCommand, Command, OverflowCommand {
+        color: #e2e8f0;
+    }
+    Button {
+        color: #e2e8f0;
+        background-color: #1f2937;
+        border: 1px solid #475569;
+    }
+    Button.pressed {
+        color: #e2e8f0;
+        background-color: #334155;
+        border: 1px solid #64748b;
+    }
+    DialogBody, DialogTitle {
+        color: #e2e8f0;
+    }
+    SideNavigationPanel {
+        background: #0f172a;
+    }
+    SideCommand {
+        color: #e2e8f0;
+        background: #0f172a;
+        border-bottom: 2px solid #334155;
+    }
+}

--- a/maven/cn1app-archetype/src/main/resources/archetype-resources/common/src/main/css/theme.css
+++ b/maven/cn1app-archetype/src/main/resources/archetype-resources/common/src/main/css/theme.css
@@ -53,34 +53,12 @@ SideCommand {
     border-bottom: 2px solid #cccccc;
 }
 
-/* Dark mode: the default theme adapts automatically when the device
- * (or simulator) is switched to dark mode. Tweak the colors below or
- * delete this block entirely if you only want a light theme. */
+/* Dark mode: the native theme handles dark mode for standard components
+ * (Form, Toolbar, Button, ...). The side menu below is the only thing this
+ * template hard-codes to light colors, so it's the only thing we flip for
+ * dark mode -- keeping the rest of the UI native. Add your own rules here as
+ * needed, or delete this block if you only want a light theme. */
 @media (prefers-color-scheme: dark) {
-    Form {
-        background-color: #0f172a;
-        color: #e2e8f0;
-    }
-    Toolbar {
-        background-color: #0f172a;
-        border: none;
-    }
-    Title, TitleCommand, Command, OverflowCommand {
-        color: #e2e8f0;
-    }
-    Button {
-        color: #e2e8f0;
-        background-color: #1f2937;
-        border: 1px solid #475569;
-    }
-    Button.pressed {
-        color: #e2e8f0;
-        background-color: #334155;
-        border: 1px solid #64748b;
-    }
-    DialogBody, DialogTitle {
-        color: #e2e8f0;
-    }
     SideNavigationPanel {
         background: #0f172a;
     }

--- a/maven/cn1app-archetype/src/main/resources/archetype-resources/tools/netbeans/nb-configuration.xml
+++ b/maven/cn1app-archetype/src/main/resources/archetype-resources/tools/netbeans/nb-configuration.xml
@@ -31,6 +31,10 @@ Without this configuration present, some functionality in the IDE may be limited
                 <property name="codename1.buildTarget">mac-os-x-native</property>
                 <property name="codename1.platform">ios</property>
             </configuration>
+            <configuration id="Linux Desktop App" profiles="">
+                <property name="codename1.buildTarget">linux-desktop</property>
+                <property name="codename1.platform">javase</property>
+            </configuration>
             <configuration id="Linux Device App" profiles="">
                 <property name="codename1.buildTarget">linux-device</property>
                 <property name="codename1.platform">linux</property>

--- a/maven/cn1app-archetype/src/main/resources/archetype-resources/win/pom.xml
+++ b/maven/cn1app-archetype/src/main/resources/archetype-resources/win/pom.xml
@@ -29,7 +29,7 @@
                 <version>${cn1.plugin.version}</version>
                 <executions>
                     <execution>
-                        <id>build-android</id>
+                        <id>build-windows</id>
                         <phase>package</phase>
                         <goals>
                             <goal>build</goal>

--- a/maven/codenameone-maven-plugin/src/main/resources/com/codename1/maven/intellij/workspace.xml
+++ b/maven/codenameone-maven-plugin/src/main/resources/com/codename1/maven/intellij/workspace.xml
@@ -620,6 +620,141 @@
             </MavenSettings>
             <method v="2" />
         </configuration>
+        <configuration name="Windows Device Build" type="MavenRunConfiguration" factoryName="Maven" folderName="Build Server">
+            <MavenSettings>
+                <option name="myGeneralSettings" />
+                <option name="myRunnerSettings">
+                    <MavenRunnerSettings>
+                        <option name="delegateBuildToMaven" value="true" />
+                        <option name="environmentProperties">
+                            <map />
+                        </option>
+                        <option name="jreName" value="#USE_PROJECT_JDK" />
+                        <option name="mavenProperties">
+                            <map>
+                                <entry key="codename1.buildTarget" value="windows-device" />
+                                <entry key="codename1.platform" value="win" />
+                            </map>
+                        </option>
+                        <option name="passParentEnv" value="true" />
+                        <option name="runMavenInBackground" value="true" />
+                        <option name="skipTests" value="true" />
+                        <option name="vmOptions" value="" />
+                    </MavenRunnerSettings>
+                </option>
+                <option name="myRunnerParameters">
+                    <MavenRunnerParameters>
+                        <option name="profiles">
+                            <set />
+                        </option>
+                        <option name="goals">
+                            <list>
+                                <option value="package" />
+                                <option value="-U" />
+                                <option value="-e" />
+                            </list>
+                        </option>
+                        <option name="pomFileName" />
+                        <option name="profilesMap">
+                            <map />
+                        </option>
+                        <option name="resolveToWorkspace" value="false" />
+                        <option name="workingDirPath" value="$PROJECT_DIR$" />
+                    </MavenRunnerParameters>
+                </option>
+            </MavenSettings>
+            <method v="2" />
+        </configuration>
+        <configuration name="Linux Desktop Build" type="MavenRunConfiguration" factoryName="Maven" folderName="Build Server">
+            <MavenSettings>
+                <option name="myGeneralSettings" />
+                <option name="myRunnerSettings">
+                    <MavenRunnerSettings>
+                        <option name="delegateBuildToMaven" value="true" />
+                        <option name="environmentProperties">
+                            <map />
+                        </option>
+                        <option name="jreName" value="#USE_PROJECT_JDK" />
+                        <option name="mavenProperties">
+                            <map>
+                                <entry key="codename1.buildTarget" value="linux-desktop" />
+                                <entry key="codename1.platform" value="javase" />
+                            </map>
+                        </option>
+                        <option name="passParentEnv" value="true" />
+                        <option name="runMavenInBackground" value="true" />
+                        <option name="skipTests" value="true" />
+                        <option name="vmOptions" value="" />
+                    </MavenRunnerSettings>
+                </option>
+                <option name="myRunnerParameters">
+                    <MavenRunnerParameters>
+                        <option name="profiles">
+                            <set />
+                        </option>
+                        <option name="goals">
+                            <list>
+                                <option value="package" />
+                                <option value="-U" />
+                                <option value="-e" />
+                            </list>
+                        </option>
+                        <option name="pomFileName" />
+                        <option name="profilesMap">
+                            <map />
+                        </option>
+                        <option name="resolveToWorkspace" value="false" />
+                        <option name="workingDirPath" value="$PROJECT_DIR$" />
+                    </MavenRunnerParameters>
+                </option>
+            </MavenSettings>
+            <method v="2" />
+        </configuration>
+        <configuration name="Linux Device Build" type="MavenRunConfiguration" factoryName="Maven" folderName="Build Server">
+            <MavenSettings>
+                <option name="myGeneralSettings" />
+                <option name="myRunnerSettings">
+                    <MavenRunnerSettings>
+                        <option name="delegateBuildToMaven" value="true" />
+                        <option name="environmentProperties">
+                            <map />
+                        </option>
+                        <option name="jreName" value="#USE_PROJECT_JDK" />
+                        <option name="mavenProperties">
+                            <map>
+                                <entry key="codename1.buildTarget" value="linux-device" />
+                                <entry key="codename1.platform" value="linux" />
+                            </map>
+                        </option>
+                        <option name="passParentEnv" value="true" />
+                        <option name="runMavenInBackground" value="true" />
+                        <option name="skipTests" value="true" />
+                        <option name="vmOptions" value="" />
+                    </MavenRunnerSettings>
+                </option>
+                <option name="myRunnerParameters">
+                    <MavenRunnerParameters>
+                        <option name="profiles">
+                            <set />
+                        </option>
+                        <option name="goals">
+                            <list>
+                                <option value="package" />
+                                <option value="-U" />
+                                <option value="-e" />
+                            </list>
+                        </option>
+                        <option name="pomFileName" />
+                        <option name="profilesMap">
+                            <map />
+                        </option>
+                        <option name="resolveToWorkspace" value="false" />
+                        <option name="workingDirPath" value="$PROJECT_DIR$" />
+                    </MavenRunnerParameters>
+                </option>
+            </MavenSettings>
+            <method v="2" />
+        </configuration>
         <configuration name="Xcode iOS Project" type="MavenRunConfiguration" factoryName="Maven" folderName="Local Builds">
             <MavenSettings>
                 <option name="myGeneralSettings" />
@@ -877,6 +1012,9 @@
             <item itemvalue="Maven.Javascript Build" />
             <item itemvalue="Maven.Mac Desktop Build" />
             <item itemvalue="Maven.Windows Desktop Build" />
+            <item itemvalue="Maven.Windows Device Build" />
+            <item itemvalue="Maven.Linux Desktop Build" />
+            <item itemvalue="Maven.Linux Device Build" />
             <item itemvalue="Maven.Cross-platform (JavaSE) Desktop App" />
             <item itemvalue="Maven.Xcode iOS Project" />
             <item itemvalue="Maven.Gradle Android Project" />

--- a/scripts/initializr/common/src/main/java/com/codename1/initializr/Initializr.java
+++ b/scripts/initializr/common/src/main/java/com/codename1/initializr/Initializr.java
@@ -164,7 +164,7 @@ public class Initializr extends Lifecycle {
             }
             String appName = appNameField.getText() == null ? "" : appNameField.getText().trim();
             String packageName = packageField.getText() == null ? "" : packageField.getText().trim();
-            ProjectOptions options = currentOptions(includeLocalizationBundles, previewLanguage, javaVersion);
+            ProjectOptions options = downloadOptions(includeLocalizationBundles, previewLanguage, javaVersion);
             GeneratorModel.create(selectedIde[0], selectedTemplate[0], appName, packageName, options).generate();
         });
 
@@ -199,16 +199,27 @@ public class Initializr extends Lifecycle {
         }, "initializr-storage-cleanup").start();
     }
 
+    // Options that drive the LIVE PREVIEW only. The preview mock-up reflects the
+    // website's current light/dark chrome (via darkMode) so a dark-host visitor
+    // still sees a dark, natively-styled preview. This is purely cosmetic: the
+    // preview is styled with the initializr's own UIIDs and never compiles the
+    // generated theme.css. Downloads use downloadOptions() instead.
     private ProjectOptions currentOptions(boolean[] includeLocalizationBundles,
                                           ProjectOptions.PreviewLanguage[] previewLanguage,
                                           ProjectOptions.JavaVersion[] javaVersion) {
-        // The initializr UI no longer exposes a theme picker, so every generated
-        // project ships the barebones default theme. That theme.css already adapts
-        // to the device's light/dark setting at runtime via an
-        // @media (prefers-color-scheme: dark) block, so we must NOT bake the
-        // website's current dark/light state into the download -- doing so used to
-        // emit hard-coded dark colors at top-level scope that then broke light mode
-        // for anyone who opened the project.
+        ProjectOptions.ThemeMode mode = darkMode ? ProjectOptions.ThemeMode.DARK : ProjectOptions.ThemeMode.LIGHT;
+        return new ProjectOptions(mode, ProjectOptions.Accent.DEFAULT, true,
+                includeLocalizationBundles[0], previewLanguage[0], javaVersion[0], "");
+    }
+
+    // Options for the generated DOWNLOAD. The UI no longer exposes a theme
+    // picker, so every project ships the barebones default theme regardless of
+    // the website's current dark/light chrome. Baking the host state in here is
+    // what used to emit top-level "Initializr Theme Overrides" that broke light
+    // mode; the default theme.css adapts to the device at runtime on its own.
+    private ProjectOptions downloadOptions(boolean[] includeLocalizationBundles,
+                                           ProjectOptions.PreviewLanguage[] previewLanguage,
+                                           ProjectOptions.JavaVersion[] javaVersion) {
         return new ProjectOptions(ProjectOptions.ThemeMode.LIGHT, ProjectOptions.Accent.DEFAULT, true,
                 includeLocalizationBundles[0], previewLanguage[0], javaVersion[0], "");
     }

--- a/scripts/initializr/common/src/main/java/com/codename1/initializr/Initializr.java
+++ b/scripts/initializr/common/src/main/java/com/codename1/initializr/Initializr.java
@@ -202,8 +202,14 @@ public class Initializr extends Lifecycle {
     private ProjectOptions currentOptions(boolean[] includeLocalizationBundles,
                                           ProjectOptions.PreviewLanguage[] previewLanguage,
                                           ProjectOptions.JavaVersion[] javaVersion) {
-        ProjectOptions.ThemeMode mode = darkMode ? ProjectOptions.ThemeMode.DARK : ProjectOptions.ThemeMode.LIGHT;
-        return new ProjectOptions(mode, ProjectOptions.Accent.DEFAULT, true,
+        // The initializr UI no longer exposes a theme picker, so every generated
+        // project ships the barebones default theme. That theme.css already adapts
+        // to the device's light/dark setting at runtime via an
+        // @media (prefers-color-scheme: dark) block, so we must NOT bake the
+        // website's current dark/light state into the download -- doing so used to
+        // emit hard-coded dark colors at top-level scope that then broke light mode
+        // for anyone who opened the project.
+        return new ProjectOptions(ProjectOptions.ThemeMode.LIGHT, ProjectOptions.Accent.DEFAULT, true,
                 includeLocalizationBundles[0], previewLanguage[0], javaVersion[0], "");
     }
 

--- a/scripts/initializr/common/src/main/java/com/codename1/initializr/model/GeneratorModel.java
+++ b/scripts/initializr/common/src/main/java/com/codename1/initializr/model/GeneratorModel.java
@@ -312,21 +312,14 @@ public class GeneratorModel {
     }
 
     private void copyZipEntriesToMap(String zipResource, Map<String, byte[]> mergedEntries, ZipEntryType zipType) throws IOException {
-        boolean dropWindowsModule = options.javaVersion == ProjectOptions.JavaVersion.JAVA_17;
         try(ZipInputStream zis = new ZipInputStream(getResourceAsStream(zipResource))) {
             ZipEntry entry = zis.getNextEntry();
             while (entry != null) {
                 if (!entry.isDirectory()) {
-                    String name = entry.getName();
-                    if (dropWindowsModule && (name.startsWith("win/") || name.startsWith("win\\"))) {
-                        // Java 17 projects don't ship the UWP/Windows native module — strip
-                        // its source tree from the extracted skeleton. The matching root-pom
-                        // <profile id="win"> block is removed in applyDataReplacements below.
-                        zis.closeEntry();
-                        entry = zis.getNextEntry();
-                        continue;
-                    }
-                    copyEntryToMap(name, readToBytesNoClose(zis), mergedEntries, zipType);
+                    // The win/ module is the native win32 target, shipped for every Java
+                    // version. (The retired UWP module that once lived here used to be
+                    // stripped for Java 17 -- that strip is gone now that win/ is win32.)
+                    copyEntryToMap(entry.getName(), readToBytesNoClose(zis), mergedEntries, zipType);
                 }
                 zis.closeEntry();
                 entry = zis.getNextEntry();
@@ -412,9 +405,6 @@ public class GeneratorModel {
         if ("pom.xml".equals(targetPath)) {
             content = replaceTagValue(content, "cn1.plugin.version", CN1_PLUGIN_VERSION);
             content = replaceTagValue(content, "cn1.version", CN1_PLUGIN_VERSION);
-            if (options.javaVersion == ProjectOptions.JavaVersion.JAVA_17) {
-                content = stripWindowsModuleProfile(content);
-            }
         }
         if ("android/pom.xml".equals(targetPath) || "ios/pom.xml".equals(targetPath) || "javascript/pom.xml".equals(targetPath)) {
             content = hardenPlatformModulePomAgainstDoubleJarAttach(content);
@@ -608,34 +598,6 @@ public class GeneratorModel {
             return xml;
         }
         return xml.substring(0, valueStart) + value + xml.substring(end);
-    }
-
-    private static String stripWindowsModuleProfile(String pom) {
-        // Remove the <profile><id>win</id>... </profile> block from the root pom.
-        // Tolerant of leading whitespace and any inner content. The win/ source
-        // tree is also dropped from the zip extraction (see copyZipEntriesToMap).
-        int idIdx = pom.indexOf("<id>win</id>");
-        if (idIdx < 0) {
-            return pom;
-        }
-        int profileStart = pom.lastIndexOf("<profile>", idIdx);
-        if (profileStart < 0) {
-            return pom;
-        }
-        int profileEnd = pom.indexOf("</profile>", idIdx);
-        if (profileEnd < 0) {
-            return pom;
-        }
-        profileEnd += "</profile>".length();
-        // Swallow trailing newline if present so we don't leave an empty line.
-        while (profileEnd < pom.length() && (pom.charAt(profileEnd) == '\n' || pom.charAt(profileEnd) == '\r')) {
-            profileEnd++;
-        }
-        // Also swallow leading whitespace on the line containing <profile>.
-        while (profileStart > 0 && (pom.charAt(profileStart - 1) == ' ' || pom.charAt(profileStart - 1) == '\t')) {
-            profileStart--;
-        }
-        return pom.substring(0, profileStart) + pom.substring(profileEnd);
     }
 
     private static String normalizeJavasePom(String pom) {

--- a/scripts/initializr/common/src/test/java/com/codename1/initializr/model/GeneratorModelMatrixTest.java
+++ b/scripts/initializr/common/src/test/java/com/codename1/initializr/model/GeneratorModelMatrixTest.java
@@ -176,16 +176,13 @@ public class GeneratorModelMatrixTest extends AbstractTest {
         assertContains(claudeStub, ".agent-skills/codename-one/SKILL.md",
                 "Claude stub should redirect to the canonical skill content");
 
-        // Java 17 projects no longer ship the legacy UWP/Windows native module.
-        // Both the win/ source tree and the <profile id="win"> block in the root pom
-        // should be absent.
-        for (String path : entries.keySet()) {
-            assertFalse(path.startsWith("win/") || path.startsWith("win\\"),
-                    "Java 17 projects should not bundle the win/ module — found: " + path);
-        }
+        // The win/ module is the native win32 target (not the retired UWP module),
+        // so Java 17 projects ship it just like Java 8 projects do.
+        assertNotNull(entries.get("win/pom.xml"),
+                "Java 17 projects should bundle the win32 (win/) module");
         String rootPom = getText(entries, "pom.xml");
-        assertFalse(rootPom.indexOf("<id>win</id>") >= 0,
-                "Java 17 root pom should not contain the Windows-module activation profile");
+        assertContains(rootPom, "<id>win</id>",
+                "Java 17 root pom should retain the win32 module activation profile");
     }
 
     private void validateLegacyJava8Generation() throws Exception {
@@ -220,12 +217,12 @@ public class GeneratorModelMatrixTest extends AbstractTest {
         assertNull(entries.get("AGENTS.md"),
                 "Java 8 projects should not bundle the AGENTS.md root pointer (Java 17-only)");
 
-        // Legacy Java 8 projects keep the win/ module — only Java 17 projects drop it.
+        // Both Java 8 and Java 17 projects ship the native win32 (win/) module.
         assertNotNull(entries.get("win/pom.xml"),
-                "Legacy Java 8 projects should retain the win/ module");
+                "Java 8 projects should retain the win32 (win/) module");
         String rootPom = getText(entries, "pom.xml");
         assertContains(rootPom, "<id>win</id>",
-                "Legacy Java 8 root pom should retain the Windows-module activation profile");
+                "Java 8 root pom should retain the win32 module activation profile");
     }
 
     private void validateJava17DefaultRegressionFixes() throws Exception {
@@ -296,6 +293,8 @@ public class GeneratorModelMatrixTest extends AbstractTest {
         }
         String themeCss = getText(entries, "common/src/main/css/theme.css");
         assertContains(themeCss, "useLargerTextScaleBool: true;", "Barebones templates should default useLargerTextScaleBool to true");
+        assertContains(themeCss, "@media (prefers-color-scheme: dark)", "Default theme should adapt to dark mode out of the box");
+        assertFalse(themeCss.indexOf("Initializr Theme Overrides") >= 0, "Default theme must not carry baked-in top-level theme overrides");
     }
 
     private static byte[] createProjectZip(IDE ide, Template template, String appName, String packageName) throws IOException {


### PR DESCRIPTION
Fixes three problems reported for projects downloaded from initializr / generated via the `cn1app-archetype`.

## 1. Missing `win/` folder — keep the win32 native module
`win/` is now the **native win32 target** (`platform=win`, `buildTarget=windows-device`, built by `WindowsNativeBuilder`), not the retired UWP module. The generator was still stripping `win/` and its root-pom `<profile id="win">` for Java 17, with stale "retired UWP" comments.

- `GeneratorModel.java` (initializr server): dropped the `dropWindowsModule` zip filter and the pom `<profile id="win">` strip; removed the now-dead `stripWindowsModuleProfile` method.
- `archetype-post-generate.groovy` (local `mvn archetype:generate`): removed the `win/` deletion + profile strip and its mirror method. Java-8 `.claude/` stripping preserved.
- `GeneratorModelMatrixTest`: Java 17 now asserts `win/` **ships** (was asserting it must be absent); Java 8 comment updated.
- `win/pom.xml`: fixed copy-paste build execution id `build-android` -> `build-windows`.

The win module ships for **every** Java version now and is activated via the `win` profile (`-Dcodename1.platform=win`).

## 2. "Initializr Theme Overrides" broke light mode — ship a dual-mode default
The UI no longer exposes a theme picker, but `currentOptions()` still derived the generated theme from the website's host dark-mode flag, emitting hard-coded dark colors at top-level CSS scope that broke light mode for anyone who opened the project.

- `Initializr.java`: generation always ships the barebones default (no host dark/light state baked in).
- `theme.css`: replaced the commented-out example with an active `@media (prefers-color-scheme: dark)` block, so the default theme adapts to both light and dark out of the box.

## 3. Missing desktop/native build targets in the IDE
- IntelliJ `workspace.xml`: added **Linux Desktop Build**, **Linux Device Build**, and **Windows Device Build** (win32), each registered in the RunManager `<list>` (the list entry is what makes a config appear).
- NetBeans `nb-configuration.xml`: added **Linux Desktop App** (it already had the win32 **Windows Device App**).

## Verification
- initializr CN1 test suite passes **6/6** (`./mvnw -pl javase -am test -Ptest -Dcodename1.platform=javase -DfailIfNoTests=false`), including `GeneratorModelMatrixTest` asserting `win/` ships for Java 17 and the dual-mode default theme.
- `workspace.xml` and `nb-configuration.xml` pass `xmllint`; groovy is brace-balanced with no dangling `win`/strip references.

## Rollout
These live in the initializr server, the `cn1app-archetype` artifact, and the `codenameone-maven-plugin` artifact — they take effect for new downloads once those are republished/redeployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)