### PR TITLE
JavaSE: fix JCEF 135 desktop CEF provisioning + simulator classpath

### DIFF
--- a/maven/cn1app-archetype/src/main/resources/archetype-resources/javase/pom.xml
+++ b/maven/cn1app-archetype/src/main/resources/archetype-resources/javase/pom.xml
@@ -73,6 +73,20 @@
           <scope>provided</scope>
       </dependency>
       <!--
+        Desktop runtime binaries: the JCEF Java API + per-platform natives (for
+        the BrowserComponent) and bundled ffmpeg (for media). codenameone-javase
+        declares jcef-api as optional, so it is not inherited transitively; this
+        aggregator puts org.cef on the app classpath for every profile (simulator,
+        IntelliJ run, run-desktop, executable-jar). Without it the simulator/desktop
+        app runs but the BrowserComponent fails to initialize CEF. The plugin
+        provisions and extracts the matching native binaries at run/build time.
+      -->
+      <dependency>
+          <groupId>com.codenameone</groupId>
+          <artifactId>cn1-binaries-javase</artifactId>
+          <type>pom</type>
+      </dependency>
+      <!--
         JUnit Jupiter so Surefire (which is bound to this module's test
         phase by default) actually runs any @Test methods under
         common/src/test/java. The codenameone-javase artifact above

--- a/maven/cn1app-archetype/src/main/resources/archetype-resources/javase/src/desktop/java/__mainName__Stub.java
+++ b/maven/cn1app-archetype/src/main/resources/archetype-resources/javase/src/desktop/java/__mainName__Stub.java
@@ -26,6 +26,7 @@
 #set( $symbol_escape = '\' )
 package ${package};
 
+import com.codename1.impl.javase.CN1Bootstrap;
 import com.codename1.impl.javase.JavaSEPort;
 import com.codename1.ui.Display;
 import java.awt.GraphicsDevice;
@@ -75,6 +76,19 @@ public class ${mainName}Stub implements Runnable, WindowListener {
      * @param args the command line arguments
      */
     public static void main(String[] args) {
+        // Bootstrap the classpath/native library path (CEF) the same way the
+        // simulator does before touching any CEF class. This puts the JCEF native
+        // directory (from cef.dir) on java.library.path so chrome_elf/libcef load,
+        // then re-invokes this main() inside the bootstrapped classloader. It is a
+        // no-op (returns false) once bootstrapping has already happened.
+        try {
+            if (CN1Bootstrap.run(${mainName}Stub.class, args)) {
+                return;
+            }
+        } catch (Throwable bootstrapError) {
+            // Fall through and run without bootstrapping; CEF may be unavailable.
+            bootstrapError.printStackTrace();
+        }
         try {
             Class.forName("org.cef.CefApp");
             System.setProperty("cn1.javase.implementation", "cef");

--- a/maven/cn1app-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/maven/cn1app-archetype/src/main/resources/archetype-resources/pom.xml
@@ -60,6 +60,21 @@
                 <artifactId>codenameone-javase</artifactId>
                 <version>${cn1.version}</version>
             </dependency>
+            <!--
+              Desktop runtime binaries (JCEF for the BrowserComponent + bundled
+              ffmpeg for media). This aggregator carries the jcef-api Java classes,
+              the per-platform jcef-natives, and ffmpeg-platform. jcef-api is
+              declared optional inside codenameone-javase, so it is NOT inherited
+              transitively; the javase module below must depend on this aggregator
+              explicitly or the simulator/desktop app has no org.cef on its
+              classpath and silently runs without a working BrowserComponent.
+            -->
+            <dependency>
+                <groupId>com.codenameone</groupId>
+                <artifactId>cn1-binaries-javase</artifactId>
+                <version>${cn1.version}</version>
+                <type>pom</type>
+            </dependency>
 
             <dependency>
                 <groupId>com.codenameone</groupId>

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/AbstractCN1Mojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/AbstractCN1Mojo.java
@@ -961,18 +961,32 @@ public abstract class AbstractCN1Mojo extends AbstractMojo {
 
     }
 
-    private File extractCefBundle(File nativeJar) {
+    private File extractCefBundle(File nativeJar, String version) {
         File extractedDir = new File(project.getBuild().getDirectory(), "cn1-cef-" + getCefPlatform());
         File cefRoot = new File(extractedDir, "cef");
         File runtimeDir = new File(cefRoot, getCefRuntimeSubdir());
         File tempExtract = new File(extractedDir, "tmp");
-        boolean needsRefresh = !runtimeDir.exists() || extractedDir.lastModified() < nativeJar.lastModified();
+        // The version stamp guards against reusing a stale extraction after a JCEF
+        // upgrade. The native binary and the jcef-api Java classes must match: a
+        // mismatch surfaces at runtime as a native<->Java skew (e.g. a
+        // NoSuchMethodError for getScreenInfo, which also silently breaks HiDPI
+        // scaling). A timestamp check alone misses this because the previously
+        // extracted directory can be newer than a freshly resolved native jar.
+        File versionStamp = new File(cefRoot, ".cn1-jcef-version");
+        boolean versionMatches = version != null && version.equals(readVersionStamp(versionStamp));
+        boolean needsRefresh = !runtimeDir.exists()
+                || extractedDir.lastModified() < nativeJar.lastModified()
+                || !versionMatches;
         if (isMac) {
             File chromiumEmbeddedFramework = new File(runtimeDir, "Chromium Embedded Framework.framework/Chromium Embedded Framework");
             needsRefresh = needsRefresh || !Files.isSymbolicLink(chromiumEmbeddedFramework.toPath());
         }
         if (!needsRefresh) {
             return cefRoot;
+        }
+        if (runtimeDir.exists() && !versionMatches) {
+            getLog().info("Refreshing CEF: extracted JCEF native version does not match "
+                    + (version == null ? "the resolved version" : version));
         }
 
         if (extractedDir.exists()) {
@@ -999,7 +1013,31 @@ public abstract class AbstractCN1Mojo extends AbstractMojo {
         tar.createArg().setFile(runtimeDir);
         tar.execute();
         delTree(tempExtract);
+        writeVersionStamp(versionStamp, version);
         return cefRoot;
+    }
+
+    private String readVersionStamp(File versionStamp) {
+        if (!versionStamp.exists()) {
+            return null;
+        }
+        try {
+            return new String(Files.readAllBytes(versionStamp.toPath()), "UTF-8").trim();
+        } catch (IOException ex) {
+            getLog().debug("Could not read CEF version stamp " + versionStamp, ex);
+            return null;
+        }
+    }
+
+    private void writeVersionStamp(File versionStamp, String version) {
+        if (version == null) {
+            return;
+        }
+        try {
+            Files.write(versionStamp.toPath(), version.getBytes("UTF-8"));
+        } catch (IOException ex) {
+            getLog().debug("Could not write CEF version stamp " + versionStamp, ex);
+        }
     }
 
     private File findFileBySuffix(File root, String suffix) {
@@ -1064,12 +1102,13 @@ public abstract class AbstractCN1Mojo extends AbstractMojo {
             getLog().warn("No upstream JCEF artifact is configured for this platform");
             return;
         }
-        File nativeJar = getJar("me.friwi", artifactId);
+        Artifact nativeArtifact = getArtifact("me.friwi", artifactId);
+        File nativeJar = nativeArtifact == null ? null : getJar(nativeArtifact);
         if (nativeJar == null || !nativeJar.exists()) {
             getLog().warn("Upstream JCEF native bundle " + artifactId + " not found in dependencies. Not adding CEF dependency");
             return;
         }
-        File cefDir = extractCefBundle(nativeJar);
+        File cefDir = extractCefBundle(nativeJar, nativeArtifact.getVersion());
         project.getProperties().setProperty("cef.dir", cefDir.getAbsolutePath());
         System.setProperty("cef.dir", cefDir.getAbsolutePath());
         fixCefPermissions(cefDir);

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/GenerateDesktopAppWrapperMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/GenerateDesktopAppWrapperMojo.java
@@ -40,6 +40,14 @@ public class GenerateDesktopAppWrapperMojo extends AbstractCN1Mojo {
 
     @Override
     protected void executeImpl() throws MojoExecutionException, MojoFailureException {
+        // Provision the JCEF natives and set the cef.dir property for the desktop
+        // app the same way the simulator goals do. Without this the desktop run
+        // has the jcef-natives jar on its classpath but the actual native binaries
+        // (e.g. chrome_elf.dll on Windows) are never extracted to disk nor placed
+        // on java.library.path, so opening a BrowserComponent fails with
+        // "no chrome_elf in java.library.path" / "Failed to create CEF browser".
+        // The generated stub boots through CN1Bootstrap, which consumes cef.dir.
+        setupCef();
         generateIcons();
         generateStub();
         registerCustomStubSourceRoot();

--- a/maven/codenameone-maven-plugin/src/main/resources/com/codename1/maven/desktop-app-stub-template.java
+++ b/maven/codenameone-maven-plugin/src/main/resources/com/codename1/maven/desktop-app-stub-template.java
@@ -22,6 +22,7 @@
  */
 package __PACKAGE__;
 
+import com.codename1.impl.javase.CN1Bootstrap;
 import com.codename1.impl.javase.JavaSEPort;
 import com.codename1.ui.Display;
 import java.awt.GraphicsDevice;
@@ -68,6 +69,19 @@ public class __MAIN_NAME__Stub implements Runnable, WindowListener {
     private __MAIN_NAME__ mainApp;
 
     public static void main(String[] args) {
+        // Bootstrap the classpath/native library path (CEF) the same way the
+        // simulator does before touching any CEF class. This puts the JCEF native
+        // directory (from cef.dir) on java.library.path so chrome_elf/libcef load,
+        // then re-invokes this main() inside the bootstrapped classloader. It is a
+        // no-op (returns false) once bootstrapping has already happened.
+        try {
+            if (CN1Bootstrap.run(__MAIN_NAME__Stub.class, args)) {
+                return;
+            }
+        } catch (Throwable bootstrapError) {
+            // Fall through and run without bootstrapping; CEF may be unavailable.
+            bootstrapError.printStackTrace();
+        }
         try {
             Class.forName("org.cef.CefApp");
             System.setProperty("cn1.javase.implementation", "cef");


### PR DESCRIPTION
## Background

After the upstream JCEF 135 upgrade (#5294) a user hit three problems that all trace back to how the JCEF Java API and native binaries reach the app at runtime. I verified each root cause empirically (dumped `${plugin.artifacts}`, ran `setupCef()` in a consumer project) before changing anything — notably confirming the plugin *does* carry the natives transitively, so the fix is **not** on the plugin dependency side.

## Root causes & fixes

**A — Simulator/IntelliJ needed a manual `pom.xml` edit to add `cn1-binaries-javase`.**
`jcef-api` is `<optional>true</optional>` in the javase port (`maven/javase/pom.xml`), so it is **not** inherited transitively. `mvn cn1:run` masks this (the plugin realm has `org.cef`), but IntelliJ builds its run classpath from *project* deps → no `org.cef` → `Class.forName("org.cef.CefApp")` fails → CEF silently disabled.
Fix: the archetype now depends on the `cn1-binaries-javase` aggregator (jcef-api + per-platform natives + ffmpeg) in the shared javase dependencies, version-managed in the top-level `dependencyManagement`. This is exactly the hand-edit the user validated, made automatic.

**B — Desktop app failed with `no chrome_elf in java.library.path` / `Failed to create CEF browser`.**
`setupCef()` (native extraction + `cef.dir`) was only wired into the simulator/build goals, never the desktop path, and the generated stub never set up the native library path.
Fix: `GenerateDesktopAppWrapperMojo` now calls `setupCef()`, and the desktop stub (both the plugin template and the archetype override example) boots through `CN1Bootstrap.run(...)` — the same proven path the simulator/`TestRunner` use to put the JCEF native dir on `java.library.path` before any CEF class loads.

**C — Simulator scaling broke with `NoSuchMethodError: getScreenInfo`.**
A native↔Java version skew from reusing a **stale** extracted CEF dir after the upgrade; the old refresh check was timestamp-only and missed it. `getScreenInfo` is the callback that feeds CEF the device-scale-factor, so a failed bind also silently breaks HiDPI scaling.
Fix: `extractCefBundle` now stamps the extracted dir with the resolved JCEF version and re-extracts on mismatch.

## Verification

- Plugin compiles (`mvn -pl codenameone-maven-plugin install`) → BUILD SUCCESS.
- Ran `generate-desktop-app-wrapper` on a consumer project (`myapp1`, which does **not** declare `cn1-binaries-javase`): now emits `Expanding CEF` and writes `.cn1-jcef-version` = `jcef-ca49ada+cef-135.0.20+...`.
- Confirmed `${plugin.artifacts}` already carries `jcef-natives-<platform>` transitively, so `setupCef()` resolves natives without project-level deps.

## Notes / follow-ups

- The macOS extraction still re-runs each build due to a pre-existing symlink check in `extractCefBundle` (unrelated to this change); Windows/Linux — including the reporter's case — now reuse via the version stamp.
- Full **distributable** desktop bundling (shipping natives inside the packaged app for an end-user machine with no `~/.codenameone/cef` and no plugin) is broader than this PR; this fixes the local `mvn`/IntelliJ run-desktop + executable-jar flows.
- Bundling `cn1-binaries-javase` at compile scope pulls all-platform natives into the executable-jar `libs` — a size tradeoff we may want to trim to the current platform later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)