### PR TITLE
Fix StackOverflowError from re-entrant ScrollListener (#5305)

### DIFF
--- a/CodenameOne/src/com/codename1/components/StickyHeaderContainer.java
+++ b/CodenameOne/src/com/codename1/components/StickyHeaderContainer.java
@@ -156,14 +156,12 @@ public class StickyHeaderContainer extends Container {
         scroller.addScrollListener(new ScrollListener() {
             @Override
             public void scrollChanged(int scrollX, int scrollY, int oldscrollX, int oldscrollY) {
-                // The ScrollContainer fires this event before its
-                // internal scrollY field is updated, so reading it back
-                // via getScrollY() returns the previous value. Drive the
-                // recompute off the new scroll position the listener was
-                // handed: a single multi-pixel drag/momentum step that
-                // crosses the push window otherwise sees pushOffset stuck
-                // at 0 and the rising header appears to slide *under* the
-                // pinned header instead of pushing it out.
+                // Drive the recompute off the new scroll position the
+                // listener was handed rather than re-reading getScrollY():
+                // a single multi-pixel drag/momentum step that crosses the
+                // push window otherwise risks seeing pushOffset stuck at 0
+                // and the rising header appears to slide *under* the pinned
+                // header instead of pushing it out.
                 updateSticky(scrollY);
             }
         });
@@ -468,10 +466,9 @@ public class StickyHeaderContainer extends Container {
         boolean activationChanged = (newActive != activeIndex);
         if (activationChanged) {
             applyActivation(newActive);
-            // Don't re-read scroller.getScrollY() here: when invoked
-            // from the ScrollListener, the scroller hasn't yet updated
-            // its internal scrollY field, so getScrollY() would return
-            // the stale value and undo the parameter we were handed.
+            // Drive everything off the sy parameter we were handed rather
+            // than re-reading scroller.getScrollY(), so the computation is
+            // identical whether invoked from the ScrollListener or directly.
         }
 
         int newPush = computePushOffset(sy);

--- a/CodenameOne/src/com/codename1/ui/Component.java
+++ b/CodenameOne/src/com/codename1/ui/Component.java
@@ -3590,10 +3590,14 @@ public class Component implements Animation, StyleListener, Editable {
             }
             repaint();
         }
-        if (scrollListeners != null) {
-            scrollListeners.fireScrollEvent(scrollXtmp, this.scrollY, this.scrollX, this.scrollY);
-        }
+        // See setScrollY: update the field before notifying listeners and skip the
+        // event when the clamped value didn't change, so a listener that scrolls the
+        // component back into view can't recurse infinitely (issue #5305).
+        int oldScrollX = this.scrollX;
         this.scrollX = scrollXtmp;
+        if (scrollListeners != null && oldScrollX != scrollXtmp) {
+            scrollListeners.fireScrollEvent(scrollXtmp, this.scrollY, oldScrollX, this.scrollY);
+        }
         onScrollX(scrollX);
     }
 
@@ -3640,10 +3644,18 @@ public class Component implements Animation, StyleListener, Editable {
             }
             repaint();
         }
-        if (scrollListeners != null) {
-            scrollListeners.fireScrollEvent(this.scrollX, scrollYtmp, this.scrollX, this.scrollY);
-        }
+        // Update the field *before* notifying listeners and only notify when the
+        // (clamped) value actually changed. A listener that reacts by scrolling the
+        // same component back into view (e.g. via scrollComponentToVisible) reads
+        // getScrollY() during its callback; if the field were still stale it would
+        // recompute the same target and re-fire forever, overflowing the stack
+        // (issue #5305). Suppressing the no-op event also lets such a listener
+        // terminate once the position has settled.
+        int oldScrollY = this.scrollY;
         this.scrollY = scrollYtmp;
+        if (scrollListeners != null && oldScrollY != scrollYtmp) {
+            scrollListeners.fireScrollEvent(this.scrollX, scrollYtmp, this.scrollX, oldScrollY);
+        }
         onScrollY(this.scrollY);
     }
 

--- a/maven/core-unittests/src/test/java/com/codename1/ui/ScrollListenerReentrancyTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/ScrollListenerReentrancyTest.java
@@ -1,0 +1,182 @@
+package com.codename1.ui;
+
+import com.codename1.junit.EdtTest;
+import com.codename1.junit.FormTest;
+import com.codename1.junit.UITestBase;
+import com.codename1.ui.events.ScrollListener;
+import com.codename1.ui.geom.Dimension;
+import com.codename1.ui.layouts.BorderLayout;
+import com.codename1.ui.layouts.BoxLayout;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/// Regression tests for issue #5305: a {@link ScrollListener} that reacts to a
+/// scroll by scrolling the same component back into view (e.g. via
+/// {@link Container#scrollComponentToVisible}) used to recurse infinitely and
+/// throw a {@link StackOverflowError}.
+///
+/// The fix in {@link Component#setScrollY(int)} / {@link Component#setScrollX(int)}
+/// does two things:
+///   1. updates the {@code scrollX}/{@code scrollY} field *before* notifying
+///      listeners, so a listener reading {@code getScrollY()} during its callback
+///      sees the new position and stops recomputing the same target; and
+///   2. only fires the scroll event when the (clamped) value actually changed,
+///      so once the position settles the listener is no longer re-invoked.
+///
+/// This class lives in the {@code com.codename1.ui} package so it can drive the
+/// protected {@code setScrollX}/{@code setScrollY} setters directly.
+class ScrollListenerReentrancyTest extends UITestBase {
+
+    /// A bare container with smooth scrolling + tensile drag enabled skips the
+    /// clamp block in the setters, giving deterministic scroll values without
+    /// needing a laid-out, scrollable viewport.
+    private static Container unclampedContainer() {
+        // make sure no earlier test left the global smooth-scroll kill switch on
+        Component.setDisableSmoothScrolling(false);
+        Container c = new Container();
+        c.setSmoothScrolling(true);
+        c.setTensileDragEnabled(true);
+        return c;
+    }
+
+    @EdtTest
+    void testNoEventFiredWhenScrollYDoesNotChange() {
+        Container c = unclampedContainer();
+        int[] count = {0};
+        c.addScrollListener((sx, sy, osx, osy) -> count[0]++);
+
+        // already at 0 -> must not fire
+        c.setScrollY(0);
+        assertEquals(0, count[0], "setScrollY to the current value must not fire an event");
+
+        // real change -> fires once with the new value
+        c.setScrollY(50);
+        assertEquals(1, count[0], "a real scroll change must fire exactly once");
+        assertEquals(50, c.getScrollY());
+
+        // repeat with same value -> suppressed (this is the loop-breaker for #5305)
+        c.setScrollY(50);
+        assertEquals(1, count[0], "repeating the same scrollY must not fire again");
+
+        // another real change -> fires again
+        c.setScrollY(0);
+        assertEquals(2, count[0], "scrolling back to a different value must fire");
+        assertEquals(0, c.getScrollY());
+    }
+
+    @EdtTest
+    void testNoEventFiredWhenScrollXDoesNotChange() {
+        Container c = unclampedContainer();
+        int[] count = {0};
+        c.addScrollListener((sx, sy, osx, osy) -> count[0]++);
+
+        c.setScrollX(0);
+        assertEquals(0, count[0], "setScrollX to the current value must not fire an event");
+
+        c.setScrollX(30);
+        assertEquals(1, count[0]);
+        assertEquals(30, c.getScrollX());
+
+        c.setScrollX(30);
+        assertEquals(1, count[0], "repeating the same scrollX must not fire again");
+
+        c.setScrollX(0);
+        assertEquals(2, count[0]);
+    }
+
+    /// The scroll field must already hold the new value while the listener runs,
+    /// otherwise a listener reading {@code getScrollY()} (as scrollComponentToVisible
+    /// does) would see a stale value and recompute the same target forever.
+    @EdtTest
+    void testScrollFieldUpdatedBeforeListenerRuns() {
+        Container c = unclampedContainer();
+        int[] observed = {-1};
+        c.addScrollListener((sx, sy, osx, osy) -> observed[0] = c.getScrollY());
+
+        c.setScrollY(77);
+        assertEquals(77, observed[0],
+                "getScrollY() inside the listener must return the new position, not the old one");
+    }
+
+    /// Faithful reproduction of the reported pattern using only the setter: a
+    /// listener that pins the component to a fixed scroll offset whenever the
+    /// component reports a different position. Before the fix this recursed until
+    /// the stack overflowed; now it converges after a single correction.
+    @EdtTest
+    void testReentrantPinningListenerConverges() {
+        Container c = unclampedContainer();
+        final int pin = 50;
+        int[] count = {0};
+        c.addScrollListener((sx, sy, osx, osy) -> {
+            count[0]++;
+            if (count[0] > 100) {
+                throw new IllegalStateException("runaway scroll recursion (#5305 regressed)");
+            }
+            // react to the component's OWN reported position, exactly like
+            // scrollComponentToVisible does via getScrollY()
+            if (c.getScrollY() != pin) {
+                c.setScrollY(pin);
+            }
+        });
+
+        c.setScrollY(200);
+
+        assertEquals(pin, c.getScrollY(), "listener should have pinned the scroll position");
+        assertTrue(count[0] <= 3,
+                "a pinning listener must converge, not recurse (callbacks=" + count[0] + ")");
+    }
+
+    /// End-to-end reproduction through the exact API chain from the issue's stack
+    /// trace: scrollComponentToVisible -> scrollRectToVisible -> setScrollY. Smooth
+    /// scrolling is disabled so the scroll happens synchronously (as in the report)
+    /// rather than being deferred to the animation thread.
+    @FormTest
+    void testScrollComponentToVisibleListenerDoesNotOverflow() {
+        Form form = Display.getInstance().getCurrent();
+        form.setLayout(new BorderLayout());
+
+        Container scrollable = new Container(new BoxLayout(BoxLayout.Y_AXIS));
+        scrollable.setScrollableY(true);
+        scrollable.setSmoothScrolling(false);
+
+        Component target = null;
+        for (int i = 0; i < 30; i++) {
+            Button b = new Button("Item " + i);
+            b.setPreferredSize(new Dimension(200, 100));
+            scrollable.add(b);
+            if (i == 25) {
+                target = b;
+            }
+        }
+        final Component pinned = target;
+
+        form.add(BorderLayout.CENTER, scrollable);
+        form.revalidate();
+
+        // precondition: the content must actually overflow the viewport, otherwise
+        // there is nothing to scroll and the test would pass vacuously.
+        assertTrue(scrollable.getScrollDimension().getHeight() > scrollable.getHeight(),
+                "precondition: container must be scrollable (content taller than viewport)");
+
+        int[] count = {0};
+        scrollable.addScrollListener((sx, sy, osx, osy) -> {
+            count[0]++;
+            if (count[0] > 200) {
+                throw new IllegalStateException("runaway scroll recursion (#5305 regressed)");
+            }
+            // the tutorial use case: keep the highlighted component in view on
+            // every scroll event
+            scrollable.scrollComponentToVisible(pinned);
+        });
+
+        // bring the target into view (fires the listener, which re-pins it)
+        scrollable.scrollComponentToVisible(pinned);
+        // then jump back to the top so the listener has to drag it into view again
+        scrollable.setScrollY(0);
+
+        assertTrue(count[0] < 50,
+                "scrollComponentToVisible listener must converge (callbacks=" + count[0] + ")");
+        assertTrue(scrollable.getScrollY() > 0,
+                "the target should have been scrolled back into view");
+    }
+}


### PR DESCRIPTION
## Problem

Issue #5305: a `ScrollListener` that reacts to a scroll by scrolling the same component back into view — the common "keep this component visible" pattern, e.g. a tutorial overlay re-pinning a highlighted component — recursed infinitely and threw a `StackOverflowError`:

```
at com_codename1_ui_Component.setScrollY:3644
at com_codename1_ui_Component.scrollRectToVisible:7488
at com_codename1_ui_Container.scrollComponentToVisible:2714
at <app>.scrollChanged                      <-- user listener
at com_codename1_ui_util_EventDispatcher.fireScrollSync:295
at com_codename1_ui_Component.setScrollY:3644
... repeats forever
```

## Root cause

Two issues in `Component.setScrollX` / `setScrollY` combined:

1. **The scroll event fired unconditionally**, even when the (clamped) scroll position did not actually change. A listener that re-pins the scroll position kept being re-invoked forever.
2. **The `scrollX`/`scrollY` field was updated *after* the event was dispatched.** During synchronous re-entrant dispatch, a listener reading `getScrollY()` (which is exactly what `scrollComponentToVisible` does) saw the *stale* value and recomputed the same target — so guarding on change alone could not break the loop.

## Fix

Update the field **before** notifying listeners, and only fire the event when the clamped value actually changed. A re-pinning listener now sees the new position during its callback and converges after a single correction instead of recursing. The event parameters (new/old x/y) are byte-for-byte unchanged.

I reviewed the tensile/over-drag and momentum code: per-frame tensile/bounce-back events are fired directly in `animate()` (not through `setScrollY`), so they are unaffected. All internal `ScrollListener`s (`Toolbar`, `AnimationManager`, `Spinner3D`, `Validator`, `StickyHeaderContainer`) drive off the event *parameters* rather than `getScrollY()` on the firing component, so the reorder is safe; `StickyHeaderContainer`'s now-inaccurate comments are updated.

## Tests

`ScrollListenerReentrancyTest` (new) covers:
- no-op scroll event suppression for both axes,
- the field-updated-before-dispatch invariant,
- a re-pinning listener converging instead of recursing,
- the end-to-end `scrollComponentToVisible -> scrollRectToVisible -> setScrollY` chain from the report.

All five tests **fail on the previous code** (3 assertion failures for spurious no-op events + the reproduced runaway recursion) and pass with the fix. The full scroll/drag-adjacent suite (187 tests incl. `StickyHeaderContainerTest`, `ScrollableAlwaysTensileTest`, `InteractiveScrollbarTest`, `DragEventsTest`, `ToolbarTest`, `SwipeableContainerTest`) stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)