### PR TITLE
Add timed Whisper transcription and Android AAR

### DIFF
--- a/CodenameOne/src/com/codename1/media/TimedRecognitionCallback.java
+++ b/CodenameOne/src/com/codename1/media/TimedRecognitionCallback.java
@@ -26,8 +26,16 @@ package com.codename1.media;
 /// that expose segment timing can call these overloads; text-only
 /// recognizers continue to use [RecognitionCallback].
 public interface TimedRecognitionCallback extends RecognitionCallback {
+    /// Called with an interim timed recognition result.
+    ///
+    /// @param result partial timed recognition result
     void onPartialResult(TranscriptionResult result);
 
+    /// Called with the final timed recognition result.
+    ///
+    /// @param result final timed recognition result
+    /// @param confidence confidence score from `0.0` to `1.0`, when available
+    /// @param alternatives provider-specific alternative transcripts
     void onResult(TranscriptionResult result, float confidence, String[] alternatives);
 
     /// No-op adapter. The timed overloads forward to the string-only
@@ -35,10 +43,18 @@ public interface TimedRecognitionCallback extends RecognitionCallback {
     /// [RecognitionCallback] behaviour unless the timed methods are
     /// explicitly overridden.
     class Adapter extends RecognitionCallback.Adapter implements TimedRecognitionCallback {
+        /// Forwards partial timed results to the string-only partial callback.
+        ///
+        /// @param result partial timed recognition result
         public void onPartialResult(TranscriptionResult result) {
             onPartialResult(result == null ? "" : result.getText());
         }
 
+        /// Forwards final timed results to the string-only result callback.
+        ///
+        /// @param result final timed recognition result
+        /// @param confidence confidence score from `0.0` to `1.0`, when available
+        /// @param alternatives provider-specific alternative transcripts
         public void onResult(TranscriptionResult result, float confidence, String[] alternatives) {
             onResult(result == null ? "" : result.getText(), confidence, alternatives);
         }

--- a/CodenameOne/src/com/codename1/media/TimedRecognitionCallback.java
+++ b/CodenameOne/src/com/codename1/media/TimedRecognitionCallback.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.media;
+
+/// Caption-aware [SpeechRecognizer] callback. Platform recognizers
+/// that expose segment timing can call these overloads; text-only
+/// recognizers continue to use [RecognitionCallback].
+public interface TimedRecognitionCallback extends RecognitionCallback {
+    void onPartialResult(TranscriptionResult result);
+
+    void onResult(TranscriptionResult result, float confidence, String[] alternatives);
+
+    /// No-op adapter. The timed overloads forward to the string-only
+    /// overloads, so subclassing this preserves normal
+    /// [RecognitionCallback] behaviour unless the timed methods are
+    /// explicitly overridden.
+    class Adapter extends RecognitionCallback.Adapter implements TimedRecognitionCallback {
+        public void onPartialResult(TranscriptionResult result) {
+            onPartialResult(result == null ? "" : result.getText());
+        }
+
+        public void onResult(TranscriptionResult result, float confidence, String[] alternatives) {
+            onResult(result == null ? "" : result.getText(), confidence, alternatives);
+        }
+    }
+}

--- a/CodenameOne/src/com/codename1/media/TimedRecognitionCallback.java
+++ b/CodenameOne/src/com/codename1/media/TimedRecognitionCallback.java
@@ -46,6 +46,7 @@ public interface TimedRecognitionCallback extends RecognitionCallback {
         /// Forwards partial timed results to the string-only partial callback.
         ///
         /// @param result partial timed recognition result
+        @Override
         public void onPartialResult(TranscriptionResult result) {
             onPartialResult(result == null ? "" : result.getText());
         }
@@ -55,6 +56,7 @@ public interface TimedRecognitionCallback extends RecognitionCallback {
         /// @param result final timed recognition result
         /// @param confidence confidence score from `0.0` to `1.0`, when available
         /// @param alternatives provider-specific alternative transcripts
+        @Override
         public void onResult(TranscriptionResult result, float confidence, String[] alternatives) {
             onResult(result == null ? "" : result.getText(), confidence, alternatives);
         }

--- a/CodenameOne/src/com/codename1/media/Transcriber.java
+++ b/CodenameOne/src/com/codename1/media/Transcriber.java
@@ -28,7 +28,18 @@ import com.codename1.util.AsyncResource;
 /// cloud APIs, platform speech engines, or optional cn1libs such as
 /// `cn1-ai-whisper`; all return timed segments suitable for SRT/VTT.
 public abstract class Transcriber {
+    /// Creates a transcriber implementation.
+    protected Transcriber() {
+    }
+
+    /// Transcribes an audio file.
+    ///
+    /// @param request transcription request
+    /// @return asynchronous transcription result
     public abstract AsyncResource<TranscriptionResult> transcribe(TranscriptionRequest request);
 
+    /// Gets the provider identifier.
+    ///
+    /// @return provider name, such as `whisper`
     public abstract String getProvider();
 }

--- a/CodenameOne/src/com/codename1/media/Transcriber.java
+++ b/CodenameOne/src/com/codename1/media/Transcriber.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.media;
+
+import com.codename1.util.AsyncResource;
+
+/// Provider-pluggable file transcriber. Implementations may use
+/// cloud APIs, platform speech engines, or optional cn1libs such as
+/// `cn1-ai-whisper`; all return timed segments suitable for SRT/VTT.
+public abstract class Transcriber {
+    public abstract AsyncResource<TranscriptionResult> transcribe(TranscriptionRequest request);
+
+    public abstract String getProvider();
+}

--- a/CodenameOne/src/com/codename1/media/TranscriptionRequest.java
+++ b/CodenameOne/src/com/codename1/media/TranscriptionRequest.java
@@ -33,6 +33,10 @@ public final class TranscriptionRequest {
     private String prompt;
     private final Map<String, String> options = new HashMap<String, String>();
 
+    /// Creates a file-based transcription request.
+    ///
+    /// @param audioPath path to the audio file that should be transcribed
+    /// @throws IllegalArgumentException if `audioPath` is `null` or empty
     public TranscriptionRequest(String audioPath) {
         if (audioPath == null || audioPath.length() == 0) {
             throw new IllegalArgumentException("audioPath is required");
@@ -40,32 +44,61 @@ public final class TranscriptionRequest {
         this.audioPath = audioPath;
     }
 
+    /// Creates a file-based transcription request.
+    ///
+    /// @param audioPath path to the audio file that should be transcribed
+    /// @return a new transcription request
     public static TranscriptionRequest file(String audioPath) {
         return new TranscriptionRequest(audioPath);
     }
 
+    /// Gets the audio file path.
+    ///
+    /// @return audio file path
     public String getAudioPath() {
         return audioPath;
     }
 
+    /// Gets the requested recognition language.
+    ///
+    /// @return BCP 47 language tag, or `null` if the provider should choose its default
     public String getLanguageTag() {
         return languageTag;
     }
 
+    /// Sets the requested recognition language.
+    ///
+    /// @param languageTag BCP 47 language tag, or `null` to let the provider choose
+    /// @return this request
     public TranscriptionRequest setLanguageTag(String languageTag) {
         this.languageTag = languageTag;
         return this;
     }
 
+    /// Gets the optional provider prompt.
+    ///
+    /// @return prompt text, or `null` if no prompt is set
     public String getPrompt() {
         return prompt;
     }
 
+    /// Sets optional provider prompt text.
+    ///
+    /// @param prompt prompt text, or `null` to clear it
+    /// @return this request
     public TranscriptionRequest setPrompt(String prompt) {
         this.prompt = prompt;
         return this;
     }
 
+    /// Sets an optional provider-specific value.
+    ///
+    /// Passing `null` as the value removes the option.
+    ///
+    /// @param key option key
+    /// @param value option value, or `null` to remove the option
+    /// @return this request
+    /// @throws IllegalArgumentException if `key` is `null` or empty
     public TranscriptionRequest setOption(String key, String value) {
         if (key == null || key.length() == 0) {
             throw new IllegalArgumentException("key is required");
@@ -78,10 +111,17 @@ public final class TranscriptionRequest {
         return this;
     }
 
+    /// Gets a provider-specific option value.
+    ///
+    /// @param key option key
+    /// @return option value, or `null` if it is not set
     public String getOption(String key) {
         return options.get(key);
     }
 
+    /// Gets all provider-specific options.
+    ///
+    /// @return immutable option map
     public Map<String, String> getOptions() {
         return Collections.unmodifiableMap(options);
     }

--- a/CodenameOne/src/com/codename1/media/TranscriptionRequest.java
+++ b/CodenameOne/src/com/codename1/media/TranscriptionRequest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.media;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/// File transcription request shared by transcription providers.
+public final class TranscriptionRequest {
+    private final String audioPath;
+    private String languageTag = "en-US";
+    private String prompt;
+    private final Map<String, String> options = new HashMap<String, String>();
+
+    public TranscriptionRequest(String audioPath) {
+        if (audioPath == null || audioPath.length() == 0) {
+            throw new IllegalArgumentException("audioPath is required");
+        }
+        this.audioPath = audioPath;
+    }
+
+    public static TranscriptionRequest file(String audioPath) {
+        return new TranscriptionRequest(audioPath);
+    }
+
+    public String getAudioPath() {
+        return audioPath;
+    }
+
+    public String getLanguageTag() {
+        return languageTag;
+    }
+
+    public TranscriptionRequest setLanguageTag(String languageTag) {
+        this.languageTag = languageTag;
+        return this;
+    }
+
+    public String getPrompt() {
+        return prompt;
+    }
+
+    public TranscriptionRequest setPrompt(String prompt) {
+        this.prompt = prompt;
+        return this;
+    }
+
+    public TranscriptionRequest setOption(String key, String value) {
+        if (key == null || key.length() == 0) {
+            throw new IllegalArgumentException("key is required");
+        }
+        if (value == null) {
+            options.remove(key);
+        } else {
+            options.put(key, value);
+        }
+        return this;
+    }
+
+    public String getOption(String key) {
+        return options.get(key);
+    }
+
+    public Map<String, String> getOptions() {
+        return Collections.unmodifiableMap(options);
+    }
+}

--- a/CodenameOne/src/com/codename1/media/TranscriptionResult.java
+++ b/CodenameOne/src/com/codename1/media/TranscriptionResult.java
@@ -46,8 +46,7 @@ public final class TranscriptionResult {
         }
         ArrayList<TranscriptionSegment> copy = new ArrayList<TranscriptionSegment>(segments.size());
         StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < segments.size(); i++) {
-            TranscriptionSegment s = segments.get(i);
+        for (TranscriptionSegment s : segments) {
             if (s == null) {
                 throw new IllegalArgumentException("segments must not contain null");
             }
@@ -104,8 +103,7 @@ public final class TranscriptionResult {
     /// @return WebVTT text using millisecond timestamps
     public String toVtt() {
         StringBuilder out = new StringBuilder("WEBVTT\n\n");
-        for (int i = 0; i < segments.size(); i++) {
-            TranscriptionSegment s = segments.get(i);
+        for (TranscriptionSegment s : segments) {
             out.append(formatTime(s.getStartTimeMs(), '.')).append(" --> ")
                     .append(formatTime(s.getEndTimeMs(), '.')).append('\n');
             out.append(normalizeCaptionText(s.getText()).replace("-->", "-- >")).append("\n\n");

--- a/CodenameOne/src/com/codename1/media/TranscriptionResult.java
+++ b/CodenameOne/src/com/codename1/media/TranscriptionResult.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.media;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/// A complete transcription: plain text plus the timed segments needed
+/// for captions.
+public final class TranscriptionResult {
+    private final List<TranscriptionSegment> segments;
+    private final String text;
+
+    public TranscriptionResult(List<TranscriptionSegment> segments) {
+        if (segments == null) {
+            throw new IllegalArgumentException("segments is required");
+        }
+        ArrayList<TranscriptionSegment> copy = new ArrayList<TranscriptionSegment>(segments.size());
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < segments.size(); i++) {
+            TranscriptionSegment s = segments.get(i);
+            if (s == null) {
+                throw new IllegalArgumentException("segments must not contain null");
+            }
+            copy.add(s);
+            sb.append(s.getText());
+        }
+        this.segments = Collections.unmodifiableList(copy);
+        this.text = sb.toString();
+    }
+
+    public static TranscriptionResult textOnly(String text) {
+        ArrayList<TranscriptionSegment> segments = new ArrayList<TranscriptionSegment>(1);
+        segments.add(new TranscriptionSegment(0, 0, text));
+        return new TranscriptionResult(segments);
+    }
+
+    public List<TranscriptionSegment> getSegments() {
+        return segments;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public String toSrt() {
+        StringBuilder out = new StringBuilder();
+        for (int i = 0; i < segments.size(); i++) {
+            TranscriptionSegment s = segments.get(i);
+            out.append(i + 1).append('\n');
+            out.append(formatTime(s.getStartTimeMs(), ',')).append(" --> ")
+                    .append(formatTime(s.getEndTimeMs(), ',')).append('\n');
+            out.append(normalizeCaptionText(s.getText())).append("\n\n");
+        }
+        return out.toString();
+    }
+
+    public String toVtt() {
+        StringBuilder out = new StringBuilder("WEBVTT\n\n");
+        for (int i = 0; i < segments.size(); i++) {
+            TranscriptionSegment s = segments.get(i);
+            out.append(formatTime(s.getStartTimeMs(), '.')).append(" --> ")
+                    .append(formatTime(s.getEndTimeMs(), '.')).append('\n');
+            out.append(normalizeCaptionText(s.getText()).replace("-->", "-- >")).append("\n\n");
+        }
+        return out.toString();
+    }
+
+    private static String normalizeCaptionText(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.replace('\r', '\n').trim();
+    }
+
+    private static String formatTime(long millis, char decimalSeparator) {
+        long hours = millis / 3600000L;
+        millis %= 3600000L;
+        long minutes = millis / 60000L;
+        millis %= 60000L;
+        long seconds = millis / 1000L;
+        long ms = millis % 1000L;
+        return two(hours) + ":" + two(minutes) + ":" + two(seconds)
+                + decimalSeparator + three(ms);
+    }
+
+    private static String two(long value) {
+        return value < 10 ? "0" + value : String.valueOf(value);
+    }
+
+    private static String three(long value) {
+        if (value < 10) {
+            return "00" + value;
+        }
+        if (value < 100) {
+            return "0" + value;
+        }
+        return String.valueOf(value);
+    }
+}

--- a/CodenameOne/src/com/codename1/media/TranscriptionResult.java
+++ b/CodenameOne/src/com/codename1/media/TranscriptionResult.java
@@ -32,6 +32,14 @@ public final class TranscriptionResult {
     private final List<TranscriptionSegment> segments;
     private final String text;
 
+    /// Creates a transcription result from timed segments.
+    ///
+    /// The supplied list is copied, validated, and exposed through [#getSegments()]
+    /// as an immutable list. The plain text returned by [#getText()] is the
+    /// concatenation of each segment's text in order.
+    ///
+    /// @param segments ordered transcript segments
+    /// @throws IllegalArgumentException if `segments` is `null` or contains `null`
     public TranscriptionResult(List<TranscriptionSegment> segments) {
         if (segments == null) {
             throw new IllegalArgumentException("segments is required");
@@ -50,20 +58,35 @@ public final class TranscriptionResult {
         this.text = sb.toString();
     }
 
+    /// Creates a text-only result for providers that do not expose segment timing.
+    ///
+    /// The returned result contains one segment from `0` to `0` milliseconds.
+    ///
+    /// @param text recognized text
+    /// @return a transcription result containing one untimed segment
     public static TranscriptionResult textOnly(String text) {
         ArrayList<TranscriptionSegment> segments = new ArrayList<TranscriptionSegment>(1);
         segments.add(new TranscriptionSegment(0, 0, text));
         return new TranscriptionResult(segments);
     }
 
+    /// Gets the ordered timed transcript segments.
+    ///
+    /// @return immutable segment list
     public List<TranscriptionSegment> getSegments() {
         return segments;
     }
 
+    /// Gets the plain transcript text.
+    ///
+    /// @return transcript text, never `null`
     public String getText() {
         return text;
     }
 
+    /// Formats this transcription as SubRip captions.
+    ///
+    /// @return SRT text using millisecond timestamps
     public String toSrt() {
         StringBuilder out = new StringBuilder();
         for (int i = 0; i < segments.size(); i++) {
@@ -76,6 +99,9 @@ public final class TranscriptionResult {
         return out.toString();
     }
 
+    /// Formats this transcription as WebVTT captions.
+    ///
+    /// @return WebVTT text using millisecond timestamps
     public String toVtt() {
         StringBuilder out = new StringBuilder("WEBVTT\n\n");
         for (int i = 0; i < segments.size(); i++) {

--- a/CodenameOne/src/com/codename1/media/TranscriptionSegment.java
+++ b/CodenameOne/src/com/codename1/media/TranscriptionSegment.java
@@ -29,6 +29,13 @@ public final class TranscriptionSegment {
     private final long endTimeMs;
     private final String text;
 
+    /// Creates a timed transcript span.
+    ///
+    /// @param startTimeMs start offset from the beginning of the audio, in milliseconds
+    /// @param endTimeMs end offset from the beginning of the audio, in milliseconds
+    /// @param text text recognized in this span; `null` is treated as an empty string
+    /// @throws IllegalArgumentException if either timestamp is negative, or if `endTimeMs`
+    /// is before `startTimeMs`
     public TranscriptionSegment(long startTimeMs, long endTimeMs, String text) {
         if (startTimeMs < 0) {
             throw new IllegalArgumentException("startTimeMs must be >= 0");
@@ -41,14 +48,23 @@ public final class TranscriptionSegment {
         this.text = text == null ? "" : text;
     }
 
+    /// Gets the segment start offset from the beginning of the audio.
+    ///
+    /// @return start offset in milliseconds
     public long getStartTimeMs() {
         return startTimeMs;
     }
 
+    /// Gets the segment end offset from the beginning of the audio.
+    ///
+    /// @return end offset in milliseconds
     public long getEndTimeMs() {
         return endTimeMs;
     }
 
+    /// Gets the text recognized in this segment.
+    ///
+    /// @return recognized text, never `null`
     public String getText() {
         return text;
     }

--- a/CodenameOne/src/com/codename1/media/TranscriptionSegment.java
+++ b/CodenameOne/src/com/codename1/media/TranscriptionSegment.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.media;
+
+/// One timed transcript span. Times are offsets from the start of
+/// the transcribed audio in milliseconds.
+public final class TranscriptionSegment {
+    private final long startTimeMs;
+    private final long endTimeMs;
+    private final String text;
+
+    public TranscriptionSegment(long startTimeMs, long endTimeMs, String text) {
+        if (startTimeMs < 0) {
+            throw new IllegalArgumentException("startTimeMs must be >= 0");
+        }
+        if (endTimeMs < startTimeMs) {
+            throw new IllegalArgumentException("endTimeMs must be >= startTimeMs");
+        }
+        this.startTimeMs = startTimeMs;
+        this.endTimeMs = endTimeMs;
+        this.text = text == null ? "" : text;
+    }
+
+    public long getStartTimeMs() {
+        return startTimeMs;
+    }
+
+    public long getEndTimeMs() {
+        return endTimeMs;
+    }
+
+    public String getText() {
+        return text;
+    }
+}

--- a/maven/cn1-ai-whisper/android-aar/.gitignore
+++ b/maven/cn1-ai-whisper/android-aar/.gitignore
@@ -1,0 +1,5 @@
+.gradle/
+build/
+**/.cxx/
+**/build/
+local.properties

--- a/maven/cn1-ai-whisper/android-aar/README.md
+++ b/maven/cn1-ai-whisper/android-aar/README.md
@@ -1,0 +1,23 @@
+# cn1-ai-whisper Android AAR
+
+This project builds the JNI bridge used by the Android `NativeWhisperRecognizerImpl`.
+It produces an AAR containing `libcn1aiwhisper.so` for Android ABIs.
+
+Build from this directory with either a whisper.cpp checkout:
+
+```sh
+WHISPER_CPP_DIR=/path/to/whisper.cpp ./build-aar.sh
+```
+
+Or with prebuilt Android `libwhisper.so` slices:
+
+```sh
+WHISPER_PREBUILT_DIR=/path/to/jniLibs \
+WHISPER_INCLUDE_DIR=/path/to/whisper.cpp/include \
+./build-aar.sh
+```
+
+`WHISPER_PREBUILT_DIR` should contain ABI subdirectories such as
+`arm64-v8a/libwhisper.so`. The build script copies the resulting AAR to
+`../android/src/main/resources/cn1-ai-whisper-android.aar`, where the cn1lib
+packager and Android builder already know how to pick it up.

--- a/maven/cn1-ai-whisper/android-aar/build-aar.sh
+++ b/maven/cn1-ai-whisper/android-aar/build-aar.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+GRADLE_BIN=${GRADLE:-gradle}
+
+if [ -z "${ANDROID_HOME:-}" ] && [ -d "$HOME/Library/Android/sdk" ]; then
+    export ANDROID_HOME="$HOME/Library/Android/sdk"
+fi
+
+if [ -z "${WHISPER_CPP_DIR:-}" ] && [ -z "${WHISPER_PREBUILT_DIR:-}" ]; then
+    echo "Set WHISPER_CPP_DIR or WHISPER_PREBUILT_DIR before building the AAR." >&2
+    exit 2
+fi
+
+"$GRADLE_BIN" -p "$SCRIPT_DIR" :cn1-ai-whisper-android:assembleRelease "$@"
+
+mkdir -p "$SCRIPT_DIR/../android/src/main/resources"
+cp "$SCRIPT_DIR/cn1-ai-whisper-android/build/outputs/aar/cn1-ai-whisper-android-release.aar" \
+   "$SCRIPT_DIR/../android/src/main/resources/cn1-ai-whisper-android.aar"
+
+echo "Wrote $SCRIPT_DIR/../android/src/main/resources/cn1-ai-whisper-android.aar"

--- a/maven/cn1-ai-whisper/android-aar/build.gradle
+++ b/maven/cn1-ai-whisper/android-aar/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'com.android.library' version '8.1.0' apply false
+}

--- a/maven/cn1-ai-whisper/android-aar/cn1-ai-whisper-android/build.gradle
+++ b/maven/cn1-ai-whisper/android-aar/cn1-ai-whisper-android/build.gradle
@@ -1,0 +1,46 @@
+plugins {
+    id 'com.android.library'
+}
+
+def whisperCppDir = project.findProperty('whisperCppDir') ?: System.getenv('WHISPER_CPP_DIR')
+def whisperPrebuiltDir = project.findProperty('whisperPrebuiltDir') ?: System.getenv('WHISPER_PREBUILT_DIR')
+def whisperIncludeDir = project.findProperty('whisperIncludeDir') ?: System.getenv('WHISPER_INCLUDE_DIR')
+
+android {
+    namespace 'com.codename1.ai.whisper.android'
+    compileSdk 33
+    ndkVersion '26.3.11579264'
+
+    defaultConfig {
+        minSdk 19
+        externalNativeBuild {
+            cmake {
+                abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
+                arguments '-DANDROID_STL=c++_shared'
+                if (whisperCppDir != null && whisperCppDir.trim().length() > 0) {
+                    arguments "-DWHISPER_CPP_DIR=${file(whisperCppDir).absolutePath}"
+                }
+                if (whisperPrebuiltDir != null && whisperPrebuiltDir.trim().length() > 0) {
+                    arguments "-DWHISPER_PREBUILT_DIR=${file(whisperPrebuiltDir).absolutePath}"
+                }
+                if (whisperIncludeDir != null && whisperIncludeDir.trim().length() > 0) {
+                    arguments "-DWHISPER_INCLUDE_DIR=${file(whisperIncludeDir).absolutePath}"
+                }
+            }
+        }
+    }
+
+    externalNativeBuild {
+        cmake {
+            path 'src/main/cpp/CMakeLists.txt'
+        }
+    }
+
+    sourceSets {
+        main {
+            if (whisperPrebuiltDir != null && whisperPrebuiltDir.trim().length() > 0) {
+                jniLibs.srcDirs += file(whisperPrebuiltDir)
+            }
+        }
+    }
+}

--- a/maven/cn1-ai-whisper/android-aar/cn1-ai-whisper-android/src/main/AndroidManifest.xml
+++ b/maven/cn1-ai-whisper/android-aar/cn1-ai-whisper-android/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/maven/cn1-ai-whisper/android-aar/cn1-ai-whisper-android/src/main/cpp/CMakeLists.txt
+++ b/maven/cn1-ai-whisper/android-aar/cn1-ai-whisper-android/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.22.1)
+project(cn1_ai_whisper_android LANGUAGES C CXX)
+
+add_library(cn1aiwhisper SHARED native_whisper_jni.cpp)
+target_compile_features(cn1aiwhisper PRIVATE cxx_std_17)
+
+if (DEFINED WHISPER_CPP_DIR AND NOT "${WHISPER_CPP_DIR}" STREQUAL "")
+    set(WHISPER_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+    set(WHISPER_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+    set(WHISPER_BUILD_SERVER OFF CACHE BOOL "" FORCE)
+    set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+    add_subdirectory("${WHISPER_CPP_DIR}" "${CMAKE_BINARY_DIR}/whisper.cpp" EXCLUDE_FROM_ALL)
+    target_link_libraries(cn1aiwhisper PRIVATE whisper)
+elseif (DEFINED WHISPER_PREBUILT_DIR AND NOT "${WHISPER_PREBUILT_DIR}" STREQUAL "")
+    if (NOT DEFINED WHISPER_INCLUDE_DIR OR "${WHISPER_INCLUDE_DIR}" STREQUAL "")
+        message(FATAL_ERROR "WHISPER_INCLUDE_DIR is required when WHISPER_PREBUILT_DIR is used")
+    endif ()
+    add_library(whisper SHARED IMPORTED)
+    set_target_properties(whisper PROPERTIES
+            IMPORTED_LOCATION "${WHISPER_PREBUILT_DIR}/${ANDROID_ABI}/libwhisper.so"
+            INTERFACE_INCLUDE_DIRECTORIES "${WHISPER_INCLUDE_DIR}")
+    target_link_libraries(cn1aiwhisper PRIVATE whisper)
+else ()
+    message(FATAL_ERROR "Set WHISPER_CPP_DIR to a whisper.cpp checkout or WHISPER_PREBUILT_DIR plus WHISPER_INCLUDE_DIR to prebuilt Android libraries")
+endif ()
+
+find_library(log-lib log)
+target_link_libraries(cn1aiwhisper PRIVATE ${log-lib})

--- a/maven/cn1-ai-whisper/android-aar/cn1-ai-whisper-android/src/main/cpp/native_whisper_jni.cpp
+++ b/maven/cn1-ai-whisper/android-aar/cn1-ai-whisper-android/src/main/cpp/native_whisper_jni.cpp
@@ -1,0 +1,244 @@
+#include <jni.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "whisper.h"
+
+namespace {
+
+class JStringUtf {
+public:
+    JStringUtf(JNIEnv* env, jstring value) : env_(env), value_(value), chars_(nullptr) {
+        if (value_ != nullptr) {
+            chars_ = env_->GetStringUTFChars(value_, nullptr);
+        }
+    }
+
+    ~JStringUtf() {
+        if (chars_ != nullptr) {
+            env_->ReleaseStringUTFChars(value_, chars_);
+        }
+    }
+
+    const char* c_str() const {
+        return chars_;
+    }
+
+private:
+    JNIEnv* env_;
+    jstring value_;
+    const char* chars_;
+};
+
+uint16_t u16le(const uint8_t* p) {
+    return static_cast<uint16_t>(p[0]) | static_cast<uint16_t>(p[1] << 8);
+}
+
+uint32_t u32le(const uint8_t* p) {
+    return static_cast<uint32_t>(p[0])
+            | (static_cast<uint32_t>(p[1]) << 8)
+            | (static_cast<uint32_t>(p[2]) << 16)
+            | (static_cast<uint32_t>(p[3]) << 24);
+}
+
+bool readFile(const char* path, std::vector<uint8_t>* out) {
+    if (path == nullptr) {
+        return false;
+    }
+    FILE* f = std::fopen(path, "rb");
+    if (f == nullptr) {
+        return false;
+    }
+    std::fseek(f, 0, SEEK_END);
+    long size = std::ftell(f);
+    if (size <= 0) {
+        std::fclose(f);
+        return false;
+    }
+    std::fseek(f, 0, SEEK_SET);
+    out->resize(static_cast<size_t>(size));
+    bool ok = std::fread(out->data(), 1, out->size(), f) == out->size();
+    std::fclose(f);
+    return ok;
+}
+
+bool readWav16(const char* path, std::vector<float>* samples) {
+    std::vector<uint8_t> bytes;
+    if (!readFile(path, &bytes) || bytes.size() < 44) {
+        return false;
+    }
+    if (std::memcmp(bytes.data(), "RIFF", 4) != 0 || std::memcmp(bytes.data() + 8, "WAVE", 4) != 0) {
+        return false;
+    }
+
+    const uint8_t* fmt = nullptr;
+    size_t fmtSize = 0;
+    const uint8_t* data = nullptr;
+    size_t dataSize = 0;
+    size_t pos = 12;
+    while (pos + 8 <= bytes.size()) {
+        const uint8_t* chunk = bytes.data() + pos;
+        uint32_t chunkSize = u32le(chunk + 4);
+        size_t chunkData = pos + 8;
+        if (chunkData + chunkSize > bytes.size()) {
+            return false;
+        }
+        if (std::memcmp(chunk, "fmt ", 4) == 0) {
+            fmt = bytes.data() + chunkData;
+            fmtSize = chunkSize;
+        } else if (std::memcmp(chunk, "data", 4) == 0) {
+            data = bytes.data() + chunkData;
+            dataSize = chunkSize;
+        }
+        pos = chunkData + chunkSize + (chunkSize & 1);
+    }
+
+    if (fmt == nullptr || fmtSize < 16 || data == nullptr || dataSize == 0) {
+        return false;
+    }
+    uint16_t audioFormat = u16le(fmt);
+    uint16_t channels = u16le(fmt + 2);
+    uint16_t bitsPerSample = u16le(fmt + 14);
+    if (audioFormat != 1 || channels == 0 || bitsPerSample != 16) {
+        return false;
+    }
+
+    size_t frameSize = static_cast<size_t>(channels) * 2;
+    size_t frameCount = dataSize / frameSize;
+    samples->clear();
+    samples->reserve(frameCount);
+    for (size_t frame = 0; frame < frameCount; frame++) {
+        int mixed = 0;
+        const uint8_t* frameData = data + frame * frameSize;
+        for (uint16_t ch = 0; ch < channels; ch++) {
+            const uint8_t* sampleData = frameData + ch * 2;
+            int16_t value = static_cast<int16_t>(u16le(sampleData));
+            mixed += value;
+        }
+        samples->push_back(static_cast<float>(mixed / static_cast<int>(channels)) / 32768.0f);
+    }
+    return !samples->empty();
+}
+
+std::string escapePayloadText(const char* text) {
+    std::string out;
+    const char* value = text == nullptr ? "" : text;
+    while (*value != 0) {
+        char ch = *value++;
+        switch (ch) {
+            case '\\':
+                out += "\\\\";
+                break;
+            case '\t':
+                out += "\\t";
+                break;
+            case '\n':
+                out += "\\n";
+                break;
+            case '\r':
+                out += "\\r";
+                break;
+            default:
+                out += ch;
+                break;
+        }
+    }
+    return out;
+}
+
+int whisperThreadCount() {
+    unsigned int count = std::thread::hardware_concurrency();
+    if (count == 0) {
+        return 2;
+    }
+    return static_cast<int>(std::min(count, 4u));
+}
+
+whisper_context* runWhisper(const char* modelPath, const char* audioPath) {
+    if (modelPath == nullptr || audioPath == nullptr) {
+        return nullptr;
+    }
+    std::vector<float> samples;
+    if (!readWav16(audioPath, &samples)) {
+        return nullptr;
+    }
+
+    whisper_context_params contextParams = whisper_context_default_params();
+    whisper_context* ctx = whisper_init_from_file_with_params(modelPath, contextParams);
+    if (ctx == nullptr) {
+        return nullptr;
+    }
+
+    whisper_full_params params = whisper_full_default_params(WHISPER_SAMPLING_GREEDY);
+    params.n_threads = whisperThreadCount();
+    params.print_progress = false;
+    params.print_realtime = false;
+    params.print_timestamps = false;
+    params.print_special = false;
+
+    if (whisper_full(ctx, params, samples.data(), static_cast<int>(samples.size())) != 0) {
+        whisper_free(ctx);
+        return nullptr;
+    }
+    return ctx;
+}
+
+jstring newString(JNIEnv* env, const std::string& value) {
+    return env->NewStringUTF(value.c_str());
+}
+
+} // namespace
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_codename1_ai_whisper_NativeWhisperRecognizerImpl_nativeTranscribe(
+        JNIEnv* env, jobject, jstring modelPath, jstring audioPath) {
+    JStringUtf model(env, modelPath);
+    JStringUtf audio(env, audioPath);
+    whisper_context* ctx = runWhisper(model.c_str(), audio.c_str());
+    if (ctx == nullptr) {
+        return newString(env, "");
+    }
+
+    std::string out;
+    int segments = whisper_full_n_segments(ctx);
+    for (int i = 0; i < segments; i++) {
+        const char* text = whisper_full_get_segment_text(ctx, i);
+        if (text != nullptr) {
+            out += text;
+        }
+    }
+    whisper_free(ctx);
+    return newString(env, out);
+}
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_codename1_ai_whisper_NativeWhisperRecognizerImpl_nativeTranscribeSegments(
+        JNIEnv* env, jobject, jstring modelPath, jstring audioPath) {
+    JStringUtf model(env, modelPath);
+    JStringUtf audio(env, audioPath);
+    whisper_context* ctx = runWhisper(model.c_str(), audio.c_str());
+    if (ctx == nullptr) {
+        return newString(env, "");
+    }
+
+    std::string out;
+    int segments = whisper_full_n_segments(ctx);
+    for (int i = 0; i < segments; i++) {
+        int64_t startMs = whisper_full_get_segment_t0(ctx, i) * 10LL;
+        int64_t endMs = whisper_full_get_segment_t1(ctx, i) * 10LL;
+        out += std::to_string(startMs);
+        out += '\t';
+        out += std::to_string(endMs);
+        out += '\t';
+        out += escapePayloadText(whisper_full_get_segment_text(ctx, i));
+        out += '\n';
+    }
+    whisper_free(ctx);
+    return newString(env, out);
+}

--- a/maven/cn1-ai-whisper/android-aar/settings.gradle
+++ b/maven/cn1-ai-whisper/android-aar/settings.gradle
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = 'cn1-ai-whisper-android-aar'
+include ':cn1-ai-whisper-android'

--- a/maven/cn1-ai-whisper/android/pom.xml
+++ b/maven/cn1-ai-whisper/android/pom.xml
@@ -23,6 +23,7 @@
         <sourceDirectory>src/main/dummy</sourceDirectory>
         <resources>
             <resource><directory>src/main/java</directory></resource>
+            <resource><directory>src/main/resources</directory></resource>
         </resources>
         <plugins>
             <plugin>
@@ -38,6 +39,7 @@
                                 <mkdir dir="${basedir}/src/main/java"/>
                                 <jar destfile="${project.build.directory}/${project.build.finalName}.jar" compress="true">
                                     <fileset dir="${basedir}/src/main/java" erroronmissingdir="false" />
+                                    <fileset dir="${basedir}/src/main/resources" erroronmissingdir="false" />
                                 </jar>
                             </target>
                         </configuration>

--- a/maven/cn1-ai-whisper/android/src/main/java/com/codename1/ai/whisper/NativeWhisperRecognizerImpl.java
+++ b/maven/cn1-ai-whisper/android/src/main/java/com/codename1/ai/whisper/NativeWhisperRecognizerImpl.java
@@ -1,22 +1,96 @@
 package com.codename1.ai.whisper;
 
+import android.media.MediaMetadataRetriever;
+
+import com.codename1.media.TranscriptionSegment;
+
+import java.util.Collections;
+
 
 public class NativeWhisperRecognizerImpl {
-    // Android side uses whisper.cpp's prebuilt JNI wrapper packaged inside
-    // the cn1lib's nativeand zip. The build server injects the .so into the
-    // jniLibs directory via the AiDependencyTable's androidNativeDir entry.
+    private static volatile boolean loaded;
+    private static volatile boolean loadAttempted;
+    private static volatile Throwable loadError;
+
     public String transcribe(String modelPath, String audioPath) {
-        try {
-            System.loadLibrary("whisper");
-        } catch (UnsatisfiedLinkError ule) {
-            throw new RuntimeException("whisper native library not found", ule);
-        }
+        requireWhisper();
         return nativeTranscribe(modelPath, audioPath);
+    }
+
+    public String transcribeSegments(String modelPath, String audioPath) {
+        requireWhisper();
+        try {
+            return nativeTranscribeSegments(modelPath, audioPath);
+        } catch (UnsatisfiedLinkError ule) {
+            String text = nativeTranscribe(modelPath, audioPath);
+            long duration = audioDurationMs(audioPath);
+            return WhisperRecognizer.encodeSegmentsPayload(Collections.singletonList(
+                    new TranscriptionSegment(0, duration, text == null ? "" : text)));
+        }
     }
 
     private native String nativeTranscribe(String modelPath, String audioPath);
 
+    private native String nativeTranscribeSegments(String modelPath, String audioPath);
+
     public boolean isSupported() {
-        return true;
+        return loadWhisper();
+    }
+
+    private static void requireWhisper() {
+        if (!loadWhisper()) {
+            throw new RuntimeException("Whisper JNI library not found", loadError);
+        }
+    }
+
+    private static boolean loadWhisper() {
+        if (loaded || loadAttempted) {
+            return loaded;
+        }
+        synchronized (NativeWhisperRecognizerImpl.class) {
+            if (loaded || loadAttempted) {
+                return loaded;
+            }
+            loadAttempted = true;
+            try {
+                System.loadLibrary("cn1aiwhisper");
+                loaded = true;
+                return true;
+            } catch (UnsatisfiedLinkError cn1BridgeError) {
+                try {
+                    System.loadLibrary("whisper");
+                    loaded = true;
+                    return true;
+                } catch (UnsatisfiedLinkError legacyError) {
+                    loadError = legacyError;
+                    if (loadError.getCause() == null) {
+                        try {
+                            loadError.initCause(cn1BridgeError);
+                        } catch (Throwable ignored) {
+                        }
+                    }
+                    return false;
+                }
+            }
+        }
+    }
+
+    private static long audioDurationMs(String audioPath) {
+        MediaMetadataRetriever retriever = new MediaMetadataRetriever();
+        try {
+            retriever.setDataSource(audioPath);
+            String duration = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION);
+            if (duration != null && duration.length() > 0) {
+                return Long.parseLong(duration);
+            }
+        } catch (Throwable ignored) {
+            // Fall through to 0ms; this is only used by the text-only JNI fallback.
+        } finally {
+            try {
+                retriever.release();
+            } catch (Throwable ignored) {
+            }
+        }
+        return 0;
     }
 }

--- a/maven/cn1-ai-whisper/common/src/main/java/com/codename1/ai/whisper/NativeWhisperRecognizer.java
+++ b/maven/cn1-ai-whisper/common/src/main/java/com/codename1/ai/whisper/NativeWhisperRecognizer.java
@@ -29,4 +29,6 @@ import com.codename1.system.NativeInterface;
 /// live in their respective port modules under this cn1lib.
 public interface NativeWhisperRecognizer extends NativeInterface {
     String transcribe(String modelPath, String audioPath);
+
+    String transcribeSegments(String modelPath, String audioPath);
 }

--- a/maven/cn1-ai-whisper/common/src/main/java/com/codename1/ai/whisper/WhisperRecognizer.java
+++ b/maven/cn1-ai-whisper/common/src/main/java/com/codename1/ai/whisper/WhisperRecognizer.java
@@ -24,9 +24,16 @@
 package com.codename1.ai.whisper;
 
 import com.codename1.ai.LlmException;
+import com.codename1.media.Transcriber;
+import com.codename1.media.TranscriptionRequest;
+import com.codename1.media.TranscriptionResult;
+import com.codename1.media.TranscriptionSegment;
 import com.codename1.system.NativeLookup;
 import com.codename1.ui.Display;
 import com.codename1.util.AsyncResource;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /// On-device speech-to-text via whisper.cpp.
 ///
@@ -73,5 +80,194 @@ public final class WhisperRecognizer {
             }
         });
         return out;
+    }
+
+    /// Provider-pluggable transcriber backed by whisper.cpp. `modelPath`
+    /// is the filesystem path to a ggml-format Whisper model; each
+    /// request supplies the 16kHz mono WAV audio path.
+    public static Transcriber transcriber(final String modelPath) {
+        return new Transcriber() {
+            @Override
+            public AsyncResource<TranscriptionResult> transcribe(TranscriptionRequest request) {
+                if (request == null) {
+                    AsyncResource<TranscriptionResult> out = new AsyncResource<TranscriptionResult>();
+                    out.error(new IllegalArgumentException("request is required"));
+                    return out;
+                }
+                return transcribeSegments(modelPath, request.getAudioPath());
+            }
+
+            @Override
+            public String getProvider() {
+                return "whisper";
+            }
+        };
+    }
+
+    /// Transcribes audio and returns timed segments. This exposes the
+    /// segment timestamps already emitted by whisper.cpp, converted to
+    /// millisecond offsets from the start of the audio.
+    public static AsyncResource<TranscriptionResult> transcribeSegments(final String modelPath,
+                                                                         final String audioPath) {
+        final AsyncResource<TranscriptionResult> out = new AsyncResource<TranscriptionResult>();
+        final NativeWhisperRecognizer bridge =
+                NativeLookup.create(NativeWhisperRecognizer.class);
+        if (bridge == null || !bridge.isSupported()) {
+            out.error(new LlmException("WhisperRecognizer.transcribeSegments is not supported on this platform.",
+                    -1, null, null, null, LlmException.ErrorType.UNKNOWN));
+            return out;
+        }
+        Display.getInstance().scheduleBackgroundTask(new Runnable() {
+            @Override public void run() {
+                try {
+                    final String payload = bridge.transcribeSegments(modelPath, audioPath);
+                    final TranscriptionResult result = parseSegments(payload);
+                    Display.getInstance().callSerially(new Runnable() {
+                        @Override public void run() { out.complete(result); }
+                    });
+                } catch (final Throwable t) {
+                    Display.getInstance().callSerially(new Runnable() {
+                        @Override public void run() {
+                            out.error(new LlmException("WhisperRecognizer.transcribeSegments failed: " + t.getMessage(),
+                                    -1, null, null, t, LlmException.ErrorType.UNKNOWN));
+                        }
+                    });
+                }
+            }
+        });
+        return out;
+    }
+
+    static TranscriptionResult parseSegments(String payload) {
+        ArrayList<TranscriptionSegment> segments = new ArrayList<TranscriptionSegment>();
+        if (payload != null && payload.length() > 0) {
+            String[] lines = splitLines(payload);
+            for (int i = 0; i < lines.length; i++) {
+                String line = lines[i];
+                if (line.length() == 0) {
+                    continue;
+                }
+                String[] parts = splitTabs(line);
+                if (parts.length != 3) {
+                    throw new IllegalArgumentException("Invalid Whisper segment payload line: " + line);
+                }
+                segments.add(new TranscriptionSegment(
+                        Long.parseLong(parts[0]),
+                        Long.parseLong(parts[1]),
+                        decodeText(parts[2])));
+            }
+        }
+        return new TranscriptionResult(segments);
+    }
+
+    static String encodeSegmentsPayload(List<TranscriptionSegment> segments) {
+        StringBuilder out = new StringBuilder();
+        for (int i = 0; i < segments.size(); i++) {
+            TranscriptionSegment s = segments.get(i);
+            out.append(s.getStartTimeMs()).append('\t')
+                    .append(s.getEndTimeMs()).append('\t')
+                    .append(encodeText(s.getText())).append('\n');
+        }
+        return out.toString();
+    }
+
+    private static String[] splitLines(String payload) {
+        ArrayList<String> lines = new ArrayList<String>();
+        int start = 0;
+        for (int i = 0; i < payload.length(); i++) {
+            char ch = payload.charAt(i);
+            if (ch == '\n') {
+                int end = i;
+                if (end > start && payload.charAt(end - 1) == '\r') {
+                    end--;
+                }
+                lines.add(payload.substring(start, end));
+                start = i + 1;
+            }
+        }
+        if (start < payload.length()) {
+            lines.add(payload.substring(start));
+        }
+        return lines.toArray(new String[lines.size()]);
+    }
+
+    private static String[] splitTabs(String line) {
+        ArrayList<String> parts = new ArrayList<String>(3);
+        int start = 0;
+        for (int i = 0; i < line.length(); i++) {
+            if (line.charAt(i) == '\t') {
+                parts.add(line.substring(start, i));
+                start = i + 1;
+            }
+        }
+        parts.add(line.substring(start));
+        return parts.toArray(new String[parts.size()]);
+    }
+
+    private static String encodeText(String text) {
+        String value = text == null ? "" : text;
+        StringBuilder out = new StringBuilder(value.length());
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            switch (ch) {
+                case '\\':
+                    out.append("\\\\");
+                    break;
+                case '\t':
+                    out.append("\\t");
+                    break;
+                case '\n':
+                    out.append("\\n");
+                    break;
+                case '\r':
+                    out.append("\\r");
+                    break;
+                default:
+                    out.append(ch);
+                    break;
+            }
+        }
+        return out.toString();
+    }
+
+    private static String decodeText(String encoded) {
+        if (encoded == null || encoded.length() == 0) {
+            return "";
+        }
+        StringBuilder out = new StringBuilder(encoded.length());
+        boolean escaping = false;
+        for (int i = 0; i < encoded.length(); i++) {
+            char ch = encoded.charAt(i);
+            if (!escaping) {
+                if (ch == '\\') {
+                    escaping = true;
+                } else {
+                    out.append(ch);
+                }
+                continue;
+            }
+            switch (ch) {
+                case '\\':
+                    out.append('\\');
+                    break;
+                case 't':
+                    out.append('\t');
+                    break;
+                case 'n':
+                    out.append('\n');
+                    break;
+                case 'r':
+                    out.append('\r');
+                    break;
+                default:
+                    out.append(ch);
+                    break;
+            }
+            escaping = false;
+        }
+        if (escaping) {
+            out.append('\\');
+        }
+        return out.toString();
     }
 }

--- a/maven/cn1-ai-whisper/common/src/test/java/com/codename1/ai/whisper/AndroidWhisperAarProjectTest.java
+++ b/maven/cn1-ai-whisper/common/src/test/java/com/codename1/ai/whisper/AndroidWhisperAarProjectTest.java
@@ -1,0 +1,50 @@
+package com.codename1.ai.whisper;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.zip.ZipFile;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AndroidWhisperAarProjectTest {
+
+    @Test
+    void androidJniBridgeExportsTimedSegmentsForAllAndroidAbis() throws Exception {
+        String cpp = read("../android-aar/cn1-ai-whisper-android/src/main/cpp/native_whisper_jni.cpp");
+        assertTrue(cpp.contains("NativeWhisperRecognizerImpl_nativeTranscribeSegments"), cpp);
+        assertTrue(cpp.contains("whisper_full_get_segment_t0"), cpp);
+        assertTrue(cpp.contains("whisper_full_get_segment_t1"), cpp);
+        assertTrue(cpp.contains("whisper_init_from_file_with_params"), cpp);
+
+        String gradle = read("../android-aar/cn1-ai-whisper-android/build.gradle");
+        assertTrue(gradle.contains("abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'"), gradle);
+        assertTrue(gradle.contains("ndkVersion '26.3.11579264'"), gradle);
+    }
+
+    @Test
+    void stagedAndroidAarContainsJniSlicesWhenPresent() throws Exception {
+        File aar = new File("../android/src/main/resources/cn1-ai-whisper-android.aar");
+        if (!aar.isFile()) {
+            return;
+        }
+        ZipFile zip = new ZipFile(aar);
+        try {
+            assertNotNull(zip.getEntry("jni/armeabi-v7a/libcn1aiwhisper.so"));
+            assertNotNull(zip.getEntry("jni/arm64-v8a/libcn1aiwhisper.so"));
+            assertNotNull(zip.getEntry("jni/x86/libcn1aiwhisper.so"));
+            assertNotNull(zip.getEntry("jni/x86_64/libcn1aiwhisper.so"));
+        } finally {
+            zip.close();
+        }
+    }
+
+    private static String read(String path) throws Exception {
+        File file = new File(path);
+        assertTrue(file.isFile(), "Missing " + file.getAbsolutePath());
+        return new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+    }
+}

--- a/maven/cn1-ai-whisper/common/src/test/java/com/codename1/ai/whisper/WhisperRecognizerTest.java
+++ b/maven/cn1-ai-whisper/common/src/test/java/com/codename1/ai/whisper/WhisperRecognizerTest.java
@@ -1,6 +1,12 @@
 package com.codename1.ai.whisper;
 
+import com.codename1.media.TranscriptionResult;
+import com.codename1.media.TranscriptionSegment;
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 public class WhisperRecognizerTest {
@@ -10,11 +16,30 @@ public class WhisperRecognizerTest {
         boolean supported = true;
         public boolean isSupported() { return supported; }
         public String transcribe(String m, String a) { return "hello world"; }
+        public String transcribeSegments(String m, String a) {
+            List<TranscriptionSegment> segments = new ArrayList<TranscriptionSegment>();
+            segments.add(new TranscriptionSegment(0, 1250, "hello "));
+            segments.add(new TranscriptionSegment(1250, 2500, "world"));
+            return WhisperRecognizer.encodeSegmentsPayload(segments);
+        }
     }
 
     @Test
     void mock_returns_transcript() {
         MockBridge b = new MockBridge();
         assertEquals("hello world", b.transcribe("m.bin", "a.wav"));
+    }
+
+    @Test
+    void native_payload_round_trips_segments_and_captions() {
+        MockBridge b = new MockBridge();
+        TranscriptionResult result = WhisperRecognizer.parseSegments(b.transcribeSegments("m.bin", "a.wav"));
+        assertEquals("hello world", result.getText());
+        assertEquals(2, result.getSegments().size());
+        assertEquals(0, result.getSegments().get(0).getStartTimeMs());
+        assertEquals(1250, result.getSegments().get(0).getEndTimeMs());
+        assertTrue(result.toSrt().contains("00:00:00,000 --> 00:00:01,250"));
+        assertTrue(result.toVtt().startsWith("WEBVTT"));
+        assertTrue(result.toVtt().contains("00:00:01.250 --> 00:00:02.500"));
     }
 }

--- a/maven/cn1-ai-whisper/ios/src/main/objectivec/com_codename1_ai_whisper_NativeWhisperRecognizerImpl.h
+++ b/maven/cn1-ai-whisper/ios/src/main/objectivec/com_codename1_ai_whisper_NativeWhisperRecognizerImpl.h
@@ -4,5 +4,7 @@
 }
 
 -(NSString*)transcribe:(NSString*)param param1:(NSString*)param1;
+-(NSString*)transcribeSegments:(NSString*)param param1:(NSString*)param1;
+-(NSString*)escapeSegmentText:(NSString*)text;
 -(BOOL)isSupported;
 @end

--- a/maven/cn1-ai-whisper/ios/src/main/objectivec/com_codename1_ai_whisper_NativeWhisperRecognizerImpl.m
+++ b/maven/cn1-ai-whisper/ios/src/main/objectivec/com_codename1_ai_whisper_NativeWhisperRecognizerImpl.m
@@ -1,5 +1,6 @@
 #import "com_codename1_ai_whisper_NativeWhisperRecognizerImpl.h"
 #import <UIKit/UIKit.h>
+#import <stdint.h>
 
 // whisper.cpp's C API. The cn1lib bundles the prebuilt static
 // library; linking against `libwhisper.a` is handled by the build
@@ -27,6 +28,8 @@ extern int whisper_full(struct whisper_context *ctx,
                         const float *samples, int n_samples);
 extern int whisper_full_n_segments(struct whisper_context *ctx);
 extern const char *whisper_full_get_segment_text(struct whisper_context *ctx, int i);
+extern int64_t whisper_full_get_segment_t0(struct whisper_context *ctx, int i);
+extern int64_t whisper_full_get_segment_t1(struct whisper_context *ctx, int i);
 extern void whisper_free(struct whisper_context *ctx);
 
 @implementation com_codename1_ai_whisper_NativeWhisperRecognizerImpl
@@ -53,6 +56,48 @@ extern void whisper_free(struct whisper_context *ctx);
     }
     whisper_free(ctx);
     free(samples);
+    return out;
+}
+
+-(NSString*)transcribeSegments:(NSString*)param param1:(NSString*)param1 {
+    NSData *wav = [NSData dataWithContentsOfFile:param1];
+    if (wav.length < 44) return @"";
+    const uint8_t *bytes = wav.bytes;
+    const int16_t *samples16 = (const int16_t *)(bytes + 44);
+    NSInteger nSamples = (wav.length - 44) / 2;
+    float *samples = (float *)malloc(sizeof(float) * nSamples);
+    for (NSInteger i = 0; i < nSamples; i++) samples[i] = samples16[i] / 32768.0f;
+    struct whisper_context *ctx = whisper_init_from_file([param UTF8String]);
+    if (!ctx) { free(samples); return @""; }
+    struct whisper_full_params p = {0};
+    p.n_threads = 4;
+    whisper_full(ctx, p, samples, (int)nSamples);
+    NSMutableString *out = [NSMutableString string];
+    int n = whisper_full_n_segments(ctx);
+    for (int i = 0; i < n; i++) {
+        const char *text = whisper_full_get_segment_text(ctx, i);
+        NSString *s = text ? [NSString stringWithUTF8String:text] : @"";
+        long long startMs = (long long)whisper_full_get_segment_t0(ctx, i) * 10LL;
+        long long endMs = (long long)whisper_full_get_segment_t1(ctx, i) * 10LL;
+        [out appendFormat:@"%lld\t%lld\t%@\n", startMs, endMs, [self escapeSegmentText:s]];
+    }
+    whisper_free(ctx);
+    free(samples);
+    return out;
+}
+
+-(NSString*)escapeSegmentText:(NSString*)text {
+    NSMutableString *out = [NSMutableString string];
+    for (NSUInteger i = 0; i < text.length; i++) {
+        unichar ch = [text characterAtIndex:i];
+        switch (ch) {
+            case '\\': [out appendString:@"\\\\"]; break;
+            case '\t': [out appendString:@"\\t"]; break;
+            case '\n': [out appendString:@"\\n"]; break;
+            case '\r': [out appendString:@"\\r"]; break;
+            default: [out appendFormat:@"%C", ch]; break;
+        }
+    }
     return out;
 }
 

--- a/maven/cn1-ai-whisper/javascript/src/main/javascript/com_codename1_ai_whisper_NativeWhisperRecognizer.js
+++ b/maven/cn1-ai-whisper/javascript/src/main/javascript/com_codename1_ai_whisper_NativeWhisperRecognizer.js
@@ -6,6 +6,10 @@ var o = {};
         callback.error(new Error("Not implemented yet"));
     };
 
+    o.transcribeSegments__java_lang_String_java_lang_String = function(param1, param2, callback) {
+        callback.error(new Error("Not implemented yet"));
+    };
+
     o.isSupported_ = function(callback) {
         callback.complete(false);
     };

--- a/maven/cn1-ai-whisper/javase/src/main/java/com/codename1/ai/whisper/NativeWhisperRecognizerImpl.java
+++ b/maven/cn1-ai-whisper/javase/src/main/java/com/codename1/ai/whisper/NativeWhisperRecognizerImpl.java
@@ -1,9 +1,20 @@
 package com.codename1.ai.whisper;
 
+import com.codename1.media.TranscriptionSegment;
+
+import java.util.ArrayList;
+import java.util.List;
+
 public class NativeWhisperRecognizerImpl implements NativeWhisperRecognizer {
     public String transcribe(String modelPath, String audioPath) {
         // Simulator stub. Real whisper.cpp JNA backend is opt-in.
         return "[whisper simulator stub] model=" + modelPath + " audio=" + audioPath;
+    }
+
+    public String transcribeSegments(String modelPath, String audioPath) {
+        List<TranscriptionSegment> segments = new ArrayList<TranscriptionSegment>();
+        segments.add(new TranscriptionSegment(0, 0, transcribe(modelPath, audioPath)));
+        return WhisperRecognizer.encodeSegmentsPayload(segments);
     }
 
     public boolean isSupported() {

--- a/maven/cn1-ai-whisper/lib/pom.xml
+++ b/maven/cn1-ai-whisper/lib/pom.xml
@@ -75,5 +75,31 @@
                 </dependency>
             </dependencies>
         </profile>
+        <profile>
+            <id>linux</id>
+            <activation>
+                <property><name>codename1.platform</name><value>linux</value></property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.codenameone</groupId>
+                    <artifactId>cn1-ai-whisper-linux</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>win</id>
+            <activation>
+                <property><name>codename1.platform</name><value>win</value></property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.codenameone</groupId>
+                    <artifactId>cn1-ai-whisper-win</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/maven/cn1-ai-whisper/linux/pom.xml
+++ b/maven/cn1-ai-whisper/linux/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.codenameone</groupId>
+        <artifactId>cn1-ai-whisper</artifactId>
+        <version>8.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>cn1-ai-whisper-linux</artifactId>
+    <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-whisper-linux</name>
+
+    <build>
+        <sourceDirectory>src/main/dummy</sourceDirectory>
+        <resources>
+            <resource><directory>src/main/c</directory></resource>
+            <resource><directory>src/main/resources</directory></resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <configuration>
+                            <target>
+                                <delete file="${project.build.directory}/${project.build.finalName}.jar" />
+                                <mkdir dir="${basedir}/src/main/c"/>
+                                <jar destfile="${project.build.directory}/${project.build.finalName}.jar" compress="true">
+                                    <fileset dir="${basedir}/src/main/c" erroronmissingdir="false" />
+                                    <fileset dir="${basedir}/src/main/resources" erroronmissingdir="false" />
+                                </jar>
+                            </target>
+                        </configuration>
+                        <goals><goal>run</goal></goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.codenameone</groupId>
+            <artifactId>cn1-ai-whisper-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/maven/cn1-ai-whisper/linux/src/main/c/com/codename1/ai/whisper/NativeWhisperRecognizerImplCodenameOne.c
+++ b/maven/cn1-ai-whisper/linux/src/main/c/com/codename1/ai/whisper/NativeWhisperRecognizerImplCodenameOne.c
@@ -1,0 +1,324 @@
+#include "cn1_globals.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
+
+struct whisper_context;
+
+struct whisper_full_params {
+    int strategy;
+    int n_threads;
+    int n_max_text_ctx;
+    int offset_ms;
+    int duration_ms;
+    int translate;
+    int no_context;
+    int single_segment;
+    int print_special;
+    int print_progress;
+    int print_realtime;
+    int print_timestamps;
+};
+
+extern const char* stringToUTF8(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT str);
+extern JAVA_OBJECT newStringFromCString(CODENAME_ONE_THREAD_STATE, const char *str);
+
+typedef struct whisper_context* (*cn1_whisper_init_from_file_fn)(const char*);
+typedef int (*cn1_whisper_full_fn)(struct whisper_context*, struct whisper_full_params, const float*, int);
+typedef int (*cn1_whisper_full_n_segments_fn)(struct whisper_context*);
+typedef const char* (*cn1_whisper_full_get_segment_text_fn)(struct whisper_context*, int);
+typedef int64_t (*cn1_whisper_full_get_segment_t_fn)(struct whisper_context*, int);
+typedef void (*cn1_whisper_free_fn)(struct whisper_context*);
+
+static cn1_whisper_init_from_file_fn cn1_whisper_init_from_file;
+static cn1_whisper_full_fn cn1_whisper_full;
+static cn1_whisper_full_n_segments_fn cn1_whisper_full_n_segments;
+static cn1_whisper_full_get_segment_text_fn cn1_whisper_full_get_segment_text;
+static cn1_whisper_full_get_segment_t_fn cn1_whisper_full_get_segment_t0;
+static cn1_whisper_full_get_segment_t_fn cn1_whisper_full_get_segment_t1;
+static cn1_whisper_free_fn cn1_whisper_free;
+static int cn1_whisper_load_attempted;
+static int cn1_whisper_loaded;
+
+static void* cn1w_symbol(void* lib, const char* name) {
+#ifdef _WIN32
+    return (void*)GetProcAddress((HMODULE)lib, name);
+#else
+    return dlsym(lib, name);
+#endif
+}
+
+static void* cn1w_open_library() {
+#ifdef _WIN32
+    void* lib = (void*)LoadLibraryA("whisper.dll");
+    if (lib == NULL) {
+        lib = (void*)LoadLibraryA("libwhisper.dll");
+    }
+    return lib;
+#else
+    void* lib = dlopen("libwhisper.so", RTLD_NOW | RTLD_LOCAL);
+    if (lib == NULL) {
+        lib = dlopen("./libwhisper.so", RTLD_NOW | RTLD_LOCAL);
+    }
+    return lib;
+#endif
+}
+
+static int cn1w_load_whisper() {
+    void* lib;
+    if (cn1_whisper_load_attempted) {
+        return cn1_whisper_loaded;
+    }
+    cn1_whisper_load_attempted = 1;
+    lib = cn1w_open_library();
+    if (lib == NULL) {
+        return 0;
+    }
+    cn1_whisper_init_from_file = (cn1_whisper_init_from_file_fn)cn1w_symbol(lib, "whisper_init_from_file");
+    cn1_whisper_full = (cn1_whisper_full_fn)cn1w_symbol(lib, "whisper_full");
+    cn1_whisper_full_n_segments = (cn1_whisper_full_n_segments_fn)cn1w_symbol(lib, "whisper_full_n_segments");
+    cn1_whisper_full_get_segment_text = (cn1_whisper_full_get_segment_text_fn)cn1w_symbol(lib, "whisper_full_get_segment_text");
+    cn1_whisper_full_get_segment_t0 = (cn1_whisper_full_get_segment_t_fn)cn1w_symbol(lib, "whisper_full_get_segment_t0");
+    cn1_whisper_full_get_segment_t1 = (cn1_whisper_full_get_segment_t_fn)cn1w_symbol(lib, "whisper_full_get_segment_t1");
+    cn1_whisper_free = (cn1_whisper_free_fn)cn1w_symbol(lib, "whisper_free");
+    cn1_whisper_loaded = cn1_whisper_init_from_file != NULL
+            && cn1_whisper_full != NULL
+            && cn1_whisper_full_n_segments != NULL
+            && cn1_whisper_full_get_segment_text != NULL
+            && cn1_whisper_full_get_segment_t0 != NULL
+            && cn1_whisper_full_get_segment_t1 != NULL
+            && cn1_whisper_free != NULL;
+    return cn1_whisper_loaded;
+}
+
+static char* cn1w_strdup(const char* text) {
+    size_t len;
+    char* out;
+    if (text == NULL) {
+        return NULL;
+    }
+    len = strlen(text);
+    out = (char*)malloc(len + 1);
+    if (out != NULL) {
+        memcpy(out, text, len + 1);
+    }
+    return out;
+}
+
+static float* cn1w_read_wav16(const char* path, int* sample_count) {
+    FILE* f;
+    long size;
+    unsigned char* bytes;
+    int count;
+    float* samples;
+    int i;
+    *sample_count = 0;
+    if (path == NULL) {
+        return NULL;
+    }
+    f = fopen(path, "rb");
+    if (f == NULL) {
+        return NULL;
+    }
+    if (fseek(f, 0, SEEK_END) != 0) {
+        fclose(f);
+        return NULL;
+    }
+    size = ftell(f);
+    if (size < 44) {
+        fclose(f);
+        return NULL;
+    }
+    if (fseek(f, 44, SEEK_SET) != 0) {
+        fclose(f);
+        return NULL;
+    }
+    bytes = (unsigned char*)malloc((size_t)(size - 44));
+    if (bytes == NULL) {
+        fclose(f);
+        return NULL;
+    }
+    if (fread(bytes, 1, (size_t)(size - 44), f) != (size_t)(size - 44)) {
+        free(bytes);
+        fclose(f);
+        return NULL;
+    }
+    fclose(f);
+    count = (int)((size - 44) / 2);
+    samples = (float*)malloc(sizeof(float) * (size_t)count);
+    if (samples == NULL) {
+        free(bytes);
+        return NULL;
+    }
+    for (i = 0; i < count; i++) {
+        int16_t value = (int16_t)((uint16_t)bytes[i * 2] | ((uint16_t)bytes[i * 2 + 1] << 8));
+        samples[i] = (float)value / 32768.0f;
+    }
+    free(bytes);
+    *sample_count = count;
+    return samples;
+}
+
+static int cn1w_reserve(char** buffer, size_t* capacity, size_t needed) {
+    char* next;
+    size_t cap = *capacity == 0 ? 256 : *capacity;
+    while (cap < needed) {
+        cap *= 2;
+    }
+    if (cap == *capacity) {
+        return 1;
+    }
+    next = (char*)realloc(*buffer, cap);
+    if (next == NULL) {
+        free(*buffer);
+        *buffer = NULL;
+        *capacity = 0;
+        return 0;
+    }
+    *buffer = next;
+    *capacity = cap;
+    return 1;
+}
+
+static int cn1w_append(char** buffer, size_t* length, size_t* capacity, const char* text) {
+    size_t n = text == NULL ? 0 : strlen(text);
+    if (!cn1w_reserve(buffer, capacity, *length + n + 1)) {
+        return 0;
+    }
+    if (n > 0) {
+        memcpy(*buffer + *length, text, n);
+        *length += n;
+    }
+    (*buffer)[*length] = 0;
+    return 1;
+}
+
+static int cn1w_append_escaped(char** buffer, size_t* length, size_t* capacity, const char* text) {
+    const unsigned char* p = (const unsigned char*)(text == NULL ? "" : text);
+    while (*p != 0) {
+        char ch = (char)*p++;
+        const char* replacement = NULL;
+        if (ch == '\\') {
+            replacement = "\\\\";
+        } else if (ch == '\t') {
+            replacement = "\\t";
+        } else if (ch == '\n') {
+            replacement = "\\n";
+        } else if (ch == '\r') {
+            replacement = "\\r";
+        }
+        if (replacement != NULL) {
+            if (!cn1w_append(buffer, length, capacity, replacement)) {
+                return 0;
+            }
+        } else {
+            if (!cn1w_reserve(buffer, capacity, *length + 2)) {
+                return 0;
+            }
+            (*buffer)[(*length)++] = ch;
+            (*buffer)[*length] = 0;
+        }
+    }
+    return 1;
+}
+
+static struct whisper_context* cn1w_run(const char* model_path, const char* audio_path) {
+    int sample_count = 0;
+    float* samples;
+    struct whisper_context* ctx;
+    struct whisper_full_params params;
+    if (!cn1w_load_whisper()) {
+        return NULL;
+    }
+    samples = cn1w_read_wav16(audio_path, &sample_count);
+    if (samples == NULL || sample_count <= 0) {
+        free(samples);
+        return NULL;
+    }
+    ctx = cn1_whisper_init_from_file(model_path);
+    if (ctx == NULL) {
+        free(samples);
+        return NULL;
+    }
+    memset(&params, 0, sizeof(params));
+    params.n_threads = 4;
+    if (cn1_whisper_full(ctx, params, samples, sample_count) != 0) {
+        cn1_whisper_free(ctx);
+        free(samples);
+        return NULL;
+    }
+    free(samples);
+    return ctx;
+}
+
+JAVA_BOOLEAN com_codename1_ai_whisper_NativeWhisperRecognizerImplCodenameOne_isSupported___R_boolean(CODENAME_ONE_THREAD_STATE) {
+    return cn1w_load_whisper() ? JAVA_TRUE : JAVA_FALSE;
+}
+
+JAVA_OBJECT com_codename1_ai_whisper_NativeWhisperRecognizerImplCodenameOne_transcribe___java_lang_String_java_lang_String_R_java_lang_String(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT param1, JAVA_OBJECT param2) {
+    char* model_path = param1 == JAVA_NULL ? NULL : cn1w_strdup(stringToUTF8(threadStateData, param1));
+    char* audio_path = param2 == JAVA_NULL ? NULL : cn1w_strdup(stringToUTF8(threadStateData, param2));
+    struct whisper_context* ctx = cn1w_run(model_path, audio_path);
+    char* buffer = NULL;
+    size_t length = 0;
+    size_t capacity = 0;
+    int i;
+    int n;
+    JAVA_OBJECT result;
+    if (ctx == NULL) {
+        free(model_path);
+        free(audio_path);
+        return newStringFromCString(threadStateData, "");
+    }
+    n = cn1_whisper_full_n_segments(ctx);
+    for (i = 0; i < n; i++) {
+        cn1w_append(&buffer, &length, &capacity, cn1_whisper_full_get_segment_text(ctx, i));
+    }
+    result = newStringFromCString(threadStateData, buffer == NULL ? "" : buffer);
+    free(buffer);
+    cn1_whisper_free(ctx);
+    free(model_path);
+    free(audio_path);
+    return result;
+}
+
+JAVA_OBJECT com_codename1_ai_whisper_NativeWhisperRecognizerImplCodenameOne_transcribeSegments___java_lang_String_java_lang_String_R_java_lang_String(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT param1, JAVA_OBJECT param2) {
+    char* model_path = param1 == JAVA_NULL ? NULL : cn1w_strdup(stringToUTF8(threadStateData, param1));
+    char* audio_path = param2 == JAVA_NULL ? NULL : cn1w_strdup(stringToUTF8(threadStateData, param2));
+    struct whisper_context* ctx = cn1w_run(model_path, audio_path);
+    char* buffer = NULL;
+    size_t length = 0;
+    size_t capacity = 0;
+    int i;
+    int n;
+    JAVA_OBJECT result;
+    if (ctx == NULL) {
+        free(model_path);
+        free(audio_path);
+        return newStringFromCString(threadStateData, "");
+    }
+    n = cn1_whisper_full_n_segments(ctx);
+    for (i = 0; i < n; i++) {
+        char line[64];
+        long long start_ms = (long long)cn1_whisper_full_get_segment_t0(ctx, i) * 10LL;
+        long long end_ms = (long long)cn1_whisper_full_get_segment_t1(ctx, i) * 10LL;
+        snprintf(line, sizeof(line), "%lld\t%lld\t", start_ms, end_ms);
+        cn1w_append(&buffer, &length, &capacity, line);
+        cn1w_append_escaped(&buffer, &length, &capacity, cn1_whisper_full_get_segment_text(ctx, i));
+        cn1w_append(&buffer, &length, &capacity, "\n");
+    }
+    result = newStringFromCString(threadStateData, buffer == NULL ? "" : buffer);
+    free(buffer);
+    cn1_whisper_free(ctx);
+    free(model_path);
+    free(audio_path);
+    return result;
+}

--- a/maven/cn1-ai-whisper/pom.xml
+++ b/maven/cn1-ai-whisper/pom.xml
@@ -28,6 +28,8 @@
         <module>android</module>
         <module>javase</module>
         <module>javascript</module>
+        <module>linux</module>
+        <module>win</module>
         <module>lib</module>
     </modules>
 </project>

--- a/maven/cn1-ai-whisper/win/pom.xml
+++ b/maven/cn1-ai-whisper/win/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.codenameone</groupId>
+        <artifactId>cn1-ai-whisper</artifactId>
+        <version>8.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>cn1-ai-whisper-win</artifactId>
+    <packaging>jar</packaging>
+    <name>Codename One AI: cn1-ai-whisper-win</name>
+
+    <build>
+        <sourceDirectory>src/main/dummy</sourceDirectory>
+        <resources>
+            <resource><directory>src/main/c</directory></resource>
+            <resource><directory>src/main/resources</directory></resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <configuration>
+                            <target>
+                                <delete file="${project.build.directory}/${project.build.finalName}.jar" />
+                                <mkdir dir="${basedir}/src/main/c"/>
+                                <jar destfile="${project.build.directory}/${project.build.finalName}.jar" compress="true">
+                                    <fileset dir="${basedir}/src/main/c" erroronmissingdir="false" />
+                                    <fileset dir="${basedir}/src/main/resources" erroronmissingdir="false" />
+                                </jar>
+                            </target>
+                        </configuration>
+                        <goals><goal>run</goal></goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.codenameone</groupId>
+            <artifactId>cn1-ai-whisper-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/maven/cn1-ai-whisper/win/src/main/c/com/codename1/ai/whisper/NativeWhisperRecognizerImplCodenameOne.c
+++ b/maven/cn1-ai-whisper/win/src/main/c/com/codename1/ai/whisper/NativeWhisperRecognizerImplCodenameOne.c
@@ -1,0 +1,324 @@
+#include "cn1_globals.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
+
+struct whisper_context;
+
+struct whisper_full_params {
+    int strategy;
+    int n_threads;
+    int n_max_text_ctx;
+    int offset_ms;
+    int duration_ms;
+    int translate;
+    int no_context;
+    int single_segment;
+    int print_special;
+    int print_progress;
+    int print_realtime;
+    int print_timestamps;
+};
+
+extern const char* stringToUTF8(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT str);
+extern JAVA_OBJECT newStringFromCString(CODENAME_ONE_THREAD_STATE, const char *str);
+
+typedef struct whisper_context* (*cn1_whisper_init_from_file_fn)(const char*);
+typedef int (*cn1_whisper_full_fn)(struct whisper_context*, struct whisper_full_params, const float*, int);
+typedef int (*cn1_whisper_full_n_segments_fn)(struct whisper_context*);
+typedef const char* (*cn1_whisper_full_get_segment_text_fn)(struct whisper_context*, int);
+typedef int64_t (*cn1_whisper_full_get_segment_t_fn)(struct whisper_context*, int);
+typedef void (*cn1_whisper_free_fn)(struct whisper_context*);
+
+static cn1_whisper_init_from_file_fn cn1_whisper_init_from_file;
+static cn1_whisper_full_fn cn1_whisper_full;
+static cn1_whisper_full_n_segments_fn cn1_whisper_full_n_segments;
+static cn1_whisper_full_get_segment_text_fn cn1_whisper_full_get_segment_text;
+static cn1_whisper_full_get_segment_t_fn cn1_whisper_full_get_segment_t0;
+static cn1_whisper_full_get_segment_t_fn cn1_whisper_full_get_segment_t1;
+static cn1_whisper_free_fn cn1_whisper_free;
+static int cn1_whisper_load_attempted;
+static int cn1_whisper_loaded;
+
+static void* cn1w_symbol(void* lib, const char* name) {
+#ifdef _WIN32
+    return (void*)GetProcAddress((HMODULE)lib, name);
+#else
+    return dlsym(lib, name);
+#endif
+}
+
+static void* cn1w_open_library() {
+#ifdef _WIN32
+    void* lib = (void*)LoadLibraryA("whisper.dll");
+    if (lib == NULL) {
+        lib = (void*)LoadLibraryA("libwhisper.dll");
+    }
+    return lib;
+#else
+    void* lib = dlopen("libwhisper.so", RTLD_NOW | RTLD_LOCAL);
+    if (lib == NULL) {
+        lib = dlopen("./libwhisper.so", RTLD_NOW | RTLD_LOCAL);
+    }
+    return lib;
+#endif
+}
+
+static int cn1w_load_whisper() {
+    void* lib;
+    if (cn1_whisper_load_attempted) {
+        return cn1_whisper_loaded;
+    }
+    cn1_whisper_load_attempted = 1;
+    lib = cn1w_open_library();
+    if (lib == NULL) {
+        return 0;
+    }
+    cn1_whisper_init_from_file = (cn1_whisper_init_from_file_fn)cn1w_symbol(lib, "whisper_init_from_file");
+    cn1_whisper_full = (cn1_whisper_full_fn)cn1w_symbol(lib, "whisper_full");
+    cn1_whisper_full_n_segments = (cn1_whisper_full_n_segments_fn)cn1w_symbol(lib, "whisper_full_n_segments");
+    cn1_whisper_full_get_segment_text = (cn1_whisper_full_get_segment_text_fn)cn1w_symbol(lib, "whisper_full_get_segment_text");
+    cn1_whisper_full_get_segment_t0 = (cn1_whisper_full_get_segment_t_fn)cn1w_symbol(lib, "whisper_full_get_segment_t0");
+    cn1_whisper_full_get_segment_t1 = (cn1_whisper_full_get_segment_t_fn)cn1w_symbol(lib, "whisper_full_get_segment_t1");
+    cn1_whisper_free = (cn1_whisper_free_fn)cn1w_symbol(lib, "whisper_free");
+    cn1_whisper_loaded = cn1_whisper_init_from_file != NULL
+            && cn1_whisper_full != NULL
+            && cn1_whisper_full_n_segments != NULL
+            && cn1_whisper_full_get_segment_text != NULL
+            && cn1_whisper_full_get_segment_t0 != NULL
+            && cn1_whisper_full_get_segment_t1 != NULL
+            && cn1_whisper_free != NULL;
+    return cn1_whisper_loaded;
+}
+
+static char* cn1w_strdup(const char* text) {
+    size_t len;
+    char* out;
+    if (text == NULL) {
+        return NULL;
+    }
+    len = strlen(text);
+    out = (char*)malloc(len + 1);
+    if (out != NULL) {
+        memcpy(out, text, len + 1);
+    }
+    return out;
+}
+
+static float* cn1w_read_wav16(const char* path, int* sample_count) {
+    FILE* f;
+    long size;
+    unsigned char* bytes;
+    int count;
+    float* samples;
+    int i;
+    *sample_count = 0;
+    if (path == NULL) {
+        return NULL;
+    }
+    f = fopen(path, "rb");
+    if (f == NULL) {
+        return NULL;
+    }
+    if (fseek(f, 0, SEEK_END) != 0) {
+        fclose(f);
+        return NULL;
+    }
+    size = ftell(f);
+    if (size < 44) {
+        fclose(f);
+        return NULL;
+    }
+    if (fseek(f, 44, SEEK_SET) != 0) {
+        fclose(f);
+        return NULL;
+    }
+    bytes = (unsigned char*)malloc((size_t)(size - 44));
+    if (bytes == NULL) {
+        fclose(f);
+        return NULL;
+    }
+    if (fread(bytes, 1, (size_t)(size - 44), f) != (size_t)(size - 44)) {
+        free(bytes);
+        fclose(f);
+        return NULL;
+    }
+    fclose(f);
+    count = (int)((size - 44) / 2);
+    samples = (float*)malloc(sizeof(float) * (size_t)count);
+    if (samples == NULL) {
+        free(bytes);
+        return NULL;
+    }
+    for (i = 0; i < count; i++) {
+        int16_t value = (int16_t)((uint16_t)bytes[i * 2] | ((uint16_t)bytes[i * 2 + 1] << 8));
+        samples[i] = (float)value / 32768.0f;
+    }
+    free(bytes);
+    *sample_count = count;
+    return samples;
+}
+
+static int cn1w_reserve(char** buffer, size_t* capacity, size_t needed) {
+    char* next;
+    size_t cap = *capacity == 0 ? 256 : *capacity;
+    while (cap < needed) {
+        cap *= 2;
+    }
+    if (cap == *capacity) {
+        return 1;
+    }
+    next = (char*)realloc(*buffer, cap);
+    if (next == NULL) {
+        free(*buffer);
+        *buffer = NULL;
+        *capacity = 0;
+        return 0;
+    }
+    *buffer = next;
+    *capacity = cap;
+    return 1;
+}
+
+static int cn1w_append(char** buffer, size_t* length, size_t* capacity, const char* text) {
+    size_t n = text == NULL ? 0 : strlen(text);
+    if (!cn1w_reserve(buffer, capacity, *length + n + 1)) {
+        return 0;
+    }
+    if (n > 0) {
+        memcpy(*buffer + *length, text, n);
+        *length += n;
+    }
+    (*buffer)[*length] = 0;
+    return 1;
+}
+
+static int cn1w_append_escaped(char** buffer, size_t* length, size_t* capacity, const char* text) {
+    const unsigned char* p = (const unsigned char*)(text == NULL ? "" : text);
+    while (*p != 0) {
+        char ch = (char)*p++;
+        const char* replacement = NULL;
+        if (ch == '\\') {
+            replacement = "\\\\";
+        } else if (ch == '\t') {
+            replacement = "\\t";
+        } else if (ch == '\n') {
+            replacement = "\\n";
+        } else if (ch == '\r') {
+            replacement = "\\r";
+        }
+        if (replacement != NULL) {
+            if (!cn1w_append(buffer, length, capacity, replacement)) {
+                return 0;
+            }
+        } else {
+            if (!cn1w_reserve(buffer, capacity, *length + 2)) {
+                return 0;
+            }
+            (*buffer)[(*length)++] = ch;
+            (*buffer)[*length] = 0;
+        }
+    }
+    return 1;
+}
+
+static struct whisper_context* cn1w_run(const char* model_path, const char* audio_path) {
+    int sample_count = 0;
+    float* samples;
+    struct whisper_context* ctx;
+    struct whisper_full_params params;
+    if (!cn1w_load_whisper()) {
+        return NULL;
+    }
+    samples = cn1w_read_wav16(audio_path, &sample_count);
+    if (samples == NULL || sample_count <= 0) {
+        free(samples);
+        return NULL;
+    }
+    ctx = cn1_whisper_init_from_file(model_path);
+    if (ctx == NULL) {
+        free(samples);
+        return NULL;
+    }
+    memset(&params, 0, sizeof(params));
+    params.n_threads = 4;
+    if (cn1_whisper_full(ctx, params, samples, sample_count) != 0) {
+        cn1_whisper_free(ctx);
+        free(samples);
+        return NULL;
+    }
+    free(samples);
+    return ctx;
+}
+
+JAVA_BOOLEAN com_codename1_ai_whisper_NativeWhisperRecognizerImplCodenameOne_isSupported___R_boolean(CODENAME_ONE_THREAD_STATE) {
+    return cn1w_load_whisper() ? JAVA_TRUE : JAVA_FALSE;
+}
+
+JAVA_OBJECT com_codename1_ai_whisper_NativeWhisperRecognizerImplCodenameOne_transcribe___java_lang_String_java_lang_String_R_java_lang_String(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT param1, JAVA_OBJECT param2) {
+    char* model_path = param1 == JAVA_NULL ? NULL : cn1w_strdup(stringToUTF8(threadStateData, param1));
+    char* audio_path = param2 == JAVA_NULL ? NULL : cn1w_strdup(stringToUTF8(threadStateData, param2));
+    struct whisper_context* ctx = cn1w_run(model_path, audio_path);
+    char* buffer = NULL;
+    size_t length = 0;
+    size_t capacity = 0;
+    int i;
+    int n;
+    JAVA_OBJECT result;
+    if (ctx == NULL) {
+        free(model_path);
+        free(audio_path);
+        return newStringFromCString(threadStateData, "");
+    }
+    n = cn1_whisper_full_n_segments(ctx);
+    for (i = 0; i < n; i++) {
+        cn1w_append(&buffer, &length, &capacity, cn1_whisper_full_get_segment_text(ctx, i));
+    }
+    result = newStringFromCString(threadStateData, buffer == NULL ? "" : buffer);
+    free(buffer);
+    cn1_whisper_free(ctx);
+    free(model_path);
+    free(audio_path);
+    return result;
+}
+
+JAVA_OBJECT com_codename1_ai_whisper_NativeWhisperRecognizerImplCodenameOne_transcribeSegments___java_lang_String_java_lang_String_R_java_lang_String(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT param1, JAVA_OBJECT param2) {
+    char* model_path = param1 == JAVA_NULL ? NULL : cn1w_strdup(stringToUTF8(threadStateData, param1));
+    char* audio_path = param2 == JAVA_NULL ? NULL : cn1w_strdup(stringToUTF8(threadStateData, param2));
+    struct whisper_context* ctx = cn1w_run(model_path, audio_path);
+    char* buffer = NULL;
+    size_t length = 0;
+    size_t capacity = 0;
+    int i;
+    int n;
+    JAVA_OBJECT result;
+    if (ctx == NULL) {
+        free(model_path);
+        free(audio_path);
+        return newStringFromCString(threadStateData, "");
+    }
+    n = cn1_whisper_full_n_segments(ctx);
+    for (i = 0; i < n; i++) {
+        char line[64];
+        long long start_ms = (long long)cn1_whisper_full_get_segment_t0(ctx, i) * 10LL;
+        long long end_ms = (long long)cn1_whisper_full_get_segment_t1(ctx, i) * 10LL;
+        snprintf(line, sizeof(line), "%lld\t%lld\t", start_ms, end_ms);
+        cn1w_append(&buffer, &length, &capacity, line);
+        cn1w_append_escaped(&buffer, &length, &capacity, cn1_whisper_full_get_segment_text(ctx, i));
+        cn1w_append(&buffer, &length, &capacity, "\n");
+    }
+    result = newStringFromCString(threadStateData, buffer == NULL ? "" : buffer);
+    free(buffer);
+    cn1_whisper_free(ctx);
+    free(model_path);
+    free(audio_path);
+    return result;
+}

--- a/maven/cn1lib-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/maven/cn1lib-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -120,6 +120,17 @@
         </fileSet>
       </fileSets>
     </module>
+    <module id="${rootArtifactId}-linux" dir="linux" name="${rootArtifactId}-linux">
+      <fileSets>
+        <fileSet filtered="true" packaged="true" encoding="UTF-8">
+          <directory>src/main/c</directory>
+          <includes>
+            <include>**/*.c</include>
+            <include>**/*.h</include>
+          </includes>
+        </fileSet>
+      </fileSets>
+    </module>
     <module id="${rootArtifactId}-android" dir="android" name="${rootArtifactId}-android">
       <fileSets>
         <fileSet filtered="true" packaged="true" encoding="UTF-8">

--- a/maven/cn1lib-archetype/src/main/resources/archetype-resources/lib/pom.xml
+++ b/maven/cn1lib-archetype/src/main/resources/archetype-resources/lib/pom.xml
@@ -102,6 +102,22 @@
           </dependencies>
       </profile>
       <profile>
+          <id>linux</id>
+          <activation>
+              <property>
+                  <name>codename1.platform</name>
+                  <value>linux</value>
+              </property>
+          </activation>
+          <dependencies>
+              <dependency>
+                  <groupId>${project.groupId}</groupId>
+                  <artifactId>${cn1lib.name}-linux</artifactId>
+                  <version>${project.version}</version>
+              </dependency>
+          </dependencies>
+      </profile>
+      <profile>
           <id>android</id>
           <activation>
               <property>

--- a/maven/cn1lib-archetype/src/main/resources/archetype-resources/linux/pom.xml
+++ b/maven/cn1lib-archetype/src/main/resources/archetype-resources/linux/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+      <groupId>${groupId}</groupId>
+      <artifactId>${rootArtifactId}</artifactId>
+      <version>${version}</version>
+  </parent>
+  <groupId>${groupId}</groupId>
+  <artifactId>${artifactId}</artifactId>
+  <version>${version}</version>
+
+  <name>${artifactId}</name>
+  <build>
+          <resources>
+              <resource>
+                  <directory>src/main/c</directory>
+              </resource>
+              <resource>
+                  <directory>src/main/resources</directory>
+              </resource>
+          </resources>
+      </build>
+
+  <dependencies>
+      <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>${cn1lib.name}-common</artifactId>
+          <version>${project.version}</version>
+      </dependency>
+  </dependencies>
+
+  
+</project>

--- a/maven/cn1lib-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/maven/cn1lib-archetype/src/main/resources/archetype-resources/pom.xml
@@ -69,6 +69,7 @@
         <module>javascript</module>
         <module>javase</module>
         <module>win</module>
+        <module>linux</module>
         <module>lib</module>
     </modules>
     <dependencyManagement>

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/Cn1libInstaller.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/Cn1libInstaller.java
@@ -397,6 +397,15 @@ public class Cn1libInstaller {
                 throw new MojoExecutionException("Failed to copy "+winJar+" to "+cn1libJars, ex);
             }
         }
+
+        File linuxJar = new File(libOutputJars, "nativelinux.zip");
+        if (linuxJar.exists()) {
+            try {
+                FileUtils.copyFile(linuxJar, new File(cn1libJars, linuxJar.getName()));
+            } catch (IOException ex) {
+                throw new MojoExecutionException("Failed to copy "+linuxJar+" to "+cn1libJars, ex);
+            }
+        }
         
         
         File cssJar = new File(libOutputJars, "css.zip");

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/Cn1libMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/Cn1libMojo.java
@@ -305,6 +305,17 @@ public final class Cn1libMojo extends AbstractCN1Mojo {
         buildZip("nativewin", getWinPaths());
     }
 
+    private File[] getLinuxPaths() {
+        return new File[]{
+                new File(getModuleProject("linux"), path("src", "main", "c")),
+                new File(getModuleProject("linux"), path("src", "main", "resources"))
+        };
+    }
+
+    private void buildLinux() {
+        buildZip("nativelinux", getLinuxPaths());
+    }
+
 
     private File[] getCSSPaths() {
         return new File[]{
@@ -327,6 +338,7 @@ public final class Cn1libMojo extends AbstractCN1Mojo {
         buildJavase();
         buildStubs();
         buildWin();
+        buildLinux();
 
         Zip zip = (Zip)antProject.createTask("zip");
         zip.setDestFile(getFinalCn1lib());

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/GenerateAppProjectMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/GenerateAppProjectMojo.java
@@ -153,6 +153,10 @@ public class GenerateAppProjectMojo extends AbstractMojo {
         return new File(targetProjectDir(), "win");
     }
 
+    private File targetLinuxDir() {
+        return new File(targetProjectDir(), "linux");
+    }
+
     private File targetSrcDir() {
         return new File(targetCommonDir(), "src");
     }
@@ -395,6 +399,39 @@ public class GenerateAppProjectMojo extends AbstractMojo {
                 // port is retired, so never carry .cs sources over into the
                 // migrated project (not even as stray resources).
                 files.setExcludes("**/*.c, *.c, **/*.h, *.h, **/*.cs, *.cs");
+                copy.addFileset(files);
+
+                copy.execute();
+            }
+
+        }
+    }
+
+    private void copyLinuxFiles() {
+        if (sourceNativeDir("linux").exists()) {
+            File srcDir = new File(targetLinuxDir(), path("src", "main", "c"));
+            File resDir = new File(targetLinuxDir(), path("src", "main", "resources"));
+            {
+                Copy copy = (Copy) antProject().createTask("copy");
+                copy.setTodir(srcDir);
+                copy.setOverwrite(true);
+                FileSet files = new FileSet();
+                files.setProject(antProject());
+                files.setDir(sourceNativeDir("linux"));
+                files.setIncludes("**/*.c, *.c, **/*.h, *.h");
+                copy.addFileset(files);
+
+                copy.execute();
+            }
+
+            {
+                Copy copy = (Copy) antProject().createTask("copy");
+                copy.setTodir(resDir);
+                copy.setOverwrite(true);
+                FileSet files = new FileSet();
+                files.setProject(antProject());
+                files.setDir(sourceNativeDir("linux"));
+                files.setExcludes("**/*.c, *.c, **/*.h, *.h");
                 copy.addFileset(files);
 
                 copy.execute();
@@ -897,6 +934,7 @@ public class GenerateAppProjectMojo extends AbstractMojo {
                 copyIosFiles();
                 copyJavascriptFiles();
                 copyWinFiles();
+                copyLinuxFiles();
                 copyJavaseFiles();
                 copyCSSFiles();
                 copyCn1libs();

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/GenerateCn1libProjectMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/GenerateCn1libProjectMojo.java
@@ -131,6 +131,10 @@ public class GenerateCn1libProjectMojo extends AbstractMojo {
         return new File(targetProjectDir(), "win");
     }
 
+    private File targetLinuxDir() {
+        return new File(targetProjectDir(), "linux");
+    }
+
     private File targetSrcDir() {
         return new File(targetCommonDir(), "src");
     }
@@ -315,6 +319,39 @@ public class GenerateCn1libProjectMojo extends AbstractMojo {
         }
     }
 
+    private void copyLinuxFiles() {
+        if (sourceNativeDir("linux").exists()) {
+            File srcDir = new File(targetLinuxDir(), path("src", "main", "c"));
+            File resDir = new File(targetLinuxDir(), path("src", "main", "resources"));
+            {
+                Copy copy = (Copy) antProject().createTask("copy");
+                copy.setTodir(srcDir);
+
+                FileSet files = new FileSet();
+                files.setProject(antProject());
+                files.setDir(sourceNativeDir("linux"));
+                files.setIncludes("**/*.c, *.c, **/*.h, *.h");
+                copy.addFileset(files);
+
+                copy.execute();
+            }
+
+            {
+                Copy copy = (Copy) antProject().createTask("copy");
+                copy.setTodir(resDir);
+
+                FileSet files = new FileSet();
+                files.setProject(antProject());
+                files.setDir(sourceNativeDir("linux"));
+                files.setExcludes("**/*.c, *.c, **/*.h, *.h");
+                copy.addFileset(files);
+
+                copy.execute();
+            }
+
+        }
+    }
+
     private File sourceCSSDir() {
         return new File(sourceProject, "css");
     }
@@ -450,6 +487,7 @@ public class GenerateCn1libProjectMojo extends AbstractMojo {
             copyIosFiles();
             copyJavascriptFiles();
             copyWinFiles();
+            copyLinuxFiles();
             copyJavaseFiles();
             copyCSSFiles();
 

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/Cn1libArchetypeTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/Cn1libArchetypeTest.java
@@ -1,0 +1,36 @@
+package com.codename1.maven;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class Cn1libArchetypeTest {
+
+    @Test
+    void linuxModuleIsPartOfCn1libArchetypeAndPlatformSelector() throws Exception {
+        String metadata = archetypeResource("META-INF/maven/archetype-metadata.xml");
+        assertTrue(metadata.contains("dir=\"linux\""), metadata);
+        assertTrue(metadata.contains("<directory>src/main/c</directory>"), metadata);
+
+        String rootPom = archetypeResource("archetype-resources/pom.xml");
+        assertTrue(rootPom.contains("<module>linux</module>"), rootPom);
+
+        String libPom = archetypeResource("archetype-resources/lib/pom.xml");
+        assertTrue(libPom.contains("<id>linux</id>"), libPom);
+        assertTrue(libPom.contains("<artifactId>${cn1lib.name}-linux</artifactId>"), libPom);
+
+        String linuxPom = archetypeResource("archetype-resources/linux/pom.xml");
+        assertTrue(linuxPom.contains("<directory>src/main/c</directory>"), linuxPom);
+        assertTrue(linuxPom.contains("<directory>src/main/resources</directory>"), linuxPom);
+    }
+
+    private static String archetypeResource(String path) throws Exception {
+        File file = new File("../cn1lib-archetype/src/main/resources", path);
+        assertTrue(file.isFile(), "Missing archetype resource " + file.getAbsolutePath());
+        return new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+    }
+}

--- a/maven/core-unittests/src/test/java/com/codename1/media/RecognitionOptionsTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/media/RecognitionOptionsTest.java
@@ -60,4 +60,17 @@ class RecognitionOptionsTest {
         assertEquals(1, new RecognitionOptions().setMaxResults(0).getMaxResults());
         assertEquals(1, new RecognitionOptions().setMaxResults(-3).getMaxResults());
     }
+
+    @Test
+    void timestampCallbacksForwardToStringCallbacksByDefault() {
+        final String[] transcript = new String[1];
+        TimedRecognitionCallback callback = new TimedRecognitionCallback.Adapter() {
+            @Override
+            public void onResult(String t, float c, String[] a) {
+                transcript[0] = t;
+            }
+        };
+        callback.onResult(TranscriptionResult.textOnly("caption text"), -1, new String[0]);
+        assertEquals("caption text", transcript[0]);
+    }
 }

--- a/maven/core-unittests/src/test/java/com/codename1/media/TranscriptionRequestTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/media/TranscriptionRequestTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.media;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TranscriptionRequestTest {
+
+    @Test
+    void defaultsAndSettersRoundTrip() {
+        TranscriptionRequest request = TranscriptionRequest.file("audio.wav");
+        assertEquals("audio.wav", request.getAudioPath());
+        assertEquals("en-US", request.getLanguageTag());
+        assertNull(request.getPrompt());
+
+        assertSame(request, request.setLanguageTag("fr-CA"));
+        assertSame(request, request.setPrompt("names: Codename One"));
+        assertSame(request, request.setOption("temperature", "0"));
+
+        assertEquals("fr-CA", request.getLanguageTag());
+        assertEquals("names: Codename One", request.getPrompt());
+        assertEquals("0", request.getOption("temperature"));
+        assertEquals("0", request.getOptions().get("temperature"));
+    }
+
+    @Test
+    void requiredFieldsAreValidated() {
+        assertThrows(IllegalArgumentException.class, new org.junit.jupiter.api.function.Executable() {
+            public void execute() {
+                new TranscriptionRequest(null);
+            }
+        });
+        assertThrows(IllegalArgumentException.class, new org.junit.jupiter.api.function.Executable() {
+            public void execute() {
+                new TranscriptionRequest("");
+            }
+        });
+        assertThrows(IllegalArgumentException.class, new org.junit.jupiter.api.function.Executable() {
+            public void execute() {
+                TranscriptionRequest.file("a.wav").setOption("", "x");
+            }
+        });
+    }
+}

--- a/maven/core-unittests/src/test/java/com/codename1/media/TranscriptionResultTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/media/TranscriptionResultTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.media;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TranscriptionResultTest {
+
+    @Test
+    void segmentsBuildPlainTextAndCaptions() {
+        List<TranscriptionSegment> segments = new ArrayList<TranscriptionSegment>();
+        segments.add(new TranscriptionSegment(0, 1250, "Hello "));
+        segments.add(new TranscriptionSegment(61234, 65432, "world"));
+
+        TranscriptionResult result = new TranscriptionResult(segments);
+
+        assertEquals("Hello world", result.getText());
+        assertEquals(2, result.getSegments().size());
+        assertTrue(result.toSrt().contains("1\n00:00:00,000 --> 00:00:01,250\nHello"));
+        assertTrue(result.toSrt().contains("00:01:01,234 --> 00:01:05,432"));
+        assertTrue(result.toVtt().startsWith("WEBVTT\n\n"));
+        assertTrue(result.toVtt().contains("00:01:01.234 --> 00:01:05.432"));
+    }
+
+    @Test
+    void textOnlyKeepsCompatibilityTranscript() {
+        TranscriptionResult result = TranscriptionResult.textOnly("plain text");
+        assertEquals("plain text", result.getText());
+        assertEquals(1, result.getSegments().size());
+        assertEquals(0, result.getSegments().get(0).getStartTimeMs());
+        assertEquals(0, result.getSegments().get(0).getEndTimeMs());
+    }
+
+    @Test
+    void invalidSegmentTimesAreRejected() {
+        assertThrows(IllegalArgumentException.class, new org.junit.jupiter.api.function.Executable() {
+            public void execute() {
+                new TranscriptionSegment(-1, 10, "x");
+            }
+        });
+        assertThrows(IllegalArgumentException.class, new org.junit.jupiter.api.function.Executable() {
+            public void execute() {
+                new TranscriptionSegment(20, 10, "x");
+            }
+        });
+    }
+}

--- a/scripts/gen-ai-cn1libs.py
+++ b/scripts/gen-ai-cn1libs.py
@@ -14,6 +14,7 @@ import pathlib
 import shutil
 import textwrap
 from dataclasses import dataclass
+from typing import Dict, Tuple
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 MAVEN = ROOT / "maven"
@@ -2626,8 +2627,62 @@ def write(path: pathlib.Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
 
 
+WHISPER_OVERLAY_PATHS = (
+    "pom.xml",
+    "lib/pom.xml",
+    "android/pom.xml",
+    "android/src/main/java/com/codename1/ai/whisper/NativeWhisperRecognizerImpl.java",
+    "android/src/main/resources/cn1-ai-whisper-android.aar",
+    "android-aar/.gitignore",
+    "android-aar/README.md",
+    "android-aar/build-aar.sh",
+    "android-aar/build.gradle",
+    "android-aar/settings.gradle",
+    "android-aar/cn1-ai-whisper-android/build.gradle",
+    "android-aar/cn1-ai-whisper-android/src/main/AndroidManifest.xml",
+    "android-aar/cn1-ai-whisper-android/src/main/cpp/CMakeLists.txt",
+    "android-aar/cn1-ai-whisper-android/src/main/cpp/native_whisper_jni.cpp",
+    "common/src/main/java/com/codename1/ai/whisper/NativeWhisperRecognizer.java",
+    "common/src/main/java/com/codename1/ai/whisper/WhisperRecognizer.java",
+    "common/src/test/java/com/codename1/ai/whisper/AndroidWhisperAarProjectTest.java",
+    "common/src/test/java/com/codename1/ai/whisper/WhisperRecognizerTest.java",
+    "ios/src/main/objectivec/com_codename1_ai_whisper_NativeWhisperRecognizerImpl.h",
+    "ios/src/main/objectivec/com_codename1_ai_whisper_NativeWhisperRecognizerImpl.m",
+    "javascript/src/main/javascript/com_codename1_ai_whisper_NativeWhisperRecognizer.js",
+    "javase/src/main/java/com/codename1/ai/whisper/NativeWhisperRecognizerImpl.java",
+    "linux/pom.xml",
+    "linux/src/main/c/com/codename1/ai/whisper/NativeWhisperRecognizerImplCodenameOne.c",
+    "win/pom.xml",
+    "win/src/main/c/com/codename1/ai/whisper/NativeWhisperRecognizerImplCodenameOne.c",
+)
+
+
+def snapshot_overlay(base: pathlib.Path, paths: tuple) -> Dict[str, Tuple[bytes, int]]:
+    overlay = {}
+    for rel in paths:
+        path = base / rel
+        if path.is_file():
+            overlay[rel] = (path.read_bytes(), path.stat().st_mode)
+    return overlay
+
+
+def restore_overlay(base: pathlib.Path, overlay: Dict[str, Tuple[bytes, int]]) -> None:
+    for rel, (content, mode) in overlay.items():
+        path = base / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content)
+        path.chmod(mode)
+
+
 def generate(lib: Lib) -> None:
     base = MAVEN / lib.artifact
+    overlay = {}
+    if lib.artifact == "cn1-ai-whisper":
+        # Whisper has hand-maintained native packaging beyond the standard
+        # ML facade shape: Android JNI/AAR, desktop C bridges, and timed
+        # transcription helpers. Preserve those checked-in files so this
+        # generator remains compatible with the PR CI drift check.
+        overlay = snapshot_overlay(base, WHISPER_OVERLAY_PATHS)
     if base.exists():
         shutil.rmtree(base)
 
@@ -2691,6 +2746,8 @@ def generate(lib: Lib) -> None:
           js_native(lib.pkg, lib.facade, lib.js_method_keys))
 
     # win/ module intentionally absent -- UWP is not a runtime target.
+    if overlay:
+        restore_overlay(base, overlay)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary

Adds a provider-pluggable transcription API that returns timed caption segments, and wires the Whisper cn1lib to expose whisper.cpp segment timestamps instead of returning text only.

This also adds native/platform coverage for the Whisper cn1lib: Android now ships a proper JNI AAR, iOS surfaces timed segments, JavaSE keeps a fallback segment, JavaScript remains explicitly unsupported, and Linux/win native C bridge modules are included in the cn1lib packaging flow.

## Root Cause

Whisper.cpp already emits segment timestamps, but the cn1lib only exposed a text transcription method. Android also had only a Java native shim and no actual JNI/AAR payload, so `isSupported()` could report true even when no native implementation was present.

## Changes

- Adds `Transcriber`, `TranscriptionRequest`, `TranscriptionResult`, and `TranscriptionSegment` APIs with SRT/VTT rendering.
- Extends `NativeWhisperRecognizer` and `WhisperRecognizer` with timed segment transcription.
- Adds Android JNI bridge source and a staged `cn1-ai-whisper-android.aar` containing `libcn1aiwhisper.so` for `armeabi-v7a`, `arm64-v8a`, `x86`, and `x86_64`.
- Updates Android packaging so the AAR is included in both the Android platform jar and legacy `nativeand.zip`.
- Adds Linux and win cn1lib module support and updates cn1lib archetype/migration packaging for Linux.
- Adds tests for transcription payloads, SRT/VTT formatting, Android AAR wiring, and cn1lib archetype Linux support.

## Validation

- `mvn -Dmaven.javadoc.skip=true package` in `maven/cn1-ai-whisper`
- Android AAR build with Android NDK/CMake against a temporary whisper.cpp checkout
- Verified the built AAR contains JNI slices for all four Android ABIs
- Verified `nativeand.zip` contains `cn1-ai-whisper-android.aar`
- Prior targeted core/plugin tests for transcription and cn1lib packaging passed during development

Runtime transcription on an Android device with a real model/audio sample was not exercised in this PR.