### PR TITLE
Remove since markers from API docs

### DIFF
--- a/.github/workflows/check-since-tags.yml
+++ b/.github/workflows/check-since-tags.yml
@@ -1,9 +1,8 @@
-name: Check @since tags
+name: Check since tags
 
-# Fails the build if any Java source under CodenameOne/src carries an @since
-# javadoc tag whose version does not correspond to an existing git tag in
-# this repository. Without this gate, prose can advertise APIs as available
-# in versions that never shipped (e.g. "@since 9.0").
+# Fails the build if Java sources under CodenameOne/src carry @since tags or
+# Markdown/Javadoc "Since" sections. Generated documentation changes have
+# repeatedly guessed versions, which is worse than omitting the metadata.
 
 permissions:
   contents: read
@@ -30,12 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          # Full history including all tags so `git tag --list` returns
-          # the complete set of released versions.
-          fetch-depth: 0
-          fetch-tags: true
 
-      - name: Validate @since references against git tags
+      - name: Reject since markers in API docs
         shell: bash
         run: scripts/check-since-tags.sh

--- a/CodenameOne/src/com/codename1/capture/Capture.java
+++ b/CodenameOne/src/com/codename1/capture/Capture.java
@@ -182,9 +182,6 @@ public abstract class Capture {
     ///
     /// the audio file location or null if the user canceled
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static String captureAudio(MediaRecorderBuilder recordingOptions) {
         CallBack c = new CallBack();
         captureAudio(recordingOptions, c);
@@ -216,9 +213,6 @@ public abstract class Capture {
     ///
     /// A video file location or null if the user canceled.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static String captureVideo(VideoCaptureConstraints constraints) {
         CallBack c = new CallBack();
         captureVideo(constraints, c);
@@ -333,9 +327,6 @@ public abstract class Capture {
     ///
     /// - `RuntimeException`: if this feature failed or unsupported on the platform
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static void captureAudio(MediaRecorderBuilder recorderOptions, ActionListener<ActionEvent> response) {
         Display.getInstance().captureAudio(recorderOptions, response);
     }
@@ -351,9 +342,6 @@ public abstract class Capture {
     ///
     /// - `response`: a callback Object to retrieve the file path
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static void captureVideo(VideoCaptureConstraints constraints, ActionListener<ActionEvent> response) {
         Display.getInstance().captureVideo(constraints, response);
     }

--- a/CodenameOne/src/com/codename1/capture/VideoCaptureConstraints.java
+++ b/CodenameOne/src/com/codename1/capture/VideoCaptureConstraints.java
@@ -80,10 +80,6 @@ package com.codename1.capture;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 7.0
-///
 /// #### See also
 ///
 /// - Capture#captureVideo(com.codename1.capture.VideoCaptureConstraints)

--- a/CodenameOne/src/com/codename1/components/AudioRecorderComponent.java
+++ b/CodenameOne/src/com/codename1/components/AudioRecorderComponent.java
@@ -246,9 +246,6 @@ import static com.codename1.ui.ComponentSelector.$;
 /// to either accept the recording, cancel it, or try again.
 /// @author Steve Hannah
 ///
-/// #### Since
-///
-/// 7.0
 public class AudioRecorderComponent extends Container implements ActionSource {
     private final Button record;
     private final Button pause;

--- a/CodenameOne/src/com/codename1/components/ButtonList.java
+++ b/CodenameOne/src/com/codename1/components/ButtonList.java
@@ -219,9 +219,6 @@ import java.util.Arrays;
 ///
 /// @author Steve Hannah
 ///
-/// #### Since
-///
-/// 6.0
 public abstract class ButtonList extends Container implements DataChangedListener, SelectionListener, ActionListener, ActionSource {
     private final EventDispatcher actionListeners = new EventDispatcher();
     private final java.util.List<Runnable> onReady = new ArrayList<Runnable>();

--- a/CodenameOne/src/com/codename1/components/CheckBoxList.java
+++ b/CodenameOne/src/com/codename1/components/CheckBoxList.java
@@ -32,10 +32,6 @@ import com.codename1.ui.list.MultipleSelectionListModel;
 ///
 /// @author Steve Hannah
 ///
-/// #### Since
-///
-/// 6.0
-///
 /// #### See also
 ///
 /// - ButtonList for code samples.

--- a/CodenameOne/src/com/codename1/components/ImageViewer.java
+++ b/CodenameOne/src/com/codename1/components/ImageViewer.java
@@ -756,9 +756,6 @@ public class ImageViewer extends Component {
     ///
     /// The cropped image.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public Image getCroppedImage(int backgroundColor) {
         if (image == null) {
             return null;
@@ -783,9 +780,6 @@ public class ImageViewer extends Component {
     ///
     /// Cropped image in specified dimensions.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public Image getCroppedImage(int width, int height, int backgroundColor) {
         if (image == null) {
             return null;

--- a/CodenameOne/src/com/codename1/components/InfiniteProgress.java
+++ b/CodenameOne/src/com/codename1/components/InfiniteProgress.java
@@ -241,9 +241,6 @@ public class InfiniteProgress extends Component {
     ///
     /// True if it animated and should be repainted.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean animate(boolean force) {
         if (!force && (!isVisible() || Display.getInstance().getCurrent() != this.getComponentForm())) { // PMD Fix: CollapsibleIfStatements merged visibility checks //NOPMD CompareObjectsWithEquals
             return false;

--- a/CodenameOne/src/com/codename1/components/MultiButton.java
+++ b/CodenameOne/src/com/codename1/components/MultiButton.java
@@ -868,9 +868,6 @@ public class MultiButton extends Container implements ActionSource, SelectableIc
     ///
     /// String with textLine1 to textLine4 delimited by "\n"
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public String getTextLines() {
         return getTextLine1() + "\n" + getTextLine2() + "\n" + getTextLine3() + "\n" + getTextLine4();
     }
@@ -882,9 +879,6 @@ public class MultiButton extends Container implements ActionSource, SelectableIc
     ///
     /// - `text`: The text to set.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public void setTextLines(String text) {
         //String currTextVal = btn.getText();
         String newTextVal0 = text;
@@ -1324,9 +1318,6 @@ public class MultiButton extends Container implements ActionSource, SelectableIc
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public int getGap() {
         return gap;
@@ -1334,9 +1325,6 @@ public class MultiButton extends Container implements ActionSource, SelectableIc
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public void setGap(int gap) {
         if (gap != this.gap) {
@@ -1347,9 +1335,6 @@ public class MultiButton extends Container implements ActionSource, SelectableIc
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public int getTextPosition() {
         String iconPosition = getIconPosition();
@@ -1371,9 +1356,6 @@ public class MultiButton extends Container implements ActionSource, SelectableIc
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public void setTextPosition(int textPosition) {
         switch (textPosition) {
@@ -1412,9 +1394,6 @@ public class MultiButton extends Container implements ActionSource, SelectableIc
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public Component getIconStyleComponent() {
         return icon;
@@ -1422,9 +1401,6 @@ public class MultiButton extends Container implements ActionSource, SelectableIc
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 8.0
     @Override
     public void setMaterialIcon(char c, float size) {
         icon.setMaterialIcon(c, size);
@@ -1432,9 +1408,6 @@ public class MultiButton extends Container implements ActionSource, SelectableIc
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 8.0
     @Override
     public void setFontIcon(Font font, char c, float size) {
         icon.setFontIcon(font, c, size);
@@ -1442,9 +1415,6 @@ public class MultiButton extends Container implements ActionSource, SelectableIc
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public Image getRolloverIcon() {
         return icon.getRolloverIcon();
@@ -1452,9 +1422,6 @@ public class MultiButton extends Container implements ActionSource, SelectableIc
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public void setRolloverIcon(Image arg0) {
         icon.setRolloverIcon(arg0);
@@ -1462,9 +1429,6 @@ public class MultiButton extends Container implements ActionSource, SelectableIc
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public Image getPressedIcon() {
         return icon.getPressedIcon();
@@ -1472,9 +1436,6 @@ public class MultiButton extends Container implements ActionSource, SelectableIc
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public void setPressedIcon(Image arg0) {
         icon.setPressedIcon(arg0);
@@ -1482,9 +1443,6 @@ public class MultiButton extends Container implements ActionSource, SelectableIc
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public Image getDisabledIcon() {
         return icon.getDisabledIcon();
@@ -1492,9 +1450,6 @@ public class MultiButton extends Container implements ActionSource, SelectableIc
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public void setDisabledIcon(Image arg0) {
         icon.setDisabledIcon(arg0);
@@ -1502,9 +1457,6 @@ public class MultiButton extends Container implements ActionSource, SelectableIc
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public Image getRolloverPressedIcon() {
         return icon.getRolloverPressedIcon();
@@ -1512,9 +1464,6 @@ public class MultiButton extends Container implements ActionSource, SelectableIc
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public void setRolloverPressedIcon(Image icn) {
         icon.setRolloverPressedIcon(icn);
@@ -1522,9 +1471,6 @@ public class MultiButton extends Container implements ActionSource, SelectableIc
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public Image getIconFromState() {
         return icon.getIconFromState();
@@ -1535,10 +1481,6 @@ public class MultiButton extends Container implements ActionSource, SelectableIc
     /// #### Returns
     ///
     /// the badge text to be used on this label.  May return if no text is set.
-    ///
-    /// #### Since
-    ///
-    /// 8.0
     ///
     /// #### See also
     ///
@@ -1561,10 +1503,6 @@ public class MultiButton extends Container implements ActionSource, SelectableIc
     /// - `badgeText`: @param badgeText The text to include in the badge.   null or empty strings will result in the
     /// badge not being rendered.
     ///
-    /// #### Since
-    ///
-    /// 8.0
-    ///
     /// #### See also
     ///
     /// - #getBadgeText()
@@ -1583,10 +1521,6 @@ public class MultiButton extends Container implements ActionSource, SelectableIc
     ///
     /// - `badgeUIID`: The UIID to use for the badge.
     ///
-    /// #### Since
-    ///
-    /// 8.0
-    ///
     /// #### See also
     ///
     /// - #setBadgeText(java.lang.String)
@@ -1601,10 +1535,6 @@ public class MultiButton extends Container implements ActionSource, SelectableIc
     /// #### Returns
     ///
     /// The component whose style can be used to style the badge.  May return null if none set.
-    ///
-    /// #### Since
-    ///
-    /// 8.0
     ///
     /// #### See also
     ///

--- a/CodenameOne/src/com/codename1/components/RadioButtonList.java
+++ b/CodenameOne/src/com/codename1/components/RadioButtonList.java
@@ -32,10 +32,6 @@ import com.codename1.ui.list.ListModel;
 ///
 /// @author Steve Hannah
 ///
-/// #### Since
-///
-/// 6.0
-///
 /// #### See also
 ///
 /// - ButtonList for code samples

--- a/CodenameOne/src/com/codename1/components/SignatureComponent.java
+++ b/CodenameOne/src/com/codename1/components/SignatureComponent.java
@@ -96,9 +96,6 @@ import com.codename1.ui.util.EventDispatcher;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 3.4
 public class SignatureComponent extends Container implements ActionSource<ActionEvent> {
 
     private final SignaturePanel signaturePanel = new SignaturePanel();

--- a/CodenameOne/src/com/codename1/components/SpanButton.java
+++ b/CodenameOne/src/com/codename1/components/SpanButton.java
@@ -208,9 +208,6 @@ public class SpanButton extends Container implements ActionSource<ActionEvent>, 
     ///
     /// The component used for styling font icons on this SpanLabel.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public Component getIconStyleComponent() {
         return actualButton.getIconStyleComponent();
@@ -313,9 +310,6 @@ public class SpanButton extends Container implements ActionSource<ActionEvent>, 
     ///
     /// - `l`
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public void addLongPressListener(ActionListener l) {
         actualButton.addLongPressListener(l);
@@ -327,9 +321,6 @@ public class SpanButton extends Container implements ActionSource<ActionEvent>, 
     ///
     /// - `l`
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public void removeLongPressListener(ActionListener l) {
         actualButton.removeLongPressListener(l);
@@ -643,9 +634,6 @@ public class SpanButton extends Container implements ActionSource<ActionEvent>, 
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public Image getRolloverPressedIcon() {
         return actualButton.getRolloverIcon();
@@ -653,9 +641,6 @@ public class SpanButton extends Container implements ActionSource<ActionEvent>, 
 
     /// {@inheritDoc}
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public void setRolloverPressedIcon(Image arg0) {
         actualButton.setRolloverPressedIcon(arg0);
@@ -663,9 +648,6 @@ public class SpanButton extends Container implements ActionSource<ActionEvent>, 
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public Image getIconFromState() {
         return actualButton.getIconFromState();

--- a/CodenameOne/src/com/codename1/components/SpanLabel.java
+++ b/CodenameOne/src/com/codename1/components/SpanLabel.java
@@ -176,9 +176,6 @@ public class SpanLabel extends Container implements IconHolder, TextHolder {
     ///
     /// The component used for styling font icons on this SpanLabel.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public Component getIconStyleComponent() {
         return icon.getIconStyleComponent();
@@ -294,9 +291,6 @@ public class SpanLabel extends Container implements IconHolder, TextHolder {
     ///
     /// The alignment.  One of `#TOP`, `#BOTTOM`, or `#CENTER`.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public int getIconValign() {
         return ((FlowLayout) iconWrapper.getLayout()).getValign();
     }
@@ -307,9 +301,6 @@ public class SpanLabel extends Container implements IconHolder, TextHolder {
     ///
     /// - `align`: One of `#TOP`, `#BOTTOM`, or `#CENTER`.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setIconValign(int align) {
         ((FlowLayout) iconWrapper.getLayout()).setValign(align);
     }
@@ -539,10 +530,6 @@ public class SpanLabel extends Container implements IconHolder, TextHolder {
     ///
     /// True if text selection is enabled on this element.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - Form#getTextSelection()
@@ -558,9 +545,6 @@ public class SpanLabel extends Container implements IconHolder, TextHolder {
     ///
     /// - `enabled`: True to enable text selection on this label.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setTextSelectionEnabled(boolean enabled) {
         text.setTextSelectionEnabled(enabled);
     }
@@ -590,9 +574,6 @@ public class SpanLabel extends Container implements IconHolder, TextHolder {
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public int getGap() {
         return gap;
@@ -600,9 +581,6 @@ public class SpanLabel extends Container implements IconHolder, TextHolder {
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public void setGap(int gap) {
         if (gap != this.gap) {
@@ -613,9 +591,6 @@ public class SpanLabel extends Container implements IconHolder, TextHolder {
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public int getTextPosition() {
         String iconPosition = getIconPosition();
@@ -637,9 +612,6 @@ public class SpanLabel extends Container implements IconHolder, TextHolder {
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public void setTextPosition(int textPosition) {
         switch (textPosition) {

--- a/CodenameOne/src/com/codename1/components/SpanMultiButton.java
+++ b/CodenameOne/src/com/codename1/components/SpanMultiButton.java
@@ -1282,9 +1282,6 @@ public class SpanMultiButton extends Container implements ActionSource, Selectab
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public int getGap() {
         return gap;
@@ -1292,9 +1289,6 @@ public class SpanMultiButton extends Container implements ActionSource, Selectab
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public void setGap(int gap) {
         if (gap != this.gap) {
@@ -1305,9 +1299,6 @@ public class SpanMultiButton extends Container implements ActionSource, Selectab
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public int getTextPosition() {
         String iconPosition = getIconPosition();
@@ -1329,9 +1320,6 @@ public class SpanMultiButton extends Container implements ActionSource, Selectab
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public void setTextPosition(int textPosition) {
         switch (textPosition) {
@@ -1375,9 +1363,6 @@ public class SpanMultiButton extends Container implements ActionSource, Selectab
 
     /// {@inheritDoc}
     ///
-    /// #### Since
-    ///
-    /// 8.0
     @Override
     public void setMaterialIcon(char c, float size) {
         icon.setMaterialIcon(c, size);
@@ -1385,9 +1370,6 @@ public class SpanMultiButton extends Container implements ActionSource, Selectab
 
     /// {@inheritDoc}
     ///
-    /// #### Since
-    ///
-    /// 8.0
     @Override
     public void setFontIcon(Font font, char c, float size) {
         icon.setFontIcon(font, c, size);
@@ -1395,9 +1377,6 @@ public class SpanMultiButton extends Container implements ActionSource, Selectab
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public Image getRolloverIcon() {
         return icon.getRolloverIcon();
@@ -1405,9 +1384,6 @@ public class SpanMultiButton extends Container implements ActionSource, Selectab
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public void setRolloverIcon(Image arg0) {
         icon.setRolloverIcon(arg0);
@@ -1415,9 +1391,6 @@ public class SpanMultiButton extends Container implements ActionSource, Selectab
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public Image getPressedIcon() {
         return icon.getPressedIcon();
@@ -1425,9 +1398,6 @@ public class SpanMultiButton extends Container implements ActionSource, Selectab
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public void setPressedIcon(Image arg0) {
         icon.setPressedIcon(arg0);
@@ -1435,9 +1405,6 @@ public class SpanMultiButton extends Container implements ActionSource, Selectab
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public Image getDisabledIcon() {
         return icon.getDisabledIcon();
@@ -1445,9 +1412,6 @@ public class SpanMultiButton extends Container implements ActionSource, Selectab
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public void setDisabledIcon(Image arg0) {
         icon.setDisabledIcon(arg0);
@@ -1455,9 +1419,6 @@ public class SpanMultiButton extends Container implements ActionSource, Selectab
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public Image getRolloverPressedIcon() {
         return icon.getRolloverPressedIcon();
@@ -1465,9 +1426,6 @@ public class SpanMultiButton extends Container implements ActionSource, Selectab
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public void setRolloverPressedIcon(Image icn) {
         icon.setRolloverPressedIcon(icn);
@@ -1475,9 +1433,6 @@ public class SpanMultiButton extends Container implements ActionSource, Selectab
 
     /// {@inheritDoc }
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public Image getIconFromState() {
         return icon.getIconFromState();

--- a/CodenameOne/src/com/codename1/components/SwitchList.java
+++ b/CodenameOne/src/com/codename1/components/SwitchList.java
@@ -36,10 +36,6 @@ import static com.codename1.ui.ComponentSelector.$;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 6.0
-///
 /// #### See also
 ///
 /// - ButtonList for code samples;

--- a/CodenameOne/src/com/codename1/components/ToastBar.java
+++ b/CodenameOne/src/com/codename1/components/ToastBar.java
@@ -402,9 +402,6 @@ public final class ToastBar {
     ///
     /// Self for chaining.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public ToastBar useFormLayeredPane(boolean useFormLayeredPane) {
         if (useFormLayeredPane != this.useFormLayeredPane) {
             ToastBarComponent c = getToastBarComponent(false);

--- a/CodenameOne/src/com/codename1/db/Database.java
+++ b/CodenameOne/src/com/codename1/db/Database.java
@@ -178,10 +178,6 @@ public abstract class Database {
     ///
     /// - `IOException`
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - RowExt#wasNull()
@@ -207,10 +203,6 @@ public abstract class Database {
     /// #### Throws
     ///
     /// - `IOException`
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///

--- a/CodenameOne/src/com/codename1/db/RowExt.java
+++ b/CodenameOne/src/com/codename1/db/RowExt.java
@@ -32,9 +32,6 @@ import java.io.IOException;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 7.0
 public interface RowExt extends Row {
     // PMD Fix (UnnecessaryModifier): Interface methods inherit public visibility.
     boolean wasNull() throws IOException;

--- a/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
+++ b/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
@@ -2325,10 +2325,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// - `opacity`: The shadow opacity.
     ///
-    /// #### Since
-    ///
-    /// 8.0
-    ///
     /// #### See also
     ///
     /// - Component#paintShadows(Graphics, int, int)
@@ -2348,10 +2344,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// True if the platform supports drawing shadows.
     ///
-    /// #### Since
-    ///
-    /// 8.0
-    ///
     /// #### See also
     ///
     /// - #drawShadow(Object, Object, int, int, int, int, int, int, int, float)
@@ -2365,9 +2357,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// True if drawing shadows is hardware accelerated.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public boolean isDrawShadowFast() {
         return false;
     }
@@ -2841,9 +2830,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// True if last mouse press was a right click.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean isRightMouseButtonDown() {
         return false;
     }
@@ -4755,10 +4741,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// The same rectangle that was passed as a parameter.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - Form#getSafeArea()
@@ -5020,10 +5002,6 @@ public abstract class CodenameOneImplementation {
     /// #### Returns
     ///
     /// a handle that can be used to control the playback of the audio
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -5364,10 +5342,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// True if the implementation handled the message.  False to let BrowserComponent handle it in its default way.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - BrowserComponent#postMessage(java.lang.String, java.lang.String)
@@ -5554,9 +5528,6 @@ public abstract class CodenameOneImplementation {
     /// then `BrowserComponent#captureScreenshot()` will just use `Component#toImage()`
     /// for screenshots.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public AsyncResource<Image> captureBrowserScreenshot(PeerComponent browserPeer) {
         return null;
     }
@@ -6058,9 +6029,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// True if platform supports native cookie sharing.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public boolean isNativeCookieSharingSupported() {
         return false;
     }
@@ -7254,10 +7222,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// An image of the screen, or null if it failed.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### Deprecated
     ///
     /// replaced by screenshot()
@@ -7287,9 +7251,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// A shared BrowserComponent
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public final BrowserComponent getSharedJavscriptContext() {
         if (sharedJavascriptContext == null) {
             sharedJavascriptContext = createSharedJavascriptContext();
@@ -7305,9 +7266,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// A shared BrowserComponent
     ///
-    /// #### Since
-    ///
-    /// 7.0
     protected BrowserComponent createSharedJavascriptContext() {
         BrowserComponent out = new BrowserComponent();
         out.setPage("<!doctype html><html><body></body></html>", null);
@@ -7355,10 +7313,6 @@ public abstract class CodenameOneImplementation {
     /// - `constraints`: Constraints for the capture.
     ///
     /// - `response`: Callback for the resulting video.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -8030,9 +7984,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// - `m12`: the Y coordinate translation element of the 3x3 matrix
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public Object makeTransformAffine(double m00,
                                       double m10,
                                       double m01,
@@ -8060,9 +8011,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// - `m12`: the Y coordinate translation element of the 3x3 matrix
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setTransformAffine(Object nativeTransform, double m00,
                                    double m10,
                                    double m01,
@@ -8747,10 +8695,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// - `aThis`
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - #deinitializeTextSelection(com.codename1.ui.TextSelection)
@@ -8763,10 +8707,6 @@ public abstract class CodenameOneImplementation {
     /// #### Parameters
     ///
     /// - `aThis`
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -8788,10 +8728,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// Native peer.  Format chosen by implementation.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - #addHeavyActionListener(java.lang.Object, com.codename1.ui.events.ActionListener)
@@ -8809,10 +8745,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// - `l`: The action listener.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - #createHeavyButton(com.codename1.ui.Button)
@@ -8829,10 +8761,6 @@ public abstract class CodenameOneImplementation {
     /// - `peer`: THe heavy button peer.
     ///
     /// - `l`: The action listener.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -8857,9 +8785,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// - `height`: The height of the light peer.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void updateHeavyButtonBounds(Object peer, int x, int y, int width, int height) {
 
     }
@@ -8870,10 +8795,6 @@ public abstract class CodenameOneImplementation {
     /// #### Parameters
     ///
     /// - `peer`: The heavy peer.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -8889,10 +8810,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// - `peer`: The heavy peer.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - #initHeavyButton(java.lang.Object)
@@ -8904,10 +8821,6 @@ public abstract class CodenameOneImplementation {
 
     /// Checks whether the current platform requires a heavy button for copy to clipboard functionality to work.
     /// This will be true on the Javascript port.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -8922,9 +8835,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// - `sel`: The current TextSelection instance for the current form.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void copySelectionToClipboard(TextSelection sel) {
         copyToClipboard(sel.getSelectionAsText());
     }
@@ -8936,10 +8846,6 @@ public abstract class CodenameOneImplementation {
     /// - `nativeGraphics`: The native graphics context
     ///
     /// - `hints`: Hints
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -8965,10 +8871,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// The current rendering hints.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - Graphics#RENDERING_HINT_FAST
@@ -8982,9 +8884,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// This is executed when the user registers a new listener using `MediaManager#setRemoteControlListener(com.codename1.media.RemoteControlListener)`
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void startRemoteControl() {
 
     }
@@ -8994,9 +8893,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// This is executed when a new listener is registered using `MediaManager#setRemoteControlListener(com.codename1.media.RemoteControlListener)`
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void stopRemoteControl() {
 
     }
@@ -9009,9 +8905,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// - `readTimeout`
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setReadTimeout(Object connection, int readTimeout) {
 
     }
@@ -9023,10 +8916,6 @@ public abstract class CodenameOneImplementation {
     /// - `connection`
     ///
     /// - `insecure`: True to make connection insecure.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -9043,9 +8932,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// True if the platform supports read timeouts.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean isReadTimeoutSupported() {
         return false;
     }
@@ -9060,10 +8946,6 @@ public abstract class CodenameOneImplementation {
     /// #### Returns
     ///
     /// The browser window object, or null.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -9100,10 +8982,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// - `l`: The listener
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - #createNativeBrowserWindow(java.lang.String)
@@ -9118,10 +8996,6 @@ public abstract class CodenameOneImplementation {
     /// - `window`: The window from which to remove the listener.
     ///
     /// - `l`: The listener
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -9140,10 +9014,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// - `height`: The height in pixels.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - #createNativeBrowserWindow(java.lang.String)
@@ -9158,10 +9028,6 @@ public abstract class CodenameOneImplementation {
     /// - `window`: The window
     ///
     /// - `title`: The title
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -9178,10 +9044,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// - `window`: The window
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - #createNativeBrowserWindow(java.lang.String)
@@ -9195,10 +9057,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// - `window`: The window
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - #createNativeBrowserWindow(java.lang.String)
@@ -9211,10 +9069,6 @@ public abstract class CodenameOneImplementation {
     /// #### Parameters
     ///
     /// - `window`: The window
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -9230,10 +9084,6 @@ public abstract class CodenameOneImplementation {
     /// - `window`: The window
     ///
     /// - `req`: The javascript eval request.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -9252,10 +9102,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// - `l`: The listener
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - #createNativeBrowserWindow(java.lang.String)
@@ -9270,10 +9116,6 @@ public abstract class CodenameOneImplementation {
     /// - `window`: The window.
     ///
     /// - `l`: The listener
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -9328,9 +9170,6 @@ public abstract class CodenameOneImplementation {
     /// - `builder`: @param builder THe media builder with settings for the recorder.
     /// getAvailableRecordingMimeTypes()
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public Media createMediaRecorder(MediaRecorderBuilder builder) throws IOException {
         return createMediaRecorder(builder.getPath(), builder.getMimeType());
     }
@@ -9841,9 +9680,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// the socket object to use
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public Object connectSocket(String host, int port, int connectTimeout) {
         throw new RuntimeException("Not supported");
     }
@@ -11223,9 +11059,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// - `message`: The message.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void postMessage(MessageEvent message) {
 
     }
@@ -11262,9 +11095,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// true when the platform indicates a larger text preference.
     ///
-    /// #### Since
-    ///
-    /// 7.1
     public boolean isLargerTextEnabled() {
         return false;
     }
@@ -11276,9 +11106,6 @@ public abstract class CodenameOneImplementation {
     ///
     /// scale factor for larger system fonts.
     ///
-    /// #### Since
-    ///
-    /// 7.1
     public float getLargerTextScale() {
         return 1.0f;
     }

--- a/CodenameOne/src/com/codename1/io/AccessToken.java
+++ b/CodenameOne/src/com/codename1/io/AccessToken.java
@@ -48,9 +48,6 @@ public class AccessToken implements Externalizable {
     /// since the expires value may just be the number of seconds that the access token is good
     /// for since it was generated - and we may not have that information stored.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     private Date expiryDate;
 
     private String refreshToken;
@@ -70,7 +67,6 @@ public class AccessToken implements Externalizable {
 
     /// Constructor with parameters
     ///
-    /// @since 7.0
     ///
     /// #### Parameters
     ///
@@ -85,7 +81,6 @@ public class AccessToken implements Externalizable {
 
     /// Constructor with parameters
     ///
-    /// @since 7.0
     ///
     /// #### Parameters
     ///
@@ -104,9 +99,6 @@ public class AccessToken implements Externalizable {
         this.identityToken = identityToken;
     }
 
-    /// #### Since
-    ///
-    /// 7.0
     public AccessToken() {
 
     }
@@ -117,9 +109,6 @@ public class AccessToken implements Externalizable {
     ///
     /// - `expiryDate`: The expiry date.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static AccessToken createWithExpiryDate(String token, Date expiryDate) {
         AccessToken out = new AccessToken(token, null);
 
@@ -238,9 +227,6 @@ public class AccessToken implements Externalizable {
     ///
     /// Refresh token.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public String getRefreshToken() {
         return refreshToken;
     }
@@ -251,9 +237,6 @@ public class AccessToken implements Externalizable {
     ///
     /// - `refreshToken`: The refresh token.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
@@ -291,9 +274,6 @@ public class AccessToken implements Externalizable {
     ///
     /// The expiry date of this token or null.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public Date getExpiryDate() {
         return expiryDate;
     }
@@ -304,9 +284,6 @@ public class AccessToken implements Externalizable {
     ///
     /// - `date`: The expiry date of this token.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setExpiryDate(Date date) {
         this.expiryDate = date;
     }
@@ -317,9 +294,6 @@ public class AccessToken implements Externalizable {
     ///
     /// False if no expiry date is set or the expiryDate is before the current time.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean isExpired() {
         return expiryDate != null && DateUtil.compare(expiryDate, new Date()) < 0;
     }
@@ -328,9 +302,6 @@ public class AccessToken implements Externalizable {
     ///
     /// the identityToken
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public String getIdentityToken() {
         return identityToken;
     }
@@ -339,9 +310,6 @@ public class AccessToken implements Externalizable {
     ///
     /// - `identityToken`: the identityToken to set
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setIdentityToken(String identityToken) {
         this.identityToken = identityToken;
     }

--- a/CodenameOne/src/com/codename1/io/ConnectionRequest.java
+++ b/CodenameOne/src/com/codename1/io/ConnectionRequest.java
@@ -354,9 +354,6 @@ public class ConnectionRequest implements IOProgressListener {
     ///
     /// True if this connection supports read timeouts;
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static boolean isReadTimeoutSupported() {
         return Util.getImplementation().isReadTimeoutSupported();
     }
@@ -425,9 +422,6 @@ public class ConnectionRequest implements IOProgressListener {
     ///
     /// true if the platform supports native cookie sharing.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public static boolean isNativeCookieSharingSupported() {
         return Util.getImplementation().isNativeCookieSharingSupported();
     }
@@ -474,9 +468,6 @@ public class ConnectionRequest implements IOProgressListener {
     ///
     /// AsyncResource that will resolve with either an exception or the parsed JSON data.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static AsyncResource<Map<String, Object>> fetchJSONAsync(String url) {
         final AsyncResource<Map<String, Object>> out = new AsyncResource<Map<String, Object>>();
         final ConnectionRequest cr = new ConnectionRequest();
@@ -591,9 +582,6 @@ public class ConnectionRequest implements IOProgressListener {
     ///
     /// True if the request is insecure, i.e. does not check SSL certificate for validity.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean isInsecure() {
         return insecure;
     }
@@ -604,9 +592,6 @@ public class ConnectionRequest implements IOProgressListener {
     ///
     /// - `insecure`
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setInsecure(boolean insecure) {
         this.insecure = insecure;
     }
@@ -711,9 +696,6 @@ public class ConnectionRequest implements IOProgressListener {
     ///
     /// The read timeout.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public int getReadTimeout() {
         return readTimeout;
     }
@@ -2660,9 +2642,6 @@ public class ConnectionRequest implements IOProgressListener {
     ///
     /// - `useCache`: If true, then this will first check the storage to see if the image is already downloaded.
     ///
-    /// #### Since
-    ///
-    /// 3.4
     public void downloadImageToStorage(String storageFile, final SuccessCallback<Image> onSuccess, FailureCallback<Image> onFail, boolean useCache) {
         setDestinationStorage(storageFile);
         downloadImage(onSuccess, onFail, useCache);
@@ -2678,9 +2657,6 @@ public class ConnectionRequest implements IOProgressListener {
     ///
     /// AsyncResource that will resolve to the loaded image.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public AsyncResource<Image> downloadImageToStorage(String storageFile) {
         return downloadImageToStorage(storageFile, true);
     }
@@ -2698,9 +2674,6 @@ public class ConnectionRequest implements IOProgressListener {
     ///
     /// AsyncResource that will resolve to the loaded image.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public AsyncResource<Image> downloadImageToStorage(String storageFile, boolean useCache) {
         final AsyncResource<Image> out = new AsyncResource<Image>();
         downloadImageToStorage(storageFile, new ImageStorageSuccessCallback(out),
@@ -2719,9 +2692,6 @@ public class ConnectionRequest implements IOProgressListener {
     ///
     /// - `useCache`: If true, then this will first check the storage to see if the image is already downloaded.
     ///
-    /// #### Since
-    ///
-    /// 3.4
     public void downloadImageToStorage(String storageFile, SuccessCallback<Image> onSuccess, boolean useCache) {
         downloadImageToStorage(storageFile, onSuccess, new CallbackAdapter<Image>(), useCache);
     }
@@ -2735,9 +2705,6 @@ public class ConnectionRequest implements IOProgressListener {
     ///
     /// - `onSuccess`: Callback called if the image is successfully loaded.
     ///
-    /// #### Since
-    ///
-    /// 3.4
     public void downloadImageToStorage(String storageFile, SuccessCallback<Image> onSuccess) {
         downloadImageToStorage(storageFile, onSuccess, new CallbackAdapter<Image>(), true);
     }
@@ -2751,9 +2718,6 @@ public class ConnectionRequest implements IOProgressListener {
     ///
     /// - `onSuccess`: Callback called if the image is successfully loaded.
     ///
-    /// #### Since
-    ///
-    /// 3.4
     public void downloadImageToStorage(String storageFile, SuccessCallback<Image> onSuccess, FailureCallback<Image> onFail) {
         downloadImageToStorage(storageFile, onSuccess, onFail, true);
     }
@@ -2771,9 +2735,6 @@ public class ConnectionRequest implements IOProgressListener {
     ///
     /// AsyncResource resolving to the downloaded image.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public AsyncResource<Image> downloadImageToFileSystem(String file, boolean useCache) {
         final AsyncResource<Image> out = new AsyncResource<Image>();
         downloadImageToFileSystem(file, new ImageFileSystemSuccessCallback(out),
@@ -2793,9 +2754,6 @@ public class ConnectionRequest implements IOProgressListener {
     ///
     /// AsyncResource resolving to the downloaded image.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public AsyncResource<Image> downloadImageToFileSystem(String file) {
         return downloadImageToFileSystem(file, true);
     }
@@ -2813,9 +2771,6 @@ public class ConnectionRequest implements IOProgressListener {
     ///
     /// - `useCache`: If true, then this will first check the storage to see if the image is already downloaded.
     ///
-    /// #### Since
-    ///
-    /// 3.4
     public void downloadImageToFileSystem(String file, final SuccessCallback<Image> onSuccess, FailureCallback<Image> onFail, boolean useCache) {
         setDestinationFile(file);
         downloadImage(onSuccess, onFail, useCache);
@@ -2832,9 +2787,6 @@ public class ConnectionRequest implements IOProgressListener {
     ///
     /// - `useCache`: If true, then this will first check the storage to see if the image is already downloaded.
     ///
-    /// #### Since
-    ///
-    /// 3.4
     public void downloadImageToFileSystem(String file, SuccessCallback<Image> onSuccess, boolean useCache) {
         downloadImageToFileSystem(file, onSuccess, new CallbackAdapter<Image>(), useCache);
     }
@@ -2848,9 +2800,6 @@ public class ConnectionRequest implements IOProgressListener {
     ///
     /// - `onSuccess`: Callback called if the image is successfully loaded.
     ///
-    /// #### Since
-    ///
-    /// 3.4
     public void downloadImageToFileSystem(String file, SuccessCallback<Image> onSuccess) {
         downloadImageToFileSystem(file, onSuccess, new CallbackAdapter<Image>(), true);
     }
@@ -2866,9 +2815,6 @@ public class ConnectionRequest implements IOProgressListener {
     ///
     /// - `onFail`: Callback called if the image fails to load.
     ///
-    /// #### Since
-    ///
-    /// 3.4
     public void downloadImageToFileSystem(String file, SuccessCallback<Image> onSuccess, FailureCallback<Image> onFail) {
         downloadImageToFileSystem(file, onSuccess, onFail, true);
     }
@@ -2981,9 +2927,6 @@ public class ConnectionRequest implements IOProgressListener {
     ///
     /// - `data`: a data to pass in the post body
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setRequestBody(Data data) {
         if (requestArguments != null) {
             throw new IllegalStateException("Request body and arguments are mutually exclusive, you can't use both");
@@ -2999,9 +2942,6 @@ public class ConnectionRequest implements IOProgressListener {
     ///
     /// the requestBody
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public Data getRequestBodyData() {
         if (requestBody != null) {
             return new Data() {

--- a/CodenameOne/src/com/codename1/io/Data.java
+++ b/CodenameOne/src/com/codename1/io/Data.java
@@ -32,9 +32,6 @@ import java.io.UnsupportedEncodingException;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 7.0
 public interface Data {
 
     /// Appends the data's content to an output stream.
@@ -89,9 +86,6 @@ public interface Data {
 
     /// Wraps a File as a Data object.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     class FileData implements Data {
         private final File file;
 
@@ -120,9 +114,6 @@ public interface Data {
 
     /// Wraps a Storage object as a Data object.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     class StorageData implements Data {
         private final String key;
 
@@ -150,9 +141,6 @@ public interface Data {
 
     /// Wraps a byte[] array as a Data object.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     class ByteData implements Data {
         private final byte[] bytes;
 

--- a/CodenameOne/src/com/codename1/io/JSONParser.java
+++ b/CodenameOne/src/com/codename1/io/JSONParser.java
@@ -1014,9 +1014,6 @@ public class JSONParser implements JSONParseCallback {
     ///
     /// - `longs`: True to use
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setUseLongsInstance(boolean longs) {
         useLongs = longs;
     }
@@ -1027,9 +1024,6 @@ public class JSONParser implements JSONParseCallback {
     ///
     /// True if null values are included in parsed content.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean isIncludeNullsInstance() {
         return includeNulls;
     }
@@ -1040,9 +1034,6 @@ public class JSONParser implements JSONParseCallback {
     ///
     /// - `include`: True to include null values in parsed content.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setIncludeNullsInstance(boolean include) {
         includeNulls = include;
     }
@@ -1053,9 +1044,6 @@ public class JSONParser implements JSONParseCallback {
     ///
     /// True if the parser will generate Boolean objects and not just Strings for boolean values.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean isUseBooleanInstance() {
         return useBoolean;
     }
@@ -1066,9 +1054,6 @@ public class JSONParser implements JSONParseCallback {
     ///
     /// - `useBoolean`: True to generate Boolean objects and not just Strings for boolean values.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setUseBooleanInstance(boolean useBoolean) {
         this.useBoolean = useBoolean;
     }
@@ -1296,10 +1281,6 @@ public class JSONParser implements JSONParseCallback {
     /// #### Returns
     ///
     /// True if strict mode is enabled.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///

--- a/CodenameOne/src/com/codename1/io/NetworkManager.java
+++ b/CodenameOne/src/com/codename1/io/NetworkManager.java
@@ -428,9 +428,6 @@ public final class NetworkManager {
     ///
     /// AsyncResource resolving to the connection request on complete.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public AsyncResource<ConnectionRequest> addToQueueAsync(final ConnectionRequest request) {
         final AsyncResource<ConnectionRequest> out = new AsyncResource<ConnectionRequest>();
         class WaitingClass implements ActionListener<NetworkEvent> {

--- a/CodenameOne/src/com/codename1/io/Oauth2.java
+++ b/CodenameOne/src/com/codename1/io/Oauth2.java
@@ -224,10 +224,6 @@ public class Oauth2 {
     /// @return True the redirect was handled.  False if it was not handled.  If this returns true, then you should just return from the start() method, and instead
     /// handle control flow in your callback.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - #setUseRedirectForWeb(boolean)
@@ -305,9 +301,6 @@ public class Oauth2 {
     ///
     /// True if this component will use an external web browser window.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean isUseBrowserWindow() {
         return useBrowserWindow;
     }
@@ -322,9 +315,6 @@ public class Oauth2 {
     ///
     /// - `useBrowserWindow`: True to use a browser window for the login process.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setUseBrowserWindow(boolean useBrowserWindow) {
         this.useBrowserWindow = useBrowserWindow;
     }
@@ -334,10 +324,6 @@ public class Oauth2 {
     /// #### Returns
     ///
     /// True if this component will use a redirect for Oauth login.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -361,10 +347,6 @@ public class Oauth2 {
     /// #### Parameters
     ///
     /// - `redirect`: Set to true to use a redirect for Oauth login instead of an iframe when running on the web.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -491,9 +473,6 @@ public class Oauth2 {
     ///
     /// - `map`: Parsed JSON object of response.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     protected void handleTokenRequestResponse(Map map) {
         token = (String) map.get("access_token");
         Object ex = map.get("expires_in");
@@ -516,9 +495,6 @@ public class Oauth2 {
     ///
     /// - `t`: The query string.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     protected void handleTokenRequestResponse(String t) {
         token = t.substring(t.indexOf("=") + 1, t.indexOf("&"));
         int off = t.indexOf("expires=");

--- a/CodenameOne/src/com/codename1/io/Properties.java
+++ b/CodenameOne/src/com/codename1/io/Properties.java
@@ -214,9 +214,6 @@ public class Properties extends HashMap<String, String> {
     ///
     /// - `IOException`
     ///
-    /// #### Since
-    ///
-    /// 1.6
     @SuppressWarnings({"fallthrough", "PMD.SwitchStmtsShouldHaveDefault"})
     public synchronized void load(Reader in) throws IOException {
         if (in == null) {
@@ -402,9 +399,6 @@ public class Properties extends HashMap<String, String> {
     ///
     /// a set of keys in the property list
     ///
-    /// #### Since
-    ///
-    /// 1.6
     public Set<String> stringPropertyNames() {
         Hashtable<String, Object> stringProperties = new Hashtable<String, Object>();
         selectProperties(stringProperties, true);
@@ -505,9 +499,6 @@ public class Properties extends HashMap<String, String> {
     ///
     /// - `ClassCastException`: if a key or value is not a string
     ///
-    /// #### Since
-    ///
-    /// 1.6
     public synchronized void store(Writer writer, String comment) throws IOException {
         if (comment != null && comment.length() > 0) {
             writer.write("#");

--- a/CodenameOne/src/com/codename1/io/SocketConnection.java
+++ b/CodenameOne/src/com/codename1/io/SocketConnection.java
@@ -49,9 +49,6 @@ public abstract class SocketConnection {
     ///
     /// - `connectTimeout`: The connect timeout.  0 for infinite.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public SocketConnection(int connectTimeout) {
         this.connectTimeout = connectTimeout;
     }
@@ -102,9 +99,6 @@ public abstract class SocketConnection {
     ///
     /// - `connectTimeout`: The connect timeout.  0 for infinite timeout.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setConnectTimeout(int connectTimeout) {
         this.connectTimeout = connectTimeout;
     }

--- a/CodenameOne/src/com/codename1/io/URL.java
+++ b/CodenameOne/src/com/codename1/io/URL.java
@@ -190,9 +190,6 @@ public class URL {
         ///
         /// - `value`: The value of the request property.
         ///
-        /// #### Since
-        ///
-        /// 7.0
         public void setRequestProperty(String key,
                                        String value) {
             properties.put(key, value);

--- a/CodenameOne/src/com/codename1/io/Util.java
+++ b/CodenameOne/src/com/codename1/io/Util.java
@@ -256,9 +256,6 @@ public final class Util {
     ///
     /// - `IOException`: If the file does not exist, or cannot be read for some reason.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public static String readToString(File file, String charset) throws IOException {
         if (charset == null) {
             charset = "UTF-8";
@@ -283,9 +280,6 @@ public final class Util {
     ///
     /// - `IOException`: If the file does not exist, or cannot be read for some reason.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public static String readToString(File file) throws IOException {
         return readToString(file, "UTF-8");
     }
@@ -302,9 +296,6 @@ public final class Util {
     ///
     /// - `IOException`: If it cannot write to the file for some reason.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public static void writeStringToFile(File file, String contents) throws IOException {
         writeStringToFile(file, contents, "UTF-8");
     }
@@ -323,9 +314,6 @@ public final class Util {
     ///
     /// - `IOException`: If it cannot write to the file for some reason.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public static void writeStringToFile(File file, String contents, String charset) throws IOException {
         if (charset == null) {
             charset = "UTF-8";
@@ -375,9 +363,6 @@ public final class Util {
     ///
     /// - `IOException`: thrown by the stream
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static String readToString(Reader reader) throws IOException {
         StringBuilder sb = new StringBuilder();
         char[] buf = new char[1024];
@@ -2124,10 +2109,6 @@ public final class Util {
     ///
     /// - `onFail`: Callback called if we fail to load the image.
     ///
-    /// #### Since
-    ///
-    /// 3.4
-    ///
     /// #### See also
     ///
     /// - ConnectionRequest#downloadImageToFileSystem(java.lang.String, com.codename1.util.SuccessCallback, com.codename1.util.FailureCallback)
@@ -2144,10 +2125,6 @@ public final class Util {
     ///
     /// - `fileName`: @param fileName The the path to the file where the image should be downloaded.  If this file already exists, it will simply load this file and skip the
     /// network request altogether.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -2183,10 +2160,6 @@ public final class Util {
     ///
     /// - `onSuccess`: Callback called on success.
     ///
-    /// #### Since
-    ///
-    /// 3.4
-    ///
     /// #### See also
     ///
     /// - ConnectionRequest#downloadImageToFileSystem(java.lang.String, com.codename1.util.SuccessCallback)
@@ -2208,10 +2181,6 @@ public final class Util {
     ///
     /// - `onFail`: Callback called if we fail to load the image.
     ///
-    /// #### Since
-    ///
-    /// 3.4
-    ///
     /// #### See also
     ///
     /// - ConnectionRequest#downloadImageToStorage(java.lang.String, com.codename1.util.SuccessCallback, com.codename1.util.FailureCallback)
@@ -2228,10 +2197,6 @@ public final class Util {
     ///
     /// - `fileName`: @param fileName The the storage file to save the image to.  If this file already exists, it will simply load this file and skip the
     /// network request altogether.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -2279,9 +2244,6 @@ public final class Util {
     ///
     /// AsyncResource to wrap the Image.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static AsyncResource<Image> downloadImageToCache(String url) {
         final AsyncResource<Image> out = new AsyncResource<Image>();
         downloadImageToCache(url, new SuccessCallback<Image>() {
@@ -2312,10 +2274,6 @@ public final class Util {
     /// network request altogether.
     ///
     /// - `onSuccess`: Callback called on success.
-    ///
-    /// #### Since
-    ///
-    /// 3.4
     ///
     /// #### See also
     ///

--- a/CodenameOne/src/com/codename1/io/oidc/OidcBrowserNative.java
+++ b/CodenameOne/src/com/codename1/io/oidc/OidcBrowserNative.java
@@ -39,7 +39,6 @@ package com.codename1.io.oidc;
 /// `redirectScheme` is the scheme half of the registered redirect URI (e.g.
 /// the `"com.example.app"` part of `"com.example.app:/oauth2redirect"`).
 ///
-/// @since 7.0.245
 public interface OidcBrowserNative {
 
     /// `true` if this implementation is usable on the current device / OS

--- a/CodenameOne/src/com/codename1/io/oidc/OidcClient.java
+++ b/CodenameOne/src/com/codename1/io/oidc/OidcClient.java
@@ -81,7 +81,6 @@ import java.util.Map;
 /// - **Implicit / hybrid / device flows.** Use the lower-level
 ///   [com.codename1.io.ConnectionRequest] APIs if you need those.
 ///
-/// @since 7.0.245
 public final class OidcClient {
 
     private final OidcConfiguration configuration;

--- a/CodenameOne/src/com/codename1/io/oidc/OidcConfiguration.java
+++ b/CodenameOne/src/com/codename1/io/oidc/OidcConfiguration.java
@@ -34,7 +34,6 @@ import java.util.Map;
 /// from a blank slate; use [#newBuilder(OidcConfiguration)] to derive one from
 /// an existing instance.
 ///
-/// @since 7.0.245
 public final class OidcConfiguration {
 
     private final String issuer;

--- a/CodenameOne/src/com/codename1/io/oidc/OidcException.java
+++ b/CodenameOne/src/com/codename1/io/oidc/OidcException.java
@@ -32,7 +32,6 @@ import java.io.IOException;
 /// (`"transport_error"`, `"state_mismatch"`, `"nonce_mismatch"`, `"user_cancelled"`,
 /// `"discovery_failed"`, `"invalid_id_token"`).
 ///
-/// @since 7.0.245
 public class OidcException extends IOException {
 
     /// Authorization server returned `error=access_denied`.

--- a/CodenameOne/src/com/codename1/io/oidc/OidcTokens.java
+++ b/CodenameOne/src/com/codename1/io/oidc/OidcTokens.java
@@ -39,7 +39,6 @@ import java.util.Map;
 /// To bridge into the older [AccessToken] API used by [com.codename1.social.Login],
 /// call [#toAccessToken()].
 ///
-/// @since 7.0.245
 public final class OidcTokens {
 
     private final String accessToken;

--- a/CodenameOne/src/com/codename1/io/oidc/PkceChallenge.java
+++ b/CodenameOne/src/com/codename1/io/oidc/PkceChallenge.java
@@ -36,7 +36,6 @@ import com.codename1.util.Base64;
 /// Microsoft both require it for mobile public clients and tolerate it for
 /// confidential clients.
 ///
-/// @since 7.0.245
 public final class PkceChallenge {
 
     /// Always `"S256"` -- the only value [OidcClient] emits. RFC 7636 also

--- a/CodenameOne/src/com/codename1/io/oidc/SystemBrowser.java
+++ b/CodenameOne/src/com/codename1/io/oidc/SystemBrowser.java
@@ -48,7 +48,6 @@ import com.codename1.util.AsyncResource;
 /// preserves cookies for single sign-on, and integrates with password and
 /// passkey autofill.
 ///
-/// @since 7.0.245
 public final class SystemBrowser {
 
     /// Port-supplied implementation, registered at app startup. Reads /

--- a/CodenameOne/src/com/codename1/io/oidc/TokenStore.java
+++ b/CodenameOne/src/com/codename1/io/oidc/TokenStore.java
@@ -42,7 +42,6 @@ import java.util.Map;
 /// All methods are asynchronous and may run network or biometric prompts on
 /// the calling thread.
 ///
-/// @since 7.0.245
 public interface TokenStore {
 
     /// Reads previously-saved tokens for `key`, or completes with `null` if

--- a/CodenameOne/src/com/codename1/io/rest/RequestBuilder.java
+++ b/CodenameOne/src/com/codename1/io/rest/RequestBuilder.java
@@ -212,10 +212,6 @@ public class RequestBuilder {
     ///
     /// RequestBuilder instance.
     ///
-    /// #### Since
-    ///
-    /// 8.0
-    ///
     /// #### See also
     ///
     /// - ConnectionRequest#setPriority(byte)
@@ -235,9 +231,6 @@ public class RequestBuilder {
     ///
     /// RequestBuilder instance.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public RequestBuilder cookiesEnabled(boolean cookiesEnabled) {
         checkFetched();
         this.cookiesEnabled = cookiesEnabled;
@@ -293,9 +286,6 @@ public class RequestBuilder {
     ///
     /// RequestBuilder instance
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public RequestBuilder queryParam(String key, String[] values) {
         checkFetched();
         queryParams.put(key, values);
@@ -344,10 +334,6 @@ public class RequestBuilder {
     /// #### Returns
     ///
     /// RequestBuilder instances
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -471,9 +457,6 @@ public class RequestBuilder {
     ///
     /// RequestBuilder instance
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public RequestBuilder onError(ActionListener<NetworkEvent> error, boolean replace) {
         checkFetched();
         if (replace) {

--- a/CodenameOne/src/com/codename1/io/webauthn/PublicKeyCredential.java
+++ b/CodenameOne/src/com/codename1/io/webauthn/PublicKeyCredential.java
@@ -41,7 +41,6 @@ import java.util.Map;
 /// attestation or assertion on the device -- that is the relying party's
 /// responsibility.
 ///
-/// @since 7.0.245
 public final class PublicKeyCredential {
 
     /// Credential type -- always `"public-key"` for WebAuthn.

--- a/CodenameOne/src/com/codename1/io/webauthn/PublicKeyCredentialCreationOptions.java
+++ b/CodenameOne/src/com/codename1/io/webauthn/PublicKeyCredentialCreationOptions.java
@@ -55,7 +55,6 @@ import java.util.Map;
 /// fields. To synthesise options client-side (rare -- usually only useful in
 /// tests) use [#newBuilder()].
 ///
-/// @since 7.0.245
 public final class PublicKeyCredentialCreationOptions {
 
     /// The full options JSON, preserved verbatim so the authenticator sees

--- a/CodenameOne/src/com/codename1/io/webauthn/PublicKeyCredentialRequestOptions.java
+++ b/CodenameOne/src/com/codename1/io/webauthn/PublicKeyCredentialRequestOptions.java
@@ -38,7 +38,6 @@ import java.util.Map;
 /// [WebAuthnClient#get(PublicKeyCredentialRequestOptions)], post the result
 /// back to your server for verification.
 ///
-/// @since 7.0.245
 public final class PublicKeyCredentialRequestOptions {
 
     private final String json;

--- a/CodenameOne/src/com/codename1/io/webauthn/WebAuthnClient.java
+++ b/CodenameOne/src/com/codename1/io/webauthn/WebAuthnClient.java
@@ -82,7 +82,6 @@ import com.codename1.util.AsyncResource;
 ///   passkey ceremony). Use this class when you specifically have your own
 ///   relying party.
 ///
-/// @since 7.0.245
 public final class WebAuthnClient {
 
     private static WebAuthnClient INSTANCE = new WebAuthnClient();

--- a/CodenameOne/src/com/codename1/io/webauthn/WebAuthnException.java
+++ b/CodenameOne/src/com/codename1/io/webauthn/WebAuthnException.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 /// (`"invalid_options"`, `"invalid_response"`) and the platform not
 /// implementing public-key credentials at all (`"not_supported"`).
 ///
-/// @since 7.0.245
 public class WebAuthnException extends IOException {
 
     /// User dismissed the OS passkey sheet, or the OS denied the request

--- a/CodenameOne/src/com/codename1/io/webauthn/WebAuthnNative.java
+++ b/CodenameOne/src/com/codename1/io/webauthn/WebAuthnNative.java
@@ -43,7 +43,6 @@ package com.codename1.io.webauthn;
 /// and lets the implementation forward the JSON straight to the OS API (both
 /// platforms accept JSON-shaped inputs in their modern APIs).
 ///
-/// @since 7.0.245
 public interface WebAuthnNative {
 
     /// `true` if this implementation can actually call the OS authenticator

--- a/CodenameOne/src/com/codename1/l10n/L10NManager.java
+++ b/CodenameOne/src/com/codename1/l10n/L10NManager.java
@@ -140,9 +140,6 @@ public class L10NManager {
     ///
     /// Short month name.  E.g. Jan, Feb, etc..
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public String getShortMonthName(Date date) {
         return limitLength(getLongMonthName(date), 3);
     }
@@ -157,9 +154,6 @@ public class L10NManager {
     ///
     /// Long month name.  E.g. January, February, etc..
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public String getLongMonthName(Date date) {
         String fmt = formatDateLongStyle(date);
         try {

--- a/CodenameOne/src/com/codename1/media/AbstractMedia.java
+++ b/CodenameOne/src/com/codename1/media/AbstractMedia.java
@@ -31,9 +31,6 @@ import com.codename1.util.SuccessCallback;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 7.0
 public abstract class AbstractMedia implements AsyncMedia {
     private final EventDispatcher stateChangeListeners = new EventDispatcher();
     private final EventDispatcher errorListeners = new EventDispatcher();

--- a/CodenameOne/src/com/codename1/media/AsyncMedia.java
+++ b/CodenameOne/src/com/codename1/media/AsyncMedia.java
@@ -37,10 +37,6 @@ import com.codename1.util.AsyncResource;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 7.0
-///
 /// #### See also
 ///
 /// - MediaManager#getAsyncMedia(com.codename1.media.Media)
@@ -104,9 +100,6 @@ public interface AsyncMedia extends Media {
 
     /// Enum encapsulating the different types of media errors that can occur.
     ///
-    /// #### Since
-    ///
-    /// type.
     enum MediaErrorType {
         /// The fetching of the associated resource was aborted by the user's request.
         Aborted("The fetching of the associated resource was aborted by the user's request"),
@@ -132,9 +125,6 @@ public interface AsyncMedia extends Media {
 
     /// Encapsulates a state-change event on a Media object.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     class MediaStateChangeEvent extends ActionEvent {
 
         private final State oldState;
@@ -176,9 +166,6 @@ public interface AsyncMedia extends Media {
 
     /// Encapsulates a media exception.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     class MediaException extends RuntimeException {
         private final MediaErrorType mediaErrorType;
 
@@ -225,9 +212,6 @@ public interface AsyncMedia extends Media {
 
     /// Encapsulates a media error event.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     class MediaErrorEvent extends ActionEvent {
         private final MediaException mediaException;
 
@@ -251,10 +235,6 @@ public interface AsyncMedia extends Media {
 
     /// An async resource used to track the progress of a playAsync() request.  It will
     /// resolve when the media has started playing, or if an error occurs first.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///

--- a/CodenameOne/src/com/codename1/media/MediaManager.java
+++ b/CodenameOne/src/com/codename1/media/MediaManager.java
@@ -332,9 +332,6 @@ public abstract class MediaManager {
     /// A static map of audio buffers.  These can be used to register an Audio buffer to receive
     /// raw PCM data from the microphone.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     private static final Map<String, AudioBuffer> audioBuffers = new HashMap<String, AudioBuffer>();
     private static RemoteControlListener remoteControlListener;
 
@@ -349,9 +346,6 @@ public abstract class MediaManager {
     ///
     /// The AudioBuffer or null if no buffer exists at that path.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static AudioBuffer getAudioBuffer(String path) {
         return getAudioBuffer(path, false, 256);
     }
@@ -372,9 +366,6 @@ public abstract class MediaManager {
     ///
     /// The audio buffer or null if no buffer exists at that path and the create flag is false.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static AudioBuffer getAudioBuffer(String path, boolean create, int size) {
         AudioBuffer buf = null;
         if (create && !audioBuffers.containsKey(path)) {
@@ -396,9 +387,6 @@ public abstract class MediaManager {
     ///
     /// - `path`: The path to the buffer.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static void releaseAudioBuffer(String path) {
         AudioBuffer buf = audioBuffers.get(path);
         if (buf != null) {
@@ -415,10 +403,6 @@ public abstract class MediaManager {
     ///
     /// - `path`: The path to the audio buffer to delete.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### Deprecated
     ///
     /// Prefer to use `#releaseAudioBuffer(java.lang.String)`
@@ -433,9 +417,6 @@ public abstract class MediaManager {
     /// @return The currently registered remote control listener, or null if
     /// none is registered.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static RemoteControlListener getRemoteControlListener() {
         return remoteControlListener;
     }
@@ -448,9 +429,6 @@ public abstract class MediaManager {
     ///
     /// - `l`: The remote control listener to set.  null to set no listener.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static synchronized void setRemoteControlListener(RemoteControlListener l) {
         boolean shouldStop = remoteControlListener != null && l == null;
         if (shouldStop) {
@@ -495,9 +473,6 @@ public abstract class MediaManager {
     /// @return Media a Media Object that can be used to control the playback
     /// of the media
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static AsyncResource<Media> createBackgroundMediaAsync(String uri) {
         return Display.getInstance().createBackgroundMediaAsync(uri);
     }
@@ -558,9 +533,6 @@ public abstract class MediaManager {
     /// @return Media a Media Object that can be used to control the playback
     /// of the media
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static AsyncResource<Media> createMediaAsync(InputStream stream, String mimeType, Runnable onCompletion) {
         return Display.getInstance().createMediaAsync(stream, mimeType, onCompletion);
     }
@@ -604,9 +576,6 @@ public abstract class MediaManager {
     /// @return Media a Media Object that can be used to control the playback
     /// of the media
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static AsyncResource<Media> createMediaAsync(String uri, boolean isVideo, Runnable onCompletion) {
         return Display.getInstance().createMediaAsync(uri, isVideo, onCompletion);
     }
@@ -732,9 +701,6 @@ public abstract class MediaManager {
     ///
     /// - `IOException`: id failed to create a Media object
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static Media createMediaRecorder(MediaRecorderBuilder builder) throws IOException {
         if (builder.isRedirectToAudioBuffer()) {
             return builder.build();
@@ -776,9 +742,6 @@ public abstract class MediaManager {
     ///
     /// The media object as an AsyncMedia instance.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static AsyncMedia getAsyncMedia(final Media media) {
         if (media instanceof AsyncMedia) {
             return (AsyncMedia) media;

--- a/CodenameOne/src/com/codename1/media/MediaMetaData.java
+++ b/CodenameOne/src/com/codename1/media/MediaMetaData.java
@@ -29,9 +29,6 @@ import com.codename1.ui.Image;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 7.0
 public class MediaMetaData {
 
     private String title;

--- a/CodenameOne/src/com/codename1/media/MediaRecorderBuilder.java
+++ b/CodenameOne/src/com/codename1/media/MediaRecorderBuilder.java
@@ -30,9 +30,6 @@ import java.io.IOException;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 7.0
 public class MediaRecorderBuilder {
     private int audioChannels = 1,
             bitRate = 64000,

--- a/CodenameOne/src/com/codename1/media/RemoteControlListener.java
+++ b/CodenameOne/src/com/codename1/media/RemoteControlListener.java
@@ -31,9 +31,6 @@ package com.codename1.media;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 7.0
 public class RemoteControlListener {
 
     /// Called when user presses play button on remote control.

--- a/CodenameOne/src/com/codename1/media/WAVWriter.java
+++ b/CodenameOne/src/com/codename1/media/WAVWriter.java
@@ -12,9 +12,6 @@ import java.io.OutputStream;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 7.0
 public class WAVWriter implements AutoCloseable {
     private final File outputFile;
     private final int samplingRate;

--- a/CodenameOne/src/com/codename1/notifications/LocalNotification.java
+++ b/CodenameOne/src/com/codename1/notifications/LocalNotification.java
@@ -264,9 +264,6 @@ public class LocalNotification {
     ///
     /// True if the notification will display in the device's notification center even when the app is in the foreground.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean isForeground() {
         return foreground;
     }
@@ -278,9 +275,6 @@ public class LocalNotification {
     ///
     /// - `foreground`: True to display this notification in the notification center even when the app is in the foreground.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setForeground(boolean foreground) {
         this.foreground = foreground;
     }

--- a/CodenameOne/src/com/codename1/payment/PendingPurchaseCallback.java
+++ b/CodenameOne/src/com/codename1/payment/PendingPurchaseCallback.java
@@ -32,9 +32,6 @@ package com.codename1.payment;
 ///
 /// @author Steve Hannah
 ///
-/// #### Since
-///
-/// 8.0
 public interface PendingPurchaseCallback extends PurchaseCallback {
     void itemPurchasePending(String sku);
 }

--- a/CodenameOne/src/com/codename1/payment/Purchase.java
+++ b/CodenameOne/src/com/codename1/payment/Purchase.java
@@ -1070,9 +1070,6 @@ public abstract class Purchase {
     ///
     /// True if the platform supports the `#manageSubscriptions(java.lang.String)` method.
     ///
-    /// #### Since
-    ///
-    /// 6.0
     public boolean isManageSubscriptionsSupported() {
         return false;
     }
@@ -1089,9 +1086,6 @@ public abstract class Purchase {
     /// management for a particular sku, so this parameter is ignored there.  If included on Android, howerver,
     /// it will open the UI for managing the specified sku.
     ///
-    /// #### Since
-    ///
-    /// 6.0
     public void manageSubscriptions(String sku) {
         Dialog.show("Not Supported", "This platform doesn't support in-app subscription management. ", "OK", null);
     }
@@ -1103,9 +1097,6 @@ public abstract class Purchase {
     /// @return The store code.  One of `Receipt#STORE_CODE_ITUNES`, `Receipt#STORE_CODE_PLAY`, `Receipt#STORE_CODE_SIMULATOR`, or
     /// `Receipt#STORE_CODE_WINDOWS`.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public String getStoreCode() {
         return null;
     }

--- a/CodenameOne/src/com/codename1/plugin/Plugin.java
+++ b/CodenameOne/src/com/codename1/plugin/Plugin.java
@@ -31,8 +31,5 @@ import com.codename1.ui.events.ActionListener;
 ///
 /// @author Steve Hannah
 ///
-/// #### Since
-///
-/// 8.0
 public interface Plugin extends ActionListener<PluginEvent> {
 }

--- a/CodenameOne/src/com/codename1/plugin/PluginSupport.java
+++ b/CodenameOne/src/com/codename1/plugin/PluginSupport.java
@@ -32,9 +32,6 @@ import java.util.List;
 ///
 /// @author Steve Hannah
 ///
-/// #### Since
-///
-/// 8.0
 public class PluginSupport {
     private final List<Plugin> plugins = new ArrayList<Plugin>();
 
@@ -44,9 +41,6 @@ public class PluginSupport {
     ///
     /// - `plugin`: The plugin to register.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public void registerPlugin(Plugin plugin) {
         synchronized (this) {
             plugins.add(plugin);
@@ -60,9 +54,6 @@ public class PluginSupport {
     ///
     /// - `plugin`: The plugin to deregister
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public void deregisterPlugin(Plugin plugin) {
         synchronized (this) {
             plugins.remove(plugin);

--- a/CodenameOne/src/com/codename1/plugin/event/IsGalleryTypeSupportedEvent.java
+++ b/CodenameOne/src/com/codename1/plugin/event/IsGalleryTypeSupportedEvent.java
@@ -27,9 +27,6 @@ package com.codename1.plugin.event;
 ///
 /// @author Steve Hannah
 ///
-/// #### Since
-///
-/// 8.0
 public class IsGalleryTypeSupportedEvent extends PluginEvent<Boolean> {
     private final int type;
 
@@ -48,10 +45,6 @@ public class IsGalleryTypeSupportedEvent extends PluginEvent<Boolean> {
     /// #### Returns
     ///
     /// The type of gallery to open.  This is one of the constants defined in `Display`.
-    ///
-    /// #### Since
-    ///
-    /// 8.0
     ///
     /// #### See also
     ///

--- a/CodenameOne/src/com/codename1/plugin/event/OpenGalleryEvent.java
+++ b/CodenameOne/src/com/codename1/plugin/event/OpenGalleryEvent.java
@@ -28,9 +28,6 @@ import com.codename1.ui.events.ActionListener;
 ///
 /// @author Steve Hannah
 ///
-/// #### Since
-///
-/// 8.0
 public class OpenGalleryEvent extends PluginEvent<Void> {
     private final ActionListener response;
 
@@ -48,10 +45,6 @@ public class OpenGalleryEvent extends PluginEvent<Void> {
     ///
     /// The response listener.
     ///
-    /// #### Since
-    ///
-    /// 8.0
-    ///
     /// #### See also
     ///
     /// - Display#openGallery(com.codename1.ui.events.ActionListener, int)
@@ -64,10 +57,6 @@ public class OpenGalleryEvent extends PluginEvent<Void> {
     /// #### Returns
     ///
     /// The type of gallery to open.
-    ///
-    /// #### Since
-    ///
-    /// 8.0
     ///
     /// #### See also
     ///

--- a/CodenameOne/src/com/codename1/plugin/event/PluginEvent.java
+++ b/CodenameOne/src/com/codename1/plugin/event/PluginEvent.java
@@ -44,9 +44,6 @@ import com.codename1.ui.events.ActionEvent;
 ///
 /// - `The`: type of the response to the event. If the event does not require a response, this should be `Void`.
 ///
-/// #### Since
-///
-/// 8.0
 public abstract class PluginEvent<T> extends ActionEvent {
 
     private T pluginEventResponse;

--- a/CodenameOne/src/com/codename1/social/AppleSignIn.java
+++ b/CodenameOne/src/com/codename1/social/AppleSignIn.java
@@ -71,7 +71,6 @@ import java.util.Map;
 /// });
 /// ```
 ///
-/// @since 7.0.245
 public final class AppleSignIn extends Login {
 
     /// Apple's public OIDC issuer.

--- a/CodenameOne/src/com/codename1/social/AppleSignInCallback.java
+++ b/CodenameOne/src/com/codename1/social/AppleSignInCallback.java
@@ -27,7 +27,6 @@ package com.codename1.social;
 /// the three terminal outcomes -- success, error, cancellation -- so the
 /// caller can tell user-intent (cancel) apart from a real failure.
 ///
-/// @since 7.0.245
 public interface AppleSignInCallback {
 
     /// User completed the sheet successfully.

--- a/CodenameOne/src/com/codename1/social/AppleSignInNative.java
+++ b/CodenameOne/src/com/codename1/social/AppleSignInNative.java
@@ -43,7 +43,6 @@ package com.codename1.social;
 /// populated on the **first** authorization (Apple does not re-send the
 /// profile on subsequent logins). The Java side persists them.
 ///
-/// @since 7.0.245
 public interface AppleSignInNative {
 
     /// `true` if this implementation is usable on the current device / OS

--- a/CodenameOne/src/com/codename1/social/AppleSignInResult.java
+++ b/CodenameOne/src/com/codename1/social/AppleSignInResult.java
@@ -31,7 +31,6 @@ package com.codename1.social;
 /// native callback; [AppleSignIn] backfills them from [com.codename1.io.Preferences]
 /// when present, so the application sees a consistent result.
 ///
-/// @since 7.0.245
 public final class AppleSignInResult {
 
     String identityToken;

--- a/CodenameOne/src/com/codename1/social/Auth0Connect.java
+++ b/CodenameOne/src/com/codename1/social/Auth0Connect.java
@@ -63,7 +63,6 @@ import java.util.Map;
 /// your custom API) pass it via [#withAudience(String)] before calling
 /// [#signIn(String, String, String...)].
 ///
-/// @since 7.0.245
 public final class Auth0Connect extends Login {
 
     private static Auth0Connect INSTANCE;
@@ -131,7 +130,6 @@ public final class Auth0Connect extends Login {
     /// [com.codename1.io.webauthn.WebAuthnException#NOT_IMPLEMENTED] on
     /// platforms that don't have a WebAuthn implementation.
     ///
-    /// @since 7.0.245
     public AsyncResource<OidcTokens> signInWithPasskey(final String clientId,
                                                        final String realm,
                                                        final String... scopes) {
@@ -173,7 +171,6 @@ public final class Auth0Connect extends Login {
     /// 2. Run [WebAuthnClient#create] with those options.
     /// 3. POST `/oauth/token` to swap the authenticator response for tokens.
     ///
-    /// @since 7.0.245
     public AsyncResource<OidcTokens> registerPasskey(final String clientId,
                                                      final String realm,
                                                      final String email,

--- a/CodenameOne/src/com/codename1/social/FacebookConnect.java
+++ b/CodenameOne/src/com/codename1/social/FacebookConnect.java
@@ -272,9 +272,6 @@ public class FacebookConnect extends Login {
     /// classic OAuth flows -- `getIdToken()` will be `null`; use
     /// `getAccessToken()` and call the Graph API to read user profile data).
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public AsyncResource<OidcTokens> signIn(String appId,
                                             String redirectUri,
                                             String... permissions) {

--- a/CodenameOne/src/com/codename1/social/FirebaseAuth.java
+++ b/CodenameOne/src/com/codename1/social/FirebaseAuth.java
@@ -63,7 +63,6 @@ import java.util.Map;
 /// They are **not** encrypted-at-rest by default -- bring your own
 /// [com.codename1.io.oidc.TokenStore] strategy if that matters to you.
 ///
-/// @since 7.0.245
 public final class FirebaseAuth {
 
     private static final String PREF_ID = "cn1.firebase.idToken";
@@ -175,7 +174,6 @@ public final class FirebaseAuth {
     /// passkeys enabled in the console. The classic Firebase Auth tier does
     /// not expose passkey endpoints.
     ///
-    /// @since 7.0.245
     public AsyncResource<FirebaseUser> registerPasskey(final String name) {
         final AsyncResource<FirebaseUser> out = new AsyncResource<FirebaseUser>();
         if (apiKey == null) {
@@ -237,7 +235,6 @@ public final class FirebaseAuth {
     ///
     /// Available wherever [WebAuthnClient#isSupported()] returns `true`.
     ///
-    /// @since 7.0.245
     public AsyncResource<FirebaseUser> signInWithPasskey() {
         final AsyncResource<FirebaseUser> out = new AsyncResource<FirebaseUser>();
         if (apiKey == null) {

--- a/CodenameOne/src/com/codename1/social/GoogleConnect.java
+++ b/CodenameOne/src/com/codename1/social/GoogleConnect.java
@@ -129,9 +129,6 @@ public class GoogleConnect extends Login {
     /// An [AsyncResource] resolving to the [OidcTokens] for the signed-in
     /// user.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public AsyncResource<OidcTokens> signIn(final String clientId,
                                             final String redirectUri,
                                             final String... scopes) {

--- a/CodenameOne/src/com/codename1/social/Login.java
+++ b/CodenameOne/src/com/codename1/social/Login.java
@@ -75,10 +75,6 @@ public abstract class Login {
     ///
     /// Self for chaining.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - #setScope(java.lang.String)
@@ -124,9 +120,6 @@ public abstract class Login {
     ///
     /// AsyncResource that can be monitored for completion.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public AsyncResource<Login> connect() {
         final AsyncResource<Login> out = new AsyncResource<Login>();
         if (isUserLoggedIn()) {
@@ -153,9 +146,6 @@ public abstract class Login {
     ///
     /// - `callback`: Callback to be called if login succeeds or fails.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void doLogin(LoginCallback callback) {
         if (callback != null) {
             loginCallbacksSingleUse.add(callback);
@@ -437,9 +427,6 @@ public abstract class Login {
     ///
     /// the preferRedirectPrompt
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean isPreferRedirectPrompt() {
         return preferRedirectPrompt;
     }
@@ -453,9 +440,6 @@ public abstract class Login {
     ///
     /// - `preferRedirectPrompt`: the preferRedirectPrompt to set
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setPreferRedirectPrompt(boolean preferRedirectPrompt) {
         this.preferRedirectPrompt = preferRedirectPrompt;
     }

--- a/CodenameOne/src/com/codename1/social/MicrosoftConnect.java
+++ b/CodenameOne/src/com/codename1/social/MicrosoftConnect.java
@@ -53,7 +53,6 @@ import com.codename1.util.SuccessCallback;
 ///     });
 /// ```
 ///
-/// @since 7.0.245
 public final class MicrosoftConnect extends Login {
 
     /// "common" -- accepts personal, work, and school accounts. Use this for

--- a/CodenameOne/src/com/codename1/testing/AbstractTest.java
+++ b/CodenameOne/src/com/codename1/testing/AbstractTest.java
@@ -301,10 +301,6 @@ public abstract class AbstractTest implements UnitTest {
         TestUtils.assertEqual(expected, actual, maxRelativeError);
     }
 
-    /// #### Since
-    ///
-    /// 8.0
-    ///
     /// #### See also
     ///
     /// - TestUtils#assertRange(double, double, double)
@@ -312,10 +308,6 @@ public abstract class AbstractTest implements UnitTest {
         TestUtils.assertRange(expected, actual, maxAbsoluteError);
     }
 
-    /// #### Since
-    ///
-    /// 8.0
-    ///
     /// #### See also
     ///
     /// - TestUtils#assertRange(double, double, double, String)

--- a/CodenameOne/src/com/codename1/testing/TestRunnerComponent.java
+++ b/CodenameOne/src/com/codename1/testing/TestRunnerComponent.java
@@ -52,9 +52,6 @@ import static com.codename1.ui.ComponentSelector.$;
 ///
 /// @author Steve Hannah
 ///
-/// #### Since
-///
-/// 7.0
 public class TestRunnerComponent extends Container {
     private final ArrayList<AbstractTest> tests = new ArrayList<AbstractTest>();
     private final Container resultsPane = new Container(BoxLayout.y());

--- a/CodenameOne/src/com/codename1/testing/TestUtils.java
+++ b/CodenameOne/src/com/codename1/testing/TestUtils.java
@@ -1328,9 +1328,6 @@ public final class TestUtils {
     ///
     /// - `absoluteError`: is the maximum allowed error, a value of 1 represents a 1% error.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public static void assertRange(double expected, double actual, double absoluteError) {
         if (verbose) {
             log("assertRange(" + expected + ", " + actual + ")");

--- a/CodenameOne/src/com/codename1/ui/AnimationManager.java
+++ b/CodenameOne/src/com/codename1/ui/AnimationManager.java
@@ -97,10 +97,6 @@ public final class AnimationManager {
     ///
     /// - `an`: The animation
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - UIMutation
@@ -171,10 +167,6 @@ public final class AnimationManager {
     /// - `an`: The animation
     ///
     /// - `callback`: A callback to be run on completion.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///

--- a/CodenameOne/src/com/codename1/ui/BlockingDisallowedException.java
+++ b/CodenameOne/src/com/codename1/ui/BlockingDisallowedException.java
@@ -29,10 +29,6 @@ package com.codename1.ui;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 7.0
-///
 /// #### See also
 ///
 /// - Display#invokeWithoutBlocking(java.lang.Runnable)

--- a/CodenameOne/src/com/codename1/ui/BrowserComponent.java
+++ b/CodenameOne/src/com/codename1/ui/BrowserComponent.java
@@ -430,9 +430,6 @@ public class BrowserComponent extends Container {
     ///
     /// a data URL that can be placed into the img src attribute in HTML e.g. data:image/png;base64,encodedData
     ///
-    /// #### Since
-    ///
-    /// 6.0
     public static String createDataURI(byte[] data, String mime) {
         return "data:" + mime + ";base64," + Base64.encodeNoNewline(data);
     }
@@ -447,10 +444,6 @@ public class BrowserComponent extends Container {
     ///
     /// True if javascript callbacks are run on the EDT.
     ///
-    /// #### Since
-    ///
-    /// 5.0
-    ///
     /// #### See also
     ///
     /// - #setFireCallbacksOnEdt(boolean)
@@ -464,9 +457,6 @@ public class BrowserComponent extends Container {
     ///
     /// - `edt`: True if callbacks should be run on EDT.  False if they should be run on the platform's main thread.
     ///
-    /// #### Since
-    ///
-    /// 5.0
     public void setFireCallbacksOnEdt(boolean edt) {
         this.fireCallbacksOnEdt = edt;
     }
@@ -479,9 +469,6 @@ public class BrowserComponent extends Container {
     ///
     /// AsyncResource resolving to an Image of the webview contents.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public AsyncResource<Image> captureScreenshot() {
         if (internal != null) {
             AsyncResource<Image> i = Display.impl.captureBrowserScreenshot(internal);
@@ -606,9 +593,6 @@ public class BrowserComponent extends Container {
     ///
     /// - `targetOrigin`: The target origin of the message.  E.g. http://example.com:1234
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void postMessage(final String message, final String targetOrigin) {
         if (internal == null) {
             onReady(new Runnable() {
@@ -774,10 +758,6 @@ public class BrowserComponent extends Container {
     ///
     /// Self for chaining.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - #waitForReady()
@@ -804,9 +784,6 @@ public class BrowserComponent extends Container {
     ///
     /// AsyncResouce that will complete when the browser component is ready.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public AsyncResource<BrowserComponent> ready() {
         return ready(5000);
     }
@@ -822,9 +799,6 @@ public class BrowserComponent extends Container {
     ///
     /// AsyncResouce that will complete when the browser component is ready.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public AsyncResource<BrowserComponent> ready(int timeout) {
         final AsyncResource<BrowserComponent> out = new AsyncResource<BrowserComponent>();
 
@@ -1332,9 +1306,6 @@ public class BrowserComponent extends Container {
     ///
     /// The result as a string.
     ///
-    /// #### Since
-    ///
-    /// 5.0
     public String executeAndReturnString(String javaScript, Object[] params) {
         return executeAndReturnString(injectParameters(javaScript, params));
     }

--- a/CodenameOne/src/com/codename1/ui/BrowserWindow.java
+++ b/CodenameOne/src/com/codename1/ui/BrowserWindow.java
@@ -33,9 +33,6 @@ import com.codename1.util.AsyncResource;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 7.0
 public class BrowserWindow {
 
     /// Implementation for BrowserWindow provided by the platform implementation.  The default
@@ -177,9 +174,6 @@ public class BrowserWindow {
 
     /// A future that is returned from the eval() method.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static class EvalRequest extends AsyncResource<String> {
         private String js;
 

--- a/CodenameOne/src/com/codename1/ui/Button.java
+++ b/CodenameOne/src/com/codename1/ui/Button.java
@@ -94,9 +94,6 @@ public class Button extends Label implements ReleasableComponent, ActionSource<A
     /// A listener used to bind the state with another button.  When that button's state
     /// changes, then this button state will also change.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     private ActionListener<? extends ActionEvent> bindListener;
 
     /// Constructs a button with an empty string for its text.
@@ -340,10 +337,6 @@ public class Button extends Label implements ReleasableComponent, ActionSource<A
     ///
     /// - `button`: The button whose state to bind to.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - #unbindStateFrom(com.codename1.ui.Button)
@@ -356,10 +349,6 @@ public class Button extends Label implements ReleasableComponent, ActionSource<A
     /// #### Parameters
     ///
     /// - `button`: The button to unbind state from.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -554,10 +543,6 @@ public class Button extends Label implements ReleasableComponent, ActionSource<A
     ///
     /// - `l`: Listener to be notified when state changes
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - #getState()
@@ -578,10 +563,6 @@ public class Button extends Label implements ReleasableComponent, ActionSource<A
     /// #### Parameters
     ///
     /// - `l`: State change listener to remove.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///

--- a/CodenameOne/src/com/codename1/ui/CN.java
+++ b/CodenameOne/src/com/codename1/ui/CN.java
@@ -165,18 +165,12 @@ public class CN extends CN1Constants {
     ///
     /// - `bookmark`: A `Runnable` that can be run to restore the app to a particular point.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public static void setBookmark(Runnable bookmark) {
         Display.getInstance().setBookmark(bookmark);
     }
 
     /// Runs the last bookmark that was set using `#setBookmark(java.lang.Runnable)`
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public static void restoreToBookmark() {
         Display.getInstance().restoreToBookmark();
     }
@@ -242,10 +236,6 @@ public class CN extends CN1Constants {
     ///
     /// Whether async stack traces are enabled.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - #setEnableAsyncStackTraces(boolean)
@@ -262,10 +252,6 @@ public class CN extends CN1Constants {
     /// #### Parameters
     ///
     /// - `enable`: True to enable async stack traces.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -413,9 +399,6 @@ public class CN extends CN1Constants {
     /// - `BlockingDisallowedException`: @throws BlockingDisallowedException If `#invokeAndBlock(java.lang.Runnable)` is attempted
     /// anywhere in the Runnable.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static void invokeWithoutBlocking(Runnable r) {
         Display.INSTANCE.invokeWithoutBlocking(r);
     }
@@ -433,9 +416,6 @@ public class CN extends CN1Constants {
     /// - `BlockingDisallowedException`: @throws BlockingDisallowedException If `#invokeAndBlock(java.lang.Runnable)` is attempted
     /// anywhere in the Runnable.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static <T> T invokeWithoutBlockingWithResultSync(RunnableWithResultSync<T> r) {
         return Display.INSTANCE.invokeWithoutBlockingWithResultSync(r);
     }
@@ -526,9 +506,6 @@ public class CN extends CN1Constants {
     ///
     /// The value converted to pixels.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public static int convertToPixels(float value, byte unitType, boolean horizontal) {
         return Display.INSTANCE.convertToPixels(value, unitType, horizontal);
     }
@@ -547,9 +524,6 @@ public class CN extends CN1Constants {
     ///
     /// The value converted to pixels.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public static int convertToPixels(float value, byte unitType) {
         return Display.INSTANCE.convertToPixels(value, unitType);
     }
@@ -747,10 +721,6 @@ public class CN extends CN1Constants {
     /// @return true on success.  This will also return true if the app is already running in full-screen mode.  It will return false
     /// if the app fails to enter full-screen mode.
     ///
-    /// #### Since
-    ///
-    /// 6.0
-    ///
     /// #### See also
     ///
     /// - #exitFullScreen()
@@ -775,10 +745,6 @@ public class CN extends CN1Constants {
     /// @return true on success.  This will also return true if the app is already NOT in full-screen mode.  It will return false
     /// if the app fails to exit full-screen mode.
     ///
-    /// #### Since
-    ///
-    /// 6.0
-    ///
     /// #### See also
     ///
     /// - #requestFullScreen()
@@ -795,10 +761,6 @@ public class CN extends CN1Constants {
     /// #### Returns
     ///
     /// true if the app is currently in full-screen mode.
-    ///
-    /// #### Since
-    ///
-    /// 6.0
     ///
     /// #### See also
     ///
@@ -824,10 +786,6 @@ public class CN extends CN1Constants {
     /// #### Returns
     ///
     /// true if Full-screen mode is supported on this platform.
-    ///
-    /// #### Since
-    ///
-    /// 6.0
     ///
     /// #### See also
     ///
@@ -2178,10 +2136,6 @@ public class CN extends CN1Constants {
     ///
     /// True if you are able to prompt the user to install the app on their homescreen.
     ///
-    /// #### Since
-    ///
-    /// 6.0
-    ///
     /// #### See also
     ///
     /// - #promptInstallOnHomescreen()
@@ -2198,10 +2152,6 @@ public class CN extends CN1Constants {
     ///
     /// @return The result of the user prompt.  true if the user accepts the installation,
     /// false if they reject it.
-    ///
-    /// #### Since
-    ///
-    /// 6.0
     ///
     /// #### See also
     ///
@@ -2220,9 +2170,6 @@ public class CN extends CN1Constants {
     /// - `r`: @param r Runnable that will be run when/if you are permitted to prompt the user to install
     /// the app on their homescreen.
     ///
-    /// #### Since
-    ///
-    /// 6.0
     public static void onCanInstallOnHomescreen(Runnable r) {
         Display.impl.onCanInstallOnHomescreen(r);
     }
@@ -2233,9 +2180,6 @@ public class CN extends CN1Constants {
     ///
     /// An image of the screen, or null if it fails.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static Image captureScreen() {
         return Display.impl.captureScreen();
     }
@@ -2253,9 +2197,6 @@ public class CN extends CN1Constants {
     ///
     /// - `l`: The listener.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static void addMessageListener(ActionListener<MessageEvent> l) {
         Display.INSTANCE.addMessageListener(l);
     }
@@ -2268,9 +2209,6 @@ public class CN extends CN1Constants {
     ///
     /// - `l`: The listener.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static void removeMessageListener(ActionListener<MessageEvent> l) {
         Display.INSTANCE.removeMessageListener(l);
     }
@@ -2287,9 +2225,6 @@ public class CN extends CN1Constants {
     ///
     /// - `message`: The message to send to the native platform.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static void postMessage(MessageEvent message) {
         Display.INSTANCE.postMessage(message);
     }
@@ -2305,10 +2240,6 @@ public class CN extends CN1Constants {
     /// #### Returns
     ///
     /// The Timer object that can be used to cancel the task.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -2329,10 +2260,6 @@ public class CN extends CN1Constants {
     /// #### Returns
     ///
     /// The timer object which can be used to cancel the task.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -2374,9 +2301,6 @@ public class CN extends CN1Constants {
     ///
     /// A shared BrowserComponent
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static BrowserComponent getSharedJavascriptContext() {
         return Display.impl.getSharedJavscriptContext();
     }
@@ -2387,9 +2311,6 @@ public class CN extends CN1Constants {
     ///
     /// The plugin support object.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public static PluginSupport getPluginSupport() {
         return Display.INSTANCE.getPluginSupport();
     }

--- a/CodenameOne/src/com/codename1/ui/CheckBox.java
+++ b/CodenameOne/src/com/codename1/ui/CheckBox.java
@@ -348,10 +348,6 @@ public class CheckBox extends Button {
     ///
     /// - `l`: Listener to be notified when selected value changes.
     ///
-    /// #### Since
-    ///
-    /// 6.0
-    ///
     /// #### See also
     ///
     /// - #removeChangeListener(com.codename1.ui.events.ActionListener)
@@ -367,10 +363,6 @@ public class CheckBox extends Button {
     /// #### Parameters
     ///
     /// - `l`
-    ///
-    /// #### Since
-    ///
-    /// 6.0
     ///
     /// #### See also
     ///

--- a/CodenameOne/src/com/codename1/ui/ComboBox.java
+++ b/CodenameOne/src/com/codename1/ui/ComboBox.java
@@ -367,9 +367,6 @@ public class ComboBox<T> extends List<T> implements ActionSource {
 
     /// Returns true if the popup dialog is currently showing for this combobox.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public boolean isShowingPopupDialog() {
         return showingPopupDialog;
     }

--- a/CodenameOne/src/com/codename1/ui/Command.java
+++ b/CodenameOne/src/com/codename1/ui/Command.java
@@ -146,9 +146,6 @@ public class Command implements ActionListener<ActionEvent> {
     ///
     /// a newly created Command instance
     ///
-    /// #### Since
-    ///
-    /// 6.0
     public static Command createMaterial(String name, char icon, final ActionListener ev) {
         Command cmd = new Command(name) {
             @Override

--- a/CodenameOne/src/com/codename1/ui/CommonProgressAnimations.java
+++ b/CodenameOne/src/com/codename1/ui/CommonProgressAnimations.java
@@ -31,16 +31,10 @@ import com.codename1.ui.plaf.Style;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 7.0
 public class CommonProgressAnimations {
 
     /// Base class for ProgressAnimations
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static abstract class ProgressAnimation extends Component {
         private static final String PROGRESS_KEY = "$$ProgressAnimation";
         protected Component cmp;
@@ -159,9 +153,6 @@ public class CommonProgressAnimations {
 
     /// A progress animation that shows an animated circle.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static class CircleProgress extends ProgressAnimation {
         int stepSize = (int) Math.round(360.0 / Display.getInstance().getFrameRate() / 1.5);
         int step = 0;
@@ -214,9 +205,6 @@ public class CommonProgressAnimations {
 
     /// An empty progress animation.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static class EmptyAnimation extends ProgressAnimation {
         /// Replaces the given component with an EmptyAnimation until its content is ready.
         /// When the component's content is ready, then make sure to call {@link ProgressAnimation#markComponentReady(com.codename1.ui.Component)}
@@ -239,9 +227,6 @@ public class CommonProgressAnimations {
     /// are rendered as filled rectangles instead of actual glyphs.  This is appropriate
     /// where a paragraph of text is scheduled to appear, but is not ready to show yet.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static class LoadingTextAnimation extends ProgressAnimation {
 
         private static final String loremIpsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";

--- a/CodenameOne/src/com/codename1/ui/Component.java
+++ b/CodenameOne/src/com/codename1/ui/Component.java
@@ -239,16 +239,10 @@ public class Component implements Animation, StyleListener, Editable {
     boolean hasLead;
     /// The elevation at which this component was rendered in its last rendering.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     int renderedElevation;
     /// The index at which this component was rendered in its last rendering.  This acts as a z-index within
     /// an elevation layer.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     int renderedElevationComponentIndex;
     Dimension scrollSize;
     boolean shouldCalcPreferredSize = true;
@@ -464,10 +458,6 @@ public class Component implements Animation, StyleListener, Editable {
     private boolean pinchBlocksDragAndDrop;
     /// Holds a reference to the current surface this this component is registered with.
     ///
-    /// #### Since
-    ///
-    /// 8.0
-    ///
     /// #### See also
     ///
     /// - #registerElevatedInternal(Component)
@@ -602,9 +592,6 @@ public class Component implements Animation, StyleListener, Editable {
     ///
     /// The editing delegate for this component.
     ///
-    /// #### Since
-    ///
-    /// 6.0
     public Editable getEditingDelegate() {
         return this.editingDelegate;
     }
@@ -618,9 +605,6 @@ public class Component implements Animation, StyleListener, Editable {
     ///
     /// - `editable`: An editable delegate.
     ///
-    /// #### Since
-    ///
-    /// 6.0
     public void setEditingDelegate(Editable editable) {
         this.editingDelegate = editable;
     }
@@ -1254,10 +1238,6 @@ public class Component implements Animation, StyleListener, Editable {
     ///
     /// Self for chaining.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - Style#stripMarginAndPadding()
@@ -1356,9 +1336,6 @@ public class Component implements Animation, StyleListener, Editable {
     ///
     /// - `opaque`: False to not paint the component's background.
     ///
-    /// #### Since
-    ///
-    /// 6.0
     public final void setOpaque(boolean opaque) {
         this.opaque = opaque;
     }
@@ -2069,9 +2046,6 @@ public class Component implements Animation, StyleListener, Editable {
     ///
     /// The owner component or null.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public Component getOwner() {
         return owner;
     }
@@ -2092,10 +2066,6 @@ public class Component implements Animation, StyleListener, Editable {
     /// #### Parameters
     ///
     /// - `owner`: The component to set as the owner of this component.
-    ///
-    /// #### Since
-    ///
-    /// 6.0
     ///
     /// #### See also
     ///
@@ -2122,10 +2092,6 @@ public class Component implements Animation, StyleListener, Editable {
     /// #### Returns
     ///
     /// True if this component is owned by cmp.
-    ///
-    /// #### Since
-    ///
-    /// 6.0
     ///
     /// #### See also
     ///
@@ -2170,10 +2136,6 @@ public class Component implements Animation, StyleListener, Editable {
     ///
     /// @return True if the coordinate is either inside the bounds of this component
     /// or a component owned by this component.
-    ///
-    /// #### Since
-    ///
-    /// 6.0
     ///
     /// #### See also
     ///
@@ -2708,10 +2670,6 @@ public class Component implements Animation, StyleListener, Editable {
     /// - `relativeX`: The relative X coordinate onto which the shadow should be drawn.
     ///
     /// - `relativeY`: The relative Y coordinate onto which the shadow should be drawn.
-    ///
-    /// #### Since
-    ///
-    /// 8.0
     ///
     /// #### See also
     ///
@@ -3835,9 +3793,6 @@ public class Component implements Animation, StyleListener, Editable {
     ///
     /// True if this component has a fixed preferred size.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean hasFixedPreferredSize() {
         return sizeRequestedByUser || preferredSizeStr != null;
     }
@@ -3937,10 +3892,6 @@ public class Component implements Animation, StyleListener, Editable {
     ///
     /// The same Rectangle that was passed as a parameter.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - #getBounds()
@@ -3977,10 +3928,6 @@ public class Component implements Animation, StyleListener, Editable {
     /// #### Returns
     ///
     /// The same Rectangle that was passed as a parameter.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -5055,9 +5002,6 @@ public class Component implements Animation, StyleListener, Editable {
     ///
     /// - `y`: The y-coordinate of the remaining finger in the drag. (Absolute)
     ///
-    /// #### Since
-    ///
-    /// 7.0
     protected void pinchReleased(int x, int y) {
 
     }
@@ -6195,9 +6139,6 @@ public class Component implements Animation, StyleListener, Editable {
     ///
     /// text selection support object
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public TextSelectionSupport getTextSelectionSupport() {
         return null;
     }
@@ -6417,9 +6358,6 @@ public class Component implements Animation, StyleListener, Editable {
     ///
     /// - `l`: Listener to be subscribed.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void addStateChangeListener(ActionListener<ComponentStateChangeEvent> l) {
         if (stateChangeListeners == null) {
             stateChangeListeners = new EventDispatcher();
@@ -6434,9 +6372,6 @@ public class Component implements Animation, StyleListener, Editable {
     ///
     /// - `l`: Listener to be unsubscribed.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void removeStateChangeListener(ActionListener<ComponentStateChangeEvent> l) {
         if (stateChangeListeners != null) {
             stateChangeListeners.removeListener(l);
@@ -6461,9 +6396,6 @@ public class Component implements Animation, StyleListener, Editable {
     ///
     /// - `l`: callback to receive pointer events
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void addLongPressListener(ActionListener l) {
         if (longPressListeners == null) {
             longPressListeners = new EventDispatcher();
@@ -6672,9 +6604,6 @@ public class Component implements Animation, StyleListener, Editable {
     ///
     /// - `l`: callback to remove
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void removeLongPressListener(ActionListener l) {
         if (longPressListeners != null) {
             longPressListeners.removeListener(l);
@@ -6960,9 +6889,6 @@ public class Component implements Animation, StyleListener, Editable {
     ///
     /// - `unselectedStyle`: The unselected style.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     protected void initUnselectedStyle(Style unselectedStyle) {
 
     }
@@ -6973,9 +6899,6 @@ public class Component implements Animation, StyleListener, Editable {
     ///
     /// - `unselectedStyle`: The pressed style.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     protected void initPressedStyle(Style pressedStyle) {
 
     }
@@ -6986,9 +6909,6 @@ public class Component implements Animation, StyleListener, Editable {
     ///
     /// - `unselectedStyle`: The disabled style.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     protected void initDisabledStyle(Style disabledStyle) {
 
     }
@@ -6999,9 +6919,6 @@ public class Component implements Animation, StyleListener, Editable {
     ///
     /// - `unselectedStyle`: The selected style.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     protected void initSelectedStyle(Style selectedStyle) {
 
     }
@@ -7801,10 +7718,6 @@ public class Component implements Animation, StyleListener, Editable {
     ///
     /// - `cmp`: The component to register with the neares surface.
     ///
-    /// #### Since
-    ///
-    /// 8.0
-    ///
     /// #### See also
     ///
     /// - Container#addElevatedComponent(Component)
@@ -8501,9 +8414,6 @@ public class Component implements Animation, StyleListener, Editable {
     ///
     /// This method is merely a public accessor for `#shouldBlockSideSwipe()`.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public final boolean blocksSideSwipe() {
         return shouldBlockSideSwipe();
     }
@@ -9024,9 +8934,6 @@ public class Component implements Animation, StyleListener, Editable {
     ///
     /// Returns true if the component is hidden.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean isHidden(boolean checkParent) {
         if (isHidden()) {
             return true;

--- a/CodenameOne/src/com/codename1/ui/ComponentImage.java
+++ b/CodenameOne/src/com/codename1/ui/ComponentImage.java
@@ -28,9 +28,6 @@ package com.codename1.ui;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 8.0
 public class ComponentImage extends Image {
 
     private final Component cmp;

--- a/CodenameOne/src/com/codename1/ui/ComponentSelector.java
+++ b/CodenameOne/src/com/codename1/ui/ComponentSelector.java
@@ -4277,10 +4277,6 @@ public class ComponentSelector implements Iterable<Component>, Set<Component> {
     ///
     /// Self for chaining.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - IconHolder#setIconUIID(java.lang.String)
@@ -4572,9 +4568,6 @@ public class ComponentSelector implements Iterable<Component>, Set<Component> {
     ///
     /// - `l`: The listener to remove
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public ComponentSelector removeActionListener(ActionListener l) {
         for (Component c : this) {
             if (c instanceof ActionSource) {
@@ -4658,10 +4651,6 @@ public class ComponentSelector implements Iterable<Component>, Set<Component> {
     /// #### Returns
     ///
     /// Self for chaining.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -5384,9 +5373,6 @@ public class ComponentSelector implements Iterable<Component>, Set<Component> {
     ///
     /// Self for chaining.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public ComponentSelector setMaterialIcon(char icon, float size) {
         for (Component c : this) {
             if (c instanceof Label) {
@@ -5457,9 +5443,6 @@ public class ComponentSelector implements Iterable<Component>, Set<Component> {
     ///
     /// A ComponentSelector with 0 or 1 element.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public ComponentSelector first() {
         if (!isEmpty()) {
             return new ComponentSelector(results.iterator().next());

--- a/CodenameOne/src/com/codename1/ui/Container.java
+++ b/CodenameOne/src/com/codename1/ui/Container.java
@@ -333,9 +333,6 @@ public class Container extends Component implements Iterable<Component> {
     ///
     /// True if this container is a surface.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public boolean isSurface() {
         return surface;
     }
@@ -346,10 +343,6 @@ public class Container extends Component implements Iterable<Component> {
     /// #### Parameters
     ///
     /// - `surface`: True to set this container as a surface.
-    ///
-    /// #### Since
-    ///
-    /// 8.0
     ///
     /// #### See also
     ///
@@ -868,9 +861,6 @@ public class Container extends Component implements Iterable<Component> {
     /// @return True if children should calculate their layout widgets as if the component
     /// weren't scrollable.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     protected boolean constrainWidthWhenScrollable() {
         return false;
     }
@@ -889,9 +879,6 @@ public class Container extends Component implements Iterable<Component> {
     /// @return True if children should calculate their layout widgets as if the component
     /// weren't scrollable.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     protected boolean constrainHeightWhenScrollable() {
         return false;
     }
@@ -1528,9 +1515,6 @@ public class Container extends Component implements Iterable<Component> {
     /// the container at its final position.  Using this method, it will
     /// wait until running animations are complete before it revalidates.
     ///
-    /// #### Since
-    ///
-    /// 6.0
     public void revalidateWithAnimationSafety() {
         if (revalidatePending) {
             return;
@@ -1891,10 +1875,6 @@ public class Container extends Component implements Iterable<Component> {
     /// #### Parameters
     ///
     /// - `allow`: Whether to allow enable layout on paint.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -2296,10 +2276,6 @@ public class Container extends Component implements Iterable<Component> {
     ///
     /// True if this container is a safe area.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - #setSafeArea(boolean)
@@ -2325,10 +2301,6 @@ public class Container extends Component implements Iterable<Component> {
     ///
     /// - `safeArea`: True to make this container a safe area.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - Form#getSafeArea()
@@ -2344,10 +2316,6 @@ public class Container extends Component implements Iterable<Component> {
     /// against whose bounds, safe area margins are calculated for child components.
     ///
     /// Forms are safe area roots by default.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -2366,9 +2334,6 @@ public class Container extends Component implements Iterable<Component> {
     /// calculating the safe areas of child components.  Setting a root can facilitate the
     /// layout of a container's children before it appears on the screen.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public Container getSafeAreaRoot() {
         if (safeAreaRoot) {
             return this;
@@ -2402,10 +2367,6 @@ public class Container extends Component implements Iterable<Component> {
     /// #### Parameters
     ///
     /// - `root`: True to make this a root.  False to make it "not" a root.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///

--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -455,18 +455,12 @@ public final class Display extends CN1Constants {
     ///
     /// - `bookmark`: A `Runnable` that can be run to restore the app to a particular point.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public void setBookmark(Runnable bookmark) {
         this.bookmark = bookmark;
     }
 
     /// Runs the last bookmark that was set using `#setBookmark(java.lang.Runnable)`
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public void restoreToBookmark() {
         if (this.bookmark != null) {
             this.bookmark.run();
@@ -479,9 +473,6 @@ public final class Display extends CN1Constants {
     ///
     /// The plugin support object.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public PluginSupport getPluginSupport() {
         return pluginSupport;
     }
@@ -706,9 +697,6 @@ public final class Display extends CN1Constants {
     ///
     /// This is executed when a new listener is registered using `com.codename1.media.MediaManager#setRemoteControlListener(com.codename1.media.RemoteControlListener)`
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void stopRemoteControl() {
         impl.stopRemoteControl();
     }
@@ -719,9 +707,6 @@ public final class Display extends CN1Constants {
     ///
     /// This is executed when the user registers a new listener using `MediaManager#setRemoteControlListener(com.codename1.media.RemoteControlListener)`
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void startRemoteControl() {
         impl.startRemoteControl();
     }
@@ -754,9 +739,6 @@ public final class Display extends CN1Constants {
     ///
     /// true when the platform indicates a larger text preference.
     ///
-    /// #### Since
-    ///
-    /// 7.1
     public boolean isLargerTextEnabled() {
         return impl.isLargerTextEnabled();
     }
@@ -768,9 +750,6 @@ public final class Display extends CN1Constants {
     ///
     /// scale factor for larger system fonts.
     ///
-    /// #### Since
-    ///
-    /// 7.1
     public float getLargerTextScale() {
         return impl.getLargerTextScale();
     }
@@ -784,10 +763,6 @@ public final class Display extends CN1Constants {
     /// #### Returns
     ///
     /// Whether async stack traces are enabled.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -805,10 +780,6 @@ public final class Display extends CN1Constants {
     /// #### Parameters
     ///
     /// - `enableAsyncStackTraces`: True to enable async stack traces.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -1400,9 +1371,6 @@ public final class Display extends CN1Constants {
     /// - `BlockingDisallowedException`: @throws BlockingDisallowedException If `#invokeAndBlock(java.lang.Runnable)` is attempted
     /// anywhere in the Runnable.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void invokeWithoutBlocking(Runnable r) {
         if (disableInvokeAndBlock || !isEdt()) {
             r.run();
@@ -1429,9 +1397,6 @@ public final class Display extends CN1Constants {
     /// - `BlockingDisallowedException`: @throws BlockingDisallowedException If `#invokeAndBlock(java.lang.Runnable)` is attempted
     /// anywhere in the Runnable.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public <T> T invokeWithoutBlockingWithResultSync(RunnableWithResultSync<T> r) {
         if (disableInvokeAndBlock || !isEdt()) {
             return r.run();
@@ -1961,9 +1926,6 @@ public final class Display extends CN1Constants {
     ///
     /// True if the last mouse press was a right click.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean isRightMouseButtonDown() {
         return impl.isRightMouseButtonDown();
     }
@@ -2944,9 +2906,6 @@ public final class Display extends CN1Constants {
     ///
     /// The value converted to pixels.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public int convertToPixels(float value, byte unitType) {
         return convertToPixels(value, unitType, true);
     }
@@ -2967,9 +2926,6 @@ public final class Display extends CN1Constants {
     ///
     /// The value converted to pixels.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public int convertToPixels(float value, byte unitType, boolean horizontal) {
         switch (unitType) {
             case Style.UNIT_TYPE_REM:
@@ -3228,10 +3184,6 @@ public final class Display extends CN1Constants {
     ///
     /// - `l`: The listener.
     ///
-    /// #### Since
-    ///
-    /// 6.0
-    ///
     /// #### See also
     ///
     /// - #removeVirtualKeyboardListener(com.codename1.ui.events.ActionListener)
@@ -3253,10 +3205,6 @@ public final class Display extends CN1Constants {
     ///
     /// - `l`: The listener.
     ///
-    /// #### Since
-    ///
-    /// 6.0
-    ///
     /// #### See also
     ///
     /// - #addVirtualKeyboardListener(com.codename1.ui.events.ActionListener)
@@ -3272,9 +3220,6 @@ public final class Display extends CN1Constants {
     ///
     /// - `show`
     ///
-    /// #### Since
-    ///
-    /// 6.0
     public void fireVirtualKeyboardEvent(boolean show) {
         if (virtualKeyboardListeners != null) {
             virtualKeyboardListeners.fireActionEvent(new ActionEvent(show));
@@ -3287,9 +3232,6 @@ public final class Display extends CN1Constants {
     ///
     /// Height of the VKB that overlaps the screen.
     ///
-    /// #### Since
-    ///
-    /// 6.0
     public int getInvisibleAreaUnderVKB() {
         return impl.getInvisibleAreaUnderVKB();
     }
@@ -3625,10 +3567,6 @@ public final class Display extends CN1Constants {
     ///
     /// true if Full-screen mode is supported on this platform.
     ///
-    /// #### Since
-    ///
-    /// 6.0
-    ///
     /// #### See also
     ///
     /// - #requestFullScreen()
@@ -3652,10 +3590,6 @@ public final class Display extends CN1Constants {
     ///
     /// @return true on success.  This will also return true if the app is already running in full-screen mode.  It will return false
     /// if the app fails to enter full-screen mode.
-    ///
-    /// #### Since
-    ///
-    /// 6.0
     ///
     /// #### See also
     ///
@@ -3681,10 +3615,6 @@ public final class Display extends CN1Constants {
     /// @return true on success.  This will also return true if the app is already NOT in full-screen mode.  It will return false
     /// if the app fails to exit full-screen mode.
     ///
-    /// #### Since
-    ///
-    /// 6.0
-    ///
     /// #### See also
     ///
     /// - #requestFullScreen()
@@ -3701,10 +3631,6 @@ public final class Display extends CN1Constants {
     /// #### Returns
     ///
     /// true if the app is currently in full-screen mode.
-    ///
-    /// #### Since
-    ///
-    /// 6.0
     ///
     /// #### See also
     ///
@@ -3792,9 +3718,6 @@ public final class Display extends CN1Constants {
     ///
     /// - `message`: The message.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void postMessage(MessageEvent message) {
         impl.postMessage(message);
     }
@@ -3810,9 +3733,6 @@ public final class Display extends CN1Constants {
     ///
     /// - `l`: The listener.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void addMessageListener(ActionListener<MessageEvent> l) {
         if (messageListeners == null) {
             messageListeners = new EventDispatcher();
@@ -3826,9 +3746,6 @@ public final class Display extends CN1Constants {
     ///
     /// - `l`: The listener.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void removeMessageListener(ActionListener<MessageEvent> l) {
         if (messageListeners != null) {
             messageListeners.removeListener(l);
@@ -3840,10 +3757,6 @@ public final class Display extends CN1Constants {
     /// #### Parameters
     ///
     /// - `evt`
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -4156,10 +4069,6 @@ public final class Display extends CN1Constants {
     ///
     /// Device density as a string.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - #getDeviceDensity()
@@ -4213,10 +4122,6 @@ public final class Display extends CN1Constants {
     /// #### Returns
     ///
     /// The display safe area.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -4310,9 +4215,6 @@ public final class Display extends CN1Constants {
     ///
     /// a handle that can be used to control the playback of the audio
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public AsyncResource<Media> createMediaAsync(String uri, boolean video, Runnable onCompletion) {
         return impl.createMediaAsync(uri, video, onCompletion);
     }
@@ -4860,9 +4762,6 @@ public final class Display extends CN1Constants {
     ///
     /// - `RuntimeException`: if this feature failed or unsupported on the platform
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void captureAudio(MediaRecorderBuilder recordingOptions, ActionListener response) {
         impl.captureAudio(recordingOptions, response);
     }
@@ -4897,10 +4796,6 @@ public final class Display extends CN1Constants {
     /// - `constraints`: Capture constraints to use.
     ///
     /// - `response`: a callback Object to retrieve the file path
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -5840,10 +5735,6 @@ public final class Display extends CN1Constants {
     ///
     /// - `IOException`
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### Deprecated
     ///
     /// use MediaRecorderBuilder#build()
@@ -6158,9 +6049,6 @@ public final class Display extends CN1Constants {
     ///
     /// True if the scroll-wheel is responsible for current pointer events.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public boolean isScrollWheeling() {
         return impl.isScrollWheeling();
     }
@@ -6850,10 +6738,6 @@ public final class Display extends CN1Constants {
     ///
     /// An image of the screen, or null if it failed.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### Deprecated
     ///
     /// use screenshot(SuccessCallback) instead
@@ -6868,9 +6752,6 @@ public final class Display extends CN1Constants {
     ///
     /// - `callback`: will be invoked on the EDT with a screenshot
     ///
-    /// #### Since
-    ///
-    /// 7.0.211
     public void screenshot(SuccessCallback<Image> callback) {
         impl.screenshot(callback);
     }
@@ -6899,10 +6780,6 @@ public final class Display extends CN1Constants {
     /// #### Returns
     ///
     /// The Timer object that can be used to cancel the task.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -6935,10 +6812,6 @@ public final class Display extends CN1Constants {
     /// #### Returns
     ///
     /// The timer object which can be used to cancel the task.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -6989,9 +6862,6 @@ public final class Display extends CN1Constants {
     ///
     /// A shared BrowserComponent
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public BrowserComponent getSharedJavascriptContext() {
         return impl.getSharedJavscriptContext();
     }

--- a/CodenameOne/src/com/codename1/ui/Editable.java
+++ b/CodenameOne/src/com/codename1/ui/Editable.java
@@ -29,9 +29,6 @@ package com.codename1.ui;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 6.0
 public interface Editable {
     /// Checks whether the component is editable.
     boolean isEditable();

--- a/CodenameOne/src/com/codename1/ui/Font.java
+++ b/CodenameOne/src/com/codename1/ui/Font.java
@@ -292,9 +292,6 @@ public class Font extends CN {
     ///
     /// a font object
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public static Font createTrueTypeFont(String fontName, float size, byte sizeUnit) {
         return createTrueTypeFont(fontName, fontName).
                 derive(Display.getInstance().convertToPixels(size, sizeUnit), STYLE_PLAIN);
@@ -515,9 +512,6 @@ public class Font extends CN {
     ///
     /// scaled font instance
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public Font derive(float size, int weight, byte unitType) {
         return derive(Display.getInstance().convertToPixels(size, unitType), weight);
     }

--- a/CodenameOne/src/com/codename1/ui/FontImage.java
+++ b/CodenameOne/src/com/codename1/ui/FontImage.java
@@ -6906,9 +6906,6 @@ public final class FontImage extends Image {
     ///
     /// false if the type isn't supported
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static boolean setMaterialIcon(Component cmp, char[] icons, float size) {
         if (cmp instanceof IconHolder) {
             setIcon((IconHolder) cmp, getMaterialDesignFont(), icons, size);
@@ -7013,10 +7010,6 @@ public final class FontImage extends Image {
     ///
     /// - `size`: The font size.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### Deprecated
     ///
     /// use `float)` instead
@@ -7037,9 +7030,6 @@ public final class FontImage extends Image {
     ///
     /// - `size`: The font size.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static void setIcon(IconHolder l, Font font, char[] icons, float size) {
         Style s = new Style(l.getIconStyleComponent().getUnselectedStyle());
         s.setFont(font.derive(rightSize(s, size), Font.STYLE_PLAIN));
@@ -7120,9 +7110,6 @@ public final class FontImage extends Image {
     ///
     /// - `size`: the size of the icon in millimeters, or -1 to use the default height of the font
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static void setMaterialIcon(Label l, char[] icons, float size) {
         setFontIcon(l, getMaterialDesignFont(), icons, size);
     }
@@ -7318,9 +7305,6 @@ public final class FontImage extends Image {
     ///
     /// - `icon`: one of the MATERIAL_* icons
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static void setMaterialIcon(IconHolder l, char icon) {
         FontImage.setIcon(l, icon, -1);
     }
@@ -8047,9 +8031,6 @@ public final class FontImage extends Image {
     ///
     /// - `alpha`: 0-255 alpha value.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public void setFgAlpha(int alpha) {
         fgAlpha = alpha;
     }

--- a/CodenameOne/src/com/codename1/ui/Form.java
+++ b/CodenameOne/src/com/codename1/ui/Form.java
@@ -286,9 +286,6 @@ public class Form extends Container {
     ///
     /// - `allow`: Whether to allow layoutOnPaint behaviour in this this form and it's containers.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public void setAllowEnableLayoutOnPaint(boolean allow) {
         super.setAllowEnableLayoutOnPaint(allow);
@@ -305,9 +302,6 @@ public class Form extends Container {
     ///
     /// - `l`: Listener registered to receive paste events.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void addPasteListener(ActionListener l) {
         if (pasteListener == null) {
             pasteListener = new EventDispatcher();
@@ -320,10 +314,6 @@ public class Form extends Container {
     /// #### Parameters
     ///
     /// - `l`: Listener to unregister to receive paste events.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -396,10 +386,6 @@ public class Form extends Container {
     ///
     /// - `l`: The paste event.  Includes no useful data currently.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - #addPasteListener(com.codename1.ui.events.ActionListener)
@@ -417,9 +403,6 @@ public class Form extends Container {
     ///
     /// The text selection support for this form.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public TextSelection getTextSelection() {
         if (textSelection == null) {
             textSelection = new TextSelection(getContentPane());
@@ -463,9 +446,6 @@ public class Form extends Container {
     ///
     /// The source command.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public Command getSourceCommand() {
         return sourceCommand;
     }
@@ -477,9 +457,6 @@ public class Form extends Container {
     ///
     /// - `sourceCommand`: The source command.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setSourceCommand(Command sourceCommand) {
         this.sourceCommand = sourceCommand;
     }
@@ -535,9 +512,6 @@ public class Form extends Container {
     ///
     /// - `invisibleAreaUnderVKB`: The area hidden by the VKB in pixels.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public void setOverrideInvisibleAreaUnderVKB(int invisibleAreaUnderVKB) {
         overrideInvisibleAreaUnderVKB = invisibleAreaUnderVKB;
     }
@@ -606,10 +580,6 @@ public class Form extends Container {
     /// #### Returns
     ///
     /// The safe area on which to draw.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -1003,10 +973,6 @@ public class Form extends Container {
     }
 
     /// Causes the display safe area to be recalculated the next time the form list laid out.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -3400,9 +3366,6 @@ public class Form extends Container {
     /// Gets the handle for the current pointer press event.  A new object
     /// is generated for each pointer press.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     Object getCurrentPointerPress() {
         return currentPointerPress;
     }

--- a/CodenameOne/src/com/codename1/ui/Graphics.java
+++ b/CodenameOne/src/com/codename1/ui/Graphics.java
@@ -41,10 +41,6 @@ public final class Graphics {
     /// primitives in a quick way, at the cost of quality, if there is an
     /// expensive operation.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - #setRenderingHints(int)
@@ -212,10 +208,6 @@ public final class Graphics {
     ///
     /// - `paint`
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - LinearGradientPaint
@@ -228,10 +220,6 @@ public final class Graphics {
     /// #### Returns
     ///
     /// The paint that is to be used for filling shapes.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -251,9 +239,6 @@ public final class Graphics {
     ///
     /// The previous color value.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public int setAndGetColor(int rgb) {
         int old = getColor();
         setColor(rgb);
@@ -1201,9 +1186,6 @@ public final class Graphics {
     ///
     /// - `transform`: The transform to concatenate.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void transform(Transform transform) {
         Transform existing = getTransform();
         existing.concatenate(transform);
@@ -1657,9 +1639,6 @@ public final class Graphics {
     ///
     /// The previous alpha setting (0-255).
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public int concatenateAlpha(int a) {
         if (a == 255) {
             return getAlpha();
@@ -1867,9 +1846,6 @@ public final class Graphics {
     ///
     /// - `angle`: the rotation angle in radians about graphics context's translated origin.
     ///
-    /// #### Since
-    ///
-    /// 6.0
     public void rotateRadians(float angle) {
         rotateRadians(angle, 0, 0);
     }
@@ -1907,9 +1883,6 @@ public final class Graphics {
     ///
     /// - `pivotY`: the pivot point relative to the current graphics context's translation.
     ///
-    /// #### Since
-    ///
-    /// 6.0
     public void rotateRadians(float angle, int pivotX, int pivotY) {
         impl.rotate(nativeGraphics, angle, pivotX + xTranslate, pivotY + yTranslate);
     }
@@ -2077,10 +2050,6 @@ public final class Graphics {
     /// #### Parameters
     ///
     /// - `hints`: int of rendering hints produced by logical AND on all applicable hints.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///

--- a/CodenameOne/src/com/codename1/ui/IconHolder.java
+++ b/CodenameOne/src/com/codename1/ui/IconHolder.java
@@ -26,9 +26,6 @@ package com.codename1.ui;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 7.0
 public interface IconHolder {
 
     /// Returns the labels icon
@@ -102,9 +99,6 @@ public interface IconHolder {
     ///
     /// - `uiid`: The uiid to use for the material icon style.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     void setIconUIID(String uiid);
 
     /// Gets the component that should be used for styling material the material icon.  If `#setIconUIID(java.lang.String)` has been used
@@ -115,9 +109,6 @@ public interface IconHolder {
     ///
     /// The component to use for styling the material icon.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     Component getIconStyleComponent();
 
     /// This method is shorthand for `char, float)`
@@ -128,9 +119,6 @@ public interface IconHolder {
     ///
     /// - `size`: the size of the icon in millimeters
     ///
-    /// #### Since
-    ///
-    /// 8.0
     void setMaterialIcon(char c, float size);
 
     /// This method is shorthand for `com.codename1.ui.Font, char, float)`
@@ -141,8 +129,5 @@ public interface IconHolder {
     ///
     /// - `size`: the size of the icon in millimeters
     ///
-    /// #### Since
-    ///
-    /// 8.0
     void setFontIcon(Font font, char c, float size);
 }

--- a/CodenameOne/src/com/codename1/ui/ImageFactory.java
+++ b/CodenameOne/src/com/codename1/ui/ImageFactory.java
@@ -43,9 +43,6 @@ package com.codename1.ui;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 8.0
 public abstract class ImageFactory {
     private static final String KEY = "$$IMAGE_FACTORY$$";
 

--- a/CodenameOne/src/com/codename1/ui/InterFormContainer.java
+++ b/CodenameOne/src/com/codename1/ui/InterFormContainer.java
@@ -41,9 +41,6 @@ import static com.codename1.ui.ComponentSelector.$;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 7.0
 public class InterFormContainer extends Container {
     private final Component content;
 

--- a/CodenameOne/src/com/codename1/ui/Label.java
+++ b/CodenameOne/src/com/codename1/ui/Label.java
@@ -289,10 +289,6 @@ public class Label extends Component implements IconHolder, TextHolder {
     ///
     /// the badge text to be used on this label.  May return if no text is set.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - #setBadgeText(java.lang.String)
@@ -314,10 +310,6 @@ public class Label extends Component implements IconHolder, TextHolder {
     /// - `badgeText`: @param badgeText The text to include in the badge.   null or empty strings will result in the
     /// badge not being rendered.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - #getBadgeText()
@@ -335,10 +327,6 @@ public class Label extends Component implements IconHolder, TextHolder {
     /// #### Parameters
     ///
     /// - `badgeUIID`: The UIID to use for the badge.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -359,10 +347,6 @@ public class Label extends Component implements IconHolder, TextHolder {
     ///
     /// The component whose style can be used to style the badge.  May return null if none set.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - #setBadgeText(java.lang.String)
@@ -382,9 +366,6 @@ public class Label extends Component implements IconHolder, TextHolder {
     ///
     /// The component to use for styling the material icon.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public Component getIconStyleComponent() {
         if (iconStyleComponent != null) {
@@ -470,9 +451,6 @@ public class Label extends Component implements IconHolder, TextHolder {
     ///
     /// - `c`: The character to render in the font.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public void setFontIcon(char c) {
         Component iconStyle = getIconStyleComponent();
         if (this.font == null) {
@@ -1408,18 +1386,12 @@ public class Label extends Component implements IconHolder, TextHolder {
     ///
     /// - `shiftMillimeters`: the shiftMillimeters to set
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setShiftMillimeters(float shiftMillimeters) {
         this.shiftMillimeters = shiftMillimeters;
     }
 
     /// Returns the number of millimeters that should be shifted in tickering as a float.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public float getShiftMillimetersF() {
         return shiftMillimeters;
     }
@@ -1526,10 +1498,6 @@ public class Label extends Component implements IconHolder, TextHolder {
     /// you must enable text selection on the Form with `Form#getTextSelection()` and `TextSelection#setEnabled(boolean)`,
     /// and also ensure that the label's text selection is enabled via `#setTextSelectionEnabled(boolean)`.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - #setTextSelectionEnabled(boolean)
@@ -1543,10 +1511,6 @@ public class Label extends Component implements IconHolder, TextHolder {
     /// #### Parameters
     ///
     /// - `enabled`
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -1659,9 +1623,6 @@ public class Label extends Component implements IconHolder, TextHolder {
     ///
     /// - `uiid`: The uiid to use for the material icon style.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     @Override
     public void setIconUIID(String uiid) {
         if (iconStyleComponent == null || !uiid.equals(iconStyleComponent.getUIID())) {

--- a/CodenameOne/src/com/codename1/ui/LeadUtil.java
+++ b/CodenameOne/src/com/codename1/ui/LeadUtil.java
@@ -26,9 +26,6 @@ package com.codename1.ui;
 ///
 /// @author Steve Hannah
 ///
-/// #### Since
-///
-/// 7.0
 abstract class LeadUtil {
 
     /// Gets the lead parent for a component, or the component itself if there is

--- a/CodenameOne/src/com/codename1/ui/LinearGradientPaint.java
+++ b/CodenameOne/src/com/codename1/ui/LinearGradientPaint.java
@@ -31,10 +31,6 @@ import static com.codename1.ui.MultipleGradientPaint.CycleMethod.REFLECT;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 7.0
-///
 /// #### See also
 ///
 /// - Graphics#setColor(com.codename1.ui.Paint)

--- a/CodenameOne/src/com/codename1/ui/MultipleGradientPaint.java
+++ b/CodenameOne/src/com/codename1/ui/MultipleGradientPaint.java
@@ -26,9 +26,6 @@ package com.codename1.ui;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 7.0
 public abstract class MultipleGradientPaint implements Paint {
 
 

--- a/CodenameOne/src/com/codename1/ui/Paint.java
+++ b/CodenameOne/src/com/codename1/ui/Paint.java
@@ -28,10 +28,6 @@ import com.codename1.ui.geom.Rectangle2D;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 7.0
-///
 /// #### See also
 ///
 /// - Graphics#setColor(com.codename1.ui.Paint)

--- a/CodenameOne/src/com/codename1/ui/RadioButton.java
+++ b/CodenameOne/src/com/codename1/ui/RadioButton.java
@@ -470,10 +470,6 @@ public class RadioButton extends Button {
     ///
     /// - `l`: Listener to be notified when selected value changes.
     ///
-    /// #### Since
-    ///
-    /// 6.0
-    ///
     /// #### See also
     ///
     /// - #removeChangeListener(com.codename1.ui.events.ActionListener)
@@ -489,10 +485,6 @@ public class RadioButton extends Button {
     /// #### Parameters
     ///
     /// - `l`
-    ///
-    /// #### Since
-    ///
-    /// 6.0
     ///
     /// #### See also
     ///

--- a/CodenameOne/src/com/codename1/ui/SelectableIconHolder.java
+++ b/CodenameOne/src/com/codename1/ui/SelectableIconHolder.java
@@ -28,9 +28,6 @@ package com.codename1.ui;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 7.0
 public interface SelectableIconHolder extends IconHolder {
 
     /// Indicates the icon that is displayed on the button when the button is in

--- a/CodenameOne/src/com/codename1/ui/Sheet.java
+++ b/CodenameOne/src/com/codename1/ui/Sheet.java
@@ -112,9 +112,6 @@ import static com.codename1.ui.ComponentSelector.$;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 7.0
 public class Sheet extends Container {
     private static Rectangle[] sheetBoundsList = new Rectangle[0];
     private static final int N = 0;
@@ -470,9 +467,6 @@ public class Sheet extends Container {
     ///
     /// The current sheet or null.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static Sheet getCurrentSheet() {
         if (CN.getCurrentForm() == null) {
             return null;
@@ -499,9 +493,6 @@ public class Sheet extends Container {
     ///
     /// The sheet containing the component, or null if it is not on a sheet.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static Sheet findContainingSheet(Component cmp) {
         Container parent = cmp.getParent();
         while (parent != null) {
@@ -533,9 +524,6 @@ public class Sheet extends Container {
     ///
     /// - `allowClose`: True to allow user to close the sheet.  False to prevent it.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setAllowClose(boolean allowClose) {
         if (allowClose != this.allowClose) {
             this.allowClose = allowClose;
@@ -561,9 +549,6 @@ public class Sheet extends Container {
     ///
     /// True if swipe-to-dismiss is enabled.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public boolean isSwipeToDismissEnabled() {
         return swipeToDismissEnabled;
     }
@@ -578,9 +563,6 @@ public class Sheet extends Container {
     ///
     /// - `swipeToDismissEnabled`: True to enable the swipe-to-dismiss gesture, false to disable it.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public void setSwipeToDismissEnabled(boolean swipeToDismissEnabled) {
         if (this.swipeToDismissEnabled != swipeToDismissEnabled) {
             this.swipeToDismissEnabled = swipeToDismissEnabled;
@@ -641,9 +623,6 @@ public class Sheet extends Container {
     ///
     /// The sheet title text.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public String getTitle() {
         return title.getText();
     }
@@ -658,9 +637,6 @@ public class Sheet extends Container {
     ///
     /// - `title`: The title text.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public void setTitle(String title) {
         this.title.setText(title);
     }
@@ -671,9 +647,6 @@ public class Sheet extends Container {
     ///
     /// The current title component.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public Component getTitleComponent() {
         return titleComponent;
     }
@@ -687,9 +660,6 @@ public class Sheet extends Container {
     ///
     /// - `cmp`: The component to use for the title area, or `null` to restore the default title label.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public void setTitleComponent(Component cmp) {
         if (cmp == null) {
             cmp = title;
@@ -979,10 +949,6 @@ public class Sheet extends Container {
     /// - `position`: One of `BorderLayout#CENTER`, `BorderLayout#NORTH`, `BorderLayout#SOUTH`,
     ///   `BorderLayout#WEST`, or `BorderLayout#EAST`.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - #setPosition(java.lang.String)
@@ -1076,10 +1042,6 @@ public class Sheet extends Container {
     ///
     /// - `tabletPosition`: Position to use on a tablet and desktop. One of `BorderLayout#CENTER`,
     ///   `BorderLayout#NORTH`, `BorderLayout#SOUTH`, `BorderLayout#WEST`, or `BorderLayout#EAST`.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -1381,9 +1343,6 @@ public class Sheet extends Container {
     ///
     /// True if the current sheet is an ancestor of sheet.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean isAncestorSheetOf(Sheet sheet) {
         sheet = sheet.getParentSheet();
         if (sheet == this) { //NOPMD CompareObjectsWithEquals
@@ -1405,9 +1364,6 @@ public class Sheet extends Container {
     ///
     /// - `l`
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void addCloseListener(ActionListener l) {
         closeListeners.addListener(l);
     }
@@ -1448,9 +1404,6 @@ public class Sheet extends Container {
     ///
     /// - `l`: Listener
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void addBackListener(ActionListener l) {
         backListeners.addListener(l);
     }

--- a/CodenameOne/src/com/codename1/ui/Slider.java
+++ b/CodenameOne/src/com/codename1/ui/Slider.java
@@ -292,9 +292,6 @@ public class Slider extends Label implements ActionSource {
     ///
     /// The progress of the slider.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public int getProgress(ActionEvent evt) {
         if (evt instanceof SliderActionEvent) {
             return ((SliderActionEvent) evt).value;

--- a/CodenameOne/src/com/codename1/ui/Tabs.java
+++ b/CodenameOne/src/com/codename1/ui/Tabs.java
@@ -1741,9 +1741,6 @@ public class Tabs extends Container {
     ///
     /// - `b`: `true` to set the swipe on the X-Axis, `false` to set the swipe on the Y-Axis
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public void setSwipeOnXAxis(boolean b) {
         if (swipeOnXAxis != b) {
             swipeOnXAxis = b;

--- a/CodenameOne/src/com/codename1/ui/TextArea.java
+++ b/CodenameOne/src/com/codename1/ui/TextArea.java
@@ -2279,9 +2279,6 @@ public class TextArea extends Component implements ActionSource, TextHolder {
     ///
     /// - `sel`: The TextSelection
     ///
-    /// #### Since
-    ///
-    /// 7.0
     protected Spans calculateTextSelectionSpan(TextSelection sel) {
         return getUIManager().getLookAndFeel().calculateTextAreaSpan(sel, this);
     }
@@ -2289,10 +2286,6 @@ public class TextArea extends Component implements ActionSource, TextHolder {
     /// Returns true if text selection is enabled on this label.  Default is false.  To enable text selection,
     /// you must enable text selection on the Form with `Form#getTextSelection()` and `TextSelection#setEnabled(boolean)`,
     /// and also ensure that the label's text selection is enabled via `#setTextSelectionEnabled(boolean)`.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///
@@ -2307,10 +2300,6 @@ public class TextArea extends Component implements ActionSource, TextHolder {
     /// #### Parameters
     ///
     /// - `enabled`
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///

--- a/CodenameOne/src/com/codename1/ui/TextHolder.java
+++ b/CodenameOne/src/com/codename1/ui/TextHolder.java
@@ -28,9 +28,6 @@ package com.codename1.ui;
 ///
 /// @author Shai Almog
 ///
-/// #### Since
-///
-/// 7.0
 public interface TextHolder {
     /// The text of the component
     ///

--- a/CodenameOne/src/com/codename1/ui/TextSelection.java
+++ b/CodenameOne/src/com/codename1/ui/TextSelection.java
@@ -57,9 +57,6 @@ import static com.codename1.ui.ComponentSelector.$;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 7.0
 public class TextSelection {
 
     /// Comparator used for ordering components in left-to-right mode.

--- a/CodenameOne/src/com/codename1/ui/UIFragment.java
+++ b/CodenameOne/src/com/codename1/ui/UIFragment.java
@@ -209,9 +209,6 @@ import static com.codename1.ui.ComponentSelector.$;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 7.0
 public final class UIFragment {
 
 

--- a/CodenameOne/src/com/codename1/ui/animations/ComponentAnimation.java
+++ b/CodenameOne/src/com/codename1/ui/animations/ComponentAnimation.java
@@ -293,10 +293,6 @@ public abstract class ComponentAnimation {
     /// that they mutate reside in separate branches of the UI tree.  I.e. As long as neither
     /// container contains the other, their mutations are compatible.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - AnimationManager#addUIMutation(com.codename1.ui.Container, com.codename1.ui.animations.ComponentAnimation)

--- a/CodenameOne/src/com/codename1/ui/animations/Motion.java
+++ b/CodenameOne/src/com/codename1/ui/animations/Motion.java
@@ -661,9 +661,6 @@ public class Motion {
     ///
     /// Current velocity in pixels per millisecond.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public double getVelocity() {
         final long localCurrentMotionTime = getCurrentMotionTime();
         final int lastReturnedValueLocal = lastReturnedValue;
@@ -690,9 +687,6 @@ public class Motion {
     ///
     /// The number of sampling points that can be used by `#getVelocity()`.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public int countAvailableVelocitySamplingPoints() {
         int count = 1;
         final long localCurrentMotionTime = getCurrentMotionTime();

--- a/CodenameOne/src/com/codename1/ui/animations/Transition.java
+++ b/CodenameOne/src/com/codename1/ui/animations/Transition.java
@@ -70,9 +70,6 @@ public abstract class Transition implements Animation {
     /// the rest of components, so the transition may need to be able to paint the source
     /// or destination without these containers, and paint them separately.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     protected void hideInterformContainers() {
         if (!(getSource() instanceof Form && getDestination() instanceof Form)) {
             return;
@@ -91,9 +88,6 @@ public abstract class Transition implements Animation {
     /// the rest of components, so the transition may need to be able to paint the source
     /// or destination without these containers, and paint them separately.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     protected void showInterformContainers() {
         if (!(getSource() instanceof Form && getDestination() instanceof Form)) {
             return;
@@ -113,9 +107,6 @@ public abstract class Transition implements Animation {
     ///
     /// - `g`: Graphics context to paint to.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     protected void paintInterformContainers(Graphics g) {
         if (!(getSource() instanceof Form && getDestination() instanceof Form)) {
             return;

--- a/CodenameOne/src/com/codename1/ui/events/ActionEvent.java
+++ b/CodenameOne/src/com/codename1/ui/events/ActionEvent.java
@@ -43,9 +43,6 @@ public class ActionEvent {
     /// us from receiving new pointer pressed events while a drag is in progress.  This flag may be added to a pointer dragged
     /// event to indicate that the pointer was pressed again - in case your listener wants to monitor for this.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     private boolean pointerPressedDuringDrag;
 
     /// The rich pointer detail attached to this event, populated for pointer events.
@@ -467,9 +464,6 @@ public class ActionEvent {
     /// pointer pressed events are not delivered.  This allows you to detect if a pointer press occurred
     /// during a scroll or drag.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public boolean isPointerPressedDuringDrag() {
         return pointerPressedDuringDrag;
     }
@@ -479,9 +473,6 @@ public class ActionEvent {
     /// pointer pressed events are not delivered.  This allows you to detect if a pointer press occurred
     /// during a scroll or drag.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public void setPointerPressedDuringDrag(boolean pressed) {
         this.pointerPressedDuringDrag = pressed;
     }

--- a/CodenameOne/src/com/codename1/ui/events/ActionSource.java
+++ b/CodenameOne/src/com/codename1/ui/events/ActionSource.java
@@ -26,9 +26,6 @@ package com.codename1.ui.events;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 7.0
 public interface ActionSource<T extends ActionEvent> {
     /// Adds ActionListener to receive action events form this source.
     ///

--- a/CodenameOne/src/com/codename1/ui/events/MessageEvent.java
+++ b/CodenameOne/src/com/codename1/ui/events/MessageEvent.java
@@ -30,10 +30,6 @@ import com.codename1.util.AsyncResource;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 7.0
-///
 /// #### See also
 ///
 /// - Display#postMessage(com.codename1.ui.events.MessageEvent)

--- a/CodenameOne/src/com/codename1/ui/geom/AffineTransform.java
+++ b/CodenameOne/src/com/codename1/ui/geom/AffineTransform.java
@@ -28,9 +28,6 @@ import com.codename1.ui.Transform;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 7.0
 public class AffineTransform {
     private double m00;
     private double m10;

--- a/CodenameOne/src/com/codename1/ui/geom/Rectangle.java
+++ b/CodenameOne/src/com/codename1/ui/geom/Rectangle.java
@@ -597,9 +597,6 @@ public class Rectangle implements Shape {
     ///
     /// - `bounds`: A rectangle whose bounds will be copied.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setBounds(Rectangle bounds) {
         setBounds(bounds.x, bounds.y, bounds.size.getWidth(), bounds.size.getHeight());
     }

--- a/CodenameOne/src/com/codename1/ui/layouts/BoxLayout.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/BoxLayout.java
@@ -87,9 +87,6 @@ public class BoxLayout extends Layout {
     public static final int Y_AXIS_BOTTOM_LAST = 4;
     private final int axis;
     private final Dimension dim = new Dimension(0, 0);
-    /// #### Since
-    ///
-    /// 7.0
     private int align = Component.TOP;
 
     /// Creates a new instance of BoxLayout
@@ -126,9 +123,6 @@ public class BoxLayout extends Layout {
     ///
     /// BoxLayout with center alignment on Y_AXIS.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static BoxLayout yCenter() {
         BoxLayout out = new BoxLayout(BoxLayout.Y_AXIS);
         out.setAlign(Component.CENTER);
@@ -141,9 +135,6 @@ public class BoxLayout extends Layout {
     ///
     /// BoxLayout with bottom alignment on Y_AXIS.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static BoxLayout yBottom() {
         BoxLayout out = new BoxLayout(BoxLayout.Y_AXIS);
         out.setAlign(Component.BOTTOM);
@@ -165,9 +156,6 @@ public class BoxLayout extends Layout {
     ///
     /// BoxLayout with center alignment on X_AXIS.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static BoxLayout xCenter() {
         BoxLayout out = new BoxLayout(BoxLayout.X_AXIS);
         out.setAlign(Component.CENTER);
@@ -180,9 +168,6 @@ public class BoxLayout extends Layout {
     ///
     /// BoxLayout with right alignment on X_AXIS.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static BoxLayout xRight() {
         BoxLayout out = new BoxLayout(BoxLayout.X_AXIS);
         out.setAlign(Component.RIGHT);
@@ -212,9 +197,6 @@ public class BoxLayout extends Layout {
     ///
     /// the newly created container
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static Container encloseYCenter(Component... cmps) {
         return Container.encloseIn(yCenter(), cmps);
     }
@@ -229,9 +211,6 @@ public class BoxLayout extends Layout {
     ///
     /// the newly created container
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static Container encloseYBottom(Component... cmps) {
         return Container.encloseIn(yBottom(), cmps);
     }
@@ -286,9 +265,6 @@ public class BoxLayout extends Layout {
     ///
     /// the newly created container
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static Container encloseXCenter(Component... cmps) {
         return Container.encloseIn(xCenter(), cmps);
     }
@@ -303,9 +279,6 @@ public class BoxLayout extends Layout {
     ///
     /// the newly created container
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static Container encloseXRight(Component... cmps) {
         return Container.encloseIn(xRight(), cmps);
     }
@@ -317,9 +290,6 @@ public class BoxLayout extends Layout {
     ///
     /// The alignment.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public int getAlign() {
         return this.align;
     }
@@ -331,9 +301,6 @@ public class BoxLayout extends Layout {
     ///
     /// - `align`: One of `Component#CENTER`, `Component#BOTTOM`, `Component#RIGHT`, to adjust the alignment of children.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setAlign(int align) {
         this.align = align;
     }

--- a/CodenameOne/src/com/codename1/ui/layouts/mig/AC.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/mig/AC.java
@@ -238,9 +238,6 @@ public final class AC {
     ///
     /// `this` so it is possible to chain calls. E.g. `new AxisConstraint().noGrid().gap().fill()`.
     ///
-    /// #### Since
-    ///
-    /// 3.7.2
     public AC sizeGroup() {
         return sizeGroup("", curIx);
     }
@@ -473,9 +470,6 @@ public final class AC {
     ///
     /// `this` so it is possible to chain calls. E.g. `new AxisConstraint().noGrid().gap().fill()`.
     ///
-    /// #### Since
-    ///
-    /// 3.7.2
     public AC grow() {
         return grow(1f, curIx);
     }
@@ -565,9 +559,6 @@ public final class AC {
     ///
     /// `this` so it is possible to chain calls. E.g. `new AxisConstraint().noGrid().gap().fill()`.
     ///
-    /// #### Since
-    ///
-    /// 3.7.2
     public AC shrink() {
         return shrink(100f, curIx);
     }
@@ -584,9 +575,6 @@ public final class AC {
     ///
     /// `this` so it is possible to chain calls. E.g. `new AxisConstraint().noGrid().gap().fill()`.
     ///
-    /// #### Since
-    ///
-    /// 3.7.2
     public AC shrink(float w) {
         return shrink(w, curIx);
     }
@@ -605,9 +593,6 @@ public final class AC {
     ///
     /// `this` so it is possible to chain calls. E.g. `new AxisConstraint().noGrid().gap().fill()`.
     ///
-    /// #### Since
-    ///
-    /// 3.7.2
     public AC shrink(float w, int... indexes) {
         Float sw = Float.valueOf(w);
         for (int i = indexes.length - 1; i >= 0; i--) {

--- a/CodenameOne/src/com/codename1/ui/layouts/mig/CC.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/mig/CC.java
@@ -301,9 +301,6 @@ public final class CC {
     ///
     /// `this` so it is possible to chain calls. E.g. `new ComponentConstraint().noGrid().gap().fill()`.
     ///
-    /// #### Since
-    ///
-    /// 3.7.2
     public CC growPrio(int... widthHeight) {
         if (widthHeight.length == 0 || widthHeight.length > 2) {
             throw new IllegalArgumentException("Illegal argument count: " + widthHeight.length);
@@ -359,9 +356,6 @@ public final class CC {
     ///
     /// `this` so it is possible to chain calls. E.g. `new ComponentConstraint().noGrid().gap().fill()`.
     ///
-    /// #### Since
-    ///
-    /// 3.7.2
     public CC grow(float... widthHeight) {
         if (widthHeight.length == 0 || widthHeight.length > 2) {
             throw new IllegalArgumentException("Illegal argument count: " + widthHeight.length);
@@ -401,9 +395,6 @@ public final class CC {
     ///
     /// `this` so it is possible to chain calls. E.g. `new ComponentConstraint().noGrid().gap().fill()`.
     ///
-    /// #### Since
-    ///
-    /// 3.7.2
     public CC shrinkPrio(int... widthHeight) {
         if (widthHeight.length == 0 || widthHeight.length > 2) {
             throw new IllegalArgumentException("Illegal argument count: " + widthHeight.length);
@@ -443,9 +434,6 @@ public final class CC {
     ///
     /// `this` so it is possible to chain calls. E.g. `new ComponentConstraint().noGrid().gap().fill()`.
     ///
-    /// #### Since
-    ///
-    /// 3.7.2
     public CC shrink(float... widthHeight) {
         if (widthHeight.length == 0 || widthHeight.length > 2) {
             throw new IllegalArgumentException("Illegal argument count: " + widthHeight.length);
@@ -485,9 +473,6 @@ public final class CC {
     ///
     /// `this` so it is possible to chain calls. E.g. `new ComponentConstraint().noGrid().gap().fill()`.
     ///
-    /// #### Since
-    ///
-    /// 3.7.2
     public CC endGroup(String... xy) {
         if (xy.length > 2 || xy.length == 0) {
             throw new IllegalArgumentException("Illegal argument count: " + xy.length);
@@ -527,9 +512,6 @@ public final class CC {
     ///
     /// `this` so it is possible to chain calls. E.g. `new ComponentConstraint().noGrid().gap().fill()`.
     ///
-    /// #### Since
-    ///
-    /// 3.7.2
     public CC sizeGroup(String... xy) {
         if (xy.length > 2 || xy.length == 0) {
             throw new IllegalArgumentException("Illegal argument count: " + xy.length);
@@ -786,10 +768,6 @@ public final class CC {
     ///
     /// `this` so it is possible to chain calls. E.g. `new LayoutConstraint().noGrid().gap().fill()`.
     ///
-    /// #### Since
-    ///
-    /// 3.7.2. Replacing cell(int, int) and cell(int, int, int, int)
-    ///
     /// #### See also
     ///
     /// - #setCellX(int)
@@ -822,10 +800,6 @@ public final class CC {
     /// #### Returns
     ///
     /// `this` so it is possible to chain calls. E.g. `new LayoutConstraint().noGrid().gap().fill()`.
-    ///
-    /// #### Since
-    ///
-    /// 3.7.2 Replaces span(int, int).
     ///
     /// #### See also
     ///
@@ -860,9 +834,6 @@ public final class CC {
     ///
     /// `this` so it is possible to chain calls. E.g. `new LayoutConstraint().noGrid().gap().fill()`.
     ///
-    /// #### Since
-    ///
-    /// 3.7.2
     public CC gap(String... args) {
         if (INVOKERS.length < args.length) {
             throw new IllegalArgumentException("Illegal argument count: " + args.length);
@@ -885,9 +856,6 @@ public final class CC {
     ///
     /// `this` so it is possible to chain calls. E.g. `new LayoutConstraint().noGrid().gap().fill()`.
     ///
-    /// #### Since
-    ///
-    /// 3.7.2
     public CC gapBefore(String boundsSize) {
         hor.setGapBefore(ConstraintParser.parseBoundSize(boundsSize, true, true));
         return this;
@@ -905,9 +873,6 @@ public final class CC {
     ///
     /// `this` so it is possible to chain calls. E.g. `new LayoutConstraint().noGrid().gap().fill()`.
     ///
-    /// #### Since
-    ///
-    /// 3.7.2
     public CC gapAfter(String boundsSize) {
         hor.setGapAfter(ConstraintParser.parseBoundSize(boundsSize, true, true));
         return this;
@@ -923,9 +888,6 @@ public final class CC {
     ///
     /// `this` so it is possible to chain calls. E.g. `new LayoutConstraint().noGrid().gap().fill()`.
     ///
-    /// #### Since
-    ///
-    /// 3.7.2
     public CC gapTop(String boundsSize) {
         ver.setGapBefore(ConstraintParser.parseBoundSize(boundsSize, true, false));
         return this;
@@ -941,9 +903,6 @@ public final class CC {
     ///
     /// `this` so it is possible to chain calls. E.g. `new LayoutConstraint().noGrid().gap().fill()`.
     ///
-    /// #### Since
-    ///
-    /// 3.7.2
     public CC gapLeft(String boundsSize) {
         hor.setGapBefore(ConstraintParser.parseBoundSize(boundsSize, true, true));
         return this;
@@ -959,9 +918,6 @@ public final class CC {
     ///
     /// `this` so it is possible to chain calls. E.g. `new LayoutConstraint().noGrid().gap().fill()`.
     ///
-    /// #### Since
-    ///
-    /// 3.7.2
     public CC gapBottom(String boundsSize) {
         ver.setGapAfter(ConstraintParser.parseBoundSize(boundsSize, true, false));
         return this;
@@ -977,9 +933,6 @@ public final class CC {
     ///
     /// `this` so it is possible to chain calls. E.g. `new LayoutConstraint().noGrid().gap().fill()`.
     ///
-    /// #### Since
-    ///
-    /// 3.7.2
     public CC gapRight(String boundsSize) {
         hor.setGapAfter(ConstraintParser.parseBoundSize(boundsSize, true, true));
         return this;
@@ -1212,10 +1165,6 @@ public final class CC {
     ///
     /// `this` so it is possible to chain calls. E.g. `new ComponentConstraint().noGrid().gap().fill()`.
     ///
-    /// #### Since
-    ///
-    /// 3.7.2
-    ///
     /// #### See also
     ///
     /// - #setSplit(int)
@@ -1251,10 +1200,6 @@ public final class CC {
     /// #### Returns
     ///
     /// `this` so it is possible to chain calls. E.g. `new ComponentConstraint().noGrid().gap().fill()`.
-    ///
-    /// #### Since
-    ///
-    /// 3.7.2
     ///
     /// #### See also
     ///
@@ -2285,10 +2230,6 @@ public final class CC {
     ///
     /// The custom gap size. NOTE! Will return `null` for both no wrap **and** default wrap.
     ///
-    /// #### Since
-    ///
-    /// 2.4.2
-    ///
     /// #### See also
     ///
     /// - #isWrap()
@@ -2304,10 +2245,6 @@ public final class CC {
     ///
     /// - `s`: @param s The custom gap size. NOTE! `null` will not turn on or off wrap, it will only set the wrap gap size to "default".
     /// A non-null value will turn on wrap though.
-    ///
-    /// #### Since
-    ///
-    /// 2.4.2
     ///
     /// #### See also
     ///
@@ -2347,10 +2284,6 @@ public final class CC {
     ///
     /// The custom gap size. NOTE! Will return `null` for both no newline **and** default newline.
     ///
-    /// #### Since
-    ///
-    /// 2.4.2
-    ///
     /// #### See also
     ///
     /// - #isNewline()
@@ -2366,10 +2299,6 @@ public final class CC {
     ///
     /// - `s`: @param s The custom gap size. NOTE! `null` will not turn on or off newline, it will only set the newline gap size to "default".
     /// A non-null value will turn on newline though.
-    ///
-    /// #### Since
-    ///
-    /// 2.4.2
     ///
     /// #### See also
     ///

--- a/CodenameOne/src/com/codename1/ui/layouts/mig/ComponentWrapper.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/mig/ComponentWrapper.java
@@ -139,10 +139,6 @@ public interface ComponentWrapper {
     ///
     /// The minimum width of the component.
     ///
-    /// #### Since
-    ///
-    /// @since 3.5. Added the hint as a parameter knowing that a correction and recompilation is necessary for
-    /// any implementing classes. This change was worth it though.
     int getMinimumWidth(int hHint);
 
     /// Returns the minimum height of the component.
@@ -158,10 +154,6 @@ public interface ComponentWrapper {
     ///
     /// The minimum height of the component.
     ///
-    /// #### Since
-    ///
-    /// @since 3.5. Added the hint as a parameter knowing that a correction and recompilation is necessary for
-    /// any implementing classes. This change was worth it though.
     int getMinimumHeight(int wHint);
 
     /// Returns the preferred width of the component.
@@ -177,10 +169,6 @@ public interface ComponentWrapper {
     ///
     /// The preferred width of the component.
     ///
-    /// #### Since
-    ///
-    /// @since 3.5. Added the hint as a parameter knowing that a correction and recompilation is necessary for
-    /// any implementing classes. This change was worth it though.
     int getPreferredWidth(int hHint);
 
     /// Returns the preferred height of the component.
@@ -196,10 +184,6 @@ public interface ComponentWrapper {
     ///
     /// The preferred height of the component.
     ///
-    /// #### Since
-    ///
-    /// @since 3.5. Added the hint as a parameter knowing that a correction and recompilation is necessary for
-    /// any implementing classes. This change was worth it though.
     int getPreferredHeight(int wHint);
 
     /// Returns the maximum width of the component.
@@ -215,10 +199,6 @@ public interface ComponentWrapper {
     ///
     /// The maximum width of the component.
     ///
-    /// #### Since
-    ///
-    /// @since 3.5. Added the hint as a parameter knowing that a correction and recompilation is necessary for
-    /// any implementing classes. This change was worth it though.
     int getMaximumWidth(int hHint);
 
     /// Returns the maximum height of the component.
@@ -234,10 +214,6 @@ public interface ComponentWrapper {
     ///
     /// The maximum height of the component.
     ///
-    /// #### Since
-    ///
-    /// @since 3.5. Added the hint as a parameter knowing that a correction and recompilation is necessary for
-    /// any implementing classes. This change was worth it though.
     int getMaximumHeight(int wHint);
 
     /// Sets the component's bounds.
@@ -410,8 +386,5 @@ public interface ComponentWrapper {
     /// If the min/pref/max width depends on it's height (not common) return `net.miginfocom.layout.LayoutUtil#VERTICAL`
     /// If there is no connection between the preferred min/pref/max and the size of the component return -1.
     ///
-    /// #### Since
-    ///
-    /// 5.0
     int getContentBias();
 }

--- a/CodenameOne/src/com/codename1/ui/layouts/mig/ConstraintParser.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/mig/ConstraintParser.java
@@ -1570,9 +1570,6 @@ public final class ConstraintParser {
     /// @return Those parts of the string that are separated with
     /// `sep`. Never null and at least of size 1
     ///
-    /// #### Since
-    ///
-    /// 6.7.2 Changed so more than one space in a row works as one space.
     private static String[] toTrimmedTokens(String s, char sep) {
         int toks = 0;
         int sSize = s.length();

--- a/CodenameOne/src/com/codename1/ui/layouts/mig/Grid.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/mig/Grid.java
@@ -1149,9 +1149,6 @@ public final class Grid {
     /// has a content bias according to
     /// `net.miginfocom.layout.ComponentWrapper#getContentBias()`.
     ///
-    /// #### Since
-    ///
-    /// 5.0
     public boolean layout(int[] bounds, UnitValue alignX, UnitValue alignY, boolean debug) {
         return layoutImpl(bounds, alignX, alignY, debug, false);
     }
@@ -1180,9 +1177,6 @@ public final class Grid {
     /// has a content bias according to
     /// `net.miginfocom.layout.ComponentWrapper#getContentBias()`.
     ///
-    /// #### Since
-    ///
-    /// 5.0
     private boolean layoutImpl(int[] bounds, UnitValue alignX, UnitValue alignY, boolean debug, boolean trialRun) {
         if (debug) {
             debugRects = new ArrayList<int[]>();
@@ -1225,7 +1219,7 @@ public final class Grid {
                                     }
                                 }
 
-                                // @since 3.7.2 Needed or absolute "pos" pointing to "visual" or "container" didn't work if
+                                // Needed or absolute "pos" pointing to "visual" or "container" didn't work if
                                 // their bounds changed during the layout cycle. At least not in SWT.
                                 if (linkTargetIDs != null && (linkTargetIDs.containsKey("visual") || linkTargetIDs.containsKey("container"))) {
                                     layoutAgain = true;

--- a/CodenameOne/src/com/codename1/ui/layouts/mig/LC.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/mig/LC.java
@@ -439,9 +439,6 @@ public final class LC {
     ///
     /// The current value. Never `null`. Check if not set with `.isUnset()`.
     ///
-    /// #### Since
-    ///
-    /// 3.5
     public BoundSize getPackWidth() {
         return packW;
     }
@@ -459,9 +456,6 @@ public final class LC {
     ///
     /// - `size`: The new pack size. If `null` it will be corrected to an "unset" BoundSize.
     ///
-    /// #### Since
-    ///
-    /// 3.5
     public void setPackWidth(BoundSize size) {
         packW = size != null ? size : BoundSize.NULL_SIZE;
     }
@@ -479,9 +473,6 @@ public final class LC {
     ///
     /// The current value. Never `null`. Check if not set with `.isUnset()`.
     ///
-    /// #### Since
-    ///
-    /// 3.5
     public BoundSize getPackHeight() {
         return packH;
     }
@@ -499,9 +490,6 @@ public final class LC {
     ///
     /// - `size`: The new pack size. If `null` it will be corrected to an "unset" BoundSize.
     ///
-    /// #### Since
-    ///
-    /// 3.5
     public void setPackHeight(BoundSize size) {
         packH = size != null ? size : BoundSize.NULL_SIZE;
     }
@@ -516,9 +504,6 @@ public final class LC {
     ///
     /// The pack alignment. Always between 0f and 1f, inclusive.
     ///
-    /// #### Since
-    ///
-    /// 3.5
     public float getPackHeightAlign() {
         return phAlign;
     }
@@ -532,9 +517,6 @@ public final class LC {
     ///
     /// - `align`: The pack alignment. Always between 0f and 1f, inclusive. Values outside this will be truncated.
     ///
-    /// #### Since
-    ///
-    /// 3.5
     public void setPackHeightAlign(float align) {
         phAlign = Math.max(0f, Math.min(1f, align));
     }
@@ -548,9 +530,6 @@ public final class LC {
     ///
     /// The pack alignment. Always between 0f and 1f, inclusive.
     ///
-    /// #### Since
-    ///
-    /// 3.5
     public float getPackWidthAlign() {
         return pwAlign;
     }
@@ -564,9 +543,6 @@ public final class LC {
     ///
     /// - `align`: The pack alignment. Always between 0f and 1f, inclusive. Values outside this will be truncated.
     ///
-    /// #### Since
-    ///
-    /// 3.5
     public void setPackWidthAlign(float align) {
         pwAlign = Math.max(0f, Math.min(1f, align));
     }
@@ -580,9 +556,6 @@ public final class LC {
     /// @return The width for the container that this layout constraint is set for. Not `null` but
     /// all sizes can be `null`.
     ///
-    /// #### Since
-    ///
-    /// 3.5
     public BoundSize getWidth() {
         return width;
     }
@@ -596,9 +569,6 @@ public final class LC {
     /// - `size`: @param size The width for the container that this layout constraint is set for. `null` is translated to
     /// a bound size containing only null sizes.
     ///
-    /// #### Since
-    ///
-    /// 3.5
     public void setWidth(BoundSize size) {
         this.width = size != null ? size : BoundSize.NULL_SIZE;
     }
@@ -612,9 +582,6 @@ public final class LC {
     /// @return The height for the container that this layout constraint is set for. Not `null` but
     /// all sizes can be `null`.
     ///
-    /// #### Since
-    ///
-    /// 3.5
     public BoundSize getHeight() {
         return height;
     }
@@ -628,9 +595,6 @@ public final class LC {
     /// - `size`: @param size The height for the container that this layout constraint is set for. `null` is translated to
     /// a bound size containing only null sizes.
     ///
-    /// #### Since
-    ///
-    /// 3.5
     public void setHeight(BoundSize size) {
         this.height = size != null ? size : BoundSize.NULL_SIZE;
     }
@@ -650,9 +614,6 @@ public final class LC {
     ///
     /// `this` so it is possible to chain calls. E.g. `new LayoutConstraint().noGrid().gap().fill()`.
     ///
-    /// #### Since
-    ///
-    /// 3.5
     public LC pack() {
         return pack("pref", "pref");
     }
@@ -674,9 +635,6 @@ public final class LC {
     ///
     /// `this` so it is possible to chain calls. E.g. `new LayoutConstraint().noGrid().gap().fill()`.
     ///
-    /// #### Since
-    ///
-    /// 3.5
     public LC pack(String width, String height) {
         setPackWidth(width != null ? ConstraintParser.parseBoundSize(width, false, true) : BoundSize.NULL_SIZE);
         setPackHeight(height != null ? ConstraintParser.parseBoundSize(height, false, false) : BoundSize.NULL_SIZE);
@@ -700,9 +658,6 @@ public final class LC {
     ///
     /// `this` so it is possible to chain calls. E.g. `new LayoutConstraint().noGrid().gap().fill()`.
     ///
-    /// #### Since
-    ///
-    /// 3.5
     public LC packAlign(float alignX, float alignY) {
         setPackWidthAlign(alignX);
         setPackHeightAlign(alignY);
@@ -837,9 +792,6 @@ public final class LC {
     ///
     /// `this` so it is possible to chain calls. E.g. `new LayoutConstraint().noGrid().gap().fill()`.
     ///
-    /// #### Since
-    ///
-    /// 3.7.2
     public LC rightToLeft() {
         setLeftToRight(Boolean.FALSE);
         return this;
@@ -865,9 +817,6 @@ public final class LC {
     ///
     /// `this` so it is possible to chain calls. E.g. `new LayoutConstraint().noGrid().gap().fill()`.
     ///
-    /// #### Since
-    ///
-    /// 3.7.2
     public LC topToBottom() {
         setTopToBottom(true);
         return this;

--- a/CodenameOne/src/com/codename1/ui/layouts/mig/LinkHandler.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/mig/LinkHandler.java
@@ -178,9 +178,6 @@ public final class LinkHandler {
     /// This method clear any weak references right away instead of waiting for the GC. This might be advantageous
     /// if lots of layout are created and disposed of quickly to keep memory consumption down.
     ///
-    /// #### Since
-    ///
-    /// 3.7.4
     public synchronized static void clearWeakReferencesNow() {
         LAYOUTS.clear();
     }

--- a/CodenameOne/src/com/codename1/ui/layouts/mig/MigLayout.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/mig/MigLayout.java
@@ -561,9 +561,6 @@ public final class MigLayout extends Layout {
         }
     }
 
-    /// #### Since
-    ///
-    /// 3.7.3
     private void resetLastInvalidOnParent(Container parent) {
         while (parent != null) {
             Layout layoutManager = parent.getLayout();

--- a/CodenameOne/src/com/codename1/ui/layouts/mig/PlatformDefaults.java
+++ b/CodenameOne/src/com/codename1/ui/layouts/mig/PlatformDefaults.java
@@ -966,9 +966,6 @@ public final class PlatformDefaults {
     ///
     /// The current value. Default is `true`.
     ///
-    /// #### Since
-    ///
-    /// 3.5
     public static boolean getDefaultRowAlignmentBaseline() {
         return dra;
     }
@@ -980,9 +977,6 @@ public final class PlatformDefaults {
     ///
     /// - `b`: The new value. Default is `true` from v3.5.
     ///
-    /// #### Since
-    ///
-    /// 3.5
     public static void setDefaultRowAlignmentBaseline(boolean b) {
         dra = b;
     }

--- a/CodenameOne/src/com/codename1/ui/list/DefaultListModel.java
+++ b/CodenameOne/src/com/codename1/ui/list/DefaultListModel.java
@@ -300,9 +300,6 @@ public class DefaultListModel<T> implements MultipleSelectionListModel<T> {
 
     /// {@inheritDoc}
     ///
-    /// #### Since
-    ///
-    /// 6.0
     @Override
     public void removeSelectedIndices(int... indices) {
         if (isMultiSelectionMode()) {
@@ -322,9 +319,6 @@ public class DefaultListModel<T> implements MultipleSelectionListModel<T> {
 
     /// {@inheritDoc}
     ///
-    /// #### Since
-    ///
-    /// 6.0
     @Override
     public int[] getSelectedIndices() {
 
@@ -363,10 +357,6 @@ public class DefaultListModel<T> implements MultipleSelectionListModel<T> {
     /// #### Throws
     ///
     /// - `IllegalArgumentException`: If `#isMultiSelectionMode()` is false, and indices length is greater than 1.
-    ///
-    /// #### Since
-    ///
-    /// 6.0
     ///
     /// #### See also
     ///
@@ -412,9 +402,6 @@ public class DefaultListModel<T> implements MultipleSelectionListModel<T> {
     ///
     /// the multiSelectionMode
     ///
-    /// #### Since
-    ///
-    /// 6.0
     public boolean isMultiSelectionMode() {
         return multiSelectionMode;
     }
@@ -425,9 +412,6 @@ public class DefaultListModel<T> implements MultipleSelectionListModel<T> {
     ///
     /// - `multiSelectionMode`: the multiSelectionMode to set
     ///
-    /// #### Since
-    ///
-    /// 6.0
     public void setMultiSelectionMode(boolean multiSelectionMode) {
         this.multiSelectionMode = multiSelectionMode;
     }

--- a/CodenameOne/src/com/codename1/ui/list/MultipleSelectionListModel.java
+++ b/CodenameOne/src/com/codename1/ui/list/MultipleSelectionListModel.java
@@ -26,9 +26,6 @@ package com.codename1.ui.list;
 ///
 /// @author Steve Hannah
 ///
-/// #### Since
-///
-/// 6.0
 public interface MultipleSelectionListModel<T> extends ListModel<T> {
     /// Adds indices to set of selected indices.
     ///

--- a/CodenameOne/src/com/codename1/ui/plaf/CSSBorder.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/CSSBorder.java
@@ -55,9 +55,6 @@ import static com.codename1.ui.Component.TOP;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 7.0
 public class CSSBorder extends Border {
     /// Constant indicating no-repeat for background images.
     public static final byte REPEAT_NONE = 0;
@@ -869,10 +866,6 @@ public class CSSBorder extends Border {
     ///
     /// Self for chaining.
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - #borderImageWithName(java.lang.String, double...)
@@ -908,10 +901,6 @@ public class CSSBorder extends Border {
     /// #### Returns
     ///
     /// Self for chaining.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///

--- a/CodenameOne/src/com/codename1/ui/plaf/LookAndFeel.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/LookAndFeel.java
@@ -223,10 +223,6 @@ public abstract class LookAndFeel {
     ///
     /// A span representing the positions of characters in the label
     ///
-    /// #### Since
-    ///
-    /// 7.0
-    ///
     /// #### See also
     ///
     /// - TextSelection
@@ -271,9 +267,6 @@ public abstract class LookAndFeel {
     ///
     /// The spans for the given text field.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public abstract Spans calculateTextAreaSpan(TextSelection sel, TextArea ta);
 
     /// Draws the text field without its cursor which is drawn in a separate method
@@ -298,9 +291,6 @@ public abstract class LookAndFeel {
     ///
     /// The spans for the given text field.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public abstract Spans calculateTextFieldSpan(TextSelection sel, TextArea ta);
 
     /// Draws the cursor of the text field, blinking is handled simply by avoiding

--- a/CodenameOne/src/com/codename1/ui/plaf/RoundBorder.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/RoundBorder.java
@@ -435,9 +435,6 @@ public final class RoundBorder extends Border {
     ///
     /// True if only left side is rounded.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean isOnlyLeftRounded() {
         return onlyLeftRounded;
     }
@@ -463,9 +460,6 @@ public final class RoundBorder extends Border {
     ///
     /// True if only right side is rounded.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean isOnlyRightRounded() {
         return onlyRightRounded;
     }

--- a/CodenameOne/src/com/codename1/ui/plaf/RoundRectBorder.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/RoundRectBorder.java
@@ -121,25 +121,16 @@ public final class RoundRectBorder extends Border {
     /// value indicates that it should just calculate the position as normal, suing the
     /// the provided tracking component bounds.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     private float trackComponentVerticalPosition = -1;
     /// Var to explicitly set the position of the arrow when tracking a component. Values
     /// between 0 and 1, with zero being the left, and 1 being the right.  Default negative
     /// value indicates that it should just calculate the position as normal, suing the
     /// the provided tracking component bounds.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     private float trackComponentHorizontalPosition = -1;
     /// Var to explicitly set the position of the arrow when tracking a component. Acceptable
     /// values `Component#TOP`, `Component#BOTTOM`, `Component#LEFT`, `Component#RIGHT`.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     private int trackComponentSide = -1;
     /// The thickness of the edge of the border if applicable, 0 if no stroke is needed
     private float strokeThickness;
@@ -198,9 +189,6 @@ public final class RoundRectBorder extends Border {
     ///
     /// a border instance
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public RoundRectBorder arrowSize(float size) {
         this.arrowSize = size;
         return this;
@@ -212,9 +200,6 @@ public final class RoundRectBorder extends Border {
     ///
     /// - `size`: Size of arrow in millimeters.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setArrowSize(float size) {
         this.arrowSize = size;
     }
@@ -250,9 +235,6 @@ public final class RoundRectBorder extends Border {
     ///
     /// Self for chaining.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public RoundRectBorder trackComponentSide(int side) {
         this.trackComponentSide = side;
         return this;
@@ -265,9 +247,6 @@ public final class RoundRectBorder extends Border {
     /// @return The side that the arrow should be rendered on. Values `Component#TOP`, `Component#BOTTOM`, `Component#LEFT`, or a negative number to indicate that the position will be calculated based on the position of the tracking component.
     /// or `Component#BOTTOM`.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public int getTrackComponentSide() {
         return trackComponentSide;
     }
@@ -283,9 +262,6 @@ public final class RoundRectBorder extends Border {
     ///
     /// Self for chainging.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public RoundRectBorder trackComponentVerticalPosition(float pos) {
         this.trackComponentVerticalPosition = pos;
         return this;
@@ -298,9 +274,6 @@ public final class RoundRectBorder extends Border {
     /// @return Vertical position of the arrow.  Values between 0 and 1 will place the arrow in the range from top to bottom.  Negative values result in
     /// default behaviour, which is to calculate the position based on the tracking component position.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public float getTrackComponentVerticalPosition() {
         return trackComponentVerticalPosition;
     }
@@ -316,9 +289,6 @@ public final class RoundRectBorder extends Border {
     ///
     /// Self for chainging.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public RoundRectBorder trackComponentHorizontalPosition(float pos) {
         this.trackComponentHorizontalPosition = pos;
         return this;
@@ -331,9 +301,6 @@ public final class RoundRectBorder extends Border {
     /// @return Vertical position of the arrow.  Values between 0 and 1 will place the arrow in the range from left to right.  Negative values result in
     /// default behaviour, which is to calculate the position based on the tracking component position.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public float getTrackComponentHorizontalPosition() {
         return trackComponentHorizontalPosition;
     }
@@ -354,9 +321,6 @@ public final class RoundRectBorder extends Border {
     ///
     /// Self for chaining.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public RoundRectBorder useCache(boolean useCache) {
         this.useCache = useCache;
         return this;

--- a/CodenameOne/src/com/codename1/ui/plaf/Style.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/Style.java
@@ -113,15 +113,9 @@ public class Style {
     public static final String ELEVATION = "elevation";
     /// Icon gap attribute name for the theme hashtable.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public static final String ICON_GAP = "iconGap";
     /// Icon gap unit attribute.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public static final String ICON_GAP_UNIT = "iconGapUnit";
     /// Surface attribute name for the theme hashtable.
     public static final String SURFACE = "surface";
@@ -229,34 +223,19 @@ public class Style {
     public static final byte UNIT_TYPE_DIPS = 2;
     /// Indicates the unit type for padding/margin as a percentage of the screen width.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public static final byte UNIT_TYPE_VW = 3;
     /// Indicates the unit type for padding/margin as a percentage of the screen height.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public static final byte UNIT_TYPE_VH = 4;
     /// Indicates the unit type for padding/margin as a percentage the minimum of screen width and height.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public static final byte UNIT_TYPE_VMIN = 5;
     /// Indicates the unit type for padding/margin as a percentage the maximum of screen width and height.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public static final byte UNIT_TYPE_VMAX = 6;
     /// Indicates the unit type for padding/margin relative to the font size of the default font.
     /// 1rem == Font.getDefaultFont().getHeight()
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public static final byte UNIT_TYPE_REM = 7;
     /// Indicates the background alignment for use in tiling or aligned images.
     private static final byte BACKGROUND_IMAGE_ALIGN_TOP = (byte) 0xa1;
@@ -597,9 +576,6 @@ public class Style {
     ///
     /// The elevation value.  Default is 0.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public int getElevation() {
         return elevation;
     }
@@ -610,18 +586,12 @@ public class Style {
     ///
     /// - `elevation`: The elevation value.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public void setElevation(int elevation) {
         setElevation(elevation, false);
     }
 
     /// Returns the icon gap in pixels.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public int getIconGap() {
         if (iconGap < 0) {
             return -1;
@@ -634,10 +604,6 @@ public class Style {
     /// #### Parameters
     ///
     /// - `gap`: The icon gap.
-    ///
-    /// #### Since
-    ///
-    /// 8.0
     ///
     /// #### See also
     ///
@@ -654,9 +620,6 @@ public class Style {
     ///
     /// The icon gap unit
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public int getIconGapUnit() {
         return iconGapUnit;
     }
@@ -667,9 +630,6 @@ public class Style {
     ///
     /// - `unit`: The icon gap unit.  One of the standard style units of measurement.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public void setIconGapUnit(byte unit) {
         setIconGapUnit(unit, false);
     }
@@ -681,9 +641,6 @@ public class Style {
     ///
     /// True if container should be rendered as a surface.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public boolean isSurface() {
         return surface;
     }
@@ -696,9 +653,6 @@ public class Style {
     ///
     /// - `surface`: True to enable surface rendering mode.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public void setSurface(boolean surface) {
         setSurface(surface, false);
     }
@@ -936,9 +890,6 @@ public class Style {
     ///
     /// the foreground alpha for the component
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public int getFgAlpha() {
         return fgAlpha;
     }
@@ -979,9 +930,6 @@ public class Style {
     /// - `override`: @param override  If set to true allows the look and feel/theme to override
     /// the value in this attribute when changing a theme/look and feel
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public void setElevation(int elevation, boolean override) {
         if (proxyTo != null) {
             for (Style s : proxyTo) {
@@ -1009,10 +957,6 @@ public class Style {
     ///
     /// - `override`: @param override If set to true allows the look and feel/theme to override
     /// the value in this attribute when changing a theme/look and feel
-    ///
-    /// #### Since
-    ///
-    /// 8.0
     ///
     /// #### See also
     ///
@@ -1044,10 +988,6 @@ public class Style {
     /// - `override`: @param override If set to true allows the look and feel/theme to override
     /// the value in this attribute when changing a theme/look and feel
     ///
-    /// #### Since
-    ///
-    /// 8.0
-    ///
     /// #### See also
     ///
     /// - #setIconGapUnit(byte, boolean)
@@ -1063,9 +1003,6 @@ public class Style {
     ///
     /// - `unit`: The unit. One of the standard style units of measurement.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public void setIconGap(float gap, byte unit) {
         setIconGap(gap, unit, false);
     }
@@ -1079,9 +1016,6 @@ public class Style {
     /// - `override`: @param override If set to true allows the look and feel/theme to override
     /// the value in this attribute when changing a theme/look and feel
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public void setIconGapUnit(byte unit, boolean override) {
         if (proxyTo != null) {
             for (Style s : proxyTo) {
@@ -1109,9 +1043,6 @@ public class Style {
     /// - `override`: @param override If set to true allows the look and feel/theme to override
     /// the value in this attribute when changing a theme/look and feel
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public void setSurface(boolean surface, boolean override) {
         if (proxyTo != null) {
             for (Style s : proxyTo) {
@@ -1486,9 +1417,6 @@ public class Style {
 
     /// Strips all margin and padding from this style.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void stripMarginAndPadding() {
         setPadding(0, 0, 0, 0);
         setMargin(0, 0, 0, 0);
@@ -1732,10 +1660,6 @@ public class Style {
     ///
     /// amount of padding in the given orientation using current units.
     ///
-    /// #### Since
-    ///
-    /// 8.0
-    ///
     /// #### See also
     ///
     /// - #getPaddingUnit()
@@ -1789,9 +1713,6 @@ public class Style {
     /// - `unit`: @param unit One of of `#UNIT_TYPE_PIXELS`, `#UNIT_TYPE_DIPS`, `#UNIT_TYPE_SCREEN_PERCENTAGE`, `#UNIT_TYPE_VW`, `#UNIT_TYPE_VH`,
     /// `#UNIT_TYPE_VMIN`, `#UNIT_TYPE_VMAX`, `#UNIT_TYPE_REM`.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setPaddingUnitLeft(byte unit) {
         if (proxyTo != null) {
             for (Style s : proxyTo) {
@@ -1810,9 +1731,6 @@ public class Style {
     /// - `unit`: @param unit One of `#UNIT_TYPE_PIXELS`, `#UNIT_TYPE_DIPS`, `#UNIT_TYPE_SCREEN_PERCENTAGE`, `#UNIT_TYPE_VW`, `#UNIT_TYPE_VH`,
     /// `#UNIT_TYPE_VMIN`, `#UNIT_TYPE_VMAX`, `#UNIT_TYPE_REM`.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setPaddingUnitRight(byte unit) {
         if (proxyTo != null) {
             for (Style s : proxyTo) {
@@ -1831,9 +1749,6 @@ public class Style {
     /// - `unit`: @param unit One of `#UNIT_TYPE_PIXELS`, `#UNIT_TYPE_DIPS`, `#UNIT_TYPE_SCREEN_PERCENTAGE`, `#UNIT_TYPE_VW`, `#UNIT_TYPE_VH`,
     /// `#UNIT_TYPE_VMIN`, `#UNIT_TYPE_VMAX`, `#UNIT_TYPE_REM`.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setPaddingUnitTop(byte unit) {
         if (proxyTo != null) {
             for (Style s : proxyTo) {
@@ -1852,9 +1767,6 @@ public class Style {
     /// - `unit`: @param unit One of `#UNIT_TYPE_PIXELS`, `#UNIT_TYPE_DIPS`, `#UNIT_TYPE_SCREEN_PERCENTAGE`, `#UNIT_TYPE_VW`, `#UNIT_TYPE_VH`,
     /// `#UNIT_TYPE_VMIN`, `#UNIT_TYPE_VMAX`, `#UNIT_TYPE_REM`.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setPaddingUnitBottom(byte unit) {
         if (proxyTo != null) {
             for (Style s : proxyTo) {
@@ -2439,9 +2351,6 @@ public class Style {
     ///
     /// number of margin using the current unit in the given orientation
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public float getMarginFloatValue(boolean rtl, int orientation) {
         if (orientation < Component.TOP || orientation > Component.RIGHT) {
             throw new IllegalArgumentException("wrong orientation " + orientation);
@@ -3054,9 +2963,6 @@ public class Style {
     ///
     /// True if change events are suppressed.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean isSuppressChangeEvents() {
         return suppressChangeEvents;
     }
@@ -3067,9 +2973,6 @@ public class Style {
     ///
     /// - `suppress`: True to suppress change events.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setSuppressChangeEvents(boolean suppress) {
         this.suppressChangeEvents = suppress;
     }
@@ -3301,9 +3204,6 @@ public class Style {
     /// - `unit`: @param unit One of `#UNIT_TYPE_PIXELS`, `#UNIT_TYPE_DIPS`, `#UNIT_TYPE_SCREEN_PERCENTAGE`, `#UNIT_TYPE_VW`, `#UNIT_TYPE_VH`,
     /// `#UNIT_TYPE_VMIN`, `#UNIT_TYPE_VMAX`, `#UNIT_TYPE_REM`.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setMarginUnitLeft(byte unit) {
         if (proxyTo != null) {
             for (Style s : proxyTo) {
@@ -3322,9 +3222,6 @@ public class Style {
     /// - `unit`: @param unit One of `#UNIT_TYPE_PIXELS`, `#UNIT_TYPE_DIPS`, `#UNIT_TYPE_SCREEN_PERCENTAGE`, `#UNIT_TYPE_VW`, `#UNIT_TYPE_VH`,
     /// `#UNIT_TYPE_VMIN`, `#UNIT_TYPE_VMAX`, `#UNIT_TYPE_REM`.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setMarginUnitRight(byte unit) {
         if (proxyTo != null) {
             for (Style s : proxyTo) {
@@ -3343,9 +3240,6 @@ public class Style {
     /// - `unit`: @param unit One of `#UNIT_TYPE_PIXELS`, `#UNIT_TYPE_DIPS`, `#UNIT_TYPE_SCREEN_PERCENTAGE`, `#UNIT_TYPE_VW`, `#UNIT_TYPE_VH`,
     /// `#UNIT_TYPE_VMIN`, `#UNIT_TYPE_VMAX`, `#UNIT_TYPE_REM`.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setMarginUnitTop(byte unit) {
         if (proxyTo != null) {
             for (Style s : proxyTo) {
@@ -3364,9 +3258,6 @@ public class Style {
     /// - `unit`: @param unit One of `#UNIT_TYPE_PIXELS`, `#UNIT_TYPE_DIPS`, `#UNIT_TYPE_SCREEN_PERCENTAGE`, `#UNIT_TYPE_VW`, `#UNIT_TYPE_VH`,
     /// `#UNIT_TYPE_VMIN`, `#UNIT_TYPE_VMAX`, `#UNIT_TYPE_REM`.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void setMarginUnitBottom(byte unit) {
         if (proxyTo != null) {
             for (Style s : proxyTo) {

--- a/CodenameOne/src/com/codename1/ui/plaf/UIManager.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/UIManager.java
@@ -419,9 +419,6 @@ public class UIManager {
     ///
     /// The IconUIID corresponding to the given ID - or null if none is defined in the theme.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public String getIconUIIDFor(String id) {
         if (id == null || id.length() == 0) {
             return null;

--- a/CodenameOne/src/com/codename1/ui/spinner/DateSpinner3D.java
+++ b/CodenameOne/src/com/codename1/ui/spinner/DateSpinner3D.java
@@ -202,9 +202,6 @@ class DateSpinner3D extends Container implements InternalPickerWidget {
     ///
     /// - `end`: The end date
     ///
-    /// #### Since
-    ///
-    /// 6.0
     public void setDateRange(Date start, Date end) {
         explicitStartMonth = true;
         explicitEndMonth = true;
@@ -282,9 +279,6 @@ class DateSpinner3D extends Container implements InternalPickerWidget {
 
     /// Gets the start month of this Spinner.
     ///
-    /// #### Since
-    ///
-    /// 6.0
     public int getStartMonth() {
         return startMonth;
     }
@@ -292,9 +286,6 @@ class DateSpinner3D extends Container implements InternalPickerWidget {
 
     /// Gets the end month of this spinner.
     ///
-    /// #### Since
-    ///
-    /// 6.0
     public int getEndMonth() {
         return endMonth;
     }
@@ -302,18 +293,12 @@ class DateSpinner3D extends Container implements InternalPickerWidget {
 
     /// Gets the start day of month.
     ///
-    /// #### Since
-    ///
-    /// 6.0
     public int getStartDay() {
         return startDay;
     }
 
     /// Gets the end day of month.
     ///
-    /// #### Since
-    ///
-    /// 6.0
     public int getEndDay() {
         return endDay;
     }

--- a/CodenameOne/src/com/codename1/ui/spinner/DateTimeSpinner3D.java
+++ b/CodenameOne/src/com/codename1/ui/spinner/DateTimeSpinner3D.java
@@ -232,10 +232,6 @@ class DateTimeSpinner3D extends Container implements InternalPickerWidget {
     ///
     /// True if time is in 12 hour format.  False otherwise.
     ///
-    /// #### Since
-    ///
-    /// 6.0
-    ///
     /// #### See also
     ///
     /// - #setShowMeridiem(boolean)
@@ -251,10 +247,6 @@ class DateTimeSpinner3D extends Container implements InternalPickerWidget {
     /// #### Parameters
     ///
     /// - `showMeridiem`: True to show times in 12 hour format (the default).  False to show in 24 hour format.
-    ///
-    /// #### Since
-    ///
-    /// 6.0
     ///
     /// #### See also
     ///
@@ -274,10 +266,6 @@ class DateTimeSpinner3D extends Container implements InternalPickerWidget {
     /// - `min`: The minimum hour to display (0-24).  -1 for no limit.
     ///
     /// - `max`: The max hour to display (0-24).  -1 for no limit.
-    ///
-    /// #### Since
-    ///
-    /// 6.0
     ///
     /// #### See also
     ///
@@ -301,10 +289,6 @@ class DateTimeSpinner3D extends Container implements InternalPickerWidget {
     ///
     /// Min hour (0-24) or -1 for no limit.
     ///
-    /// #### Since
-    ///
-    /// 6.0
-    ///
     /// #### See also
     ///
     /// - #getMaxHour()
@@ -322,10 +306,6 @@ class DateTimeSpinner3D extends Container implements InternalPickerWidget {
     /// #### Returns
     ///
     /// Max hour (0-24) or -1 for no limit.
-    ///
-    /// #### Since
-    ///
-    /// 6.0
     ///
     /// #### See also
     ///

--- a/CodenameOne/src/com/codename1/ui/spinner/Picker.java
+++ b/CodenameOne/src/com/codename1/ui/spinner/Picker.java
@@ -1110,10 +1110,6 @@ public class Picker extends Button {
     ///
     /// - `max`: The maximum hour to display (0-24) or -1 for no limit
     ///
-    /// #### Since
-    ///
-    /// 6.0
-    ///
     /// #### See also
     ///
     /// - #getMinHour()
@@ -1134,10 +1130,6 @@ public class Picker extends Button {
     ///
     /// The minimum hour.  0-24, or -1 for no limit.
     ///
-    /// #### Since
-    ///
-    /// 6.0
-    ///
     /// #### See also
     ///
     /// - #getMaxHour()
@@ -1153,10 +1145,6 @@ public class Picker extends Button {
     /// #### Returns
     ///
     /// The minimum hour.  0-24, or -1 for no limit.
-    ///
-    /// #### Since
-    ///
-    /// 6.0
     ///
     /// #### See also
     ///
@@ -1175,10 +1163,6 @@ public class Picker extends Button {
     /// @return The start date or null if there is none set.
     ///
     /// This does not apply to the time.  Only the date.  You can set the hour range using `int)`.
-    ///
-    /// #### Since
-    ///
-    /// 6.0
     ///
     /// #### See also
     ///
@@ -1200,10 +1184,6 @@ public class Picker extends Button {
     ///
     /// - `start`: The start date.
     ///
-    /// #### Since
-    ///
-    /// 6.0
-    ///
     /// #### See also
     ///
     /// - #getStartDate()
@@ -1221,10 +1201,6 @@ public class Picker extends Button {
     /// @return The end date or null if there is none set.
     ///
     /// This does not apply to the time.  Only the date.  You can set the hour range using `int)`.
-    ///
-    /// #### Since
-    ///
-    /// 6.0
     ///
     /// #### See also
     ///
@@ -1245,10 +1221,6 @@ public class Picker extends Button {
     /// #### Parameters
     ///
     /// - `end`: The end date.
-    ///
-    /// #### Since
-    ///
-    /// 6.0
     ///
     /// #### See also
     ///

--- a/CodenameOne/src/com/codename1/ui/spinner/TimeSpinner3D.java
+++ b/CodenameOne/src/com/codename1/ui/spinner/TimeSpinner3D.java
@@ -261,10 +261,6 @@ class TimeSpinner3D extends Container implements InternalPickerWidget {
     ///
     /// - `IllegalStateException`: If the spinner is not in 24 hour mode.
     ///
-    /// #### Since
-    ///
-    /// 6.0
-    ///
     /// #### See also
     ///
     /// - #getMinHour()
@@ -285,10 +281,6 @@ class TimeSpinner3D extends Container implements InternalPickerWidget {
     ///
     /// The current minimum hour (0-24).  -1 for no limit.
     ///
-    /// #### Since
-    ///
-    /// 6.0
-    ///
     /// #### See also
     ///
     /// - #setHourRange(int, int)
@@ -303,10 +295,6 @@ class TimeSpinner3D extends Container implements InternalPickerWidget {
     /// #### Returns
     ///
     /// The current maximum hour (0-24). -1 for no limit.
-    ///
-    /// #### Since
-    ///
-    /// 6.0
     ///
     /// #### See also
     ///

--- a/CodenameOne/src/com/codename1/ui/tree/Tree.java
+++ b/CodenameOne/src/com/codename1/ui/tree/Tree.java
@@ -412,9 +412,6 @@ public class Tree extends Container {
     ///
     /// The corresponding component in the UI or null if not found.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public Component findNodeComponent(Object node) {
         return findNodeComponent(node, this);
     }
@@ -431,9 +428,6 @@ public class Tree extends Container {
     ///
     /// The corresponding UI component for node, or null if not found.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public Component findNodeComponent(Object node, Component root) {
         if (root == null) {
             return findNodeComponent(node, this);
@@ -570,9 +564,6 @@ public class Tree extends Container {
     ///
     /// UI component for the given node's parent.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public Component getParentComponent(Component nodeComponent) {
         if (nodeComponent == null) {
             return null;
@@ -586,9 +577,6 @@ public class Tree extends Container {
     ///
     /// - `nodeComponent`: The node component.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void refreshNode(Component nodeComponent) {
         if (nodeComponent == null) {
             throw new IllegalArgumentException("refreshNode expects a non-null argument");
@@ -727,9 +715,6 @@ public class Tree extends Container {
     ///
     /// - `size`: The size in millimetres for the icon.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     protected void setNodeMaterialIcon(char c, Component node, float size) {
         FontImage.setMaterialIcon(node, FontImage.MATERIAL_FOLDER, 3);
     }
@@ -805,9 +790,6 @@ public class Tree extends Container {
     ///
     /// The model.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     protected Object getModel(Component node) {
         return node.getClientProperty(KEY_OBJECT);
     }

--- a/CodenameOne/src/com/codename1/ui/validation/ExistInConstraint.java
+++ b/CodenameOne/src/com/codename1/ui/validation/ExistInConstraint.java
@@ -30,9 +30,6 @@ import java.util.List;
 ///
 /// @author Diamond Mubaarak
 ///
-/// #### Since
-///
-/// 7.0
 public class ExistInConstraint implements Constraint {
 
     private final List<String> items;

--- a/CodenameOne/src/com/codename1/ui/validation/NotConstraint.java
+++ b/CodenameOne/src/com/codename1/ui/validation/NotConstraint.java
@@ -26,9 +26,6 @@ package com.codename1.ui.validation;
 ///
 /// @author Diamond Mubaarak
 ///
-/// #### Since
-///
-/// 7.0
 public class NotConstraint implements Constraint {
 
     private final Constraint[] constraints;

--- a/CodenameOne/src/com/codename1/util/AbstractStringBuilder.java
+++ b/CodenameOne/src/com/codename1/util/AbstractStringBuilder.java
@@ -21,10 +21,6 @@ package com.codename1.util;
 /// and modifying Strings. This class is intended as a base class for
 /// `StringBuffer` and `StringBuilder`.
 ///
-/// #### Since
-///
-/// 1.5
-///
 /// #### See also
 ///
 /// - StringBuffer
@@ -562,10 +558,6 @@ abstract class AbstractStringBuilder {
     /// @return the index of the specified character, -1 if the character isn't
     /// found.
     ///
-    /// #### Since
-    ///
-    /// 1.4
-    ///
     /// #### See also
     ///
     /// - #lastIndexOf(String)
@@ -586,10 +578,6 @@ abstract class AbstractStringBuilder {
     ///
     /// @return the index of the specified character, -1 if the character isn't
     /// found
-    ///
-    /// #### Since
-    ///
-    /// 1.4
     ///
     /// #### See also
     ///
@@ -646,10 +634,6 @@ abstract class AbstractStringBuilder {
     ///
     /// - `NullPointerException`: if `string` is `null`.
     ///
-    /// #### Since
-    ///
-    /// 1.4
-    ///
     /// #### See also
     ///
     /// - String#lastIndexOf(java.lang.String)
@@ -674,10 +658,6 @@ abstract class AbstractStringBuilder {
     /// #### Throws
     ///
     /// - `NullPointerException`: if `subString` is `null`.
-    ///
-    /// #### Since
-    ///
-    /// 1.4
     ///
     /// #### See also
     ///
@@ -725,9 +705,6 @@ abstract class AbstractStringBuilder {
     /// Trims off any extra capacity beyond the current length. Note, this method
     /// is NOT guaranteed to change the capacity of this object.
     ///
-    /// #### Since
-    ///
-    /// 1.5
     public void trimToSize() {
         if (count < value.length) {
             char[] newValue = new char[count];
@@ -750,10 +727,6 @@ abstract class AbstractStringBuilder {
     ///
     /// - `IndexOutOfBoundsException`: @throws IndexOutOfBoundsException if `index` is negative or greater than or equal to
     /// `#length()`.
-    ///
-    /// #### Since
-    ///
-    /// 1.5
     ///
     /// #### See also
     ///
@@ -781,10 +754,6 @@ abstract class AbstractStringBuilder {
     ///
     /// - `IndexOutOfBoundsException`: @throws IndexOutOfBoundsException if `index` is less than 1 or greater than
     /// `#length()`.
-    ///
-    /// #### Since
-    ///
-    /// 1.5
     ///
     /// #### See also
     ///
@@ -816,10 +785,6 @@ abstract class AbstractStringBuilder {
     /// - `IndexOutOfBoundsException`: @throws IndexOutOfBoundsException if `beginIndex` is negative or greater than
     /// `endIndex` or `endIndex` is greater than
     /// `#length()`.
-    ///
-    /// #### Since
-    ///
-    /// 1.5
     ///
     /// #### See also
     ///
@@ -854,10 +819,6 @@ abstract class AbstractStringBuilder {
     /// `#length()` or if there aren't enough code points
     /// before or after `index` to match
     /// `codePointOffset`.
-    ///
-    /// #### Since
-    ///
-    /// 1.5
     ///
     /// #### See also
     ///

--- a/CodenameOne/src/com/codename1/util/AsyncResource.java
+++ b/CodenameOne/src/com/codename1/util/AsyncResource.java
@@ -45,9 +45,6 @@ import static com.codename1.ui.CN.isEdt;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 7.0
 public class AsyncResource<V> extends Observable {
     private final Object lock = new Object();
     private V value;
@@ -73,9 +70,6 @@ public class AsyncResource<V> extends Observable {
     ///
     /// True if the exception was caused by cancelling an AsyncResource.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static boolean isCancelled(Throwable t) {
         if (t == null) {
             return false;
@@ -98,9 +92,6 @@ public class AsyncResource<V> extends Observable {
     ///
     /// A combined AsyncResource.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static AsyncResource<Boolean> all(AsyncResource<?>... resources) {
         final AsyncResource<Boolean> out = new AsyncResource<Boolean>();
         final Set<AsyncResource> pending = new HashSet<AsyncResource>(Arrays.asList(resources));
@@ -154,9 +145,6 @@ public class AsyncResource<V> extends Observable {
     ///
     /// A combined AsyncResource.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static AsyncResource<Boolean> all(java.util.Collection<AsyncResource<?>> resources) {
         return all(resources.toArray(new AsyncResource[resources.size()]));
     }
@@ -168,9 +156,6 @@ public class AsyncResource<V> extends Observable {
     ///
     /// - `resources`: The resources to wait for.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static void await(java.util.Collection<AsyncResource<?>> resources) throws AsyncExecutionException {
         await(resources.toArray(new AsyncResource[resources.size()]));
     }
@@ -182,9 +167,6 @@ public class AsyncResource<V> extends Observable {
     ///
     /// - `resources`: The resources to wait for.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static void await(AsyncResource<?>... resources) throws AsyncExecutionException {
         final boolean[] complete = new boolean[1];
         final Throwable[] t = new Throwable[1];
@@ -575,9 +557,6 @@ public class AsyncResource<V> extends Observable {
     ///
     /// - `resource`
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void addListener(final AsyncResource<V> resource) {
         ready(new SuccessCallback<V>() {
             @Override
@@ -604,9 +583,6 @@ public class AsyncResource<V> extends Observable {
     /// to test the error parameter of `java.lang.Throwable)` to see if
     /// if was caused by a cancellation.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public void onResult(final AsyncResult<V> onResult) {
         ready(new SuccessCallback<V>() {
             @Override
@@ -627,9 +603,6 @@ public class AsyncResource<V> extends Observable {
     ///
     /// A Promise wrapping this AsyncResource.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public Promise<V> asPromise() {
         return Promise.promisify(this);
     }
@@ -658,9 +631,6 @@ public class AsyncResource<V> extends Observable {
         ///
         /// True if this exception was caused by cancelling an AsyncResource.
         ///
-        /// #### Since
-        ///
-        /// 7.0
         public boolean isCancelled() {
             if (cause != null && cause.getClass() == CancellationException.class) {
                 return true;
@@ -677,10 +647,6 @@ public class AsyncResource<V> extends Observable {
     /// to test a particular exception to see if it resulted from cancelling an AsyncResource as this will
     /// return true if the exception itself is a CancellationException, or if the exception was caused by
     /// a CancellationException.
-    ///
-    /// #### Since
-    ///
-    /// 7.0
     ///
     /// #### See also
     ///

--- a/CodenameOne/src/com/codename1/util/AsyncResult.java
+++ b/CodenameOne/src/com/codename1/util/AsyncResult.java
@@ -27,9 +27,6 @@ package com.codename1.util;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 7.0
 public interface AsyncResult<V> {
     /// Called when an AsyncResource completes.  If it completes with an error, then error will be non-null.
     ///

--- a/CodenameOne/src/com/codename1/util/CStringBuilder.java
+++ b/CodenameOne/src/com/codename1/util/CStringBuilder.java
@@ -27,10 +27,6 @@ package com.codename1.util;
 /// chaining method calls together. For example, `new StringBuilder("One
 /// should ").append("always strive ").append("to achieve Harmony")`.
 ///
-/// #### Since
-///
-/// 1.5
-///
 /// #### Deprecated
 ///
 /// we will be moving to the proper string builder very soon

--- a/CodenameOne/src/com/codename1/util/DateUtil.java
+++ b/CodenameOne/src/com/codename1/util/DateUtil.java
@@ -65,9 +65,6 @@ public class DateUtil {
     ///
     /// The earliest of a set of dates.
     ///
-    /// #### Since
-    ///
-    /// 6.0
     public static Date min(Date... dates) {
         int len = dates.length;
         if (len == 0) {
@@ -97,9 +94,6 @@ public class DateUtil {
     ///
     /// -1 if first date is earlier.  1 if first date is later.  0 if they are the same.
     ///
-    /// #### Since
-    ///
-    /// 6.0
     public static int compare(Date d1, Date d2) {
         if (d1 == null) {
             return d2 == null ? 0 : -1;
@@ -155,9 +149,6 @@ public class DateUtil {
     ///
     /// - == 0 - if they are equal.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public static Comparator<Date> compareByDateField(final long field) {
         return new Comparator<Date>() {
             @Override
@@ -205,9 +196,6 @@ public class DateUtil {
     ///
     /// The latest of a set of dates.
     ///
-    /// #### Since
-    ///
-    /// 6.0
     public static Date max(Date... dates) {
         int len = dates.length;
         if (len == 0) {
@@ -279,9 +267,6 @@ public class DateUtil {
     ///
     /// True if the two times are on the same year.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean isSameYear(Calendar c1, Calendar c2) {
 
         return c1.get(Calendar.YEAR) == c2.get(Calendar.YEAR);
@@ -299,9 +284,6 @@ public class DateUtil {
     ///
     /// True if the two dates are on the same year.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean isSameYear(Date d1, Date d2) {
         Calendar c1 = Calendar.getInstance(tz);
         c1.setTime(d1);
@@ -323,9 +305,6 @@ public class DateUtil {
     ///
     /// True if the two times are on the same month.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean isSameMonth(Calendar c1, Calendar c2) {
 
         return isSameYear(c1, c2)
@@ -344,9 +323,6 @@ public class DateUtil {
     ///
     /// True if the two dates are on the same month.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean isSameMonth(Date d1, Date d2) {
         Calendar c1 = Calendar.getInstance(tz);
         c1.setTime(d1);
@@ -368,9 +344,6 @@ public class DateUtil {
     ///
     /// True if the two times are on the same day.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean isSameDay(Calendar c1, Calendar c2) {
 
         return isSameMonth(c1, c2)
@@ -389,9 +362,6 @@ public class DateUtil {
     ///
     /// True if the two dates are on the same day.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean isSameDay(Date d1, Date d2) {
         Calendar c1 = Calendar.getInstance(tz);
         c1.setTime(d1);
@@ -413,9 +383,6 @@ public class DateUtil {
     ///
     /// True if the two times are on the same hour.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean isSameHour(Calendar c1, Calendar c2) {
 
         return isSameDay(c1, c2)
@@ -434,9 +401,6 @@ public class DateUtil {
     ///
     /// True if the two dates are on the same hour.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean isSameHour(Date d1, Date d2) {
         Calendar c1 = Calendar.getInstance(tz);
         c1.setTime(d1);
@@ -458,9 +422,6 @@ public class DateUtil {
     ///
     /// True if the two times are on the same minute.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean isSameMinute(Calendar c1, Calendar c2) {
 
         return isSameHour(c1, c2)
@@ -479,9 +440,6 @@ public class DateUtil {
     ///
     /// True if the two dates are on the same minute.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean isSameMinute(Date d1, Date d2) {
         Calendar c1 = Calendar.getInstance(tz);
         c1.setTime(d1);
@@ -503,9 +461,6 @@ public class DateUtil {
     ///
     /// True if the two times are on the same second.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean isSameSecond(Calendar c1, Calendar c2) {
 
         return isSameMinute(c1, c2)
@@ -524,9 +479,6 @@ public class DateUtil {
     ///
     /// True if the two dates are on the same second.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean isSameSecond(Date d1, Date d2) {
         Calendar c1 = Calendar.getInstance(tz);
         c1.setTime(d1);
@@ -548,9 +500,6 @@ public class DateUtil {
     ///
     /// True if the two times are on the same time.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean isSameTime(Calendar c1, Calendar c2) {
 
         return c1.getTime().getTime() == c2.getTime().getTime();
@@ -568,9 +517,6 @@ public class DateUtil {
     ///
     /// True if the two dates are on the same time.
     ///
-    /// #### Since
-    ///
-    /// 7.0
     public boolean isSameTime(Date d1, Date d2) {
         return d1.getTime() == d2.getTime();
     }
@@ -585,9 +531,6 @@ public class DateUtil {
     ///
     /// String representing how long ago from now the given date is.
     ///
-    /// #### Since
-    ///
-    /// 6.0
     public String getTimeAgo(Date date) {
         if (date == null) {
             return "N/A";

--- a/CodenameOne/src/com/codename1/util/MathUtil.java
+++ b/CodenameOne/src/com/codename1/util/MathUtil.java
@@ -1447,9 +1447,6 @@ public abstract class MathUtil {
     /// if `f1` is numerically greater than
     /// `f2`.
     ///
-    /// #### Since
-    ///
-    /// 1.4
     public static int compare(float f1, float f2) {
         if (f1 < f2) {
             return -1;           // Neither val is NaN, thisVal is smaller
@@ -1495,9 +1492,6 @@ public abstract class MathUtil {
     /// if `d1` is numerically greater than
     /// `d2`.
     ///
-    /// #### Since
-    ///
-    /// 1.4
     public static int compare(double d1, double d2) {
         if (d1 < d2) {
             return -1;           // Neither val is NaN, thisVal is smaller

--- a/CodenameOne/src/com/codename1/util/StringUtil.java
+++ b/CodenameOne/src/com/codename1/util/StringUtil.java
@@ -288,9 +288,6 @@ public abstract class StringUtil {
     ///
     /// The joined string.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public static String join(Iterable strings, String delimiter) {
         StringBuilder sb = new StringBuilder();
         for (Object obj : strings) {
@@ -314,9 +311,6 @@ public abstract class StringUtil {
     ///
     /// The joined string.
     ///
-    /// #### Since
-    ///
-    /// 8.0
     public static String join(Object[] strings, String delimiter) {
         StringBuilder sb = new StringBuilder();
         for (Object obj : strings) {

--- a/CodenameOne/src/com/codename1/util/TBigDecimal.java
+++ b/CodenameOne/src/com/codename1/util/TBigDecimal.java
@@ -694,9 +694,6 @@ class TBigDecimal {
     ///
     /// The number of trailing zeros.
     ///
-    /// #### Since
-    ///
-    /// 1.5
     static int numberOfTrailingZeros(long lng) {
         return bitCount((lng & -lng) - 1);
     }
@@ -712,9 +709,6 @@ class TBigDecimal {
     ///
     /// The number of leading zeros.
     ///
-    /// #### Since
-    ///
-    /// 1.5
     public static int numberOfLeadingZeros(long lng) {
         lng |= lng >> 1;
         lng |= lng >> 2;
@@ -736,9 +730,6 @@ class TBigDecimal {
     ///
     /// The number of 1 bits.
     ///
-    /// #### Since
-    ///
-    /// 1.5
     static int bitCount(long lng) {
         lng = (lng & 0x5555555555555555L) + ((lng >> 1) & 0x5555555555555555L);
         lng = (lng & 0x3333333333333333L) + ((lng >> 2) & 0x3333333333333333L);
@@ -762,9 +753,6 @@ class TBigDecimal {
     ///
     /// -1 if negative, 1 if positive otherwise 0.
     ///
-    /// #### Since
-    ///
-    /// 1.5
     static int signum(long lng) {
         return (lng == 0 ? 0 : (lng < 0 ? -1 : 1));
     }
@@ -788,9 +776,6 @@ class TBigDecimal {
     ///
     /// The bit mask indicating the highest 1 bit.
     ///
-    /// #### Since
-    ///
-    /// 1.5
     static int highestOneBit(int i) {
         i |= (i >> 1);
         i |= (i >> 2);

--- a/CodenameOne/src/com/codename1/util/promise/ExecutorFunction.java
+++ b/CodenameOne/src/com/codename1/util/promise/ExecutorFunction.java
@@ -27,9 +27,6 @@ package com.codename1.util.promise;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 8.0
 public interface ExecutorFunction {
     /// Calls the function.
     ///

--- a/CodenameOne/src/com/codename1/util/promise/Functor.java
+++ b/CodenameOne/src/com/codename1/util/promise/Functor.java
@@ -26,9 +26,6 @@ package com.codename1.util.promise;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 8.0
 public interface Functor<T, V> {
 
     /// Calls the function.

--- a/CodenameOne/src/com/codename1/util/promise/Promise.java
+++ b/CodenameOne/src/com/codename1/util/promise/Promise.java
@@ -52,10 +52,6 @@ import static com.codename1.ui.CN.invokeAndBlock;
 ///
 /// @author shannah
 ///
-/// #### Since
-///
-/// 8.0
-///
 /// #### See also
 ///
 /// - [MDN documentation for Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)

--- a/scripts/check-since-tags.sh
+++ b/scripts/check-since-tags.sh
@@ -1,18 +1,17 @@
 #!/usr/bin/env bash
 #
-# Scan Java sources under CodenameOne/src for @since javadoc tags whose
-# referenced version does NOT correspond to a git tag in this repository.
+# Scan Java sources under CodenameOne/src for since markers in Javadoc or
+# Markdown Javadoc comments.
 #
-# Background: Claude (and human contributors) sometimes write @since markers
-# for releases that never shipped, leaving the API reference claiming a
-# feature is available in versions readers cannot install. This check fails
-# the build until every @since X.Y.Z matches an existing git tag
-# (with or without a leading "v").
+# Background: generated documentation changes have repeatedly added @since
+# tags and Markdown "Since" sections with guessed versions. Incorrect
+# availability metadata is worse than no metadata, so public sources should
+# not carry these markers at all.
 #
 # Exit codes:
-#   0 - all @since values match a tag
-#   1 - one or more @since values do not match any tag
-#   2 - misconfiguration (missing dirs, no tags fetched, etc.)
+#   0 - no since markers were found
+#   1 - one or more since markers were found
+#   2 - misconfiguration
 #
 # Usage:
 #   scripts/check-since-tags.sh [source-dir]
@@ -30,106 +29,25 @@ if [[ ! -d "$SRC_DIR" ]]; then
   exit 2
 fi
 
-if ! command -v git >/dev/null 2>&1; then
-  echo "check-since-tags: git is not on PATH; cannot enumerate tags." >&2
-  exit 2
-fi
-
-# Build the allowed-versions set from `git tag`, stripping a leading "v" so
-# both "v7.0" and "7.0" map to the same allowed value.
-#
-# We also seed the set with the "next patch" of every X.Y.Z tag because
-# contributors necessarily write @since BEFORE the release that ships the
-# feature is tagged. Concretely, if the highest 7.0.x tag is 7.0.244, we
-# also accept @since 7.0.245 so the upcoming release can be referenced
-# without flipping the build red on every PR. We deliberately do NOT
-# auto-accept next-minor or next-major bumps (e.g. 7.1 or 8.0) — those
-# require an explicit prior tag, because they are also exactly the values
-# Claude hallucinates most often.
-ALLOWED_TAGS_FILE="$(mktemp -t cn1-since-tags.XXXXXX)"
-trap 'rm -f "$ALLOWED_TAGS_FILE"' EXIT
-
-# Pipe through awk to add next-patch entries, then sort -u.
-git -C "$REPO_ROOT" tag --list \
-  | sed -E 's/^v//' \
-  | awk '
-      { print $0 }
-      # Capture every X.Y.Z (numeric Z) and track the largest Z per X.Y.
-      /^[0-9]+\.[0-9]+\.[0-9]+$/ {
-        n = split($0, parts, ".")
-        prefix = parts[1] "." parts[2]
-        patch = parts[3] + 0
-        if (patch > max_patch[prefix]) {
-          max_patch[prefix] = patch
-        }
-      }
-      END {
-        # Emit one extra allowed version per release line: max+1.
-        for (prefix in max_patch) {
-          print prefix "." (max_patch[prefix] + 1)
-        }
-      }
-  ' \
-  | sort -u > "$ALLOWED_TAGS_FILE"
-
-if [[ ! -s "$ALLOWED_TAGS_FILE" ]]; then
-  echo "check-since-tags: no git tags found in $REPO_ROOT." >&2
-  echo "  Make sure the workspace was cloned with tags (e.g. CI uses" >&2
-  echo "  actions/checkout with fetch-tags: true)." >&2
-  exit 2
-fi
-
-# Collect every '@since <version>' occurrence with file:line context.
-# We deliberately match in any kind of comment (//, /** */, ///) because the
-# tag is meaningful in all three forms.
 HITS_FILE="$(mktemp -t cn1-since-hits.XXXXXX)"
-trap 'rm -f "$ALLOWED_TAGS_FILE" "$HITS_FILE"' EXIT
+trap 'rm -f "$HITS_FILE"' EXIT
 
-# -E for ERE, -H to print filename, -n for line numbers, -r for recurse.
-# The version captures digits.dots optionally followed by letters/dashes
-# (e.g. "7.0.245", "3.5", "1.0-RC1"). A trailing period is stripped below.
-#
-# We deliberately require the @since to be preceded on the same line by a
-# javadoc marker (`*` from /** */ blocks or `///` from Markdown javadoc).
-# That excludes plain `// @since X.Y` code comments — which appear in
-# vendored libraries (e.g. MiG Layout in ui/layouts/mig) where the value
-# references the upstream library's changelog, not a Codename One release.
-grep -EHnr --include='*.java' \
-  '(\*|///).*@since[[:space:]]+[0-9][0-9A-Za-z._-]*' \
+# Match both classic tags and generated Markdown sections such as:
+#   /// @since 7.0.245
+#   /// #### Since
+#   * Since
+#   // @since 3.7.2 ...
+grep -EHinr --include='*.java' \
+  '(@since|^[[:space:]]*(///|//|/\*+|\*)[[:space:]]*(#+[[:space:]]*)?since[[:space:]:.]*$)' \
   "$SRC_DIR" > "$HITS_FILE" || true
 
-violations=0
-
-while IFS= read -r hit; do
-  # hit format: path:line:full-line
-  file="${hit%%:*}"
-  rest="${hit#*:}"
-  line="${rest%%:*}"
-  text="${rest#*:}"
-
-  # Extract every @since version on the line (a line may contain only one,
-  # but the regex is tolerant of multiple).
-  while IFS= read -r raw_version; do
-    [[ -z "$raw_version" ]] && continue
-    # Strip a trailing dot that is sentence punctuation, e.g.
-    # "@since 3.5. Added the hint..."
-    version="${raw_version%.}"
-    if ! grep -Fxq "$version" "$ALLOWED_TAGS_FILE"; then
-      printf '%s:%s: @since %s does not match any git tag\n' \
-        "$file" "$line" "$version"
-      violations=$((violations + 1))
-    fi
-  done < <(printf '%s\n' "$text" \
-    | grep -oE '@since[[:space:]]+[0-9][0-9A-Za-z._-]*' \
-    | sed -E 's/@since[[:space:]]+//')
-done < "$HITS_FILE"
-
-if (( violations > 0 )); then
+if [[ -s "$HITS_FILE" ]]; then
+  cat "$HITS_FILE"
   echo "" >&2
-  echo "check-since-tags: $violations @since reference(s) point at versions" >&2
-  echo "  with no matching git tag. Either fix the @since to a released" >&2
-  echo "  version, or tag the release before merging." >&2
+  echo "check-since-tags: since markers are not allowed in CodenameOne API docs." >&2
+  echo "  Remove @since tags and Markdown/Javadoc 'Since' sections instead of" >&2
+  echo "  guessing release versions." >&2
   exit 1
 fi
 
-echo "check-since-tags: all @since tags reference released versions."
+echo "check-since-tags: no since markers found."


### PR DESCRIPTION
## Summary

- Remove existing `@since` tags and generated Markdown `#### Since` sections from Java API docs under `CodenameOne/src`.
- Change `scripts/check-since-tags.sh` from version validation to a hard ban on since markers in API docs.
- Update the dedicated GitHub workflow to run the stricter check without fetching git tags.

## Why

Generated documentation changes have repeatedly added guessed since versions. Incorrect API availability metadata is worse than omitting it, so CI should reject these markers entirely.

## Validation

- `scripts/check-since-tags.sh`
- negative temp fixture covering `@since`, `/// #### since`, and classic `* Since`
- `git diff --check`