### PR TITLE
Limit fidelity tests to CSS theme changes

### DIFF
--- a/.github/workflows/scripts-fidelity.yml
+++ b/.github/workflows/scripts-fidelity.yml
@@ -10,39 +10,13 @@ name: Native theme fidelity
 # are re-seedable drift artifacts (FIDELITY_UPDATE_GOLDENS / _BASELINE).
 
 'on':
-  # Manual dispatch: this PR's changed-file count exceeds GitHub's paths-filter
-  # diff limit, so pull_request triggers stopped firing -- dispatch with
-  #   gh workflow run <file> --ref <branch>
+  # Keep manual dispatch available for deliberate fidelity runs outside the
+  # native-theme CSS change workflow.
   workflow_dispatch:
   pull_request:
     paths:
-      - '.github/workflows/scripts-fidelity.yml'
-      - 'scripts/setup-workspace.sh'
-      - 'scripts/build-android-port.sh'
-      - 'scripts/build-ios-port.sh'
-      - 'scripts/build-android-app.sh'
-      - 'scripts/build-ios-app.sh'
-      - 'scripts/build-fidelity-app.sh'
-      - 'scripts/run-android-fidelity-tests.sh'
-      - 'scripts/run-ios-fidelity-tests.sh'
-      - 'scripts/lib/cn1ss.sh'
-      - 'scripts/common/java/**'
-      - 'scripts/fidelity-app/**'
-      - 'native-themes/ios-modern/**'
-      - '!native-themes/ios-modern/**/*.md'
-      - 'native-themes/android-material/**'
-      - '!native-themes/android-material/**/*.md'
-      - 'CodenameOne/src/**'
-      - '!CodenameOne/src/**/*.md'
-      - 'Ports/Android/**'
-      - '!Ports/Android/**/*.md'
-      - 'Ports/iOSPort/**'
-      - '!Ports/iOSPort/**/*.md'
-      - 'vm/**'
-      - '!vm/**/*.md'
-      - 'maven/**'
-      - '!maven/core-unittests/**'
-      - '!docs/**'
+      - 'native-themes/ios-modern/theme.css'
+      - 'native-themes/android-material/theme.css'
   push:
     branches: [master]
     paths:

--- a/scripts/fidelity-app/README.md
+++ b/scripts/fidelity-app/README.md
@@ -131,8 +131,9 @@ xcodebuild -workspace <FidelityApp.xcworkspace> -scheme FidelityApp \
 To re-seed in a fresh environment:
 `FIDELITY_UPDATE_GOLDENS=1 FIDELITY_UPDATE_BASELINE=1 ./scripts/run-...`.
 
-CI runs both platforms in `.github/workflows/scripts-fidelity.yml`, gating each
-PR that touches the native themes, the app, or the renderers.
+CI runs both platforms in `.github/workflows/scripts-fidelity.yml`, gating PRs
+that change the iOS Modern or Android Material CSS theme sources. Other changes
+can be tested deliberately with the workflow's manual dispatch.
 
 ## Current standing
 


### PR DESCRIPTION
## Summary

- limit the native-theme fidelity workflow's PR trigger to the iOS Modern and Android Material CSS sources
- keep manual workflow dispatch available for deliberate fidelity runs
- update the fidelity-app documentation to match the trigger behavior

## Root cause and impact

The PR path filter included broad framework, port, VM, Maven, fidelity harness, and workflow paths. As a result, unrelated changes caused the expensive Android and iOS fidelity jobs to run. PRs now trigger these jobs only when one of the two new CSS theme source files changes.

## Validation

- `git diff --check`
- parsed `.github/workflows/scripts-fidelity.yml` successfully as YAML
