### PR TITLE
Deploy publisher-triggered port status updates

### DIFF
--- a/.github/workflows/port-status-nightly.yml
+++ b/.github/workflows/port-status-nightly.yml
@@ -106,4 +106,4 @@ jobs:
         if: github.ref == 'refs/heads/master'
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh workflow run website-docs.yml --ref master
+        run: gh workflow run website-docs.yml --ref master -f deploy_production=true

--- a/.github/workflows/port-status-publish.yml
+++ b/.github/workflows/port-status-publish.yml
@@ -56,4 +56,4 @@ jobs:
       - name: Rebuild the static Port Status snapshot
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh workflow run website-docs.yml --ref master
+        run: gh workflow run website-docs.yml --ref master -f deploy_production=true

--- a/.github/workflows/website-docs.yml
+++ b/.github/workflows/website-docs.yml
@@ -42,6 +42,12 @@ on:
       - '.github/scripts/build_javadocs.sh'
       - '.github/workflows/website-docs.yml'
   workflow_dispatch:
+    inputs:
+      deploy_production:
+        description: 'Deploy this master build to production'
+        required: false
+        default: false
+        type: boolean
   # Daily production rebuild so future-dated blog posts (the daily release
   # follow-ups) publish on their own date with no manual push. Production
   # builds keep HUGO_BUILD_FUTURE=false, so a post only appears once its date
@@ -446,12 +452,12 @@ jobs:
           done < /tmp/cf_deployments_to_delete.txt
 
       - name: Check Cloudflare deploy credentials
-        if: ${{ ((github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master')) || github.event_name == 'schedule') && env.CLOUDFLARE_TOKEN == '' }}
+        if: ${{ ((github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master')) || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.deploy_production && (github.ref_name == 'main' || github.ref_name == 'master'))) && env.CLOUDFLARE_TOKEN == '' }}
         run: |
           echo "::warning::Skipping Cloudflare Pages deploy because no API token secret is configured. Set CLOUDFLARE_TOKEN (preferred) or CF_API_TOKEN."
 
       - name: Deploy to Cloudflare Pages
-        if: ${{ ((github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master')) || github.event_name == 'schedule') && env.CLOUDFLARE_TOKEN != '' }}
+        if: ${{ ((github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master')) || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.deploy_production && (github.ref_name == 'main' || github.ref_name == 'master'))) && env.CLOUDFLARE_TOKEN != '' }}
         uses: cloudflare/wrangler-action@v3
         env:
           # Keep these env vars explicit so Wrangler can authenticate in non-interactive CI.


### PR DESCRIPTION
## Summary

- add an explicit `deploy_production` input to the website workflow
- let Port Status publication and nightly workflows opt into production deployment
- keep ordinary manual dispatches build-only and restrict opted-in deployment to `main` or `master`

## Root cause

Port Status publication rebuilt the website from `master` using `workflow_dispatch`, but the Cloudflare deployment steps only accepted push and scheduled events. The website artifact contained the Port Status page and navigation entry, but the successful dispatch never reached production.

## Validation

- parsed all three changed workflows as YAML
- passed actionlint 1.7.12 on all three changed workflows
- verified the deployment-condition truth table for push, schedule, pull request, ordinary manual dispatch, authorized master dispatch, and feature-branch dispatch
- built the production Hugo site locally
- passed `scripts/website/validate_port_status.mjs`
- verified the generated homepage links to `/port-status/` and the generated page exists
