### PR TITLE
Fix DesktopMode iOS screenshot late-present race (700ms -> 1500ms settle)

### DIFF
--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/DesktopModeScreenshotTest.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/DesktopModeScreenshotTest.java
@@ -108,11 +108,14 @@ public class DesktopModeScreenshotTest extends BaseTest {
     /// The 30-row scrollable form is heavy enough that on the iOS Metal backend
     /// its first frame is occasionally presented just after the capture fires,
     /// so Display.screenshot() reads the previous test's framebuffer and this
-    /// test "captures the wrong form". Force a repaint and a short extra settle
-    /// so the DesktopMode form is fully presented before the screenshot.
+    /// test "captures the wrong form". Force a repaint and an extra settle so the
+    /// DesktopMode form is fully presented before the screenshot. 700ms still lost
+    /// the race on a starved CI runner (the capture showed the preceding
+    /// MutableImageClip form), so use the same 1500ms margin the OrientationLock
+    /// test relies on for its post-rotation present.
     @Override
     protected long extraSettleBeforeCaptureMillis() {
-        return 700;
+        return 1500;
     }
 
     @Override


### PR DESCRIPTION
## Problem

The `DesktopMode` iOS screenshot test intermittently captures the **wrong form** — observed in CI capturing the preceding `MutableImageClip` form under the `DesktopMode` name. This is the documented iOS Metal **late-present race**: the heavy 30-row scrollable form's first frame is presented just *after* `Display.screenshot()` reads the framebuffer, so the grab returns the previous test's pixels.

It surfaced repeatedly on the device-input PR (#5309) CI as a `build-ios` / `packaging` failure that "cleared on re-run" — i.e. a real timing bug, not noise.

## Root cause

`DesktopModeScreenshotTest` already opts into the sanctioned `extraSettleBeforeCaptureMillis()` mitigation (repaint + wait for GPU present before capture), but its **700ms** value still loses the race on a starved CI runner.

## Fix

Raise the settle to **1500ms** — the same post-present margin `OrientationLockScreenshotTest` already relies on. The captured form is unchanged, so the reference image is unaffected; only the wait before the grab is longer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)