### PR TITLE
Fix JS port: Initializr Generate fails with Unhandled host call __cn1_build_version__ (#5288 regression)

### DIFF
--- a/Ports/JavaScriptPort/src/main/webapp/port.js
+++ b/Ports/JavaScriptPort/src/main/webapp/port.js
@@ -1838,7 +1838,21 @@ bindNative([
   if (typeof jvm.invokeHostNative !== "function") {
     return null;
   }
-  const value = yield jvm.invokeHostNative("__cn1_build_version__", []);
+  // Preserve the original @JSBody's null-safe contract. That script returned
+  // null whenever document was unreadable (always, in the worker) and
+  // getBuildVersion() then fell back to the AppVersion property -- it never
+  // threw. This binding replaced it with a host call, but browser_bridge.js
+  // ships from the translator artifact while port.js ships fresh from source,
+  // so a host bundle predating the __cn1_build_version__ handler rejects the
+  // call with "Unhandled host call". getBuildVersion() runs during boot inside
+  // the synchronous getArrayBufferInputStream (cache-busting ?v=), so that
+  // error would propagate out and abort app init. Swallow it and fall back.
+  let value;
+  try {
+    value = yield jvm.invokeHostNative("__cn1_build_version__", []);
+  } catch (err) {
+    return null;
+  }
   return value == null ? null : jvm.createStringLiteral(String(value));
 });
 


### PR DESCRIPTION
## Problem

The Initializr Generate button stopped working on the deployed JS port. Boot aborts with:

```
java.lang.RuntimeException: Unhandled host call __cn1_build_version__
```

repeated through app init (e.g. `TemplatePreviewPanel` construction), surfaced as an `IOException` out of the synchronous resource-loading path.

## Root cause

Regression from **#5288** (`9738dfe908`). That commit converted `HTML5Implementation.getBuildVersion_()` from a **null-safe `@JSBody`** — which ran in the worker, found no `document`, and returned `null` so `getBuildVersion()` fell back to the `AppVersion` property (it never threw) — into a **host call** to `__cn1_build_version__`.

The build sources the two sides of that call from **different artifacts** (`JavascriptBundleWriter`):

| File | Source | Freshness |
|------|--------|-----------|
| `port.js` (worker — *makes* the call) | copied fresh from source `Ports/JavaScriptPort/.../webapp/port.js` | always current |
| `browser_bridge.js` (main thread — *handles* the call) | `writeResource(...)`, baked into the ByteCodeTranslator jar | only as fresh as the jar |

A deploy with the post-#5288 `port.js` (which now calls `__cn1_build_version__`) but a translator jar built **before** #5288 (whose embedded `browser_bridge.js` has no handler) → `Unhandled host call`. Because `getBuildVersion()` runs during boot inside the synchronous `getArrayBufferInputStream` (cache-busting `?v=` on theme/resource fetches), the throw aborts app init and Generate fails.

## Fix

Restore the original null-safe contract in the `getBuildVersion_` binding in `port.js` — swallow a host-call failure and return `null`, so `getBuildVersion()` falls back to `AppVersion` exactly as before #5288:

```js
let value;
try {
  value = yield jvm.invokeHostNative("__cn1_build_version__", []);
} catch (err) {
  return null;
}
return value == null ? null : jvm.createStringLiteral(String(value));
```

`port.js` ships fresh from source on every deploy, so this lands on the next deploy **without** needing the translator jar rebuilt, and real cache-busting resumes automatically once the jar carries the handler again.

Only `__cn1_build_version__` runs during boot; the other #5288 host calls (clipboard/share/camera/fullscreen/print) are user-triggered, so a stale bridge only degrades those features rather than blocking boot — matching their pre-#5288 worker-broken state.

## Testing

- `node --check` passes on the edited `port.js`.
- The host-callback error is delivered into the worker generator via `generator.throw(resumeError)` at the `yield` point (`parparvm_runtime.js`), so the `try/catch` around the yield catches it and the generator completes normally with `null`.

## Follow-up (not in this PR)

Consider ensuring the ByteCodeTranslator jar is rebuilt before the Initializr deploy so `browser_bridge.js` carries the `__cn1_build_version__` handler and actual cache-busting resumes. This PR makes the app correct either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)