### PR TITLE
iOS Metal: rebuild private-storage textures after suspend (#5349)

### DIFF
--- a/Ports/iOSPort/nativeSources/CN1Metalcompat.h
+++ b/Ports/iOSPort/nativeSources/CN1Metalcompat.h
@@ -382,5 +382,11 @@ void CN1MetalUnregisterMutableImage(GLUIImage *image);
 // re-seed from getImage. Must be called on the main thread.
 void CN1MetalBackupMutableImagesForSuspend(void);
 
+// Texture-discard recovery (issue #5349). The generation is bumped on foreground
+// and memory warning; GLUIImage.getMTLTexture re-decodes its read-only texture
+// from the retained UIImage when its cached generation lags.
+int  CN1MetalTextureValidateGeneration(void);
+void CN1MetalBumpTextureValidateGeneration(void);
+
 #endif /* CN1_USE_METAL */
 #endif /* CN1Metalcompat_h */

--- a/Ports/iOSPort/nativeSources/CN1Metalcompat.m
+++ b/Ports/iOSPort/nativeSources/CN1Metalcompat.m
@@ -1933,6 +1933,30 @@ void CN1MetalUnregisterMutableImage(GLUIImage *image) {
     }
 }
 
+// --------------- Texture-discard recovery (issue #5349) ---------------
+//
+// iOS discards the contents of MTLStorageModePrivate textures while the app is
+// suspended (and can reclaim them under memory pressure). CN1 caches such
+// textures for every image, so after a resume it would sample the discarded
+// garbage and paint a violet/magenta fill on any surface the diff-painter does
+// not fully repaint (Toolbar, unselected Tabs, a FAB shadow, a Switch thumb).
+//
+// A monotonically increasing generation, bumped on foreground and on memory
+// warning. GLUIImage.getMTLTexture re-decodes its read-only texture from the
+// retained UIImage the first time it is sampled in a newer generation. This is
+// the only safe recovery signal: probing the OS purgeable state per-draw
+// (setPurgeableState) trips Metal's commit-time lockPurgeableObjects validation
+// on textures already referenced by an in-flight command buffer.
+static volatile int gTextureValidateGeneration = 0;
+
+int CN1MetalTextureValidateGeneration(void) {
+    return gTextureValidateGeneration;
+}
+
+void CN1MetalBumpTextureValidateGeneration(void) {
+    gTextureValidateGeneration++;
+}
+
 void CN1MetalBackupMutableImagesForSuspend(void) {
     if (gMutableImageRegistry == nil) return;
     NSArray *snapshot;
@@ -1945,6 +1969,13 @@ void CN1MetalBackupMutableImagesForSuspend(void) {
     }
     for (GLUIImage *image in snapshot) {
         if ([image mtlMutableTexture] == nil) {
+            // Layer B (issue #5349): a plain read-only image whose texture was
+            // uploaded from a UIImage. Drop it now so it re-decodes from that
+            // retained UIImage after resume instead of sampling the contents
+            // iOS discards during suspend. (Also frees GPU memory before we go
+            // to the background.) getMTLTexture's generation check is the
+            // primary guard; this just reclaims eagerly.
+            [image dropReadOnlyCachedTexture];
             continue;
         }
         // Read the current GPU pixels back into a UIImage *before* dropping
@@ -1962,6 +1993,10 @@ void CN1MetalBackupMutableImagesForSuspend(void) {
         // invalidates the read-only mtlTexture cache.
         [image setImage:backup];
     }
+    // Glyph atlases are private-storage textures too; drop them so text
+    // re-rasterises after resume rather than sampling discarded contents.
+    extern void CN1MetalGlyphAtlasReleaseAll(void);
+    CN1MetalGlyphAtlasReleaseAll();
 }
 
 // --------------- Memory-pressure cache release ---------------
@@ -1983,6 +2018,11 @@ void CN1MetalReleaseCaches(void) {
     // linear-gradient / radial-gradient), no offscreen bitmap to cache.
     // Only the glyph atlases need releasing under memory pressure.
     CN1MetalGlyphAtlasReleaseAll();
+    // issue #5349: a memory warning means the OS is (or is about to start)
+    // reclaiming resources -- bump the generation so cached read-only image
+    // textures re-decode from their UIImage on next use rather than risk
+    // sampling contents the OS discarded.
+    CN1MetalBumpTextureValidateGeneration();
 }
 
 #endif /* CN1_USE_METAL */

--- a/Ports/iOSPort/nativeSources/CodenameOne_GLAppDelegate.m
+++ b/Ports/iOSPort/nativeSources/CodenameOne_GLAppDelegate.m
@@ -301,6 +301,14 @@ static void installSignalHandlers() {
         if ([renderingView respondsToSelector:@selector(invalidateRetainedFramebuffer)]) {
             [renderingView invalidateRetainedFramebuffer];
         }
+        // issue #5349: iOS may have discarded the contents of our private-storage
+        // image/glyph textures while suspended. Bump the texture-validate
+        // generation so every cached read-only image texture re-decodes from its
+        // retained UIImage on next sample instead of rendering the discarded
+        // garbage (a violet/magenta fill) on surfaces the diff-painter does not
+        // fully repaint this frame. Pairs with the screenTexture clear above.
+        extern void CN1MetalBumpTextureValidateGeneration(void);
+        CN1MetalBumpTextureValidateGeneration();
 #endif
         // Defer to the next runloop so UIKit can settle the view bounds
         // after the snapshot rotation. updateCanvas itself also

--- a/Ports/iOSPort/nativeSources/GLUIImage.h
+++ b/Ports/iOSPort/nativeSources/GLUIImage.h
@@ -41,6 +41,13 @@
     int textureHeight;
 #ifdef CN1_USE_METAL
     id<MTLTexture> mtlTexture;
+    // issue #5349: the texture-validate generation this cached read-only
+    // mtlTexture was last confirmed against. When it lags the global counter
+    // (bumped on foreground / memory warning), getMTLTexture re-decodes from
+    // the retained UIImage -- iOS may have discarded the private-storage
+    // texture's contents while the app was suspended, and we must not sample
+    // the leftover garbage (which renders as a violet/magenta fill).
+    int mtlTextureGeneration;
     // Phase 3 v2: mutable-image render target. Allocated lazily by
     // CN1MetalEnsureMutableTexture sized to the mutable image's logical
     // dimensions. drawFrame opens an MTLRenderCommandEncoder against this
@@ -81,6 +88,12 @@
 // (Phase 3 mutable-image render target), that is returned instead -- it
 // is the freshest pixel source.
 -(id<MTLTexture>)getMTLTexture;
+
+// issue #5349: drop the cached read-only mtlTexture so the next getMTLTexture
+// re-decodes it from the retained UIImage. Called from the suspend backup for
+// every registered image that is NOT a mutable render target (those go through
+// the readback path instead). Safe no-op when no read-only texture is cached.
+-(void)dropReadOnlyCachedTexture;
 
 // Phase 3 v2 mutable-image accessors. CN1Metalcompat owns the lifecycle;
 // these are the storage hooks. Accessors only -- consumers outside this

--- a/Ports/iOSPort/nativeSources/GLUIImage.m
+++ b/Ports/iOSPort/nativeSources/GLUIImage.m
@@ -184,10 +184,40 @@ extern int nextPowerOf2(int val);
     // pixel source. Screen-side DrawImage samples this; the cached UIImage-
     // derived mtlTexture is only relevant for never-drawn-into images.
     if (mtlMutableTexture != nil) return mtlMutableTexture;
-    if (mtlTexture != nil) return mtlTexture;
+    if (mtlTexture != nil) {
+        // issue #5349: the first time this cached read-only texture is sampled
+        // after a foreground/resume (or a memory warning), re-decode it from the
+        // retained UIImage. iOS can discard a private-storage texture's contents
+        // while the app is suspended, and the leftover bytes render as a
+        // violet/magenta fill; re-decoding from the CPU-side UIImage is cheap and
+        // always correct. A plain generation compare is used (no OS purgeable
+        // probe) -- setPurgeableState on a texture already referenced by an
+        // in-flight command buffer trips Metal's commit-time validation.
+        int gen = CN1MetalTextureValidateGeneration();
+        if (mtlTextureGeneration != gen) {
+            mtlTextureGeneration = gen;
+            [mtlTexture release];
+            mtlTexture = nil;
+        } else {
+            return mtlTexture;
+        }
+    }
     if (img == nil) return nil;
     mtlTexture = CN1MetalTextureFromUIImage(img);
+    mtlTextureGeneration = CN1MetalTextureValidateGeneration();
+    // Track every GPU-backed image (not just mutable render targets) so the
+    // suspend backup can drop/rebuild its texture too (issue #5349). The weak
+    // registry drops the entry automatically on dealloc.
+    CN1MetalRegisterMutableImage(self);
     return mtlTexture;
+}
+
+-(void)dropReadOnlyCachedTexture {
+    // issue #5349: release the cached read-only texture; getMTLTexture rebuilds
+    // it from the retained UIImage on next use. Bumping the generation match is
+    // unnecessary -- a nil texture is unconditionally rebuilt.
+    [mtlTexture release];
+    mtlTexture = nil;
 }
 
 -(id<MTLTexture>)mtlMutableTexture { return mtlMutableTexture; }

--- a/Ports/iOSPort/nativeSources/METALView.m
+++ b/Ports/iOSPort/nativeSources/METALView.m
@@ -796,7 +796,16 @@ extern BOOL isRetinaBug();
 
 -(void)invalidateRetainedFramebuffer {
     retainedFramebufferInvalid = YES;
-    clearRetainedFramebufferOnNextFrame = NO;
+    // issue #5349: after a suspend/resume iOS may have discarded the contents
+    // of the private-storage screenTexture, so loading it (MTLLoadActionLoad)
+    // paints garbage/violet in any region the diff-painter does not repaint
+    // this frame (the Toolbar/title bar, unselected Tabs, a FAB shadow, ...).
+    // Previously the clear only happened once a repaint covered the whole
+    // screen -- but a partial animation repaint routinely lands first, loads
+    // the stale texture and pins the garbage until a touch dirties the region.
+    // Force the very next frame to clear unconditionally so no discarded pixels
+    // can survive; the full repaint triggered on foreground then fills content.
+    clearRetainedFramebufferOnNextFrame = YES;
     // A preserved resize frame is also stale after a suspend/resume cycle.
     needsResizePresent = NO;
 }


### PR DESCRIPTION
Fixes #5349 — rare violet/magenta fills and partially-drawn components (FAB shadow, Switch thumb, unselected Tabs, Toolbar) that appear on the Metal backend after bringing the app back to the foreground.

## Root cause
iOS discards the contents of `MTLStorageModePrivate` textures while the app is suspended (and can reclaim them under memory pressure). CN1 caches such textures per image and per glyph atlas, plus a persistent full-screen `screenTexture`. On resume it samples the discarded garbage on any surface the diff-painter does **not** fully repaint that frame — which renders as the violet fill / "not drawn until you touch it" the reporter described. This is legal-but-undefined Metal, so Apple's API validation never flagged it (the CI Metal-validation job stays green), and it only reproduces on a real device.

Extends the partial #5153 fix, which only protected *registered mutable images*; static/theme image textures, glyph atlases, and the `screenTexture` were left exposed.

## The fix (iOS Metal path only — no portable/core changes)
- **`screenTexture`** (`METALView.m`): `invalidateRetainedFramebuffer` now forces a full clear on the next frame instead of only clearing when the first post-foreground repaint happens to cover the whole screen (a partial animation repaint routinely landed first and pinned the stale contents).
- **Read-only image textures** (`GLUIImage` + `CN1Metalcompat`): a texture-validate **generation** counter, bumped on foreground and on memory warning, makes `getMTLTexture` re-decode its cached read-only texture from the retained `UIImage` the first time it is sampled in a newer generation. Every GPU-backed image (not just mutable render targets) is now registered so the suspend backup drops its texture, and glyph atlases are dropped too.
- **Mutable images**: existing #5153 readback-on-resign-active, unchanged.

A plain generation compare is the only recovery signal on the hot path. A per-draw purgeable-state probe (`setPurgeableState`) was tried and **dropped** — it trips Metal's commit-time `lockPurgeableObjects` validation on a texture already referenced by an in-flight command buffer (it crashed the first CI run in exactly that assertion).

## Verification
Reproduced deterministically with a texture fault-injector (injected via `DYLD_INSERT_LIBRARIES`, no framework changes) that fills every private-storage texture with magenta on suspend:

| | Toolbar on resume |
|---|---|
| pre-fix | 10–79% magenta |
| screenTexture clear only | still magenta |
| **full fix** | **0% (clean) across repeated runs incl. a max-corruption pass** |

The app also renders the full iOS Metal screenshot suite (143 tests) under Metal API + shader validation in **assert** mode with no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)