### PR TITLE
Enforce copyright headers and relicense JavaScript port

### DIFF
--- a/.github/workflows/check-copyright-headers.yml
+++ b/.github/workflows/check-copyright-headers.yml
@@ -1,0 +1,40 @@
+name: Check copyright headers
+
+# New source files must use Codename One's complete GPLv2 + Classpath
+# Exception header. Existing older source may retain Oracle's complete form.
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  check-copyright-headers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Validate added and modified source headers
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BASE_SHA: ${{ github.event.before }}
+        run: |
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            base_sha="$PR_BASE_SHA"
+          elif [[ -n "$PUSH_BASE_SHA" && "$PUSH_BASE_SHA" != "0000000000000000000000000000000000000000" ]]; then
+            base_sha="$PUSH_BASE_SHA"
+          else
+            base_sha="$(git rev-parse HEAD^)"
+          fi
+          scripts/check-copyright-headers.sh --base "$base_sha" --head "$GITHUB_SHA"

--- a/Ports/JavaScriptPort/LICENSE.md
+++ b/Ports/JavaScriptPort/LICENSE.md
@@ -1,6 +1,9 @@
-JavaScriptPort and its dedicated fixtures are licensed under the PolyForm Noncommercial License 1.0.0.
+JavaScriptPort and its dedicated fixtures are part of Codename One and are
+licensed under the repository's GNU General Public License version 2 with the
+Classpath Exception. See the root [`LICENSE`](../../LICENSE) file for the full
+license text.
 
-Official license text:
-[https://polyformproject.org/licenses/noncommercial/1.0.0/](https://polyformproject.org/licenses/noncommercial/1.0.0/)
-
-This license boundary applies to files inside `Ports/JavaScriptPort/**` unless a file states otherwise.
+Bundled third-party material retains its upstream copyright and license terms.
+Source files that must retain an upstream header are identified by exact path in
+[`scripts/copyright-header-exclusions.txt`](../../scripts/copyright-header-exclusions.txt)
+and retain their embedded notices.

--- a/Ports/JavaScriptPort/NOTICE.md
+++ b/Ports/JavaScriptPort/NOTICE.md
@@ -1,5 +1,9 @@
-<!-- Licensed under the PolyForm Noncommercial License 1.0.0 -->
+JavaScriptPort is licensed with the rest of Codename One under GPLv2 with the
+Classpath Exception. It is not a separate proprietary or noncommercial license
+boundary.
 
-This subtree is intentionally licensed separately from the parent Codename One repository.
-
-Files in `Ports/JavaScriptPort/**` are licensed under PolyForm Noncommercial 1.0.0 and must not inherit the parent repository's standard source-file license headers.
+The web runtime includes narrowly identified third-party assets. Their
+copyright and license notices remain in those files, and the source files that
+must retain upstream headers are listed individually in
+`scripts/copyright-header-exclusions.txt`. The list intentionally contains no
+directory or wildcard exclusions.

--- a/Ports/JavaScriptPort/README.md
+++ b/Ports/JavaScriptPort/README.md
@@ -1,14 +1,11 @@
-<!-- Licensed under the PolyForm Noncommercial License 1.0.0 -->
-
 JavaScriptPort is the browser-runtime work area for the new Codename One JavaScript port.
 
 Scope of this bootstrap:
-- imported HTML5/runtime code from the existing proprietary browser port as the behavioral/source baseline
-- PolyForm-licensed port boundary under `Ports/JavaScriptPort/**`
+- imported HTML5/runtime code from the former browser port as the behavioral/source baseline
+- GPLv2 + Classpath Exception licensing consistent with the rest of Codename One
 - ParparVM-oriented smoke fixtures under `Ports/JavaScriptPort/tests/**`
 - executable translator/runtime coverage through the local ParparVM test suite in `vm/tests`
 
 License boundary:
-- `Ports/JavaScriptPort/**` is licensed under PolyForm Noncommercial 1.0.0
-- dedicated smoke fixtures under `Ports/JavaScriptPort/tests/**` use the same license boundary
-- the rest of the repository remains under its existing licensing
+- first-party files under `Ports/JavaScriptPort/**` use Codename One's GPLv2 + Classpath Exception license
+- bundled third-party material retains its upstream terms; source-header exceptions are identified by exact path in `scripts/copyright-header-exclusions.txt`

--- a/Ports/JavaScriptPort/STATUS.md
+++ b/Ports/JavaScriptPort/STATUS.md
@@ -1,5 +1,3 @@
-<!-- Licensed under the PolyForm Noncommercial License 1.0.0 -->
-
 JavaScript Port Status (ParparVM)
 =================================
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/interop/AsyncCallback.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/interop/AsyncCallback.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.interop;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/interop/SuppressSyncErrors.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/interop/SuppressSyncErrors.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.interop;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/JSBody.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/JSBody.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/JSFunctor.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/JSFunctor.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/JSMethod.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/JSMethod.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/JSObject.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/JSObject.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/JSProperty.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/JSProperty.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/NativeJS.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/NativeJS.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/ajax/ReadyStateChangeHandler.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/ajax/ReadyStateChangeHandler.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.ajax;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/ajax/XMLHttpRequest.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/ajax/XMLHttpRequest.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.ajax;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/browser/AnimationFrameCallback.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/browser/AnimationFrameCallback.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.browser;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/browser/Document.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/browser/Document.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.browser;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/browser/History.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/browser/History.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.browser;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/browser/Location.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/browser/Location.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.browser;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/browser/TimerHandler.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/browser/TimerHandler.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.browser;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/browser/Window.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/browser/Window.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.browser;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/canvas/CanvasGradient.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/canvas/CanvasGradient.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.canvas;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/canvas/CanvasImageSource.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/canvas/CanvasImageSource.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.canvas;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/canvas/CanvasPattern.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/canvas/CanvasPattern.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.canvas;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/canvas/CanvasRenderingContext2D.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/canvas/CanvasRenderingContext2D.java
@@ -1,6 +1,24 @@
 /*
- * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
- * Licensed under the PolyForm Noncommercial License 1.0.0
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.canvas;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/canvas/ImageData.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/canvas/ImageData.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.canvas;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/canvas/TextMetrics.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/canvas/TextMetrics.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.canvas;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/core/JSArray.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/core/JSArray.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.core;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/core/JSBoolean.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/core/JSBoolean.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.core;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/core/JSFunction.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/core/JSFunction.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.core;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/core/JSNumber.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/core/JSNumber.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.core;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/core/JSRegExp.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/core/JSRegExp.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.core;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/core/JSString.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/core/JSString.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.core;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/CSSStyleDeclaration.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/CSSStyleDeclaration.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.dom;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/Document.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/Document.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.dom;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/Element.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/Element.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.dom;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/Event.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/Event.java
@@ -1,6 +1,24 @@
 /*
- * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
- * Licensed under the PolyForm Noncommercial License 1.0.0
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.dom;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/EventListener.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/EventListener.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.dom;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/HTMLButtonElement.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/HTMLButtonElement.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.dom;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/HTMLCanvasElement.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/HTMLCanvasElement.java
@@ -1,6 +1,24 @@
 /*
- * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
- * Licensed under the PolyForm Noncommercial License 1.0.0
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.dom;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/HTMLDocument.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/HTMLDocument.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.dom;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/HTMLElement.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/HTMLElement.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.dom;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/HTMLImageElement.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/HTMLImageElement.java
@@ -1,6 +1,24 @@
 /*
- * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
- * Licensed under the PolyForm Noncommercial License 1.0.0
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.dom;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/HTMLInputElement.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/HTMLInputElement.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.dom;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/HTMLLinkElement.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/HTMLLinkElement.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.dom;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/HTMLMediaElement.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/HTMLMediaElement.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.dom;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/HTMLOptionElement.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/HTMLOptionElement.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.dom;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/HTMLScriptElement.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/HTMLScriptElement.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.dom;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/HTMLTextAreaElement.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/HTMLTextAreaElement.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.dom;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/HTMLVideoElement.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/HTMLVideoElement.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.dom;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/MessageEvent.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/MessageEvent.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.dom;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/MouseEvent.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/MouseEvent.java
@@ -1,6 +1,24 @@
 /*
- * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
- * Licensed under the PolyForm Noncommercial License 1.0.0
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.dom;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/Node.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/Node.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.dom;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/NodeList.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/NodeList.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.dom;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/TextRectangle.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/dom/TextRectangle.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.dom;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/typedarrays/ArrayBuffer.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/typedarrays/ArrayBuffer.java
@@ -1,6 +1,24 @@
 /*
- * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
- * Licensed under the PolyForm Noncommercial License 1.0.0
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.typedarrays;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/typedarrays/ArrayBufferView.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/typedarrays/ArrayBufferView.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.typedarrays;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/typedarrays/Float32Array.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/typedarrays/Float32Array.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.typedarrays;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/typedarrays/Float64Array.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/typedarrays/Float64Array.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.typedarrays;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/typedarrays/Int16Array.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/typedarrays/Int16Array.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.typedarrays;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/typedarrays/Int32Array.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/typedarrays/Int32Array.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.typedarrays;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/typedarrays/Uint8Array.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/typedarrays/Uint8Array.java
@@ -1,6 +1,24 @@
 /*
- * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
- * Licensed under the PolyForm Noncommercial License 1.0.0
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.typedarrays;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/typedarrays/Uint8ClampedArray.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/typedarrays/Uint8ClampedArray.java
@@ -1,6 +1,24 @@
 /*
- * SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
- * Licensed under the PolyForm Noncommercial License 1.0.0
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.typedarrays;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/webgl/WebGLBuffer.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/webgl/WebGLBuffer.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.webgl;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/webgl/WebGLProgram.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/webgl/WebGLProgram.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.webgl;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/webgl/WebGLRenderingContext.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/webgl/WebGLRenderingContext.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.webgl;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/webgl/WebGLShader.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/webgl/WebGLShader.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.webgl;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/webgl/WebGLTexture.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/webgl/WebGLTexture.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.webgl;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/webgl/WebGLUniformLocation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/html5/js/webgl/WebGLUniformLocation.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.html5.js.webgl;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/ImplementationFactory.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/ImplementationFactory.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/BufferedGraphics.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/BufferedGraphics.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/FileChooser.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/FileChooser.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5BrowserComponent.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5BrowserComponent.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5BrowserWindow.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5BrowserWindow.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5CameraImpl.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5CameraImpl.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5GLSurface.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5GLSurface.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Graphics.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Graphics.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5GraphicsDevice.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5GraphicsDevice.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Keyboard.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Keyboard.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5LocationManager.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5LocationManager.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Media.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Media.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5MediaPool.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5MediaPool.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5MediaRecorder.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5MediaRecorder.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Peer.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Peer.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Push.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Push.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5VideoIO.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5VideoIO.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5WebSocketImpl.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5WebSocketImpl.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JSOImplementations.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JSOImplementations.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptAnimationFrameCallback.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptAnimationFrameCallback.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptAsyncImageLoadCoordinator.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptAsyncImageLoadCoordinator.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptBootstrapCoordinator.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptBootstrapCoordinator.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptBrowserInteractionCoordinator.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptBrowserInteractionCoordinator.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptBrowserLifecycleCoordinator.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptBrowserLifecycleCoordinator.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptCanvasImageBufferLifecycle.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptCanvasImageBufferLifecycle.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptCanvasLayout.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptCanvasLayout.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptDisplayMetrics.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptDisplayMetrics.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptEventWiring.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptEventWiring.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptExecutableOpFactory.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptExecutableOpFactory.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptImageDataAdapter.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptImageDataAdapter.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptImageTransformRenderAdapter.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptImageTransformRenderAdapter.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptInitializationAdapter.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptInitializationAdapter.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptInputCoordinator.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptInputCoordinator.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptKeyboardInteractionAdapter.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptKeyboardInteractionAdapter.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptNativeImageAdapter.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptNativeImageAdapter.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptNetworkAdapter.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptNetworkAdapter.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptPointerSessionState.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptPointerSessionState.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptPortBootstrap.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptPortBootstrap.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptPrimitiveRenderAdapter.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptPrimitiveRenderAdapter.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptRenderQueueCoordinator.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptRenderQueueCoordinator.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptRenderQueueState.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptRenderQueueState.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptRenderState.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptRenderState.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptRenderingBackend.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptRenderingBackend.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptRuntimeEnvironment.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptRuntimeEnvironment.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptRuntimeFacade.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptRuntimeFacade.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptShapeGradientRenderAdapter.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptShapeGradientRenderAdapter.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptShapePathAdapter.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptShapePathAdapter.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptStorageAdapter.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptStorageAdapter.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptTextMetricsAdapter.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptTextMetricsAdapter.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/MediaInputStream.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/MediaInputStream.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/NativePicker.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/NativePicker.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/NativePickerStrings.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/NativePickerStrings.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/NetworkConnection.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/NetworkConnection.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/ParparVMBootstrap.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/ParparVMBootstrap.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/Stub.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/Stub.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/URLProxifier.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/URLProxifier.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/WebAudioSoundPool.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/WebAudioSoundPool.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.html5;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/components/ContextMenu.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/components/ContextMenu.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.components;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/database/CursorImpl.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/database/CursorImpl.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.database;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/database/DatabaseImpl.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/database/DatabaseImpl.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.database;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/BlurRegion.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/BlurRegion.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.graphics;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/ClearRect.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/ClearRect.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.graphics;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/ClipRect.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/ClipRect.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.graphics;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/ClipShape.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/ClipShape.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.graphics;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/ClipState.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/ClipState.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.graphics;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/DrawArc.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/DrawArc.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.graphics;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/DrawCanvas.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/DrawCanvas.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.graphics;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/DrawImage.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/DrawImage.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.graphics;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/DrawLine.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/DrawLine.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.graphics;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/DrawPolygon.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/DrawPolygon.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.graphics;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/DrawRect.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/DrawRect.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.graphics;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/DrawRoundRect.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/DrawRoundRect.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.graphics;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/DrawShape.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/DrawShape.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.graphics;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/DrawString.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/DrawString.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.graphics;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/ExecutableOp.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/ExecutableOp.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.graphics;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/FillArc.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/FillArc.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.graphics;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/FillLinearGradient.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/FillLinearGradient.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.graphics;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/FillPolygon.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/FillPolygon.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.graphics;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/FillRadialGradient.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/FillRadialGradient.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.graphics;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/FillRect.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/FillRect.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.graphics;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/FillRectRadialGradient.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/FillRectRadialGradient.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.graphics;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/FillRoundRect.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/FillRoundRect.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.graphics;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/FillShape.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/FillShape.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.graphics;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/GraphicsUtils.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/GraphicsUtils.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.graphics;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/LensRegion.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/LensRegion.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.graphics;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/SetTransform.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/SetTransform.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.graphics;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/SurfaceCommandRecorder.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/SurfaceCommandRecorder.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.graphics;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/TileImage.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/TileImage.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.graphics;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/tools/CSSTool.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/tools/CSSTool.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.tools;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/tools/GAPILoader.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/tools/GAPILoader.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.tools;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/tools/ImageTool.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/tools/ImageTool.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.tools;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/tools/ScriptTool.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/tools/ScriptTool.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.tools;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/videojs/JSVideoCaptureConstraintsCompiler.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/videojs/JSVideoCaptureConstraintsCompiler.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.videojs;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/videojs/MediaTool.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/videojs/MediaTool.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.videojs;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/videojs/VideoJS.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/videojs/VideoJS.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.impl.html5.videojs;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/platform/js/JavaScriptPortHost.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/platform/js/JavaScriptPortHost.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.platform.js;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/platform/js/NativeInterfaceBridge.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/platform/js/NativeInterfaceBridge.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.platform.js;
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/ext/bootstrap/Popover.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/ext/bootstrap/Popover.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.teavm.ext.bootstrap;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/ext/jquery/JQuery.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/ext/jquery/JQuery.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.teavm.ext.jquery;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/ext/localforage/LocalForage.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/ext/localforage/LocalForage.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.teavm.ext.localforage;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/ext/usermedia/FileChooser.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/ext/usermedia/FileChooser.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.teavm.ext.usermedia;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/ext/usermedia/PhotoCapture.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/ext/usermedia/PhotoCapture.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.teavm.ext.usermedia;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/ext/websql/WebSQL.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/ext/websql/WebSQL.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.teavm.ext.websql;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/geom/JSAffineTransform.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/geom/JSAffineTransform.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.teavm.geom;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/geom/JSMatrix4.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/geom/JSMatrix4.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.teavm.geom;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/io/ArrayBufferInputStream.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/io/ArrayBufferInputStream.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.teavm.io;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/io/BlobUtil.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/io/BlobUtil.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.teavm.io;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/jso/io/Blob.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/jso/io/Blob.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.teavm.jso.io;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/jso/io/FileList.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/jso/io/FileList.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.teavm.jso.io;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/jso/io/FileReader.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/jso/io/FileReader.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.teavm.jso.io;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/jso/util/EventUtil.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/jso/util/EventUtil.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.teavm.jso.util;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/jso/util/JS.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/jso/util/JS.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.teavm.jso.util;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/jso/util/JSDateFormat.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/jso/util/JSDateFormat.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.teavm.jso.util;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/jso/util/JSList.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/jso/util/JSList.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.teavm.jso.util;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/jso/util/JSNumberFormat.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/jso/util/JSNumberFormat.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.teavm.jso.util;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/jso/util/JSType.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/teavm/jso/util/JSType.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.teavm.jso.util;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/ui/Accessor.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/ui/Accessor.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.ui;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/ui/HeavyButtonImpl.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/ui/HeavyButtonImpl.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.ui;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/ui/spinner/SpinnerAccessor.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/ui/spinner/SpinnerAccessor.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 package com.codename1.ui.spinner;

--- a/Ports/JavaScriptPort/src/main/webapp/js/localforage-shim.js
+++ b/Ports/JavaScriptPort/src/main/webapp/js/localforage-shim.js
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 // Minimal localforage shim for the ParparVM JavaScript port.
 //
 // The Java-side ``com.codename1.teavm.ext.localforage.LocalForage`` class

--- a/Ports/JavaScriptPort/src/main/webapp/js/pwa.js
+++ b/Ports/JavaScriptPort/src/main/webapp/js/pwa.js
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 UpUp.start({
     'content-url': 'offline.html',
     'assets': [

--- a/Ports/JavaScriptPort/src/main/webapp/js/videojs/browser-workarounds.js
+++ b/Ports/JavaScriptPort/src/main/webapp/js/videojs/browser-workarounds.js
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 /* workaround browser issues */
 
 var isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);

--- a/Ports/JavaScriptPort/src/main/webapp/port.js
+++ b/Ports/JavaScriptPort/src/main/webapp/port.js
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 /**
  * JavaScriptPort - Native bindings for JSO interfaces
  * This file contains native implementations for the com.codename1.html5.js.* interfaces

--- a/Ports/JavaScriptPort/src/main/webapp/style.css
+++ b/Ports/JavaScriptPort/src/main/webapp/style.css
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 html, body {
     margin: 0;
     padding: 0;

--- a/Ports/JavaScriptPort/tests/LICENSE.md
+++ b/Ports/JavaScriptPort/tests/LICENSE.md
@@ -1,4 +1,3 @@
-JavaScriptPort dedicated test fixtures are licensed under the PolyForm Noncommercial License 1.0.0.
-
-Official license text:
-[https://polyformproject.org/licenses/noncommercial/1.0.0/](https://polyformproject.org/licenses/noncommercial/1.0.0/)
+JavaScriptPort dedicated test fixtures are licensed under the Codename One
+repository's GNU General Public License version 2 with the Classpath Exception.
+See the root [`LICENSE`](../../../LICENSE) file for the full license text.

--- a/Ports/JavaScriptPort/tests/README.md
+++ b/Ports/JavaScriptPort/tests/README.md
@@ -1,5 +1,3 @@
-<!-- Licensed under the PolyForm Noncommercial License 1.0.0 -->
-
 These fixtures define the smoke-test host contract for the in-repo ParparVM JavaScript port work.
 
 They are not built through TeaVM. They are compiled and translated by the local ParparVM JavaScript backend in `vm/ByteCodeTranslator`, and exercised by integration tests in `vm/tests`.

--- a/Ports/JavaScriptPort/tests/fixtures/JavaScriptPortSmokeApp.java
+++ b/Ports/JavaScriptPort/tests/fixtures/JavaScriptPortSmokeApp.java
@@ -1,8 +1,24 @@
 /*
- * Copyright (c) 2026 Codename One and contributors.
- * Licensed under the PolyForm Noncommercial License 1.0.0.
- * You may use this file only in compliance with that license.
- * The license notice for this subtree is available in Ports/JavaScriptPort/LICENSE.md.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 import com.codename1.impl.platform.js.JavaScriptPortHost;
 

--- a/scripts/check-copyright-headers.sh
+++ b/scripts/check-copyright-headers.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+#
+# Validate GPLv2 + Classpath Exception headers on added or modified source
+# files.  Existing source may retain the historical Oracle header; newly
+# added source must use the Codename One header.
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)"
+EXCLUSIONS_FILE="$SCRIPT_DIR/copyright-header-exclusions.txt"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/check-copyright-headers.sh
+  scripts/check-copyright-headers.sh --base REV [--head REV]
+  scripts/check-copyright-headers.sh --all [PATH ...]
+  scripts/check-copyright-headers.sh PATH [PATH ...]
+
+With no arguments, checks added and modified working-tree files.  --base is
+intended for CI.  --all checks tracked source files, optionally below the
+given paths.
+EOF
+}
+
+is_source_file() {
+  case "$1" in
+    *.java|*.js|*.jsx|*.ts|*.tsx|*.css|*.c|*.cc|*.cpp|*.cxx|*.h|*.hh|*.hpp|*.hxx|*.m|*.mm|*.metal|*.kt|*.kts|*.swift|*.cs) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_excluded() {
+  local candidate="$1"
+  awk -F '\\|' -v candidate="$candidate" '
+    /^[[:space:]]*(#|$)/ { next }
+    {
+      path = $1
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", path)
+      if (path == candidate) found = 1
+    }
+    END { exit(found ? 0 : 1) }
+  ' "$EXCLUSIONS_FILE"
+}
+
+validate_exclusions() {
+  local failed=0
+  local seen_file="$1"
+  : > "$seen_file"
+
+  while IFS='|' read -r raw_path raw_reason; do
+    local path reason
+    path="$(printf '%s' "$raw_path" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    reason="$(printf '%s' "${raw_reason:-}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    case "$path" in
+      ''|'#'*) continue ;;
+    esac
+
+    if [[ -z "$reason" ]]; then
+      echo "check-copyright-headers: exclusion lacks a rationale: $path" >&2
+      failed=1
+    fi
+    if [[ "$path" = /* || "$path" == *'*'* || "$path" == *'?'* || "$path" == */ ]]; then
+      echo "check-copyright-headers: exclusions must be exact repository-relative files: $path" >&2
+      failed=1
+    fi
+    if grep -Fqx "$path" "$seen_file"; then
+      echo "check-copyright-headers: duplicate exclusion: $path" >&2
+      failed=1
+    else
+      printf '%s\n' "$path" >> "$seen_file"
+    fi
+    if [[ ! -f "$REPO_ROOT/$path" ]]; then
+      echo "check-copyright-headers: excluded file does not exist: $path" >&2
+      failed=1
+    elif ! is_source_file "$path"; then
+      echo "check-copyright-headers: exclusion is not a checked source type: $path" >&2
+      failed=1
+    fi
+  done < "$EXCLUSIONS_FILE"
+
+  return "$failed"
+}
+
+header_kind() {
+  local file="$1"
+  local header_file="$2"
+  sed -n '1,40p' "$file" > "$header_file"
+
+  if [[ "$(awk 'NF { print; exit }' "$header_file")" != '/*' ]]; then
+    return 1
+  fi
+
+  grep -Fq 'DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.' "$header_file" || return 1
+  grep -Fq 'This code is free software; you can redistribute it and/or modify it' "$header_file" || return 1
+  grep -Fq 'GNU General Public License version 2 only' "$header_file" || return 1
+  grep -Fq 'particular file as subject to the "Classpath" exception' "$header_file" || return 1
+  grep -Fq 'but WITHOUT' "$header_file" || return 1
+  grep -Fq 'ANY WARRANTY' "$header_file" || return 1
+
+  if grep -Eq '^ \* Copyright \(c\) [0-9]{4}([,-][[:space:]]*[0-9]{4})*, Codename One and/or its affiliates\. All rights reserved\.$' "$header_file" \
+      && grep -Fq 'Codename One designates this' "$header_file" \
+      && grep -Fq 'Please contact Codename One ' "$header_file"; then
+    printf '%s\n' codename-one
+    return 0
+  fi
+
+  if grep -Eq '^ \* Copyright \(c\) [0-9]{4}([,-][[:space:]]*[0-9]{4})*, Oracle and/or its affiliates\. All rights reserved\.$' "$header_file" \
+      && grep -Fq 'Oracle designates this' "$header_file" \
+      && grep -Fq 'Please contact Oracle' "$header_file"; then
+    printf '%s\n' oracle
+    return 0
+  fi
+
+  return 1
+}
+
+MODE=working
+BASE=''
+HEAD=HEAD
+PATHS_FILE="$(mktemp -t cn1-copyright-paths.XXXXXX)"
+NEW_FILES="$(mktemp -t cn1-copyright-new.XXXXXX)"
+SEEN_EXCLUSIONS="$(mktemp -t cn1-copyright-exclusions.XXXXXX)"
+HEADER_FILE="$(mktemp -t cn1-copyright-header.XXXXXX)"
+BASE_FILE="$(mktemp -t cn1-copyright-base.XXXXXX)"
+BASE_HEADER_FILE="$(mktemp -t cn1-copyright-base-header.XXXXXX)"
+trap 'rm -f "$PATHS_FILE" "$NEW_FILES" "$SEEN_EXCLUSIONS" "$HEADER_FILE" "$BASE_FILE" "$BASE_HEADER_FILE"' EXIT
+: > "$PATHS_FILE"
+: > "$NEW_FILES"
+REFERENCE=''
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)
+      [[ $# -ge 2 ]] || { usage >&2; exit 2; }
+      MODE=base
+      BASE="$2"
+      shift 2
+      ;;
+    --head)
+      [[ $# -ge 2 ]] || { usage >&2; exit 2; }
+      HEAD="$2"
+      shift 2
+      ;;
+    --all)
+      MODE=all
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      while [[ $# -gt 0 ]]; do POSITIONAL+=("$1"); shift; done
+      ;;
+    -*)
+      echo "check-copyright-headers: unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      POSITIONAL+=("$1")
+      shift
+      ;;
+  esac
+done
+
+cd "$REPO_ROOT"
+
+if [[ ! -f "$EXCLUSIONS_FILE" ]]; then
+  echo "check-copyright-headers: exclusions file not found: $EXCLUSIONS_FILE" >&2
+  exit 2
+fi
+if ! validate_exclusions "$SEEN_EXCLUSIONS"; then
+  exit 2
+fi
+
+case "$MODE" in
+  base)
+    if [[ -z "$BASE" ]] || ! git cat-file -e "$BASE^{commit}" 2>/dev/null; then
+      echo "check-copyright-headers: base revision not found: $BASE" >&2
+      exit 2
+    fi
+    if ! git cat-file -e "$HEAD^{commit}" 2>/dev/null; then
+      echo "check-copyright-headers: head revision not found: $HEAD" >&2
+      exit 2
+    fi
+    git diff --name-only --diff-filter=AMR "$BASE" "$HEAD" -- > "$PATHS_FILE"
+    git diff --name-only --diff-filter=A "$BASE" "$HEAD" -- > "$NEW_FILES"
+    REFERENCE="$BASE"
+    ;;
+  all)
+    if [[ ${#POSITIONAL[@]} -eq 0 ]]; then
+      git ls-files > "$PATHS_FILE"
+    else
+      for path in "${POSITIONAL[@]}"; do
+        if [[ -f "$path" ]]; then
+          printf '%s\n' "${path#./}" >> "$PATHS_FILE"
+        else
+          git ls-files -- "${path#./}" >> "$PATHS_FILE"
+        fi
+      done
+    fi
+    ;;
+  working)
+    if [[ ${#POSITIONAL[@]} -gt 0 ]]; then
+      for path in "${POSITIONAL[@]}"; do
+        if [[ -f "$path" ]]; then
+          printf '%s\n' "${path#./}" >> "$PATHS_FILE"
+        else
+          git ls-files -- "${path#./}" >> "$PATHS_FILE"
+        fi
+      done
+    else
+      git diff --name-only --diff-filter=AMR HEAD -- > "$PATHS_FILE"
+      git ls-files --others --exclude-standard >> "$PATHS_FILE"
+      git ls-files --others --exclude-standard > "$NEW_FILES"
+      REFERENCE=HEAD
+    fi
+    ;;
+esac
+
+sort -u "$PATHS_FILE" -o "$PATHS_FILE"
+sort -u "$NEW_FILES" -o "$NEW_FILES"
+
+checked=0
+excluded=0
+failed=0
+while IFS= read -r path; do
+  path="${path#./}"
+  [[ -n "$path" && -f "$path" ]] || continue
+  is_source_file "$path" || continue
+
+  if is_excluded "$path"; then
+    excluded=$((excluded + 1))
+    continue
+  fi
+
+  checked=$((checked + 1))
+  kind=''
+  if kind="$(header_kind "$path" "$HEADER_FILE")"; then
+    if grep -Fqx "$path" "$NEW_FILES" && [[ "$kind" != codename-one ]]; then
+      echo "$path: newly added source files must use the Codename One GPLv2 + Classpath Exception header" >&2
+      failed=$((failed + 1))
+    elif [[ "$kind" == oracle && -n "$REFERENCE" ]]; then
+      base_kind=''
+      if ! git show "$REFERENCE:$path" > "$BASE_FILE" 2>/dev/null \
+          || ! base_kind="$(header_kind "$BASE_FILE" "$BASE_HEADER_FILE")" \
+          || [[ "$base_kind" != oracle ]]; then
+        echo "$path: the Oracle header is only allowed when the base version already used it" >&2
+        echo "  Use the complete Codename One GPLv2 + Classpath Exception header for other source." >&2
+        failed=$((failed + 1))
+      fi
+    fi
+  else
+    echo "$path: missing or unsupported copyright header" >&2
+    echo "  Use the complete Codename One GPLv2 + Classpath Exception header." >&2
+    echo "  Existing older files may retain the complete Oracle GPLv2 + Classpath Exception header." >&2
+    failed=$((failed + 1))
+  fi
+done < "$PATHS_FILE"
+
+if [[ "$failed" -ne 0 ]]; then
+  echo "check-copyright-headers: $failed file(s) failed; $checked checked, $excluded explicitly excluded." >&2
+  exit 1
+fi
+
+echo "check-copyright-headers: $checked file(s) passed; $excluded explicitly excluded."

--- a/scripts/copyright-header-exclusions.txt
+++ b/scripts/copyright-header-exclusions.txt
@@ -1,0 +1,20 @@
+# Exact third-party source files excluded from the Codename One/Oracle header
+# check.  Wildcards and directories are deliberately rejected by the validator.
+# Format: repository-relative path | provenance/license rationale
+
+Ports/JavaScriptPort/src/main/webapp/css/bootstrap-theme.min.css | Bootstrap 3.3.4, Copyright Twitter, MIT license
+Ports/JavaScriptPort/src/main/webapp/css/bootstrap.min.css | Bootstrap 3.3.4 and normalize.css 3.0.2, MIT licenses
+Ports/JavaScriptPort/src/main/webapp/js/bootstrap.min.js | Bootstrap 3.3.4, Copyright Twitter, MIT license
+Ports/JavaScriptPort/src/main/webapp/js/fontmetrics.js | Bundles Web Font Loader and other Apache-2.0/MIT third-party font utilities
+Ports/JavaScriptPort/src/main/webapp/js/jquery.min.js | jQuery 2.1.3, Copyright jQuery Foundation, MIT license
+Ports/JavaScriptPort/src/main/webapp/js/manup.js | ManUp.js web-app-manifest polyfill, Apache-2.0 license
+Ports/JavaScriptPort/src/main/webapp/js/push.js | Contains js-base64 2.1.9 third-party code alongside the port push adapter
+Ports/JavaScriptPort/src/main/webapp/js/samplerate.min.js | Emscripten-generated third-party sample-rate conversion library
+Ports/JavaScriptPort/src/main/webapp/js/upup.min.js | UpUp 1.0.0, Copyright Tal Ater, MIT license
+Ports/JavaScriptPort/src/main/webapp/js/videojs/RecordRTC.min.js | RecordRTC 5.5.3 and bundled dependencies, MIT and other upstream licenses
+Ports/JavaScriptPort/src/main/webapp/js/videojs/adapter.js | WebRTC adapter.js, BSD-style license
+Ports/JavaScriptPort/src/main/webapp/js/videojs/video-js.min.css | Minified Video.js third-party stylesheet
+Ports/JavaScriptPort/src/main/webapp/js/videojs/video.min.js | Video.js 7.4.1 and vtt.js, Apache-2.0 licenses
+Ports/JavaScriptPort/src/main/webapp/js/videojs/videojs.record.min.css | videojs-record 3.5.0 third-party stylesheet
+Ports/JavaScriptPort/src/main/webapp/js/videojs/videojs.record.min.js | videojs-record 3.5.0 third-party bundle
+Ports/JavaScriptPort/src/main/webapp/sw.js | Codename One service-worker adapter containing the UpUp 1.0.0 MIT-licensed service worker

--- a/vm/tests/src/test/java/com/codename1/tools/translator/JavaScriptPortSmokeIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/JavaScriptPortSmokeIntegrationTest.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.tools.translator;
 
 import org.junit.jupiter.params.ParameterizedTest;
@@ -56,7 +78,7 @@ class JavaScriptPortSmokeIntegrationTest {
     }
 
     @org.junit.jupiter.api.Test
-    void javascriptPortBoundaryUsesPolyformHeaders() throws Exception {
+    void javascriptPortUsesCodenameOneGplClasspathHeaders() throws Exception {
         try (Stream<Path> paths = Files.walk(LICENSE_ROOT)) {
             paths.filter(Files::isRegularFile)
                     .filter(path -> path.toString().endsWith(".java") || path.toString().endsWith(".md"))
@@ -64,12 +86,16 @@ class JavaScriptPortSmokeIntegrationTest {
                         try {
                             String text = new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
                             if (path.toString().endsWith(".java")) {
-                                assertTrue(text.contains("PolyForm Noncommercial License 1.0.0"),
-                                        "Missing PolyForm header in " + path);
+                                assertTrue(text.contains("Codename One and/or its affiliates. All rights reserved."),
+                                        "Missing Codename One copyright in " + path);
+                                assertTrue(text.contains("GNU General Public License version 2 only"),
+                                        "Missing GPLv2 header in " + path);
+                                assertTrue(text.contains("\"Classpath\" exception"),
+                                        "Missing Classpath Exception header in " + path);
+                                assertTrue(text.contains("DO NOT ALTER OR REMOVE COPYRIGHT NOTICES"),
+                                        "Missing complete Codename One header in " + path);
                             }
-                            assertFalse(text.contains("Classpath exception"), "Inherited parent license header found in " + path);
-                            assertFalse(text.contains("GNU General Public License"), "Inherited GPL text found in " + path);
-                            assertFalse(text.contains("DO NOT ALTER OR REMOVE COPYRIGHT NOTICES"), "Inherited Oracle/CN1 header found in " + path);
+                            assertFalse(text.contains("PolyForm"), "Obsolete PolyForm license found in " + path);
                         } catch (Exception ex) {
                             throw new RuntimeException(ex);
                         }


### PR DESCRIPTION
## Summary

- add a changed-source CI gate that accepts only complete Codename One GPLv2 + Classpath Exception headers or inherited Oracle GPLv2 + Classpath Exception headers
- migrate the JavaScript port and its fixtures from the PolyForm Noncommercial license to the Codename One GPLv2 + Classpath Exception license
- retain 16 exact, documented third-party source exceptions without directory or wildcard exclusions
- add regression coverage for the JavaScript port license boundary

## Why

Incomplete three-line copyright notices omit the actual GPLv2 + Classpath Exception grant, while the JavaScript port declared a proprietary/noncommercial license boundary inconsistent with the rest of the project.

## Validation

- `scripts/check-copyright-headers.sh --base origin/master --head HEAD`
- `scripts/check-copyright-headers.sh --all Ports/JavaScriptPort`
- Java 8 Maven test: `JavaScriptPortSmokeIntegrationTest#javascriptPortUsesCodenameOneGplClasspathHeaders`
- `git diff --check origin/master...HEAD`

A full JavaScript bundle rebuild was also attempted, but is blocked before the changed files compile by existing unrelated failures in `vm/JavaAPI` (`HashMap.valuesCollection`) and stale accessibility artifacts.