### PR TITLE
Link CoreText in generated iOS projects

### DIFF
--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeTranslator.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeTranslator.java
@@ -638,6 +638,7 @@ public class ByteCodeTranslator {
         includeFrameworks.add("MessageUI.framework");
         includeFrameworks.add("MediaPlayer.framework");
         includeFrameworks.add("AVFoundation.framework");
+        includeFrameworks.add("CoreText.framework");
         includeFrameworks.add("CoreVideo.framework");
         includeFrameworks.add("QuickLook.framework");
         //includeFrameworks.add("iAd.framework");

--- a/vm/tests/src/test/java/com/codename1/tools/translator/BytecodeInstructionIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/BytecodeInstructionIntegrationTest.java
@@ -1027,6 +1027,10 @@ class BytecodeInstructionIntegrationTest {
             assertTrue(Files.exists(srcRoot.resolve("Images.xcassets")));
             assertTrue(Files.exists(dist.resolve("MyAppIOS.xcodeproj")));
             assertTrue(Files.exists(srcRoot.resolve("MyAppIOS-Info.plist")));
+            String pbxproj = new String(Files.readAllBytes(
+                    dist.resolve("MyAppIOS.xcodeproj/project.pbxproj")), StandardCharsets.UTF_8);
+            assertTrue(pbxproj.contains("CoreText.framework"),
+                    "iOS projects must link CoreText for IOSNative bundled font registration");
 
             // Verify bundle copied
             assertTrue(Files.exists(srcRoot.resolve("test.bundle")));


### PR DESCRIPTION
## Summary

Adds `CoreText.framework` to the baseline iOS framework list emitted by `ByteCodeTranslator`.

## Root Cause

The tvOS/watch font registration work added a core runtime call to `CTFontManagerRegisterFontsForURL` in `IOSNative.m`, but the generated iOS Xcode project did not link `CoreText.framework`. User iOS builds could therefore fail at link time with:

`Undefined symbols for architecture arm64: _CTFontManagerRegisterFontsForURL`

## Impact

Generated iOS projects now link the framework required by the core runtime font registration path. Apps no longer need to work around this by manually adding `CoreText.framework` to `ios.add_libs`.

## Validation

Ran:

```bash
mvn -pl tests -am '-Dtest=BytecodeInstructionIntegrationTest#handleIosOutputGeneratesProjectStructure' -Dsurefire.failIfNoSpecifiedTests=false test
```

Result: passing, 5 tests run, 0 failures.