### PR TITLE
Raise local iOS translator heap to 1024m to fix OOM (#5344)

### DIFF
--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
@@ -2682,7 +2682,33 @@ public class IPhoneBuilder extends Executor {
                     // both the iOS app target and the tvOS target.
                     parparCmd.add(tvNativeBuilder.parparvmOptionalFrameworksArg());
                 }
-                parparCmd.add("-Xmx384m");
+                // Pass through extra translator JVM options (notably a larger
+                // -Xmx) from the CN1_TRANSLATOR_OPTS environment variable. The
+                // forked JVM does not inherit the Maven process's -D properties,
+                // so this is the only way to reach the translator for tuning.
+                String translatorOpts = System.getenv("CN1_TRANSLATOR_OPTS");
+                boolean heapOverridden = false;
+                if (translatorOpts != null && !translatorOpts.trim().isEmpty()) {
+                    for (String opt : translatorOpts.trim().split("\\s+")) {
+                        if (!opt.isEmpty()) {
+                            parparCmd.add(opt);
+                            if (opt.startsWith("-Xmx")) {
+                                heapOverridden = true;
+                            }
+                        }
+                    }
+                }
+                // Default heap; a -Xmx in CN1_TRANSLATOR_OPTS takes precedence.
+                // The dead-code cull builds an in-memory suffix automaton over
+                // all native symbols (NativeSymbolIndex, from #5236) to avoid the
+                // old O(N^2) substring scan that timed out on large apps -- that
+                // index trades time for memory, so the historical 384m cap now
+                // OOMs local iOS builds as the CN1 class count grows (issue
+                // #5344). The cloud builder already runs the same translator at
+                // 1024m; match it here so local and server builds behave alike.
+                if (!heapOverridden) {
+                    parparCmd.add("-Xmx1024m");
+                }
                 parparCmd.add("-jar");
                 parparCmd.add(parparVMCompilerJar);
                 parparCmd.add("ios");


### PR DESCRIPTION
## Problem

Local `mvn` iOS builds fail with `java.lang.OutOfMemoryError: Java heap space` in the ParparVM translator (issue #5344):

```
Error while working with the class: com_codename1_router_PopGuard
java.lang.OutOfMemoryError: Java heap space
	at com.codename1.tools.translator.NativeSymbolIndex.newState(NativeSymbolIndex.java:73)
	at com.codename1.tools.translator.NativeSymbolIndex.extend(NativeSymbolIndex.java:78)
	at com.codename1.tools.translator.NativeSymbolIndex.<init>(NativeSymbolIndex.java:66)
	at com.codename1.tools.translator.Parser.getNativeSymbolIndex(Parser.java:304)
	at com.codename1.tools.translator.BytecodeMethod.isMethodUsedByNative(BytecodeMethod.java:596)
	...
```

## Root cause

The dead-code cull originally did a per-method substring scan over *all* native source text — `O(methods × native_bytes)` — which grew slow enough to **time out** on large apps as the CN1 class count increased. PR #5236 fixed the timeout by inverting the scan: `NativeSymbolIndex` builds an in-memory **suffix automaton** over all native identifier tokens (one `HashMap` per state, `2 × text.length()` states), giving O(|X|) lookups.

That index trades **time for memory**. The cloud builder (BuildDaemon) was bumped to `-Xmx1024m` to feed it, but the local maven-plugin path in `IPhoneBuilder` was overlooked and still capped the translator at the historical `-Xmx384m`. So the automaton now exhausts the heap on local iOS builds while cloud builds are fine.

## Fix

- Raise the local iOS translator heap `384m → 1024m`, matching the cloud builder.
- Add a `CN1_TRANSLATOR_OPTS` pass-through (mirroring `JavaScriptBuilder`) so a `-Xmx` override reaches the forked translator JVM without a rebuild, and so the local/cloud heaps can't silently drift apart again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)