### PR TITLE
Ignore cancelled port status producers

### DIFF
--- a/.github/workflows/port-status-publish.yml
+++ b/.github/workflows/port-status-publish.yml
@@ -18,7 +18,10 @@ permissions:
 
 jobs:
   publish:
-    if: (github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'schedule') && github.event.workflow_run.head_branch == 'master'
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      (github.event.workflow_run.event == 'push' || github.event.workflow_run.event == 'schedule') &&
+      github.event.workflow_run.head_branch == 'master'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## What changed

- require a successful upstream workflow conclusion before publishing Port Status artifacts
- ignore cancelled or failed producer runs instead of launching a misleading publisher failure

## Root cause

Run `29551726398` was triggered by cancelled Mac producer run `29551613034`. The publisher only checked the upstream event and branch, so it attempted to download artifacts from a run that never produced any and failed with `No normalized port reports were found`.

## Validation

- `git diff --check`
- parsed `.github/workflows/port-status-publish.yml` with Ruby YAML
