### PR TITLE
Fix release CI: bump certificatewizard poms to release version

### DIFF
--- a/maven/update-version.sh
+++ b/maven/update-version.sh
@@ -82,11 +82,31 @@ if [ -f "$gbParent" ]; then
   perl -pi -e "s{<cn1\.plugin\.version>\Q$oldVersion\E</cn1\.plugin\.version>}{<cn1.plugin.version>$version</cn1.plugin.version>}g" "$gbParent"
 fi
 
+# Signing/Certificate Wizard editor (scripts/certificatewizard) is the same
+# shape as the Game Builder above: an out-of-reactor Codename One desktop app
+# with its own coordinates that the release workflow deploys to Central. If its
+# module version is not bumped to the release version it stays 8.0-SNAPSHOT, so
+# `mvn deploy` targets the Central *snapshots* repo and fails with 403 Forbidden
+# (the release job has no snapshot-publish rights). Rewrite its module version
+# plus the cn1.version/cn1.plugin.version it builds against, matching the
+# gamebuilder handling.
+for f in ../scripts/certificatewizard/pom.xml \
+         ../scripts/certificatewizard/common/pom.xml \
+         ../scripts/certificatewizard/javase/pom.xml; do
+  [ -f "$f" ] && perl -pi -e "s{<version>\Q$oldVersion\E</version>}{<version>$version</version>}g" "$f"
+done
+cwParent=../scripts/certificatewizard/pom.xml
+if [ -f "$cwParent" ]; then
+  perl -pi -e "s{<cn1\.version>\Q$oldVersion\E</cn1\.version>}{<cn1.version>$version</cn1.version>}g" "$cwParent"
+  perl -pi -e "s{<cn1\.plugin\.version>\Q$oldVersion\E</cn1\.plugin\.version>}{<cn1.plugin.version>$version</cn1.plugin.version>}g" "$cwParent"
+fi
+
 echo "Committing version change in git"
 git add -u .
 # Note: the -u is to prevent adding files that aren't added to git yet.  Only changed
 # files.  This is to help avoid accidents.
 git add -u ../scripts/gamebuilder
+git add -u ../scripts/certificatewizard
 git commit -m "Updated version to $version"
 if [[ "$version" == *-SNAPSHOT ]]; then
   echo "This is a snapshot version so not adding a tag"


### PR DESCRIPTION
## Problem

The `Release on Maven Central` workflow failed on tag **7.0.257** ([run 29073446803](https://github.com/codenameone/CodenameOne/actions/runs/29073446803)). The core release, archetypes, and Game Builder editor all published fine — only the **Deploy Signing Wizard editor** step failed:

```
codenameone-certificatewizard ...................... FAILURE
[ERROR] Failed to deploy artifacts: Could not transfer artifact
com.codenameone:codenameone-certificatewizard:jar:8.0-20260710.063207-1
... status code: 403, reason phrase: Forbidden (403)
```

## Root cause

`maven/update-version.sh` bumps the out-of-reactor **gamebuilder** poms to the release version, but has no equivalent block for the **certificatewizard** editor (added later without the matching wiring). So its poms stayed at `8.0-SNAPSHOT`; `mvn deploy` then routed to the Central *snapshots* repo, which the release job has no rights to publish to → 403.

## Fix

Mirror the gamebuilder handling for `scripts/certificatewizard`: rewrite the three module `<version>`s plus the parent's `cn1.version`/`cn1.plugin.version`, and `git add` the tree before committing. Dry-run confirms all five `8.0-SNAPSHOT` references bump to the release version and none remain.

## Note on 7.0.257

This fixes **future** releases. The 7.0.257 certificatewizard artifact never made it to Central (core/archetypes/gamebuilder for 7.0.257 did). Since Central versions are immutable, backfilling it needs a separate manual deploy of just that module if 7.0.257 must be complete — happy to do that on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)