### PR TITLE
Separate JavaSE reference probes from port compliance

### DIFF
--- a/scripts/hellocodenameone/README.adoc
+++ b/scripts/hellocodenameone/README.adoc
@@ -72,9 +72,12 @@ Renderer variants and CPU architectures intentionally remain separate so a
 regression cannot be hidden by a combined platform result.
 
 The feature contract lives in
-`docs/website/data/port_status.json`. Every test registered in
-`Cn1ssDeviceRunner`, including tests installed through `addTest()`, must appear
-under exactly one feature. Every committed CN1SS golden filename must map back
+`docs/website/data/port_status.json`. Every test in
+`Cn1ssDeviceRunner.DEFAULT_TEST_CLASSES`, and every test installed through
+`addTest()`, must appear under exactly one feature. JavaSE-only visual reference
+probes live separately in `JAVASE_REFERENCE_TEST_CLASSES`: they remain available
+to filtered simulator runs but are not portability tests and do not appear on
+the public Port Status page. Every committed CN1SS golden filename must map back
 to its producing test. Validate both rules from the repository root:
 
 [source,shell]

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/Cn1ssDeviceRunner.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/Cn1ssDeviceRunner.java
@@ -154,7 +154,6 @@ public final class Cn1ssDeviceRunner extends DeviceRunner {
             new MorphTransitionScrubScreenshotTest(),
             new MorphElementMorphScreenshotTest(),
             new TabsAnimatedIndicatorScreenshotTest(),
-            new TabsLiquidGlassAnimationScreenshotTest(),
             new PullToRefreshSpinnerScreenshotTest(),
             new AnimateLayoutScreenshotTest(),
             new AnimateHierarchyScreenshotTest(),
@@ -439,6 +438,14 @@ public final class Cn1ssDeviceRunner extends DeviceRunner {
             new VideoIORoundTripTest()
     };
 
+    // Visual probes used to compare the simulator renderer with native
+    // reference captures are not portability tests. Keep them available to a
+    // filtered JavaSE run without adding always-skipped rows to the public
+    // cross-port compliance contract.
+    private static final BaseTest[] JAVASE_REFERENCE_TEST_CLASSES = new BaseTest[]{
+            new TabsLiquidGlassAnimationScreenshotTest()
+    };
+
     private static BaseTest prependedTest;
 
     /// Index of the test that has consumed its one-shot silent-timeout retry
@@ -465,12 +472,26 @@ public final class Cn1ssDeviceRunner extends DeviceRunner {
 
     private void runNextTest(int index) {
         int offset = prependedTest != null ? 1 : 0;
-        int total = DEFAULT_TEST_CLASSES.length + offset;
+        boolean includeJavaSeReferences = "SE".equals(
+                Display.getInstance().getProperty("OS", ""));
+        int referenceCount = includeJavaSeReferences
+                ? JAVASE_REFERENCE_TEST_CLASSES.length
+                : 0;
+        int total = DEFAULT_TEST_CLASSES.length + referenceCount + offset;
         if (index >= total) {
             finishSuite();
             return;
         }
-        BaseTest testClass = (offset == 1 && index == 0) ? prependedTest : DEFAULT_TEST_CLASSES[index - offset];
+        BaseTest testClass;
+        int suiteIndex = index - offset;
+        if (offset == 1 && index == 0) {
+            testClass = prependedTest;
+        } else if (suiteIndex < DEFAULT_TEST_CLASSES.length) {
+            testClass = DEFAULT_TEST_CLASSES[suiteIndex];
+        } else {
+            testClass = JAVASE_REFERENCE_TEST_CLASSES[
+                    suiteIndex - DEFAULT_TEST_CLASSES.length];
+        }
         String testName = testClass.getClass().getSimpleName();
         if (!matchesFilter(testName)) {
             // Optional subset run: -Dcn1ss.filter=<substr> or CN1SS_FILTER=<substr>


### PR DESCRIPTION
## What changed

- move the JavaSE-only Liquid Glass frame probe out of the cross-port compliance test array
- keep the probe available to filtered JavaSE simulator runs through a separate reference-test array
- document the boundary between portability tests and simulator reference probes

## Root cause

`TabsLiquidGlassAnimationScreenshotTest` was added to `DEFAULT_TEST_CLASSES`, but it deliberately skips every portability target and only produces JavaSE reference frames. The Port Status gate correctly rejected it as an unmapped compliance test during website run `29552778957`.

Mapping it into the public table would be misleading because every displayed platform would show a skip. This change keeps it out of the portability contract without deleting the reference probe.

## Validation

- `python3 scripts/hellocodenameone/conformance/port_status.py validate`
- `python3 -m unittest -v test_port_status.py` from the conformance directory
- Hugo minified build
- `node scripts/website/validate_port_status.mjs /tmp/cn1-port-status-site`
- Java compilation of all 202 HelloCodenameOne common sources under JDK 17
- `git diff --check`

The full local fixture package continued past Java and Kotlin compilation but later failed in the existing Codename One CSS/CEF tooling; that failure is outside the changed source path.
