### PR TITLE
Add device input and form-factor APIs (pointer detail, mouse buttons, wheel, stylus, foldables)

### DIFF
--- a/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
+++ b/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
@@ -2872,6 +2872,141 @@ public abstract class CodenameOneImplementation {
         return false;
     }
 
+    // -----------------------------------------------------------------------------------------
+    // Rich pointer metadata. Platform ports populate these fields from the native event right
+    // before they call one of the pointerPressed/Dragged/Released/Hover methods. The framework
+    // reads the current values when it dispatches the matching event, mirroring the way the
+    // modifier-key state above is exposed. Every value carries a safe default so ports that do
+    // not opt in keep behaving exactly as before.
+    private int currentPointerButton = com.codename1.ui.events.PointerEvent.BUTTON_PRIMARY;
+    private int currentPointerButtonMask = com.codename1.ui.events.PointerEvent.MASK_PRIMARY;
+    private int currentPointerType = com.codename1.ui.events.PointerEvent.TYPE_UNKNOWN;
+    private float currentPointerPressure = 1f;
+    private float currentPointerTiltX;
+    private float currentPointerTiltY;
+    private float currentPointerContactSize;
+    private int currentPointerModifiers;
+    private boolean currentPointerHovering;
+
+    /// Resets the rich pointer metadata back to its defaults. Ports may call this between
+    /// gestures so stale button or pressure values do not leak into unrelated events.
+    public void resetPointerEventMetadata() {
+        currentPointerButton = com.codename1.ui.events.PointerEvent.BUTTON_PRIMARY;
+        currentPointerButtonMask = com.codename1.ui.events.PointerEvent.MASK_PRIMARY;
+        currentPointerType = com.codename1.ui.events.PointerEvent.TYPE_UNKNOWN;
+        currentPointerPressure = 1f;
+        currentPointerTiltX = 0;
+        currentPointerTiltY = 0;
+        currentPointerContactSize = 0;
+        currentPointerModifiers = 0;
+        currentPointerHovering = false;
+    }
+
+    /// Populates all of the rich pointer metadata in one call. Platform ports invoke this from
+    /// their native input handler immediately before dispatching a pointer event.
+    public void setPointerEventMetadata(int button, int buttonMask, int pointerType, float pressure,
+            float tiltX, float tiltY, float contactSize, int modifiers, boolean hovering) {
+        currentPointerButton = button;
+        currentPointerButtonMask = buttonMask;
+        currentPointerType = pointerType;
+        currentPointerPressure = pressure;
+        currentPointerTiltX = tiltX;
+        currentPointerTiltY = tiltY;
+        currentPointerContactSize = contactSize;
+        currentPointerModifiers = modifiers;
+        currentPointerHovering = hovering;
+    }
+
+    /// Sets the button and button mask for the next dispatched pointer event.
+    public void setPointerButton(int button, int buttonMask) {
+        currentPointerButton = button;
+        currentPointerButtonMask = buttonMask;
+    }
+
+    /// Sets the pointing device type (one of the `PointerEvent.TYPE_*` constants) for the next event.
+    public void setPointerType(int pointerType) {
+        currentPointerType = pointerType;
+    }
+
+    /// Sets the normalized pressure for the next dispatched pointer event.
+    public void setPointerPressure(float pressure) {
+        currentPointerPressure = pressure;
+    }
+
+    /// Sets the stylus tilt for the next dispatched pointer event.
+    public void setPointerTilt(float tiltX, float tiltY) {
+        currentPointerTiltX = tiltX;
+        currentPointerTiltY = tiltY;
+    }
+
+    /// Sets the normalized contact size for the next dispatched pointer event.
+    public void setPointerContactSize(float contactSize) {
+        currentPointerContactSize = contactSize;
+    }
+
+    /// Sets the keyboard modifier mask for the next dispatched pointer event.
+    public void setPointerModifiers(int modifiers) {
+        currentPointerModifiers = modifiers;
+    }
+
+    /// Sets whether the next dispatched pointer event is a hover (no contact).
+    public void setPointerHovering(boolean hovering) {
+        currentPointerHovering = hovering;
+    }
+
+    /// The button associated with the current pointer event, one of the `PointerEvent.BUTTON_*` constants.
+    public int getPointerButton() {
+        return currentPointerButton;
+    }
+
+    /// A bitmask of the buttons currently held, built from the `PointerEvent.MASK_*` constants.
+    public int getPointerButtonMask() {
+        return currentPointerButtonMask;
+    }
+
+    /// The current pointing device type, one of the `PointerEvent.TYPE_*` constants.
+    public int getPointerType() {
+        return currentPointerType;
+    }
+
+    /// The normalized pressure of the current pointer event between `0.0` and `1.0`.
+    public float getPointerPressure() {
+        return currentPointerPressure;
+    }
+
+    /// The stylus tilt across the x axis for the current pointer event, in degrees.
+    public float getPointerTiltX() {
+        return currentPointerTiltX;
+    }
+
+    /// The stylus tilt across the y axis for the current pointer event, in degrees.
+    public float getPointerTiltY() {
+        return currentPointerTiltY;
+    }
+
+    /// The normalized contact size of the current pointer event between `0.0` and `1.0`.
+    public float getPointerContactSize() {
+        return currentPointerContactSize;
+    }
+
+    /// The keyboard modifier mask held during the current pointer event.
+    public int getPointerModifiers() {
+        return currentPointerModifiers;
+    }
+
+    /// True if the current pointer event is a hover (no contact with the surface).
+    public boolean isPointerHovering() {
+        return currentPointerHovering;
+    }
+
+    /// Builds an immutable `PointerEvent` snapshot from the current metadata for the given coordinates.
+    /// Used by the framework when it dispatches a pointer event.
+    public com.codename1.ui.events.PointerEvent buildPointerEvent(int x, int y, boolean hovering) {
+        return new com.codename1.ui.events.PointerEvent(x, y, currentPointerButton, currentPointerButtonMask,
+                currentPointerType, currentPointerPressure, currentPointerTiltX, currentPointerTiltY,
+                currentPointerContactSize, currentPointerModifiers, hovering || currentPointerHovering);
+    }
+
     /// Subclasses should invoke this method, it delegates the event to the display and into
     /// Codename One.
     ///
@@ -5739,6 +5874,65 @@ public abstract class CodenameOneImplementation {
         return b != null && b.isConnected();
     }
 
+    /// True if the device is a foldable or dual screen device. False on the base implementation.
+    public boolean isFoldable() {
+        return false;
+    }
+
+    /// The current fold posture, one of the `com.codename1.ui.DevicePosture` `POSTURE_*` constants.
+    /// Defaults to `POSTURE_UNKNOWN`.
+    public int getDevicePosture() {
+        return com.codename1.ui.DevicePosture.POSTURE_UNKNOWN;
+    }
+
+    /// The current hinge angle in degrees between 0 and 180, or -1 when not reported.
+    public int getHingeAngle() {
+        return -1;
+    }
+
+    /// The orientation of the fold, one of the `com.codename1.ui.DevicePosture` `FOLD_ORIENTATION_*`
+    /// constants. Defaults to `FOLD_ORIENTATION_NONE`.
+    public int getFoldOrientation() {
+        return com.codename1.ui.DevicePosture.FOLD_ORIENTATION_NONE;
+    }
+
+    /// True if the fold currently separates the display into two distinct logical areas.
+    public boolean isPostureSeparating() {
+        return false;
+    }
+
+    /// Returns the bounds of the region occluded by the hinge in display coordinates, or null when
+    /// there is no separating fold.
+    ///
+    /// #### Parameters
+    ///
+    /// - `rect`: a rectangle to populate and return, or null to allocate a new one
+    ///
+    /// #### Returns
+    ///
+    /// the hinge bounds, or null when there is no separating fold
+    public Rectangle getFoldBounds(Rectangle rect) {
+        return null;
+    }
+
+    /// True if the application is currently running in a desktop windowing mode such as Samsung DeX,
+    /// Android desktop windowing or iPad Stage Manager, where the app shares the screen with other
+    /// windows and behaves like a desktop application. Distinct from `#isDesktop()` which reports a
+    /// genuine desktop platform. Defaults to false.
+    public boolean isDesktopMode() {
+        return false;
+    }
+
+    /// The number of displays (monitors or external screens) currently attached. Defaults to 1.
+    public int getDisplayCount() {
+        return 1;
+    }
+
+    /// True if an external or secondary display is currently attached. Defaults to false.
+    public boolean isExternalDisplayConnected() {
+        return getDisplayCount() > 1;
+    }
+
     /// Returns true if the device has dialing capabilities
     ///
     /// #### Returns
@@ -8352,13 +8546,53 @@ public abstract class CodenameOneImplementation {
     /// - `scrollY`: vertical scroll amount in pixels; a positive value reveals
     /// content above, as if the finger were dragged down
     public void pointerWheelMoved(final int x, final int y, final int scrollX, final int scrollY) {
+        pointerWheelMoved(x, y, scrollX, scrollY, false, 0);
+    }
+
+    /// Richer entry point for wheel events that also carries whether the deltas come from a high
+    /// resolution device (a trackpad rather than a notched wheel) and the held keyboard modifiers.
+    /// Ports that can report these should call this overload. The framework first dispatches a
+    /// `com.codename1.ui.events.WheelEvent` to any mouse wheel listeners on the component under the
+    /// cursor; if a listener consumes it the default scrolling gesture is skipped, enabling
+    /// gestures such as control plus wheel to zoom.
+    ///
+    /// #### Parameters
+    ///
+    /// - `x`: pointer x in display coordinates
+    ///
+    /// - `y`: pointer y in display coordinates
+    ///
+    /// - `scrollX`: horizontal scroll amount in pixels; a positive value reveals content to the left
+    ///
+    /// - `scrollY`: vertical scroll amount in pixels; a positive value reveals content above
+    ///
+    /// - `precise`: true if the deltas come from a high resolution device such as a trackpad
+    ///
+    /// - `modifiers`: bitmask of the held keyboard modifiers (the `PointerEvent` `MODIFIER_*` constants)
+    public void pointerWheelMoved(final int x, final int y, final int scrollX, final int scrollY,
+            final boolean precise, final int modifiers) {
         if (scrollX == 0 && scrollY == 0) {
             return;
         }
         final Display d = Display.getInstance();
-        // Quarter the gesture across four EDT cycles: a single press->drag(full)
-        // ->release would read as a fling and overshoot, whereas stepped drags let
-        // the scroll container settle the way a finger drag does.
+        // First give mouse wheel listeners a chance to handle (and consume) the event on the EDT.
+        // Only when no listener consumes it do we fall through to the default scrolling gesture.
+        d.callSerially(new Runnable() {
+            @Override
+            public void run() {
+                if (d.fireMouseWheelEvent(x, y, scrollX, scrollY, precise, modifiers)) {
+                    return;
+                }
+                playWheelScrollGesture(d, x, y, scrollX, scrollY);
+            }
+        });
+    }
+
+    /// Plays the default scroll gesture for a wheel movement. Quarter the gesture across four EDT
+    /// cycles: a single press->drag(full)->release would read as a fling and overshoot, whereas
+    /// stepped drags let the scroll container settle the way a finger drag does. While it runs
+    /// `#isScrollWheeling` reports `true`.
+    private void playWheelScrollGesture(final Display d, final int x, final int y, final int scrollX, final int scrollY) {
         d.callSerially(new Runnable() {
             @Override
             public void run() {

--- a/CodenameOne/src/com/codename1/ui/CN.java
+++ b/CodenameOne/src/com/codename1/ui/CN.java
@@ -924,6 +924,104 @@ public class CN extends CN1Constants {
         return Display.impl.isCarConnected();
     }
 
+    /// Returns a snapshot of the rich detail for the pointer event currently being dispatched such
+    /// as the mouse button, pointer type (finger/mouse/stylus), pressure and stylus tilt.
+    ///
+    /// #### Returns
+    ///
+    /// the current `com.codename1.ui.events.PointerEvent`, never null
+    public static com.codename1.ui.events.PointerEvent getCurrentPointerEvent() {
+        return Display.getInstance().getCurrentPointerEvent();
+    }
+
+    /// The mouse button associated with the current pointer event, one of the
+    /// `com.codename1.ui.events.PointerEvent` `BUTTON_*` constants.
+    public static int getPointerButton() {
+        return Display.impl.getPointerButton();
+    }
+
+    /// A bitmask of the mouse buttons currently held down, built from the
+    /// `com.codename1.ui.events.PointerEvent` `MASK_*` constants.
+    public static int getPressedButtonMask() {
+        return Display.impl.getPointerButtonMask();
+    }
+
+    /// The current pointing device type, one of the `com.codename1.ui.events.PointerEvent` `TYPE_*`
+    /// constants (finger, mouse, stylus or eraser).
+    public static int getPointerType() {
+        return Display.impl.getPointerType();
+    }
+
+    /// The normalized pressure of the current pointer event between `0.0` and `1.0`. Devices and
+    /// ports that do not report pressure return `1.0`.
+    public static float getPointerPressure() {
+        return Display.impl.getPointerPressure();
+    }
+
+    /// The stylus tilt across the x axis of the current pointer event in degrees, or `0` when not reported.
+    public static float getPointerTiltX() {
+        return Display.impl.getPointerTiltX();
+    }
+
+    /// The stylus tilt across the y axis of the current pointer event in degrees, or `0` when not reported.
+    public static float getPointerTiltY() {
+        return Display.impl.getPointerTiltY();
+    }
+
+    /// The normalized contact size of the current pointer event between `0.0` and `1.0`, or `0` when not reported.
+    public static float getPointerContactSize() {
+        return Display.impl.getPointerContactSize();
+    }
+
+    /// True if the current pointer is a stylus or pen (Apple Pencil, S-Pen and similar).
+    public static boolean isStylusPointer() {
+        return Display.getInstance().isStylusPointer();
+    }
+
+    /// True if the device is a foldable or dual screen device.
+    public static boolean isFoldable() {
+        return Display.impl.isFoldable();
+    }
+
+    /// Returns the live device fold posture. See `com.codename1.ui.DevicePosture`.
+    public static DevicePosture getDevicePosture() {
+        return DevicePosture.getInstance();
+    }
+
+    /// Adds a listener that is notified when the device is folded, unfolded or changes posture.
+    ///
+    /// #### Parameters
+    ///
+    /// - `l`: the listener to add
+    public static void addPostureListener(com.codename1.ui.events.ActionListener l) {
+        Display.getInstance().addPostureListener(l);
+    }
+
+    /// Removes a posture listener.
+    ///
+    /// #### Parameters
+    ///
+    /// - `l`: the listener to remove
+    public static void removePostureListener(com.codename1.ui.events.ActionListener l) {
+        Display.getInstance().removePostureListener(l);
+    }
+
+    /// True if the application is currently running in a desktop windowing mode such as Samsung DeX,
+    /// Android desktop windowing or iPad Stage Manager.
+    public static boolean isDesktopMode() {
+        return Display.impl.isDesktopMode();
+    }
+
+    /// Returns the number of displays (monitors or external screens) currently attached.
+    public static int getDisplayCount() {
+        return Display.impl.getDisplayCount();
+    }
+
+    /// True if an external or secondary display is currently attached.
+    public static boolean isExternalDisplayConnected() {
+        return Display.impl.isExternalDisplayConnected();
+    }
+
     /// Returns the size of the desktop hosting the application window when running on a desktop platform.
     ///
     /// #### Returns

--- a/CodenameOne/src/com/codename1/ui/CN.java
+++ b/CodenameOne/src/com/codename1/ui/CN.java
@@ -993,7 +993,7 @@ public class CN extends CN1Constants {
     /// #### Parameters
     ///
     /// - `l`: the listener to add
-    public static void addPostureListener(com.codename1.ui.events.ActionListener l) {
+    public static void addPostureListener(ActionListener l) {
         Display.getInstance().addPostureListener(l);
     }
 
@@ -1002,7 +1002,7 @@ public class CN extends CN1Constants {
     /// #### Parameters
     ///
     /// - `l`: the listener to remove
-    public static void removePostureListener(com.codename1.ui.events.ActionListener l) {
+    public static void removePostureListener(ActionListener l) {
         Display.getInstance().removePostureListener(l);
     }
 

--- a/CodenameOne/src/com/codename1/ui/Component.java
+++ b/CodenameOne/src/com/codename1/ui/Component.java
@@ -5078,6 +5078,21 @@ public class Component implements Animation, StyleListener, Editable {
         return false;
     }
 
+    /// Invoked when a rotation (twist) gesture occurs over this component, such as a two finger
+    /// trackpad rotation on macOS or a two finger rotate on a touch screen. Override to rotate
+    /// content. Returning true marks the gesture as handled.
+    ///
+    /// #### Parameters
+    ///
+    /// - `radians`: the incremental rotation in radians since the previous callback; positive is clockwise
+    ///
+    /// #### Returns
+    ///
+    /// false by default, true if the rotation is handled
+    protected boolean rotation(float radians) {
+        return false;
+    }
+
     /// returns true if pinch will block drag and drop
     public boolean isPinchBlocksDragAndDrop() {
         return pinchBlocksDragAndDrop;

--- a/CodenameOne/src/com/codename1/ui/Component.java
+++ b/CodenameOne/src/com/codename1/ui/Component.java
@@ -261,6 +261,9 @@ public class Component implements Animation, StyleListener, Editable {
     EventDispatcher pointerDraggedListeners;
     EventDispatcher dragFinishedListeners;
     EventDispatcher longPressListeners;
+    EventDispatcher contextMenuListeners;
+    EventDispatcher mouseWheelListeners;
+    EventDispatcher stylusListeners;
     boolean isUnselectedStyle;
     /// A flag used by `Container#paintElevatedPane(Graphics)` to turn off rendering of elevated components
     /// when rendering the non-elevated pane.
@@ -6451,6 +6454,159 @@ public class Component implements Animation, StyleListener, Editable {
             longPressListeners = new EventDispatcher();
         }
         longPressListeners.addListener(l);
+    }
+
+    /// Adds a listener that is notified when the user requests a context menu on this component.
+    /// A context menu request is triggered by a secondary (right) mouse button click, a stylus
+    /// barrel button click or a long press, giving touch and desktop a single unified callback.
+    /// The delivered `com.codename1.ui.events.ActionEvent` carries the pointer location and, via
+    /// `com.codename1.ui.events.ActionEvent#getPointerEvent()`, the button and pointer type detail.
+    ///
+    /// #### Parameters
+    ///
+    /// - `l`: callback to receive context menu requests
+    public void addContextMenuListener(ActionListener l) {
+        if (contextMenuListeners == null) {
+            contextMenuListeners = new EventDispatcher();
+        }
+        contextMenuListeners.addListener(l);
+    }
+
+    /// Removes a context menu listener.
+    ///
+    /// #### Parameters
+    ///
+    /// - `l`: callback to remove
+    public void removeContextMenuListener(ActionListener l) {
+        if (contextMenuListeners != null) {
+            contextMenuListeners.removeListener(l);
+        }
+    }
+
+    /// Adds a listener that is notified when the mouse wheel (or a trackpad scroll gesture) is
+    /// moved while the pointer is over this component. The delivered event is a
+    /// `com.codename1.ui.events.WheelEvent` exposing the scroll deltas and modifiers. Consuming the
+    /// event with `com.codename1.ui.events.ActionEvent#consume()` prevents the default scrolling
+    /// behavior, which is useful for gestures such as control plus wheel to zoom.
+    ///
+    /// #### Parameters
+    ///
+    /// - `l`: callback to receive wheel events
+    public void addMouseWheelListener(ActionListener l) {
+        if (mouseWheelListeners == null) {
+            mouseWheelListeners = new EventDispatcher();
+        }
+        mouseWheelListeners.addListener(l);
+    }
+
+    /// Removes a mouse wheel listener.
+    ///
+    /// #### Parameters
+    ///
+    /// - `l`: callback to remove
+    public void removeMouseWheelListener(ActionListener l) {
+        if (mouseWheelListeners != null) {
+            mouseWheelListeners.removeListener(l);
+        }
+    }
+
+    /// Adds a listener that is notified for stylus and pen interactions (Apple Pencil, S-Pen,
+    /// Surface Pen and similar) on this component. The listener fires on press, drag and release
+    /// when the pointer type is a stylus or eraser. The delivered event carries the full pointer
+    /// detail via `com.codename1.ui.events.ActionEvent#getPointerEvent()` including pressure and tilt.
+    ///
+    /// #### Parameters
+    ///
+    /// - `l`: callback to receive stylus events
+    public void addStylusListener(ActionListener l) {
+        if (stylusListeners == null) {
+            stylusListeners = new EventDispatcher();
+        }
+        stylusListeners.addListener(l);
+    }
+
+    /// Removes a stylus listener.
+    ///
+    /// #### Parameters
+    ///
+    /// - `l`: callback to remove
+    public void removeStylusListener(ActionListener l) {
+        if (stylusListeners != null) {
+            stylusListeners.removeListener(l);
+        }
+    }
+
+    /// Fires a context menu request to the registered listeners walking up the component hierarchy
+    /// until a listener consumes the event. Returns true if a listener consumed the request.
+    ///
+    /// #### Parameters
+    ///
+    /// - `x`: the pointer x coordinate
+    ///
+    /// - `y`: the pointer y coordinate
+    ///
+    /// #### Returns
+    ///
+    /// true if a listener consumed the context menu request
+    boolean fireContextMenu(int x, int y) {
+        Component c = this;
+        while (c != null) {
+            if (c.contextMenuListeners != null && c.contextMenuListeners.hasListeners()) {
+                ActionEvent ev = new ActionEvent(c, ActionEvent.Type.PointerReleased, x, y);
+                ev.setPointerEvent(Display.impl.buildPointerEvent(x, y, false));
+                c.contextMenuListeners.fireActionEvent(ev);
+                if (ev.isConsumed()) {
+                    return true;
+                }
+            }
+            c = c.getParent();
+        }
+        return false;
+    }
+
+    /// Dispatches a mouse wheel event to the registered listeners walking up the component
+    /// hierarchy until a listener consumes the event. Returns true if a listener consumed it,
+    /// in which case the default scrolling behavior should be skipped.
+    ///
+    /// #### Parameters
+    ///
+    /// - `ev`: the wheel event to dispatch
+    ///
+    /// #### Returns
+    ///
+    /// true if a listener consumed the wheel event
+    boolean fireMouseWheelEvent(com.codename1.ui.events.WheelEvent ev) {
+        Component c = this;
+        while (c != null) {
+            if (c.mouseWheelListeners != null && c.mouseWheelListeners.hasListeners()) {
+                c.mouseWheelListeners.fireActionEvent(ev);
+                if (ev.isConsumed()) {
+                    return true;
+                }
+            }
+            c = c.getParent();
+        }
+        return false;
+    }
+
+    /// Fires a stylus event of the given type when this component (or a parent) has stylus
+    /// listeners and the current pointer is a stylus or eraser.
+    void fireStylusEvent(ActionEvent.Type type, int x, int y) {
+        if (!Display.getInstance().isStylusPointer()) {
+            return;
+        }
+        Component c = this;
+        while (c != null) {
+            if (c.stylusListeners != null && c.stylusListeners.hasListeners()) {
+                ActionEvent ev = new ActionEvent(c, type, x, y);
+                ev.setPointerEvent(Display.impl.buildPointerEvent(x, y, false));
+                c.stylusListeners.fireActionEvent(ev);
+                if (ev.isConsumed()) {
+                    return;
+                }
+            }
+            c = c.getParent();
+        }
     }
 
     /// Invoked to draw the ripple effect overlay in Android where the finger of the user causes a growing

--- a/CodenameOne/src/com/codename1/ui/DevicePosture.java
+++ b/CodenameOne/src/com/codename1/ui/DevicePosture.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores
+ * CA 94065 USA or visit www.oracle.com if you need additional information or
+ * have any questions.
+ */
+package com.codename1.ui;
+
+import com.codename1.ui.geom.Rectangle;
+
+/// Describes the physical fold posture of a foldable or dual screen device such as a Galaxy Fold,
+/// Galaxy Flip, Pixel Fold or Surface Duo.
+///
+/// Obtain the live posture with `DevicePosture#getInstance()`. The returned object reads the
+/// current posture on demand, so a single instance can be kept and queried whenever needed; it is
+/// never null. On devices that are not foldable, or platforms that do not report fold information,
+/// the posture is `POSTURE_UNKNOWN`, `#isFoldable()` is false and `#getFoldBounds(Rectangle)`
+/// returns null.
+///
+/// To be notified when the device is folded, unfolded or changes posture register a listener with
+/// `com.codename1.ui.Display#addPostureListener(com.codename1.ui.events.ActionListener)`.
+///
+/// When the fold separates the screen into two logical areas (book or tabletop posture) the hinge
+/// rectangle returned by `#getFoldBounds(Rectangle)` reports the region the hinge occludes, similar
+/// to the way `com.codename1.ui.Form#getSafeArea()` reports the area obscured by a notch. Lay out
+/// interactive content to avoid that region, or split a master and detail experience across the two
+/// halves.
+public final class DevicePosture {
+
+    /// The posture could not be determined, typically because the device is not foldable.
+    public static final int POSTURE_UNKNOWN = 0;
+
+    /// The device is open and flat (a continuous surface). This is the normal posture of an unfolded
+    /// device and the only posture reported by non-foldable devices that still report fold state.
+    public static final int POSTURE_FLAT = 1;
+
+    /// The device is half opened, forming a laptop, book or tabletop posture with the hinge between
+    /// roughly 30 and 150 degrees.
+    public static final int POSTURE_HALF_OPENED = 2;
+
+    /// The device is folded shut.
+    public static final int POSTURE_CLOSED = 3;
+
+    /// There is no fold separating the display.
+    public static final int FOLD_ORIENTATION_NONE = 0;
+
+    /// The hinge runs vertically, splitting the display into a left and a right half.
+    public static final int FOLD_ORIENTATION_VERTICAL = 1;
+
+    /// The hinge runs horizontally, splitting the display into a top and a bottom half.
+    public static final int FOLD_ORIENTATION_HORIZONTAL = 2;
+
+    private static DevicePosture instance;
+
+    private DevicePosture() {
+    }
+
+    /// Returns the shared device posture instance. The returned object reads live posture data, so
+    /// the same instance reflects the current posture every time it is queried.
+    ///
+    /// #### Returns
+    ///
+    /// the shared device posture, never null
+    public static DevicePosture getInstance() {
+        if (instance == null) {
+            instance = new DevicePosture();
+        }
+        return instance;
+    }
+
+    /// True if the device is a foldable or dual screen device.
+    public boolean isFoldable() {
+        return Display.impl.isFoldable();
+    }
+
+    /// The current posture, one of the `POSTURE_*` constants.
+    public int getPosture() {
+        return Display.impl.getDevicePosture();
+    }
+
+    /// The current hinge angle in degrees between `0` (closed) and `180` (flat), or `-1` when the
+    /// device does not report a hinge angle.
+    public int getHingeAngle() {
+        return Display.impl.getHingeAngle();
+    }
+
+    /// The orientation of the fold, one of the `FOLD_ORIENTATION_*` constants.
+    public int getFoldOrientation() {
+        return Display.impl.getFoldOrientation();
+    }
+
+    /// True if the fold currently separates the display into two distinct logical areas (a book or
+    /// tabletop posture) rather than presenting a single continuous surface.
+    public boolean isSeparating() {
+        return Display.impl.isPostureSeparating();
+    }
+
+    /// True if the device is in a tabletop or book posture (half opened and separating the display).
+    public boolean isTableTop() {
+        return getPosture() == POSTURE_HALF_OPENED && isSeparating();
+    }
+
+    /// Returns the bounds of the region occluded by the hinge in display coordinates, or null when
+    /// there is no separating fold. When the fold is a thin crease the rectangle has zero width or
+    /// height along the hinge.
+    ///
+    /// #### Parameters
+    ///
+    /// - `rect`: a rectangle to populate and return, or null to allocate a new one
+    ///
+    /// #### Returns
+    ///
+    /// the hinge bounds, or null when there is no separating fold
+    public Rectangle getFoldBounds(Rectangle rect) {
+        return Display.impl.getFoldBounds(rect);
+    }
+}

--- a/CodenameOne/src/com/codename1/ui/DevicePosture.java
+++ b/CodenameOne/src/com/codename1/ui/DevicePosture.java
@@ -67,7 +67,7 @@ public final class DevicePosture {
     /// The hinge runs horizontally, splitting the display into a top and a bottom half.
     public static final int FOLD_ORIENTATION_HORIZONTAL = 2;
 
-    private static DevicePosture instance;
+    private static final DevicePosture INSTANCE = new DevicePosture();
 
     private DevicePosture() {
     }
@@ -79,10 +79,7 @@ public final class DevicePosture {
     ///
     /// the shared device posture, never null
     public static DevicePosture getInstance() {
-        if (instance == null) {
-            instance = new DevicePosture();
-        }
-        return instance;
+        return INSTANCE;
     }
 
     /// True if the device is a foldable or dual screen device.

--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -64,6 +64,7 @@ import com.codename1.ui.animations.Transition;
 import com.codename1.ui.events.ActionEvent;
 import com.codename1.ui.events.ActionListener;
 import com.codename1.ui.events.MessageEvent;
+import com.codename1.ui.events.PointerEvent;
 import com.codename1.ui.events.WindowEvent;
 import com.codename1.ui.geom.Dimension;
 import com.codename1.ui.geom.Rectangle;
@@ -289,7 +290,7 @@ public final class Display extends CN1Constants {
     private boolean recursivePointerReleaseB;
     private int pointerX;
     private int pointerY;
-    private com.codename1.ui.events.PointerEvent currentPointerEvent;
+    private PointerEvent currentPointerEvent;
     private boolean keyRepeatCharged;
     private boolean longPressCharged;
     private long longKeyPressTime;
@@ -1979,8 +1980,8 @@ public final class Display extends CN1Constants {
     ///
     /// #### Returns
     ///
-    /// the current `com.codename1.ui.events.PointerEvent`, never null
-    public com.codename1.ui.events.PointerEvent getCurrentPointerEvent() {
+    /// the current `PointerEvent`, never null
+    public PointerEvent getCurrentPointerEvent() {
         if (currentPointerEvent != null) {
             return currentPointerEvent;
         }
@@ -1988,18 +1989,18 @@ public final class Display extends CN1Constants {
     }
 
     /// The mouse button associated with the current pointer event, one of the
-    /// `com.codename1.ui.events.PointerEvent` `BUTTON_*` constants.
+    /// `PointerEvent` `BUTTON_*` constants.
     public int getPointerButton() {
         return impl.getPointerButton();
     }
 
     /// A bitmask of the mouse buttons currently held down, built from the
-    /// `com.codename1.ui.events.PointerEvent` `MASK_*` constants.
+    /// `PointerEvent` `MASK_*` constants.
     public int getPressedButtonMask() {
         return impl.getPointerButtonMask();
     }
 
-    /// The current pointing device type, one of the `com.codename1.ui.events.PointerEvent` `TYPE_*`
+    /// The current pointing device type, one of the `PointerEvent` `TYPE_*`
     /// constants (finger, mouse, stylus or eraser).
     public int getPointerType() {
         return impl.getPointerType();
@@ -2029,8 +2030,8 @@ public final class Display extends CN1Constants {
     /// True if the current pointer is a stylus or pen (Apple Pencil, S-Pen and similar).
     public boolean isStylusPointer() {
         int t = impl.getPointerType();
-        return t == com.codename1.ui.events.PointerEvent.TYPE_STYLUS
-                || t == com.codename1.ui.events.PointerEvent.TYPE_ERASER;
+        return t == PointerEvent.TYPE_STYLUS
+                || t == PointerEvent.TYPE_ERASER;
     }
 
     /// Dispatches a mouse wheel event to the component under the given coordinates. Invoked by the
@@ -4574,6 +4575,7 @@ public final class Display extends CN1Constants {
     public void postureChanged() {
         if (postureListeners != null && postureListeners.hasListeners()) {
             callSerially(new Runnable() {
+                @Override
                 public void run() {
                     postureListeners.fireActionEvent(new ActionEvent(DevicePosture.getInstance(),
                             ActionEvent.Type.PostureChange));

--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -2073,6 +2073,66 @@ public final class Display extends CN1Constants {
         return cmp.fireMouseWheelEvent(we);
     }
 
+    /// Dispatches a magnify (pinch) gesture to the component under the given coordinates, walking up
+    /// the hierarchy until a component handles it. Invoked by the implementation for native
+    /// trackpad / multi touch magnify gestures; routes to `com.codename1.ui.Component#pinch(float)`.
+    ///
+    /// #### Parameters
+    ///
+    /// - `x`: the gesture x position in display pixels
+    ///
+    /// - `y`: the gesture y position in display pixels
+    ///
+    /// - `scale`: the magnification scale, larger than 1 zooms in and smaller than 1 zooms out
+    public void fireMagnifyGesture(int x, int y, float scale) {
+        Form f = getCurrent();
+        if (f == null) {
+            return;
+        }
+        Component cmp;
+        try {
+            cmp = f.getComponentAt(x, y);
+        } catch (Throwable t) {
+            cmp = null;
+        }
+        while (cmp != null) {
+            if (cmp.pinch(scale)) {
+                return;
+            }
+            cmp = cmp.getParent();
+        }
+    }
+
+    /// Dispatches a rotation (twist) gesture to the component under the given coordinates, walking
+    /// up the hierarchy until a component handles it. Invoked by the implementation for native
+    /// trackpad / multi touch rotation gestures; routes to `com.codename1.ui.Component#rotation(float)`.
+    ///
+    /// #### Parameters
+    ///
+    /// - `x`: the gesture x position in display pixels
+    ///
+    /// - `y`: the gesture y position in display pixels
+    ///
+    /// - `radians`: the incremental rotation in radians, positive is clockwise
+    public void fireRotationGesture(int x, int y, float radians) {
+        Form f = getCurrent();
+        if (f == null) {
+            return;
+        }
+        Component cmp;
+        try {
+            cmp = f.getComponentAt(x, y);
+        } catch (Throwable t) {
+            cmp = null;
+        }
+        while (cmp != null) {
+            if (cmp.rotation(radians)) {
+                return;
+            }
+            cmp = cmp.getParent();
+        }
+    }
+
     /// Pushes a key press event with the given keycode into Codename One
     ///
     /// #### Parameters

--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -236,6 +236,7 @@ public final class Display extends CN1Constants {
     private Runnable bookmark;
     private EventDispatcher messageListeners;
     private EventDispatcher windowListeners;
+    private EventDispatcher postureListeners;
     /// Tracks whether the initial window size hint has already been consumed for the first shown form.
     private boolean initialWindowSizeApplied;
     private boolean disableInvokeAndBlock;
@@ -288,6 +289,7 @@ public final class Display extends CN1Constants {
     private boolean recursivePointerReleaseB;
     private int pointerX;
     private int pointerY;
+    private com.codename1.ui.events.PointerEvent currentPointerEvent;
     private boolean keyRepeatCharged;
     private boolean longPressCharged;
     private long longKeyPressTime;
@@ -1969,6 +1971,107 @@ public final class Display extends CN1Constants {
         return impl.isShiftKeyDown();
     }
 
+    /// Returns a snapshot of the rich detail for the pointer event currently being dispatched
+    /// such as the mouse button, pointer type (finger/mouse/stylus), pressure and stylus tilt.
+    ///
+    /// This is most useful when called from within a pointer listener. When no pointer event has
+    /// been dispatched yet a default snapshot at the last known pointer location is returned.
+    ///
+    /// #### Returns
+    ///
+    /// the current `com.codename1.ui.events.PointerEvent`, never null
+    public com.codename1.ui.events.PointerEvent getCurrentPointerEvent() {
+        if (currentPointerEvent != null) {
+            return currentPointerEvent;
+        }
+        return impl.buildPointerEvent(pointerX, pointerY, impl.isPointerHovering());
+    }
+
+    /// The mouse button associated with the current pointer event, one of the
+    /// `com.codename1.ui.events.PointerEvent` `BUTTON_*` constants.
+    public int getPointerButton() {
+        return impl.getPointerButton();
+    }
+
+    /// A bitmask of the mouse buttons currently held down, built from the
+    /// `com.codename1.ui.events.PointerEvent` `MASK_*` constants.
+    public int getPressedButtonMask() {
+        return impl.getPointerButtonMask();
+    }
+
+    /// The current pointing device type, one of the `com.codename1.ui.events.PointerEvent` `TYPE_*`
+    /// constants (finger, mouse, stylus or eraser).
+    public int getPointerType() {
+        return impl.getPointerType();
+    }
+
+    /// The normalized pressure of the current pointer event between `0.0` and `1.0`. Devices and
+    /// ports that do not report pressure return `1.0`.
+    public float getPointerPressure() {
+        return impl.getPointerPressure();
+    }
+
+    /// The stylus tilt across the x axis of the current pointer event in degrees, or `0` when not reported.
+    public float getPointerTiltX() {
+        return impl.getPointerTiltX();
+    }
+
+    /// The stylus tilt across the y axis of the current pointer event in degrees, or `0` when not reported.
+    public float getPointerTiltY() {
+        return impl.getPointerTiltY();
+    }
+
+    /// The normalized contact size of the current pointer event between `0.0` and `1.0`, or `0` when not reported.
+    public float getPointerContactSize() {
+        return impl.getPointerContactSize();
+    }
+
+    /// True if the current pointer is a stylus or pen (Apple Pencil, S-Pen and similar).
+    public boolean isStylusPointer() {
+        int t = impl.getPointerType();
+        return t == com.codename1.ui.events.PointerEvent.TYPE_STYLUS
+                || t == com.codename1.ui.events.PointerEvent.TYPE_ERASER;
+    }
+
+    /// Dispatches a mouse wheel event to the component under the given coordinates. Invoked by the
+    /// implementation on the EDT before the default scrolling gesture is synthesized. Returns true
+    /// if a listener consumed the event, in which case the default scroll should be skipped.
+    ///
+    /// #### Parameters
+    ///
+    /// - `x`: the pointer x position in display pixels
+    ///
+    /// - `y`: the pointer y position in display pixels
+    ///
+    /// - `scrollX`: the horizontal scroll amount in display pixels
+    ///
+    /// - `scrollY`: the vertical scroll amount in display pixels
+    ///
+    /// - `precise`: true if the deltas come from a high resolution device such as a trackpad
+    ///
+    /// - `modifiers`: bitmask of the held keyboard modifiers
+    ///
+    /// #### Returns
+    ///
+    /// true if a listener consumed the wheel event
+    public boolean fireMouseWheelEvent(int x, int y, int scrollX, int scrollY, boolean precise, int modifiers) {
+        Form f = getCurrent();
+        if (f == null) {
+            return false;
+        }
+        Component cmp;
+        try {
+            cmp = f.getComponentAt(x, y);
+        } catch (Throwable t) {
+            cmp = null;
+        }
+        if (cmp == null) {
+            return false;
+        }
+        com.codename1.ui.events.WheelEvent we = new com.codename1.ui.events.WheelEvent(cmp, x, y, scrollX, scrollY, precise, modifiers);
+        return cmp.fireMouseWheelEvent(we);
+    }
+
     /// Pushes a key press event with the given keycode into Codename One
     ///
     /// #### Parameters
@@ -2391,6 +2494,7 @@ public final class Display extends CN1Constants {
                 offset++;
                 yArray1[0] = inputEventStackTmp[offset];
                 offset++;
+                currentPointerEvent = impl.buildPointerEvent(xArray1[0], yArray1[0], false);
                 f.pointerPressed(xArray1, yArray1);
                 eventForm = f;
                 break;
@@ -2405,6 +2509,7 @@ public final class Display extends CN1Constants {
                 offset += array1.length + 1;
                 int[] array2 = readArrayStackArgument(inputEventStackTmp, offset);
                 offset += array2.length + 1;
+                currentPointerEvent = impl.buildPointerEvent(array1[0], array2[0], false);
                 f.pointerPressed(array1, array2);
                 eventForm = f;
                 break;
@@ -2426,6 +2531,7 @@ public final class Display extends CN1Constants {
                     offset++;
                     yArray1[0] = inputEventStackTmp[offset];
                     offset++;
+                    currentPointerEvent = impl.buildPointerEvent(xArray1[0], yArray1[0], false);
                     f.pointerReleased(xArray1, yArray1);
                 }
                 recursivePointerReleaseA = false;
@@ -2448,6 +2554,7 @@ public final class Display extends CN1Constants {
                     offset += array1.length + 1;
                     int[] array2 = readArrayStackArgument(inputEventStackTmp, offset);
                     offset += array2.length + 1;
+                    currentPointerEvent = impl.buildPointerEvent(array1[0], array2[0], false);
                     f.pointerReleased(array1, array1);
                 }
                 recursivePointerReleaseA = false;
@@ -2465,6 +2572,7 @@ public final class Display extends CN1Constants {
                 pointerPressedAndNotReleasedOrDragged = false;
                 xArray1[0] = arg1;
                 yArray1[0] = arg2;
+                currentPointerEvent = impl.buildPointerEvent(arg1, arg2, false);
                 f.pointerDragged(xArray1, yArray1);
                 break;
             }
@@ -2475,6 +2583,7 @@ public final class Display extends CN1Constants {
                 offset += array1.length + 1;
                 int[] array2 = readArrayStackArgument(inputEventStackTmp, offset);
                 offset += array2.length + 1;
+                currentPointerEvent = impl.buildPointerEvent(array1[0], array2[0], false);
                 f.pointerDragged(array1, array2);
                 break;
             }
@@ -2488,6 +2597,7 @@ public final class Display extends CN1Constants {
                 updateDragSpeedStatus(arg1, arg2, timestamp);
                 xArray1[0] = arg1;
                 yArray1[0] = arg2;
+                currentPointerEvent = impl.buildPointerEvent(arg1, arg2, true);
                 f.pointerHover(xArray1, yArray1);
                 break;
             }
@@ -2498,6 +2608,7 @@ public final class Display extends CN1Constants {
                 offset++;
                 xArray1[0] = arg1;
                 yArray1[0] = arg2;
+                currentPointerEvent = impl.buildPointerEvent(arg1, arg2, true);
                 f.pointerHoverReleased(xArray1, yArray1);
                 break;
             }
@@ -2508,6 +2619,7 @@ public final class Display extends CN1Constants {
                 offset++;
                 xArray1[0] = arg1;
                 yArray1[0] = arg2;
+                currentPointerEvent = impl.buildPointerEvent(arg1, arg2, true);
                 f.pointerHoverPressed(xArray1, yArray1);
                 break;
             }
@@ -4411,6 +4523,92 @@ public final class Display extends CN1Constants {
     /// true if a car is connected
     public boolean isCarConnected() {
         return impl.isCarConnected();
+    }
+
+    /// True if the device is a foldable or dual screen device such as a Galaxy Fold, Galaxy Flip,
+    /// Pixel Fold or Surface Duo.
+    ///
+    /// #### Returns
+    ///
+    /// true if the device is foldable
+    public boolean isFoldable() {
+        return impl.isFoldable();
+    }
+
+    /// Returns the live device fold posture. See `com.codename1.ui.DevicePosture` for details.
+    ///
+    /// #### Returns
+    ///
+    /// the device posture, never null
+    public DevicePosture getDevicePosture() {
+        return DevicePosture.getInstance();
+    }
+
+    /// Adds a listener that is notified when the device is folded, unfolded or changes posture. The
+    /// delivered `com.codename1.ui.events.ActionEvent` has the type `PostureChange`; query the new
+    /// posture from `com.codename1.ui.DevicePosture#getInstance()`.
+    ///
+    /// #### Parameters
+    ///
+    /// - `l`: the listener to add
+    public void addPostureListener(ActionListener l) {
+        if (postureListeners == null) {
+            postureListeners = new EventDispatcher();
+        }
+        postureListeners.addListener(l);
+    }
+
+    /// Removes a posture listener.
+    ///
+    /// #### Parameters
+    ///
+    /// - `l`: the listener to remove
+    public void removePostureListener(ActionListener l) {
+        if (postureListeners != null) {
+            postureListeners.removeListener(l);
+        }
+    }
+
+    /// Invoked by the implementation when the device fold posture changes. Fires the registered
+    /// posture listeners on the EDT.
+    public void postureChanged() {
+        if (postureListeners != null && postureListeners.hasListeners()) {
+            callSerially(new Runnable() {
+                public void run() {
+                    postureListeners.fireActionEvent(new ActionEvent(DevicePosture.getInstance(),
+                            ActionEvent.Type.PostureChange));
+                }
+            });
+        }
+    }
+
+    /// True if the application is currently running in a desktop windowing mode such as Samsung DeX,
+    /// Android desktop windowing or iPad Stage Manager. This is distinct from `#isDesktop()` which
+    /// reports a genuine desktop platform (Windows, macOS or Linux).
+    ///
+    /// #### Returns
+    ///
+    /// true if running in a desktop windowing mode
+    public boolean isDesktopMode() {
+        return impl.isDesktopMode();
+    }
+
+    /// Returns the number of displays (monitors or external screens) currently attached.
+    ///
+    /// #### Returns
+    ///
+    /// the number of attached displays, at least 1
+    public int getDisplayCount() {
+        return impl.getDisplayCount();
+    }
+
+    /// True if an external or secondary display is currently attached.
+    ///
+    /// #### Returns
+    ///
+    /// true if an external display is connected
+    public boolean isExternalDisplayConnected() {
+        return impl.isExternalDisplayConnected();
     }
 
     /// Returns the platform bridge used by the `com.codename1.car` API to render in-car templates, or

--- a/CodenameOne/src/com/codename1/ui/Form.java
+++ b/CodenameOne/src/com/codename1/ui/Form.java
@@ -3105,6 +3105,11 @@ public class Form extends Container {
                 return;
             }
         }
+        // a long press is the touch equivalent of a right click: surface it as a context menu request
+        Component ctxCmp = resolveInputComponent(x, y);
+        if (ctxCmp != null && ctxCmp.fireContextMenu(x, y)) {
+            return;
+        }
         if (focused != null && focused.contains(x, y)) {
             if (focused.getComponentForm() == this) { //NOPMD CompareObjectsWithEquals
                 LeadUtil.longPointerPress(focused, x, y);
@@ -3402,9 +3407,40 @@ public class Form extends Container {
     }
 
 
+    /// Resolves the component under the given coordinates for device-input listener dispatch
+    /// (context menu, stylus), mirroring the resolution used for normal pointer dispatch.
+    private Component resolveInputComponent(int x, int y) {
+        Container actual = getActualPane(formLayeredPane, x, y);
+        if (actual == null) {
+            return null;
+        }
+        Component cmp = actual.getComponentAt(x, y);
+        while (cmp != null && cmp.isIgnorePointerEvents()) {
+            cmp = cmp.getParent();
+        }
+        return cmp;
+    }
+
     /// {@inheritDoc}
     @Override
     public void pointerPressed(int x, int y) {
+        // Device-input dispatch happens here, at the form level, so it works uniformly for every
+        // component (including ones such as Button that override pointerPressed without calling
+        // super). A secondary (right / stylus barrel) button press is a context menu request; if a
+        // listener consumes it the normal press is suppressed. Stylus presses are also surfaced
+        // here so addStylusListener fires regardless of the target component.
+        if (Display.getInstance().getPointerButton() == com.codename1.ui.events.PointerEvent.BUTTON_SECONDARY) {
+            Component ctxCmp = resolveInputComponent(x, y);
+            if (ctxCmp != null && ctxCmp.fireContextMenu(x, y)) {
+                return;
+            }
+        }
+        if (Display.getInstance().isStylusPointer()) {
+            Component stylusCmp = resolveInputComponent(x, y);
+            if (stylusCmp != null) {
+                stylusCmp.fireStylusEvent(ActionEvent.Type.PointerPressed, x, y);
+            }
+        }
         currentPointerPress = new Object();
         // a press (the start of a click or drag) dismisses any tooltip so it can't linger
         // over a drag image or get stranded when the gesture rebuilds the UI
@@ -3594,6 +3630,12 @@ public class Form extends Container {
     /// {@inheritDoc}
     @Override
     public void pointerDragged(int x, int y) {
+        if (Display.getInstance().isStylusPointer()) {
+            Component stylusCmp = resolveInputComponent(x, y);
+            if (stylusCmp != null) {
+                stylusCmp.fireStylusEvent(ActionEvent.Type.PointerDrag, x, y);
+            }
+        }
         // disable the drag stop flag if we are dragging again
         boolean isScrollWheeling = Display.impl.isScrollWheeling();
         if (dragStopFlag) {
@@ -3913,6 +3955,12 @@ public class Form extends Container {
     /// {@inheritDoc}
     @Override
     public void pointerReleased(int x, int y) {
+        if (Display.getInstance().isStylusPointer()) {
+            Component stylusCmp = resolveInputComponent(x, y);
+            if (stylusCmp != null) {
+                stylusCmp.fireStylusEvent(ActionEvent.Type.PointerReleased, x, y);
+            }
+        }
         try {
             Component origPressedCmp = pressedCmp;
             setRippleMotion(null);

--- a/CodenameOne/src/com/codename1/ui/Form.java
+++ b/CodenameOne/src/com/codename1/ui/Form.java
@@ -30,6 +30,7 @@ import com.codename1.ui.animations.Motion;
 import com.codename1.ui.animations.Transition;
 import com.codename1.ui.events.ActionEvent;
 import com.codename1.ui.events.ActionListener;
+import com.codename1.ui.events.PointerEvent;
 import com.codename1.ui.geom.Dimension;
 import com.codename1.ui.geom.Rectangle;
 import com.codename1.ui.layouts.BorderLayout;
@@ -3429,7 +3430,7 @@ public class Form extends Container {
         // super). A secondary (right / stylus barrel) button press is a context menu request; if a
         // listener consumes it the normal press is suppressed. Stylus presses are also surfaced
         // here so addStylusListener fires regardless of the target component.
-        if (Display.getInstance().getPointerButton() == com.codename1.ui.events.PointerEvent.BUTTON_SECONDARY) {
+        if (Display.getInstance().getPointerButton() == PointerEvent.BUTTON_SECONDARY) {
             Component ctxCmp = resolveInputComponent(x, y);
             if (ctxCmp != null && ctxCmp.fireContextMenu(x, y)) {
                 return;

--- a/CodenameOne/src/com/codename1/ui/events/ActionEvent.java
+++ b/CodenameOne/src/com/codename1/ui/events/ActionEvent.java
@@ -48,6 +48,9 @@ public class ActionEvent {
     /// 8.0
     private boolean pointerPressedDuringDrag;
 
+    /// The rich pointer detail attached to this event, populated for pointer events.
+    private PointerEvent pointerEvent;
+
     /// Creates a new instance of ActionEvent.  This is unused locally, but provided so existing customer code
     /// with still work.
     ///
@@ -405,6 +408,42 @@ public class ActionEvent {
         return longEvent;
     }
 
+    /// Returns the rich pointer detail for this event such as the triggering mouse button, the
+    /// pointing device type (finger, mouse, stylus or eraser), the pressure applied and the stylus
+    /// tilt. For pointer events that did not have an explicit snapshot attached this falls back to
+    /// the pointer event currently being dispatched, so the detail is available from any pointer
+    /// listener. Returns null for non pointer events.
+    ///
+    /// #### Returns
+    ///
+    /// the `PointerEvent` detail or null when this is not a pointer event
+    public PointerEvent getPointerEvent() {
+        if (pointerEvent != null) {
+            return pointerEvent;
+        }
+        switch (trigger) {
+            case Pointer:
+            case PointerPressed:
+            case PointerReleased:
+            case PointerDrag:
+            case PointerWheel:
+            case LongPointerPress:
+            case Swipe:
+                return com.codename1.ui.Display.getInstance().getCurrentPointerEvent();
+            default:
+                return null;
+        }
+    }
+
+    /// Attaches an explicit rich pointer detail snapshot to this event.
+    ///
+    /// #### Parameters
+    ///
+    /// - `pointerEvent`: the snapshot to attach
+    public void setPointerEvent(PointerEvent pointerEvent) {
+        this.pointerEvent = pointerEvent;
+    }
+
     /// Set in the case of a drop listener, returns the component being dragged
     ///
     /// #### Returns
@@ -469,6 +508,13 @@ public class ActionEvent {
 
         /// Pointer event
         PointerDrag,
+
+
+        /// Mouse wheel or trackpad scroll event delivered as a `com.codename1.ui.events.WheelEvent`
+        PointerWheel,
+
+        /// Device fold posture change delivered when a foldable device is folded or unfolded
+        PostureChange,
 
 
         /// Pointer swipe event currently fired by `com.codename1.ui.SwipeableContainer#addSwipeOpenListener(com.codename1.ui.events.ActionListener)`

--- a/CodenameOne/src/com/codename1/ui/events/PointerEvent.java
+++ b/CodenameOne/src/com/codename1/ui/events/PointerEvent.java
@@ -265,6 +265,7 @@ public final class PointerEvent {
         return (modifiers & MODIFIER_META) != 0;
     }
 
+    @Override
     public String toString() {
         return "PointerEvent[x=" + x + ", y=" + y + ", button=" + button + ", buttonMask=" + buttonMask
                 + ", type=" + pointerType + ", pressure=" + pressure + ", tiltX=" + tiltX + ", tiltY=" + tiltY

--- a/CodenameOne/src/com/codename1/ui/events/PointerEvent.java
+++ b/CodenameOne/src/com/codename1/ui/events/PointerEvent.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores
+ * CA 94065 USA or visit www.oracle.com if you need additional information or
+ * have any questions.
+ */
+package com.codename1.ui.events;
+
+/// Immutable snapshot describing the rich detail of a pointer interaction that goes
+/// beyond the simple x/y coordinates carried by the legacy pointer callbacks.
+///
+/// A `PointerEvent` exposes which mouse button triggered the interaction, the kind of
+/// pointing device used (finger, mouse, stylus or eraser), the pressure applied, stylus
+/// tilt, the size of the contact area and the keyboard modifiers that were held down.
+///
+/// The snapshot is available in two ways:
+///
+/// - From an `ActionEvent` fired by a pointer listener via `ActionEvent#getPointerEvent()`.
+/// - By polling `com.codename1.ui.Display#getCurrentPointerEvent()` (or the matching `com.codename1.ui.CN`
+///   convenience method) while a pointer event is being dispatched.
+///
+/// Every value carries a safe default so code written against the rich API behaves predictably
+/// on devices and ports that do not supply the extra detail. On such ports the button defaults to
+/// `BUTTON_PRIMARY`, the pressure to `1.0`, the type to `TYPE_UNKNOWN` and tilt/contact size to `0`.
+public final class PointerEvent {
+
+    /// The pointing device could not be determined.
+    public static final int TYPE_UNKNOWN = 0;
+
+    /// The interaction came from a finger on a touch screen.
+    public static final int TYPE_TOUCH = 1;
+
+    /// The interaction came from a mouse or trackpad.
+    public static final int TYPE_MOUSE = 2;
+
+    /// The interaction came from a stylus or pen (Apple Pencil, S-Pen, Surface Pen and similar).
+    public static final int TYPE_STYLUS = 3;
+
+    /// The interaction came from the eraser end of a stylus.
+    public static final int TYPE_ERASER = 4;
+
+    /// No button is associated with this event (for example a hover or a plain touch).
+    public static final int BUTTON_NONE = -1;
+
+    /// The primary (usually left) mouse button, or a plain touch/stylus contact.
+    public static final int BUTTON_PRIMARY = 0;
+
+    /// The secondary (usually right) mouse button or stylus barrel button.
+    public static final int BUTTON_SECONDARY = 1;
+
+    /// The middle mouse button (often the scroll wheel click).
+    public static final int BUTTON_MIDDLE = 2;
+
+    /// The back (fourth) mouse button.
+    public static final int BUTTON_BACK = 3;
+
+    /// The forward (fifth) mouse button.
+    public static final int BUTTON_FORWARD = 4;
+
+    /// Button mask bit for the primary button.
+    public static final int MASK_PRIMARY = 1;
+
+    /// Button mask bit for the secondary button.
+    public static final int MASK_SECONDARY = 1 << 1;
+
+    /// Button mask bit for the middle button.
+    public static final int MASK_MIDDLE = 1 << 2;
+
+    /// Button mask bit for the back button.
+    public static final int MASK_BACK = 1 << 3;
+
+    /// Button mask bit for the forward button.
+    public static final int MASK_FORWARD = 1 << 4;
+
+    /// Modifier mask bit indicating the shift key was held.
+    public static final int MODIFIER_SHIFT = 1;
+
+    /// Modifier mask bit indicating the control key was held.
+    public static final int MODIFIER_CONTROL = 1 << 1;
+
+    /// Modifier mask bit indicating the alt/option key was held.
+    public static final int MODIFIER_ALT = 1 << 2;
+
+    /// Modifier mask bit indicating the meta/command/windows key was held.
+    public static final int MODIFIER_META = 1 << 3;
+
+    private final int x;
+    private final int y;
+    private final int button;
+    private final int buttonMask;
+    private final int pointerType;
+    private final float pressure;
+    private final float tiltX;
+    private final float tiltY;
+    private final float contactSize;
+    private final int modifiers;
+    private final boolean hovering;
+
+    /// Creates a new immutable pointer event snapshot.
+    ///
+    /// #### Parameters
+    ///
+    /// - `x`: the x position of the pointer in display pixels
+    ///
+    /// - `y`: the y position of the pointer in display pixels
+    ///
+    /// - `button`: one of the `BUTTON_*` constants describing the triggering button
+    ///
+    /// - `buttonMask`: bitmask of the `MASK_*` constants describing all currently held buttons
+    ///
+    /// - `pointerType`: one of the `TYPE_*` constants describing the pointing device
+    ///
+    /// - `pressure`: normalized pressure between `0.0` and `1.0`, defaulting to `1.0`
+    ///
+    /// - `tiltX`: stylus tilt across the x axis in degrees, `0` when not available
+    ///
+    /// - `tiltY`: stylus tilt across the y axis in degrees, `0` when not available
+    ///
+    /// - `contactSize`: normalized size of the contact area between `0.0` and `1.0`
+    ///
+    /// - `modifiers`: bitmask of the `MODIFIER_*` constants describing held keyboard modifiers
+    ///
+    /// - `hovering`: true if the pointer is hovering above the surface without contact
+    public PointerEvent(int x, int y, int button, int buttonMask, int pointerType,
+            float pressure, float tiltX, float tiltY, float contactSize, int modifiers, boolean hovering) {
+        this.x = x;
+        this.y = y;
+        this.button = button;
+        this.buttonMask = buttonMask;
+        this.pointerType = pointerType;
+        this.pressure = pressure;
+        this.tiltX = tiltX;
+        this.tiltY = tiltY;
+        this.contactSize = contactSize;
+        this.modifiers = modifiers;
+        this.hovering = hovering;
+    }
+
+    /// The x position of the pointer in display pixels.
+    public int getX() {
+        return x;
+    }
+
+    /// The y position of the pointer in display pixels.
+    public int getY() {
+        return y;
+    }
+
+    /// The button that triggered this event, one of the `BUTTON_*` constants. Defaults to
+    /// `BUTTON_PRIMARY` for plain touch interactions and `BUTTON_NONE` for hover events.
+    public int getButton() {
+        return button;
+    }
+
+    /// A bitmask of all buttons currently held down, built from the `MASK_*` constants.
+    public int getButtonMask() {
+        return buttonMask;
+    }
+
+    /// The kind of pointing device that produced this event, one of the `TYPE_*` constants.
+    public int getPointerType() {
+        return pointerType;
+    }
+
+    /// The normalized pressure applied by the pointer between `0.0` and `1.0`. Ports that do not
+    /// report pressure return `1.0` so that pressure aware code keeps working.
+    public float getPressure() {
+        return pressure;
+    }
+
+    /// The stylus tilt across the x axis in degrees, or `0` when not reported.
+    public float getTiltX() {
+        return tiltX;
+    }
+
+    /// The stylus tilt across the y axis in degrees, or `0` when not reported.
+    public float getTiltY() {
+        return tiltY;
+    }
+
+    /// The normalized size of the contact area between `0.0` and `1.0`, or `0` when not reported.
+    public float getContactSize() {
+        return contactSize;
+    }
+
+    /// A bitmask of the keyboard modifiers held during this event, built from the `MODIFIER_*` constants.
+    public int getModifiers() {
+        return modifiers;
+    }
+
+    /// True if the pointer is hovering above the surface without making contact.
+    public boolean isHovering() {
+        return hovering;
+    }
+
+    /// True if this event came from a finger on a touch screen.
+    public boolean isTouch() {
+        return pointerType == TYPE_TOUCH;
+    }
+
+    /// True if this event came from a mouse or trackpad.
+    public boolean isMouse() {
+        return pointerType == TYPE_MOUSE;
+    }
+
+    /// True if this event came from a stylus or the eraser end of a stylus.
+    public boolean isStylus() {
+        return pointerType == TYPE_STYLUS || pointerType == TYPE_ERASER;
+    }
+
+    /// True if this event came from the eraser end of a stylus.
+    public boolean isEraser() {
+        return pointerType == TYPE_ERASER;
+    }
+
+    /// True if the triggering button is the primary (left) button.
+    public boolean isPrimaryButton() {
+        return button == BUTTON_PRIMARY;
+    }
+
+    /// True if the triggering button is the secondary (right) button or stylus barrel button.
+    public boolean isSecondaryButton() {
+        return button == BUTTON_SECONDARY;
+    }
+
+    /// True if the triggering button is the middle button.
+    public boolean isMiddleButton() {
+        return button == BUTTON_MIDDLE;
+    }
+
+    /// True if the shift key was held during this event.
+    public boolean isShiftDown() {
+        return (modifiers & MODIFIER_SHIFT) != 0;
+    }
+
+    /// True if the control key was held during this event.
+    public boolean isControlDown() {
+        return (modifiers & MODIFIER_CONTROL) != 0;
+    }
+
+    /// True if the alt/option key was held during this event.
+    public boolean isAltDown() {
+        return (modifiers & MODIFIER_ALT) != 0;
+    }
+
+    /// True if the meta/command/windows key was held during this event.
+    public boolean isMetaDown() {
+        return (modifiers & MODIFIER_META) != 0;
+    }
+
+    public String toString() {
+        return "PointerEvent[x=" + x + ", y=" + y + ", button=" + button + ", buttonMask=" + buttonMask
+                + ", type=" + pointerType + ", pressure=" + pressure + ", tiltX=" + tiltX + ", tiltY=" + tiltY
+                + ", contactSize=" + contactSize + ", modifiers=" + modifiers + ", hovering=" + hovering + "]";
+    }
+}

--- a/CodenameOne/src/com/codename1/ui/events/WheelEvent.java
+++ b/CodenameOne/src/com/codename1/ui/events/WheelEvent.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores
+ * CA 94065 USA or visit www.oracle.com if you need additional information or
+ * have any questions.
+ */
+package com.codename1.ui.events;
+
+/// Event delivered to mouse wheel listeners when the wheel or a trackpad scroll gesture is moved.
+///
+/// The deltas are reported in display pixels (already converted from the native notch count by the
+/// port). A positive `deltaY` reveals content above (the user scrolled the wheel down), and a
+/// positive `deltaX` reveals content to the left. Consuming this event with `#consume()` prevents
+/// the default scrolling behavior, which is useful for gestures such as control plus wheel to zoom.
+public class WheelEvent extends ActionEvent {
+
+    private final int deltaX;
+    private final int deltaY;
+    private final boolean precise;
+    private final int modifiers;
+
+    /// Creates a new wheel event.
+    ///
+    /// #### Parameters
+    ///
+    /// - `source`: the component the wheel was moved over
+    ///
+    /// - `x`: the pointer x position in display pixels
+    ///
+    /// - `y`: the pointer y position in display pixels
+    ///
+    /// - `deltaX`: the horizontal scroll amount in display pixels
+    ///
+    /// - `deltaY`: the vertical scroll amount in display pixels
+    ///
+    /// - `precise`: true if the deltas come from a high resolution device such as a trackpad
+    ///
+    /// - `modifiers`: bitmask of the `PointerEvent` `MODIFIER_*` constants for held keyboard modifiers
+    public WheelEvent(Object source, int x, int y, int deltaX, int deltaY, boolean precise, int modifiers) {
+        super(source, Type.PointerWheel, x, y);
+        this.deltaX = deltaX;
+        this.deltaY = deltaY;
+        this.precise = precise;
+        this.modifiers = modifiers;
+    }
+
+    /// The horizontal scroll amount in display pixels. A positive value reveals content to the left.
+    public int getDeltaX() {
+        return deltaX;
+    }
+
+    /// The vertical scroll amount in display pixels. A positive value reveals content above.
+    public int getDeltaY() {
+        return deltaY;
+    }
+
+    /// True if the deltas come from a high resolution device such as a trackpad rather than a
+    /// notched mouse wheel.
+    public boolean isPrecise() {
+        return precise;
+    }
+
+    /// A bitmask of the keyboard modifiers held during this event, built from the `PointerEvent`
+    /// `MODIFIER_*` constants.
+    public int getModifiers() {
+        return modifiers;
+    }
+
+    /// True if the shift key was held during this event.
+    public boolean isShiftDown() {
+        return (modifiers & PointerEvent.MODIFIER_SHIFT) != 0;
+    }
+
+    /// True if the control key was held during this event.
+    public boolean isControlDown() {
+        return (modifiers & PointerEvent.MODIFIER_CONTROL) != 0;
+    }
+
+    /// True if the alt/option key was held during this event.
+    public boolean isAltDown() {
+        return (modifiers & PointerEvent.MODIFIER_ALT) != 0;
+    }
+
+    /// True if the meta/command/windows key was held during this event.
+    public boolean isMetaDown() {
+        return (modifiers & PointerEvent.MODIFIER_META) != 0;
+    }
+}

--- a/Ports/Android/src/com/codename1/impl/android/AndroidFoldablePosture.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidFoldablePosture.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores
+ * CA 94065 USA or visit www.oracle.com if you need additional information or
+ * have any questions.
+ */
+package com.codename1.impl.android;
+
+import android.app.Activity;
+import android.content.Context;
+import android.graphics.Rect;
+import com.codename1.ui.Display;
+import com.codename1.ui.DevicePosture;
+import com.codename1.ui.geom.Rectangle;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.concurrent.Executor;
+
+/**
+ * Reads the device fold posture from androidx.window entirely through reflection so the core
+ * Android port carries no compile-time dependency on androidx.window. The dependency is added to
+ * the generated build only when the app opts in with the build hint
+ * {@code android.foldableSupport=true} (see AndroidGradleBuilder). When androidx.window is not on
+ * the classpath, or the device is not foldable, every query degrades safely to "not foldable".
+ *
+ * <p>This avoids the Kotlin coroutine based WindowInfoTracker flow by using the Java friendly
+ * androidx.window.java.layout.WindowInfoTrackerCallbackAdapter and an androidx.core.util.Consumer
+ * implemented with a dynamic proxy.</p>
+ */
+class AndroidFoldablePosture {
+    private static volatile boolean foldable;
+    private static volatile int posture = DevicePosture.POSTURE_UNKNOWN;
+    private static volatile int foldOrientation = DevicePosture.FOLD_ORIENTATION_NONE;
+    private static volatile boolean separating;
+    private static volatile boolean hasBounds;
+    private static volatile int boundsX;
+    private static volatile int boundsY;
+    private static volatile int boundsW;
+    private static volatile int boundsH;
+    private static boolean started;
+
+    static boolean isFoldable() {
+        return foldable;
+    }
+
+    static int getPosture() {
+        return foldable ? posture : DevicePosture.POSTURE_UNKNOWN;
+    }
+
+    static int getFoldOrientation() {
+        return foldable ? foldOrientation : DevicePosture.FOLD_ORIENTATION_NONE;
+    }
+
+    static boolean isSeparating() {
+        return separating;
+    }
+
+    static Rectangle getFoldBounds(Rectangle rect) {
+        if (!hasBounds) {
+            return null;
+        }
+        return new Rectangle(boundsX, boundsY, boundsW, boundsH);
+    }
+
+    /**
+     * Starts the androidx.window layout listener if it has not been started yet. Safe to call
+     * repeatedly and safe to call when androidx.window is absent (it simply does nothing).
+     */
+    static synchronized void start(final Activity activity) {
+        if (started || activity == null) {
+            return;
+        }
+        try {
+            Class<?> trackerCls = Class.forName("androidx.window.layout.WindowInfoTracker");
+            Object tracker = trackerCls.getMethod("getOrCreate", Context.class).invoke(null, activity);
+            if (tracker == null) {
+                return;
+            }
+            Class<?> adapterCls = Class.forName("androidx.window.java.layout.WindowInfoTrackerCallbackAdapter");
+            Object adapter = adapterCls.getConstructor(trackerCls).newInstance(tracker);
+            final Class<?> foldingFeatureCls = Class.forName("androidx.window.layout.FoldingFeature");
+            Class<?> consumerCls = Class.forName("androidx.core.util.Consumer");
+            Executor executor = new Executor() {
+                public void execute(Runnable command) {
+                    activity.runOnUiThread(command);
+                }
+            };
+            InvocationHandler handler = new InvocationHandler() {
+                public Object invoke(Object proxy, Method method, Object[] args) {
+                    String name = method.getName();
+                    if ("accept".equals(name) && args != null && args.length == 1 && args[0] != null) {
+                        try {
+                            onLayoutInfo(args[0], foldingFeatureCls);
+                        } catch (Throwable t) {
+                            // ignore - leave posture unchanged on a parse failure
+                        }
+                        return null;
+                    }
+                    if ("toString".equals(name)) {
+                        return "CN1FoldConsumer";
+                    }
+                    if ("hashCode".equals(name)) {
+                        return System.identityHashCode(proxy);
+                    }
+                    if ("equals".equals(name)) {
+                        return proxy == args[0];
+                    }
+                    return null;
+                }
+            };
+            Object consumer = Proxy.newProxyInstance(adapterCls.getClassLoader(),
+                    new Class[]{consumerCls}, handler);
+            adapterCls.getMethod("addWindowLayoutInfoListener", Activity.class, Executor.class, consumerCls)
+                    .invoke(adapter, activity, executor, consumer);
+            started = true;
+        } catch (Throwable t) {
+            // androidx.window not present or an API mismatch: stay non-foldable.
+        }
+    }
+
+    private static void onLayoutInfo(Object info, Class<?> foldingFeatureCls) throws Exception {
+        List<?> features = (List<?>) info.getClass().getMethod("getDisplayFeatures").invoke(info);
+        boolean foundFold = false;
+        int newPosture = DevicePosture.POSTURE_FLAT;
+        int newOrientation = DevicePosture.FOLD_ORIENTATION_NONE;
+        boolean newSeparating = false;
+        Rect bounds = null;
+        if (features != null) {
+            for (Object feature : features) {
+                if (foldingFeatureCls.isInstance(feature)) {
+                    foundFold = true;
+                    Object state = foldingFeatureCls.getMethod("getState").invoke(feature);
+                    Object orientation = foldingFeatureCls.getMethod("getOrientation").invoke(feature);
+                    newSeparating = Boolean.TRUE.equals(
+                            foldingFeatureCls.getMethod("isSeparating").invoke(feature));
+                    Object rect = foldingFeatureCls.getMethod("getBounds").invoke(feature);
+                    if (rect instanceof Rect) {
+                        bounds = (Rect) rect;
+                    }
+                    String s = String.valueOf(state);
+                    newPosture = s.contains("HALF") ? DevicePosture.POSTURE_HALF_OPENED
+                            : DevicePosture.POSTURE_FLAT;
+                    String o = String.valueOf(orientation);
+                    if (o.contains("VERTICAL")) {
+                        newOrientation = DevicePosture.FOLD_ORIENTATION_VERTICAL;
+                    } else if (o.contains("HORIZONTAL")) {
+                        newOrientation = DevicePosture.FOLD_ORIENTATION_HORIZONTAL;
+                    }
+                }
+            }
+        }
+        if (foundFold) {
+            // Once a folding feature is observed, the device is foldable for the rest of the session.
+            foldable = true;
+            posture = newPosture;
+            foldOrientation = newOrientation;
+            separating = newSeparating;
+            if (bounds != null && newSeparating) {
+                boundsX = bounds.left;
+                boundsY = bounds.top;
+                boundsW = bounds.width();
+                boundsH = bounds.height();
+                hasBounds = true;
+            } else {
+                hasBounds = false;
+            }
+        } else if (foldable) {
+            // A known foldable currently reporting no folding feature is open and flat.
+            posture = DevicePosture.POSTURE_FLAT;
+            foldOrientation = DevicePosture.FOLD_ORIENTATION_NONE;
+            separating = false;
+            hasBounds = false;
+        }
+        Display.getInstance().postureChanged();
+    }
+}

--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -5675,6 +5675,40 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
                 >= Configuration.SCREENLAYOUT_SIZE_LARGE;
     }
 
+    // Foldable / device posture, backed by androidx.window via reflection. The androidx.window
+    // dependency is only present when the app opts in with the android.foldableSupport build hint;
+    // when absent these all degrade safely to "not foldable". The tracker is started lazily so it
+    // only spins up for apps that query the posture APIs.
+    @Override
+    public boolean isFoldable() {
+        AndroidFoldablePosture.start(getActivity());
+        return AndroidFoldablePosture.isFoldable();
+    }
+
+    @Override
+    public int getDevicePosture() {
+        AndroidFoldablePosture.start(getActivity());
+        return AndroidFoldablePosture.getPosture();
+    }
+
+    @Override
+    public int getFoldOrientation() {
+        AndroidFoldablePosture.start(getActivity());
+        return AndroidFoldablePosture.getFoldOrientation();
+    }
+
+    @Override
+    public boolean isPostureSeparating() {
+        AndroidFoldablePosture.start(getActivity());
+        return AndroidFoldablePosture.isSeparating();
+    }
+
+    @Override
+    public com.codename1.ui.geom.Rectangle getFoldBounds(com.codename1.ui.geom.Rectangle rect) {
+        AndroidFoldablePosture.start(getActivity());
+        return AndroidFoldablePosture.getFoldBounds(rect);
+    }
+
     private Boolean watchCache;
 
     @Override

--- a/Ports/Android/src/com/codename1/impl/android/CodenameOneView.java
+++ b/Ports/Android/src/com/codename1/impl/android/CodenameOneView.java
@@ -623,7 +623,9 @@ public class CodenameOneView {
             isPeer = !Sheet.isSheetVisibleAt(primaryX, primaryY);
         }
         boolean consumeEvent = !isPeer || cn1GrabbedPointer;
-    
+
+        updatePointerMetadata(event, false);
+
         switch (event.getAction()) {
             case MotionEvent.ACTION_DOWN:
                 if (x == null) {
@@ -668,6 +670,7 @@ public class CodenameOneView {
         }
         final int x = (int) event.getX();
         final int y = (int) event.getY();
+        updatePointerMetadata(event, true);
         switch (event.getActionMasked()) {
             case MotionEvent.ACTION_HOVER_ENTER:
                 this.implementation.pointerHoverPressed(x, y);
@@ -680,6 +683,127 @@ public class CodenameOneView {
                 return true;
         }
         return false;
+    }
+
+    /**
+     * Routes Android generic motion events into Codename One. This captures the
+     * mouse wheel and trackpad scroll axes (vertical and horizontal) from
+     * external pointing devices (BT mouse, Chromebook trackpad, DeX) which are
+     * not delivered through onTouchEvent.
+     */
+    public boolean onGenericMotionEvent(MotionEvent event) {
+        if (this.implementation.getCurrentForm() == null) {
+            return false;
+        }
+        if (event.getActionMasked() == MotionEvent.ACTION_SCROLL) {
+            float vscroll = event.getAxisValue(MotionEvent.AXIS_VSCROLL);
+            float hscroll = event.getAxisValue(MotionEvent.AXIS_HSCROLL);
+            if (vscroll == 0 && hscroll == 0) {
+                return false;
+            }
+            int x = (int) event.getX();
+            int y = (int) event.getY();
+            // A positive scrollY reveals content above (drag down); Android reports a
+            // positive VSCROLL when scrolling away from the user, so negate to match.
+            int step = this.implementation.convertToPixels(20, true);
+            int scrollY = Math.round(-vscroll * step);
+            int scrollX = Math.round(-hscroll * step);
+            this.implementation.pointerWheelMoved(x, y, scrollX, scrollY, true, motionModifierMask(event));
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Translates the Android MotionEvent tool type, pressure, contact size, tilt
+     * and button state into the cross-platform pointer metadata so the
+     * multi-button mouse and stylus APIs work on Android. When hovering is true
+     * the metadata is flagged as a hover (no contact).
+     */
+    private void updatePointerMetadata(MotionEvent event, boolean hovering) {
+        int toolType;
+        try {
+            toolType = event.getToolType(0);
+        } catch (Throwable t) {
+            toolType = MotionEvent.TOOL_TYPE_UNKNOWN;
+        }
+        int type;
+        switch (toolType) {
+            case MotionEvent.TOOL_TYPE_STYLUS:
+                type = com.codename1.ui.events.PointerEvent.TYPE_STYLUS;
+                break;
+            case MotionEvent.TOOL_TYPE_ERASER:
+                type = com.codename1.ui.events.PointerEvent.TYPE_ERASER;
+                break;
+            case MotionEvent.TOOL_TYPE_MOUSE:
+                type = com.codename1.ui.events.PointerEvent.TYPE_MOUSE;
+                break;
+            case MotionEvent.TOOL_TYPE_FINGER:
+                type = com.codename1.ui.events.PointerEvent.TYPE_TOUCH;
+                break;
+            default:
+                type = com.codename1.ui.events.PointerEvent.TYPE_UNKNOWN;
+                break;
+        }
+        float pressure = event.getPressure(0);
+        if (pressure <= 0) {
+            pressure = 1f;
+        }
+        float contactSize = event.getSize(0);
+        float tiltX = (float) Math.toDegrees(event.getAxisValue(MotionEvent.AXIS_TILT, 0));
+
+        int buttonState = event.getButtonState();
+        int mask = 0;
+        if ((buttonState & MotionEvent.BUTTON_PRIMARY) != 0) {
+            mask |= com.codename1.ui.events.PointerEvent.MASK_PRIMARY;
+        }
+        if ((buttonState & MotionEvent.BUTTON_SECONDARY) != 0) {
+            mask |= com.codename1.ui.events.PointerEvent.MASK_SECONDARY;
+        }
+        if ((buttonState & MotionEvent.BUTTON_TERTIARY) != 0) {
+            mask |= com.codename1.ui.events.PointerEvent.MASK_MIDDLE;
+        }
+        if ((buttonState & MotionEvent.BUTTON_BACK) != 0) {
+            mask |= com.codename1.ui.events.PointerEvent.MASK_BACK;
+        }
+        if ((buttonState & MotionEvent.BUTTON_FORWARD) != 0) {
+            mask |= com.codename1.ui.events.PointerEvent.MASK_FORWARD;
+        }
+        int button = com.codename1.ui.events.PointerEvent.BUTTON_PRIMARY;
+        if ((mask & com.codename1.ui.events.PointerEvent.MASK_SECONDARY) != 0) {
+            button = com.codename1.ui.events.PointerEvent.BUTTON_SECONDARY;
+        } else if ((mask & com.codename1.ui.events.PointerEvent.MASK_MIDDLE) != 0) {
+            button = com.codename1.ui.events.PointerEvent.BUTTON_MIDDLE;
+        } else if ((mask & com.codename1.ui.events.PointerEvent.MASK_BACK) != 0) {
+            button = com.codename1.ui.events.PointerEvent.BUTTON_BACK;
+        } else if ((mask & com.codename1.ui.events.PointerEvent.MASK_FORWARD) != 0) {
+            button = com.codename1.ui.events.PointerEvent.BUTTON_FORWARD;
+        } else if (mask == 0) {
+            mask = com.codename1.ui.events.PointerEvent.MASK_PRIMARY;
+        }
+        this.implementation.setPointerEventMetadata(button, mask, type, pressure, tiltX, 0, contactSize,
+                motionModifierMask(event), hovering);
+    }
+
+    /**
+     * Builds the cross-platform keyboard modifier mask from an Android MotionEvent meta state.
+     */
+    private int motionModifierMask(MotionEvent event) {
+        int meta = event.getMetaState();
+        int modifiers = 0;
+        if ((meta & android.view.KeyEvent.META_SHIFT_ON) != 0) {
+            modifiers |= com.codename1.ui.events.PointerEvent.MODIFIER_SHIFT;
+        }
+        if ((meta & android.view.KeyEvent.META_CTRL_ON) != 0) {
+            modifiers |= com.codename1.ui.events.PointerEvent.MODIFIER_CONTROL;
+        }
+        if ((meta & android.view.KeyEvent.META_ALT_ON) != 0) {
+            modifiers |= com.codename1.ui.events.PointerEvent.MODIFIER_ALT;
+        }
+        if ((meta & android.view.KeyEvent.META_META_ON) != 0) {
+            modifiers |= com.codename1.ui.events.PointerEvent.MODIFIER_META;
+        }
+        return modifiers;
     }
 
     public AndroidGraphics getGraphics() {

--- a/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
@@ -2306,6 +2306,85 @@ public class JavaSEPort extends CodenameOneImplementation {
         }
         return false;
     }
+
+    // Foldable device simulation controls. The desktop simulator is not foldable, but these
+    // settable fields let developers exercise the foldable / device posture APIs from the
+    // simulator and from unit tests.
+    private static boolean simulatedFoldable;
+    private static int simulatedPosture = com.codename1.ui.DevicePosture.POSTURE_FLAT;
+    private static int simulatedFoldOrientation = com.codename1.ui.DevicePosture.FOLD_ORIENTATION_VERTICAL;
+    private static int simulatedHingeAngle = 180;
+
+    /// Enables or disables foldable device simulation in the desktop simulator.
+    public static void setSimulatedFoldable(boolean foldable) {
+        simulatedFoldable = foldable;
+        Display.getInstance().postureChanged();
+    }
+
+    /// Sets the simulated fold posture (a `com.codename1.ui.DevicePosture` POSTURE_* constant).
+    public static void setSimulatedPosture(int posture) {
+        simulatedPosture = posture;
+        Display.getInstance().postureChanged();
+    }
+
+    /// Sets the simulated fold orientation (a `com.codename1.ui.DevicePosture` FOLD_ORIENTATION_* constant).
+    public static void setSimulatedFoldOrientation(int orientation) {
+        simulatedFoldOrientation = orientation;
+        Display.getInstance().postureChanged();
+    }
+
+    /// Sets the simulated hinge angle in degrees (0 closed, 180 flat).
+    public static void setSimulatedHingeAngle(int angle) {
+        simulatedHingeAngle = angle;
+        Display.getInstance().postureChanged();
+    }
+
+    @Override
+    public boolean isFoldable() {
+        return simulatedFoldable;
+    }
+
+    @Override
+    public int getDevicePosture() {
+        return simulatedFoldable ? simulatedPosture : com.codename1.ui.DevicePosture.POSTURE_UNKNOWN;
+    }
+
+    @Override
+    public int getHingeAngle() {
+        return simulatedFoldable ? simulatedHingeAngle : -1;
+    }
+
+    @Override
+    public int getFoldOrientation() {
+        return simulatedFoldable ? simulatedFoldOrientation : com.codename1.ui.DevicePosture.FOLD_ORIENTATION_NONE;
+    }
+
+    @Override
+    public boolean isPostureSeparating() {
+        return simulatedFoldable && simulatedPosture == com.codename1.ui.DevicePosture.POSTURE_HALF_OPENED;
+    }
+
+    @Override
+    public com.codename1.ui.geom.Rectangle getFoldBounds(com.codename1.ui.geom.Rectangle rect) {
+        if (!simulatedFoldable || simulatedFoldOrientation == com.codename1.ui.DevicePosture.FOLD_ORIENTATION_NONE) {
+            return null;
+        }
+        int w = getDisplayWidthImpl();
+        int h = getDisplayHeightImpl();
+        if (simulatedFoldOrientation == com.codename1.ui.DevicePosture.FOLD_ORIENTATION_VERTICAL) {
+            return new com.codename1.ui.geom.Rectangle(w / 2 - 1, 0, 2, h);
+        }
+        return new com.codename1.ui.geom.Rectangle(0, h / 2 - 1, w, 2);
+    }
+
+    @Override
+    public int getDisplayCount() {
+        try {
+            return java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment().getScreenDevices().length;
+        } catch (Throwable t) {
+            return 1;
+        }
+    }
     
     private static void dumpSwingHierarchy(java.awt.Component root, String indent) {
         System.out.println(indent + root.getName()+" "+root.getClass() + " "+root.getBounds());
@@ -3017,6 +3096,7 @@ public class JavaSEPort extends CodenameOneImplementation {
                         if (testRecorder != null) {
                             testRecorder.eventPointerPressed(x, y);
                         }
+                        updatePointerMetadata(e, true);
                         JavaSEPort.this.pointerPressed(x, y);
                     }
                 } else {
@@ -3081,6 +3161,7 @@ public class JavaSEPort extends CodenameOneImplementation {
                         if (testRecorder != null) {
                             testRecorder.eventPointerReleased(x, y);
                         }
+                        updatePointerMetadata(e, true);
                         JavaSEPort.this.pointerReleased(x, y);
                     }
                 }
@@ -3118,6 +3199,7 @@ public class JavaSEPort extends CodenameOneImplementation {
                         if (testRecorder != null && hasDragStarted(x, y)) {
                             testRecorder.eventPointerDragged(x, y);
                         }
+                        updatePointerMetadata(e, false);
                         JavaSEPort.this.pointerDragged(x, y);
                     }
                 }
@@ -3140,6 +3222,64 @@ public class JavaSEPort extends CodenameOneImplementation {
         private boolean isPinchZoom(MouseEvent e) {
             return ((e.getModifiers() & MouseEvent.BUTTON3_MASK) != 0)
                     || ((e.getModifiers() & MouseEvent.SHIFT_MASK) != 0);
+        }
+
+        /// Translates the AWT mouse button and keyboard modifier state into the cross-platform
+        /// pointer metadata so that the simulator can exercise the multi-button mouse APIs.
+        /// When useButton is true the triggering button is read from getButton (valid for press
+        /// and release); for drag events the button is derived from the held button mask instead.
+        private void updatePointerMetadata(MouseEvent e, boolean useButton) {
+            int mask = 0;
+            int mods = e.getModifiersEx();
+            if ((mods & InputEvent.BUTTON1_DOWN_MASK) != 0) {
+                mask |= com.codename1.ui.events.PointerEvent.MASK_PRIMARY;
+            }
+            if ((mods & InputEvent.BUTTON2_DOWN_MASK) != 0) {
+                mask |= com.codename1.ui.events.PointerEvent.MASK_MIDDLE;
+            }
+            if ((mods & InputEvent.BUTTON3_DOWN_MASK) != 0) {
+                mask |= com.codename1.ui.events.PointerEvent.MASK_SECONDARY;
+            }
+            int button = com.codename1.ui.events.PointerEvent.BUTTON_PRIMARY;
+            if (useButton) {
+                switch (e.getButton()) {
+                    case MouseEvent.BUTTON2:
+                        button = com.codename1.ui.events.PointerEvent.BUTTON_MIDDLE;
+                        break;
+                    case MouseEvent.BUTTON3:
+                        button = com.codename1.ui.events.PointerEvent.BUTTON_SECONDARY;
+                        break;
+                    default:
+                        button = com.codename1.ui.events.PointerEvent.BUTTON_PRIMARY;
+                        break;
+                }
+            } else {
+                if ((mask & com.codename1.ui.events.PointerEvent.MASK_SECONDARY) != 0) {
+                    button = com.codename1.ui.events.PointerEvent.BUTTON_SECONDARY;
+                } else if ((mask & com.codename1.ui.events.PointerEvent.MASK_MIDDLE) != 0) {
+                    button = com.codename1.ui.events.PointerEvent.BUTTON_MIDDLE;
+                }
+            }
+            JavaSEPort.this.setPointerEventMetadata(button, mask,
+                    com.codename1.ui.events.PointerEvent.TYPE_MOUSE, 1f, 0, 0, 0, modifierMask(e), false);
+        }
+
+        /// Builds the cross-platform keyboard modifier mask from an AWT input event.
+        private int modifierMask(InputEvent e) {
+            int modifiers = 0;
+            if (e.isShiftDown()) {
+                modifiers |= com.codename1.ui.events.PointerEvent.MODIFIER_SHIFT;
+            }
+            if (e.isControlDown()) {
+                modifiers |= com.codename1.ui.events.PointerEvent.MODIFIER_CONTROL;
+            }
+            if (e.isAltDown()) {
+                modifiers |= com.codename1.ui.events.PointerEvent.MODIFIER_ALT;
+            }
+            if (e.isMetaDown()) {
+                modifiers |= com.codename1.ui.events.PointerEvent.MODIFIER_META;
+            }
+            return modifiers;
         }
         private Cursor handCursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR);
         private Cursor defaultCursor = Cursor.getDefaultCursor();        
@@ -3429,8 +3569,16 @@ public class JavaSEPort extends CodenameOneImplementation {
                 // Hand the wheel scroll to the shared CodenameOneImplementation
                 // gesture so every port maps the wheel the same way; it replays
                 // the press/drag/release across EDT cycles and tracks
-                // isScrollWheeling() for us.
-                pointerWheelMoved(x, y, 0, units);
+                // isScrollWheeling() for us. Holding shift turns the wheel into a
+                // horizontal scroll, matching the convention on desktop platforms,
+                // and high resolution (trackpad) deltas are flagged as precise.
+                boolean precise = e.getPreciseWheelRotation() != e.getWheelRotation();
+                int modifiers = modifierMask(e);
+                if (e.isShiftDown()) {
+                    pointerWheelMoved(x, y, units, 0, precise, modifiers);
+                } else {
+                    pointerWheelMoved(x, y, 0, units, precise, modifiers);
+                }
             }
         }
         

--- a/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
@@ -5876,6 +5876,8 @@ public class JavaSEPort extends CodenameOneImplementation {
 
         final JMenu nfcMenu = installNfcSimulationMenu(simulateMenu, pref);
 
+        final JMenu foldableMenu = installFoldableSimulationMenu(simulateMenu, pref);
+
         // Mirrors cn1FireStatusBarTap in CodenameOne_GLViewController.m, which
         // synthesizes a tap inside CN1's StatusBar component (the bar at the
         // top of Toolbar created by Toolbar.initTitleBarStatus). The native
@@ -6387,6 +6389,7 @@ public class JavaSEPort extends CodenameOneImplementation {
         simulateMenu.add(pushSim);
         simulateMenu.add(biometricMenu);
         simulateMenu.add(nfcMenu);
+        simulateMenu.add(foldableMenu);
         simulateMenu.add(statusBarTapDiag);
         simulateMenu.addSeparator();
         simulateMenu.add(darkLightModeMenu);
@@ -7679,6 +7682,107 @@ public class JavaSEPort extends CodenameOneImplementation {
         nfcMenu.add(deactivate);
 
         return nfcMenu;
+    }
+
+    /// Builds the Simulate -> Foldable submenu so developers can exercise the
+    /// com.codename1.ui.DevicePosture API in the desktop simulator: toggle foldable mode, pick a
+    /// posture and fold orientation, and set the hinge angle. Selections are persisted and applied
+    /// through the JavaSEPort simulated-posture state, which fires the same posture-change events an
+    /// app would receive on a real foldable device.
+    private JMenu installFoldableSimulationMenu(JMenu simulateMenu, final Preferences pref) {
+        JMenu foldableMenu = new JMenu("Foldable");
+
+        // Apply any persisted selections to the simulator state up front.
+        boolean enabled = pref.getBoolean("FoldableSim.enabled", false);
+        int posture = pref.getInt("FoldableSim.posture", com.codename1.ui.DevicePosture.POSTURE_HALF_OPENED);
+        int orientation = pref.getInt("FoldableSim.orientation", com.codename1.ui.DevicePosture.FOLD_ORIENTATION_VERTICAL);
+        int hinge = pref.getInt("FoldableSim.hingeAngle", 180);
+        simulatedPosture = posture;
+        simulatedFoldOrientation = orientation;
+        simulatedHingeAngle = hinge;
+        simulatedFoldable = enabled;
+
+        final JCheckBoxMenuItem enable = new JCheckBoxMenuItem("Enable foldable device", enabled);
+        enable.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent ae) {
+                pref.putBoolean("FoldableSim.enabled", enable.isSelected());
+                setSimulatedFoldable(enable.isSelected());
+            }
+        });
+        foldableMenu.add(enable);
+        foldableMenu.addSeparator();
+
+        // Posture radio group.
+        JMenu postureMenu = new JMenu("Posture");
+        ButtonGroup postureGroup = new ButtonGroup();
+        final int[] postureValues = {
+            com.codename1.ui.DevicePosture.POSTURE_FLAT,
+            com.codename1.ui.DevicePosture.POSTURE_HALF_OPENED,
+            com.codename1.ui.DevicePosture.POSTURE_CLOSED
+        };
+        String[] postureLabels = {"Flat (open)", "Half-opened", "Closed"};
+        for (int i = 0; i < postureValues.length; i++) {
+            final int value = postureValues[i];
+            JRadioButtonMenuItem item = new JRadioButtonMenuItem(postureLabels[i], posture == value);
+            item.addActionListener(new ActionListener() {
+                @Override
+                public void actionPerformed(ActionEvent ae) {
+                    pref.putInt("FoldableSim.posture", value);
+                    setSimulatedPosture(value);
+                }
+            });
+            postureGroup.add(item);
+            postureMenu.add(item);
+        }
+        foldableMenu.add(postureMenu);
+
+        // Fold orientation radio group.
+        JMenu orientationMenu = new JMenu("Fold orientation");
+        ButtonGroup orientationGroup = new ButtonGroup();
+        final int[] orientationValues = {
+            com.codename1.ui.DevicePosture.FOLD_ORIENTATION_VERTICAL,
+            com.codename1.ui.DevicePosture.FOLD_ORIENTATION_HORIZONTAL
+        };
+        String[] orientationLabels = {"Vertical (splits left/right)", "Horizontal (splits top/bottom)"};
+        for (int i = 0; i < orientationValues.length; i++) {
+            final int value = orientationValues[i];
+            JRadioButtonMenuItem item = new JRadioButtonMenuItem(orientationLabels[i], orientation == value);
+            item.addActionListener(new ActionListener() {
+                @Override
+                public void actionPerformed(ActionEvent ae) {
+                    pref.putInt("FoldableSim.orientation", value);
+                    setSimulatedFoldOrientation(value);
+                }
+            });
+            orientationGroup.add(item);
+            orientationMenu.add(item);
+        }
+        foldableMenu.add(orientationMenu);
+
+        // Hinge angle dialog.
+        final JMenuItem hingeItem = new JMenuItem("Set hinge angle...");
+        hingeItem.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent ae) {
+                String def = String.valueOf(pref.getInt("FoldableSim.hingeAngle", 180));
+                String val = JOptionPane.showInputDialog(canvas,
+                        "Hinge angle in degrees (0 closed - 180 flat):", def);
+                if (val == null) {
+                    return;
+                }
+                try {
+                    int angle = Math.max(0, Math.min(180, Integer.parseInt(val.trim())));
+                    pref.putInt("FoldableSim.hingeAngle", angle);
+                    setSimulatedHingeAngle(angle);
+                } catch (NumberFormatException nfe) {
+                    JOptionPane.showMessageDialog(canvas, "Please enter a whole number between 0 and 180.");
+                }
+            }
+        });
+        foldableMenu.add(hingeItem);
+
+        return foldableMenu;
     }
 
     private static byte[] parseHex(String hex) {

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -2668,26 +2668,55 @@ public class HTML5Implementation extends CodenameOneImplementation {
     @JSBody(params={}, script="return window.cn1WheelMultiplier || 1.0")
     private static native double wheelMultiplier();
     
-    /// Records the mouse button and pointer type for the next dispatched pointer event so the
-    /// cross-platform PointerEvent / context-menu APIs work in the browser. DOM mouse buttons are
-    /// 0 (left), 1 (middle), 2 (right).
+    /// Records the mouse button, button mask and keyboard modifiers for the next dispatched pointer
+    /// event so the cross-platform PointerEvent / context-menu APIs work in the browser. The DOM
+    /// {@code button} that changed is 0 (left), 1 (middle), 2 (right), 3 (back), 4 (forward); the DOM
+    /// {@code buttons} bitmask of held buttons aligns 1:1 with PointerEvent.MASK_* so it is used
+    /// directly (it drives the mask during a drag).
     private void applyMouseMetadata(MouseEvent me) {
-        int button = com.codename1.ui.events.PointerEvent.BUTTON_PRIMARY;
-        int mask = com.codename1.ui.events.PointerEvent.MASK_PRIMARY;
+        int button;
         switch (me.getButton()) {
             case 1:
                 button = com.codename1.ui.events.PointerEvent.BUTTON_MIDDLE;
-                mask = com.codename1.ui.events.PointerEvent.MASK_MIDDLE;
                 break;
             case 2:
                 button = com.codename1.ui.events.PointerEvent.BUTTON_SECONDARY;
-                mask = com.codename1.ui.events.PointerEvent.MASK_SECONDARY;
+                break;
+            case 3:
+                button = com.codename1.ui.events.PointerEvent.BUTTON_BACK;
+                break;
+            case 4:
+                button = com.codename1.ui.events.PointerEvent.BUTTON_FORWARD;
                 break;
             default:
+                button = com.codename1.ui.events.PointerEvent.BUTTON_PRIMARY;
                 break;
         }
+        // buttons is 0 on mouseup, so fall back to the single button that changed (1 << button).
+        int mask = me.getButtons();
+        if (mask == 0) {
+            mask = 1 << button;
+        }
         setPointerEventMetadata(button, mask, com.codename1.ui.events.PointerEvent.TYPE_MOUSE,
-                1f, 0, 0, 0, 0, false);
+                1f, 0, 0, 0, mouseModifiers(me), false);
+    }
+
+    /// Folds the DOM modifier-key flags into the PointerEvent.MODIFIER_* bitmask.
+    private int mouseModifiers(MouseEvent me) {
+        int modifiers = 0;
+        if (me.isShiftKey()) {
+            modifiers |= com.codename1.ui.events.PointerEvent.MODIFIER_SHIFT;
+        }
+        if (me.isCtrlKey()) {
+            modifiers |= com.codename1.ui.events.PointerEvent.MODIFIER_CONTROL;
+        }
+        if (me.isAltKey()) {
+            modifiers |= com.codename1.ui.events.PointerEvent.MODIFIER_ALT;
+        }
+        if (me.isMetaKey()) {
+            modifiers |= com.codename1.ui.events.PointerEvent.MODIFIER_META;
+        }
+        return modifiers;
     }
 
     /// Flags the next dispatched pointer event as a finger touch.
@@ -9361,13 +9390,13 @@ public class HTML5Implementation extends CodenameOneImplementation {
                 cache = new HashMap<Character,Integer>();
                 charWidthCache.put(getCSS(), cache);
             }
-            Character ch = new Character(c);
+            Character ch = c;
             Integer i = cache.get(ch);
             if (i != null){
                 return i.intValue();
             }
             int w = graphics.charsWidth(this, new char[]{c},0,1);
-            cache.put(ch, new Integer(w));
+            cache.put(ch, w);
             return w;
         }
         
@@ -9384,7 +9413,7 @@ public class HTML5Implementation extends CodenameOneImplementation {
                     return i.intValue();
                 }
                 int w = graphics.stringWidth(this, str);
-                cache.put(str, new Integer(w));
+                cache.put(str, w);
                 return w;
             } else {
                 return graphics.stringWidth(this, str);

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -1578,6 +1578,7 @@ public class HTML5Implementation extends CodenameOneImplementation {
                 nativeCallSerially(new Runnable() {
                     public void run() {
                         try {
+                            applyMouseMetadata(me);
                             HTML5Implementation.this.pointerPressed(new int[]{x}, new int[]{y});
                         } finally {
                             completePressInFlight();
@@ -1631,6 +1632,7 @@ public class HTML5Implementation extends CodenameOneImplementation {
 
                 pointerState.setLastTouchUpPosition(x, y);
                 installBacksideHooksInUserInteraction();
+                applyMouseMetadata(me);
 
                 final Runnable releaseDispatch = new Runnable() {
                     public void run() {
@@ -1738,6 +1740,7 @@ public class HTML5Implementation extends CodenameOneImplementation {
                 });
                 if (touchDecision.shouldFirePointerPressed()) {
                     installBacksideHooksInUserInteraction();
+                    applyTouchMetadata();
                     nativeCallSerially(new Runnable() {
 
                         @Override
@@ -2665,6 +2668,35 @@ public class HTML5Implementation extends CodenameOneImplementation {
     @JSBody(params={}, script="return window.cn1WheelMultiplier || 1.0")
     private static native double wheelMultiplier();
     
+    /// Records the mouse button and pointer type for the next dispatched pointer event so the
+    /// cross-platform PointerEvent / context-menu APIs work in the browser. DOM mouse buttons are
+    /// 0 (left), 1 (middle), 2 (right).
+    private void applyMouseMetadata(MouseEvent me) {
+        int button = com.codename1.ui.events.PointerEvent.BUTTON_PRIMARY;
+        int mask = com.codename1.ui.events.PointerEvent.MASK_PRIMARY;
+        switch (me.getButton()) {
+            case 1:
+                button = com.codename1.ui.events.PointerEvent.BUTTON_MIDDLE;
+                mask = com.codename1.ui.events.PointerEvent.MASK_MIDDLE;
+                break;
+            case 2:
+                button = com.codename1.ui.events.PointerEvent.BUTTON_SECONDARY;
+                mask = com.codename1.ui.events.PointerEvent.MASK_SECONDARY;
+                break;
+            default:
+                break;
+        }
+        setPointerEventMetadata(button, mask, com.codename1.ui.events.PointerEvent.TYPE_MOUSE,
+                1f, 0, 0, 0, 0, false);
+    }
+
+    /// Flags the next dispatched pointer event as a finger touch.
+    private void applyTouchMetadata() {
+        setPointerEventMetadata(com.codename1.ui.events.PointerEvent.BUTTON_PRIMARY,
+                com.codename1.ui.events.PointerEvent.MASK_PRIMARY,
+                com.codename1.ui.events.PointerEvent.TYPE_TOUCH, 1f, 0, 0, 0, 0, false);
+    }
+
     public void mouseWheelMoved(WheelEvent e) {
         NormalizedWheelEvent ne = normalizeWheelEvent(e);
         
@@ -2683,6 +2715,11 @@ public class HTML5Implementation extends CodenameOneImplementation {
         final int dx = -(int)(ne.getPixelX() * getDevicePixelRatio() * wheelMultiplier());
         final int dy = -(int)(ne.getPixelY() * getDevicePixelRatio() * wheelMultiplier());
         //debugLog("dx="+dx+"; dy="+dy);
+        // Give mouse wheel listeners a chance to handle (and consume) the wheel before the default
+        // scroll gesture, so WheelEvent is the same universal scroll API used on desktop and mobile.
+        if (Display.getInstance().fireMouseWheelEvent(x, y, dx, dy, true, 0)) {
+            return;
+        }
         Display.getInstance().callSerially(new Runnable() {
             public void run() {
                 scrollWheeling = true;

--- a/Ports/LinuxPort/nativeSources/cn1_linux.h
+++ b/Ports/LinuxPort/nativeSources/cn1_linux.h
@@ -65,6 +65,20 @@ typedef enum {
     CN1_EVENT_MOUSE_HWHEEL = 9
 } CN1EventType;
 
+/* For pointer (pressed/released/dragged) events the otherwise-unused keyCode
+ * field carries the pointer metadata: the low bits are a button bitmask that
+ * mirrors com.codename1.ui.events.PointerEvent.MASK_* (so a press/release carry
+ * the button that changed and a drag carries the buttons held down), and the
+ * high bits flag a touch digitizer so the Java side reports TYPE_TOUCH. A value
+ * of 0 means "no detail" and defaults to a primary mouse press.
+ * LinuxImplementation.drainInput decodes this. */
+#define CN1_PE_MASK_PRIMARY   1
+#define CN1_PE_MASK_SECONDARY 2
+#define CN1_PE_MASK_MIDDLE    4
+#define CN1_PE_MASK_BACK      8
+#define CN1_PE_MASK_FORWARD   16
+#define CN1_PE_TOUCH_FLAG     256
+
 /* Pushes one event onto the ring buffer (called from the GTK thread). */
 void cn1LinuxPushEvent(int type, int x, int y, int keyCode);
 

--- a/Ports/LinuxPort/nativeSources/cn1_linux.h
+++ b/Ports/LinuxPort/nativeSources/cn1_linux.h
@@ -62,8 +62,18 @@ typedef enum {
     CN1_EVENT_SIZE_CHANGED = 6,
     CN1_EVENT_CLOSE = 7,
     CN1_EVENT_MOUSE_WHEEL = 8,
-    CN1_EVENT_MOUSE_HWHEEL = 9
+    CN1_EVENT_MOUSE_HWHEEL = 9,
+    /* Touchpad pinch / rotate: x/y are the gesture's widget coordinates and
+     * keyCode is the incremental value in 1/10000 units -- an incremental scale
+     * multiplier for PINCH (10000 == scale 1.0) and incremental radians for
+     * ROTATE. drainInput decodes these into Display.fireMagnifyGesture /
+     * fireRotationGesture, the same hooks the macOS trackpad drives. */
+    CN1_EVENT_PINCH = 10,
+    CN1_EVENT_ROTATE = 11
 } CN1EventType;
+
+/* Fixed-point scale for the gesture keyCode field (see CN1_EVENT_PINCH). */
+#define CN1_GESTURE_FIXED 10000
 
 /* For pointer (pressed/released/dragged) events the otherwise-unused keyCode
  * field carries the pointer metadata: the low bits are a button bitmask that

--- a/Ports/LinuxPort/nativeSources/cn1_linux_window.c
+++ b/Ports/LinuxPort/nativeSources/cn1_linux_window.c
@@ -343,6 +343,42 @@ static gboolean cn1OnKey(GtkWidget* widget, GdkEventKey* e, gpointer data) {
     return TRUE;
 }
 
+/* Touchpad pinch / rotate (GDK_TOUCHPAD_PINCH, libinput). scale is cumulative
+ * relative to the gesture's BEGIN, so we forward the incremental multiplier;
+ * angle_delta is already a per-event delta in degrees, forwarded as incremental
+ * radians. These map to Display.fireMagnifyGesture / fireRotationGesture, the
+ * same hooks the macOS trackpad drives. Delivered through the generic "event"
+ * signal, so we return FALSE for anything else to leave other handlers intact. */
+static double cn1PinchLastScale = 1.0;
+
+static gboolean cn1OnGenericEvent(GtkWidget* widget, GdkEvent* e, gpointer data) {
+    (void) widget;
+    (void) data;
+    if (e->type != GDK_TOUCHPAD_PINCH) {
+        return FALSE;
+    }
+    GdkEventTouchpadPinch* pe = (GdkEventTouchpadPinch*) e;
+    if (pe->phase == GDK_TOUCHPAD_GESTURE_PHASE_BEGIN) {
+        cn1PinchLastScale = pe->scale > 0 ? pe->scale : 1.0;
+    } else if (pe->phase == GDK_TOUCHPAD_GESTURE_PHASE_UPDATE) {
+        int x = (int) pe->x;
+        int y = (int) pe->y;
+        if (pe->scale > 0 && cn1PinchLastScale > 0) {
+            double inc = pe->scale / cn1PinchLastScale;
+            cn1PinchLastScale = pe->scale;
+            if (inc != 1.0) {
+                cn1LinuxPushEvent(CN1_EVENT_PINCH, x, y, (int) (inc * CN1_GESTURE_FIXED + 0.5));
+            }
+        }
+        if (pe->angle_delta != 0.0) {
+            double rad = pe->angle_delta * G_PI / 180.0;
+            cn1LinuxPushEvent(CN1_EVENT_ROTATE, x, y,
+                    (int) (rad * CN1_GESTURE_FIXED + (rad >= 0 ? 0.5 : -0.5)));
+        }
+    }
+    return TRUE;
+}
+
 static gboolean cn1OnScroll(GtkWidget* widget, GdkEventScroll* e, gpointer data) {
     (void) widget;
     (void) data;
@@ -490,7 +526,7 @@ JAVA_VOID com_codename1_impl_linux_LinuxNative_initDisplay___java_lang_String_in
     gtk_widget_set_events(cn1DrawingArea,
             GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_POINTER_MOTION_MASK |
             GDK_KEY_PRESS_MASK | GDK_KEY_RELEASE_MASK | GDK_SCROLL_MASK | GDK_TOUCH_MASK |
-            GDK_STRUCTURE_MASK);
+            GDK_TOUCHPAD_GESTURE_MASK | GDK_STRUCTURE_MASK);
     gtk_widget_set_can_focus(cn1DrawingArea, TRUE);
 
     /* A GtkOverlay layers a transparent, pass-through GtkFixed over the drawing
@@ -510,6 +546,7 @@ JAVA_VOID com_codename1_impl_linux_LinuxNative_initDisplay___java_lang_String_in
     g_signal_connect(cn1DrawingArea, "button-release-event", G_CALLBACK(cn1OnButton), 0);
     g_signal_connect(cn1DrawingArea, "motion-notify-event", G_CALLBACK(cn1OnMotion), 0);
     g_signal_connect(cn1DrawingArea, "touch-event", G_CALLBACK(cn1OnTouch), 0);
+    g_signal_connect(cn1DrawingArea, "event", G_CALLBACK(cn1OnGenericEvent), 0);
     g_signal_connect(cn1Window, "key-press-event", G_CALLBACK(cn1OnKey), 0);
     g_signal_connect(cn1Window, "key-release-event", G_CALLBACK(cn1OnKey), 0);
     g_signal_connect(cn1DrawingArea, "scroll-event", G_CALLBACK(cn1OnScroll), 0);

--- a/Ports/LinuxPort/nativeSources/cn1_linux_window.c
+++ b/Ports/LinuxPort/nativeSources/cn1_linux_window.c
@@ -225,21 +225,94 @@ static gboolean cn1OnConfigure(GtkWidget* widget, GdkEventConfigure* e, gpointer
     return FALSE;
 }
 
+/* Maps a GdkEventButton.button (1=left, 2=middle, 3=right, 8=back, 9=forward)
+ * to a CN1_PE_MASK_* bit. */
+static int cn1LinuxButtonMask(guint button) {
+    switch (button) {
+        case 1:  return CN1_PE_MASK_PRIMARY;
+        case 2:  return CN1_PE_MASK_MIDDLE;
+        case 3:  return CN1_PE_MASK_SECONDARY;
+        case 8:  return CN1_PE_MASK_BACK;
+        case 9:  return CN1_PE_MASK_FORWARD;
+        default: return CN1_PE_MASK_PRIMARY;
+    }
+}
+
+/* Buttons held down according to a GdkEvent state mask, used to label a drag. */
+static int cn1LinuxStateMask(guint state) {
+    int mask = 0;
+    if (state & GDK_BUTTON1_MASK) mask |= CN1_PE_MASK_PRIMARY;
+    if (state & GDK_BUTTON2_MASK) mask |= CN1_PE_MASK_MIDDLE;
+    if (state & GDK_BUTTON3_MASK) mask |= CN1_PE_MASK_SECONDARY;
+    if (state & GDK_BUTTON4_MASK) mask |= CN1_PE_MASK_BACK;
+    if (state & GDK_BUTTON5_MASK) mask |= CN1_PE_MASK_FORWARD;
+    return mask;
+}
+
+/* True when an event originated from a touchscreen. GTK also synthesizes button
+ * / motion events from touch for widgets that ignore touch, so we drop those
+ * here and let cn1OnTouch drive the pointer instead (avoids double dispatch). */
+static int cn1LinuxIsTouchSource(GdkEvent* e) {
+    GdkDevice* dev = gdk_event_get_source_device(e);
+    return dev != NULL && gdk_device_get_source(dev) == GDK_SOURCE_TOUCHSCREEN;
+}
+
 static gboolean cn1OnButton(GtkWidget* widget, GdkEventButton* e, gpointer data) {
     (void) widget;
     (void) data;
+    if (cn1LinuxIsTouchSource((GdkEvent*) e)) {
+        return TRUE;
+    }
     cn1LinuxPushEvent(e->type == GDK_BUTTON_PRESS ? CN1_EVENT_POINTER_PRESSED : CN1_EVENT_POINTER_RELEASED,
-            (int) e->x, (int) e->y, 0);
+            (int) e->x, (int) e->y, cn1LinuxButtonMask(e->button));
     return TRUE;
 }
 
 static gboolean cn1OnMotion(GtkWidget* widget, GdkEventMotion* e, gpointer data) {
     (void) widget;
     (void) data;
-    if (e->state & GDK_BUTTON1_MASK) {
-        cn1LinuxPushEvent(CN1_EVENT_POINTER_DRAGGED, (int) e->x, (int) e->y, 0);
+    if (cn1LinuxIsTouchSource((GdkEvent*) e)) {
+        return TRUE;
+    }
+    int mask = cn1LinuxStateMask(e->state);
+    if (mask != 0) {
+        cn1LinuxPushEvent(CN1_EVENT_POINTER_DRAGGED, (int) e->x, (int) e->y, mask);
     }
     return TRUE;
+}
+
+/* The primary touch sequence currently driving the pointer (single-touch
+ * model). Additional concurrent fingers are ignored until it ends. */
+static GdkEventSequence* cn1TouchSeq = NULL;
+
+static gboolean cn1OnTouch(GtkWidget* widget, GdkEventTouch* e, gpointer data) {
+    (void) widget;
+    (void) data;
+    switch (e->type) {
+        case GDK_TOUCH_BEGIN:
+            if (cn1TouchSeq == NULL) {
+                cn1TouchSeq = e->sequence;
+                cn1LinuxPushEvent(CN1_EVENT_POINTER_PRESSED, (int) e->x, (int) e->y,
+                        CN1_PE_MASK_PRIMARY | CN1_PE_TOUCH_FLAG);
+            }
+            return TRUE;
+        case GDK_TOUCH_UPDATE:
+            if (e->sequence == cn1TouchSeq) {
+                cn1LinuxPushEvent(CN1_EVENT_POINTER_DRAGGED, (int) e->x, (int) e->y,
+                        CN1_PE_MASK_PRIMARY | CN1_PE_TOUCH_FLAG);
+            }
+            return TRUE;
+        case GDK_TOUCH_END:
+        case GDK_TOUCH_CANCEL:
+            if (e->sequence == cn1TouchSeq) {
+                cn1TouchSeq = NULL;
+                cn1LinuxPushEvent(CN1_EVENT_POINTER_RELEASED, (int) e->x, (int) e->y,
+                        CN1_PE_MASK_PRIMARY | CN1_PE_TOUCH_FLAG);
+            }
+            return TRUE;
+        default:
+            return FALSE;
+    }
 }
 
 static gboolean cn1OnKey(GtkWidget* widget, GdkEventKey* e, gpointer data) {
@@ -416,7 +489,8 @@ JAVA_VOID com_codename1_impl_linux_LinuxNative_initDisplay___java_lang_String_in
     cn1DrawingArea = gtk_drawing_area_new();
     gtk_widget_set_events(cn1DrawingArea,
             GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_POINTER_MOTION_MASK |
-            GDK_KEY_PRESS_MASK | GDK_KEY_RELEASE_MASK | GDK_SCROLL_MASK | GDK_STRUCTURE_MASK);
+            GDK_KEY_PRESS_MASK | GDK_KEY_RELEASE_MASK | GDK_SCROLL_MASK | GDK_TOUCH_MASK |
+            GDK_STRUCTURE_MASK);
     gtk_widget_set_can_focus(cn1DrawingArea, TRUE);
 
     /* A GtkOverlay layers a transparent, pass-through GtkFixed over the drawing
@@ -435,6 +509,7 @@ JAVA_VOID com_codename1_impl_linux_LinuxNative_initDisplay___java_lang_String_in
     g_signal_connect(cn1DrawingArea, "button-press-event", G_CALLBACK(cn1OnButton), 0);
     g_signal_connect(cn1DrawingArea, "button-release-event", G_CALLBACK(cn1OnButton), 0);
     g_signal_connect(cn1DrawingArea, "motion-notify-event", G_CALLBACK(cn1OnMotion), 0);
+    g_signal_connect(cn1DrawingArea, "touch-event", G_CALLBACK(cn1OnTouch), 0);
     g_signal_connect(cn1Window, "key-press-event", G_CALLBACK(cn1OnKey), 0);
     g_signal_connect(cn1Window, "key-release-event", G_CALLBACK(cn1OnKey), 0);
     g_signal_connect(cn1DrawingArea, "scroll-event", G_CALLBACK(cn1OnScroll), 0);
@@ -465,6 +540,30 @@ JAVA_INT com_codename1_impl_linux_LinuxNative_screenDpi___R_int(CODENAME_ONE_THR
         }
     }
     return 96;
+}
+
+/* True when the default seat has a touchscreen pointing device attached, so the
+ * framework reports a touch device (Display.isTouchScreen()). */
+JAVA_BOOLEAN com_codename1_impl_linux_LinuxNative_isTouchDevice___R_boolean(CODENAME_ONE_THREAD_STATE) {
+    GdkDisplay* display = gdk_display_get_default();
+    if (display == NULL) {
+        return JAVA_FALSE;
+    }
+    GdkSeat* seat = gdk_display_get_default_seat(display);
+    if (seat == NULL) {
+        return JAVA_FALSE;
+    }
+    GList* devices = gdk_seat_get_slaves(seat, GDK_SEAT_CAPABILITY_ALL_POINTING);
+    int found = 0;
+    for (GList* l = devices; l != NULL; l = l->next) {
+        GdkDevice* dev = (GdkDevice*) l->data;
+        if (dev != NULL && gdk_device_get_source(dev) == GDK_SOURCE_TOUCHSCREEN) {
+            found = 1;
+            break;
+        }
+    }
+    g_list_free(devices);
+    return found ? JAVA_TRUE : JAVA_FALSE;
 }
 
 JAVA_LONG com_codename1_impl_linux_LinuxNative_getWindowGraphics___R_long(CODENAME_ONE_THREAD_STATE) {

--- a/Ports/LinuxPort/src/com/codename1/impl/linux/LinuxImplementation.java
+++ b/Ports/LinuxPort/src/com/codename1/impl/linux/LinuxImplementation.java
@@ -592,13 +592,36 @@ public class LinuxImplementation extends CodenameOneImplementation {
         // not pump or drain on its own (it is not the window's owning thread).
     }
 
-    // Flags the next dispatched pointer event as coming from a mouse so the cross-platform
-    // PointerEvent type is correct on this desktop port. The native event protocol does not yet
-    // distinguish mouse buttons, so the button defaults to primary.
-    private void markMousePointer() {
-        setPointerEventMetadata(com.codename1.ui.events.PointerEvent.BUTTON_PRIMARY,
-                com.codename1.ui.events.PointerEvent.MASK_PRIMARY,
-                com.codename1.ui.events.PointerEvent.TYPE_MOUSE, 1f, 0, 0, 0, 0, false);
+    // High bit the native layer ORs into a pointer event's key field to flag a touch
+    // digitizer (see cn1_linux.h CN1_PE_TOUCH_FLAG); the low byte is the button
+    // bitmask (PointerEvent.MASK_*).
+    private static final int POINTER_BUTTON_BITS = 0xFF;
+    private static final int POINTER_TOUCH_FLAG = 256;
+
+    // Decodes the native pointer key field (button mask + touch flag) into the
+    // cross-platform PointerEvent metadata for the next dispatched pointer event, so
+    // the rich pointer / context-menu APIs report the real button and device type.
+    private void markPointer(int keyField) {
+        int mask = keyField & POINTER_BUTTON_BITS;
+        int type = (keyField & POINTER_TOUCH_FLAG) != 0
+                ? com.codename1.ui.events.PointerEvent.TYPE_TOUCH
+                : com.codename1.ui.events.PointerEvent.TYPE_MOUSE;
+        int button;
+        if (mask == 0) {
+            mask = com.codename1.ui.events.PointerEvent.MASK_PRIMARY;
+            button = com.codename1.ui.events.PointerEvent.BUTTON_PRIMARY;
+        } else if ((mask & com.codename1.ui.events.PointerEvent.MASK_PRIMARY) != 0) {
+            button = com.codename1.ui.events.PointerEvent.BUTTON_PRIMARY;
+        } else if ((mask & com.codename1.ui.events.PointerEvent.MASK_SECONDARY) != 0) {
+            button = com.codename1.ui.events.PointerEvent.BUTTON_SECONDARY;
+        } else if ((mask & com.codename1.ui.events.PointerEvent.MASK_MIDDLE) != 0) {
+            button = com.codename1.ui.events.PointerEvent.BUTTON_MIDDLE;
+        } else if ((mask & com.codename1.ui.events.PointerEvent.MASK_BACK) != 0) {
+            button = com.codename1.ui.events.PointerEvent.BUTTON_BACK;
+        } else {
+            button = com.codename1.ui.events.PointerEvent.BUTTON_FORWARD;
+        }
+        setPointerEventMetadata(button, mask, type, 1f, 0, 0, 0, 0, false);
     }
 
     private void drainInput() {
@@ -609,15 +632,15 @@ public class LinuxImplementation extends CodenameOneImplementation {
             int key = eventScratch[3];
             switch (type) {
                 case EVENT_POINTER_PRESSED:
-                    markMousePointer();
+                    markPointer(key);
                     pointerPressed(x, y);
                     break;
                 case EVENT_POINTER_RELEASED:
-                    markMousePointer();
+                    markPointer(key);
                     pointerReleased(x, y);
                     break;
                 case EVENT_POINTER_DRAGGED:
-                    markMousePointer();
+                    markPointer(key);
                     pointerDragged(x, y);
                     break;
                 case EVENT_KEY_PRESSED:
@@ -2021,7 +2044,7 @@ public class LinuxImplementation extends CodenameOneImplementation {
 
     @Override
     public boolean isTouchDevice() {
-        return false;
+        return LinuxNative.isTouchDevice();
     }
 
     @Override

--- a/Ports/LinuxPort/src/com/codename1/impl/linux/LinuxImplementation.java
+++ b/Ports/LinuxPort/src/com/codename1/impl/linux/LinuxImplementation.java
@@ -592,6 +592,15 @@ public class LinuxImplementation extends CodenameOneImplementation {
         // not pump or drain on its own (it is not the window's owning thread).
     }
 
+    // Flags the next dispatched pointer event as coming from a mouse so the cross-platform
+    // PointerEvent type is correct on this desktop port. The native event protocol does not yet
+    // distinguish mouse buttons, so the button defaults to primary.
+    private void markMousePointer() {
+        setPointerEventMetadata(com.codename1.ui.events.PointerEvent.BUTTON_PRIMARY,
+                com.codename1.ui.events.PointerEvent.MASK_PRIMARY,
+                com.codename1.ui.events.PointerEvent.TYPE_MOUSE, 1f, 0, 0, 0, 0, false);
+    }
+
     private void drainInput() {
         while (LinuxNative.pollEvent(eventScratch)) {
             int type = eventScratch[0];
@@ -600,12 +609,15 @@ public class LinuxImplementation extends CodenameOneImplementation {
             int key = eventScratch[3];
             switch (type) {
                 case EVENT_POINTER_PRESSED:
+                    markMousePointer();
                     pointerPressed(x, y);
                     break;
                 case EVENT_POINTER_RELEASED:
+                    markMousePointer();
                     pointerReleased(x, y);
                     break;
                 case EVENT_POINTER_DRAGGED:
+                    markMousePointer();
                     pointerDragged(x, y);
                     break;
                 case EVENT_KEY_PRESSED:

--- a/Ports/LinuxPort/src/com/codename1/impl/linux/LinuxImplementation.java
+++ b/Ports/LinuxPort/src/com/codename1/impl/linux/LinuxImplementation.java
@@ -78,6 +78,12 @@ public class LinuxImplementation extends CodenameOneImplementation {
     private static final int EVENT_CLOSE = 7;
     private static final int EVENT_MOUSE_WHEEL = 8;
     private static final int EVENT_MOUSE_HWHEEL = 9;
+    private static final int EVENT_PINCH = 10;
+    private static final int EVENT_ROTATE = 11;
+
+    // The native gesture events encode their float (incremental scale / radians) as
+    // an int in 1/10000 units; see CN1_GESTURE_FIXED in cn1_linux.h.
+    private static final float GESTURE_FIXED = 10000f;
 
     // One mouse-wheel notch is WHEEL_DELTA (120). Linux defaults to scrolling
     // three lines per notch; * 5 then converted through the screen DPI gives a
@@ -663,6 +669,14 @@ public class LinuxImplementation extends CodenameOneImplementation {
                     // A positive horizontal notch tilts right (scrolls content
                     // left), i.e. drags the finger left -> negative scrollX.
                     pointerWheelMoved(x, y, -wheelUnits(key), 0);
+                    break;
+                case EVENT_PINCH:
+                    // key is the incremental scale multiplier in 1/10000 units.
+                    Display.getInstance().fireMagnifyGesture(x, y, key / GESTURE_FIXED);
+                    break;
+                case EVENT_ROTATE:
+                    // key is the incremental rotation in 1/10000 radians.
+                    Display.getInstance().fireRotationGesture(x, y, key / GESTURE_FIXED);
                     break;
                 case EVENT_CLOSE:
                     Display.getInstance().exitApplication();

--- a/Ports/LinuxPort/src/com/codename1/impl/linux/LinuxNative.java
+++ b/Ports/LinuxPort/src/com/codename1/impl/linux/LinuxNative.java
@@ -121,6 +121,12 @@ public final class LinuxNative {
     public static native boolean pollEvent(int[] out);
 
     /**
+     * True when the default seat has a touchscreen device, used for
+     * {@code Display.isTouchScreen()}.
+     */
+    public static native boolean isTouchDevice();
+
+    /**
      * Parks the calling (main) thread to keep the process alive in headless
      * screenshot mode, where there is no window message loop. The EDT exits the
      * process via {@link #headlessTick()} once the screenshot has been written.

--- a/Ports/WindowsPort/nativeSources/cn1_windows.h
+++ b/Ports/WindowsPort/nativeSources/cn1_windows.h
@@ -104,6 +104,21 @@ typedef struct {
     JAVA_INT keyCode;
 } CN1Event;
 
+/* For pointer (pressed/released/dragged) events the otherwise-unused keyCode
+ * field carries the pointer metadata: the low bits are a button bitmask that
+ * mirrors com.codename1.ui.events.PointerEvent.MASK_* (so a press/release carry
+ * the button that changed and a drag carries the buttons held down), and the
+ * high bits flag a touch / pen digitizer so the Java side reports the right
+ * PointerEvent type. A value of 0 means "no detail" and defaults to a primary
+ * mouse press. WindowsImplementation.drainInput decodes this. */
+#define CN1_PE_MASK_PRIMARY   1
+#define CN1_PE_MASK_SECONDARY 2
+#define CN1_PE_MASK_MIDDLE    4
+#define CN1_PE_MASK_BACK      8
+#define CN1_PE_MASK_FORWARD   16
+#define CN1_PE_TOUCH_FLAG     256
+#define CN1_PE_PEN_FLAG       512
+
 #define CN1_EVENT_QUEUE_CAPACITY 1024
 
 /* --------------------------------------------------------------- graphics */

--- a/Ports/WindowsPort/nativeSources/cn1_windows.h
+++ b/Ports/WindowsPort/nativeSources/cn1_windows.h
@@ -94,8 +94,18 @@ typedef enum {
      * signed wheel delta in WHEEL_DELTA (120) units. The EDT turns it into a
      * synthetic scroll gesture (see WindowsImplementation.drainInput). */
     CN1_EVENT_MOUSE_WHEEL = 8,
-    CN1_EVENT_MOUSE_HWHEEL = 9
+    CN1_EVENT_MOUSE_HWHEEL = 9,
+    /* Trackpad pinch / rotate: x/y are the gesture's client coordinates and
+     * keyCode is the incremental value in 1/10000 units -- an incremental scale
+     * multiplier for PINCH (10000 == scale 1.0) and incremental radians for
+     * ROTATE. drainInput decodes these into Display.fireMagnifyGesture /
+     * fireRotationGesture, the same hooks the macOS trackpad drives. */
+    CN1_EVENT_PINCH = 10,
+    CN1_EVENT_ROTATE = 11
 } CN1EventType;
+
+/* Fixed-point scale for the gesture keyCode field (see CN1_EVENT_PINCH). */
+#define CN1_GESTURE_FIXED 10000
 
 typedef struct {
     JAVA_INT type;

--- a/Ports/WindowsPort/nativeSources/cn1_windows_window.cpp
+++ b/Ports/WindowsPort/nativeSources/cn1_windows_window.cpp
@@ -379,6 +379,55 @@ static int cn1WinTouchFlag(void) {
     return 0;
 }
 
+#ifdef WM_GESTURE
+/* macOS-style trackpad / touchscreen pinch and rotate via the Win32 gesture API.
+ * GID_ZOOM reports the absolute distance between the fingers and GID_ROTATE the
+ * absolute angle (radians); we forward the incremental scale / radians since the
+ * cross-platform pinch() / rotation() callbacks expect deltas like the Mac. */
+static double cn1WinZoomLast = 0.0;
+static double cn1WinRotateLast = 0.0;
+
+static int cn1WinHandleGesture(HWND hwnd, LPARAM lParam) {
+    GESTUREINFO gi;
+    ZeroMemory(&gi, sizeof(gi));
+    gi.cbSize = sizeof(gi);
+    if (!GetGestureInfo((HGESTUREINFO) lParam, &gi)) {
+        return 0;
+    }
+    int handled = 0;
+    POINT pt;
+    pt.x = gi.ptsLocation.x;
+    pt.y = gi.ptsLocation.y;
+    ScreenToClient(hwnd, &pt);
+    if (gi.dwID == GID_ZOOM) {
+        double dist = (double) gi.ullArguments;
+        if (gi.dwFlags & GF_BEGIN) {
+            cn1WinZoomLast = dist;
+        } else if (cn1WinZoomLast > 0.0 && dist > 0.0) {
+            double scale = dist / cn1WinZoomLast;
+            cn1WinZoomLast = dist;
+            cn1WinPushEvent(CN1_EVENT_PINCH, pt.x, pt.y, (int) (scale * CN1_GESTURE_FIXED + 0.5));
+        }
+        handled = 1;
+    } else if (gi.dwID == GID_ROTATE) {
+        if (gi.dwFlags & GF_BEGIN) {
+            cn1WinRotateLast = 0.0;
+        } else {
+            double angle = GID_ROTATE_ANGLE_FROM_ARGUMENT(gi.ullArguments);
+            double delta = angle - cn1WinRotateLast;
+            cn1WinRotateLast = angle;
+            cn1WinPushEvent(CN1_EVENT_ROTATE, pt.x, pt.y,
+                    (int) (delta * CN1_GESTURE_FIXED + (delta >= 0 ? 0.5 : -0.5)));
+        }
+        handled = 1;
+    }
+    if (handled) {
+        CloseGestureInfoHandle((HGESTUREINFO) lParam);
+    }
+    return handled;
+}
+#endif
+
 /* ------------------------------------------------------------- window proc */
 
 LRESULT CALLBACK cn1WinWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
@@ -435,6 +484,13 @@ LRESULT CALLBACK cn1WinWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam
             }
             return 0;
         }
+#ifdef WM_GESTURE
+        case WM_GESTURE:
+            if (cn1WinHandleGesture(hwnd, lParam)) {
+                return 0;
+            }
+            return DefWindowProcW(hwnd, msg, wParam, lParam);
+#endif
         case WM_MOUSEWHEEL:
         case WM_MOUSEHWHEEL: {
             /* The wheel message reports the cursor in SCREEN coordinates; the

--- a/Ports/WindowsPort/nativeSources/cn1_windows_window.cpp
+++ b/Ports/WindowsPort/nativeSources/cn1_windows_window.cpp
@@ -332,23 +332,109 @@ int cn1WinPollEvent(CN1Event* out) {
     return hasEvent;
 }
 
+/* ------------------------------------------------------------- input helpers */
+
+/* Bitmask (CN1_PE_MASK_*) of the mouse buttons currently held. Mouse capture is
+ * held while ANY button is down so a drag that starts inside the window keeps
+ * delivering WM_MOUSEMOVE after the cursor leaves it, and released only once the
+ * last button comes up. */
+static int cn1WinButtonMask = 0;
+
+static void cn1WinButtonDown(HWND hwnd, int mask) {
+    if (cn1WinButtonMask == 0) {
+        SetCapture(hwnd);
+    }
+    cn1WinButtonMask |= mask;
+}
+
+static void cn1WinButtonUp(HWND hwnd, int mask) {
+    cn1WinButtonMask &= ~mask;
+    if (cn1WinButtonMask == 0) {
+        ReleaseCapture();
+    }
+}
+
+/* Buttons currently held according to a WM_MOUSEMOVE wParam, used to label a
+ * drag with the right button(s). */
+static int cn1WinMoveMask(WPARAM wParam) {
+    int mask = 0;
+    if (wParam & MK_LBUTTON)  mask |= CN1_PE_MASK_PRIMARY;
+    if (wParam & MK_RBUTTON)  mask |= CN1_PE_MASK_SECONDARY;
+    if (wParam & MK_MBUTTON)  mask |= CN1_PE_MASK_MIDDLE;
+    if (wParam & MK_XBUTTON1) mask |= CN1_PE_MASK_BACK;
+    if (wParam & MK_XBUTTON2) mask |= CN1_PE_MASK_FORWARD;
+    return mask;
+}
+
+/* Windows promotes touch and pen input to ordinary mouse messages and tags the
+ * message's extra-info word with a signature (see GetMessageExtraInfo docs:
+ * MI_WP_SIGNATURE 0xFF515700, with bit 0x80 distinguishing pen from touch). We
+ * use it to flag the synthesized mouse event as a touch / pen so the
+ * cross-platform PointerEvent type is correct on touch-enabled PCs. */
+static int cn1WinTouchFlag(void) {
+    LONG_PTR extra = GetMessageExtraInfo();
+    if ((extra & 0xFFFFFF00) == 0xFF515700) {
+        return (extra & 0x80) ? CN1_PE_PEN_FLAG : CN1_PE_TOUCH_FLAG;
+    }
+    return 0;
+}
+
 /* ------------------------------------------------------------- window proc */
 
 LRESULT CALLBACK cn1WinWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam) {
     switch (msg) {
         case WM_LBUTTONDOWN:
-            SetCapture(hwnd);
-            cn1WinPushEvent(CN1_EVENT_POINTER_PRESSED, GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam), 0);
+            cn1WinButtonDown(hwnd, CN1_PE_MASK_PRIMARY);
+            cn1WinPushEvent(CN1_EVENT_POINTER_PRESSED, GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam),
+                    CN1_PE_MASK_PRIMARY | cn1WinTouchFlag());
             return 0;
         case WM_LBUTTONUP:
-            ReleaseCapture();
-            cn1WinPushEvent(CN1_EVENT_POINTER_RELEASED, GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam), 0);
+            cn1WinButtonUp(hwnd, CN1_PE_MASK_PRIMARY);
+            cn1WinPushEvent(CN1_EVENT_POINTER_RELEASED, GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam),
+                    CN1_PE_MASK_PRIMARY | cn1WinTouchFlag());
             return 0;
-        case WM_MOUSEMOVE:
-            if ((wParam & MK_LBUTTON) != 0) {
-                cn1WinPushEvent(CN1_EVENT_POINTER_DRAGGED, GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam), 0);
+        case WM_RBUTTONDOWN:
+            cn1WinButtonDown(hwnd, CN1_PE_MASK_SECONDARY);
+            cn1WinPushEvent(CN1_EVENT_POINTER_PRESSED, GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam),
+                    CN1_PE_MASK_SECONDARY | cn1WinTouchFlag());
+            return 0;
+        case WM_RBUTTONUP:
+            cn1WinButtonUp(hwnd, CN1_PE_MASK_SECONDARY);
+            cn1WinPushEvent(CN1_EVENT_POINTER_RELEASED, GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam),
+                    CN1_PE_MASK_SECONDARY | cn1WinTouchFlag());
+            return 0;
+        case WM_MBUTTONDOWN:
+            cn1WinButtonDown(hwnd, CN1_PE_MASK_MIDDLE);
+            cn1WinPushEvent(CN1_EVENT_POINTER_PRESSED, GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam),
+                    CN1_PE_MASK_MIDDLE | cn1WinTouchFlag());
+            return 0;
+        case WM_MBUTTONUP:
+            cn1WinButtonUp(hwnd, CN1_PE_MASK_MIDDLE);
+            cn1WinPushEvent(CN1_EVENT_POINTER_RELEASED, GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam),
+                    CN1_PE_MASK_MIDDLE | cn1WinTouchFlag());
+            return 0;
+        case WM_XBUTTONDOWN: {
+            int xmask = (GET_XBUTTON_WPARAM(wParam) == XBUTTON1) ? CN1_PE_MASK_BACK : CN1_PE_MASK_FORWARD;
+            cn1WinButtonDown(hwnd, xmask);
+            cn1WinPushEvent(CN1_EVENT_POINTER_PRESSED, GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam),
+                    xmask | cn1WinTouchFlag());
+            return TRUE; /* per WM_XBUTTON* contract */
+        }
+        case WM_XBUTTONUP: {
+            int xmask = (GET_XBUTTON_WPARAM(wParam) == XBUTTON1) ? CN1_PE_MASK_BACK : CN1_PE_MASK_FORWARD;
+            cn1WinButtonUp(hwnd, xmask);
+            cn1WinPushEvent(CN1_EVENT_POINTER_RELEASED, GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam),
+                    xmask | cn1WinTouchFlag());
+            return TRUE;
+        }
+        case WM_MOUSEMOVE: {
+            int moveMask = cn1WinMoveMask(wParam);
+            if (moveMask != 0) {
+                cn1WinPushEvent(CN1_EVENT_POINTER_DRAGGED, GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam),
+                        moveMask | cn1WinTouchFlag());
             }
             return 0;
+        }
         case WM_MOUSEWHEEL:
         case WM_MOUSEHWHEEL: {
             /* The wheel message reports the cursor in SCREEN coordinates; the
@@ -641,6 +727,27 @@ JAVA_INT com_codename1_impl_windows_WindowsNative_screenDpi___R_int(CODENAME_ONE
         }
     }
     return (JAVA_INT) dpi;
+}
+
+/* True when an integrated or external touch digitizer is present, so the
+ * framework reports a touch device (Display.isTouchScreen()). SM_DIGITIZER bits
+ * cover touch and pen; we treat any reported touch capability as a touch
+ * device. */
+JAVA_BOOLEAN com_codename1_impl_windows_WindowsNative_isTouchDevice___R_boolean(CODENAME_ONE_THREAD_STATE) {
+    /* SM_DIGITIZER / NID_* / SM_MAXIMUMTOUCHES need Windows 7+ headers; guard so
+     * the port still builds against an older SDK target (reports no touch then). */
+#if defined(SM_DIGITIZER) && defined(NID_INTEGRATED_TOUCH) && defined(NID_EXTERNAL_TOUCH)
+    int caps = GetSystemMetrics(SM_DIGITIZER);
+    if ((caps & (NID_INTEGRATED_TOUCH | NID_EXTERNAL_TOUCH)) != 0) {
+        return JAVA_TRUE;
+    }
+#endif
+#if defined(SM_MAXIMUMTOUCHES)
+    if (GetSystemMetrics(SM_MAXIMUMTOUCHES) > 0) {
+        return JAVA_TRUE;
+    }
+#endif
+    return JAVA_FALSE;
 }
 
 JAVA_INT com_codename1_impl_windows_WindowsNative_getDisplayHeight___R_int(CODENAME_ONE_THREAD_STATE) {

--- a/Ports/WindowsPort/src/com/codename1/impl/windows/WindowsImplementation.java
+++ b/Ports/WindowsPort/src/com/codename1/impl/windows/WindowsImplementation.java
@@ -571,6 +571,15 @@ public class WindowsImplementation extends CodenameOneImplementation {
         // not pump or drain on its own (it is not the window's owning thread).
     }
 
+    // Flags the next dispatched pointer event as coming from a mouse so the cross-platform
+    // PointerEvent type is correct on this desktop port. The native event protocol does not yet
+    // distinguish mouse buttons, so the button defaults to primary.
+    private void markMousePointer() {
+        setPointerEventMetadata(com.codename1.ui.events.PointerEvent.BUTTON_PRIMARY,
+                com.codename1.ui.events.PointerEvent.MASK_PRIMARY,
+                com.codename1.ui.events.PointerEvent.TYPE_MOUSE, 1f, 0, 0, 0, 0, false);
+    }
+
     private void drainInput() {
         while (WindowsNative.pollEvent(eventScratch)) {
             int type = eventScratch[0];
@@ -579,12 +588,15 @@ public class WindowsImplementation extends CodenameOneImplementation {
             int key = eventScratch[3];
             switch (type) {
                 case EVENT_POINTER_PRESSED:
+                    markMousePointer();
                     pointerPressed(x, y);
                     break;
                 case EVENT_POINTER_RELEASED:
+                    markMousePointer();
                     pointerReleased(x, y);
                     break;
                 case EVENT_POINTER_DRAGGED:
+                    markMousePointer();
                     pointerDragged(x, y);
                     break;
                 case EVENT_KEY_PRESSED:

--- a/Ports/WindowsPort/src/com/codename1/impl/windows/WindowsImplementation.java
+++ b/Ports/WindowsPort/src/com/codename1/impl/windows/WindowsImplementation.java
@@ -69,6 +69,12 @@ public class WindowsImplementation extends CodenameOneImplementation {
     private static final int EVENT_CLOSE = 7;
     private static final int EVENT_MOUSE_WHEEL = 8;
     private static final int EVENT_MOUSE_HWHEEL = 9;
+    private static final int EVENT_PINCH = 10;
+    private static final int EVENT_ROTATE = 11;
+
+    // The native gesture events encode their float (incremental scale / radians) as
+    // an int in 1/10000 units; see CN1_GESTURE_FIXED in cn1_windows.h.
+    private static final float GESTURE_FIXED = 10000f;
 
     // One mouse-wheel notch is WHEEL_DELTA (120). Windows defaults to scrolling
     // three lines per notch; * 5 then converted through the screen DPI gives a
@@ -648,6 +654,14 @@ public class WindowsImplementation extends CodenameOneImplementation {
                     // A positive horizontal notch tilts right (scrolls content
                     // left), i.e. drags the finger left -> negative scrollX.
                     pointerWheelMoved(x, y, -wheelUnits(key), 0);
+                    break;
+                case EVENT_PINCH:
+                    // key is the incremental scale multiplier in 1/10000 units.
+                    Display.getInstance().fireMagnifyGesture(x, y, key / GESTURE_FIXED);
+                    break;
+                case EVENT_ROTATE:
+                    // key is the incremental rotation in 1/10000 radians.
+                    Display.getInstance().fireRotationGesture(x, y, key / GESTURE_FIXED);
                     break;
                 case EVENT_CLOSE:
                     Display.getInstance().exitApplication();

--- a/Ports/WindowsPort/src/com/codename1/impl/windows/WindowsImplementation.java
+++ b/Ports/WindowsPort/src/com/codename1/impl/windows/WindowsImplementation.java
@@ -571,13 +571,42 @@ public class WindowsImplementation extends CodenameOneImplementation {
         // not pump or drain on its own (it is not the window's owning thread).
     }
 
-    // Flags the next dispatched pointer event as coming from a mouse so the cross-platform
-    // PointerEvent type is correct on this desktop port. The native event protocol does not yet
-    // distinguish mouse buttons, so the button defaults to primary.
-    private void markMousePointer() {
-        setPointerEventMetadata(com.codename1.ui.events.PointerEvent.BUTTON_PRIMARY,
-                com.codename1.ui.events.PointerEvent.MASK_PRIMARY,
-                com.codename1.ui.events.PointerEvent.TYPE_MOUSE, 1f, 0, 0, 0, 0, false);
+    // High bits the native layer ORs into a pointer event's key field to flag the
+    // input source (see cn1_windows.h CN1_PE_TOUCH_FLAG / CN1_PE_PEN_FLAG); the low
+    // byte is the button bitmask (PointerEvent.MASK_*).
+    private static final int POINTER_BUTTON_BITS = 0xFF;
+    private static final int POINTER_TOUCH_FLAG = 256;
+    private static final int POINTER_PEN_FLAG = 512;
+
+    // Decodes the native pointer key field (button mask + touch/pen flags) into the
+    // cross-platform PointerEvent metadata for the next dispatched pointer event, so
+    // the rich pointer / context-menu APIs report the real button and device type.
+    private void markPointer(int keyField) {
+        int mask = keyField & POINTER_BUTTON_BITS;
+        int type;
+        if ((keyField & POINTER_PEN_FLAG) != 0) {
+            type = com.codename1.ui.events.PointerEvent.TYPE_STYLUS;
+        } else if ((keyField & POINTER_TOUCH_FLAG) != 0) {
+            type = com.codename1.ui.events.PointerEvent.TYPE_TOUCH;
+        } else {
+            type = com.codename1.ui.events.PointerEvent.TYPE_MOUSE;
+        }
+        int button;
+        if (mask == 0) {
+            mask = com.codename1.ui.events.PointerEvent.MASK_PRIMARY;
+            button = com.codename1.ui.events.PointerEvent.BUTTON_PRIMARY;
+        } else if ((mask & com.codename1.ui.events.PointerEvent.MASK_PRIMARY) != 0) {
+            button = com.codename1.ui.events.PointerEvent.BUTTON_PRIMARY;
+        } else if ((mask & com.codename1.ui.events.PointerEvent.MASK_SECONDARY) != 0) {
+            button = com.codename1.ui.events.PointerEvent.BUTTON_SECONDARY;
+        } else if ((mask & com.codename1.ui.events.PointerEvent.MASK_MIDDLE) != 0) {
+            button = com.codename1.ui.events.PointerEvent.BUTTON_MIDDLE;
+        } else if ((mask & com.codename1.ui.events.PointerEvent.MASK_BACK) != 0) {
+            button = com.codename1.ui.events.PointerEvent.BUTTON_BACK;
+        } else {
+            button = com.codename1.ui.events.PointerEvent.BUTTON_FORWARD;
+        }
+        setPointerEventMetadata(button, mask, type, 1f, 0, 0, 0, 0, false);
     }
 
     private void drainInput() {
@@ -588,15 +617,15 @@ public class WindowsImplementation extends CodenameOneImplementation {
             int key = eventScratch[3];
             switch (type) {
                 case EVENT_POINTER_PRESSED:
-                    markMousePointer();
+                    markPointer(key);
                     pointerPressed(x, y);
                     break;
                 case EVENT_POINTER_RELEASED:
-                    markMousePointer();
+                    markPointer(key);
                     pointerReleased(x, y);
                     break;
                 case EVENT_POINTER_DRAGGED:
-                    markMousePointer();
+                    markPointer(key);
                     pointerDragged(x, y);
                     break;
                 case EVENT_KEY_PRESSED:
@@ -2000,7 +2029,7 @@ public class WindowsImplementation extends CodenameOneImplementation {
 
     @Override
     public boolean isTouchDevice() {
-        return false;
+        return WindowsNative.isTouchDevice();
     }
 
     @Override

--- a/Ports/WindowsPort/src/com/codename1/impl/windows/WindowsNative.java
+++ b/Ports/WindowsPort/src/com/codename1/impl/windows/WindowsNative.java
@@ -117,6 +117,12 @@ public final class WindowsNative {
     public static native boolean pollEvent(int[] out);
 
     /**
+     * True when an integrated or external touch digitizer is present, used for
+     * {@code Display.isTouchScreen()} (queries GetSystemMetrics(SM_DIGITIZER)).
+     */
+    public static native boolean isTouchDevice();
+
+    /**
      * Parks the calling (main) thread to keep the process alive in headless
      * screenshot mode, where there is no window message loop. The EDT exits the
      * process via {@link #headlessTick()} once the screenshot has been written.

--- a/Ports/iOSPort/nativeSources/CN1TapGestureRecognizer.m
+++ b/Ports/iOSPort/nativeSources/CN1TapGestureRecognizer.m
@@ -32,6 +32,7 @@
 extern void pointerPressedC(int* x, int* y, int length);
 extern void pointerDraggedC(int* x, int* y, int length);
 extern void pointerReleasedC(int* x, int* y, int length);
+extern void cn1CapturePointerMetadata(UITouch* touch);
 extern NSMutableArray* touchesArray;
 extern int CN1lastTouchX;
 extern int CN1lastTouchY;
@@ -169,6 +170,7 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
         CN1lastTouchX = (int)point.x;
         CN1lastTouchY = (int)point.y;
     }
+    cn1CapturePointerMetadata(touch);
     pointerPressedC(xArray, yArray, [touches count]);
     POOL_END();
 }
@@ -200,6 +202,7 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
         return;
     }
     CGPoint point = [touch locationInView:ctrl.view];
+    cn1CapturePointerMetadata(touch);
     if([touchesArray count] > 1) {
         for(int iter = 0 ; iter < [touchesArray count] ; iter++) {
             UITouch* currentTouch = [touchesArray objectAtIndex:iter];
@@ -264,6 +267,7 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
         //CGPoint scaledPoint = CGPointMake(point.x * scaleValue, point.y * scaleValue);
         [ctrl foldKeyboard:point];
     }
+    cn1CapturePointerMetadata(touch);
     pointerReleasedC(xArray, yArray, [touches count]);
     self.state = UIGestureRecognizerStateEnded;
     POOL_END();
@@ -308,6 +312,7 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
     if(!isVKBAlwaysOpen()) {
         [ctrl foldKeyboard:point];
     }
+    cn1CapturePointerMetadata(touch);
     pointerReleasedC(xArray, yArray, [touches count]);
     self.state = UIGestureRecognizerStateCancelled;
     POOL_END();

--- a/Ports/iOSPort/nativeSources/CN1WatchHost.m
+++ b/Ports/iOSPort/nativeSources/CN1WatchHost.m
@@ -32,6 +32,7 @@ extern void cn1_watch_paintFrame(void);         // drain the op queue -> render 
 extern void cn1_watch_pointerPressed(int x, int y);
 extern void cn1_watch_pointerDragged(int x, int y);
 extern void cn1_watch_pointerReleased(int x, int y);
+extern void pointerWheelMovedCallback(int x, int y, int scrollX, int scrollY);
 
 static CN1WatchHost *sharedHostInstance = nil;
 
@@ -118,14 +119,14 @@ static CN1WatchHost *sharedHostInstance = nil;
 #pragma mark - Input
 
 - (void)crownRotatedBy:(CGFloat)crownDelta {
-    // Map crown rotation to a vertical scroll drag at the horizontal center.
-    // The watch UI treats a press/drag/release sequence (with movement) as a
-    // scroll, vs a press/release at the same point as a tap.
+    // Route the Digital Crown through the cross-platform wheel pipeline so it is the same universal
+    // scroll-gesture input as a mouse wheel or trackpad: it scrolls the component under the center
+    // of the watch face and is also delivered to any mouse wheel listeners as a WheelEvent. A
+    // positive crown delta reveals content above (scrolls down), matching the wheel convention.
     needsDisplay = YES;
     int cx = _renderingView != nil ? [_renderingView logicalWidth] / 2 : 0;
-    cn1_watch_pointerPressed(cx, 0);
-    cn1_watch_pointerDragged(cx, (int)(-crownDelta));
-    cn1_watch_pointerReleased(cx, (int)(-crownDelta));
+    int cy = _renderingView != nil ? [_renderingView logicalHeight] / 2 : 0;
+    pointerWheelMovedCallback(cx, cy, 0, (int)(-crownDelta));
 }
 
 - (void)tapAtX:(int)x y:(int)y {

--- a/Ports/iOSPort/nativeSources/CodenameOne_GLViewController.m
+++ b/Ports/iOSPort/nativeSources/CodenameOne_GLViewController.m
@@ -488,7 +488,9 @@ void deinitVMImpl() {
 extern void pointerPressed(int* x, int* y, int length);
 extern void pointerDragged(int* x, int* y, int length);
 extern void pointerReleased(int* x, int* y, int length);
+#if !TARGET_OS_WATCH
 extern void cn1CapturePointerMetadata(UITouch* touch);
+#endif
 extern void pointerWheelMovedCallback(int x, int y, int scrollX, int scrollY);
 extern void pinchMagnifyCallback(float scale, int x, int y);
 extern void rotationGestureCallback(float radians, int x, int y);
@@ -3318,8 +3320,8 @@ bool lockDrawing;
 #endif
 }
 
-- (void)cn1HandlePinch:(UIPinchGestureRecognizer *)recognizer {
 #if TARGET_OS_MACCATALYST
+- (void)cn1HandlePinch:(UIPinchGestureRecognizer *)recognizer {
     if (recognizer.state == UIGestureRecognizerStateChanged) {
         CGPoint loc = [recognizer locationInView:self.view];
         float scale = (float)recognizer.scale;
@@ -3329,8 +3331,8 @@ bool lockDrawing;
             recognizer.scale = 1.0;
         }
     }
-#endif
 }
+#endif
 
 - (void)cn1InstallRotationRecognizer {
 #if TARGET_OS_MACCATALYST
@@ -3347,8 +3349,8 @@ bool lockDrawing;
 #endif
 }
 
-- (void)cn1HandleRotation:(UIRotationGestureRecognizer *)recognizer {
 #if TARGET_OS_MACCATALYST
+- (void)cn1HandleRotation:(UIRotationGestureRecognizer *)recognizer {
     if (recognizer.state == UIGestureRecognizerStateChanged) {
         CGPoint loc = [recognizer locationInView:self.view];
         float radians = (float)recognizer.rotation;
@@ -3358,8 +3360,8 @@ bool lockDrawing;
             recognizer.rotation = 0;
         }
     }
-#endif
 }
+#endif
 
 #ifdef USE_ES2
 extern GLKMatrix4 CN1transformMatrix;

--- a/Ports/iOSPort/nativeSources/CodenameOne_GLViewController.m
+++ b/Ports/iOSPort/nativeSources/CodenameOne_GLViewController.m
@@ -490,6 +490,8 @@ extern void pointerDragged(int* x, int* y, int length);
 extern void pointerReleased(int* x, int* y, int length);
 extern void cn1CapturePointerMetadata(UITouch* touch);
 extern void pointerWheelMovedCallback(int x, int y, int scrollX, int scrollY);
+extern void pinchMagnifyCallback(float scale, int x, int y);
+extern void rotationGestureCallback(float radians, int x, int y);
 extern void screenSizeChanged(int width, int height);
 extern void keyPressedNative(int keyCode);
 extern void keyReleasedNative(int keyCode);
@@ -526,6 +528,35 @@ extern void pointerHoverReleasedNative(int x, int y);
 #define CN1_IOS_KEY_F10         (-23478)
 #define CN1_IOS_KEY_F11         (-23479)
 #define CN1_IOS_KEY_F12         (-23480)
+
+// Codename One's Display.MEDIA_KEY_PLAY_PAUSE value, forwarded for the Apple TV remote play/pause.
+#define CN1_IOS_KEY_PLAY_PAUSE  (25)
+
+#if TARGET_OS_TV
+// Translate an Apple TV Siri Remote button (UIPressType) into the framework key code. The remote
+// delivers these via UIPress.type rather than UIPress.key. Menu maps to the back/escape key,
+// Select to enter, the directional buttons to the arrow keys and play/pause to the media key.
+static int cn1MapUIPressTypeToKeyCode(UIPressType type) {
+    switch (type) {
+        case UIPressTypeUpArrow:
+            return CN1_IOS_KEY_UP;
+        case UIPressTypeDownArrow:
+            return CN1_IOS_KEY_DOWN;
+        case UIPressTypeLeftArrow:
+            return CN1_IOS_KEY_LEFT;
+        case UIPressTypeRightArrow:
+            return CN1_IOS_KEY_RIGHT;
+        case UIPressTypeSelect:
+            return CN1_IOS_KEY_ENTER;
+        case UIPressTypeMenu:
+            return CN1_IOS_KEY_ESCAPE;
+        case UIPressTypePlayPause:
+            return CN1_IOS_KEY_PLAY_PAUSE;
+        default:
+            return 0;
+    }
+}
+#endif
 
 // Translate a UIKey from a hardware keyboard into the integer the framework
 // expects: a negative sentinel for non-printable keys, a unicode codepoint for
@@ -2798,6 +2829,8 @@ static CodenameOne_GLViewController *sharedSingleton;
     [self cn1InstallStatusBarTapProxy];
     [self cn1InstallHoverRecognizer];
     [self cn1InstallScrollRecognizer];
+    [self cn1InstallPinchRecognizer];
+    [self cn1InstallRotationRecognizer];
     //replaceViewDidLoad
     [self initGoogleConnect];
 }
@@ -2813,6 +2846,8 @@ static CodenameOne_GLViewController *sharedSingleton;
     [self cn1InstallStatusBarTapProxy];
     [self cn1InstallHoverRecognizer];
     [self cn1InstallScrollRecognizer];
+    [self cn1InstallPinchRecognizer];
+    [self cn1InstallRotationRecognizer];
     //replaceViewDidLoad
     [self initGoogleConnect];
 }
@@ -3088,10 +3123,15 @@ bool lockDrawing;
         NSMutableSet *passthrough = nil;
         for (UIPress *press in presses) {
             UIKey *key = press.key;
-            if (key == nil) {
+            int code = key != nil ? cn1MapUIKeyToKeyCode(key) : 0;
+#if TARGET_OS_TV
+            if (code == 0) {
+                code = cn1MapUIPressTypeToKeyCode(press.type);
+            }
+#endif
+            if (code == 0 && key == nil) {
                 continue;
             }
-            int code = cn1MapUIKeyToKeyCode(key);
             if (code != 0) {
                 keyPressedNative(code);
                 handled = YES;
@@ -3118,10 +3158,15 @@ bool lockDrawing;
         NSMutableSet *passthrough = nil;
         for (UIPress *press in presses) {
             UIKey *key = press.key;
-            if (key == nil) {
+            int code = key != nil ? cn1MapUIKeyToKeyCode(key) : 0;
+#if TARGET_OS_TV
+            if (code == 0) {
+                code = cn1MapUIPressTypeToKeyCode(press.type);
+            }
+#endif
+            if (code == 0 && key == nil) {
                 continue;
             }
-            int code = cn1MapUIKeyToKeyCode(key);
             if (code != 0) {
                 keyReleasedNative(code);
                 handled = YES;
@@ -3146,10 +3191,15 @@ bool lockDrawing;
     if (@available(iOS 13.4, *)) {
         for (UIPress *press in presses) {
             UIKey *key = press.key;
-            if (key == nil) {
+            int code = key != nil ? cn1MapUIKeyToKeyCode(key) : 0;
+#if TARGET_OS_TV
+            if (code == 0) {
+                code = cn1MapUIPressTypeToKeyCode(press.type);
+            }
+#endif
+            if (code == 0 && key == nil) {
                 continue;
             }
-            int code = cn1MapUIKeyToKeyCode(key);
             if (code != 0) {
                 keyReleasedNative(code);
             }
@@ -3244,6 +3294,71 @@ bool lockDrawing;
             [recognizer setTranslation:CGPointZero inView:self.view];
         }
     }
+}
+
+// Magnify (pinch) and rotation gesture recognizers for the Mac Catalyst trackpad. These are scoped
+// to Mac Catalyst on purpose: on iOS a two finger pinch already drives the existing multi-touch
+// Component pinch via pointerDragged, so installing a UIPinchGestureRecognizer there would double
+// apply it. On the Mac the trackpad pinch/rotate are not delivered as multi-touch, so these
+// recognizers give the "beyond the scroll wheel" trackpad gestures the desktop expects. Each maps
+// to the cross-platform Component pinch / rotation callbacks and resets its scale/rotation after
+// every callback so the delta is incremental.
+- (void)cn1InstallPinchRecognizer {
+#if TARGET_OS_MACCATALYST
+    UIPinchGestureRecognizer *pinch = [[UIPinchGestureRecognizer alloc]
+                                       initWithTarget:self
+                                               action:@selector(cn1HandlePinch:)];
+    pinch.cancelsTouchesInView = NO;
+    pinch.delaysTouchesBegan = NO;
+    pinch.delaysTouchesEnded = NO;
+    [self.view addGestureRecognizer:pinch];
+#ifndef CN1_USE_ARC
+    [pinch release];
+#endif
+#endif
+}
+
+- (void)cn1HandlePinch:(UIPinchGestureRecognizer *)recognizer {
+#if TARGET_OS_MACCATALYST
+    if (recognizer.state == UIGestureRecognizerStateChanged) {
+        CGPoint loc = [recognizer locationInView:self.view];
+        float scale = (float)recognizer.scale;
+        if (scale > 0) {
+            pinchMagnifyCallback(scale, (int)(loc.x * scaleValue), (int)(loc.y * scaleValue));
+            // Reset so each callback carries an incremental scale relative to 1.0.
+            recognizer.scale = 1.0;
+        }
+    }
+#endif
+}
+
+- (void)cn1InstallRotationRecognizer {
+#if TARGET_OS_MACCATALYST
+    UIRotationGestureRecognizer *rotate = [[UIRotationGestureRecognizer alloc]
+                                           initWithTarget:self
+                                                   action:@selector(cn1HandleRotation:)];
+    rotate.cancelsTouchesInView = NO;
+    rotate.delaysTouchesBegan = NO;
+    rotate.delaysTouchesEnded = NO;
+    [self.view addGestureRecognizer:rotate];
+#ifndef CN1_USE_ARC
+    [rotate release];
+#endif
+#endif
+}
+
+- (void)cn1HandleRotation:(UIRotationGestureRecognizer *)recognizer {
+#if TARGET_OS_MACCATALYST
+    if (recognizer.state == UIGestureRecognizerStateChanged) {
+        CGPoint loc = [recognizer locationInView:self.view];
+        float radians = (float)recognizer.rotation;
+        if (radians != 0) {
+            rotationGestureCallback(radians, (int)(loc.x * scaleValue), (int)(loc.y * scaleValue));
+            // Reset so each callback carries an incremental rotation.
+            recognizer.rotation = 0;
+        }
+    }
+#endif
 }
 
 #ifdef USE_ES2

--- a/Ports/iOSPort/nativeSources/CodenameOne_GLViewController.m
+++ b/Ports/iOSPort/nativeSources/CodenameOne_GLViewController.m
@@ -488,6 +488,8 @@ void deinitVMImpl() {
 extern void pointerPressed(int* x, int* y, int length);
 extern void pointerDragged(int* x, int* y, int length);
 extern void pointerReleased(int* x, int* y, int length);
+extern void cn1CapturePointerMetadata(UITouch* touch);
+extern void pointerWheelMovedCallback(int x, int y, int scrollX, int scrollY);
 extern void screenSizeChanged(int width, int height);
 extern void keyPressedNative(int keyCode);
 extern void keyReleasedNative(int keyCode);
@@ -2795,6 +2797,7 @@ static CodenameOne_GLViewController *sharedSingleton;
     updateDisplayMetricsFromView(self.view);
     [self cn1InstallStatusBarTapProxy];
     [self cn1InstallHoverRecognizer];
+    [self cn1InstallScrollRecognizer];
     //replaceViewDidLoad
     [self initGoogleConnect];
 }
@@ -2809,6 +2812,7 @@ static CodenameOne_GLViewController *sharedSingleton;
     updateDisplayMetricsFromView(self.view);
     [self cn1InstallStatusBarTapProxy];
     [self cn1InstallHoverRecognizer];
+    [self cn1InstallScrollRecognizer];
     //replaceViewDidLoad
     [self initGoogleConnect];
 }
@@ -3196,6 +3200,49 @@ bool lockDrawing;
             break;
         default:
             break;
+    }
+}
+
+// Trackpad / Magic Mouse / mouse wheel scroll support. A pan recognizer with
+// maximumNumberOfTouches == 0 only fires for indirect-pointer scrolling (no
+// finger on the glass), so it never competes with the touch / tap recognizers.
+// allowedScrollTypesMask == all picks up both discrete (wheel) and continuous
+// (trackpad) scrolling. The scroll delta is routed through the same wheel
+// pipeline as the desktop and Android ports so WheelEvent is one universal
+// scroll-gesture API across every platform. Requires iOS 13.4+.
+- (void)cn1InstallScrollRecognizer {
+#if !TARGET_OS_TV
+    if (@available(iOS 13.4, *)) {
+        UIPanGestureRecognizer *scroll = [[UIPanGestureRecognizer alloc]
+                                          initWithTarget:self
+                                                  action:@selector(cn1HandleScroll:)];
+        scroll.allowedScrollTypesMask = UIScrollTypeMaskAll;
+        scroll.maximumNumberOfTouches = 0;
+        scroll.cancelsTouchesInView = NO;
+        scroll.delaysTouchesBegan = NO;
+        scroll.delaysTouchesEnded = NO;
+        [self.view addGestureRecognizer:scroll];
+#ifndef CN1_USE_ARC
+        [scroll release];
+#endif
+    }
+#endif
+}
+
+- (void)cn1HandleScroll:(UIPanGestureRecognizer *)recognizer API_AVAILABLE(ios(13.4)) {
+    if (recognizer.state == UIGestureRecognizerStateBegan
+            || recognizer.state == UIGestureRecognizerStateChanged) {
+        CGPoint loc = [recognizer locationInView:self.view];
+        CGPoint t = [recognizer translationInView:self.view];
+        int dx = (int)(t.x * scaleValue);
+        int dy = (int)(t.y * scaleValue);
+        if (dx != 0 || dy != 0) {
+            // A scroll pan is a drag-like gesture, so the translation maps
+            // directly onto the wheel delta (positive dy reveals content above).
+            pointerWheelMovedCallback((int)(loc.x * scaleValue), (int)(loc.y * scaleValue), dx, dy);
+            // Reset so each callback carries an incremental delta.
+            [recognizer setTranslation:CGPointZero inView:self.view];
+        }
     }
 }
 
@@ -4532,6 +4579,7 @@ BOOL prefersStatusBarHidden = NO;
         CN1lastTouchX = (int)point.x;
         CN1lastTouchY = (int)point.y;
     }
+    cn1CapturePointerMetadata(touch);
     pointerPressedC(xArray, yArray, [touches count]);
     POOL_END();
 }
@@ -4598,6 +4646,7 @@ BOOL prefersStatusBarHidden = NO;
     if(!isVKBAlwaysOpen()) {
         [self foldKeyboard:point];
     }
+    cn1CapturePointerMetadata(touch);
     pointerReleasedC(xArray, yArray, [touches count]);
     POOL_END();
 }
@@ -4640,6 +4689,7 @@ BOOL prefersStatusBarHidden = NO;
         //CGPoint scaledPoint = CGPointMake(point.x * scaleValue, point.y * scaleValue);
         [self foldKeyboard:point];
     }
+    cn1CapturePointerMetadata(touch);
     pointerReleasedC(xArray, yArray, [touches count]);
     POOL_END();
 }
@@ -4659,6 +4709,7 @@ BOOL prefersStatusBarHidden = NO;
     int xArray[[touchesArray count]];
     int yArray[[touchesArray count]];
     CGPoint point = [touch locationInView:self.view];
+    cn1CapturePointerMetadata(touch);
     if([touchesArray count] > 1) {
         for(int iter = 0 ; iter < [touchesArray count] ; iter++) {
             UITouch* currentTouch = [touchesArray objectAtIndex:iter];

--- a/Ports/iOSPort/nativeSources/IOSNative.m
+++ b/Ports/iOSPort/nativeSources/IOSNative.m
@@ -1556,6 +1556,46 @@ void com_codename1_impl_ios_IOSNative_shearGlobal___float_float(CN1_THREAD_STATE
 
 
 
+// Extracts the rich pointer detail (tool type, pressure, Apple Pencil tilt and contact size)
+// from a UITouch and forwards it to Java just before the pointer event is dispatched, so the
+// cross-platform stylus and pressure APIs work on iOS. Invoked from both the view controller
+// touch handlers and the CN1TapGestureRecognizer.
+void cn1CapturePointerMetadata(UITouch* touch) {
+    if (touch == nil) {
+        return;
+    }
+    int pointerType = 1; // PointerEvent.TYPE_TOUCH
+    float pressure = 1.0f;
+    float tiltX = 0.0f;
+    float tiltY = 0.0f;
+    float contactSize = 0.0f;
+    if (@available(iOS 9.0, *)) {
+        if (touch.type == UITouchTypeStylus) {
+            pointerType = 3; // PointerEvent.TYPE_STYLUS
+            CGFloat maxForce = touch.maximumPossibleForce;
+            if (maxForce > 0) {
+                pressure = (float)(touch.force / maxForce);
+            }
+            tiltX = (float)((M_PI_2 - touch.altitudeAngle) * 180.0 / M_PI);
+            tiltY = (float)([touch azimuthAngleInView:nil] * 180.0 / M_PI);
+        } else {
+            CGFloat maxForce = touch.maximumPossibleForce;
+            if (maxForce > 0 && touch.force > 0) {
+                pressure = (float)(touch.force / maxForce);
+            }
+        }
+    }
+    if (@available(iOS 13.4, *)) {
+        if (touch.type == UITouchTypeIndirectPointer) {
+            pointerType = 2; // PointerEvent.TYPE_MOUSE
+        }
+    }
+    if (touch.majorRadius > 0) {
+        contactSize = (float)touch.majorRadius;
+    }
+    com_codename1_impl_ios_IOSImplementation_pointerMetadataCallback___int_float_float_float_float(CN1_THREAD_GET_STATE_PASS_ARG pointerType, pressure, tiltX, tiltY, contactSize);
+}
+
 void pointerPressed(int* x, int* y, int length) {
     if(length == 1) {
         com_codename1_impl_ios_IOSImplementation_pointerPressedCallback___int_int(CN1_THREAD_GET_STATE_PASS_ARG x[0], y[0]);
@@ -1649,6 +1689,10 @@ void pointerHoverNative(int x, int y) {
 
 void pointerHoverReleasedNative(int x, int y) {
     com_codename1_impl_ios_IOSImplementation_pointerHoverReleasedCallback___int_int(CN1_THREAD_GET_STATE_PASS_ARG x, y);
+}
+
+void pointerWheelMovedCallback(int x, int y, int scrollX, int scrollY) {
+    com_codename1_impl_ios_IOSImplementation_pointerWheelMovedCallback___int_int_int_int(CN1_THREAD_GET_STATE_PASS_ARG x, y, scrollX, scrollY);
 }
 
 void stringEdit(int finished, int cursorPos, NSString* text) {

--- a/Ports/iOSPort/nativeSources/IOSNative.m
+++ b/Ports/iOSPort/nativeSources/IOSNative.m
@@ -1559,7 +1559,9 @@ void com_codename1_impl_ios_IOSNative_shearGlobal___float_float(CN1_THREAD_STATE
 // Extracts the rich pointer detail (tool type, pressure, Apple Pencil tilt and contact size)
 // from a UITouch and forwards it to Java just before the pointer event is dispatched, so the
 // cross-platform stylus and pressure APIs work on iOS. Invoked from both the view controller
-// touch handlers and the CN1TapGestureRecognizer.
+// touch handlers and the CN1TapGestureRecognizer. UITouch is unavailable on
+// watchOS, so the helper (and its callers) are compiled out there.
+#if !TARGET_OS_WATCH
 void cn1CapturePointerMetadata(UITouch* touch) {
     if (touch == nil) {
         return;
@@ -1595,6 +1597,7 @@ void cn1CapturePointerMetadata(UITouch* touch) {
     }
     com_codename1_impl_ios_IOSImplementation_pointerMetadataCallback___int_float_float_float_float(CN1_THREAD_GET_STATE_PASS_ARG pointerType, pressure, tiltX, tiltY, contactSize);
 }
+#endif // !TARGET_OS_WATCH
 
 void pointerPressed(int* x, int* y, int length) {
     if(length == 1) {

--- a/Ports/iOSPort/nativeSources/IOSNative.m
+++ b/Ports/iOSPort/nativeSources/IOSNative.m
@@ -1695,6 +1695,14 @@ void pointerWheelMovedCallback(int x, int y, int scrollX, int scrollY) {
     com_codename1_impl_ios_IOSImplementation_pointerWheelMovedCallback___int_int_int_int(CN1_THREAD_GET_STATE_PASS_ARG x, y, scrollX, scrollY);
 }
 
+void pinchMagnifyCallback(float scale, int x, int y) {
+    com_codename1_impl_ios_IOSImplementation_pinchMagnifyCallback___float_int_int(CN1_THREAD_GET_STATE_PASS_ARG scale, x, y);
+}
+
+void rotationGestureCallback(float radians, int x, int y) {
+    com_codename1_impl_ios_IOSImplementation_rotationGestureCallback___float_int_int(CN1_THREAD_GET_STATE_PASS_ARG radians, x, y);
+}
+
 void stringEdit(int finished, int cursorPos, NSString* text) {
     com_codename1_impl_ios_IOSImplementation_editingUpdate___java_lang_String_int_boolean(CN1_THREAD_GET_STATE_PASS_ARG
                                                                                           fromNSString(CN1_THREAD_GET_STATE_PASS_ARG text), cursorPos, finished != 0

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
@@ -1456,6 +1456,31 @@ public class IOSImplementation extends CodenameOneImplementation {
         singleDimensionX[0] = x; singleDimensionY[0] = y;
         instance.pointerDragged(singleDimensionX, singleDimensionY);
     }
+
+    /// Invoked from the native touch handler immediately before a pointer event to forward the
+    /// rich pointer detail (pointer type, pressure, Apple Pencil tilt and contact size) so the
+    /// cross-platform stylus and pressure APIs work on iOS. pointerType uses the
+    /// `com.codename1.ui.events.PointerEvent` TYPE_* constants.
+    public static void pointerMetadataCallback(int pointerType, float pressure, float tiltX, float tiltY, float contactSize) {
+        if (instance == null) {
+            return;
+        }
+        instance.setPointerEventMetadata(
+                com.codename1.ui.events.PointerEvent.BUTTON_PRIMARY,
+                com.codename1.ui.events.PointerEvent.MASK_PRIMARY,
+                pointerType, pressure, tiltX, tiltY, contactSize, 0, false);
+    }
+
+    /// Invoked from the native trackpad / Magic Mouse / wheel scroll handler. Routes the scroll
+    /// through the shared wheel pipeline so that `com.codename1.ui.events.WheelEvent` is a single
+    /// universal scroll-gesture API across desktop, Android and iOS. The deltas come from a high
+    /// resolution device so the event is flagged as precise.
+    public static void pointerWheelMovedCallback(int x, int y, int scrollX, int scrollY) {
+        if (dropEvents || instance == null) {
+            return;
+        }
+        instance.pointerWheelMoved(x, y, scrollX, scrollY, true, 0);
+    }
     
     protected void pointerPressed(final int[] x, final int[] y) {
         super.pointerPressed(x, y);

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
@@ -1481,7 +1481,25 @@ public class IOSImplementation extends CodenameOneImplementation {
         }
         instance.pointerWheelMoved(x, y, scrollX, scrollY, true, 0);
     }
-    
+
+    /// Invoked from the native magnify (pinch) gesture recognizer, used by the Mac Catalyst trackpad
+    /// pinch and the iOS two finger pinch. Routes to the cross-platform pinch gesture dispatch.
+    public static void pinchMagnifyCallback(float scale, int x, int y) {
+        if (dropEvents || instance == null) {
+            return;
+        }
+        com.codename1.ui.Display.getInstance().fireMagnifyGesture(x, y, scale);
+    }
+
+    /// Invoked from the native rotation gesture recognizer (Mac Catalyst trackpad rotate / iOS two
+    /// finger rotate). Routes to the cross-platform rotation gesture dispatch.
+    public static void rotationGestureCallback(float radians, int x, int y) {
+        if (dropEvents || instance == null) {
+            return;
+        }
+        com.codename1.ui.Display.getInstance().fireRotationGesture(x, y, radians);
+    }
+
     protected void pointerPressed(final int[] x, final int[] y) {
         super.pointerPressed(x, y);
     }

--- a/docs/developer-guide/Device-Input-And-Form-Factors.asciidoc
+++ b/docs/developer-guide/Device-Input-And-Form-Factors.asciidoc
@@ -1,0 +1,180 @@
+== Device Input and Form Factors
+
+[[device-input-top-level-section,Device Input Section]]
+Codename One runs on a wide range of hardware, from phones and tablets to desktops, foldables,
+and devices driven by a mouse or a stylus. This chapter covers the cross-platform APIs that expose
+that hardware: rich pointer detail (mouse buttons, pen pressure and tilt, the pointing device
+type), the mouse wheel, foldable device posture, and multi-display / desktop-window awareness.
+
+All of these APIs are additive and degrade gracefully: on a device or platform that does not report
+a given capability the value falls back to a sensible default, so a single code base keeps working
+everywhere.
+
+=== Rich pointer events
+
+The classic `pointerPressed`, `pointerReleased` and `pointerDragged` callbacks carry only the x/y
+coordinates of the touch. Modern devices provide far more detail: which mouse button was used, the
+kind of pointing device (finger, mouse, stylus or eraser), the pressure applied, the stylus tilt,
+the contact area and the keyboard modifiers held at the time.
+
+That detail is exposed through the immutable
+https://www.codenameone.com/javadoc/com/codename1/ui/events/PointerEvent.html[`PointerEvent`]
+snapshot. There are two ways to read it.
+
+==== From an ActionEvent
+
+Any pointer listener receives an `ActionEvent`; call `getPointerEvent()` on it:
+
+[source,java]
+----
+myComponent.addPointerPressedListener(e -> {
+    PointerEvent pe = e.getPointerEvent();
+    if (pe.isSecondaryButton()) {
+        showContextMenu(pe.getX(), pe.getY());
+    }
+    System.out.println("pressure=" + pe.getPressure() + " type=" + pe.getPointerType());
+});
+----
+
+==== By polling
+
+When you are inside a pointer callback you can also poll the current values directly from `CN`
+(or `Display`), mirroring the existing `CN.isShiftKeyDown()` family:
+
+[source,java]
+----
+int button = CN.getPointerButton();      // PointerEvent.BUTTON_PRIMARY, BUTTON_SECONDARY, ...
+float pressure = CN.getPointerPressure(); // 0.0 - 1.0, defaults to 1.0
+boolean pen = CN.isStylusPointer();
+PointerEvent current = CN.getCurrentPointerEvent();
+----
+
+TIP: Values default safely. On a plain touch screen the button is `BUTTON_PRIMARY`, the pressure is
+`1.0` and the type is `TYPE_TOUCH` (or `TYPE_UNKNOWN` on ports that do not classify the device).
+
+=== Two and three button mice
+
+`PointerEvent.getButton()` returns one of `BUTTON_PRIMARY`, `BUTTON_SECONDARY`, `BUTTON_MIDDLE`,
+`BUTTON_BACK` or `BUTTON_FORWARD`. `CN.getPressedButtonMask()` returns a bitmask of every button
+currently held (`MASK_PRIMARY`, `MASK_SECONDARY`, ...), which is useful during a drag.
+
+For the common case of a context menu, use the unified `addContextMenuListener`. It fires for a
+secondary (right) mouse click, a stylus barrel button click and a long press, so the same code
+handles desktop and touch:
+
+[source,java]
+----
+label.addContextMenuListener(e -> {
+    e.consume(); // suppress the normal click/long-press handling
+    showMyContextMenu(e.getX(), e.getY());
+});
+----
+
+=== Mouse wheel and trackpad scrolling
+
+By default the mouse wheel and trackpad scroll a scrollable container automatically. To react to
+the wheel yourself - for example control plus wheel to zoom, or horizontal scrolling - add a
+`addMouseWheelListener`. The listener receives a
+https://www.codenameone.com/javadoc/com/codename1/ui/events/WheelEvent.html[`WheelEvent`];
+consuming it prevents the default scroll.
+
+[source,java]
+----
+canvas.addMouseWheelListener(e -> {
+    WheelEvent w = (WheelEvent) e;
+    if (w.isControlDown()) {
+        zoom(w.getDeltaY());
+        w.consume(); // do not scroll, we zoomed instead
+    }
+});
+----
+
+A positive `getDeltaY()` reveals content above (the user scrolled down); a positive `getDeltaX()`
+reveals content to the left. `isPrecise()` is true for high resolution devices such as trackpads.
+On the desktop simulator, hold shift while turning the wheel to produce horizontal scrolling.
+
+`WheelEvent` is a single universal scroll-gesture API: it is fed by the mouse wheel and trackpad on
+the desktop, by the wheel / external trackpad on Android, and by the trackpad, Magic Mouse and
+mouse wheel on iOS and iPadOS (captured natively and routed through the same pipeline). Continuous
+trackpad scrolling reports `isPrecise() == true`, while a notched wheel reports `false`.
+
+=== Stylus and pen support
+
+When a stylus is used (Apple Pencil, S-Pen, Surface Pen) the pointer type is `TYPE_STYLUS`, or
+`TYPE_ERASER` for the eraser end. The `PointerEvent` then also carries:
+
+* `getPressure()` - normalized pressure between `0.0` and `1.0`.
+* `getTiltX()` / `getTiltY()` - tilt in degrees (altitude and azimuth on iOS).
+* `getContactSize()` - normalized size of the contact area.
+
+For drawing surfaces a dedicated `addStylusListener` fires on press, drag and release only when the
+pointer is a stylus or eraser:
+
+[source,java]
+----
+drawingArea.addStylusListener(e -> {
+    PointerEvent pe = e.getPointerEvent();
+    float width = 1f + pe.getPressure() * 9f; // pressure controls stroke width
+    if (pe.isEraser()) {
+        erase(pe.getX(), pe.getY());
+    } else {
+        drawPoint(pe.getX(), pe.getY(), width);
+    }
+});
+----
+
+Pen hover (the pen moving above the screen without touching, available on devices such as the S-Pen
+and the M2 iPad with Apple Pencil) flows through the existing `pointerHover` callbacks; the snapshot
+reports `isHovering()` as true.
+
+=== Foldable devices and posture
+
+Foldable and dual screen devices (Galaxy Fold, Galaxy Flip, Pixel Fold, Surface Duo) change shape
+at runtime. Query the live posture through
+https://www.codenameone.com/javadoc/com/codename1/ui/DevicePosture.html[`DevicePosture`]:
+
+[source,java]
+----
+DevicePosture p = CN.getDevicePosture();
+if (p.isFoldable() && p.isTableTop()) {
+    // half-opened, hinge horizontal: put media on top, controls on the bottom half
+    layoutForTableTop(p.getFoldBounds(null));
+}
+----
+
+* `getPosture()` - `POSTURE_FLAT`, `POSTURE_HALF_OPENED`, `POSTURE_CLOSED` or `POSTURE_UNKNOWN`.
+* `getHingeAngle()` - hinge angle in degrees (`-1` when unknown).
+* `getFoldOrientation()` - `FOLD_ORIENTATION_VERTICAL`, `FOLD_ORIENTATION_HORIZONTAL` or `FOLD_ORIENTATION_NONE`.
+* `getFoldBounds(Rectangle)` - the region the hinge occludes, in display coordinates, or null when
+  there is no separating fold. Treat it like `Form.getSafeArea()`: keep interactive content out of
+  it, or split a master and detail layout across the two halves.
+
+React to fold changes with a posture listener:
+
+[source,java]
+----
+CN.addPostureListener(e -> relayoutForPosture(CN.getDevicePosture()));
+----
+
+NOTE: To exercise this in the desktop simulator, the JavaSE port lets you drive a simulated posture
+programmatically via `JavaSEPort.setSimulatedFoldable(true)`,
+`JavaSEPort.setSimulatedPosture(DevicePosture.POSTURE_HALF_OPENED)` and the matching
+`setSimulatedFoldOrientation` / `setSimulatedHingeAngle` helpers.
+
+On Android the real fold posture is read from `androidx.window`. That dependency is *opt-in* so it
+never bloats apps that do not use foldables: add the build hint `android.foldableSupport=true` to
+pull it in (the version can be overridden with `android.windowVersion`). The core port talks to
+`androidx.window` purely through reflection, so without the build hint every posture query simply
+reports "not foldable". Android reports posture, fold orientation and the hinge bounds; the hinge
+*angle* is not exposed by `androidx.window`, so `getHingeAngle()` returns `-1` there.
+
+=== Desktop windowing and external displays
+
+Some mobile devices run in a desktop windowing mode where the app shares the screen with other
+windows: Samsung DeX, Android desktop windowing and iPad Stage Manager. `CN.isDesktopMode()`
+reports this. It is distinct from `CN.isDesktop()`, which reports a genuine desktop platform
+(Windows, macOS or Linux).
+
+`CN.getDisplayCount()` returns the number of attached displays and `CN.isExternalDisplayConnected()`
+is a convenience for `getDisplayCount() > 1`. On the desktop port these reflect the real monitors
+attached to the machine.

--- a/docs/developer-guide/Device-Input-And-Form-Factors.asciidoc
+++ b/docs/developer-guide/Device-Input-And-Form-Factors.asciidoc
@@ -57,6 +57,10 @@ is `1.0` and the type is `TYPE_TOUCH` (or `TYPE_UNKNOWN` on ports that don't cla
 `BUTTON_BACK` or `BUTTON_FORWARD`. `CN.getPressedButtonMask()` returns a bitmask of every button
 currently held (`MASK_PRIMARY`, `MASK_SECONDARY`, ...), which is useful during a drag.
 
+The real button is reported on every desktop port - macOS, Windows and Linux - and in the browser,
+so the right, middle and (where the mouse has them) back and forward buttons are all distinguished.
+On a plain touch screen there is only the primary button.
+
 For the common case of a context menu, use the unified `addContextMenuListener`. It fires for a
 secondary (right) mouse click, a stylus barrel button click and a long press, so the same code
 handles desktop and touch:
@@ -148,6 +152,11 @@ drawingArea.addStylusListener(e -> {
 Pen hover (the pen moving above the screen without touching, available on devices such as the S-Pen
 and the M2 iPad with Apple Pencil) flows through the existing `pointerHover` callbacks; the snapshot
 reports `isHovering()` as true.
+
+Touch-enabled desktops are handled too: on a Windows or Linux PC with a touch screen the finger
+reports `TYPE_TOUCH`, and a Windows pen reports `TYPE_STYLUS`, so the same drawing and gesture code
+runs on a touch laptop as on a phone. `Display.getInstance().isTouchScreenDevice()` is true on those
+machines.
 
 === Foldable devices and posture
 

--- a/docs/developer-guide/Device-Input-And-Form-Factors.asciidoc
+++ b/docs/developer-guide/Device-Input-And-Form-Factors.asciidoc
@@ -6,9 +6,8 @@ and devices driven by a mouse or a stylus. This chapter covers the cross-platfor
 that hardware: rich pointer detail (mouse buttons, pen pressure and tilt, the pointing device
 type), the mouse wheel, foldable device posture, and multi-display / desktop-window awareness.
 
-All of these APIs are additive and degrade gracefully: on a device or platform that does not report
-a given capability the value falls back to a sensible default, so a single code base keeps working
-everywhere.
+These APIs are additive: on a device or platform that doesn't report a given capability the value
+falls back to a sensible default, so a single code base keeps working everywhere.
 
 === Rich pointer events
 
@@ -38,7 +37,7 @@ myComponent.addPointerPressedListener(e -> {
 
 ==== By polling
 
-When you are inside a pointer callback you can also poll the current values directly from `CN`
+When you're inside a pointer callback you can also poll the current values directly from `CN`
 (or `Display`), mirroring the existing `CN.isShiftKeyDown()` family:
 
 [source,java]
@@ -49,8 +48,8 @@ boolean pen = CN.isStylusPointer();
 PointerEvent current = CN.getCurrentPointerEvent();
 ----
 
-TIP: Values default safely. On a plain touch screen the button is `BUTTON_PRIMARY`, the pressure is
-`1.0` and the type is `TYPE_TOUCH` (or `TYPE_UNKNOWN` on ports that do not classify the device).
+TIP: Values have safe defaults. On a plain touch screen the button is `BUTTON_PRIMARY`, the pressure
+is `1.0` and the type is `TYPE_TOUCH` (or `TYPE_UNKNOWN` on ports that don't classify the device).
 
 === Two and three button mice
 
@@ -93,7 +92,7 @@ A positive `getDeltaY()` reveals content above (the user scrolled down); a posit
 reveals content to the left. `isPrecise()` is true for high resolution devices such as trackpads.
 On the desktop simulator, hold shift while turning the wheel to produce horizontal scrolling.
 
-`WheelEvent` is a single universal scroll-gesture API: it is fed by the mouse wheel and trackpad on
+`WheelEvent` is a single universal scroll-gesture API: it's fed by the mouse wheel and trackpad on
 the desktop, by the wheel / external trackpad on Android, and by the trackpad, Magic Mouse and
 mouse wheel on iOS and iPadOS (captured natively and routed through the same pipeline). Continuous
 trackpad scrolling reports `isPrecise() == true`, while a notched wheel reports `false`.
@@ -162,17 +161,17 @@ programmatically via `JavaSEPort.setSimulatedFoldable(true)`,
 `setSimulatedFoldOrientation` / `setSimulatedHingeAngle` helpers.
 
 On Android the real fold posture is read from `androidx.window`. That dependency is *opt-in* so it
-never bloats apps that do not use foldables: add the build hint `android.foldableSupport=true` to
+never bloats apps that don't use foldables: add the build hint `android.foldableSupport=true` to
 pull it in (the version can be overridden with `android.windowVersion`). The core port talks to
 `androidx.window` purely through reflection, so without the build hint every posture query simply
-reports "not foldable". Android reports posture, fold orientation and the hinge bounds; the hinge
-*angle* is not exposed by `androidx.window`, so `getHingeAngle()` returns `-1` there.
+reports "not foldable." Android reports posture, fold orientation and the hinge bounds; the hinge
+*angle* isn't exposed by `androidx.window`, so `getHingeAngle()` returns `-1` there.
 
 === Desktop windowing and external displays
 
 Some mobile devices run in a desktop windowing mode where the app shares the screen with other
 windows: Samsung DeX, Android desktop windowing and iPad Stage Manager. `CN.isDesktopMode()`
-reports this. It is distinct from `CN.isDesktop()`, which reports a genuine desktop platform
+reports this. It's distinct from `CN.isDesktop()`, which reports a genuine desktop platform
 (Windows, macOS or Linux).
 
 `CN.getDisplayCount()` returns the number of attached displays and `CN.isExternalDisplayConnected()`

--- a/docs/developer-guide/Device-Input-And-Form-Factors.asciidoc
+++ b/docs/developer-guide/Device-Input-And-Form-Factors.asciidoc
@@ -105,10 +105,20 @@ mouse wheel listener receives the crown as a `WheelEvent`.
 
 === Trackpad gestures (magnify and rotate)
 
-Beyond scrolling, the macOS trackpad reports magnify (pinch) and rotate gestures. Override
+Beyond scrolling, the trackpad reports magnify (pinch) and rotate gestures. Override
 `pinch(float scale)` to zoom and `rotation(float radians)` to rotate; both return true to mark the
 gesture as handled. `pinch` is also driven by a two finger pinch on touch screens, so the same code
-works on mobile and the Mac.
+works on mobile and the desktop.
+
+The trackpad gestures are wired on every desktop port: the macOS trackpad, the Windows touch screen
+and gesture-capable touchpads (through the system `WM_GESTURE` messages), and the Linux touchpad
+(through the GTK touchpad gesture events). `scale` is an incremental zoom factor (just above or below
+`1.0`) and `radians` is the incremental rotation since the previous callback, so accumulate them to
+track the total.
+
+NOTE: A Windows precision touchpad usually reports a pinch as control plus wheel rather than a system
+gesture, so it also arrives through the universal wheel API. Handle that case with a
+`addMouseWheelListener` that checks `isControlDown()` (shown above) if you target those devices.
 
 [source,java]
 ----

--- a/docs/developer-guide/Device-Input-And-Form-Factors.asciidoc
+++ b/docs/developer-guide/Device-Input-And-Form-Factors.asciidoc
@@ -95,7 +95,30 @@ On the desktop simulator, hold shift while turning the wheel to produce horizont
 `WheelEvent` is a single universal scroll-gesture API: it's fed by the mouse wheel and trackpad on
 the desktop, by the wheel / external trackpad on Android, and by the trackpad, Magic Mouse and
 mouse wheel on iOS and iPadOS (captured natively and routed through the same pipeline). Continuous
-trackpad scrolling reports `isPrecise() == true`, while a notched wheel reports `false`.
+trackpad scrolling reports `isPrecise() == true`, while a notched wheel reports `false`. On the
+Apple Watch the Digital Crown also feeds this same pipeline, so a list scrolls under the crown and a
+mouse wheel listener receives the crown as a `WheelEvent`.
+
+=== Trackpad gestures (magnify and rotate)
+
+Beyond scrolling, the macOS trackpad reports magnify (pinch) and rotate gestures. Override
+`pinch(float scale)` to zoom and `rotation(float radians)` to rotate; both return true to mark the
+gesture as handled. `pinch` is also driven by a two finger pinch on touch screens, so the same code
+works on mobile and the Mac.
+
+[source,java]
+----
+Container photo = new Container() {
+    protected boolean pinch(float scale) {
+        zoom(scale);                 // trackpad pinch or two finger pinch
+        return true;
+    }
+    protected boolean rotation(float radians) {
+        rotate(radians);             // trackpad two finger rotate
+        return true;
+    }
+};
+----
 
 === Stylus and pen support
 
@@ -155,17 +178,15 @@ React to fold changes with a posture listener:
 CN.addPostureListener(e -> relayoutForPosture(CN.getDevicePosture()));
 ----
 
-NOTE: To exercise this in the desktop simulator, the JavaSE port lets you drive a simulated posture
-programmatically via `JavaSEPort.setSimulatedFoldable(true)`,
-`JavaSEPort.setSimulatedPosture(DevicePosture.POSTURE_HALF_OPENED)` and the matching
-`setSimulatedFoldOrientation` / `setSimulatedHingeAngle` helpers.
+To exercise this in the desktop simulator, use the *Simulate -> Foldable* menu: enable foldable
+mode, then pick a posture (flat, half-opened or closed), the fold orientation (vertical or
+horizontal) and the hinge angle. The running app receives the same posture changes and listener
+callbacks it would on a real foldable device.
 
-On Android the real fold posture is read from `androidx.window`. That dependency is *opt-in* so it
-never bloats apps that don't use foldables: add the build hint `android.foldableSupport=true` to
-pull it in (the version can be overridden with `android.windowVersion`). The core port talks to
-`androidx.window` purely through reflection, so without the build hint every posture query simply
-reports "not foldable." Android reports posture, fold orientation and the hinge bounds; the hinge
-*angle* isn't exposed by `androidx.window`, so `getHingeAngle()` returns `-1` there.
+Foldable support on Android is opt-in so it never adds weight to apps that don't use it. Enable it
+with the `android.foldableSupport=true` build hint (the version can be overridden with
+`android.windowVersion`). Note that the hinge *angle* isn't available on Android, so
+`getHingeAngle()` returns `-1` there.
 
 === Desktop windowing and external displays
 
@@ -177,3 +198,11 @@ reports this. It's distinct from `CN.isDesktop()`, which reports a genuine deskt
 `CN.getDisplayCount()` returns the number of attached displays and `CN.isExternalDisplayConnected()`
 is a convenience for `getDisplayCount() > 1`. On the desktop port these reflect the real monitors
 attached to the machine.
+
+=== Apple TV remote
+
+On Apple TV the Siri Remote is delivered through the standard key handling, so the same
+`keyPressed`/`keyReleased` and game-key code you write for other platforms works on the TV. The
+directional buttons map to the arrow / game keys, the click maps to enter (fire), the menu button
+maps to the back key, and play/pause maps to the media play/pause key. No TV specific API is
+required.

--- a/docs/developer-guide/developer-guide.asciidoc
+++ b/docs/developer-guide/developer-guide.asciidoc
@@ -75,6 +75,8 @@ include::Game-Assets.asciidoc[]
 
 include::Events.asciidoc[]
 
+include::Device-Input-And-Form-Factors.asciidoc[]
+
 include::io.asciidoc[]
 
 include::Push-Notifications.asciidoc[]

--- a/docs/developer-guide/languagetool-accept.txt
+++ b/docs/developer-guide/languagetool-accept.txt
@@ -658,3 +658,8 @@ dylibs?
 Zimperium
 Promon
 DeviceCheck
+
+# Device input / form-factor terms (Device-Input-And-Form-Factors.asciidoc)
+foldables?
+bitmask
+DeX

--- a/docs/developer-guide/languagetool-accept.txt
+++ b/docs/developer-guide/languagetool-accept.txt
@@ -663,3 +663,4 @@ DeviceCheck
 foldables?
 bitmask
 DeX
+Siri

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
@@ -1767,6 +1767,23 @@ public class AndroidGradleBuilder extends Executor {
             }
         }
 
+        // Foldable / dual-screen support. The com.codename1.ui.DevicePosture API reads the device
+        // fold posture through androidx.window using reflection, so the gradle dependency is added
+        // ONLY when the app opts in with the build hint android.foldableSupport=true. Apps that do
+        // not use the foldable APIs get zero added weight. The version can be overridden with
+        // android.windowVersion.
+        boolean useFoldableSupport = "true".equals(request.getArg("android.foldableSupport", "false"));
+        if (useFoldableSupport) {
+            if (!request.getArg("gradleDependencies", "").contains("androidx.window:window")) {
+                request.putArgument(
+                        "gradleDependencies",
+                        request.getArg("gradleDependencies", "") +
+                                "\n"+compile+" \"androidx.window:window:" +
+                                request.getArg("android.windowVersion", "1.3.0") + "\"\n"
+                );
+            }
+        }
+
 
 
         // if a flag is declared we don't want the default play flag to be true

--- a/maven/core-unittests/src/test/java/com/codename1/ui/DeviceInputListenersTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/DeviceInputListenersTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.ui;
+
+import com.codename1.junit.FormTest;
+import com.codename1.junit.UITestBase;
+import com.codename1.ui.events.ActionEvent;
+import com.codename1.ui.events.ActionListener;
+import com.codename1.ui.events.PointerEvent;
+import com.codename1.ui.events.WheelEvent;
+import com.codename1.ui.geom.Dimension;
+import com.codename1.ui.layouts.BorderLayout;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Exercises the Component level device-input listeners (context menu, mouse wheel, stylus) and
+ * {@link ActionEvent#getPointerEvent()} by dispatching synthetic pointer events on the EDT.
+ */
+class DeviceInputListenersTest extends UITestBase {
+
+    private static Button centerButton(String text) {
+        Form form = Display.getInstance().getCurrent();
+        form.setLayout(new BorderLayout());
+        Button b = new Button(text);
+        b.setPreferredSize(new Dimension(200, 120));
+        form.add(BorderLayout.CENTER, b);
+        form.revalidate();
+        return b;
+    }
+
+    private static int centerX(Button b) {
+        return b.getAbsoluteX() + b.getWidth() / 2;
+    }
+
+    private static int centerY(Button b) {
+        return b.getAbsoluteY() + b.getHeight() / 2;
+    }
+
+    @FormTest
+    void contextMenuFiresOnSecondaryButton() {
+        Button b = centerButton("ctx");
+        final AtomicBoolean ctx = new AtomicBoolean(false);
+        final AtomicBoolean buttonPressed = new AtomicBoolean(false);
+        b.addContextMenuListener(new ActionListener() {
+            public void actionPerformed(ActionEvent evt) {
+                ctx.set(true);
+                evt.consume();
+            }
+        });
+        b.addPointerPressedListener(new ActionListener() {
+            public void actionPerformed(ActionEvent evt) {
+                buttonPressed.set(true);
+            }
+        });
+
+        implementation.setPointerEventMetadata(PointerEvent.BUTTON_SECONDARY,
+                PointerEvent.MASK_SECONDARY, PointerEvent.TYPE_MOUSE, 1f, 0, 0, 0, 0, false);
+        Display.getInstance().getCurrent().pointerPressed(centerX(b), centerY(b));
+        implementation.resetPointerEventMetadata();
+
+        assertTrue(ctx.get(), "context menu listener should fire on a secondary button press");
+        assertFalse(buttonPressed.get(), "a consumed context menu should suppress the normal press");
+    }
+
+    @FormTest
+    void contextMenuFiresOnLongPress() {
+        Button b = centerButton("ctx2");
+        final AtomicBoolean ctx = new AtomicBoolean(false);
+        b.addContextMenuListener(new ActionListener() {
+            public void actionPerformed(ActionEvent evt) {
+                ctx.set(true);
+                evt.consume();
+            }
+        });
+        Display.getInstance().getCurrent().longPointerPress(centerX(b), centerY(b));
+        assertTrue(ctx.get(), "long press should be surfaced as a context menu request");
+    }
+
+    @FormTest
+    void noContextMenuOnPrimaryButton() {
+        Button b = centerButton("primary");
+        final AtomicBoolean ctx = new AtomicBoolean(false);
+        b.addContextMenuListener(new ActionListener() {
+            public void actionPerformed(ActionEvent evt) {
+                ctx.set(true);
+            }
+        });
+        implementation.setPointerEventMetadata(PointerEvent.BUTTON_PRIMARY,
+                PointerEvent.MASK_PRIMARY, PointerEvent.TYPE_MOUSE, 1f, 0, 0, 0, 0, false);
+        Display.getInstance().getCurrent().pointerPressed(centerX(b), centerY(b));
+        Display.getInstance().getCurrent().pointerReleased(centerX(b), centerY(b));
+        implementation.resetPointerEventMetadata();
+        assertFalse(ctx.get(), "primary button must not request a context menu");
+    }
+
+    @FormTest
+    void stylusListenerFiresOnlyForStylus() {
+        Button b = centerButton("pen");
+        final AtomicReference<PointerEvent> got = new AtomicReference<PointerEvent>();
+        b.addStylusListener(new ActionListener() {
+            public void actionPerformed(ActionEvent evt) {
+                got.set(evt.getPointerEvent());
+            }
+        });
+
+        // stylus -> fires, with the pressure carried through
+        implementation.setPointerEventMetadata(PointerEvent.BUTTON_PRIMARY, PointerEvent.MASK_PRIMARY,
+                PointerEvent.TYPE_STYLUS, 0.6f, 0, 0, 0, 0, false);
+        Display.getInstance().getCurrent().pointerPressed(centerX(b), centerY(b));
+        assertNotNull(got.get(), "stylus listener should fire for a stylus pointer");
+        assertTrue(got.get().isStylus());
+        assertEquals(0.6f, got.get().getPressure(), 0.0001f);
+
+        // touch -> does not fire
+        got.set(null);
+        implementation.setPointerEventMetadata(PointerEvent.BUTTON_PRIMARY, PointerEvent.MASK_PRIMARY,
+                PointerEvent.TYPE_TOUCH, 1f, 0, 0, 0, 0, false);
+        Display.getInstance().getCurrent().pointerPressed(centerX(b), centerY(b));
+        implementation.resetPointerEventMetadata();
+        assertNull(got.get(), "stylus listener must not fire for a finger touch");
+    }
+
+    @FormTest
+    void mouseWheelListenerReceivesDeltasAndConsumes() {
+        Form form = Display.getInstance().getCurrent();
+        form.setLayout(new BorderLayout());
+        Button b = new Button("wheel");
+        b.setPreferredSize(new Dimension(200, 120));
+        form.add(BorderLayout.CENTER, b);
+        form.revalidate();
+
+        final AtomicReference<WheelEvent> got = new AtomicReference<WheelEvent>();
+        b.addMouseWheelListener(new ActionListener() {
+            public void actionPerformed(ActionEvent evt) {
+                got.set((WheelEvent) evt);
+                evt.consume();
+            }
+        });
+
+        int x = b.getAbsoluteX() + b.getWidth() / 2;
+        int y = b.getAbsoluteY() + b.getHeight() / 2;
+        boolean consumed = Display.getInstance().fireMouseWheelEvent(x, y, 0, 30, true,
+                PointerEvent.MODIFIER_CONTROL);
+
+        assertTrue(consumed, "a consumed wheel event should report consumed");
+        assertNotNull(got.get());
+        assertEquals(30, got.get().getDeltaY());
+        assertTrue(got.get().isPrecise());
+        assertTrue(got.get().isControlDown());
+    }
+
+    @FormTest
+    void actionEventExposesPointerEventForPointerTypesOnly() {
+        ActionEvent pointer = new ActionEvent("src", ActionEvent.Type.PointerPressed, 3, 4);
+        assertNotNull(pointer.getPointerEvent(), "pointer events expose the current pointer snapshot");
+
+        ActionEvent theme = new ActionEvent("src", ActionEvent.Type.Theme);
+        assertNull(theme.getPointerEvent(), "non pointer events have no pointer snapshot");
+
+        // an explicitly attached snapshot is returned verbatim
+        PointerEvent explicit = new PointerEvent(1, 2, PointerEvent.BUTTON_MIDDLE,
+                PointerEvent.MASK_MIDDLE, PointerEvent.TYPE_MOUSE, 1f, 0, 0, 0, 0, false);
+        ActionEvent custom = new ActionEvent("src", ActionEvent.Type.Theme);
+        custom.setPointerEvent(explicit);
+        assertSame(explicit, custom.getPointerEvent());
+    }
+}

--- a/maven/core-unittests/src/test/java/com/codename1/ui/DeviceInputListenersTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/DeviceInputListenersTest.java
@@ -188,4 +188,39 @@ class DeviceInputListenersTest extends UITestBase {
         custom.setPointerEvent(explicit);
         assertSame(explicit, custom.getPointerEvent());
     }
+
+    @FormTest
+    void magnifyAndRotationGesturesDispatchToComponent() {
+        Form form = Display.getInstance().getCurrent();
+        form.setLayout(new BorderLayout());
+        final AtomicReference<Float> scaleGot = new AtomicReference<Float>();
+        final AtomicReference<Float> radiansGot = new AtomicReference<Float>();
+        Container gestureCmp = new Container() {
+            @Override
+            protected boolean pinch(float scale) {
+                scaleGot.set(scale);
+                return true;
+            }
+
+            @Override
+            protected boolean rotation(float radians) {
+                radiansGot.set(radians);
+                return true;
+            }
+        };
+        gestureCmp.setPreferredSize(new Dimension(200, 120));
+        form.add(BorderLayout.CENTER, gestureCmp);
+        form.revalidate();
+
+        int x = gestureCmp.getAbsoluteX() + gestureCmp.getWidth() / 2;
+        int y = gestureCmp.getAbsoluteY() + gestureCmp.getHeight() / 2;
+
+        Display.getInstance().fireMagnifyGesture(x, y, 1.5f);
+        assertNotNull(scaleGot.get(), "magnify gesture should reach the component pinch callback");
+        assertEquals(1.5f, scaleGot.get(), 0.0001f);
+
+        Display.getInstance().fireRotationGesture(x, y, 0.25f);
+        assertNotNull(radiansGot.get(), "rotation gesture should reach the component rotation callback");
+        assertEquals(0.25f, radiansGot.get(), 0.0001f);
+    }
 }

--- a/maven/core-unittests/src/test/java/com/codename1/ui/DevicePostureTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/DevicePostureTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.ui;
+
+import com.codename1.junit.UITestBase;
+import com.codename1.ui.events.ActionEvent;
+import com.codename1.ui.events.ActionListener;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies the device posture and multi-display capability APIs and their safe defaults on a
+ * non-foldable test implementation, plus posture listener dispatch.
+ */
+class DevicePostureTest extends UITestBase {
+
+    @Test
+    void getInstanceNeverNull() {
+        assertNotNull(DevicePosture.getInstance());
+        assertSame(DevicePosture.getInstance(), display.getDevicePosture());
+    }
+
+    @Test
+    void defaultsForNonFoldableDevice() {
+        DevicePosture p = DevicePosture.getInstance();
+        assertFalse(p.isFoldable());
+        assertFalse(display.isFoldable());
+        assertEquals(DevicePosture.POSTURE_UNKNOWN, p.getPosture());
+        assertEquals(-1, p.getHingeAngle());
+        assertEquals(DevicePosture.FOLD_ORIENTATION_NONE, p.getFoldOrientation());
+        assertFalse(p.isSeparating());
+        assertFalse(p.isTableTop());
+        assertNull(p.getFoldBounds(null));
+    }
+
+    @Test
+    void multiDisplayDefaults() {
+        assertFalse(display.isDesktopMode());
+        assertTrue(display.getDisplayCount() >= 1);
+        assertEquals(display.getDisplayCount() > 1, display.isExternalDisplayConnected());
+    }
+
+    @Test
+    void postureConstantsAreDistinct() {
+        assertNotEquals(DevicePosture.POSTURE_FLAT, DevicePosture.POSTURE_HALF_OPENED);
+        assertNotEquals(DevicePosture.POSTURE_HALF_OPENED, DevicePosture.POSTURE_CLOSED);
+        assertNotEquals(DevicePosture.FOLD_ORIENTATION_VERTICAL, DevicePosture.FOLD_ORIENTATION_HORIZONTAL);
+    }
+
+    @Test
+    void postureListenerIsNotified() {
+        final AtomicReference<ActionEvent> received = new AtomicReference<ActionEvent>();
+        ActionListener l = new ActionListener() {
+            public void actionPerformed(ActionEvent evt) {
+                received.set(evt);
+            }
+        };
+        display.addPostureListener(l);
+        try {
+            display.postureChanged();
+            DisplayTest.flushEdt();
+            // give the serial call a moment to drain on slower CI machines
+            for (int i = 0; received.get() == null && i < 100; i++) {
+                DisplayTest.flushEdt();
+            }
+            assertNotNull(received.get());
+            assertEquals(ActionEvent.Type.PostureChange, received.get().getEventType());
+        } finally {
+            display.removePostureListener(l);
+        }
+    }
+}

--- a/maven/core-unittests/src/test/java/com/codename1/ui/PointerMetadataTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/PointerMetadataTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.ui;
+
+import com.codename1.junit.UITestBase;
+import com.codename1.ui.events.PointerEvent;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies the rich pointer metadata pipeline: the implementation accepts metadata supplied by a
+ * port, exposes it through {@link Display}, builds matching {@link PointerEvent} snapshots and
+ * resets to safe defaults.
+ */
+class PointerMetadataTest extends UITestBase {
+
+    @Test
+    void defaultsAreSafe() {
+        implementation.resetPointerEventMetadata();
+        assertEquals(PointerEvent.BUTTON_PRIMARY, display.getPointerButton());
+        assertEquals(PointerEvent.TYPE_UNKNOWN, display.getPointerType());
+        assertEquals(1f, display.getPointerPressure(), 0.0001f);
+        assertEquals(0f, display.getPointerTiltX(), 0.0001f);
+        assertEquals(0f, display.getPointerContactSize(), 0.0001f);
+        assertFalse(display.isStylusPointer());
+    }
+
+    @Test
+    void metadataFlowsThroughDisplay() {
+        implementation.setPointerEventMetadata(PointerEvent.BUTTON_SECONDARY,
+                PointerEvent.MASK_SECONDARY, PointerEvent.TYPE_STYLUS, 0.75f, 30f, -10f, 0.4f,
+                PointerEvent.MODIFIER_ALT, false);
+        assertEquals(PointerEvent.BUTTON_SECONDARY, display.getPointerButton());
+        assertEquals(PointerEvent.MASK_SECONDARY, display.getPressedButtonMask());
+        assertEquals(PointerEvent.TYPE_STYLUS, display.getPointerType());
+        assertEquals(0.75f, display.getPointerPressure(), 0.0001f);
+        assertEquals(30f, display.getPointerTiltX(), 0.0001f);
+        assertEquals(-10f, display.getPointerTiltY(), 0.0001f);
+        assertEquals(0.4f, display.getPointerContactSize(), 0.0001f);
+        assertTrue(display.isStylusPointer());
+        implementation.resetPointerEventMetadata();
+    }
+
+    @Test
+    void buildPointerEventSnapshotMatchesMetadata() {
+        implementation.setPointerEventMetadata(PointerEvent.BUTTON_MIDDLE, PointerEvent.MASK_MIDDLE,
+                PointerEvent.TYPE_MOUSE, 0.9f, 0, 0, 0.1f, PointerEvent.MODIFIER_CONTROL, false);
+        PointerEvent e = implementation.buildPointerEvent(42, 84, false);
+        assertEquals(42, e.getX());
+        assertEquals(84, e.getY());
+        assertEquals(PointerEvent.BUTTON_MIDDLE, e.getButton());
+        assertEquals(PointerEvent.TYPE_MOUSE, e.getPointerType());
+        assertEquals(0.9f, e.getPressure(), 0.0001f);
+        assertTrue(e.isMiddleButton());
+        assertTrue(e.isControlDown());
+        assertFalse(e.isHovering());
+
+        // hovering override is honored
+        PointerEvent hover = implementation.buildPointerEvent(1, 2, true);
+        assertTrue(hover.isHovering());
+        implementation.resetPointerEventMetadata();
+    }
+
+    @Test
+    void convenienceSettersUpdateIndividualFields() {
+        implementation.resetPointerEventMetadata();
+        implementation.setPointerType(PointerEvent.TYPE_ERASER);
+        implementation.setPointerPressure(0.3f);
+        implementation.setPointerTilt(5f, 6f);
+        implementation.setPointerContactSize(0.2f);
+        assertEquals(PointerEvent.TYPE_ERASER, display.getPointerType());
+        assertTrue(display.isStylusPointer());
+        assertEquals(0.3f, display.getPointerPressure(), 0.0001f);
+        assertEquals(5f, display.getPointerTiltX(), 0.0001f);
+        assertEquals(6f, display.getPointerTiltY(), 0.0001f);
+        assertEquals(0.2f, display.getPointerContactSize(), 0.0001f);
+        implementation.resetPointerEventMetadata();
+    }
+
+    @Test
+    void getCurrentPointerEventNeverNull() {
+        assertNotNull(display.getCurrentPointerEvent());
+    }
+}

--- a/maven/core-unittests/src/test/java/com/codename1/ui/events/PointerEventTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/events/PointerEventTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.ui.events;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for the immutable {@link PointerEvent} value object covering the button, pointer type,
+ * pressure, tilt, contact size and modifier accessors and their helper predicates.
+ */
+class PointerEventTest {
+
+    @Test
+    void exposesAllConstructorValues() {
+        PointerEvent e = new PointerEvent(10, 20, PointerEvent.BUTTON_SECONDARY,
+                PointerEvent.MASK_PRIMARY | PointerEvent.MASK_SECONDARY, PointerEvent.TYPE_STYLUS,
+                0.5f, 12.5f, -3.0f, 0.25f, PointerEvent.MODIFIER_SHIFT | PointerEvent.MODIFIER_CONTROL, true);
+        assertEquals(10, e.getX());
+        assertEquals(20, e.getY());
+        assertEquals(PointerEvent.BUTTON_SECONDARY, e.getButton());
+        assertEquals(PointerEvent.MASK_PRIMARY | PointerEvent.MASK_SECONDARY, e.getButtonMask());
+        assertEquals(PointerEvent.TYPE_STYLUS, e.getPointerType());
+        assertEquals(0.5f, e.getPressure(), 0.0001f);
+        assertEquals(12.5f, e.getTiltX(), 0.0001f);
+        assertEquals(-3.0f, e.getTiltY(), 0.0001f);
+        assertEquals(0.25f, e.getContactSize(), 0.0001f);
+        assertTrue(e.isHovering());
+    }
+
+    @Test
+    void pointerTypePredicates() {
+        assertTrue(touchEvent().isTouch());
+        assertFalse(touchEvent().isStylus());
+
+        PointerEvent stylus = typed(PointerEvent.TYPE_STYLUS);
+        assertTrue(stylus.isStylus());
+        assertFalse(stylus.isEraser());
+        assertFalse(stylus.isMouse());
+
+        PointerEvent eraser = typed(PointerEvent.TYPE_ERASER);
+        assertTrue(eraser.isStylus());
+        assertTrue(eraser.isEraser());
+
+        assertTrue(typed(PointerEvent.TYPE_MOUSE).isMouse());
+    }
+
+    @Test
+    void buttonPredicates() {
+        assertTrue(button(PointerEvent.BUTTON_PRIMARY).isPrimaryButton());
+        assertTrue(button(PointerEvent.BUTTON_SECONDARY).isSecondaryButton());
+        assertTrue(button(PointerEvent.BUTTON_MIDDLE).isMiddleButton());
+        assertFalse(button(PointerEvent.BUTTON_PRIMARY).isSecondaryButton());
+    }
+
+    @Test
+    void modifierPredicates() {
+        PointerEvent e = new PointerEvent(0, 0, PointerEvent.BUTTON_PRIMARY, PointerEvent.MASK_PRIMARY,
+                PointerEvent.TYPE_MOUSE, 1f, 0, 0, 0,
+                PointerEvent.MODIFIER_SHIFT | PointerEvent.MODIFIER_META, false);
+        assertTrue(e.isShiftDown());
+        assertTrue(e.isMetaDown());
+        assertFalse(e.isControlDown());
+        assertFalse(e.isAltDown());
+    }
+
+    @Test
+    void buttonConstantsAreDistinct() {
+        assertEquals(-1, PointerEvent.BUTTON_NONE);
+        assertEquals(0, PointerEvent.BUTTON_PRIMARY);
+        assertNotEquals(PointerEvent.BUTTON_PRIMARY, PointerEvent.BUTTON_SECONDARY);
+        assertNotEquals(PointerEvent.BUTTON_SECONDARY, PointerEvent.BUTTON_MIDDLE);
+        // mask bits must not overlap
+        assertEquals(0, PointerEvent.MASK_PRIMARY & PointerEvent.MASK_SECONDARY);
+        assertEquals(0, PointerEvent.MASK_MIDDLE & PointerEvent.MASK_BACK);
+    }
+
+    private static PointerEvent touchEvent() {
+        return typed(PointerEvent.TYPE_TOUCH);
+    }
+
+    private static PointerEvent typed(int type) {
+        return new PointerEvent(0, 0, PointerEvent.BUTTON_PRIMARY, PointerEvent.MASK_PRIMARY, type,
+                1f, 0, 0, 0, 0, false);
+    }
+
+    private static PointerEvent button(int button) {
+        return new PointerEvent(0, 0, button, PointerEvent.MASK_PRIMARY, PointerEvent.TYPE_MOUSE,
+                1f, 0, 0, 0, 0, false);
+    }
+}

--- a/maven/core-unittests/src/test/java/com/codename1/ui/events/WheelEventTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/events/WheelEventTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.ui.events;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link WheelEvent} covering its deltas, precise flag, modifiers and the inherited
+ * consume behavior used to suppress the default scroll gesture.
+ */
+class WheelEventTest {
+
+    @Test
+    void exposesDeltasAndModifiers() {
+        WheelEvent e = new WheelEvent("src", 5, 6, -3, 12, true,
+                PointerEvent.MODIFIER_CONTROL);
+        assertEquals(5, e.getX());
+        assertEquals(6, e.getY());
+        assertEquals(-3, e.getDeltaX());
+        assertEquals(12, e.getDeltaY());
+        assertTrue(e.isPrecise());
+        assertTrue(e.isControlDown());
+        assertFalse(e.isShiftDown());
+        assertEquals(ActionEvent.Type.PointerWheel, e.getEventType());
+    }
+
+    @Test
+    void consumeSuppressesDefault() {
+        WheelEvent e = new WheelEvent("src", 0, 0, 0, 10, false, 0);
+        assertFalse(e.isConsumed());
+        e.consume();
+        assertTrue(e.isConsumed());
+    }
+
+    @Test
+    void notchedWheelIsNotPrecise() {
+        WheelEvent e = new WheelEvent("src", 0, 0, 0, 40, false, 0);
+        assertFalse(e.isPrecise());
+        assertEquals(0, e.getModifiers());
+    }
+}

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/DeviceInputDemo.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/DeviceInputDemo.java
@@ -1,0 +1,181 @@
+package com.codenameone.examples.hellocodenameone;
+
+import com.codename1.ui.Button;
+import com.codename1.ui.CN;
+import com.codename1.ui.Component;
+import com.codename1.ui.Container;
+import com.codename1.ui.DevicePosture;
+import com.codename1.ui.Form;
+import com.codename1.ui.Label;
+import com.codename1.ui.events.ActionEvent;
+import com.codename1.ui.events.ActionListener;
+import com.codename1.ui.events.PointerEvent;
+import com.codename1.ui.events.WheelEvent;
+import com.codename1.ui.layouts.BoxLayout;
+
+/**
+ * Interactive demonstration of the device input and form-factor APIs. Show this form in the
+ * simulator (or on device) and interact with the surface to watch the live pointer detail,
+ * mouse wheel events, context menu requests and device posture update in real time.
+ *
+ * <p>This is a manual demo rather than an automated test - the APIs it shows depend on physical
+ * input (mouse buttons, a stylus, a foldable hinge) that cannot be synthesized headlessly.</p>
+ */
+public class DeviceInputDemo {
+
+    private final Label pointerInfo = new Label("Touch / click the surface");
+    private final Label wheelInfo = new Label("Scroll the wheel here");
+    private final Label contextInfo = new Label("Right click or long press for a context menu");
+    private final Label postureInfo = new Label();
+    private final Label displayInfo = new Label();
+
+    /**
+     * Builds the demo form. Pass the form to return to when the back command is pressed, or null.
+     */
+    public Form build(final Form back) {
+        Form f = new Form("Device Input", BoxLayout.y());
+
+        Container surface = new Container(BoxLayout.y());
+        surface.add(new Label("Interaction surface:"));
+        surface.add(pointerInfo);
+        surface.add(wheelInfo);
+        surface.add(contextInfo);
+
+        // Rich pointer metadata on every press / drag / release.
+        ActionListener pointerListener = new ActionListener() {
+            public void actionPerformed(ActionEvent evt) {
+                PointerEvent pe = evt.getPointerEvent();
+                if (pe != null) {
+                    pointerInfo.setText("button=" + describeButton(pe.getButton())
+                            + " type=" + describeType(pe.getPointerType())
+                            + " pressure=" + round(pe.getPressure())
+                            + " tiltX=" + round(pe.getTiltX())
+                            + (pe.isHovering() ? " (hover)" : ""));
+                    pointerInfo.getParent().revalidate();
+                }
+            }
+        };
+        surface.addPointerPressedListener(pointerListener);
+        surface.addPointerDraggedListener(pointerListener);
+
+        // Mouse wheel - control plus wheel is intercepted to show consumption.
+        surface.addMouseWheelListener(new ActionListener() {
+            public void actionPerformed(ActionEvent evt) {
+                WheelEvent w = (WheelEvent) evt;
+                wheelInfo.setText("wheel dx=" + w.getDeltaX() + " dy=" + w.getDeltaY()
+                        + (w.isPrecise() ? " precise" : "")
+                        + (w.isControlDown() ? " +ctrl(consumed)" : ""));
+                wheelInfo.getParent().revalidate();
+                if (w.isControlDown()) {
+                    w.consume();
+                }
+            }
+        });
+
+        // Unified context menu request: right click, stylus barrel button or long press.
+        surface.addContextMenuListener(new ActionListener() {
+            public void actionPerformed(ActionEvent evt) {
+                contextInfo.setText("context menu requested at " + evt.getX() + "," + evt.getY());
+                contextInfo.getParent().revalidate();
+                evt.consume();
+            }
+        });
+
+        Button refresh = new Button("Refresh posture / display info");
+        refresh.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent evt) {
+                updatePostureInfo();
+                updateDisplayInfo();
+            }
+        });
+
+        CN.addPostureListener(new ActionListener() {
+            public void actionPerformed(ActionEvent evt) {
+                updatePostureInfo();
+            }
+        });
+
+        updatePostureInfo();
+        updateDisplayInfo();
+
+        f.add(surface);
+        f.add(new Label("Device posture:"));
+        f.add(postureInfo);
+        f.add(new Label("Displays:"));
+        f.add(displayInfo);
+        f.add(refresh);
+
+        if (back != null) {
+            f.getToolbar().setBackCommand("Back", new ActionListener() {
+                public void actionPerformed(ActionEvent evt) {
+                    back.showBack();
+                }
+            });
+        }
+        return f;
+    }
+
+    private void updatePostureInfo() {
+        DevicePosture p = CN.getDevicePosture();
+        postureInfo.setText("foldable=" + p.isFoldable()
+                + " posture=" + describePosture(p.getPosture())
+                + " hinge=" + p.getHingeAngle()
+                + " orientation=" + describeFoldOrientation(p.getFoldOrientation())
+                + " separating=" + p.isSeparating());
+        if (postureInfo.getParent() != null) {
+            postureInfo.getParent().revalidate();
+        }
+    }
+
+    private void updateDisplayInfo() {
+        displayInfo.setText("count=" + CN.getDisplayCount()
+                + " external=" + CN.isExternalDisplayConnected()
+                + " desktopMode=" + CN.isDesktopMode()
+                + " desktop=" + CN.isDesktop());
+        if (displayInfo.getParent() != null) {
+            displayInfo.getParent().revalidate();
+        }
+    }
+
+    private static String round(float v) {
+        return "" + (Math.round(v * 100) / 100.0);
+    }
+
+    private static String describeButton(int button) {
+        switch (button) {
+            case PointerEvent.BUTTON_PRIMARY: return "primary";
+            case PointerEvent.BUTTON_SECONDARY: return "secondary";
+            case PointerEvent.BUTTON_MIDDLE: return "middle";
+            case PointerEvent.BUTTON_BACK: return "back";
+            case PointerEvent.BUTTON_FORWARD: return "forward";
+            default: return "none";
+        }
+    }
+
+    private static String describeType(int type) {
+        switch (type) {
+            case PointerEvent.TYPE_TOUCH: return "touch";
+            case PointerEvent.TYPE_MOUSE: return "mouse";
+            case PointerEvent.TYPE_STYLUS: return "stylus";
+            case PointerEvent.TYPE_ERASER: return "eraser";
+            default: return "unknown";
+        }
+    }
+
+    private static String describePosture(int posture) {
+        switch (posture) {
+            case DevicePosture.POSTURE_FLAT: return "flat";
+            case DevicePosture.POSTURE_HALF_OPENED: return "half-opened";
+            case DevicePosture.POSTURE_CLOSED: return "closed";
+            default: return "unknown";
+        }
+    }
+
+    private static String describeFoldOrientation(int orientation) {
+        switch (orientation) {
+            case DevicePosture.FOLD_ORIENTATION_VERTICAL: return "vertical";
+            case DevicePosture.FOLD_ORIENTATION_HORIZONTAL: return "horizontal";
+            default: return "none";
+        }
+    }
+}

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/Cn1ssDeviceRunner.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/Cn1ssDeviceRunner.java
@@ -319,6 +319,7 @@ public final class Cn1ssDeviceRunner extends DeviceRunner {
             new BridgeBulkTransferGuardTest(),
             new VPNDetectionAPITest(),
             new CallDetectionAPITest(),
+            new DeviceInputApiTest(),
             new LocalNotificationOverrideTest(),
             new Base64NativePerformanceTest(),
             new AccessibilityTest(),

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/DeviceInputApiTest.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/DeviceInputApiTest.java
@@ -1,0 +1,106 @@
+package com.codenameone.examples.hellocodenameone.tests;
+
+import com.codename1.ui.CN;
+import com.codename1.ui.Display;
+import com.codename1.ui.DevicePosture;
+import com.codename1.ui.Label;
+import com.codename1.ui.events.ActionEvent;
+import com.codename1.ui.events.ActionListener;
+import com.codename1.ui.events.PointerEvent;
+
+/**
+ * Exercises the device input and form-factor APIs (rich pointer metadata, multi-button mice,
+ * mouse wheel, stylus, foldable posture and multi-display detection) end-to-end against whatever
+ * platform the suite runs on. It only asserts that the API surface is reachable and returns the
+ * documented safe defaults, so it runs everywhere without a golden image.
+ */
+public class DeviceInputApiTest extends BaseTest {
+    @Override
+    public boolean runTest() {
+        try {
+            // Rich pointer metadata is always reachable and never null.
+            PointerEvent current = CN.getCurrentPointerEvent();
+            if (current == null) {
+                fail("CN.getCurrentPointerEvent() must never return null");
+                return false;
+            }
+            CN.getPointerButton();
+            CN.getPressedButtonMask();
+            CN.getPointerType();
+            float pressure = CN.getPointerPressure();
+            if (pressure < 0f || pressure > 4f) {
+                fail("Unexpected pressure value: " + pressure);
+                return false;
+            }
+            CN.getPointerTiltX();
+            CN.getPointerTiltY();
+            CN.getPointerContactSize();
+            CN.isStylusPointer();
+
+            // PointerEvent value object behaves as documented.
+            PointerEvent pe = new PointerEvent(3, 4, PointerEvent.BUTTON_SECONDARY,
+                    PointerEvent.MASK_SECONDARY, PointerEvent.TYPE_STYLUS, 0.5f, 10f, 20f, 0.3f,
+                    PointerEvent.MODIFIER_ALT, false);
+            if (!pe.isSecondaryButton() || !pe.isStylus() || !pe.isAltDown()
+                    || pe.getX() != 3 || pe.getY() != 4) {
+                fail("PointerEvent accessors returned unexpected values");
+                return false;
+            }
+
+            // Foldable / device posture API and its safe defaults.
+            DevicePosture posture = CN.getDevicePosture();
+            if (posture == null) {
+                fail("DevicePosture.getInstance() must never return null");
+                return false;
+            }
+            posture.getPosture();
+            posture.getHingeAngle();
+            posture.getFoldOrientation();
+            posture.isSeparating();
+            posture.isTableTop();
+            posture.getFoldBounds(null);
+            boolean foldable = CN.isFoldable();
+            if (!foldable && posture.getFoldBounds(null) != null) {
+                fail("A non-foldable device must not report fold bounds");
+                return false;
+            }
+
+            // Desktop windowing / multi-display detection.
+            CN.isDesktopMode();
+            if (CN.getDisplayCount() < 1) {
+                fail("getDisplayCount() must be at least 1");
+                return false;
+            }
+            if (CN.isExternalDisplayConnected() != (CN.getDisplayCount() > 1)) {
+                fail("isExternalDisplayConnected() must agree with getDisplayCount()");
+                return false;
+            }
+
+            // Listener registration must be safe even when nothing fires.
+            ActionListener noop = new ActionListener() {
+                public void actionPerformed(ActionEvent evt) {
+                }
+            };
+            CN.addPostureListener(noop);
+            CN.removePostureListener(noop);
+            Label probe = new Label("probe");
+            probe.addContextMenuListener(noop);
+            probe.removeContextMenuListener(noop);
+            probe.addMouseWheelListener(noop);
+            probe.removeMouseWheelListener(noop);
+            probe.addStylusListener(noop);
+            probe.removeStylusListener(noop);
+
+            done();
+            return true;
+        } catch (Throwable t) {
+            fail("Device input API invocation failed: " + t);
+            return false;
+        }
+    }
+
+    @Override
+    public boolean shouldTakeScreenshot() {
+        return false;
+    }
+}

--- a/scripts/initializr/pom.xml
+++ b/scripts/initializr/pom.xml
@@ -121,10 +121,12 @@
            instead of the pinned release, so the local ParparVM JavaScript
            build reflects repo source. The website CI bootstraps these
            8.0-SNAPSHOT artifacts via bootstrap_local_cn1_snapshots before
-           building the initializr with -Dcn1.localWorkspace=true. -->
+           building the initializr with -Dcn1.localWorkspace=true. Must match the
+           repo snapshot version (and the cn1playground cn1-local-workspace
+           profile) so the repo JavaScript port compiles against repo-HEAD core. -->
       <properties>
-        <cn1.version>7.0.255</cn1.version>
-        <cn1.plugin.version>7.0.255</cn1.plugin.version>
+        <cn1.version>8.0-SNAPSHOT</cn1.version>
+        <cn1.plugin.version>8.0-SNAPSHOT</cn1.plugin.version>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
## Summary

Adds the cross-platform device-input and form-factor APIs that Codename One was missing: rich pointer detail (mouse buttons, pen pressure/tilt, pointing-device type), a universal mouse-wheel/trackpad event, foldable device posture, and desktop-windowing / multi-display awareness. Everything is additive and backward compatible — every value has a safe default, so existing apps are unaffected and code written against the new APIs runs everywhere.

## What's included

- **`PointerEvent`** — immutable snapshot: button, button mask, pointer type (touch/mouse/stylus/eraser), pressure, tilt, contact size, modifiers, hover. Read it from `ActionEvent.getPointerEvent()` or poll `CN`/`Display` (`getPointerButton`, `getPointerPressure`, `getPointerType`, `isStylusPointer`, …).
- **2/3-button mice + secondary click** — button constants/mask and `Component.addContextMenuListener` (fires on right-click **and** long-press). Wired in JavaSE, Android (`getButtonState`), iOS.
- **Mouse wheel (universal)** — `WheelEvent` + `Component.addMouseWheelListener` (consume to suppress scroll), horizontal scroll, and a `precise` flag for trackpads. iOS trackpad / Magic Mouse / wheel are captured natively (`UIPanGestureRecognizer`) and routed through the same `pointerWheelMoved` pipeline, so `WheelEvent` is one scroll-gesture API across JavaSE/Android/iOS.
- **Stylus/pen** — pressure, tilt, eraser via `Component.addStylusListener`; Android `getToolType`/`getPressure`/`AXIS_TILT`, iOS Apple Pencil `force`/`altitudeAngle`/`azimuthAngle`.
- **Foldables** — `DevicePosture` (posture, hinge orientation, fold/occlusion bounds) + `Display.addPostureListener`. Android reads `androidx.window` through reflection, pulled in **only** when `android.foldableSupport=true` (zero weight otherwise). The JavaSE simulator can drive a simulated posture for testing.
- **Desktop windowing / displays** — `isDesktopMode` (DeX/Stage Manager), `getDisplayCount`, `isExternalDisplayConnected`.

## Design notes

- Pointer metadata follows the existing `isShiftKeyDown()` precedent — current state on the implementation plus a dispatch-time snapshot — rather than threading through the hot EDT event queue.
- Device-input listeners are dispatched from `Form` (the single chokepoint) so they work even for components like `Button` that override the pointer methods without calling `super`.

## Docs

`docs/developer-guide/Device-Input-And-Form-Factors.asciidoc` (registered in the guide).

## Tests / validation

- `maven/core-unittests`: `PointerEventTest`, `WheelEventTest`, `PointerMetadataTest`, `DevicePostureTest`, `DeviceInputListenersTest`. **Full suite green: 3676 tests, 0 failures.**
- Built locally: core + JavaSE; iOS port + app + arm64 Xcode link (native trackpad recognizer + Apple Pencil upcall compile and link); Android port (foldable reflection helper compiles); hellocodenameone app (interactive `DeviceInputDemo` + `DeviceInputApiTest`).

> Note: the matching `android.foldableSupport` gradle-dependency block has been mirrored to the cloud build daemon's `AndroidGradleBuilder`; the iOS native changes reach the daemon via the published `codenameone-ios` artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
