### PR TITLE
Fix tagged static final heap removal crash

### DIFF
--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -654,7 +654,10 @@ pthread_mutex_t* getMemoryAccessMutex() {
 }
 
 int findPointerPosInHeap(JAVA_OBJECT obj) {
-    if(obj == 0) {
+    // Tagged Integers are immediate values, not heap objects, and therefore have
+    // no header/heap position to read.  Keep this low-level helper total so a
+    // caller can never turn a legal boxed Integer into a tagged-pointer fault.
+    if(obj == 0 || CN1_IS_TAGGED(obj)) {
         return -1;
     }
     return obj->__heapPosition;
@@ -1626,6 +1629,15 @@ void codenameOneGCSweep() {
 }
 
 JAVA_BOOLEAN removeObjectFromHeapCollection(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT o) {
+    // A tagged Integer has no heap entry to remove (and no object header).  Static
+    // final boxed values reach this path because the translator historically
+    // removes immutable static finals from the heap collection.  Treat the
+    // immediate as already outside the heap instead of falling through to a
+    // header dereference in findPointerPosInHeap().
+    if(o != JAVA_NULL && CN1_IS_TAGGED(o)) {
+        return JAVA_TRUE;
+    }
+
     // Initialize allObjectsInHeap if it hasn't been initialized yet
     // This can happen if GC runs before any objects are allocated
     if(allObjectsInHeap == 0) {

--- a/vm/tests/src/test/java/com/codename1/tools/translator/CleanTargetIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/CleanTargetIntegrationTest.java
@@ -1645,8 +1645,13 @@ class CleanTargetIntegrationTest {
 
     static String helloWorldSource() {
         return "public class HelloWorld {\n" +
+                // Small boxed static finals use ParparVM's tagged-Integer representation.
+                // Their generated setter removes immutable finals from heap tracking; this
+                // exercises that path before main and guards against dereferencing the tag.
+                "    private static final Integer YEAR_OPTION_DAY_OF_YEAR = Integer.valueOf(6);\n" +
                 "    private static native void nativeHello();\n" +
                 "    public static void main(String[] args) {\n" +
+                "        if (YEAR_OPTION_DAY_OF_YEAR.intValue() != 6) { throw new AssertionError(); }\n" +
                 "        nativeHello();\n" +
                 "    }\n" +
                 "}\n";


### PR DESCRIPTION
## Summary

- treat tagged `Integer` immediates as already outside the heap in `removeObjectFromHeapCollection()`
- make `findPointerPosInHeap()` defensive for tagged values
- add an end-to-end native regression for a small boxed `static final Integer`

## Root cause

The tagged-`Integer` optimization makes `Integer.valueOf()` return an immediate value on 64-bit targets. Generated setters for immutable static-final object fields call `removeObjectFromHeapCollection()`. That function avoided a header read in its BiBOP branch for tagged values, but then fell through to `findPointerPosInHeap()`, which unconditionally dereferenced the immediate as an object header.

This produces the `findPointerPosInHeap -> removeObjectFromHeapCollection -> set_static_*` crash reported on iOS after continuing past the GC pressure signal.

## Impact

Small boxed integers stored in qualifying `static final` fields no longer crash during class initialization. Normal heap objects retain the existing removal and immortal-root behavior.

## Validation

```text
mvn -pl tests -am -Dtest=CleanTargetIntegrationTest#generatesRunnableHelloWorldUsingCleanTarget -Dsurefire.failIfNoSpecifiedTests=false test

Tests run: 5, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

The generated native C was also inspected to confirm the regression executes `Integer.valueOf(6) -> CN1_TAG_INT(6) -> generated static setter -> removeObjectFromHeapCollection()`.

Fixes #5362