### PR TITLE
Fix #5370: honor TextField horizontal alignment while editing

### DIFF
--- a/Ports/Android/src/com/codename1/impl/android/InPlaceEditView.java
+++ b/Ports/Android/src/com/codename1/impl/android/InPlaceEditView.java
@@ -651,6 +651,7 @@ public class InPlaceEditView extends FrameLayout{
         final int scrollX;
         final int scrollY;
         final int verticalAlignment;
+        final int absoluteAlignment;
         final int height;
         final int width;
         final int fontHeight;
@@ -694,6 +695,10 @@ public class InPlaceEditView extends FrameLayout{
             return verticalAlignment;
         }
 
+        int getAbsoluteAlignment() {
+            return absoluteAlignment;
+        }
+
         boolean isRTL() {
             return isRTL;
         }
@@ -733,6 +738,7 @@ public class InPlaceEditView extends FrameLayout{
             paddingBottom = s.getPaddingBottom();
             isTextField = (ta instanceof TextField);
             verticalAlignment = ta.getVerticalAlignment();
+            absoluteAlignment = ta.getAbsoluteAlignment();
             height = ta.getHeight();
             width = ta.getWidth();
             fontHeight = s.getFont().getHeight();
@@ -874,10 +880,20 @@ public class InPlaceEditView extends FrameLayout{
 
         mEditText.setLayoutParams(mEditLayoutParams);
 
-        if(textArea.isRTL()){
-            mEditText.setGravity(Gravity.RIGHT | Gravity.TOP);
-        }else{
-            mEditText.setGravity(Gravity.LEFT | Gravity.TOP);
+        // Honor the field's horizontal alignment (issue #5370) so a right- or
+        // center-aligned field doesn't jump to the left when the native editor
+        // takes over. getAbsoluteAlignment() already resolves LEFT/RIGHT for RTL,
+        // so it covers the previous RTL-only behavior too.
+        switch (textArea.getAbsoluteAlignment()) { // snapshot value, safe off the EDT
+            case Component.RIGHT:
+                mEditText.setGravity(Gravity.RIGHT | Gravity.TOP);
+                break;
+            case Component.CENTER:
+                mEditText.setGravity(Gravity.CENTER_HORIZONTAL | Gravity.TOP);
+                break;
+            default:
+                mEditText.setGravity(Gravity.LEFT | Gravity.TOP);
+                break;
         }
 
         mEditText.setPadding(paddingLeft, paddingTop, paddingRight, paddingBottom);

--- a/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
@@ -9368,6 +9368,23 @@ public class JavaSEPort extends CodenameOneImplementation {
                 });
                 */
             }
+            // Honor the field's horizontal alignment (issue #5370) so a right- or
+            // center-aligned field doesn't jump to the left when the native editor
+            // takes over. getAbsoluteAlignment() already resolves LEFT/RIGHT for RTL.
+            // Both JTextField and JPasswordField (a JTextField subclass) support this.
+            if (t instanceof JTextField) {
+                switch (((com.codename1.ui.TextArea)cmp).getAbsoluteAlignment()) {
+                    case com.codename1.ui.Component.RIGHT:
+                        ((JTextField)t).setHorizontalAlignment(JTextField.RIGHT);
+                        break;
+                    case com.codename1.ui.Component.CENTER:
+                        ((JTextField)t).setHorizontalAlignment(JTextField.CENTER);
+                        break;
+                    default:
+                        ((JTextField)t).setHorizontalAlignment(JTextField.LEADING);
+                        break;
+                }
+            }
             swingT = t;
             textCmp = swingT;
         } else {


### PR DESCRIPTION
## Problem

Editing a right-aligned decimal `TextField` made the number **jump to the left** the moment editing started (issue #5370). With a hint set it was worse: the hint stayed pinned to the right while the cursor appeared on the left, which is easy to miss.

## Root cause

When a field is edited, Codename One overlays a **native inline editor** and hides the lightweight component. The idle lightweight render honors the field's `RIGHT` alignment, but the native editor's horizontal alignment is decided per-port — and the ports were out of sync:

- **iOS** — already honors it (`CodenameOne_GLViewController.m` maps alignment `3 → NSTextAlignmentRight`, `4 → center`), fed from `getStyle().getAlignment()`. No jump.
- **Android** (`InPlaceEditView`) — set gravity from `isRTL()` **only**, never from alignment → always left for non-RTL.
- **JavaSE simulator** (`editString`) — built a plain `JTextField` and never called `setHorizontalAlignment` → Swing default leading/left.

So on Android and in the simulator a right/center-aligned field always left-aligned during editing, producing the visible jump. This is longstanding behavior, not a recent regression on the horizontal axis (the recent #5345/#5358 change was about *vertical* alignment).

## Fix

Bring Android and the simulator in line with iOS by driving the native editor's horizontal alignment from the field's `getAbsoluteAlignment()` (which already resolves LEFT/RIGHT for RTL, so the previous RTL behavior is preserved).

- **Android** — set `EditText` gravity from the alignment. The value is snapshotted into `TextAreaData` on the CN1 EDT (new `absoluteAlignment` field) so it is read safely off the EDT, consistent with the other cached properties.
- **JavaSE simulator** — set the single-line Swing editor's horizontal alignment (`JTextField` / `JPasswordField`). Multi-line `JTextArea` has no per-line horizontal alignment in Swing and is unaffected (not part of this issue).
- **iOS** — no change needed; already correct.

## Testing

- `mvn -Plocal-dev-javase -pl javase compile` — green.
- `mvn -pl android compile` — green.

Closes #5370.

🤖 Generated with [Claude Code](https://claude.com/claude-code)