### PR TITLE
Fix search contrast in light mode

### DIFF
--- a/docs/website/assets/css/extended/cn1-search.css
+++ b/docs/website/assets/css/extended/cn1-search.css
@@ -7,16 +7,28 @@
   min-width: 1.25rem;
 }
 
-.cn1-search-shell {
-  border: 1px solid rgba(29, 82, 255, 0.35);
-  border-radius: 14px;
-  padding: 1rem;
-  background: rgba(68, 82, 123, 0.22);
+.cn1-search-page {
+  --cn1-search-soft-text: #4d5f8e;
+  --cn1-search-link: #1d52ff;
+  --cn1-search-link-strong: #102154;
 }
 
-body.light .cn1-search-shell {
+.dark .cn1-search-page {
+  --cn1-search-soft-text: rgba(217, 228, 255, 0.85);
+  --cn1-search-link: #afc1ff;
+  --cn1-search-link-strong: #f5f8ff;
+}
+
+.cn1-search-shell {
+  border: 1px solid #d7e2ff;
+  border-radius: 14px;
+  padding: 1rem;
   background: #f5f8ff;
-  border-color: #d7e2ff;
+}
+
+.dark .cn1-search-shell {
+  background: rgba(68, 82, 123, 0.22);
+  border-color: rgba(29, 82, 255, 0.35);
 }
 
 .cn1-search-label {
@@ -24,37 +36,37 @@ body.light .cn1-search-shell {
   font-size: 0.86rem;
   font-weight: 600;
   margin-bottom: 0.35rem;
-  color: var(--cn1-course-link, #afc1ff);
+  color: var(--cn1-search-link);
 }
 
 .cn1-search-input {
   width: 100%;
-  border: 1px solid rgba(175, 193, 255, 0.4);
+  border: 1px solid #c9d6ff;
   border-radius: 10px;
   padding: 0.75rem 0.85rem;
-  background: rgba(8, 17, 55, 0.5);
-  color: #f5f8ff;
+  background: #fff;
+  color: #1c2a55;
   font-family: "Poppins", sans-serif;
   font-size: 0.98rem;
 }
 
-body.light .cn1-search-input {
-  background: #fff;
-  color: #1c2a55;
-  border-color: #c9d6ff;
+.dark .cn1-search-input {
+  background: rgba(8, 17, 55, 0.5);
+  color: #f5f8ff;
+  border-color: rgba(175, 193, 255, 0.4);
 }
 
 .cn1-search-status {
   margin: 0.7rem 0 0;
   font-size: 0.86rem;
-  color: var(--cn1-course-soft-text, rgba(217, 228, 255, 0.85));
+  color: var(--cn1-search-soft-text);
 }
 
 .cn1-search-note {
   margin: 0.7rem 0 0;
   font-size: 0.82rem;
   line-height: 1.45;
-  color: var(--cn1-course-soft-text, rgba(217, 228, 255, 0.78));
+  color: var(--cn1-search-soft-text);
 }
 
 .cn1-search-note a {
@@ -69,15 +81,15 @@ body.light .cn1-search-input {
 }
 
 .cn1-search-result {
-  border: 1px solid rgba(175, 193, 255, 0.25);
+  border: 1px solid #d7e2ff;
   border-radius: 10px;
   padding: 0.75rem 0.8rem;
-  background: rgba(8, 17, 55, 0.22);
+  background: rgba(255, 255, 255, 0.75);
 }
 
-body.light .cn1-search-result {
-  background: rgba(255, 255, 255, 0.75);
-  border-color: #d7e2ff;
+.dark .cn1-search-result {
+  background: rgba(8, 17, 55, 0.22);
+  border-color: rgba(175, 193, 255, 0.25);
 }
 
 .cn1-search-result h2 {
@@ -86,19 +98,19 @@ body.light .cn1-search-result {
 }
 
 .cn1-search-result h2 a {
-  color: var(--cn1-course-link-strong, #f5f8ff);
+  color: var(--cn1-search-link-strong);
   text-decoration: none;
 }
 
 .cn1-search-result h2 a:hover {
-  color: var(--cn1-course-link, #afc1ff);
+  color: var(--cn1-search-link);
 }
 
 .cn1-search-result p {
   margin: 0.4rem 0;
   font-size: 0.9rem;
   line-height: 1.45;
-  color: var(--cn1-course-soft-text, rgba(217, 228, 255, 0.85));
+  color: var(--cn1-search-soft-text);
 }
 
 .cn1-search-result__meta {
@@ -112,11 +124,11 @@ body.light .cn1-search-result {
 .cn1-search-result__url {
   font-size: 0.8rem;
   text-decoration: none;
-  color: var(--cn1-course-link, #afc1ff);
+  color: var(--cn1-search-link);
 }
 
 .cn1-search-result__date {
   font-size: 0.78rem;
-  color: var(--cn1-course-soft-text, rgba(217, 228, 255, 0.7));
+  color: var(--cn1-search-soft-text);
   white-space: nowrap;
 }


### PR DESCRIPTION
## Summary

- make the search page use its light palette by default
- apply the existing dark palette only when PaperMod adds the `.dark` class
- scope search colors to search-specific CSS variables

## Root cause

PaperMod represents light mode by the absence of `.dark`, but the search stylesheet expected a `body.light` class that is never added. As a result, light mode continued using the low-contrast dark search colors.

## Impact

Search labels, input text, result titles, snippets, URLs, dates, and status text are readable in light mode while dark mode retains its existing appearance.

Fixes #5364.

## Validation

- `hugo --source docs/website --destination /tmp/cn1-issue-5364-site --baseURL http://127.0.0.1:1313/ --buildDrafts --buildFuture`
- `git diff --check`
- verified light-mode text contrast ratios from 5.33:1 to 15.36:1