### PR TITLE
Fail fast on stale application classes before build-server upload

### DIFF
--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/CN1BuildMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/CN1BuildMojo.java
@@ -184,6 +184,91 @@ public class CN1BuildMojo extends AbstractCN1Mojo {
         task.execute();
     }
 
+    /**
+     * Fails the build when the staged jar-with-dependencies contains an
+     * application class that references another application class which is not
+     * in the jar. Stale build output causes exactly this -- e.g. an IDE deletes
+     * the class files of removed/renamed sources while a dependent class
+     * compiled against them survives in target/classes, and an incremental
+     * Maven compile then ships it. The server-side VM translators only warn
+     * about the dangling reference and the build later fails with an obscure
+     * native compiler error (a missing generated header on iOS), so catch it
+     * here with an actionable message before uploading anything.
+     */
+    private void verifyApplicationClassClosure(File jarWithDependencies, List<String> cpElements) throws MojoFailureException {
+        if ("true".equals(System.getProperty("codename1.skipClassClosureCheck", "false"))
+                || "true".equals(project.getProperties().getProperty("codename1.skipClassClosureCheck", "false"))) {
+            getLog().info("Skipping application class closure check because codename1.skipClassClosureCheck=true");
+            return;
+        }
+        // The project package space: compiled output directories plus module
+        // jars owned by this build (the app's common jar reaches the platform
+        // modules as a jar dependency, identified by the shared groupId).
+        List<File> projectClassRoots = new ArrayList<File>();
+        for (String element : cpElements) {
+            File dir = new File(element);
+            if (dir.isDirectory()) {
+                projectClassRoots.add(dir);
+            }
+        }
+        for (Artifact artifact : project.getArtifacts()) {
+            if (project.getGroupId().equals(artifact.getGroupId())) {
+                File jar = getJar(artifact);
+                if (jar != null && jar.isFile()) {
+                    projectClassRoots.add(jar);
+                }
+            }
+        }
+        // Classes stripped from the upload that the build server re-supplies:
+        // references into them are not missing.
+        List<File> providedJars = new ArrayList<File>();
+        for (Artifact artifact : project.getArtifacts()) {
+            boolean providedByServer = GROUP_ID.equals(artifact.getGroupId())
+                    && contains(artifact.getArtifactId(), BUNDLE_ARTIFACT_ID_BLACKLIST);
+            providedByServer = providedByServer || ("org.jetbrains.kotlin".equals(artifact.getGroupId())
+                    && "kotlin-stdlib".equals(artifact.getArtifactId()));
+            if (providedByServer) {
+                File jar = getJar(artifact);
+                if (jar != null && jar.isFile()) {
+                    providedJars.add(jar);
+                }
+            }
+        }
+        Map<String, Set<String>> missing;
+        try {
+            missing = ClassClosureVerifier.findMissingProjectReferences(jarWithDependencies, projectClassRoots, providedJars);
+        } catch (IOException ex) {
+            getLog().warn("Could not verify the consistency of the application classes: " + ex.getMessage());
+            return;
+        }
+        if (missing.isEmpty()) {
+            return;
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append("The compiled application classes are inconsistent. The following class");
+        sb.append(missing.size() == 1 ? " is" : "es are");
+        sb.append(" referenced by your code but missing from the build:\n");
+        for (Map.Entry<String, Set<String>> e : missing.entrySet()) {
+            sb.append(" - ").append(e.getKey().replace('/', '.'))
+                    .append(" (referenced from ");
+            boolean first = true;
+            for (String referencing : e.getValue()) {
+                if (!first) {
+                    sb.append(", ");
+                }
+                first = false;
+                sb.append(referencing.replace('/', '.'));
+            }
+            sb.append(")\n");
+        }
+        sb.append("This usually means the build output contains stale classes from a previous build,\n");
+        sb.append("e.g. after renaming, moving or deleting a class, or switching branches, without a\n");
+        sb.append("clean rebuild. Run 'mvn clean' and rebuild. If a listed class was removed\n");
+        sb.append("intentionally, also remove or update the code that still references it.\n");
+        sb.append("To bypass this check build with -Dcodename1.skipClassClosureCheck=true");
+        throw new MojoFailureException(sb.toString());
+    }
+
 
     /**
      * Localized launcher icons (cn1_icon_&lt;lang&gt;[_&lt;country&gt;].png) are scaled up to the
@@ -594,6 +679,8 @@ public class CN1BuildMojo extends AbstractCN1Mojo {
             mergeJars(jarWithDependencies, jarsToMerge.toArray(new File[jarsToMerge.size()]));
 
         }
+
+        verifyApplicationClassClosure(jarWithDependencies, cpElements);
 
         try {
             updateCodenameOne(false);

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/CN1BuildMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/CN1BuildMojo.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2021, 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.maven;
 
 import com.codename1.ant.AntExecutor;

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/ClassClosureVerifier.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/ClassClosureVerifier.java
@@ -1,0 +1,327 @@
+package com.codename1.maven;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.Handle;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+/**
+ * Verifies that the application classes staged for a build-server submission are
+ * self-consistent: every class in the application's own package space that is
+ * referenced from another application class must actually be present in the
+ * staged jar (or in an artifact the build server provides, such as
+ * codenameone-core / java-runtime / kotlin-stdlib).
+ *
+ * Stale build output produces exactly this inconsistency -- e.g. an IDE deletes
+ * the class files of removed sources but a dependent class compiled against them
+ * survives in target/classes, and an incremental Maven compile then ships it.
+ * The server-side VM translators only log a warning for the dangling reference
+ * and the build later dies with an obscure native compiler error (a missing
+ * generated header on iOS), so this check exists to fail fast with a clear
+ * message before anything is uploaded.
+ *
+ * The check is deliberately scoped to the project's own packages (the packages
+ * that contain classes in the project's output directories). Third-party
+ * libraries routinely reference optional dependencies that are legitimately
+ * absent; those references are outside the project package space and are
+ * ignored here, matching the translators' tolerance for them.
+ */
+final class ClassClosureVerifier {
+
+    private ClassClosureVerifier() {
+    }
+
+    /**
+     * Scans the staged jar and returns the dangling project-package references.
+     *
+     * @param stagedJar the merged jar-with-dependencies that will be uploaded
+     * @param projectClassRoots the project's own compiled classes -- output
+     *                          directories and/or module jars (e.g. the app's
+     *                          common jar); their contents define the project
+     *                          package space
+     * @param providedJars jars stripped from the upload that the build server
+     *                     re-supplies; classes found in them are not missing
+     * @return map of missing class internal name to the internal names of the
+     *         classes that reference it, empty when the closure is consistent
+     */
+    static Map<String, Set<String>> findMissingProjectReferences(File stagedJar, List<File> projectClassRoots, List<File> providedJars) throws IOException {
+        Set<String> projectPackages = new HashSet<String>();
+        for (File root : projectClassRoots) {
+            if (root.isDirectory()) {
+                collectPackages(root, "", projectPackages);
+            } else if (root.isFile()) {
+                Set<String> classNames = new HashSet<String>();
+                collectClassEntryNames(root, classNames);
+                for (String className : classNames) {
+                    projectPackages.add(packageOf(className));
+                }
+            }
+        }
+        if (projectPackages.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        Set<String> containedClasses = new HashSet<String>();
+        Map<String, Set<String>> referencingClassesByReference = new HashMap<String, Set<String>>();
+        InputStream in = new BufferedInputStream(new FileInputStream(stagedJar));
+        try {
+            ZipInputStream zip = new ZipInputStream(in);
+            ZipEntry entry;
+            while ((entry = zip.getNextEntry()) != null) {
+                if (entry.isDirectory() || !isRelevantClassEntry(entry.getName())) {
+                    continue;
+                }
+                String internalName = entry.getName().substring(0, entry.getName().length() - ".class".length());
+                containedClasses.add(internalName);
+                if (projectPackages.contains(packageOf(internalName))) {
+                    collectReferences(internalName, readAllBytes(zip), referencingClassesByReference);
+                }
+            }
+        } finally {
+            in.close();
+        }
+
+        Set<String> providedClasses = new HashSet<String>();
+        for (File jar : providedJars) {
+            collectClassEntryNames(jar, providedClasses);
+        }
+
+        Map<String, Set<String>> missing = new TreeMap<String, Set<String>>();
+        for (Map.Entry<String, Set<String>> e : referencingClassesByReference.entrySet()) {
+            String referenced = e.getKey();
+            if (containedClasses.contains(referenced) || providedClasses.contains(referenced)) {
+                continue;
+            }
+            if (!projectPackages.contains(packageOf(referenced))) {
+                continue;
+            }
+            missing.put(referenced, new TreeSet<String>(e.getValue()));
+        }
+        return missing;
+    }
+
+    private static boolean isRelevantClassEntry(String entryName) {
+        if (!entryName.endsWith(".class")) {
+            return false;
+        }
+        if (entryName.startsWith("META-INF/")) {
+            return false;
+        }
+        return !entryName.endsWith("module-info.class");
+    }
+
+    private static String packageOf(String internalName) {
+        int slash = internalName.lastIndexOf('/');
+        return slash < 0 ? "" : internalName.substring(0, slash);
+    }
+
+    private static void collectPackages(File dir, String packagePath, Set<String> out) {
+        File[] children = dir.listFiles();
+        if (children == null) {
+            return;
+        }
+        for (File child : children) {
+            if (child.isDirectory()) {
+                collectPackages(child, packagePath.isEmpty() ? child.getName() : packagePath + "/" + child.getName(), out);
+            } else if (child.getName().endsWith(".class")) {
+                out.add(packagePath);
+            }
+        }
+    }
+
+    private static void collectClassEntryNames(File jar, Set<String> out) throws IOException {
+        if (jar == null || !jar.isFile()) {
+            return;
+        }
+        InputStream in = new BufferedInputStream(new FileInputStream(jar));
+        try {
+            ZipInputStream zip = new ZipInputStream(in);
+            ZipEntry entry;
+            while ((entry = zip.getNextEntry()) != null) {
+                if (!entry.isDirectory() && isRelevantClassEntry(entry.getName())) {
+                    out.add(entry.getName().substring(0, entry.getName().length() - ".class".length()));
+                }
+            }
+        } finally {
+            in.close();
+        }
+    }
+
+    private static byte[] readAllBytes(InputStream input) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        byte[] buffer = new byte[8192];
+        int len;
+        while ((len = input.read(buffer)) != -1) {
+            out.write(buffer, 0, len);
+        }
+        return out.toByteArray();
+    }
+
+    /**
+     * Collects the classes referenced from the given class's supertypes, member
+     * descriptors and method bodies -- the references the VM translators render
+     * and therefore the ones whose absence breaks a build. Metadata-only
+     * references (annotations, generic signatures, the InnerClasses attribute)
+     * are deliberately not collected: the translators tolerate their absence.
+     */
+    private static void collectReferences(final String sourceClass, byte[] classBytes, final Map<String, Set<String>> out) {
+        final ReferenceSink sink = new ReferenceSink(sourceClass, out);
+        ClassReader reader = new ClassReader(classBytes);
+        reader.accept(new ClassVisitor(Opcodes.ASM9) {
+            @Override
+            public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+                sink.addInternalName(superName);
+                if (interfaces != null) {
+                    for (String iface : interfaces) {
+                        sink.addInternalName(iface);
+                    }
+                }
+            }
+
+            @Override
+            public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
+                sink.addType(Type.getType(descriptor));
+                return null;
+            }
+
+            @Override
+            public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+                sink.addMethodDescriptor(descriptor);
+                if (exceptions != null) {
+                    for (String exception : exceptions) {
+                        sink.addInternalName(exception);
+                    }
+                }
+                return new MethodVisitor(Opcodes.ASM9) {
+                    @Override
+                    public void visitTypeInsn(int opcode, String type) {
+                        sink.addInternalName(type);
+                    }
+
+                    @Override
+                    public void visitMethodInsn(int opcode, String owner, String methodName, String methodDescriptor, boolean isInterface) {
+                        sink.addInternalName(owner);
+                        sink.addMethodDescriptor(methodDescriptor);
+                    }
+
+                    @Override
+                    public void visitFieldInsn(int opcode, String owner, String fieldName, String fieldDescriptor) {
+                        sink.addInternalName(owner);
+                        sink.addType(Type.getType(fieldDescriptor));
+                    }
+
+                    @Override
+                    public void visitLdcInsn(Object value) {
+                        if (value instanceof Type) {
+                            sink.addType((Type) value);
+                        } else if (value instanceof Handle) {
+                            sink.addHandle((Handle) value);
+                        }
+                    }
+
+                    @Override
+                    public void visitInvokeDynamicInsn(String indyName, String indyDescriptor, Handle bootstrapMethodHandle, Object... bootstrapMethodArguments) {
+                        sink.addMethodDescriptor(indyDescriptor);
+                        sink.addHandle(bootstrapMethodHandle);
+                        for (Object argument : bootstrapMethodArguments) {
+                            if (argument instanceof Type) {
+                                sink.addType((Type) argument);
+                            } else if (argument instanceof Handle) {
+                                sink.addHandle((Handle) argument);
+                            }
+                        }
+                    }
+
+                    @Override
+                    public void visitMultiANewArrayInsn(String arrayDescriptor, int numDimensions) {
+                        sink.addType(Type.getType(arrayDescriptor));
+                    }
+
+                    @Override
+                    public void visitTryCatchBlock(org.objectweb.asm.Label start, org.objectweb.asm.Label end, org.objectweb.asm.Label handler, String type) {
+                        sink.addInternalName(type);
+                    }
+                };
+            }
+        }, ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
+    }
+
+    private static final class ReferenceSink {
+        private final String sourceClass;
+        private final Map<String, Set<String>> out;
+
+        private ReferenceSink(String sourceClass, Map<String, Set<String>> out) {
+            this.sourceClass = sourceClass;
+            this.out = out;
+        }
+
+        private void addInternalName(String internalName) {
+            if (internalName == null) {
+                return;
+            }
+            if (internalName.charAt(0) == '[') {
+                addType(Type.getType(internalName));
+                return;
+            }
+            Set<String> referencing = out.get(internalName);
+            if (referencing == null) {
+                referencing = new HashSet<String>();
+                out.put(internalName, referencing);
+            }
+            referencing.add(sourceClass);
+        }
+
+        private void addType(Type type) {
+            switch (type.getSort()) {
+                case Type.ARRAY:
+                    addType(type.getElementType());
+                    break;
+                case Type.OBJECT:
+                    addInternalName(type.getInternalName());
+                    break;
+                case Type.METHOD:
+                    addMethodDescriptor(type.getDescriptor());
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        private void addMethodDescriptor(String descriptor) {
+            for (Type argumentType : Type.getArgumentTypes(descriptor)) {
+                addType(argumentType);
+            }
+            addType(Type.getReturnType(descriptor));
+        }
+
+        private void addHandle(Handle handle) {
+            addInternalName(handle.getOwner());
+            String descriptor = handle.getDesc();
+            if (descriptor.startsWith("(")) {
+                addMethodDescriptor(descriptor);
+            } else {
+                addType(Type.getType(descriptor));
+            }
+        }
+    }
+}

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/ClassClosureVerifier.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/ClassClosureVerifier.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.maven;
 
 import org.objectweb.asm.ClassReader;

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/ClassClosureVerifierTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/ClassClosureVerifierTest.java
@@ -1,0 +1,153 @@
+package com.codename1.maven;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClassClosureVerifierTest {
+
+    @Test
+    void reportsMissingClassInProjectPackage(@TempDir Path tempDir) throws Exception {
+        byte[] caller = classCalling("app/Caller", "app/Gone");
+        Path classesDir = tempDir.resolve("classes");
+        writeClassFile(classesDir, "app/Caller", caller);
+        File jar = writeJar(tempDir.resolve("staged.jar"), entry("app/Caller", caller));
+
+        Map<String, Set<String>> missing = ClassClosureVerifier.findMissingProjectReferences(
+                jar, Collections.singletonList(classesDir.toFile()), Collections.<File>emptyList());
+
+        assertEquals(Collections.singleton("app/Gone"), missing.keySet());
+        assertEquals(Collections.singleton("app/Caller"), missing.get("app/Gone"));
+    }
+
+    @Test
+    void ignoresMissingClassOutsideProjectPackages(@TempDir Path tempDir) throws Exception {
+        byte[] caller = classCalling("app/Caller", "lib/OptionalDep");
+        Path classesDir = tempDir.resolve("classes");
+        writeClassFile(classesDir, "app/Caller", caller);
+        File jar = writeJar(tempDir.resolve("staged.jar"), entry("app/Caller", caller));
+
+        Map<String, Set<String>> missing = ClassClosureVerifier.findMissingProjectReferences(
+                jar, Collections.singletonList(classesDir.toFile()), Collections.<File>emptyList());
+
+        assertTrue(missing.isEmpty(), "References outside the project package space must be tolerated");
+    }
+
+    @Test
+    void acceptsClassPresentInStagedJar(@TempDir Path tempDir) throws Exception {
+        byte[] caller = classCalling("app/Caller", "app/Target");
+        byte[] target = emptyClass("app/Target");
+        Path classesDir = tempDir.resolve("classes");
+        writeClassFile(classesDir, "app/Caller", caller);
+        writeClassFile(classesDir, "app/Target", target);
+        File jar = writeJar(tempDir.resolve("staged.jar"), entry("app/Caller", caller), entry("app/Target", target));
+
+        Map<String, Set<String>> missing = ClassClosureVerifier.findMissingProjectReferences(
+                jar, Collections.singletonList(classesDir.toFile()), Collections.<File>emptyList());
+
+        assertTrue(missing.isEmpty());
+    }
+
+    @Test
+    void acceptsClassPresentInServerProvidedJar(@TempDir Path tempDir) throws Exception {
+        byte[] caller = classCalling("app/Caller", "app/ServerSide");
+        Path classesDir = tempDir.resolve("classes");
+        writeClassFile(classesDir, "app/Caller", caller);
+        File jar = writeJar(tempDir.resolve("staged.jar"), entry("app/Caller", caller));
+        File providedJar = writeJar(tempDir.resolve("provided.jar"), entry("app/ServerSide", emptyClass("app/ServerSide")));
+
+        Map<String, Set<String>> missing = ClassClosureVerifier.findMissingProjectReferences(
+                jar, Collections.singletonList(classesDir.toFile()), Collections.singletonList(providedJar));
+
+        assertTrue(missing.isEmpty());
+    }
+
+    @Test
+    void derivesProjectPackagesFromModuleJarRoots(@TempDir Path tempDir) throws Exception {
+        byte[] caller = classCalling("app/Caller", "app/Gone");
+        // The app's own classes reach the platform module as a jar dependency
+        // (the common module jar), not as a classes directory.
+        File commonJar = writeJar(tempDir.resolve("common.jar"), entry("app/Caller", caller));
+        File jar = writeJar(tempDir.resolve("staged.jar"), entry("app/Caller", caller));
+
+        Map<String, Set<String>> missing = ClassClosureVerifier.findMissingProjectReferences(
+                jar, Collections.singletonList(commonJar), Collections.<File>emptyList());
+
+        assertEquals(Collections.singleton("app/Gone"), missing.keySet());
+        assertEquals(Collections.singleton("app/Caller"), missing.get("app/Gone"));
+    }
+
+    @Test
+    void reportsMissingFieldTypeAndSupertype(@TempDir Path tempDir) throws Exception {
+        ClassWriter writer = new ClassWriter(0);
+        writer.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, "app/Holder", null, "app/GoneParent", null);
+        writer.visitField(Opcodes.ACC_PRIVATE, "field", "Lapp/GoneFieldType;", null, null).visitEnd();
+        writer.visitEnd();
+        byte[] holder = writer.toByteArray();
+        Path classesDir = tempDir.resolve("classes");
+        writeClassFile(classesDir, "app/Holder", holder);
+        File jar = writeJar(tempDir.resolve("staged.jar"), entry("app/Holder", holder));
+
+        Map<String, Set<String>> missing = ClassClosureVerifier.findMissingProjectReferences(
+                jar, Collections.singletonList(classesDir.toFile()), Collections.<File>emptyList());
+
+        assertEquals(new java.util.TreeSet<String>(Arrays.asList("app/GoneFieldType", "app/GoneParent")), missing.keySet());
+    }
+
+    private static byte[] classCalling(String className, String calleeInternalName) {
+        ClassWriter writer = new ClassWriter(0);
+        writer.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, className, null, "java/lang/Object", null);
+        MethodVisitor method = writer.visitMethod(Opcodes.ACC_PUBLIC, "run", "()V", null, null);
+        method.visitCode();
+        method.visitMethodInsn(Opcodes.INVOKESTATIC, calleeInternalName, "show", "()V", false);
+        method.visitInsn(Opcodes.RETURN);
+        method.visitMaxs(0, 1);
+        method.visitEnd();
+        writer.visitEnd();
+        return writer.toByteArray();
+    }
+
+    private static byte[] emptyClass(String className) {
+        ClassWriter writer = new ClassWriter(0);
+        writer.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, className, null, "java/lang/Object", null);
+        writer.visitEnd();
+        return writer.toByteArray();
+    }
+
+    private static void writeClassFile(Path classesDir, String internalName, byte[] bytes) throws Exception {
+        Path classFile = classesDir.resolve(internalName + ".class");
+        Files.createDirectories(classFile.getParent());
+        Files.write(classFile, bytes);
+    }
+
+    private static Object[] entry(String internalName, byte[] bytes) {
+        return new Object[] {internalName + ".class", bytes};
+    }
+
+    private static File writeJar(Path jarPath, Object[]... entries) throws Exception {
+        try (JarOutputStream jar = new JarOutputStream(new FileOutputStream(jarPath.toFile()))) {
+            for (Object[] entry : entries) {
+                jar.putNextEntry(new JarEntry((String) entry[0]));
+                jar.write((byte[]) entry[1]);
+                jar.closeEntry();
+            }
+        }
+        return jarPath.toFile();
+    }
+}

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/ClassClosureVerifierTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/ClassClosureVerifierTest.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.maven;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## Problem

A support case (error-72) showed an iOS cloud build failing deep in the Xcode step with:

```
com_edmundsassoc_inventoryapp_ViewBatchForm.m:13:10: error:
'com_edmundsassoc_inventoryapp_IssueForm.h' file not found
```

Root cause: the uploaded classes were internally inconsistent -- `ViewBatchForm.class` was compiled against `IssueForm`/`ReserveForm`, but those classes were absent from the upload. This is classic stale build output: an IDE (which writes to `target/classes` outside Maven's `maven-status` tracking) deletes the class files of removed/renamed sources while a stale dependent class survives, and Maven's incremental compile then ships it without recompiling anything. ParparVM only logs `WARNING: Failed to find class object for owner ...` and the build dies ~11,000 log lines later with an unrelated-looking native compiler error.

## Fix

Add a class-closure check to `cn1:build` that runs right after the `jar-with-dependencies` is staged, on both the fresh-merge and cached-jar paths, before anything is uploaded:

- `ClassClosureVerifier` (new) scans the staged jar with ASM and collects every class referenced from the app's own package space: supertypes, field/method descriptors, and all method-body references (type/method/field instructions, invokedynamic, LDC class constants, try/catch types).
- A reference is a failure only when it resolves in neither the staged jar nor the server-provided artifacts (`codenameone-core`, `java-runtime`, `kotlin-stdlib`) **and** it lives in the project's own package space (packages derived from the project's output directories plus module jars sharing the app's groupId, since platform modules see `common` as a jar). References outside the project package space stay tolerated, matching the translators' existing leniency toward optional third-party dependencies.
- On failure the build aborts locally with the missing classes, the classes referencing them, and a "run `mvn clean`" hint.
- Escape hatch: `-Dcodename1.skipClassClosureCheck=true` (also settable as a project property). An IO failure inside the check only warns and never blocks a build.

Example failure output:

```
The compiled application classes are inconsistent. The following class is referenced by your code but missing from the build:
 - com.example.Gone (referenced from com.example.Caller)
This usually means the build output contains stale classes from a previous build,
e.g. after renaming, moving or deleting a class, or switching branches, without a
clean rebuild. Run 'mvn clean' and rebuild. If a listed class was removed
intentionally, also remove or update the code that still references it.
To bypass this check build with -Dcodename1.skipClassClosureCheck=true
```

Note: `BytecodeComplianceMojo` catches some of these states, but with a misleading "forbidden API reference" message, an mtime skip-gate that misses class-file deletions, and it checks `target/classes` rather than the jar actually uploaded. This check is the reliable last gate on the shipped artifact. A follow-up on the server side (promoting the ParparVM warning to a friendly fatal for app-package classes) would additionally protect users on old plugin versions.

## Testing

- 6 new unit tests in `ClassClosureVerifierTest`; full plugin suite passes (256 tests, 0 failures).
- End-to-end repro with a fresh archetype app: injected a stale class into `common/target/classes` referencing a deleted class, ran `mvn package -Dcodename1.platform=ios -Dcodename1.buildTarget=ios-source` -- build aborts at `cn1:build` with the message above instead of reaching translation/Xcode. Verified the consistent-state build still passes and the bypass flag works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)