### PR TITLE
Update versioned build pricing tiers

### DIFF
--- a/docs/website/layouts/_default/pricing.html
+++ b/docs/website/layouts/_default/pricing.html
@@ -30,6 +30,7 @@
         <li>8.5 MB build JAR size</li>
         <li>Push notifications (1K/month)</li>
         <li>Unlimited local builds</li>
+        <li>Versioning (master only)</li>
         <li>Community support</li>
         <li>Royalty free</li>
         <li>Commerce IAP validation up to $200/mo</li>
@@ -48,6 +49,7 @@
         <li>Unlimited build credits</li>
         <li>Access to native sources</li>
         <li>50 MB build JAR size</li>
+        <li>Versioning (master + 2 weeks)</li>
         <li>Push notifications (5K/month)</li>
         <li>Commerce IAP validation up to $10K/mo</li>
       </ul>
@@ -71,7 +73,7 @@
       </header>
       <ul>
         <li>Everything in Basic</li>
-        <li>Versioning (2 months)</li>
+        <li>Versioning (master + 2 months)</li>
         <li>Crash reporting</li>
         <li>Native desktop apps</li>
         <li>Push notifications (1M/month)</li>
@@ -100,7 +102,7 @@
         <li>Everything in Pro</li>
         <li>JavaScript app generation</li>
         <li>High priority builds</li>
-        <li>Versioning (6 months)</li>
+        <li>Versioning (master + 6 months)</li>
         <li>Continuous integration</li>
         <li>On-device unit tests</li>
         <li>Push notifications (10M/month)</li>


### PR DESCRIPTION
## Summary

Updates the docs website pricing matrix to reflect the revised versioned-build policy:

- Free accounts can build against `master`.
- Basic accounts get `master` plus 2 weeks of versioned build history.
- Pro and Enterprise explicitly show `master` plus their existing longer history windows.

## Validation

- Documentation-only change; no site build was run.

## Notes

An unrelated untracked local directory remains excluded from this PR: `scripts/hellocodenameone/common/androidCerts/`.