### PR TITLE
Fix NPE in JavaSEPort.editString when switching editable fields (#5304)

### DIFF
--- a/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
@@ -8772,19 +8772,25 @@ public class JavaSEPort extends CodenameOneImplementation {
             editStringLegacy(cmp, maxSize, constraint, text, keyCode);
             return;
         }
-        if (editingInProgress != null) {
+        // Snapshot the field into a local: editingInProgress is read on the CN1 EDT
+        // here but nulled on the AWT event dispatch thread when the previous native
+        // edit completes (focusLost/done). Without the snapshot the field can turn
+        // null between the check and the dereferences below, causing an NPE when
+        // quickly switching between editable fields (issue #5304).
+        final EditingInProgress currentEditing = editingInProgress;
+        if (currentEditing != null) {
             final String fText = text;
-            editingInProgress.invokeAfter(new Runnable() {
+            currentEditing.invokeAfter(new Runnable() {
                 public void run() {
                     CN.callSerially(new Runnable() {
                         public void run() {
                             editString(cmp, maxSize, constraint, fText, keyCode);
                         }
                     });
-                    
+
                 }
             });
-            editingInProgress.endEditing();
+            currentEditing.endEditing();
             return;
         }
         //a workaround to fix an issue where the previous Text Component wasn't removed properly. 


### PR DESCRIPTION
Fixes #5304.

## Root cause

The reported crash is a check-then-use thread race in the simulator:

```
java.lang.NullPointerException
	at com.codename1.impl.javase.JavaSEPort.editString(JavaSEPort.java:8703)
	at com.codename1.impl.CodenameOneImplementation.editStringImpl(...)
	...
	at com.codename1.ui.TextArea.pointerReleased(TextArea.java:893)
```

In 7.0.251, the failing line is `editingInProgress.endEditing();` inside:

```java
if (editingInProgress != null) {          // check  (CN1 EDT)
    editingInProgress.invokeAfter(...);
    editingInProgress.endEditing();        // use -> NPE  (CN1 EDT)
    return;
}
```

`editingInProgress` is an unsynchronized field touched from two threads:

- **read** in `editString` on the **Codename One EDT** (`pointerReleased -> editString`);
- **set to `null`** in the edit `Listener.actionPerformed()` on the **AWT event dispatch thread**, which finalizes the previous native edit (reached via `focusLost` / done / key handling).

When the user taps a *different* editable field while one is already being edited, the tap pulls focus off the old Swing component. The AWT thread then nulls `editingInProgress` in the window between the null-check and the dereference, producing an intermittent `NullPointerException`. It is simulator-only (`JavaSEPort`) and matches the reporter's inability to pin a clean trigger.

## Fix

Snapshot the field into a local before the null-check so the checked value and the dereferenced value are the same reference:

```java
final EditingInProgress currentEditing = editingInProgress;
if (currentEditing != null) {
    currentEditing.invokeAfter(...);
    currentEditing.endEditing();
    return;
}
```

`endEditing()` -> `actionPerformed()` is already idempotent (guarded by the `performed` flag), so acting on a listener that just completed is harmless. If the field is already null, the method falls through and edits the new field directly.

## Testing

Change is a local-variable extraction with no behavioral change on the non-racing path; `EditingInProgress` is the field's declared type in the same class. The race window is timing-dependent and only manifests in the desktop simulator.