### PR TITLE
Fix local iOS builds after ParparVM optimizations

### DIFF
--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
@@ -229,6 +229,15 @@ public class IPhoneBuilder extends Executor {
     static String escapeRubyStr(String input) {
         return escapeRuby(input);
     }
+
+    static String createLldbSchemeSetupScript() {
+        return "lldb_init_file = File.join(File.dirname(project_file), 'cn1.lldbinit')\n"
+                + "File.write(lldb_init_file, \"# Codename One LLDB settings\\nprocess handle -s false -n false -p true SIGUSR2\\n\")\n"
+                + "configure_cn1_lldb = lambda do |scheme|\n"
+                + "  scheme.launch_action.xml_element.attributes['customLLDBInitFile'] = '$(SRCROOT)/cn1.lldbinit'\n"
+                + "  scheme.test_action.xml_element.attributes['customLLDBInitFile'] = '$(SRCROOT)/cn1.lldbinit'\n"
+                + "end\n";
+    }
     
     @Override
     protected String getDeviceIdCode() {
@@ -3018,9 +3027,17 @@ public class IPhoneBuilder extends Executor {
                                 tmpDir.getAbsolutePath() + "/dist/" +
                                 request.getMainClass() + ".xcodeproj\"\n" +
                             "xcproj = Xcodeproj::Project.open(project_file)\n" +
+                            createLldbSchemeSetupScript() +
                             installLocalizedStrings  +
                             "begin\n"
-                            + "  xcproj.recreate_user_schemes\n"
+                            + "  xcproj.recreate_user_schemes do |scheme, target|\n"
+                            + "    configure_cn1_lldb.call(scheme)\n"
+                            + "  end\n"
+                            + "  Dir.glob(File.join(project_file, 'xcshareddata', 'xcschemes', '*.xcscheme')).each do |scheme_path|\n"
+                            + "    scheme = Xcodeproj::XCScheme.new(scheme_path)\n"
+                            + "    configure_cn1_lldb.call(scheme)\n"
+                            + "    scheme.save!\n"
+                            + "  end\n"
                             + "rescue => e\n"
                             + "  puts \"Error during processing: #{$!}\"\n"
                             + "  puts \"Backtrace:\\n\\t#{e.backtrace.join(\"\\n\\t\")}\"\n"

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/buildWrappers/AbstractBuildWrapperMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/buildWrappers/AbstractBuildWrapperMojo.java
@@ -9,6 +9,7 @@ import org.apache.maven.shared.invoker.*;
 
 import java.io.File;
 import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 
 /**
@@ -34,7 +35,7 @@ public abstract class AbstractBuildWrapperMojo extends AbstractMojo {
         }
         InvocationRequest request = new DefaultInvocationRequest();
         request.setPomFile(new File("pom.xml"));
-        request.setGoals(Collections.singletonList("package"));
+        request.setGoals(getGoals());
 
         Properties properties = new Properties();
         properties.setProperty("skipTests", "true");
@@ -62,6 +63,10 @@ public abstract class AbstractBuildWrapperMojo extends AbstractMojo {
 
     protected abstract String getPlatform();
     protected abstract String getBuildTarget();
+
+    protected List<String> getGoals() {
+        return Collections.singletonList("package");
+    }
 
     protected boolean buildExecutableJar() {
         return false;

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/buildWrappers/BuildIosXcodeProjectMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/buildWrappers/BuildIosXcodeProjectMojo.java
@@ -4,6 +4,9 @@ package com.codename1.maven.buildWrappers;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
+import java.util.Arrays;
+import java.util.List;
+
 @Mojo(name="buildIosXcodeProject", requiresDependencyResolution = ResolutionScope.NONE,
         requiresDependencyCollection = ResolutionScope.NONE)
 public class BuildIosXcodeProjectMojo extends AbstractBuildWrapperMojo {
@@ -15,5 +18,12 @@ public class BuildIosXcodeProjectMojo extends AbstractBuildWrapperMojo {
     @Override
     protected String getBuildTarget() {
         return "ios-source";
+    }
+
+    @Override
+    protected List<String> getGoals() {
+        // Incremental native source generation can leave an Xcode project with
+        // stale VM output.  Always regenerate it from a clean Maven build.
+        return Arrays.asList("clean", "package");
     }
 }

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/IPhoneBuilderLldbConfigTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/IPhoneBuilderLldbConfigTest.java
@@ -1,0 +1,18 @@
+package com.codename1.builders;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class IPhoneBuilderLldbConfigTest {
+
+    @Test
+    void generatedSchemesIgnoreParparVmGcStopSignal() {
+        String script = IPhoneBuilder.createLldbSchemeSetupScript();
+
+        assertTrue(script.contains("process handle -s false -n false -p true SIGUSR2"));
+        assertTrue(script.contains("scheme.launch_action.xml_element.attributes['customLLDBInitFile']"));
+        assertTrue(script.contains("scheme.test_action.xml_element.attributes['customLLDBInitFile']"));
+        assertTrue(script.contains("$(SRCROOT)/cn1.lldbinit"));
+    }
+}

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/buildWrappers/BuildIosXcodeProjectMojoTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/buildWrappers/BuildIosXcodeProjectMojoTest.java
@@ -1,0 +1,17 @@
+package com.codename1.maven.buildWrappers;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+public class BuildIosXcodeProjectMojoTest {
+
+    @Test
+    public void cleansBeforeGeneratingXcodeProject() {
+        BuildIosXcodeProjectMojo mojo = new BuildIosXcodeProjectMojo();
+
+        assertEquals(Arrays.asList("clean", "package"), mojo.getGoals());
+    }
+}


### PR DESCRIPTION
## Summary

- allow build wrapper goals to customize the nested Maven lifecycle
- run `clean` before `package` for `buildIosXcodeProject`
- generate a project-local LLDB init file that passes ParparVM's internal `SIGUSR2` through without stopping or notifying the debugger
- apply the LLDB init file to generated Run and Test schemes, including shared schemes recreated during dependency integration
- add regression tests for both behaviors

## Root cause

The local iOS Xcode project goal reused generated native output across builds. After the VM virtual-method optimizations, stale generated sources can be incompatible with newly generated code and cause runtime failures such as `EXC_BAD_ACCESS` in `findPointerPosInHeap`.

Clean builds exposed a separate debugging interruption: ParparVM's conservative native-stack scanning uses `SIGUSR2` internally to suspend threads. Xcode stops on that signal by default even though it is expected VM behavior.

## Impact

Local iOS Xcode projects are now regenerated from a clean Maven build every time. Generated projects also configure LLDB to pass `SIGUSR2` to ParparVM without interrupting a debug session. Other build wrapper goals keep their existing package-only behavior.

## Validation

- Java 8 focused Maven reactor test with `-Plocal-dev-javase`
- `BuildIosXcodeProjectMojoTest`: passed
- `IPhoneBuilderLldbConfigTest`: passed
- `git diff --check`

Fixes #5362
