### PR TITLE
Add cross-platform motion sensor API with gesture detection

### DIFF
--- a/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
+++ b/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
@@ -6988,6 +6988,17 @@ public abstract class CodenameOneImplementation {
         return null;
     }
 
+    /// Returns the port-specific motion sensor entry point. Default
+    /// implementation returns {@code null}; ports that expose the device motion
+    /// hardware override this to return a cached manager. Application code
+    /// should use
+    /// {@link com.codename1.sensors.MotionSensorManager#getInstance()} instead
+    /// of calling this directly --- it transparently substitutes a no-op
+    /// manager when the port returns {@code null}.
+    public com.codename1.sensors.MotionSensorManager getMotionSensorManager() {
+        return null;
+    }
+
     /// Returns the port-specific biometric authentication entry point. Default
     /// implementation returns {@code null}; ports that support biometrics
     /// override this to return a cached singleton. Application code should

--- a/CodenameOne/src/com/codename1/sensors/GestureEngine.java
+++ b/CodenameOne/src/com/codename1/sensors/GestureEngine.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.sensors;
+
+import com.codename1.util.MathUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/// Platform independent gesture recognizer. It is fed a stream of accelerometer
+/// samples together with a low pass estimate of the gravity vector and returns
+/// the gestures it recognizes. Keeping the recognition here means every port
+/// that can produce accelerometer readings gets the full gesture set for free.
+///
+/// This class is intentionally free of any framework dependency (no EDT, no
+/// `Display`) so it can be unit tested with synthetic data. All tuning
+/// constants are package visible and surfaced through setters on
+/// [MotionSensorManager].
+class GestureEngine {
+
+    private static final double G = MotionSensorManager.STANDARD_GRAVITY;
+    // Sentinel for "this gesture has not fired yet". Comparisons guard against
+    // it explicitly so we never compute time - TIME_NONE (which would overflow).
+    private static final long TIME_NONE = Long.MIN_VALUE;
+
+    // ---- shake tuning ----
+    double shakeThreshold = 12.0;            // linear acceleration spike, m/s^2
+    long shakeWindowMs = 800;                // jolts must fall inside this window
+    int shakeJoltsNeeded = 3;                // number of jolts that make a shake
+    long shakeCooldownMs = 1000;             // minimum gap between two shakes
+
+    // ---- flip tuning ----
+    double flipGravityFraction = 0.72;       // fraction of gravity on z to be flat
+    long flipStableMs = 350;                 // orientation must hold this long
+
+    // ---- tilt tuning ----
+    double tiltEnterAngle = 0.6;             // ~34 degrees, radians
+    double tiltExitAngle = 0.35;             // hysteresis back to flat, radians
+
+    // ---- pick up tuning ----
+    double pickUpRestLinear = 0.7;           // max linear accel while at rest
+    long pickUpRestMs = 350;                 // time at rest before a pick up counts
+    double pickUpMoveLinear = 2.8;           // movement that triggers the pick up
+    long pickUpCooldownMs = 1500;
+
+    // ---- free fall tuning ----
+    double freeFallThreshold = 3.0;          // total acceleration, m/s^2
+    long freeFallMinMs = 80;                 // sustained for this long
+    long freeFallCooldownMs = 1500;
+
+    // ---- shake state ----
+    private final ArrayList<Long> joltTimes = new ArrayList<Long>();
+    private boolean shakeAbove;
+    private double shakePeak;
+    private long lastShakeTime = Long.MIN_VALUE;
+
+    // ---- flip state ----
+    private static final int FACE_UNKNOWN = 0;
+    private static final int FACE_UP = 1;
+    private static final int FACE_DOWN = 2;
+    private int faceState = FACE_UNKNOWN;
+    private int faceCandidate = FACE_UNKNOWN;
+    private long faceCandidateSince;
+
+    // ---- tilt state ----
+    private static final int FLAT = 0;
+    private static final int NEG = 1;
+    private static final int POS = 2;
+    private int rollState = FLAT;
+    private int pitchState = FLAT;
+
+    // ---- pick up state ----
+    private boolean resting;
+    private long restSince = Long.MIN_VALUE;
+    private long lastPickUpTime = Long.MIN_VALUE;
+
+    // ---- free fall state ----
+    private long freeFallSince = Long.MIN_VALUE;
+    private long lastFreeFallTime = Long.MIN_VALUE;
+
+    /// Resets all internal state. Used when sampling is (re)started so that
+    /// stale orientation does not produce a spurious gesture on the first sample.
+    void reset() {
+        joltTimes.clear();
+        shakeAbove = false;
+        shakePeak = 0;
+        lastShakeTime = Long.MIN_VALUE;
+        faceState = FACE_UNKNOWN;
+        faceCandidate = FACE_UNKNOWN;
+        faceCandidateSince = 0;
+        rollState = FLAT;
+        pitchState = FLAT;
+        resting = false;
+        restSince = Long.MIN_VALUE;
+        lastPickUpTime = Long.MIN_VALUE;
+        freeFallSince = Long.MIN_VALUE;
+        lastFreeFallTime = Long.MIN_VALUE;
+    }
+
+    /// Feeds a single sample to the recognizer.
+    ///
+    /// #### Parameters
+    ///
+    /// - `ax`, `ay`, `az`: the raw accelerometer reading in m/s^2 including gravity
+    /// - `gx`, `gy`, `gz`: a low pass estimate of the gravity vector in m/s^2
+    /// - `time`: the sample time in milliseconds
+    ///
+    /// #### Returns
+    ///
+    /// the gestures recognized for this sample, never `null` (usually empty)
+    List<GestureEvent> onSample(double ax, double ay, double az,
+                                double gx, double gy, double gz, long time) {
+        List<GestureEvent> events = new ArrayList<GestureEvent>(2);
+
+        double lx = ax - gx;
+        double ly = ay - gy;
+        double lz = az - gz;
+        double linearMag = Math.sqrt(lx * lx + ly * ly + lz * lz);
+        double totalMag = Math.sqrt(ax * ax + ay * ay + az * az);
+
+        detectShake(linearMag, time, events);
+        detectFlip(gz, time, events);
+        detectTilt(gx, gy, gz, time, events);
+        detectPickUp(gz, linearMag, time, events);
+        detectFreeFall(totalMag, time, events);
+
+        return events;
+    }
+
+    private void detectShake(double linearMag, long time, List<GestureEvent> events) {
+        if (linearMag > shakeThreshold) {
+            if (!shakeAbove) {
+                shakeAbove = true;
+                shakePeak = linearMag;
+                joltTimes.add(Long.valueOf(time));
+            } else if (linearMag > shakePeak) {
+                shakePeak = linearMag;
+            }
+        } else if (linearMag < shakeThreshold * 0.7) {
+            shakeAbove = false;
+        }
+
+        long windowStart = time - shakeWindowMs;
+        while (!joltTimes.isEmpty() && joltTimes.get(0).longValue() < windowStart) {
+            joltTimes.remove(0);
+        }
+
+        if (joltTimes.size() >= shakeJoltsNeeded
+                && (lastShakeTime == TIME_NONE || time - lastShakeTime >= shakeCooldownMs)) {
+            lastShakeTime = time;
+            double peak = shakePeak;
+            joltTimes.clear();
+            shakePeak = 0;
+            events.add(new GestureEvent(GestureEvent.TYPE_SHAKE, peak, time));
+        }
+    }
+
+    private void detectFlip(double gz, long time, List<GestureEvent> events) {
+        double flat = G * flipGravityFraction;
+        int instant;
+        if (gz > flat) {
+            instant = FACE_UP;
+        } else if (gz < -flat) {
+            instant = FACE_DOWN;
+        } else {
+            instant = FACE_UNKNOWN;
+        }
+
+        if (instant != faceCandidate) {
+            faceCandidate = instant;
+            faceCandidateSince = time;
+            return;
+        }
+        if (instant == FACE_UNKNOWN || instant == faceState) {
+            return;
+        }
+        if (time - faceCandidateSince >= flipStableMs) {
+            faceState = instant;
+            if (instant == FACE_DOWN) {
+                events.add(new GestureEvent(GestureEvent.TYPE_FLIP_FACE_DOWN, gz, time));
+            } else {
+                events.add(new GestureEvent(GestureEvent.TYPE_FLIP_FACE_UP, gz, time));
+            }
+        }
+    }
+
+    private void detectTilt(double gx, double gy, double gz, long time, List<GestureEvent> events) {
+        double horizontal = Math.sqrt(gx * gx + gz * gz);
+        double roll = MathUtil.atan2(gx, gz);
+        double pitch = MathUtil.atan2(-gy, horizontal);
+
+        rollState = tiltAxis(roll, rollState, GestureEvent.TYPE_TILT_RIGHT,
+                GestureEvent.TYPE_TILT_LEFT, time, events);
+        pitchState = tiltAxis(pitch, pitchState, GestureEvent.TYPE_TILT_BACKWARD,
+                GestureEvent.TYPE_TILT_FORWARD, time, events);
+    }
+
+    private int tiltAxis(double angle, int state, int posType, int negType,
+                         long time, List<GestureEvent> events) {
+        if (state == FLAT) {
+            if (angle > tiltEnterAngle) {
+                events.add(new GestureEvent(posType, angle, time));
+                return POS;
+            }
+            if (angle < -tiltEnterAngle) {
+                events.add(new GestureEvent(negType, angle, time));
+                return NEG;
+            }
+            return FLAT;
+        }
+        if (Math.abs(angle) < tiltExitAngle) {
+            return FLAT;
+        }
+        return state;
+    }
+
+    private void detectPickUp(double gz, double linearMag, long time, List<GestureEvent> events) {
+        boolean flatFaceUp = gz > G * 0.8;
+        if (flatFaceUp && linearMag < pickUpRestLinear) {
+            if (restSince == Long.MIN_VALUE) {
+                restSince = time;
+            } else if (time - restSince >= pickUpRestMs) {
+                resting = true;
+            }
+        } else {
+            if (resting && linearMag > pickUpMoveLinear
+                    && (lastPickUpTime == TIME_NONE || time - lastPickUpTime >= pickUpCooldownMs)) {
+                lastPickUpTime = time;
+                events.add(new GestureEvent(GestureEvent.TYPE_PICK_UP, linearMag, time));
+            }
+            resting = false;
+            restSince = Long.MIN_VALUE;
+        }
+    }
+
+    private void detectFreeFall(double totalMag, long time, List<GestureEvent> events) {
+        if (totalMag < freeFallThreshold) {
+            if (freeFallSince == Long.MIN_VALUE) {
+                freeFallSince = time;
+            } else if (time - freeFallSince >= freeFallMinMs
+                    && (lastFreeFallTime == TIME_NONE || time - lastFreeFallTime >= freeFallCooldownMs)) {
+                lastFreeFallTime = time;
+                freeFallSince = Long.MIN_VALUE;
+                events.add(new GestureEvent(GestureEvent.TYPE_FREE_FALL, totalMag, time));
+            }
+        } else {
+            freeFallSince = Long.MIN_VALUE;
+        }
+    }
+}

--- a/CodenameOne/src/com/codename1/sensors/GestureEvent.java
+++ b/CodenameOne/src/com/codename1/sensors/GestureEvent.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.sensors;
+
+/// A high level gesture detected by the framework from the motion sensor
+/// stream and delivered to a [GestureListener]. The gesture detection runs in
+/// the core so the same gestures are available on every platform that exposes
+/// an accelerometer.
+///
+/// The available gestures are identified by the `TYPE_*` constants on this
+/// class; register interest in one of them through
+/// [MotionSensorManager#addGestureListener(int, GestureListener)].
+public final class GestureEvent {
+
+    /// The device was shaken back and forth.
+    public static final int TYPE_SHAKE = 1;
+
+    /// The device was turned face down (screen towards the ground).
+    public static final int TYPE_FLIP_FACE_DOWN = 2;
+
+    /// The device was turned face up (screen towards the sky).
+    public static final int TYPE_FLIP_FACE_UP = 3;
+
+    /// The device was tilted to the left (top edge rotating towards the user's
+    /// left hand).
+    public static final int TYPE_TILT_LEFT = 4;
+
+    /// The device was tilted to the right.
+    public static final int TYPE_TILT_RIGHT = 5;
+
+    /// The top of the device was tilted away from the user (pitched forward).
+    public static final int TYPE_TILT_FORWARD = 6;
+
+    /// The top of the device was tilted towards the user (pitched backward).
+    public static final int TYPE_TILT_BACKWARD = 7;
+
+    /// The device was picked up from a resting position.
+    public static final int TYPE_PICK_UP = 8;
+
+    /// The device is in free fall (near weightlessness was detected).
+    public static final int TYPE_FREE_FALL = 9;
+
+    private final int type;
+    private final double value;
+    private final long timestamp;
+
+    /// Creates a new gesture event. Application code does not normally
+    /// construct these; they are delivered by the framework.
+    ///
+    /// #### Parameters
+    ///
+    /// - `type`: one of the `TYPE_*` constants
+    /// - `value`: a magnitude describing the gesture; the peak acceleration in
+    ///   meters per second squared for `TYPE_SHAKE`, `TYPE_PICK_UP` and
+    ///   `TYPE_FREE_FALL`, or the tilt angle in radians for the tilt and flip
+    ///   gestures
+    /// - `timestamp`: the event time in milliseconds
+    public GestureEvent(int type, double value, long timestamp) {
+        this.type = type;
+        this.value = value;
+        this.timestamp = timestamp;
+    }
+
+    /// The gesture that occurred, one of the `TYPE_*` constants.
+    public int getType() {
+        return type;
+    }
+
+    /// A magnitude describing the strength of the gesture. See the constructor
+    /// documentation for the meaning per gesture type.
+    public double getValue() {
+        return value;
+    }
+
+    /// The time at which the gesture was detected, in milliseconds, compatible
+    /// with `System.currentTimeMillis()`.
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    /// A human readable name for the gesture type, useful for logging.
+    public String getName() {
+        switch (type) {
+            case TYPE_SHAKE:
+                return "shake";
+            case TYPE_FLIP_FACE_DOWN:
+                return "flipFaceDown";
+            case TYPE_FLIP_FACE_UP:
+                return "flipFaceUp";
+            case TYPE_TILT_LEFT:
+                return "tiltLeft";
+            case TYPE_TILT_RIGHT:
+                return "tiltRight";
+            case TYPE_TILT_FORWARD:
+                return "tiltForward";
+            case TYPE_TILT_BACKWARD:
+                return "tiltBackward";
+            case TYPE_PICK_UP:
+                return "pickUp";
+            case TYPE_FREE_FALL:
+                return "freeFall";
+            default:
+                return "unknown";
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "GestureEvent[" + getName() + ", value=" + value + "]";
+    }
+}

--- a/CodenameOne/src/com/codename1/sensors/GestureListener.java
+++ b/CodenameOne/src/com/codename1/sensors/GestureListener.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.sensors;
+
+/// Receives high level gestures (shake, flip, tilt, pick up, free fall) derived
+/// from the motion sensors. Register an implementation through
+/// [MotionSensorManager#addGestureListener(int, GestureListener)]. Callbacks are
+/// always invoked on the EDT so it is safe to update the UI directly from them.
+public interface GestureListener {
+
+    /// Invoked when a gesture is detected.
+    ///
+    /// #### Parameters
+    ///
+    /// - `evt`: the detected gesture
+    void gestureDetected(GestureEvent evt);
+}

--- a/CodenameOne/src/com/codename1/sensors/MotionEvent.java
+++ b/CodenameOne/src/com/codename1/sensors/MotionEvent.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.sensors;
+
+/// A single immutable reading from a motion sensor delivered to a
+/// [MotionSensorListener]. The meaning of the three axis values depends on the
+/// sensor type that produced the event (see [MotionSensorManager] for the
+/// constants and their units):
+///
+/// - For the acceleration sensors (`TYPE_ACCELEROMETER`,
+///   `TYPE_LINEAR_ACCELERATION`, `TYPE_GRAVITY`) `x`, `y` and `z` are in meters
+///   per second squared.
+/// - For `TYPE_GYROSCOPE` they are angular velocities in radians per second.
+/// - For `TYPE_MAGNETOMETER` they are the magnetic field in microtesla.
+/// - For `TYPE_ORIENTATION` `x` is the azimuth, `y` the pitch and `z` the roll,
+///   all expressed in radians. Use [#getAzimuth()], [#getPitch()] and
+///   [#getRoll()] for readable access.
+///
+/// All ports normalize their readings to the axis convention of a device held
+/// upright in portrait: `x` points to the right, `y` points up and `z` points
+/// out of the screen towards the user.
+public final class MotionEvent {
+    private final int type;
+    private final float x;
+    private final float y;
+    private final float z;
+    private final long timestamp;
+
+    /// Creates a new immutable motion event. Application code does not normally
+    /// construct these; they are delivered by the framework.
+    ///
+    /// #### Parameters
+    ///
+    /// - `type`: one of the `MotionSensorManager.TYPE_*` constants
+    /// - `x`: the first axis value
+    /// - `y`: the second axis value
+    /// - `z`: the third axis value
+    /// - `timestamp`: the event time in milliseconds (see `System.currentTimeMillis()`)
+    public MotionEvent(int type, float x, float y, float z, long timestamp) {
+        this.type = type;
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.timestamp = timestamp;
+    }
+
+    /// The sensor type that produced this event, one of the
+    /// `MotionSensorManager.TYPE_*` constants.
+    public int getType() {
+        return type;
+    }
+
+    /// The value of the first (x) axis. See the class documentation for the
+    /// unit which depends on the sensor type.
+    public float getX() {
+        return x;
+    }
+
+    /// The value of the second (y) axis. See the class documentation for the
+    /// unit which depends on the sensor type.
+    public float getY() {
+        return y;
+    }
+
+    /// The value of the third (z) axis. See the class documentation for the
+    /// unit which depends on the sensor type.
+    public float getZ() {
+        return z;
+    }
+
+    /// The azimuth (rotation around the z axis) in radians. Only meaningful for
+    /// `TYPE_ORIENTATION` events; equivalent to [#getX()].
+    public float getAzimuth() {
+        return x;
+    }
+
+    /// The pitch (rotation around the x axis) in radians. Only meaningful for
+    /// `TYPE_ORIENTATION` events; equivalent to [#getY()].
+    public float getPitch() {
+        return y;
+    }
+
+    /// The roll (rotation around the y axis) in radians. Only meaningful for
+    /// `TYPE_ORIENTATION` events; equivalent to [#getZ()].
+    public float getRoll() {
+        return z;
+    }
+
+    /// The Euclidean magnitude of the three axis values. For the acceleration
+    /// sensors this is the total acceleration in meters per second squared.
+    public double getMagnitude() {
+        return Math.sqrt(((double) x) * x + ((double) y) * y + ((double) z) * z);
+    }
+
+    /// The time at which this reading was sampled, in milliseconds, compatible
+    /// with `System.currentTimeMillis()`.
+    public long getTimestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public String toString() {
+        return "MotionEvent[type=" + type + ", x=" + x + ", y=" + y + ", z=" + z + "]";
+    }
+}

--- a/CodenameOne/src/com/codename1/sensors/MotionSensor.java
+++ b/CodenameOne/src/com/codename1/sensors/MotionSensor.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.sensors;
+
+import java.util.ArrayList;
+
+/// Represents a single motion sensor (for example the accelerometer or the
+/// gyroscope). Obtain an instance from
+/// [MotionSensorManager#getSensor(int)] and start receiving readings by
+/// registering a [MotionSensorListener]:
+///
+/// ```java
+/// MotionSensor accel = MotionSensorManager.getInstance().getSensor(MotionSensorManager.TYPE_ACCELEROMETER);
+/// if (accel != null) {
+///     accel.addListener(new MotionSensorListener() {
+///         public void motionReceived(MotionEvent evt) {
+///             label.setText("x=" + evt.getX() + " y=" + evt.getY() + " z=" + evt.getZ());
+///         }
+///     });
+/// }
+/// ```
+///
+/// Sampling is reference counted: the underlying hardware sensor is only active
+/// while at least one listener is registered, so always remove your listener
+/// (typically when the form is no longer showing) to conserve battery.
+public class MotionSensor {
+    private final MotionSensorManager manager;
+    private final int type;
+    private final ArrayList<MotionSensorListener> listeners = new ArrayList<MotionSensorListener>();
+    private final float[] last = new float[3];
+    private boolean hasReading;
+    private long lastTimestamp;
+
+    MotionSensor(MotionSensorManager manager, int type) {
+        this.manager = manager;
+        this.type = type;
+    }
+
+    /// The type of this sensor, one of the `MotionSensorManager.TYPE_*`
+    /// constants.
+    public int getType() {
+        return type;
+    }
+
+    /// Whether this sensor is available on the current device. A sensor with no
+    /// hardware backing can still be obtained but will never deliver readings.
+    public boolean isSupported() {
+        return manager.isSensorSupported(type);
+    }
+
+    /// Registers a listener that will receive readings on the EDT. Registering
+    /// the first listener starts the underlying hardware sensor.
+    ///
+    /// #### Parameters
+    ///
+    /// - `l`: the listener to add, ignored if `null` or already registered
+    public void addListener(MotionSensorListener l) {
+        if (l == null) {
+            return;
+        }
+        synchronized (listeners) {
+            if (!listeners.contains(l)) {
+                listeners.add(l);
+            }
+        }
+        manager.sensorActivityChanged();
+    }
+
+    /// Removes a previously registered listener. Removing the last listener
+    /// stops the underlying hardware sensor.
+    ///
+    /// #### Parameters
+    ///
+    /// - `l`: the listener to remove
+    public void removeListener(MotionSensorListener l) {
+        synchronized (listeners) {
+            listeners.remove(l);
+        }
+        manager.sensorActivityChanged();
+    }
+
+    /// The most recent value of the x axis, or `0` if no reading has arrived yet.
+    public float getX() {
+        return last[0];
+    }
+
+    /// The most recent value of the y axis, or `0` if no reading has arrived yet.
+    public float getY() {
+        return last[1];
+    }
+
+    /// The most recent value of the z axis, or `0` if no reading has arrived yet.
+    public float getZ() {
+        return last[2];
+    }
+
+    /// Whether at least one reading has been received from this sensor.
+    public boolean hasReading() {
+        return hasReading;
+    }
+
+    /// The timestamp of the most recent reading in milliseconds.
+    public long getTimestamp() {
+        return lastTimestamp;
+    }
+
+    boolean hasListeners() {
+        synchronized (listeners) {
+            return !listeners.isEmpty();
+        }
+    }
+
+    void dispatch(float x, float y, float z, long timestamp) {
+        last[0] = x;
+        last[1] = y;
+        last[2] = z;
+        lastTimestamp = timestamp;
+        hasReading = true;
+        MotionSensorListener[] snapshot;
+        synchronized (listeners) {
+            if (listeners.isEmpty()) {
+                return;
+            }
+            snapshot = new MotionSensorListener[listeners.size()];
+            listeners.toArray(snapshot);
+        }
+        manager.runOnEventThread(new DispatchEvent(snapshot, new MotionEvent(type, x, y, z, timestamp)));
+    }
+
+    // Delivers a reading to a snapshot of listeners on the EDT. A named static
+    // class (rather than an anonymous one) since it only needs the captured
+    // values, not the enclosing sensor.
+    private static final class DispatchEvent implements Runnable {
+        private final MotionSensorListener[] targets;
+        private final MotionEvent evt;
+
+        DispatchEvent(MotionSensorListener[] targets, MotionEvent evt) {
+            this.targets = targets;
+            this.evt = evt;
+        }
+
+        @Override
+        public void run() {
+            for (MotionSensorListener target : targets) {
+                target.motionReceived(evt);
+            }
+        }
+    }
+}

--- a/CodenameOne/src/com/codename1/sensors/MotionSensorListener.java
+++ b/CodenameOne/src/com/codename1/sensors/MotionSensorListener.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.sensors;
+
+/// Receives raw readings from a [MotionSensor]. Register an implementation with
+/// [MotionSensor#addListener(MotionSensorListener)]. Callbacks are always
+/// invoked on the EDT so it is safe to update the UI directly from them.
+public interface MotionSensorListener {
+
+    /// Invoked when a new sensor reading is available.
+    ///
+    /// #### Parameters
+    ///
+    /// - `evt`: the reading; its axis values are interpreted according to the
+    ///   sensor type as documented in [MotionEvent]
+    void motionReceived(MotionEvent evt);
+}

--- a/CodenameOne/src/com/codename1/sensors/MotionSensorManager.java
+++ b/CodenameOne/src/com/codename1/sensors/MotionSensorManager.java
@@ -1,0 +1,643 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.sensors;
+
+import com.codename1.ui.Display;
+import com.codename1.util.MathUtil;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/// Cross platform access to the device motion sensors (accelerometer,
+/// gyroscope, magnetometer and the derived gravity, linear acceleration and
+/// orientation) together with high level gesture detection (shake, flip, tilt,
+/// pick up and free fall).
+///
+/// Obtain the singleton through [#getInstance()]. The instance is always non
+/// `null`; on a device or port without motion sensors every sensor simply
+/// reports as unsupported and no events are delivered.
+///
+/// #### Reading a sensor
+///
+/// ```java
+/// MotionSensorManager m = MotionSensorManager.getInstance();
+/// MotionSensor accel = m.getSensor(MotionSensorManager.TYPE_ACCELEROMETER);
+/// if (accel != null) {
+///     accel.addListener(new MotionSensorListener() {
+///         public void motionReceived(MotionEvent evt) {
+///             // evt.getX(), evt.getY(), evt.getZ() are in m/s^2
+///         }
+///     });
+/// }
+/// ```
+///
+/// #### Listening for a gesture
+///
+/// ```java
+/// MotionSensorManager.getInstance().addGestureListener(GestureEvent.TYPE_SHAKE, new GestureListener() {
+///     public void gestureDetected(GestureEvent evt) {
+///         Dialog.show("Shaken", "You shook the device", "OK", null);
+///     }
+/// });
+/// ```
+///
+/// All callbacks are delivered on the EDT. Sampling is reference counted so the
+/// hardware sensors are only powered while at least one listener (sensor or
+/// gesture) is registered; remember to remove your listeners to save battery.
+///
+/// **iOS note:** access to the motion hardware requires the build argument
+/// `ios.NSMotionUsageDescription` describing why the app reads motion data.
+public abstract class MotionSensorManager {
+
+    /// Accelerometer including the effect of gravity, in meters per second
+    /// squared.
+    public static final int TYPE_ACCELEROMETER = 1;
+
+    /// Acceleration with the effect of gravity removed, in meters per second
+    /// squared. Derived in the core from the accelerometer when the platform
+    /// does not provide it natively.
+    public static final int TYPE_LINEAR_ACCELERATION = 2;
+
+    /// The gravity vector in meters per second squared. Derived in the core
+    /// from the accelerometer when the platform does not provide it natively.
+    public static final int TYPE_GRAVITY = 3;
+
+    /// Rate of rotation around the three axes in radians per second.
+    public static final int TYPE_GYROSCOPE = 4;
+
+    /// The ambient magnetic field in microtesla.
+    public static final int TYPE_MAGNETOMETER = 5;
+
+    /// Device orientation as azimuth, pitch and roll in radians. Derived in the
+    /// core from the gravity vector (and the magnetometer for the azimuth).
+    public static final int TYPE_ORIENTATION = 6;
+
+    /// Standard earth gravity in meters per second squared, the unit used by the
+    /// acceleration sensors.
+    public static final double STANDARD_GRAVITY = 9.80665;
+
+    private static final int MAX_TYPE = 6;
+    private static final float GRAVITY_FILTER_ALPHA = 0.8f;
+
+    private static MotionSensorManager unsupportedInstance;
+
+    private final Object lock = new Object();
+    private final Map<Integer, MotionSensor> sensors = new HashMap<Integer, MotionSensor>();
+    private final Map<Integer, ArrayList<GestureListener>> gestureListeners =
+            new HashMap<Integer, ArrayList<GestureListener>>();
+    private final GestureEngine engine = new GestureEngine();
+
+    private final boolean[] nativeStarted = new boolean[MAX_TYPE + 1];
+    private final float[] readBuffer = new float[3];
+    private final float[] gravityEstimate = new float[3];
+    private boolean gravityInitialized;
+    private boolean threadRunning;
+    private int gestureListenerCount;
+    private int samplingInterval = 50;
+
+    private final Runnable pollRunnable = new Runnable() {
+        @Override
+        public void run() {
+            pollLoop();
+        }
+    };
+
+    /// Returns the shared motion sensor manager. Never `null`: when the active
+    /// port does not provide motion sensors a no-op manager is returned whose
+    /// sensors all report as unsupported.
+    public static MotionSensorManager getInstance() {
+        MotionSensorManager m = Display.getInstance().getMotionSensorManager();
+        if (m != null) {
+            return m;
+        }
+        synchronized (MotionSensorManager.class) {
+            if (unsupportedInstance == null) {
+                unsupportedInstance = new UnsupportedMotionSensorManager();
+            }
+            return unsupportedInstance;
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Hooks implemented by the platform ports
+    // ------------------------------------------------------------------
+
+    /// Whether the named hardware sensor is present on this device. Only the
+    /// hardware backed types (`TYPE_ACCELEROMETER`, `TYPE_GYROSCOPE`,
+    /// `TYPE_MAGNETOMETER` and, where the OS exposes them, `TYPE_GRAVITY` and
+    /// `TYPE_LINEAR_ACCELERATION`) are queried here; derived types are resolved
+    /// by [#isSensorSupported(int)].
+    ///
+    /// #### Parameters
+    ///
+    /// - `type`: one of the `TYPE_*` constants
+    protected abstract boolean isNativeSensorSupported(int type);
+
+    /// Starts the named hardware sensor. Called when the first listener that
+    /// needs it is registered.
+    protected abstract void startNativeSensor(int type);
+
+    /// Stops the named hardware sensor. Called when the last listener that
+    /// needed it is removed.
+    protected abstract void stopNativeSensor(int type);
+
+    /// Reads the latest value of the named hardware sensor.
+    ///
+    /// #### Parameters
+    ///
+    /// - `type`: one of the `TYPE_*` constants
+    /// - `out`: a three element array to receive the x, y and z values
+    ///
+    /// #### Returns
+    ///
+    /// `true` if a value was written, `false` if no reading is available yet
+    protected abstract boolean readNativeSensor(int type, float[] out);
+
+    // ------------------------------------------------------------------
+    // Public API
+    // ------------------------------------------------------------------
+
+    /// Whether the given sensor type can deliver readings on this device. Takes
+    /// into account values that the core derives from other sensors, so for
+    /// example `TYPE_ORIENTATION` is supported whenever the accelerometer is.
+    ///
+    /// #### Parameters
+    ///
+    /// - `type`: one of the `TYPE_*` constants
+    public boolean isSensorSupported(int type) {
+        switch (type) {
+            case TYPE_ACCELEROMETER:
+            case TYPE_GYROSCOPE:
+            case TYPE_MAGNETOMETER:
+                return isNativeSensorSupported(type);
+            case TYPE_GRAVITY:
+            case TYPE_LINEAR_ACCELERATION:
+                return isNativeSensorSupported(type) || isNativeSensorSupported(TYPE_ACCELEROMETER);
+            case TYPE_ORIENTATION:
+                return isNativeSensorSupported(TYPE_GRAVITY) || isNativeSensorSupported(TYPE_ACCELEROMETER);
+            default:
+                return false;
+        }
+    }
+
+    /// Returns the sensor object for the given type, or `null` if the type is
+    /// not supported on this device. The same instance is returned for repeated
+    /// calls with the same type.
+    ///
+    /// #### Parameters
+    ///
+    /// - `type`: one of the `TYPE_*` constants
+    public MotionSensor getSensor(int type) {
+        if (!isSensorSupported(type)) {
+            return null;
+        }
+        Integer key = Integer.valueOf(type);
+        synchronized (lock) {
+            MotionSensor s = sensors.get(key);
+            if (s == null) {
+                s = new MotionSensor(this, type);
+                sensors.put(key, s);
+            }
+            return s;
+        }
+    }
+
+    /// Registers a listener for a specific gesture. The accelerometer is powered
+    /// automatically while at least one gesture listener is registered.
+    ///
+    /// #### Parameters
+    ///
+    /// - `gestureType`: one of the `GestureEvent.TYPE_*` constants
+    /// - `l`: the listener to invoke when the gesture occurs
+    public void addGestureListener(int gestureType, GestureListener l) {
+        if (l == null) {
+            return;
+        }
+        Integer key = Integer.valueOf(gestureType);
+        synchronized (lock) {
+            ArrayList<GestureListener> list = gestureListeners.get(key);
+            if (list == null) {
+                list = new ArrayList<GestureListener>();
+                gestureListeners.put(key, list);
+            }
+            if (!list.contains(l)) {
+                list.add(l);
+                gestureListenerCount++;
+            }
+        }
+        ensureRunning();
+    }
+
+    /// Removes a previously registered gesture listener.
+    ///
+    /// #### Parameters
+    ///
+    /// - `gestureType`: the gesture the listener was registered for
+    /// - `l`: the listener to remove
+    public void removeGestureListener(int gestureType, GestureListener l) {
+        Integer key = Integer.valueOf(gestureType);
+        synchronized (lock) {
+            ArrayList<GestureListener> list = gestureListeners.get(key);
+            if (list != null && list.remove(l)) {
+                gestureListenerCount--;
+                if (list.isEmpty()) {
+                    gestureListeners.remove(key);
+                }
+            }
+        }
+    }
+
+    /// The requested time between sensor samples in milliseconds. Defaults to
+    /// 50ms (20Hz). The actual rate the hardware delivers may differ.
+    public int getSamplingInterval() {
+        return samplingInterval;
+    }
+
+    /// Sets the requested time between sensor samples in milliseconds. Smaller
+    /// values give more responsive gestures at a higher battery cost. Values are
+    /// clamped to the range 10ms..1000ms.
+    ///
+    /// #### Parameters
+    ///
+    /// - `millis`: the requested interval
+    public void setSamplingInterval(int millis) {
+        if (millis < 10) {
+            millis = 10;
+        }
+        if (millis > 1000) {
+            millis = 1000;
+        }
+        synchronized (lock) {
+            samplingInterval = millis;
+        }
+    }
+
+    /// Sets the linear acceleration spike, in meters per second squared, above
+    /// which jolts are counted towards a shake. Larger values require a more
+    /// vigorous shake. The default is 12.0.
+    public void setShakeThreshold(double threshold) {
+        engine.shakeThreshold = threshold;
+    }
+
+    /// Sets the tilt angle, in radians, at which the tilt gestures fire. The
+    /// default is roughly 0.6 (about 34 degrees).
+    public void setTiltThreshold(double radians) {
+        engine.tiltEnterAngle = radians;
+        engine.tiltExitAngle = radians * 0.5;
+    }
+
+    /// Sets the total acceleration, in meters per second squared, below which
+    /// the device is considered to be in free fall. The default is 3.0.
+    public void setFreeFallThreshold(double threshold) {
+        engine.freeFallThreshold = threshold;
+    }
+
+    /// Stops every sensor and removes all registered listeners. Mostly useful
+    /// for tests and for an explicit shutdown.
+    public void stop() {
+        synchronized (lock) {
+            sensors.clear();
+            gestureListeners.clear();
+            gestureListenerCount = 0;
+            for (int t = 1; t <= MAX_TYPE; t++) {
+                if (nativeStarted[t]) {
+                    stopNativeSensor(t);
+                    nativeStarted[t] = false;
+                }
+            }
+            threadRunning = false;
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Internal plumbing used by MotionSensor
+    // ------------------------------------------------------------------
+
+    void sensorActivityChanged() {
+        ensureRunning();
+    }
+
+    void runOnEventThread(Runnable r) {
+        Display.getInstance().callSerially(r);
+    }
+
+    // ------------------------------------------------------------------
+    // Sampling loop
+    // ------------------------------------------------------------------
+
+    private void ensureRunning() {
+        synchronized (lock) {
+            if (threadRunning) {
+                return;
+            }
+            boolean[] needed = computeNeeded();
+            if (!anyNeeded(needed)) {
+                return;
+            }
+            threadRunning = true;
+            gravityInitialized = false;
+            engine.reset();
+            Display.getInstance().startThread(pollRunnable, "CN1 Motion Sensors").start();
+        }
+    }
+
+    private void pollLoop() {
+        while (true) {
+            int sleep;
+            synchronized (lock) {
+                if (!threadRunning) {
+                    return;
+                }
+                if (!tick()) {
+                    return;
+                }
+                sleep = samplingInterval;
+            }
+            try {
+                Thread.sleep(sleep);
+            } catch (InterruptedException ignored) {
+                // resume sampling on the next iteration
+            }
+        }
+    }
+
+    // Runs one sampling cycle. Caller holds lock. Returns false to stop the loop.
+    private boolean tick() {
+        boolean[] needed = computeNeeded();
+        applyNativeDiff(needed);
+        if (!anyNeeded(needed)) {
+            threadRunning = false;
+            return false;
+        }
+
+        long time = System.currentTimeMillis();
+
+        boolean accelOk = needed[TYPE_ACCELEROMETER] && read(TYPE_ACCELEROMETER);
+        float ax = readBuffer[0];
+        float ay = readBuffer[1];
+        float az = readBuffer[2];
+
+        boolean nativeGravityOk = needed[TYPE_GRAVITY] && read(TYPE_GRAVITY);
+        float ngx = readBuffer[0];
+        float ngy = readBuffer[1];
+        float ngz = readBuffer[2];
+
+        updateGravityEstimate(accelOk, ax, ay, az, nativeGravityOk, ngx, ngy, ngz);
+
+        dispatchSensors(accelOk, ax, ay, az, nativeGravityOk, ngx, ngy, ngz, time);
+
+        if (gestureListenerCount > 0 && accelOk && gravityInitialized) {
+            List<GestureEvent> events = engine.onSample(ax, ay, az,
+                    gravityEstimate[0], gravityEstimate[1], gravityEstimate[2], time);
+            for (GestureEvent event : events) {
+                dispatchGesture(event);
+            }
+        }
+        return true;
+    }
+
+    private void dispatchSensors(boolean accelOk, float ax, float ay, float az,
+                                 boolean nativeGravityOk, float ngx, float ngy, float ngz,
+                                 long time) {
+        for (MotionSensor s : sensors.values()) {
+            if (!s.hasListeners()) {
+                continue;
+            }
+            int type = s.getType();
+            switch (type) {
+                case TYPE_ACCELEROMETER:
+                    if (accelOk) {
+                        s.dispatch(ax, ay, az, time);
+                    }
+                    break;
+                case TYPE_GRAVITY:
+                    if (nativeGravityOk) {
+                        s.dispatch(ngx, ngy, ngz, time);
+                    } else if (gravityInitialized) {
+                        s.dispatch(gravityEstimate[0], gravityEstimate[1], gravityEstimate[2], time);
+                    }
+                    break;
+                case TYPE_LINEAR_ACCELERATION:
+                    if (isNativeSensorSupported(TYPE_LINEAR_ACCELERATION) && read(TYPE_LINEAR_ACCELERATION)) {
+                        s.dispatch(readBuffer[0], readBuffer[1], readBuffer[2], time);
+                    } else if (accelOk && gravityInitialized) {
+                        s.dispatch(ax - gravityEstimate[0], ay - gravityEstimate[1],
+                                az - gravityEstimate[2], time);
+                    }
+                    break;
+                case TYPE_GYROSCOPE:
+                    if (read(TYPE_GYROSCOPE)) {
+                        s.dispatch(readBuffer[0], readBuffer[1], readBuffer[2], time);
+                    }
+                    break;
+                case TYPE_MAGNETOMETER:
+                    if (read(TYPE_MAGNETOMETER)) {
+                        s.dispatch(readBuffer[0], readBuffer[1], readBuffer[2], time);
+                    }
+                    break;
+                case TYPE_ORIENTATION:
+                    if (gravityInitialized) {
+                        float[] o = computeOrientation();
+                        s.dispatch(o[0], o[1], o[2], time);
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    private void updateGravityEstimate(boolean accelOk, float ax, float ay, float az,
+                                       boolean nativeGravityOk, float ngx, float ngy, float ngz) {
+        if (nativeGravityOk) {
+            gravityEstimate[0] = ngx;
+            gravityEstimate[1] = ngy;
+            gravityEstimate[2] = ngz;
+            gravityInitialized = true;
+        } else if (accelOk) {
+            if (!gravityInitialized) {
+                gravityEstimate[0] = ax;
+                gravityEstimate[1] = ay;
+                gravityEstimate[2] = az;
+                gravityInitialized = true;
+            } else {
+                gravityEstimate[0] = GRAVITY_FILTER_ALPHA * gravityEstimate[0] + (1 - GRAVITY_FILTER_ALPHA) * ax;
+                gravityEstimate[1] = GRAVITY_FILTER_ALPHA * gravityEstimate[1] + (1 - GRAVITY_FILTER_ALPHA) * ay;
+                gravityEstimate[2] = GRAVITY_FILTER_ALPHA * gravityEstimate[2] + (1 - GRAVITY_FILTER_ALPHA) * az;
+            }
+        }
+    }
+
+    // Computes azimuth, pitch and roll (radians). Pitch and roll come directly
+    // from the gravity estimate; the azimuth (compass heading) needs the
+    // magnetometer and follows the rotation matrix derivation used by Android's
+    // SensorManager.getRotationMatrix / getOrientation.
+    private float[] computeOrientation() {
+        double gx = gravityEstimate[0];
+        double gy = gravityEstimate[1];
+        double gz = gravityEstimate[2];
+
+        float azimuth = 0;
+        if (isNativeSensorSupported(TYPE_MAGNETOMETER) && read(TYPE_MAGNETOMETER)) {
+            double ex = readBuffer[0];
+            double ey = readBuffer[1];
+            double ez = readBuffer[2];
+            // H = E x A : the device "east" axis
+            double hx = ey * gz - ez * gy;
+            double hy = ez * gx - ex * gz;
+            double hz = ex * gy - ey * gx;
+            double normH = Math.sqrt(hx * hx + hy * hy + hz * hz);
+            double normA = Math.sqrt(gx * gx + gy * gy + gz * gz);
+            if (normH >= 0.1 && normA >= 0.1) {
+                hx /= normH;
+                hy /= normH;
+                hz /= normH;
+                double axn = gx / normA;
+                double azn = gz / normA;
+                // M = A x H : the device "north" axis; we only need its y term
+                double my = azn * hx - axn * hz;
+                azimuth = (float) MathUtil.atan2(hy, my);
+            }
+        }
+
+        double horizontal = Math.sqrt(gx * gx + gz * gz);
+        float roll = (float) MathUtil.atan2(gx, gz);
+        float pitch = (float) MathUtil.atan2(-gy, horizontal);
+        return new float[]{azimuth, pitch, roll};
+    }
+
+    private void dispatchGesture(GestureEvent evt) {
+        Integer key = Integer.valueOf(evt.getType());
+        ArrayList<GestureListener> list = gestureListeners.get(key);
+        if (list == null || list.isEmpty()) {
+            return;
+        }
+        GestureListener[] targets = new GestureListener[list.size()];
+        list.toArray(targets);
+        runOnEventThread(new DispatchGesture(targets, evt));
+    }
+
+    // Delivers a gesture to a snapshot of listeners on the EDT. A named static
+    // class (rather than an anonymous one) since it only needs the captured
+    // values, not the enclosing manager.
+    private static final class DispatchGesture implements Runnable {
+        private final GestureListener[] targets;
+        private final GestureEvent event;
+
+        DispatchGesture(GestureListener[] targets, GestureEvent event) {
+            this.targets = targets;
+            this.event = event;
+        }
+
+        @Override
+        public void run() {
+            for (GestureListener target : targets) {
+                target.gestureDetected(event);
+            }
+        }
+    }
+
+    private boolean read(int type) {
+        return readNativeSensor(type, readBuffer);
+    }
+
+    private boolean[] computeNeeded() {
+        boolean[] needed = new boolean[MAX_TYPE + 1];
+        for (MotionSensor s : sensors.values()) {
+            if (s.hasListeners()) {
+                addSources(needed, s.getType());
+            }
+        }
+        if (gestureListenerCount > 0) {
+            need(needed, TYPE_ACCELEROMETER);
+        }
+        return needed;
+    }
+
+    private void addSources(boolean[] needed, int type) {
+        switch (type) {
+            case TYPE_ACCELEROMETER:
+                need(needed, TYPE_ACCELEROMETER);
+                break;
+            case TYPE_GYROSCOPE:
+                need(needed, TYPE_GYROSCOPE);
+                break;
+            case TYPE_MAGNETOMETER:
+                need(needed, TYPE_MAGNETOMETER);
+                break;
+            case TYPE_GRAVITY:
+                if (isNativeSensorSupported(TYPE_GRAVITY)) {
+                    need(needed, TYPE_GRAVITY);
+                } else {
+                    need(needed, TYPE_ACCELEROMETER);
+                }
+                break;
+            case TYPE_LINEAR_ACCELERATION:
+                if (isNativeSensorSupported(TYPE_LINEAR_ACCELERATION)) {
+                    need(needed, TYPE_LINEAR_ACCELERATION);
+                } else {
+                    need(needed, TYPE_ACCELEROMETER);
+                }
+                break;
+            case TYPE_ORIENTATION:
+                if (isNativeSensorSupported(TYPE_GRAVITY)) {
+                    need(needed, TYPE_GRAVITY);
+                } else {
+                    need(needed, TYPE_ACCELEROMETER);
+                }
+                need(needed, TYPE_MAGNETOMETER);
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void need(boolean[] needed, int type) {
+        if (isNativeSensorSupported(type)) {
+            needed[type] = true;
+        }
+    }
+
+    private void applyNativeDiff(boolean[] needed) {
+        for (int t = 1; t <= MAX_TYPE; t++) {
+            if (needed[t] && !nativeStarted[t]) {
+                startNativeSensor(t);
+                nativeStarted[t] = true;
+            } else if (!needed[t] && nativeStarted[t]) {
+                stopNativeSensor(t);
+                nativeStarted[t] = false;
+            }
+        }
+    }
+
+    private boolean anyNeeded(boolean[] needed) {
+        for (int t = 1; t <= MAX_TYPE; t++) {
+            if (needed[t]) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/CodenameOne/src/com/codename1/sensors/UnsupportedMotionSensorManager.java
+++ b/CodenameOne/src/com/codename1/sensors/UnsupportedMotionSensorManager.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.sensors;
+
+/// No-op fallback returned by [MotionSensorManager#getInstance()] on ports that
+/// do not provide motion sensors. Every sensor reports as unsupported so
+/// application code can call the API unconditionally without a null check on the
+/// manager itself.
+class UnsupportedMotionSensorManager extends MotionSensorManager {
+    @Override
+    protected boolean isNativeSensorSupported(int type) {
+        return false;
+    }
+
+    @Override
+    protected void startNativeSensor(int type) {
+    }
+
+    @Override
+    protected void stopNativeSensor(int type) {
+    }
+
+    @Override
+    protected boolean readNativeSensor(int type, float[] out) {
+        return false;
+    }
+}

--- a/CodenameOne/src/com/codename1/sensors/package-info.java
+++ b/CodenameOne/src/com/codename1/sensors/package-info.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+/// Cross platform access to the device motion sensors and high level gesture
+/// detection.
+///
+/// The entry point is [com.codename1.sensors.MotionSensorManager]. It exposes
+/// the raw sensors (accelerometer, gyroscope, magnetometer) plus the values the
+/// framework derives from them (gravity, linear acceleration and orientation),
+/// and it recognizes a set of common gestures (shake, flip, tilt, pick up and
+/// free fall) entirely in the core so the gestures work on every platform that
+/// has an accelerometer.
+///
+/// Reading the accelerometer:
+///
+/// ```java
+/// MotionSensor accel = MotionSensorManager.getInstance().getSensor(MotionSensorManager.TYPE_ACCELEROMETER);
+/// if (accel != null) {
+///     accel.addListener(new MotionSensorListener() {
+///         public void motionReceived(MotionEvent evt) {
+///             // evt.getX(), evt.getY(), evt.getZ() in m/s^2, delivered on the EDT
+///         }
+///     });
+/// }
+/// ```
+///
+/// Reacting to a shake:
+///
+/// ```java
+/// MotionSensorManager.getInstance().addGestureListener(GestureEvent.TYPE_SHAKE, new GestureListener() {
+///     public void gestureDetected(GestureEvent evt) {
+///         // the device was shaken
+///     }
+/// });
+/// ```
+///
+/// Sampling is reference counted: the hardware sensors are only powered while a
+/// listener is registered, so always remove your listeners when you no longer
+/// need them. On iOS the build argument `ios.NSMotionUsageDescription` must be
+/// supplied to gain access to the motion hardware.
+package com.codename1.sensors;

--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -4509,6 +4509,15 @@ public final class Display extends CN1Constants {
         return impl.getLocationManager();
     }
 
+    /// Returns the platform motion sensor entry point or {@code null} when the
+    /// current port does not provide motion sensors. Prefer
+    /// {@link com.codename1.sensors.MotionSensorManager#getInstance()} in
+    /// application code --- it handles the fallback to a no-op manager when the
+    /// current port returns {@code null}.
+    public com.codename1.sensors.MotionSensorManager getMotionSensorManager() {
+        return impl.getMotionSensorManager();
+    }
+
     /// Returns the platform biometric authentication entry point. Prefer
     /// {@link com.codename1.security.Biometrics#getInstance()} in application
     /// code --- it handles the fallback to a no-op stub when the current port

--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -7306,6 +7306,20 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
         }
     }
 
+    private AndroidMotionSensorManager motionSensorManager;
+
+    @Override
+    public com.codename1.sensors.MotionSensorManager getMotionSensorManager() {
+        if (motionSensorManager == null) {
+            Context ctx = getContext();
+            if (ctx == null) {
+                return null;
+            }
+            motionSensorManager = new AndroidMotionSensorManager(ctx);
+        }
+        return motionSensorManager;
+    }
+
     private String fixAttachmentPath(String attachment) {
         com.codename1.io.File cn1File = new com.codename1.io.File(attachment);
         File mediaStorageDir = new File(new File(getContext().getCacheDir(), "intent_files"), "Attachment");

--- a/Ports/Android/src/com/codename1/impl/android/AndroidMotionSensorManager.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidMotionSensorManager.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.impl.android;
+
+import android.content.Context;
+import android.hardware.Sensor;
+import android.hardware.SensorEvent;
+import android.hardware.SensorEventListener;
+import android.hardware.SensorManager;
+
+import com.codename1.sensors.MotionSensorManager;
+
+/**
+ * Android implementation of the motion sensors backed by the platform
+ * {@link android.hardware.SensorManager}. The hardware backed sensor types are
+ * mapped to their Android equivalents; the core derives the orientation from the
+ * gravity vector and the magnetometer. Android already reports acceleration in
+ * m/s^2, angular velocity in rad/s and the magnetic field in microtesla using
+ * the same axis convention the API documents, so no unit conversion is needed.
+ *
+ * @author Codename One
+ */
+public class AndroidMotionSensorManager extends MotionSensorManager {
+    private static final int MAX_TYPE = 6;
+
+    private final SensorManager sensorManager;
+    private final Object lock = new Object();
+    private final float[][] cached = new float[MAX_TYPE + 1][3];
+    private final boolean[] hasData = new boolean[MAX_TYPE + 1];
+    private final SensorEventListener[] listeners = new SensorEventListener[MAX_TYPE + 1];
+
+    public AndroidMotionSensorManager(Context context) {
+        sensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
+    }
+
+    private int androidType(int type) {
+        switch (type) {
+            case TYPE_ACCELEROMETER:
+                return Sensor.TYPE_ACCELEROMETER;
+            case TYPE_LINEAR_ACCELERATION:
+                return Sensor.TYPE_LINEAR_ACCELERATION;
+            case TYPE_GRAVITY:
+                return Sensor.TYPE_GRAVITY;
+            case TYPE_GYROSCOPE:
+                return Sensor.TYPE_GYROSCOPE;
+            case TYPE_MAGNETOMETER:
+                return Sensor.TYPE_MAGNETIC_FIELD;
+            default:
+                return -1;
+        }
+    }
+
+    @Override
+    protected boolean isNativeSensorSupported(int type) {
+        if (sensorManager == null) {
+            return false;
+        }
+        int a = androidType(type);
+        if (a < 0) {
+            return false;
+        }
+        return sensorManager.getDefaultSensor(a) != null;
+    }
+
+    @Override
+    protected void startNativeSensor(final int type) {
+        if (sensorManager == null) {
+            return;
+        }
+        int a = androidType(type);
+        if (a < 0) {
+            return;
+        }
+        Sensor sensor = sensorManager.getDefaultSensor(a);
+        if (sensor == null) {
+            return;
+        }
+        SensorEventListener listener = new SensorEventListener() {
+            @Override
+            public void onSensorChanged(SensorEvent event) {
+                synchronized (lock) {
+                    cached[type][0] = event.values[0];
+                    cached[type][1] = event.values[1];
+                    cached[type][2] = event.values[2];
+                    hasData[type] = true;
+                }
+            }
+
+            @Override
+            public void onAccuracyChanged(Sensor s, int accuracy) {
+            }
+        };
+        synchronized (lock) {
+            listeners[type] = listener;
+            hasData[type] = false;
+        }
+        sensorManager.registerListener(listener, sensor, getSamplingInterval() * 1000);
+    }
+
+    @Override
+    protected void stopNativeSensor(int type) {
+        if (sensorManager == null) {
+            return;
+        }
+        SensorEventListener listener;
+        synchronized (lock) {
+            listener = listeners[type];
+            listeners[type] = null;
+            hasData[type] = false;
+        }
+        if (listener != null) {
+            sensorManager.unregisterListener(listener);
+        }
+    }
+
+    @Override
+    protected boolean readNativeSensor(int type, float[] out) {
+        if (type < 0 || type > MAX_TYPE) {
+            return false;
+        }
+        synchronized (lock) {
+            if (!hasData[type]) {
+                return false;
+            }
+            out[0] = cached[type][0];
+            out[1] = cached[type][1];
+            out[2] = cached[type][2];
+            return true;
+        }
+    }
+}

--- a/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEMotionSensorManager.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEMotionSensorManager.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.impl.javase;
+
+import com.codename1.sensors.MotionSensorManager;
+
+/**
+ * Simulator implementation of the motion sensors. It synthesizes accelerometer,
+ * gyroscope and magnetometer readings from a simulated device orientation (set
+ * through the "Simulate &gt; Motion / Gesture Simulation" window) plus transient
+ * bursts used to reproduce the shake, pick up and free fall gestures. The core
+ * derives gravity, linear acceleration and orientation from these readings, so
+ * every gesture can be exercised from the desktop without hardware.
+ *
+ * @author Codename One
+ */
+public class JavaSEMotionSensorManager extends MotionSensorManager {
+    static final int TRANSIENT_NONE = 0;
+    static final int TRANSIENT_SHAKE = 1;
+    static final int TRANSIENT_FREE_FALL = 2;
+    static final int TRANSIENT_PICK_UP = 3;
+
+    private static volatile double simRollRad;
+    private static volatile double simPitchRad;
+    private static volatile int transientType;
+    private static volatile long transientStart;
+    private static volatile long transientDuration;
+
+    /**
+     * Sets the simulated device orientation.
+     *
+     * @param pitchDegrees forward/backward tilt in degrees
+     * @param rollDegrees left/right tilt in degrees
+     */
+    public static void setOrientation(double pitchDegrees, double rollDegrees) {
+        simPitchRad = Math.toRadians(pitchDegrees);
+        simRollRad = Math.toRadians(rollDegrees);
+    }
+
+    /**
+     * Injects a short oscillating burst so the core recognizes a shake.
+     */
+    public static void triggerShake() {
+        transientType = TRANSIENT_SHAKE;
+        transientStart = System.currentTimeMillis();
+        transientDuration = 700;
+    }
+
+    /**
+     * Drops the simulated acceleration to near zero so the core recognizes free
+     * fall.
+     */
+    public static void triggerFreeFall() {
+        transientType = TRANSIENT_FREE_FALL;
+        transientStart = System.currentTimeMillis();
+        transientDuration = 400;
+    }
+
+    /**
+     * Injects a short movement burst so the core recognizes a pick up. The
+     * device must have been at rest and roughly flat beforehand.
+     */
+    public static void triggerPickUp() {
+        transientType = TRANSIENT_PICK_UP;
+        transientStart = System.currentTimeMillis();
+        transientDuration = 350;
+    }
+
+    @Override
+    protected boolean isNativeSensorSupported(int type) {
+        return type == TYPE_ACCELEROMETER || type == TYPE_GYROSCOPE || type == TYPE_MAGNETOMETER;
+    }
+
+    @Override
+    protected void startNativeSensor(int type) {
+    }
+
+    @Override
+    protected void stopNativeSensor(int type) {
+    }
+
+    @Override
+    protected boolean readNativeSensor(int type, float[] out) {
+        switch (type) {
+            case TYPE_ACCELEROMETER:
+                readAccelerometer(out);
+                return true;
+            case TYPE_GYROSCOPE:
+                out[0] = 0;
+                out[1] = 0;
+                out[2] = 0;
+                return true;
+            case TYPE_MAGNETOMETER:
+                // A constant northward field so the orientation azimuth resolves.
+                out[0] = 0;
+                out[1] = 30;
+                out[2] = 0;
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private void readAccelerometer(float[] out) {
+        double g = STANDARD_GRAVITY;
+        double roll = simRollRad;
+        double pitch = simPitchRad;
+        double gx = g * Math.sin(roll);
+        double gy = -g * Math.sin(pitch);
+        double gz = g * Math.cos(roll) * Math.cos(pitch);
+
+        int tt = transientType;
+        if (tt != TRANSIENT_NONE) {
+            long elapsed = System.currentTimeMillis() - transientStart;
+            if (elapsed < transientDuration) {
+                double t = elapsed / 1000.0;
+                switch (tt) {
+                    case TRANSIENT_SHAKE: {
+                        double w = 2 * Math.PI * 8;
+                        gx += Math.sin(w * t) * 22;
+                        gy += Math.cos(w * t) * 22;
+                        gz += Math.sin(2 * w * t) * 10;
+                        break;
+                    }
+                    case TRANSIENT_FREE_FALL:
+                        gx = 0;
+                        gy = 0;
+                        gz = 0;
+                        break;
+                    case TRANSIENT_PICK_UP:
+                        gx += 4;
+                        gz += 4;
+                        break;
+                    default:
+                        break;
+                }
+            } else {
+                transientType = TRANSIENT_NONE;
+            }
+        }
+
+        out[0] = (float) gx;
+        out[1] = (float) gy;
+        out[2] = (float) gz;
+    }
+}

--- a/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
@@ -881,6 +881,8 @@ public class JavaSEPort extends CodenameOneImplementation {
     private ComponentTreeInspector componentTreeInspector;
     private static PerformanceMonitor perfMonitor;
     static LocationSimulation locSimulation;
+    static MotionSimulation motionSimulation;
+    private JavaSEMotionSensorManager motionSensorManager;
     static PushSimulator pushSimulation;
     private static boolean blockMonitors;
     private static boolean useAppFrame = computeUseAppFrame();
@@ -5632,6 +5634,18 @@ public class JavaSEPort extends CodenameOneImplementation {
         });
         simulateMenu.add(locationSim);
 
+        JMenuItem motionSim = new JMenuItem("Motion / Gesture Simulation");
+        motionSim.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent ae) {
+                if(motionSimulation == null) {
+                        motionSimulation = new MotionSimulation();
+                }
+                motionSimulation.setVisible(true);
+            }
+        });
+        simulateMenu.add(motionSim);
+
         JMenuItem pushSim = new JMenuItem("Push Simulation");
         pushSim.addActionListener(new ActionListener() {
             @Override
@@ -6236,6 +6250,7 @@ public class JavaSEPort extends CodenameOneImplementation {
         simulateMenu.add(appArg);
         simulateMenu.addSeparator();
         simulateMenu.add(locationSim);
+        simulateMenu.add(motionSim);
         simulateMenu.add(pushSim);
         simulateMenu.add(biometricMenu);
         simulateMenu.add(nfcMenu);
@@ -13764,6 +13779,19 @@ public class JavaSEPort extends CodenameOneImplementation {
             
             
         };
+    }
+
+    @Override
+    public com.codename1.sensors.MotionSensorManager getMotionSensorManager() {
+        // Motion simulation is only meaningful in the simulator, not in the
+        // designer or a plain JavaSE deployment.
+        if(portraitSkin == null) {
+            return null;
+        }
+        if(motionSensorManager == null) {
+            motionSensorManager = new JavaSEMotionSensorManager();
+        }
+        return motionSensorManager;
     }
 
     @Override

--- a/Ports/JavaSE/src/com/codename1/impl/javase/MotionSimulation.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/MotionSimulation.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.impl.javase;
+
+import java.awt.BorderLayout;
+import java.awt.GridLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JSlider;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+
+/**
+ * Simulator window that drives {@link JavaSEMotionSensorManager}. The two
+ * sliders set the simulated device orientation (which the accelerometer
+ * reflects) while the buttons inject the transient motion needed to fire the
+ * shake, flip, pick up and free fall gestures.
+ *
+ * @author Codename One
+ */
+public class MotionSimulation extends JFrame {
+    private final JSlider pitchSlider = new JSlider(-90, 90, 0);
+    private final JSlider rollSlider = new JSlider(-180, 180, 0);
+
+    public MotionSimulation() {
+        super("Motion / Gesture Simulation");
+        setDefaultCloseOperation(JFrame.HIDE_ON_CLOSE);
+        setLayout(new BorderLayout());
+
+        JPanel sliders = new JPanel(new GridLayout(2, 1));
+        sliders.setBorder(BorderFactory.createTitledBorder("Device orientation"));
+        sliders.add(labeledSlider("Pitch (forward/back)", pitchSlider));
+        sliders.add(labeledSlider("Roll (left/right)", rollSlider));
+
+        ChangeListener orientationListener = new ChangeListener() {
+            @Override
+            public void stateChanged(ChangeEvent e) {
+                updateOrientation();
+            }
+        };
+        pitchSlider.addChangeListener(orientationListener);
+        rollSlider.addChangeListener(orientationListener);
+
+        JPanel buttons = new JPanel(new GridLayout(3, 2, 6, 6));
+        buttons.setBorder(BorderFactory.createTitledBorder("Gestures"));
+        buttons.add(gestureButton("Shake", new Runnable() {
+            @Override
+            public void run() {
+                JavaSEMotionSensorManager.triggerShake();
+            }
+        }));
+        buttons.add(gestureButton("Free Fall", new Runnable() {
+            @Override
+            public void run() {
+                JavaSEMotionSensorManager.triggerFreeFall();
+            }
+        }));
+        buttons.add(gestureButton("Flip Face Down", new Runnable() {
+            @Override
+            public void run() {
+                pitchSlider.setValue(0);
+                rollSlider.setValue(180);
+            }
+        }));
+        buttons.add(gestureButton("Flip Face Up", new Runnable() {
+            @Override
+            public void run() {
+                pitchSlider.setValue(0);
+                rollSlider.setValue(0);
+            }
+        }));
+        buttons.add(gestureButton("Pick Up", new Runnable() {
+            @Override
+            public void run() {
+                JavaSEMotionSensorManager.triggerPickUp();
+            }
+        }));
+        buttons.add(gestureButton("Reset Flat", new Runnable() {
+            @Override
+            public void run() {
+                pitchSlider.setValue(0);
+                rollSlider.setValue(0);
+            }
+        }));
+
+        add(sliders, BorderLayout.CENTER);
+        add(buttons, BorderLayout.SOUTH);
+        pack();
+        setLocationByPlatform(true);
+        updateOrientation();
+    }
+
+    private JPanel labeledSlider(String title, JSlider slider) {
+        JPanel p = new JPanel(new BorderLayout());
+        slider.setMajorTickSpacing(45);
+        slider.setPaintTicks(true);
+        slider.setPaintLabels(true);
+        p.add(new JLabel(title), BorderLayout.NORTH);
+        p.add(slider, BorderLayout.CENTER);
+        return p;
+    }
+
+    private JButton gestureButton(String text, final Runnable action) {
+        JButton b = new JButton(text);
+        b.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                action.run();
+            }
+        });
+        return b;
+    }
+
+    private void updateOrientation() {
+        JavaSEMotionSensorManager.setOrientation(pitchSlider.getValue(), rollSlider.getValue());
+    }
+}

--- a/Ports/iOSPort/nativeSources/IOSNative.m
+++ b/Ports/iOSPort/nativeSources/IOSNative.m
@@ -73,6 +73,9 @@
 #endif
 #import <MediaPlayer/MediaPlayer.h>
 #import <CoreLocation/CoreLocation.h>
+#if !TARGET_OS_TV
+#import <CoreMotion/CoreMotion.h>
+#endif
 #import <MobileCoreServices/UTCoreTypes.h>
 #import <Foundation/Foundation.h>
 #import <CoreText/CoreText.h>
@@ -2524,6 +2527,175 @@ void com_codename1_impl_ios_IOSNative_setDisableScreenshots___boolean(CN1_THREAD
 extern void vibrateDevice();
 void com_codename1_impl_ios_IOSNative_vibrate___int(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject, JAVA_INT duration) {
     vibrateDevice();
+}
+
+// ---- CoreMotion backed motion sensors (com.codename1.sensors) ----
+// These constants mirror MotionSensorManager.TYPE_*. iOS exposes the raw
+// accelerometer, gyroscope and magnetometer natively; the core derives the
+// gravity, linear acceleration and orientation values from them.
+#define CN1_MOTION_ACCELEROMETER 1
+#define CN1_MOTION_GYROSCOPE 4
+#define CN1_MOTION_MAGNETOMETER 5
+#define CN1_MOTION_G 9.80665
+
+#if !TARGET_OS_TV
+static CMMotionManager *cn1MotionManager = nil;
+static CMMotionManager *cn1GetMotionManager() {
+    if(cn1MotionManager == nil) {
+        cn1MotionManager = [[CMMotionManager alloc] init];
+    }
+    return cn1MotionManager;
+}
+#endif
+
+JAVA_BOOLEAN com_codename1_impl_ios_IOSNative_isMotionSensorSupported___int(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject, JAVA_INT type) {
+#if TARGET_OS_TV
+    return JAVA_FALSE;
+#else
+    CMMotionManager *m = cn1GetMotionManager();
+    switch(type) {
+        case CN1_MOTION_ACCELEROMETER:
+            return m.accelerometerAvailable ? JAVA_TRUE : JAVA_FALSE;
+        case CN1_MOTION_GYROSCOPE:
+            return m.gyroAvailable ? JAVA_TRUE : JAVA_FALSE;
+        case CN1_MOTION_MAGNETOMETER:
+            return m.magnetometerAvailable ? JAVA_TRUE : JAVA_FALSE;
+        default:
+            return JAVA_FALSE;
+    }
+#endif
+}
+JAVA_BOOLEAN com_codename1_impl_ios_IOSNative_isMotionSensorSupported___int_R_boolean(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject, JAVA_INT type) {
+    return com_codename1_impl_ios_IOSNative_isMotionSensorSupported___int(CN1_THREAD_STATE_PASS_ARG instanceObject, type);
+}
+
+void com_codename1_impl_ios_IOSNative_startMotionSensor___int_int(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject, JAVA_INT type, JAVA_INT rateMillis) {
+#if !TARGET_OS_TV
+    CMMotionManager *m = cn1GetMotionManager();
+    NSTimeInterval interval = ((double)rateMillis) / 1000.0;
+    switch(type) {
+        case CN1_MOTION_ACCELEROMETER:
+            m.accelerometerUpdateInterval = interval;
+            [m startAccelerometerUpdates];
+            break;
+        case CN1_MOTION_GYROSCOPE:
+            m.gyroUpdateInterval = interval;
+            [m startGyroUpdates];
+            break;
+        case CN1_MOTION_MAGNETOMETER:
+            m.magnetometerUpdateInterval = interval;
+            [m startMagnetometerUpdates];
+            break;
+        default:
+            break;
+    }
+#endif
+}
+
+void com_codename1_impl_ios_IOSNative_stopMotionSensor___int(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject, JAVA_INT type) {
+#if !TARGET_OS_TV
+    CMMotionManager *m = cn1GetMotionManager();
+    switch(type) {
+        case CN1_MOTION_ACCELEROMETER:
+            [m stopAccelerometerUpdates];
+            break;
+        case CN1_MOTION_GYROSCOPE:
+            [m stopGyroUpdates];
+            break;
+        case CN1_MOTION_MAGNETOMETER:
+            [m stopMagnetometerUpdates];
+            break;
+        default:
+            break;
+    }
+#endif
+}
+
+JAVA_BOOLEAN com_codename1_impl_ios_IOSNative_hasMotionData___int(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject, JAVA_INT type) {
+#if TARGET_OS_TV
+    return JAVA_FALSE;
+#else
+    CMMotionManager *m = cn1GetMotionManager();
+    switch(type) {
+        case CN1_MOTION_ACCELEROMETER:
+            return m.accelerometerData != nil ? JAVA_TRUE : JAVA_FALSE;
+        case CN1_MOTION_GYROSCOPE:
+            return m.gyroData != nil ? JAVA_TRUE : JAVA_FALSE;
+        case CN1_MOTION_MAGNETOMETER:
+            return m.magnetometerData != nil ? JAVA_TRUE : JAVA_FALSE;
+        default:
+            return JAVA_FALSE;
+    }
+#endif
+}
+JAVA_BOOLEAN com_codename1_impl_ios_IOSNative_hasMotionData___int_R_boolean(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject, JAVA_INT type) {
+    return com_codename1_impl_ios_IOSNative_hasMotionData___int(CN1_THREAD_STATE_PASS_ARG instanceObject, type);
+}
+
+#if !TARGET_OS_TV
+// axis: 0 = x, 1 = y, 2 = z
+static JAVA_FLOAT cn1ReadMotionAxis(JAVA_INT type, int axis) {
+    CMMotionManager *m = cn1GetMotionManager();
+    switch(type) {
+        case CN1_MOTION_ACCELEROMETER: {
+            CMAccelerometerData *d = m.accelerometerData;
+            if(d == nil) {
+                return 0;
+            }
+            CMAcceleration a = d.acceleration;
+            double v = (axis == 0) ? a.x : (axis == 1 ? a.y : a.z);
+            // CoreMotion reports G units with gravity negative when face up;
+            // negate and scale to m/s^2 so the convention matches the API
+            // (at rest, face up, z reports +9.81).
+            return (JAVA_FLOAT)(-v * CN1_MOTION_G);
+        }
+        case CN1_MOTION_GYROSCOPE: {
+            CMGyroData *d = m.gyroData;
+            if(d == nil) {
+                return 0;
+            }
+            CMRotationRate r = d.rotationRate;
+            double v = (axis == 0) ? r.x : (axis == 1 ? r.y : r.z);
+            return (JAVA_FLOAT)v;
+        }
+        case CN1_MOTION_MAGNETOMETER: {
+            CMMagnetometerData *d = m.magnetometerData;
+            if(d == nil) {
+                return 0;
+            }
+            CMMagneticField f = d.magneticField;
+            double v = (axis == 0) ? f.x : (axis == 1 ? f.y : f.z);
+            return (JAVA_FLOAT)v;
+        }
+        default:
+            return 0;
+    }
+}
+#else
+static JAVA_FLOAT cn1ReadMotionAxis(JAVA_INT type, int axis) {
+    return 0;
+}
+#endif
+
+JAVA_FLOAT com_codename1_impl_ios_IOSNative_getMotionSensorX___int(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject, JAVA_INT type) {
+    return cn1ReadMotionAxis(type, 0);
+}
+JAVA_FLOAT com_codename1_impl_ios_IOSNative_getMotionSensorX___int_R_float(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject, JAVA_INT type) {
+    return cn1ReadMotionAxis(type, 0);
+}
+
+JAVA_FLOAT com_codename1_impl_ios_IOSNative_getMotionSensorY___int(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject, JAVA_INT type) {
+    return cn1ReadMotionAxis(type, 1);
+}
+JAVA_FLOAT com_codename1_impl_ios_IOSNative_getMotionSensorY___int_R_float(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject, JAVA_INT type) {
+    return cn1ReadMotionAxis(type, 1);
+}
+
+JAVA_FLOAT com_codename1_impl_ios_IOSNative_getMotionSensorZ___int(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject, JAVA_INT type) {
+    return cn1ReadMotionAxis(type, 2);
+}
+JAVA_FLOAT com_codename1_impl_ios_IOSNative_getMotionSensorZ___int_R_float(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject, JAVA_INT type) {
+    return cn1ReadMotionAxis(type, 2);
 }
 
 // Peer Component methods

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
@@ -3838,6 +3838,18 @@ public class IOSImplementation extends CodenameOneImplementation {
         }
     }
 
+    private IOSMotionSensorManager motionSensorManager;
+
+    @Override
+    public com.codename1.sensors.MotionSensorManager getMotionSensorManager() {
+        synchronized (IOSImplementation.class) {
+            if (motionSensorManager == null) {
+                motionSensorManager = new IOSMotionSensorManager();
+            }
+            return motionSensorManager;
+        }
+    }
+
     /**
      * @inheritDoc
      */

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSMotionSensorManager.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSMotionSensorManager.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.impl.ios;
+
+import com.codename1.sensors.MotionSensorManager;
+
+/**
+ * iOS implementation of the motion sensors backed by CoreMotion
+ * (CMMotionManager). It exposes the raw accelerometer, gyroscope and
+ * magnetometer; the core derives gravity, linear acceleration and orientation
+ * from them. The native layer converts the accelerometer reading from G units
+ * to m/s^2 and matches the axis convention documented by the API (at rest, face
+ * up, z reports +9.81). Access to the motion hardware requires the build
+ * argument {@code ios.NSMotionUsageDescription}.
+ *
+ * @author Codename One
+ */
+public class IOSMotionSensorManager extends MotionSensorManager {
+
+    @Override
+    protected boolean isNativeSensorSupported(int type) {
+        return IOSImplementation.nativeInstance.isMotionSensorSupported(type);
+    }
+
+    @Override
+    protected void startNativeSensor(int type) {
+        IOSImplementation.nativeInstance.startMotionSensor(type, getSamplingInterval());
+    }
+
+    @Override
+    protected void stopNativeSensor(int type) {
+        IOSImplementation.nativeInstance.stopMotionSensor(type);
+    }
+
+    @Override
+    protected boolean readNativeSensor(int type, float[] out) {
+        IOSNative ni = IOSImplementation.nativeInstance;
+        if (!ni.hasMotionData(type)) {
+            return false;
+        }
+        out[0] = ni.getMotionSensorX(type);
+        out[1] = ni.getMotionSensorY(type);
+        out[2] = ni.getMotionSensorZ(type);
+        return true;
+    }
+}

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSNative.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSNative.java
@@ -209,6 +209,20 @@ public final class IOSNative {
 
     native void vibrate(int duration);
 
+    native boolean isMotionSensorSupported(int type);
+
+    native void startMotionSensor(int type, int rateMillis);
+
+    native void stopMotionSensor(int type);
+
+    native boolean hasMotionData(int type);
+
+    native float getMotionSensorX(int type);
+
+    native float getMotionSensorY(int type);
+
+    native float getMotionSensorZ(int type);
+
     native int getAudioDuration(long peer);
 
     native void playAudio(long peer);

--- a/docs/developer-guide/Motion-Sensors.asciidoc
+++ b/docs/developer-guide/Motion-Sensors.asciidoc
@@ -57,7 +57,7 @@ Each sensor is identified by a `TYPE_*` constant on `MotionSensorManager`. The t
 |Azimuth, pitch and roll, in radians.
 |===
 
-Readings use a single convention across every port: the x axis points to the right, the y axis points up, and the z axis points out of the screen toward the user, with the device held upright in portrait. At rest, face up, the accelerometer reports about `+9.81` on the z axis.
+Readings use a single convention across every port: the x-axis points to the right, the y-axis points up, and the z-axis points out of the screen toward the user, with the device held upright in portrait. At rest, face up, the accelerometer reports about `+9.81` on the z-axis.
 
 === Detecting gestures
 

--- a/docs/developer-guide/Motion-Sensors.asciidoc
+++ b/docs/developer-guide/Motion-Sensors.asciidoc
@@ -1,0 +1,107 @@
+== Motion Sensors
+
+The `com.codename1.sensors` package exposes the device motion hardware through a single entry point, `MotionSensorManager`, and layers high-level gesture detection on top of the raw sensor stream. The raw sensors are the accelerometer, the gyroscope and the magnetometer. From those readings the framework derives the gravity vector, the linear acceleration and the device orientation, and it recognizes a set of common gestures: shake, flip, tilt, pick up and free fall.
+
+Gesture detection lives in the core rather than in each platform port. Any platform that reports an accelerometer therefore gets the full gesture set, with no per-device work.
+
+=== Reading a sensor
+
+`MotionSensorManager.getInstance()` always returns a manager. On a device without motion hardware every sensor reports as unsupported, so application code can call the API without a null check on the manager itself. `getSensor(int)` returns `null` when the requested sensor isn't available on the current device:
+
+[source,java]
+----
+MotionSensorManager m = MotionSensorManager.getInstance();
+MotionSensor accelerometer = m.getSensor(MotionSensorManager.TYPE_ACCELEROMETER);
+if (accelerometer != null) {
+    accelerometer.addListener(new MotionSensorListener() {
+        public void motionReceived(MotionEvent evt) {
+            // x, y and z are in meters per second squared
+            label.setText(evt.getX() + ", " + evt.getY() + ", " + evt.getZ());
+            label.getParent().revalidate();
+        }
+    });
+}
+----
+
+Callbacks arrive on the EDT, so the listener can update the UI directly. Sampling is reference counted: the hardware sensor draws power only while at least one listener is registered. Remove the listener once the screen is no longer visible, typically from the form's `removeNotify`, so the sensor powers down:
+
+[source,java]
+----
+accelerometer.removeListener(listener);
+----
+
+=== Sensor types
+
+Each sensor is identified by a `TYPE_*` constant on `MotionSensorManager`. The three hardware sensors map directly to the device. The gravity, linear acceleration and orientation values are derived in the core from the accelerometer (and the magnetometer, for the compass azimuth) when the platform doesn't report them on its own.
+
+[cols="1,3"]
+|===
+|Constant |Reading
+
+|`TYPE_ACCELEROMETER`
+|Acceleration including gravity, in meters per second squared.
+
+|`TYPE_LINEAR_ACCELERATION`
+|Acceleration with gravity removed, in meters per second squared.
+
+|`TYPE_GRAVITY`
+|The gravity vector on its own, in meters per second squared.
+
+|`TYPE_GYROSCOPE`
+|Rate of rotation around each axis, in radians per second.
+
+|`TYPE_MAGNETOMETER`
+|The ambient magnetic field, in microtesla.
+
+|`TYPE_ORIENTATION`
+|Azimuth, pitch and roll, in radians.
+|===
+
+Readings use a single convention across every port: the x axis points to the right, the y axis points up, and the z axis points out of the screen toward the user, with the device held upright in portrait. At rest, face up, the accelerometer reports about `+9.81` on the z axis.
+
+=== Detecting gestures
+
+Register a `GestureListener` for one of the `GestureEvent.TYPE_*` gestures. The accelerometer powers on for the duration that a gesture listener stays registered:
+
+[source,java]
+----
+MotionSensorManager.getInstance().addGestureListener(GestureEvent.TYPE_SHAKE, new GestureListener() {
+    public void gestureDetected(GestureEvent evt) {
+        Dialog.show("Shaken", "You shook the device", "OK", null);
+    }
+});
+----
+
+The recognized gestures are:
+
+* `TYPE_SHAKE` -- the device was shaken back and forth.
+* `TYPE_FLIP_FACE_DOWN` and `TYPE_FLIP_FACE_UP` -- the device was turned screen down or screen up.
+* `TYPE_TILT_LEFT`, `TYPE_TILT_RIGHT`, `TYPE_TILT_FORWARD` and `TYPE_TILT_BACKWARD` -- the device crossed a tilt angle on the roll or pitch axis.
+* `TYPE_PICK_UP` -- the device was lifted from a resting position.
+* `TYPE_FREE_FALL` -- the device is falling (near weightlessness was detected).
+
+The detection thresholds suit most apps as shipped, and you can tune them when a gesture needs to be more or less sensitive:
+
+[source,java]
+----
+MotionSensorManager m = MotionSensorManager.getInstance();
+m.setShakeThreshold(15.0);     // require a more vigorous shake
+m.setTiltThreshold(0.5);       // tilt angle in radians
+m.setSamplingInterval(33);     // sample at about 30Hz for snappier gestures
+----
+
+A smaller sampling interval makes gestures more responsive at a higher battery cost. The value is clamped to the range 10ms through 1000ms.
+
+=== Device orientation
+
+`TYPE_ORIENTATION` is a derived sensor. Its event carries the azimuth, pitch and roll in radians, available through `getAzimuth()`, `getPitch()` and `getRoll()` on `MotionEvent`. Pitch and roll come from the gravity vector and need only the accelerometer. The azimuth is a compass heading and needs the magnetometer; on a device without one the azimuth stays at zero.
+
+=== Platform notes
+
+* *Android* -- backed by `android.hardware.SensorManager`. Android already reports its readings in the units and axis convention this API documents, so no conversion takes place.
+* *iOS* -- backed by CoreMotion (`CMMotionManager`). Add the build hint `ios.NSMotionUsageDescription` with a short sentence describing why the app reads motion data; iOS denies access to the motion hardware without it. The iOS Simulator doesn't expose an accelerometer, so the sensors report as unsupported there. Test motion features on a real device.
+* *Other ports* -- a port that doesn't implement the sensors returns an unsupported manager, so the API stays safe to call everywhere.
+
+=== Testing in the simulator
+
+The simulator can stand in for real hardware. Open *Simulate > Motion / Gesture Simulation* to show a small control window. The two sliders set the simulated device orientation, which the accelerometer reflects, and the buttons inject the motion needed to fire the shake, flip, pick up and free fall gestures. This lets you wire up and debug a gesture handler on the desktop before deploying to a device.

--- a/docs/developer-guide/developer-guide.asciidoc
+++ b/docs/developer-guide/developer-guide.asciidoc
@@ -85,6 +85,8 @@ include::Maps.asciidoc[]
 
 include::In-Car-Experiences.asciidoc[]
 
+include::Motion-Sensors.asciidoc[]
+
 include::Miscellaneous-Features.asciidoc[]
 
 include::performance.asciidoc[]

--- a/maven/core-unittests/src/test/java/com/codename1/sensors/GestureEngineTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/sensors/GestureEngineTest.java
@@ -1,0 +1,137 @@
+package com.codename1.sensors;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the platform independent gesture recognizer. The engine has no framework dependency
+ * so it can be driven directly with synthetic accelerometer samples.
+ */
+class GestureEngineTest {
+  private static final double G = MotionSensorManager.STANDARD_GRAVITY;
+
+  private boolean fired(List<GestureEvent> events, int type) {
+    for (GestureEvent e : events) {
+      if (e.getType() == type) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Test
+  void detectsShake() {
+    GestureEngine engine = new GestureEngine();
+    boolean shaken = false;
+    long t = 0;
+    // Alternate a strong sideways jolt with a rest sample every 50ms. Each rising edge counts as
+    // one jolt; three within the window fire a shake.
+    for (int i = 0; i < 12; i++) {
+      float ax = (i % 2 == 0) ? 25f : 0f;
+      List<GestureEvent> evt = engine.onSample(ax, 0, (float) G, 0, 0, (float) G, t);
+      if (fired(evt, GestureEvent.TYPE_SHAKE)) {
+        shaken = true;
+      }
+      t += 50;
+    }
+    assertTrue(shaken, "expected a shake to be detected");
+  }
+
+  @Test
+  void quietDeviceDoesNotShake() {
+    GestureEngine engine = new GestureEngine();
+    boolean shaken = false;
+    long t = 0;
+    for (int i = 0; i < 40; i++) {
+      float ax = (i % 2 == 0) ? 0.5f : -0.5f;
+      List<GestureEvent> evt = engine.onSample(ax, 0, (float) G, 0, 0, (float) G, t);
+      if (fired(evt, GestureEvent.TYPE_SHAKE)) {
+        shaken = true;
+      }
+      t += 50;
+    }
+    assertFalse(shaken, "a still device must not register a shake");
+  }
+
+  @Test
+  void detectsFlipFaceDown() {
+    GestureEngine engine = new GestureEngine();
+    long t = 0;
+    for (int i = 0; i < 10; i++) {
+      engine.onSample(0, 0, (float) G, 0, 0, (float) G, t);
+      t += 50;
+    }
+    boolean flipped = false;
+    for (int i = 0; i < 12; i++) {
+      List<GestureEvent> evt = engine.onSample(0, 0, (float) -G, 0, 0, (float) -G, t);
+      if (fired(evt, GestureEvent.TYPE_FLIP_FACE_DOWN)) {
+        flipped = true;
+      }
+      t += 50;
+    }
+    assertTrue(flipped, "expected a face-down flip");
+  }
+
+  @Test
+  void detectsTiltRight() {
+    GestureEngine engine = new GestureEngine();
+    long t = 0;
+    for (int i = 0; i < 5; i++) {
+      engine.onSample(0, 0, (float) G, 0, 0, (float) G, t);
+      t += 50;
+    }
+    double roll = 0.9; // radians, beyond the tilt threshold
+    float gx = (float) (G * Math.sin(roll));
+    float gz = (float) (G * Math.cos(roll));
+    boolean tilted = false;
+    for (int i = 0; i < 5; i++) {
+      List<GestureEvent> evt = engine.onSample(gx, 0, gz, gx, 0, gz, t);
+      if (fired(evt, GestureEvent.TYPE_TILT_RIGHT)) {
+        tilted = true;
+      }
+      t += 50;
+    }
+    assertTrue(tilted, "expected a tilt-right gesture");
+  }
+
+  @Test
+  void detectsFreeFall() {
+    GestureEngine engine = new GestureEngine();
+    long t = 0;
+    for (int i = 0; i < 5; i++) {
+      engine.onSample(0, 0, (float) G, 0, 0, (float) G, t);
+      t += 50;
+    }
+    boolean falling = false;
+    for (int i = 0; i < 6; i++) {
+      List<GestureEvent> evt = engine.onSample(0, 0, 0, 0, 0, (float) G, t);
+      if (fired(evt, GestureEvent.TYPE_FREE_FALL)) {
+        falling = true;
+      }
+      t += 50;
+    }
+    assertTrue(falling, "expected a free-fall gesture");
+  }
+
+  @Test
+  void detectsPickUp() {
+    GestureEngine engine = new GestureEngine();
+    long t = 0;
+    for (int i = 0; i < 12; i++) {
+      engine.onSample(0, 0, (float) G, 0, 0, (float) G, t);
+      t += 50;
+    }
+    boolean pickedUp = false;
+    for (int i = 0; i < 6; i++) {
+      List<GestureEvent> evt = engine.onSample(4f, 0, (float) (G + 4f), 0, 0, (float) G, t);
+      if (fired(evt, GestureEvent.TYPE_PICK_UP)) {
+        pickedUp = true;
+      }
+      t += 50;
+    }
+    assertTrue(pickedUp, "expected a pick-up gesture");
+  }
+}

--- a/maven/javase/src/test/java/com/codename1/impl/javase/JavaSEMotionSensorManagerTest.java
+++ b/maven/javase/src/test/java/com/codename1/impl/javase/JavaSEMotionSensorManagerTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.impl.javase;
+
+import com.codename1.sensors.MotionSensorManager;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the synthetic sensor readings produced by the simulator motion
+ * sensor manager. The values are computed without any UI, so they can be tested
+ * directly.
+ */
+public class JavaSEMotionSensorManagerTest {
+    private static final double G = MotionSensorManager.STANDARD_GRAVITY;
+
+    private double magnitude(float[] v) {
+        return Math.sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+    }
+
+    @Test
+    public void simulatedSensorValues() {
+        JavaSEMotionSensorManager m = new JavaSEMotionSensorManager();
+        float[] out = new float[3];
+
+        // Raw sensors are simulated; the derived types are resolved by the core.
+        Assertions.assertTrue(m.isNativeSensorSupported(MotionSensorManager.TYPE_ACCELEROMETER));
+        Assertions.assertTrue(m.isNativeSensorSupported(MotionSensorManager.TYPE_GYROSCOPE));
+        Assertions.assertTrue(m.isNativeSensorSupported(MotionSensorManager.TYPE_MAGNETOMETER));
+        Assertions.assertFalse(m.isNativeSensorSupported(MotionSensorManager.TYPE_GRAVITY));
+        Assertions.assertFalse(m.isNativeSensorSupported(MotionSensorManager.TYPE_ORIENTATION));
+
+        // Flat and face up: gravity reads about +9.81 on the z axis.
+        JavaSEMotionSensorManager.setOrientation(0, 0);
+        Assertions.assertTrue(m.readNativeSensor(MotionSensorManager.TYPE_ACCELEROMETER, out));
+        Assertions.assertEquals(0.0, out[0], 0.01);
+        Assertions.assertEquals(0.0, out[1], 0.01);
+        Assertions.assertEquals(G, out[2], 0.01);
+
+        // Rolled 90 degrees: gravity shifts onto the x axis.
+        JavaSEMotionSensorManager.setOrientation(0, 90);
+        m.readNativeSensor(MotionSensorManager.TYPE_ACCELEROMETER, out);
+        Assertions.assertEquals(G, out[0], 0.05);
+        Assertions.assertEquals(0.0, out[2], 0.05);
+
+        // The magnetometer returns a constant northward field.
+        Assertions.assertTrue(m.readNativeSensor(MotionSensorManager.TYPE_MAGNETOMETER, out));
+        Assertions.assertEquals(30.0, out[1], 0.01);
+
+        // Shake injects a strong transient acceleration.
+        JavaSEMotionSensorManager.setOrientation(0, 0);
+        JavaSEMotionSensorManager.triggerShake();
+        double peak = 0;
+        for (int i = 0; i < 20; i++) {
+            m.readNativeSensor(MotionSensorManager.TYPE_ACCELEROMETER, out);
+            peak = Math.max(peak, magnitude(out));
+        }
+        Assertions.assertTrue(peak > 15, "shake should produce a large acceleration, was " + peak);
+
+        // Free fall overrides the reading with near-zero acceleration.
+        JavaSEMotionSensorManager.triggerFreeFall();
+        m.readNativeSensor(MotionSensorManager.TYPE_ACCELEROMETER, out);
+        Assertions.assertTrue(magnitude(out) < 3, "free fall should be near weightless");
+    }
+}

--- a/maven/javase/src/test/java/com/codename1/impl/javase/MotionSensorIntegrationTest.java
+++ b/maven/javase/src/test/java/com/codename1/impl/javase/MotionSensorIntegrationTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.impl.javase;
+
+import com.codename1.sensors.GestureEvent;
+import com.codename1.sensors.GestureListener;
+import com.codename1.sensors.MotionSensorManager;
+import com.codename1.testing.junit.CodenameOneTest;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+/**
+ * End-to-end test of the motion sensor pipeline running inside a real simulator
+ * Display. A synthetic accelerometer that oscillates like a shake is fed through
+ * the live sampling thread, gesture engine and EDT dispatch; the test passes
+ * only if the shake reaches a registered listener. This exercises the whole
+ * {@link MotionSensorManager} plumbing (thread start via {@code Display}, source
+ * reference counting, derivation and {@code callSerially} dispatch) rather than
+ * any single platform port.
+ */
+@CodenameOneTest
+@DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
+public class MotionSensorIntegrationTest {
+
+    // A manager whose accelerometer continuously oscillates, which the engine
+    // recognizes as a shake.
+    private static final class ShakingManager extends MotionSensorManager {
+        @Override
+        protected boolean isNativeSensorSupported(int type) {
+            return type == TYPE_ACCELEROMETER;
+        }
+
+        @Override
+        protected void startNativeSensor(int type) {
+        }
+
+        @Override
+        protected void stopNativeSensor(int type) {
+        }
+
+        @Override
+        protected boolean readNativeSensor(int type, float[] out) {
+            if (type != TYPE_ACCELEROMETER) {
+                return false;
+            }
+            // A single-axis 2Hz oscillation: zero mean (so the gravity low-pass
+            // does not absorb it) and passing through zero each half-cycle, so the
+            // linear acceleration magnitude rises above and falls below the shake
+            // threshold repeatedly.
+            double t = System.currentTimeMillis() / 1000.0;
+            out[0] = (float) (Math.sin(2 * Math.PI * 2 * t) * 30);
+            out[1] = 0;
+            out[2] = (float) STANDARD_GRAVITY;
+            return true;
+        }
+    }
+
+    @Test
+    public void shakeReachesListenerThroughTheFullStack() throws Exception {
+        MotionSensorManager m = new ShakingManager();
+
+        final boolean[] shaken = {false};
+        final Object lock = new Object();
+        GestureListener listener = new GestureListener() {
+            @Override
+            public void gestureDetected(GestureEvent evt) {
+                synchronized (lock) {
+                    shaken[0] = true;
+                    lock.notifyAll();
+                }
+            }
+        };
+
+        m.addGestureListener(GestureEvent.TYPE_SHAKE, listener);
+        try {
+            synchronized (lock) {
+                long deadline = System.currentTimeMillis() + 5000;
+                while (!shaken[0] && System.currentTimeMillis() < deadline) {
+                    lock.wait(250);
+                }
+            }
+        } finally {
+            m.removeGestureListener(GestureEvent.TYPE_SHAKE, listener);
+            m.stop();
+        }
+
+        Assertions.assertTrue(shaken[0],
+                "shake gesture should reach the listener through the full pipeline");
+    }
+}

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/Cn1ssDeviceRunner.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/Cn1ssDeviceRunner.java
@@ -313,6 +313,7 @@ public final class Cn1ssDeviceRunner extends DeviceRunner {
             new StringApiTest(),
             new TimeApiTest(),
             new NanoTimeApiTest(),
+            new MotionSensorDeviceTest(),
             new CryptoApiTest(),
             new Java17Tests(),
             new BackgroundThreadUiAccessTest(),

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/MotionSensorDeviceTest.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/MotionSensorDeviceTest.java
@@ -1,0 +1,87 @@
+package com.codenameone.examples.hellocodenameone.tests;
+
+import com.codename1.sensors.MotionEvent;
+import com.codename1.sensors.MotionSensor;
+import com.codename1.sensors.MotionSensorListener;
+import com.codename1.sensors.MotionSensorManager;
+import com.codename1.ui.Display;
+
+/**
+ * On-device coverage for the motion sensor API (com.codename1.sensors).
+ *
+ * <p>The accelerometer is wired to a different native API on every port -- the
+ * Android {@code SensorManager} on Android and CoreMotion's {@code
+ * CMMotionManager} on iOS -- so a port that forgets to register its manager, or
+ * whose native bridge fails to link, would never deliver a reading. Running this
+ * on the device is what catches that.
+ *
+ * <p>The check adapts to the hardware: when the accelerometer is present (the
+ * Android emulator exposes one) it registers a listener and asserts that a real
+ * reading flows all the way through the sampling thread and the EDT dispatch.
+ * When it is absent (the iOS Simulator has no CoreMotion accelerometer) the test
+ * instead asserts that the API degrades gracefully -- the manager is still
+ * non-null and reports the sensor as unsupported without throwing -- which still
+ * exercises the native bridge end to end.
+ */
+public class MotionSensorDeviceTest extends BaseTest {
+
+    @Override
+    public boolean shouldTakeScreenshot() {
+        return false;
+    }
+
+    @Override
+    public int getTimeoutMillis() {
+        return 30000;
+    }
+
+    @Override
+    public boolean runTest() {
+        final MotionSensorManager manager = MotionSensorManager.getInstance();
+        assertBool(manager != null, "MotionSensorManager.getInstance() returned null");
+
+        if (!manager.isSensorSupported(MotionSensorManager.TYPE_ACCELEROMETER)) {
+            // No accelerometer on this device (e.g. the iOS Simulator). The API
+            // must still be safe to call: getSensor returns null and no events
+            // are delivered.
+            assertNull(manager.getSensor(MotionSensorManager.TYPE_ACCELEROMETER),
+                    "getSensor must return null for an unsupported sensor");
+            done();
+            return true;
+        }
+
+        final MotionSensor accelerometer = manager.getSensor(MotionSensorManager.TYPE_ACCELEROMETER);
+        assertBool(accelerometer != null, "accelerometer is supported but getSensor returned null");
+
+        final boolean[] received = {false};
+        final MotionSensorListener listener = new MotionSensorListener() {
+            @Override
+            public void motionReceived(MotionEvent evt) {
+                received[0] = true;
+            }
+        };
+        accelerometer.addListener(listener);
+
+        // Wait off the EDT for a reading so the polling thread and the EDT
+        // dispatch stay free to deliver it.
+        Display.getInstance().startThread(new Runnable() {
+            @Override
+            public void run() {
+                long deadline = System.currentTimeMillis() + 5000;
+                while (!received[0] && System.currentTimeMillis() < deadline) {
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException ignored) {
+                        // keep polling
+                    }
+                }
+                accelerometer.removeListener(listener);
+                if (!received[0]) {
+                    fail("no accelerometer reading was delivered within 5 seconds");
+                }
+                done();
+            }
+        }, "MotionSensorDeviceTest").start();
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new `com.codename1.sensors` package giving cross-platform access to the device motion hardware plus high-level gesture detection.

- **Raw sensors:** accelerometer, gyroscope, magnetometer.
- **Derived in core:** gravity, linear acceleration, orientation (azimuth/pitch/roll).
- **Gestures:** shake, flip (face up/down), tilt (left/right/forward/back), pick up, free fall.

Gesture recognition lives in the core (`GestureEngine`) on top of the accelerometer/gravity stream, so any port that exposes an accelerometer gets the full gesture set. Each port implements only four small hooks (`isNativeSensorSupported` / `start` / `stop` / `readNativeSensor`); the core owns the sampling thread, gravity low-pass filter, value derivation, recognition and EDT dispatch. Sampling is reference counted — sensors are powered only while a listener is registered.

## API

```java
// Raw sensor
MotionSensor accel = MotionSensorManager.getInstance().getSensor(MotionSensorManager.TYPE_ACCELEROMETER);
if (accel != null) {
    accel.addListener(evt -> label.setText(evt.getX() + ", " + evt.getY() + ", " + evt.getZ()));
}

// Gesture
MotionSensorManager.getInstance().addGestureListener(GestureEvent.TYPE_SHAKE,
    evt -> Dialog.show("Shaken", "You shook the device", "OK", null));
```

## Layers

| Layer | Change |
|-------|--------|
| core | `MotionSensorManager`/`MotionSensor`/`MotionSensorListener`/`MotionEvent`/`GestureListener`/`GestureEvent`/`GestureEngine`; `Display.getMotionSensorManager()` + impl hook |
| JavaSE | `JavaSEMotionSensorManager` + **Simulate → Motion / Gesture Simulation** window |
| Android | `AndroidMotionSensorManager` backed by `SensorManager` |
| iOS | `IOSMotionSensorManager` + `IOSNative` native methods + CoreMotion (`CMMotionManager`) in `IOSNative.m` (G → m/s² conversion) |

**iOS build hint:** access to motion hardware requires `ios.NSMotionUsageDescription`.

## Tests & docs

- `maven/core-unittests`: `GestureEngineTest` (shake / flip / tilt / pick-up / free-fall, + negative case).
- `maven/javase`: `JavaSEMotionSensorManagerTest` (synthetic values) and `MotionSensorIntegrationTest` (full pipeline inside a live simulator `Display`).
- `scripts/hellocodenameone`: `MotionSensorDeviceTest` registered in `Cn1ssDeviceRunner` for on-device Android/iOS coverage.
- `docs/developer-guide`: new **Motion Sensors** chapter (passes Vale / asciidoctor / paragraph-cap).

## Validation performed locally

- ✅ Core compiles; `GestureEngineTest` passes; **spotbugs (Max/Low)** clean on the new core classes.
- ✅ JavaSE port builds; port + live-`Display` integration tests pass.
- ✅ **Android port** builds with the Android SDK + JDK 17 (`AndroidMotionSensorManager` compiled into the port); **hellocodenameone Android APK** (`assembleDebug`) builds.
- ✅ **iOS app** builds for the simulator (ParparVM → Xcode 26.3): `IOSNative.m` CoreMotion code **compiles and links** (BUILD SUCCEEDED).
- Emulator instrumentation run of the device suite was exercised for runtime coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)