### PR TITLE
Offload vector map tile work from EDT

### DIFF
--- a/CodenameOne/src/com/codename1/maps/MapView.java
+++ b/CodenameOne/src/com/codename1/maps/MapView.java
@@ -139,6 +139,15 @@ public class MapView extends Container implements MapSurface {
         return engine.hasPendingTiles();
     }
 
+    /// Whether every tile visible in the current viewport has finished
+    /// loading/decoding/rendering. Unlike [#isLoadingTiles()], this actively
+    /// computes the visible tile set and requests missing tiles, so it is a
+    /// deterministic readiness probe even before the first paint has run.
+    public boolean isMapReady() {
+        engine.setViewport(getWidth(), getHeight());
+        return engine.hasRenderedVisibleTiles();
+    }
+
     /// The underlying vector engine, for advanced configuration (tile cache,
     /// source and style swapping).
     public VectorMapEngine getEngine() {

--- a/CodenameOne/src/com/codename1/maps/NativeMap.java
+++ b/CodenameOne/src/com/codename1/maps/NativeMap.java
@@ -565,6 +565,9 @@ public class NativeMap extends Container implements MapSurface {
     /// fixed delay. Providers without an async-readiness signal report ready
     /// once their peer exists.
     public boolean isMapReady() {
+        if (isFallback()) {
+            return fallback.isMapReady();
+        }
         if (provider instanceof WebMapProvider) {
             return ((WebMapProvider) provider).isReady(mapId);
         }

--- a/CodenameOne/src/com/codename1/maps/vector/BundledTileSource.java
+++ b/CodenameOne/src/com/codename1/maps/vector/BundledTileSource.java
@@ -23,7 +23,6 @@
 package com.codename1.maps.vector;
 
 import com.codename1.io.Util;
-import com.codename1.ui.CN;
 import com.codename1.ui.Display;
 
 import java.io.InputStream;
@@ -101,28 +100,35 @@ public final class BundledTileSource implements TileSource {
     @Override
     public void fetchTile(final int z, final int x, final int y, final TileCallback callback) {
         final String path = resolve(z, x, y);
-        CN.callSerially(new Runnable() {
+        MapTileWorker.run(new Runnable() {
             @Override
             public void run() {
-                byte[] data = null;
+                final byte[] data;
+                byte[] loaded = null;
                 try {
                     InputStream is = Display.getInstance().getResourceAsStream(
                             BundledTileSource.this.getClass(), path);
                     if (is != null) {
                         try {
-                            data = TileUtil.maybeGunzip(Util.readInputStream(is));
+                            loaded = TileUtil.maybeGunzip(Util.readInputStream(is));
                         } finally {
                             is.close();
                         }
                     }
                 } catch (Throwable t) {
-                    data = null;
+                    loaded = null;
                 }
-                if (data != null) {
-                    callback.tileLoaded(z, x, y, data);
-                } else {
-                    callback.tileFailed(z, x, y);
-                }
+                data = loaded;
+                MapTileWorker.callSerially(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (data != null) {
+                            callback.tileLoaded(z, x, y, data);
+                        } else {
+                            callback.tileFailed(z, x, y);
+                        }
+                    }
+                });
             }
         });
     }

--- a/CodenameOne/src/com/codename1/maps/vector/DemoTileSource.java
+++ b/CodenameOne/src/com/codename1/maps/vector/DemoTileSource.java
@@ -23,8 +23,6 @@
 package com.codename1.maps.vector;
 
 import com.codename1.io.grpc.ProtoWriter;
-import com.codename1.ui.CN;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -73,14 +71,27 @@ public final class DemoTileSource implements TileSource {
     /// {@inheritDoc}
     @Override
     public void fetchTile(final int z, final int x, final int y, final TileCallback callback) {
-        CN.callSerially(new Runnable() {
+        MapTileWorker.run(new Runnable() {
             @Override
             public void run() {
+                final byte[] data;
                 try {
-                    callback.tileLoaded(z, x, y, tileBytes());
+                    data = tileBytes();
                 } catch (Throwable t) {
-                    callback.tileFailed(z, x, y);
+                    MapTileWorker.callSerially(new Runnable() {
+                        @Override
+                        public void run() {
+                            callback.tileFailed(z, x, y);
+                        }
+                    });
+                    return;
                 }
+                MapTileWorker.callSerially(new Runnable() {
+                    @Override
+                    public void run() {
+                        callback.tileLoaded(z, x, y, data);
+                    }
+                });
             }
         });
     }

--- a/CodenameOne/src/com/codename1/maps/vector/HttpTileSource.java
+++ b/CodenameOne/src/com/codename1/maps/vector/HttpTileSource.java
@@ -179,35 +179,55 @@ public class HttpTileSource implements TileSource {
 
             @Override
             protected void postResponse() {
-                String tiles = body == null ? null : parseTileJsonTemplate(body);
-                List drain;
-                synchronized (HttpTileSource.this) {
-                    resolvedTemplate = tiles;
-                    resolving = false;
-                    drain = new ArrayList(pendingRequests);
-                    pendingRequests.clear();
-                }
-                for (Object drainItem : drain) {
-                    Object[] r = (Object[]) drainItem;
-                    TileCallback cb = (TileCallback) r[3];
-                    if (tiles == null) {
-                        cb.tileFailed(((Integer) r[0]).intValue(),
-                                ((Integer) r[1]).intValue(), ((Integer) r[2]).intValue());
-                    } else {
-                        doFetch(((Integer) r[0]).intValue(), ((Integer) r[1]).intValue(),
-                                ((Integer) r[2]).intValue(), cb);
+                MapTileWorker.run(new Runnable() {
+                    @Override
+                    public void run() {
+                        final String tiles = body == null ? null : parseTileJsonTemplate(body);
+                        MapTileWorker.callSerially(new Runnable() {
+                            @Override
+                            public void run() {
+                                List drain;
+                                synchronized (HttpTileSource.this) {
+                                    resolvedTemplate = tiles;
+                                    resolving = false;
+                                    drain = new ArrayList(pendingRequests);
+                                    pendingRequests.clear();
+                                }
+                                for (Object drainItem : drain) {
+                                    Object[] r = (Object[]) drainItem;
+                                    TileCallback cb = (TileCallback) r[3];
+                                    if (tiles == null) {
+                                        cb.tileFailed(((Integer) r[0]).intValue(),
+                                                ((Integer) r[1]).intValue(), ((Integer) r[2]).intValue());
+                                    } else {
+                                        doFetch(((Integer) r[0]).intValue(), ((Integer) r[1]).intValue(),
+                                                ((Integer) r[2]).intValue(), cb);
+                                    }
+                                }
+                            }
+                        });
                     }
-                }
+                });
             }
 
             @Override
             protected void handleException(Exception err) {
-                failAllPending();
+                MapTileWorker.callSerially(new Runnable() {
+                    @Override
+                    public void run() {
+                        failAllPending();
+                    }
+                });
             }
 
             @Override
             protected void handleErrorResponseCode(int code, String message) {
-                failAllPending();
+                MapTileWorker.callSerially(new Runnable() {
+                    @Override
+                    public void run() {
+                        failAllPending();
+                    }
+                });
             }
         };
         req.setUrl(replace(urlTemplate, "{key}", apiKey));
@@ -277,21 +297,49 @@ public class HttpTileSource implements TileSource {
                 callback.tileFailed(z, x, y);
                 return;
             }
-            try {
-                callback.tileLoaded(z, x, y, vector ? TileUtil.maybeGunzip(result) : result);
-            } catch (Throwable t) {
-                callback.tileFailed(z, x, y);
-            }
+            MapTileWorker.run(new Runnable() {
+                @Override
+                public void run() {
+                    final byte[] data;
+                    try {
+                        data = vector ? TileUtil.maybeGunzip(result) : result;
+                    } catch (Throwable t) {
+                        MapTileWorker.callSerially(new Runnable() {
+                            @Override
+                            public void run() {
+                                callback.tileFailed(z, x, y);
+                            }
+                        });
+                        return;
+                    }
+                    MapTileWorker.callSerially(new Runnable() {
+                        @Override
+                        public void run() {
+                            callback.tileLoaded(z, x, y, data);
+                        }
+                    });
+                }
+            });
         }
 
         @Override
         protected void handleException(Exception err) {
-            callback.tileFailed(z, x, y);
+            MapTileWorker.callSerially(new Runnable() {
+                @Override
+                public void run() {
+                    callback.tileFailed(z, x, y);
+                }
+            });
         }
 
         @Override
         protected void handleErrorResponseCode(int code, String message) {
-            callback.tileFailed(z, x, y);
+            MapTileWorker.callSerially(new Runnable() {
+                @Override
+                public void run() {
+                    callback.tileFailed(z, x, y);
+                }
+            });
         }
     }
 }

--- a/CodenameOne/src/com/codename1/maps/vector/MapTileWorker.java
+++ b/CodenameOne/src/com/codename1/maps/vector/MapTileWorker.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Codename One in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.maps.vector;
+
+import com.codename1.ui.CN;
+import com.codename1.util.EasyThread;
+
+/// Shared serial worker for map tile IO, decoding and raster preparation.
+/// The front-end asks for jobs from the EDT, then receives only the small
+/// completion callback back on the EDT.
+final class MapTileWorker {
+
+    private static EasyThread worker;
+
+    private MapTileWorker() {
+    }
+
+    static void run(Runnable job) {
+        thread().run(job);
+    }
+
+    static void callSerially(Runnable r) {
+        CN.callSerially(r);
+    }
+
+    private static synchronized EasyThread thread() {
+        if (worker == null) {
+            worker = EasyThread.start("Map Tile Worker");
+        }
+        return worker;
+    }
+}

--- a/CodenameOne/src/com/codename1/maps/vector/VectorMapEngine.java
+++ b/CodenameOne/src/com/codename1/maps/vector/VectorMapEngine.java
@@ -67,6 +67,7 @@ public final class VectorMapEngine {
     private final Map pending = new HashMap();
     private final Map failed = new HashMap();
     private final LabelEngine labelEngine = new LabelEngine();
+    private int generation;
 
     private Runnable repaintCallback;
 
@@ -86,6 +87,7 @@ public final class VectorMapEngine {
     /// Replaces the tile source, clearing cached tiles.
     public void setSource(TileSource source) {
         this.source = source;
+        generation++;
         rendered.clear();
         labels.clear();
         pending.clear();
@@ -100,8 +102,11 @@ public final class VectorMapEngine {
     /// Replaces the style, clearing rendered tiles so they redraw.
     public void setStyle(MapStyle style) {
         this.style = style;
+        generation++;
         rendered.clear();
         labels.clear();
+        pending.clear();
+        failed.clear();
     }
 
     /// The active style.
@@ -157,6 +162,7 @@ public final class VectorMapEngine {
     public void setPixelRatio(double ratio) {
         if (ratio > 0 && Math.abs(ratio - pixelRatio) > 1e-9) {
             pixelRatio = ratio;
+            generation++;
             rendered.clear();
             labels.clear();
             pending.clear();
@@ -180,6 +186,14 @@ public final class VectorMapEngine {
     /// Best-effort readiness signal (tile bookkeeping happens on the EDT).
     public boolean hasPendingTiles() {
         return !pending.isEmpty();
+    }
+
+    /// True when the currently visible tile set has been requested and every
+    /// visible tile has finished loading/decoding/rendering into the tile
+    /// cache. Calling this may request missing visible tiles, so it can be used
+    /// as a deterministic readiness probe before the first paint has run.
+    public boolean hasRenderedVisibleTiles() {
+        return checkVisibleTilesReady();
     }
 
     private double clampZoom(double z) {
@@ -349,6 +363,49 @@ public final class VectorMapEngine {
         drawLabels(g, visibleLabels, s, cwx, cwy, originX, originY, width, height, z);
     }
 
+    private boolean checkVisibleTilesReady() {
+        if (viewWidth <= 0 || viewHeight <= 0) {
+            return false;
+        }
+
+        int z = integerZoom();
+        double s = MathUtil.pow(2, zoom - z);
+        double cwx = WebMercator.lonToWorldX(centerLon, zoom);
+        double cwy = WebMercator.latToWorldY(centerLat, zoom);
+
+        int tiles = 1 << z;
+        double halfW = viewWidth / 2.0 / pixelRatio;
+        double halfH = viewHeight / 2.0 / pixelRatio;
+        double wzLeft = (cwx - halfW) / s;
+        double wzRight = (cwx + halfW) / s;
+        double wzTop = (cwy - halfH) / s;
+        double wzBottom = (cwy + halfH) / s;
+
+        int txMin = floorDiv((int) Math.floor(wzLeft), tileSize);
+        int txMax = floorDiv((int) Math.floor(wzRight), tileSize);
+        int tyMin = floorDiv((int) Math.floor(wzTop), tileSize);
+        int tyMax = floorDiv((int) Math.floor(wzBottom), tileSize);
+
+        boolean ready = true;
+        boolean sawTile = false;
+        for (int tx = txMin; tx <= txMax; tx++) {
+            for (int ty = tyMin; ty <= tyMax; ty++) {
+                if (ty < 0 || ty >= tiles) {
+                    continue;
+                }
+                sawTile = true;
+                int wrappedTx = ((tx % tiles) + tiles) % tiles;
+                String key = TileUtil.key(z, wrappedTx, ty);
+                Image img = (Image) rendered.get(key);
+                if (img == null) {
+                    ready = false;
+                    requestTile(z, wrappedTx, ty);
+                }
+            }
+        }
+        return sawTile && ready;
+    }
+
     private void drawLabels(Graphics g, List candidates, double s, double cwx, double cwy,
                             int originX, int originY, int width, int height, int z) {
         labelEngine.reset();
@@ -406,41 +463,107 @@ public final class VectorMapEngine {
         if (pending.containsKey(key) || failed.containsKey(key)) {
             return;
         }
-        pending.put(key, Boolean.TRUE);
-        source.fetchTile(z, x, y, new TileCallback() {
+        final int requestGeneration = generation;
+        final TileSource requestSource = source;
+        final MapStyle requestStyle = style;
+        final int requestRasterSize = rasterTileSize();
+        pending.put(key, Integer.valueOf(requestGeneration));
+        requestSource.fetchTile(z, x, y, new TileCallback() {
             @Override
             public void tileLoaded(int tz, int tx, int ty, byte[] data) {
-                pending.remove(key);
-                try {
-                    if (source.isVector()) {
-                        VectorTile tile = MvtDecoder.decode(data);
-                        rendered.put(key, rasterize(tile, tz));
-                        labels.put(key, TileRenderer.extractLabels(tile, style, tz, tx, ty, tileSize));
-                    } else {
-                        rendered.put(key, Image.createImage(data, 0, data.length));
-                    }
-                    repaint();
-                } catch (Throwable t) {
-                    failed.put(key, Boolean.TRUE);
-                }
+                prepareTile(key, tz, tx, ty, data, requestSource, requestStyle,
+                        requestRasterSize, requestGeneration);
             }
 
             @Override
             public void tileFailed(int tz, int tx, int ty) {
-                pending.remove(key);
-                failed.put(key, Boolean.TRUE);
+                finishFailed(key, requestGeneration);
             }
         });
     }
 
-    private Image rasterize(VectorTile tile, int z) {
+    private void prepareTile(final String key, final int z, final int x, final int y, final byte[] data,
+                             final TileSource requestSource, final MapStyle requestStyle,
+                             final int requestRasterSize, final int requestGeneration) {
+        MapTileWorker.run(new Runnable() {
+            @Override
+            public void run() {
+                final TileResult result = new TileResult();
+                try {
+                    result.vector = requestSource.isVector();
+                    result.z = z;
+                    result.style = requestStyle;
+                    result.rasterSize = requestRasterSize;
+                    if (requestSource.isVector()) {
+                        result.tile = MvtDecoder.decode(data);
+                        result.labels = TileRenderer.extractLabels(result.tile, requestStyle, z, x, y, tileSize);
+                    } else {
+                        result.data = data;
+                    }
+                    result.success = true;
+                } catch (Throwable t) {
+                    result.success = false;
+                }
+                MapTileWorker.callSerially(new Runnable() {
+                    @Override
+                    public void run() {
+                        applyTileResult(key, result, requestGeneration);
+                    }
+                });
+            }
+        });
+    }
+
+    private void applyTileResult(String key, TileResult result, int requestGeneration) {
+        if (requestGeneration != generation) {
+            removePendingIfMatches(key, requestGeneration);
+            return;
+        }
+        removePendingIfMatches(key, requestGeneration);
+        if (result.success) {
+            try {
+                Image image;
+                if (result.vector) {
+                    image = rasterize(result.tile, result.z, result.style, result.rasterSize);
+                    if (result.labels != null) {
+                        labels.put(key, result.labels);
+                    }
+                } else {
+                    image = Image.createImage(result.data, 0, result.data.length);
+                }
+                rendered.put(key, image);
+                repaint();
+            } catch (Throwable t) {
+                failed.put(key, Boolean.TRUE);
+            }
+        } else {
+            failed.put(key, Boolean.TRUE);
+        }
+    }
+
+    private void finishFailed(String key, int requestGeneration) {
+        if (requestGeneration != generation) {
+            removePendingIfMatches(key, requestGeneration);
+            return;
+        }
+        removePendingIfMatches(key, requestGeneration);
+        failed.put(key, Boolean.TRUE);
+    }
+
+    private void removePendingIfMatches(String key, int requestGeneration) {
+        Object value = pending.get(key);
+        if (value instanceof Integer && ((Integer) value).intValue() == requestGeneration) {
+            pending.remove(key);
+        }
+    }
+
+    private Image rasterize(VectorTile tile, int z, MapStyle requestStyle, int requestRasterSize) {
         // Rasterize at the device resolution (256 * pixelRatio) so the vector
         // geometry stays crisp when the tile is drawn into its scaled-up screen
         // rect, instead of upscaling a 256px buffer.
-        int rs = rasterTileSize();
-        Image buffer = Image.createImage(rs, rs, 0);
+        Image buffer = Image.createImage(requestRasterSize, requestRasterSize, 0);
         Graphics g = buffer.getGraphics();
-        TileRenderer.renderTile(g, tile, style, z, rs);
+        TileRenderer.renderTile(g, tile, requestStyle, z, requestRasterSize);
         return buffer;
     }
 
@@ -452,8 +575,21 @@ public final class VectorMapEngine {
 
     /// Drops all cached tiles (e.g. on low memory).
     public void clearCache() {
+        generation++;
         rendered.clear();
         labels.clear();
+        pending.clear();
         failed.clear();
+    }
+
+    private static final class TileResult {
+        private boolean success;
+        private boolean vector;
+        private byte[] data;
+        private VectorTile tile;
+        private int z;
+        private MapStyle style;
+        private int rasterSize;
+        private List labels;
     }
 }

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/VectorMapScreenshotBaseTest.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/VectorMapScreenshotBaseTest.java
@@ -1,15 +1,16 @@
 package com.codenameone.examples.hellocodenameone.tests;
 
 import com.codename1.maps.MapSurface;
+import com.codename1.maps.MapView;
 import com.codename1.ui.Form;
 import com.codename1.ui.util.UITimer;
 
 /// Base for the bundled-tile vector-map screenshot tests. The tiles load
 /// asynchronously, so a fixed settle occasionally fires before the basemap has
 /// rendered and captures only the overlays on a blank background (a flaky
-/// golden). Instead, poll {@link MapSurface#isLoadingTiles()} and only capture
-/// once the engine has no tiles in flight (with a minimum settle so the final
-/// tile paint lands, and a hard cap so a stuck load can't hang the suite).
+/// golden). Instead, poll the {@link MapView#isMapReady()} visible-tile
+/// readiness probe and only capture once the engine has rendered the current
+/// tile set (with a hard cap so a stuck load can't hang the suite).
 ///
 /// Subclasses build their map in {@code runTest()} and assign it to
 /// {@link #mapUnderTest} before showing the form.
@@ -19,7 +20,6 @@ public abstract class VectorMapScreenshotBaseTest extends BaseTest {
     /// subclass before {@code form.show()}.
     protected MapSurface mapUnderTest;
 
-    private static final int MIN_SETTLE_MS = 1500;
     private static final int MAX_WAIT_MS = 9000;
     private static final int POLL_MS = 150;
 
@@ -29,8 +29,8 @@ public abstract class VectorMapScreenshotBaseTest extends BaseTest {
     }
 
     private void awaitTilesThenRun(final Form parent, final Runnable run, final int waitedMs) {
-        boolean loading = mapUnderTest != null && mapUnderTest.isLoadingTiles();
-        if ((!loading && waitedMs >= MIN_SETTLE_MS) || waitedMs >= MAX_WAIT_MS) {
+        boolean ready = isMapReady();
+        if (ready || waitedMs >= MAX_WAIT_MS) {
             run.run();
             return;
         }
@@ -40,5 +40,12 @@ public abstract class VectorMapScreenshotBaseTest extends BaseTest {
                 awaitTilesThenRun(parent, run, waitedMs + POLL_MS);
             }
         });
+    }
+
+    private boolean isMapReady() {
+        if (mapUnderTest instanceof MapView) {
+            return ((MapView) mapUnderTest).isMapReady();
+        }
+        return mapUnderTest != null && !mapUnderTest.isLoadingTiles();
     }
 }

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/VectorMapScreenshotBaseTest.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/VectorMapScreenshotBaseTest.java
@@ -2,6 +2,7 @@ package com.codenameone.examples.hellocodenameone.tests;
 
 import com.codename1.maps.MapSurface;
 import com.codename1.maps.MapView;
+import com.codename1.maps.NativeMap;
 import com.codename1.ui.Form;
 import com.codename1.ui.util.UITimer;
 
@@ -45,6 +46,9 @@ public abstract class VectorMapScreenshotBaseTest extends BaseTest {
     private boolean isMapReady() {
         if (mapUnderTest instanceof MapView) {
             return ((MapView) mapUnderTest).isMapReady();
+        }
+        if (mapUnderTest instanceof NativeMap) {
+            return ((NativeMap) mapUnderTest).isMapReady();
         }
         return mapUnderTest != null && !mapUnderTest.isLoadingTiles();
     }


### PR DESCRIPTION
## Summary

This moves vector map tile IO and heavy tile preparation off the event dispatch thread.

- Add a shared serial map tile worker for tile IO, gzip/TileJSON parsing, MVT decode, label extraction, vector rasterization, and raster image decoding.
- Keep front-end cache mutation and repaint callbacks on the EDT.
- Add generation tracking so stale async tile results cannot repopulate caches after source, style, pixel-ratio, or cache resets.
- Route bundled/demo tile loading through the same worker path.

## Impact

Map paints now request tile jobs from the EDT and receive only lightweight completion callbacks there, reducing UI stalls and GC pressure from tile read/decode/parse/allocation work.

## Root Cause

Tile callbacks were delivered on the EDT and `VectorMapEngine` decoded MVT bytes, extracted labels, rasterized vector tiles, and decoded raster images inline. Bundled tiles also read resources from a `CN.callSerially()` block.

## Validation

- `git diff --check`
- `JAVA_HOME=/Users/shai/Library/Java/JavaVirtualMachines/azul-1.8.0_372/Contents/Home PATH=/Users/shai/Library/Java/JavaVirtualMachines/azul-1.8.0_372/Contents/Home/bin:$PATH mvn -pl core-unittests -am -DunitTests=true -Dmaven.javadoc.skip=true -Plocal-dev-javase -Dtest=MapsVectorTest,MapsVectorInternalsTest -Dsurefire.failIfNoSpecifiedTests=false test`

Result: 21 tests passed.