### PR TITLE
Initializr: fix white box behind generate-button icon; shift button clear of Crisp launcher

### DIFF
--- a/scripts/initializr/android/src/main/java/com/codename1/initializr/WebsiteThemeNativeImpl.java
+++ b/scripts/initializr/android/src/main/java/com/codename1/initializr/WebsiteThemeNativeImpl.java
@@ -9,4 +9,8 @@ public class WebsiteThemeNativeImpl {
         return false;
     }
     public void notifyUiReady() {}
+
+    public int chatLauncherClearance() {
+        return 0;
+    }
 }

--- a/scripts/initializr/common/src/main/java/com/codename1/initializr/Initializr.java
+++ b/scripts/initializr/common/src/main/java/com/codename1/initializr/Initializr.java
@@ -29,6 +29,7 @@ import com.codename1.ui.events.ActionListener;
 import com.codename1.ui.layouts.BorderLayout;
 import com.codename1.ui.layouts.BoxLayout;
 import com.codename1.ui.layouts.GridLayout;
+import com.codename1.ui.plaf.Style;
 import com.codename1.ui.util.UITimer;
 import com.codename1.util.StringUtil;
 
@@ -43,6 +44,15 @@ public class Initializr extends Lifecycle {
      *  the exact form they triggered (the simulator's app-under-test lifecycle
      *  keeps an earlier form "current", so getCurrent() is not reliable in-test). */
     static Form lastBuiltForm;
+
+    /** The primary "Generate Project" button. Held so the website-theme poll can
+     *  nudge it left when the host page's Crisp chat launcher would cover it. */
+    private Button generateButton;
+
+    /** Last chat-launcher clearance (pixels) applied to the generate button's
+     *  right margin. -1 forces the next poll to (re)apply it, e.g. after a theme
+     *  refresh reloads the button style and drops the margin override. */
+    private int lastChatClearance = -1;
 
     // UIIDs that have a "...Dark" variant in theme.css. Used to re-skin the whole
     // tree when the host website / system switches between light and dark.
@@ -153,8 +163,13 @@ public class Initializr extends Lifecycle {
 
         // ----- generate bar -----
         final Button generateButton = new Button("Generate Project");
-        FontImage.setMaterialIcon(generateButton, FontImage.MATERIAL_DOWNLOAD);
         generateButton.setUIID("InitializrPrimaryButton");
+        // Derive the icon AFTER the UIID is applied. setMaterialIcon bakes the
+        // component's current background into the FontImage; doing it while the
+        // button still carried the default Button style is what painted a white
+        // box behind the download glyph.
+        FontImage.setMaterialIcon(generateButton, FontImage.MATERIAL_DOWNLOAD);
+        this.generateButton = generateButton;
         generateButton.addActionListener(e -> {
             if (!validateInputs(appNameField, packageField)) {
                 updateValidationErrorLabels(appNameField, packageField, appNameError, packageError);
@@ -549,7 +564,24 @@ public class Initializr extends Lifecycle {
             if (nowDark != darkMode) {
                 applyDarkMode(form, nowDark);
             }
+            applyChatLauncherClearance(form, websiteThemeNative.chatLauncherClearance());
         });
+    }
+
+    // The Crisp chat launcher floats over the bottom-right of the host page,
+    // directly on top of the generate button. The website reports how many
+    // pixels of horizontal clearance the launcher needs (0 when it is hidden);
+    // we add that as a right margin so the button slides left, clear of it. The
+    // JS port works in CSS pixels, so the reported value maps 1:1.
+    private void applyChatLauncherClearance(Form form, int clearancePx) {
+        if (generateButton == null || clearancePx < 0 || clearancePx == lastChatClearance) {
+            return;
+        }
+        lastChatClearance = clearancePx;
+        Style all = generateButton.getAllStyles();
+        all.setMarginUnitRight(Style.UNIT_TYPE_PIXELS);
+        all.setMarginRight(clearancePx);
+        form.revalidate();
     }
 
     private void applyDarkMode(Form form, boolean dark) {
@@ -564,6 +596,9 @@ public class Initializr extends Lifecycle {
         }
         applyTheme(form, dark);
         form.refreshTheme();
+        // refreshTheme reloads the button style from the theme, dropping the
+        // chat-launcher margin override; force the next poll to reapply it.
+        lastChatClearance = -1;
     }
 
     private void applyTheme(Component component, boolean dark) {

--- a/scripts/initializr/common/src/main/java/com/codename1/initializr/WebsiteThemeNative.java
+++ b/scripts/initializr/common/src/main/java/com/codename1/initializr/WebsiteThemeNative.java
@@ -5,4 +5,10 @@ import com.codename1.system.NativeInterface;
 public interface WebsiteThemeNative extends NativeInterface {
     boolean isDarkMode();
     void notifyUiReady();
+
+    /// Horizontal clearance, in CSS pixels, that the host page's chat launcher
+    /// (Crisp) currently needs at the bottom-right, or 0 when it is hidden. The
+    /// generate button is shifted left by this amount so the launcher does not
+    /// cover it.
+    int chatLauncherClearance();
 }

--- a/scripts/initializr/javascript/src/main/javascript/com_codename1_initializr_WebsiteThemeNative.js
+++ b/scripts/initializr/javascript/src/main/javascript/com_codename1_initializr_WebsiteThemeNative.js
@@ -89,6 +89,35 @@ var o = {};
         }
     };
 
+    // Horizontal clearance (CSS px) the host page's Crisp chat launcher needs at
+    // the bottom-right, so the generate button can be nudged left of it. The
+    // default Crisp launcher bubble (~64px) sits ~24px from the page edge;
+    // CHAT_CLEARANCE_PX reserves enough to clear it with a small visual gap.
+    var CHAT_CLEARANCE_PX = 96;
+
+    function chatLauncherVisible() {
+        try {
+            var parentWindow = (window.parent && window.parent !== window) ? window.parent : window;
+            var doc = parentWindow.document;
+            var client = doc ? doc.querySelector(".crisp-client") : null;
+            if (!client) {
+                return false;
+            }
+            var cs = parentWindow.getComputedStyle ? parentWindow.getComputedStyle(client) : null;
+            if (cs && (cs.display === "none" || cs.visibility === "hidden" || parseFloat(cs.opacity || "1") === 0)) {
+                return false;
+            }
+            return true;
+        } catch (ignored) {
+            // Cross-origin / sandbox / missing widget: reserve nothing.
+            return false;
+        }
+    }
+
+    o.chatLauncherClearance_ = function(callback) {
+        callback.complete(chatLauncherVisible() ? CHAT_CLEARANCE_PX : 0);
+    };
+
     o.isSupported_ = function(callback) {
         callback.complete(true);
     };

--- a/scripts/initializr/javase/src/main/java/com/codename1/initializr/WebsiteThemeNativeImpl.java
+++ b/scripts/initializr/javase/src/main/java/com/codename1/initializr/WebsiteThemeNativeImpl.java
@@ -10,4 +10,8 @@ public class WebsiteThemeNativeImpl implements com.codename1.initializr.WebsiteT
     }
     public void notifyUiReady() {}
 
+    public int chatLauncherClearance() {
+        return 0;
+    }
+
 }


### PR DESCRIPTION
## Problem

Two issues on the [start.codenameone.com](https://start.codenameone.com) Initializr "Generate Project" button:

1. **White box behind the download icon.** The icon was set *before* the `InitializrPrimaryButton` UIID was applied. `FontImage.create()` bakes the component's current background into the glyph image (`FontImage.java:7643-7644`, painted at `:7781`), so it captured the default `Button` style's opaque white background and drew a white box behind the glyph.
2. **Button obscured by the Crisp chat launcher.** The button sits at the bottom-right of the iframe; Crisp's bubble floats over the bottom-right of the host page, directly on top of it.

## Fix

**Icon** — derive the icon *after* `setUIID(...)` so it captures the lime primary-button background. This matches the existing order used for the hero pill dot (`Initializr.java:251-252`); the generate button was the lone anomaly. The icon box now blends into the button instead of showing white.

**Crisp shift** — reuse the existing website↔iframe native bridge (which already polls dark-mode every 900ms):

- `WebsiteThemeNative.chatLauncherClearance()` — new method returning the horizontal clearance (CSS px) the Crisp launcher needs, `0` when hidden. The JS impl reports `96` when a visible `.crisp-client` exists in the parent document (the launcher's standard footprint), `0` when it is hidden or consent was declined. The javase/android impls return `0`.
- `Initializr.applyChatLauncherClearance()` — applies that as a right margin on the button so it slides left, clear of the bubble. The JS port works in CSS pixels (`overridePixelRatio = 1`), so the reported value maps 1:1. It only relayouts on change, and `applyDarkMode` resets the cache so a theme refresh re-applies the margin.

## Verification

- Compiled the full `common` source tree + the javase impl (against the fresh interface) + the android impl with JDK 8 against the `8.0-SNAPSHOT` core — no errors.
- `node --check` passes on the JS native.
- `callback.complete(<number>)` int-return convention confirmed against the existing `StatusBarTapDiagnosticNative.js:10` precedent.

Note: I did not run the full ParparVM JS site build (heavy). The 96px clearance is a bounded constant sized to Crisp's default launcher; happy to tune it after an in-browser build if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)