### PR TITLE
Fix iOS floating toString termination

### DIFF
--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/Cn1ssDeviceRunner.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/Cn1ssDeviceRunner.java
@@ -316,6 +316,7 @@ public final class Cn1ssDeviceRunner extends DeviceRunner {
             new StringApiTest(),
             new TimeApiTest(),
             new NanoTimeApiTest(),
+            new FloatingToStringTest(),
             new MotionSensorDeviceTest(),
             new CryptoApiTest(),
             new Java17Tests(),

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/FloatingToStringTest.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/FloatingToStringTest.java
@@ -1,0 +1,66 @@
+package com.codenameone.examples.hellocodenameone.tests;
+
+import com.codename1.io.JSONParser;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Device-side guard for float/double string conversion in the platform runtime.
+ * iOS and other ParparVM targets use the native toStringImpl() path, while
+ * JavaSE/Android/JavaScript use their own runtime implementations.
+ */
+public class FloatingToStringTest extends BaseTest {
+
+    @Override
+    public boolean runTest() {
+        try {
+            check("double-min-scientific", Double.toString(10000000.0d), "1.0E7");
+            check("double-trimmed-scientific", Double.toString(12500000.0d), "1.25E7");
+            check("double-large-scientific", Double.toString(125000000.0d), "1.25E8");
+            check("float-min-scientific", Float.toString(10000000.0f), "1.0E7");
+            check("float-trimmed-scientific", Float.toString(12500000.0f), "1.25E7");
+            check("float-large-scientific", Float.toString(16777216.0f), "1.6777216E7");
+            check("string-valueOf-double", String.valueOf(12500000.0d), "1.25E7");
+            check("string-valueOf-float", String.valueOf(12500000.0f), "1.25E7");
+            check("concat-double", "balance=" + 12500000.0d, "balance=1.25E7");
+            check("builder-double", new StringBuilder().append(12500000.0d).toString(), "1.25E7");
+            check("buffer-float", new StringBuffer().append(12500000.0f).toString(), "1.25E7");
+            check("arrays-double", Arrays.toString(new double[]{12500000.0d}), "[1.25E7]");
+            check("arrays-float", Arrays.toString(new float[]{12500000.0f}), "[1.25E7]");
+
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            PrintStream ps = new PrintStream(out);
+            ps.print(12500000.0d);
+            ps.print('|');
+            ps.print(12500000.0f);
+            check("printstream", out.toString(), "1.25E7|1.25E7");
+
+            Map<String, Object> json = new HashMap<String, Object>();
+            json.put("balance", Double.valueOf(12500000.0d));
+            json.put("floatBalance", Float.valueOf(12500000.0f));
+            String jsonText = JSONParser.toJson(json);
+            assertTrue(jsonText.indexOf("\"balance\":1.25E7") >= 0,
+                    "JSON double should use terminated floating string, got " + jsonText);
+            assertTrue(jsonText.indexOf("\"floatBalance\":1.25E7") >= 0,
+                    "JSON float should use terminated floating string, got " + jsonText);
+        } catch (Throwable t) {
+            fail("Floating toString test failed: " + t);
+            return false;
+        }
+        done();
+        return true;
+    }
+
+    private void check(String name, String actual, String expected) {
+        assertEqual(expected, actual,
+                name + " expected=[" + expected + "] actual=[" + actual + "] len=" + actual.length());
+    }
+
+    @Override
+    public boolean shouldTakeScreenshot() {
+        return false;
+    }
+}

--- a/vm/ByteCodeTranslator/src/nativeMethods.m
+++ b/vm/ByteCodeTranslator/src/nativeMethods.m
@@ -942,12 +942,10 @@ JAVA_OBJECT java_lang_Double_toStringImpl___double_boolean_R_java_lang_String(CO
         }
     }
     i=0;
-    while (j-->0){
+    while (j-->0 && i < 31){
         s[i++]=s2[j];
-        if (s[i]=='\0'){
-            break;
-        }
     }
+    s[i]='\0';
     if (strcmp(s, "NAN") == 0) {
         s[1] = 'a';
     }
@@ -1004,12 +1002,10 @@ JAVA_OBJECT java_lang_Float_toStringImpl___float_boolean_R_java_lang_String(CODE
         }
     }
     i=0;
-    while (j-->0){
+    while (j-->0 && i < 31){
         s[i++]=s2[j];
-        if (s[i]=='\0'){
-            break;
-        }
     }
+    s[i]='\0';
     if (strcmp(s, "NAN") == 0) {
         s[1] = 'a';
     }

--- a/vm/tests/src/test/java/com/codename1/tools/translator/CleanTargetIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/CleanTargetIntegrationTest.java
@@ -105,6 +105,51 @@ class CleanTargetIntegrationTest {
 
     @ParameterizedTest
     @org.junit.jupiter.params.provider.MethodSource("com.codename1.tools.translator.BytecodeInstructionIntegrationTest#provideCompilerConfigs")
+    void scientificFloatToStringOutputIsTerminated(CompilerHelper.CompilerConfig config) throws Exception {
+        Parser.cleanup();
+
+        Path sourceDir = Files.createTempDirectory("float-string-sources");
+        Path classesDir = Files.createTempDirectory("float-string-classes");
+        Path javaApiDir = Files.createTempDirectory("float-string-java-api");
+        Files.write(sourceDir.resolve("FloatingToStringApp.java"),
+                floatingToStringSource().getBytes(StandardCharsets.UTF_8));
+
+        JavascriptTargetIntegrationTest.compileAgainstJavaApi(config, sourceDir, classesDir, javaApiDir);
+
+        Path outputDir = Files.createTempDirectory("float-string-output");
+        runTranslator(classesDir, outputDir, "FloatingToStringApp");
+
+        Path distDir = outputDir.resolve("dist");
+        Path cmakeLists = distDir.resolve("CMakeLists.txt");
+        assertTrue(Files.exists(cmakeLists), "Translator should emit a CMake project");
+
+        Path srcRoot = distDir.resolve("FloatingToStringApp-src");
+        replaceLibraryWithExecutableTarget(cmakeLists, srcRoot.getFileName().toString());
+
+        Path buildDir = distDir.resolve("build");
+        Files.createDirectories(buildDir);
+
+        List<String> configure = new java.util.ArrayList<>(Arrays.asList(
+                "cmake",
+                "-S", distDir.toString(),
+                "-B", buildDir.toString(),
+                "-DCMAKE_BUILD_TYPE=Release"));
+        configure.addAll(CompilerHelper.cmakeToolchainArgs());
+        runCommand(configure, distDir);
+
+        runCommand(Arrays.asList("cmake", "--build", buildDir.toString()), distDir);
+
+        Path executable = buildDir.resolve(CompilerHelper.executableName("FloatingToStringApp"));
+        String output = runCommand(Arrays.asList(executable.toString()), buildDir);
+
+        assertFalse(output.contains("FLOATING_TO_STRING_FAIL"),
+                "Scientific float/double strings should not retain stale buffer contents:\n" + output);
+        assertTrue(output.contains("FLOATING_TO_STRING_PASS"),
+                "FloatingToStringApp should report success, actual output was:\n" + output);
+    }
+
+    @ParameterizedTest
+    @org.junit.jupiter.params.provider.MethodSource("com.codename1.tools.translator.BytecodeInstructionIntegrationTest#provideCompilerConfigs")
     void generatesRunnableExecutableForWindowsAppType(CompilerHelper.CompilerConfig config) throws Exception {
         Parser.cleanup();
 
@@ -1604,6 +1649,44 @@ class CleanTargetIntegrationTest {
                 "#include <stdio.h>\n" +
                 "void HelloWorld_nativeHello__(CODENAME_ONE_THREAD_STATE) {\n" +
                 "    printf(\"Hello, Clean Target!\\n\");\n" +
+                "}\n";
+    }
+
+    static String floatingToStringSource() {
+        return "public class FloatingToStringApp {\n" +
+                "    public static void main(String[] args) {\n" +
+                "        int failures = 0;\n" +
+                "        failures += check(\"double-min-scientific\", Double.toString(10000000.0d), \"1.0E7\");\n" +
+                "        failures += check(\"double-trimmed-scientific\", Double.toString(12500000.0d), \"1.25E7\");\n" +
+                "        failures += check(\"double-large-scientific\", Double.toString(125000000.0d), \"1.25E8\");\n" +
+                "        failures += check(\"float-min-scientific\", Float.toString(10000000.0f), \"1.0E7\");\n" +
+                "        failures += check(\"float-trimmed-scientific\", Float.toString(12500000.0f), \"1.25E7\");\n" +
+                "        failures += check(\"float-large-scientific\", Float.toString(16777216.0f), \"1.6777216E7\");\n" +
+                "        failures += check(\"string-valueOf-double\", String.valueOf(12500000.0d), \"1.25E7\");\n" +
+                "        failures += check(\"string-valueOf-float\", String.valueOf(12500000.0f), \"1.25E7\");\n" +
+                "        failures += check(\"concat-double\", \"balance=\" + 12500000.0d, \"balance=1.25E7\");\n" +
+                "        failures += check(\"builder-double\", new StringBuilder().append(12500000.0d).toString(), \"1.25E7\");\n" +
+                "        failures += check(\"buffer-float\", new StringBuffer().append(12500000.0f).toString(), \"1.25E7\");\n" +
+                "        failures += check(\"arrays-double\", java.util.Arrays.toString(new double[]{12500000.0d}), \"[1.25E7]\");\n" +
+                "        failures += check(\"arrays-float\", java.util.Arrays.toString(new float[]{12500000.0f}), \"[1.25E7]\");\n" +
+                "        java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();\n" +
+                "        java.io.PrintStream ps = new java.io.PrintStream(out);\n" +
+                "        ps.print(12500000.0d);\n" +
+                "        ps.print('|');\n" +
+                "        ps.print(12500000.0f);\n" +
+                "        failures += check(\"printstream\", out.toString(), \"1.25E7|1.25E7\");\n" +
+                "        if (failures == 0) {\n" +
+                "            System.out.println(\"FLOATING_TO_STRING_PASS\");\n" +
+                "        }\n" +
+                "    }\n" +
+                "\n" +
+                "    private static int check(String name, String actual, String expected) {\n" +
+                "        if (!expected.equals(actual)) {\n" +
+                "            System.out.println(\"FLOATING_TO_STRING_FAIL \" + name + \" expected=[\" + expected + \"] actual=[\" + actual + \"] len=\" + actual.length());\n" +
+                "            return 1;\n" +
+                "        }\n" +
+                "        return 0;\n" +
+                "    }\n" +
                 "}\n";
     }
 


### PR DESCRIPTION
## Summary

Fixes ParparVM float/double string conversion so the rebuilt C string is explicitly null-terminated after trimming/reversing scientific notation output.

## Root Cause

`java_lang_Double_toStringImpl()` and `java_lang_Float_toStringImpl()` reused the original `snprintf()` buffer after shortening the representation, but did not write a new `\0` terminator. On iOS builds this could let `newStringFromCString()` read stale bytes from the previous formatted value, showing a valid-looking number followed by repeated zeroes.

## Changes

- Null-terminate the reconstructed `double` and `float` strings in `nativeMethods.m`.
- Add a native clean-target regression test for scientific `Double.toString()` / `Float.toString()` output.
- Add a non-screenshot `FloatingToStringTest` to the HelloCodenameOne device suite so this runs across supported platforms.

## Validation

Passed:

```sh
mvn -f vm/pom.xml -pl tests -am -Dtest=CleanTargetIntegrationTest#scientificFloatToStringOutputIsTerminated -Dsurefire.failIfNoSpecifiedTests=false test
```

Attempted:

```sh
mvn -f scripts/hellocodenameone/pom.xml -pl common -DskipTests compile
```

This compile currently fails on pre-existing unresolved API symbols in the HelloCodenameOne module dependency set, unrelated to this new test.