### PR TITLE
Fix syndication state loss after concurrent master updates

### DIFF
--- a/.github/workflows/blog-syndication.yml
+++ b/.github/workflows/blog-syndication.yml
@@ -96,7 +96,10 @@ jobs:
           retention-days: 14
 
       - name: Commit updated syndication state and queue
-        if: ${{ inputs.dry_run != true }}
+        # always() so a successful publish is committed even when a later step
+        # (browser syndication, queueing) fails -- otherwise the recorded state is
+        # discarded and the same post is re-selected and rejected on the next run.
+        if: ${{ always() && inputs.dry_run != true }}
         run: |
           set -euo pipefail
           if git diff --quiet -- scripts/website/syndication-state.json scripts/website/syndication-queue.json; then

--- a/.github/workflows/blog-syndication.yml
+++ b/.github/workflows/blog-syndication.yml
@@ -27,11 +27,18 @@ jobs:
         with:
           # Token with write scope so the post-run commit can push the state file.
           token: ${{ secrets.GITHUB_TOKEN }}
+          # The state commit rebases onto the latest default-branch commit before
+          # pushing. A complete history is required when master advanced after
+          # this scheduled run was created.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+
+      - name: Run syndication regression tests
+        run: python3 scripts/website/test_syndicate_blog_posts.py
 
       - name: Run API syndication script
         id: syndicate_api
@@ -100,14 +107,4 @@ jobs:
         # (browser syndication, queueing) fails -- otherwise the recorded state is
         # discarded and the same post is re-selected and rejected on the next run.
         if: ${{ always() && inputs.dry_run != true }}
-        run: |
-          set -euo pipefail
-          if git diff --quiet -- scripts/website/syndication-state.json scripts/website/syndication-queue.json; then
-            echo "No state or queue changes to commit."
-            exit 0
-          fi
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git add scripts/website/syndication-state.json scripts/website/syndication-queue.json
-          git commit -m "ci: record blog syndication results"
-          git push
+        run: bash scripts/website/commit_syndication_state.sh

--- a/scripts/website/commit_syndication_state.sh
+++ b/scripts/website/commit_syndication_state.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly REMOTE="${SYNDICATION_GIT_REMOTE:-origin}"
+readonly BRANCH="${GITHUB_REF_NAME:-master}"
+readonly MAX_PUSH_ATTEMPTS="${SYNDICATION_PUSH_ATTEMPTS:-3}"
+readonly STATE_PATHS=(
+    scripts/website/syndication-state.json
+    scripts/website/syndication-queue.json
+)
+
+if git diff --quiet -- "${STATE_PATHS[@]}"; then
+    echo "No state or queue changes to commit."
+    exit 0
+fi
+
+git config user.name 'github-actions[bot]'
+git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+# Scheduled workflows run against the commit that was current when GitHub
+# created the run. Master can advance before this final step, so update the
+# checkout while preserving the generated state and queue changes.
+git fetch "$REMOTE" "$BRANCH"
+git rebase --autostash "$REMOTE/$BRANCH"
+
+git add "${STATE_PATHS[@]}"
+if git diff --staged --quiet -- "${STATE_PATHS[@]}"; then
+    echo "The latest $BRANCH already contains these state changes."
+    exit 0
+fi
+git commit -m "ci: record blog syndication results"
+
+attempt=1
+while ! git push "$REMOTE" "HEAD:$BRANCH"; do
+    if [ "$attempt" -ge "$MAX_PUSH_ATTEMPTS" ]; then
+        echo "Failed to push syndication state after $attempt attempts." >&2
+        exit 1
+    fi
+    attempt=$((attempt + 1))
+    echo "The $BRANCH branch advanced; rebasing before push attempt $attempt."
+    git fetch "$REMOTE" "$BRANCH"
+    git rebase "$REMOTE/$BRANCH"
+done

--- a/scripts/website/syndicate_blog_posts.py
+++ b/scripts/website/syndicate_blog_posts.py
@@ -381,6 +381,15 @@ def render_syndicated_body(post: Post, posts: list[Post] | None = None, today: d
 USER_AGENT = "CodenameOneBlogSyndicator/1.0 (+https://github.com/codenameone/CodenameOne)"
 
 
+class HttpJsonError(RuntimeError):
+    """An HTTP error from a JSON endpoint, carrying the status code and body."""
+
+    def __init__(self, url: str, status: int, detail: str) -> None:
+        super().__init__(f"{url} returned HTTP {status}: {detail}")
+        self.status = status
+        self.detail = detail
+
+
 def http_post_json(url: str, headers: dict[str, str], payload: dict[str, Any]) -> dict[str, Any]:
     data = json.dumps(payload).encode("utf-8")
     request = urllib.request.Request(url, data=data, method="POST")
@@ -394,10 +403,58 @@ def http_post_json(url: str, headers: dict[str, str], payload: dict[str, Any]) -
             body = response.read().decode("utf-8")
     except urllib.error.HTTPError as err:
         detail = err.read().decode("utf-8", errors="replace")
-        raise RuntimeError(f"{url} returned HTTP {err.code}: {detail}") from err
+        raise HttpJsonError(url, err.code, detail) from err
     if not body:
         return {}
     return json.loads(body)
+
+
+def http_get_json(url: str, headers: dict[str, str]) -> Any:
+    request = urllib.request.Request(url, method="GET")
+    request.add_header("User-Agent", USER_AGENT)
+    request.add_header("Accept", "application/json")
+    for key, value in headers.items():
+        request.add_header(key, value)
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            body = response.read().decode("utf-8")
+    except urllib.error.HTTPError as err:
+        detail = err.read().decode("utf-8", errors="replace")
+        raise HttpJsonError(url, err.code, detail) from err
+    if not body:
+        return {}
+    return json.loads(body)
+
+
+def find_devto_article_by_canonical(canonical_url: str, api_key: str) -> dict[str, Any] | None:
+    """Return the caller's already-published dev.to article for ``canonical_url``.
+
+    Used to self-heal when a POST is rejected with "Canonical url has already
+    been taken" -- the post is live on dev.to but its URL was never recorded in
+    our state (e.g. a prior run published it but failed before committing state).
+    Looking the article up lets us record it and advance the rotation instead of
+    wedging on the same post forever.
+    """
+    target = canonical_url.rstrip("/")
+    page = 1
+    while page <= 20:  # dev.to caps per_page at 1000; 20 pages is a hard safety stop
+        articles = http_get_json(
+            f"https://dev.to/api/articles/me/all?per_page=100&page={page}",
+            headers={"api-key": api_key, "Accept": "application/vnd.forem.api-v1+json"},
+        )
+        if not isinstance(articles, list) or not articles:
+            break
+        for article in articles:
+            if str(article.get("canonical_url") or "").rstrip("/") == target:
+                return {
+                    "id": article.get("id"),
+                    "url": article.get("url") or article.get("canonical_url"),
+                    "syndicated_at": article.get("published_at")
+                    or dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds"),
+                    "recovered": True,
+                }
+        page += 1
+    return None
 
 
 def publish_to_devto(post: Post, body_markdown: str, api_key: str, draft: bool = False) -> dict[str, Any]:
@@ -416,11 +473,21 @@ def publish_to_devto(post: Post, body_markdown: str, api_key: str, draft: bool =
         payload["article"]["main_image"] = cover
     payload["article"] = {k: v for k, v in payload["article"].items() if v is not None}
 
-    response = http_post_json(
-        "https://dev.to/api/articles",
-        headers={"api-key": api_key, "Accept": "application/vnd.forem.api-v1+json"},
-        payload=payload,
-    )
+    try:
+        response = http_post_json(
+            "https://dev.to/api/articles",
+            headers={"api-key": api_key, "Accept": "application/vnd.forem.api-v1+json"},
+            payload=payload,
+        )
+    except HttpJsonError as err:
+        # A 422 "Canonical url has already been taken" means this post is already
+        # live on dev.to but we never recorded it. Recover its URL so the caller
+        # records it and the rotation advances, instead of failing every run.
+        if err.status == 422 and "canonical url has already been taken" in err.detail.lower():
+            existing = find_devto_article_by_canonical(post.canonical_url, api_key)
+            if existing:
+                return existing
+        raise
     article_id = response.get("id")
     # The URL field on dev.to returns the public canonical URL of the article,
     # but for unpublished drafts that URL 404s for anyone who is not the author.

--- a/scripts/website/syndicate_blog_posts.py
+++ b/scripts/website/syndicate_blog_posts.py
@@ -437,7 +437,7 @@ def find_devto_article_by_canonical(canonical_url: str, api_key: str) -> dict[st
     """
     target = canonical_url.rstrip("/")
     page = 1
-    while page <= 20:  # dev.to caps per_page at 1000; 20 pages is a hard safety stop
+    while page <= 20:  # Hard stop prevents an unexpected API response from paging forever.
         articles = http_get_json(
             f"https://dev.to/api/articles/me/all?per_page=100&page={page}",
             headers={"api-key": api_key, "Accept": "application/vnd.forem.api-v1+json"},

--- a/scripts/website/syndication-state.json
+++ b/scripts/website/syndication-state.json
@@ -954,6 +954,13 @@
         "canonical_set": true,
         "syndicated_at": "2026-07-14T15:02:26+00:00"
       }
+    },
+    "videoio-audio-mixer-whisper": {
+      "devto": {
+        "id": 4151334,
+        "url": "https://dev.to/codenameone/videoio-pcm-mixing-and-timed-whisper-captions-1l3n",
+        "syndicated_at": "2026-07-15T14:58:28+00:00"
+      }
     }
   }
 }

--- a/scripts/website/test_syndicate_blog_posts.py
+++ b/scripts/website/test_syndicate_blog_posts.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+
+import datetime as dt
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+MODULE_PATH = SCRIPT_DIR / "syndicate_blog_posts.py"
+COMMIT_SCRIPT = SCRIPT_DIR / "commit_syndication_state.sh"
+
+spec = importlib.util.spec_from_file_location("syndicate_blog_posts", MODULE_PATH)
+syndicate = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = syndicate
+spec.loader.exec_module(syndicate)
+
+
+class DevToRecoveryTest(unittest.TestCase):
+    def setUp(self):
+        self.post = syndicate.Post(
+            path=Path("post.md"),
+            slug="lost-state",
+            title="Lost State",
+            date=dt.date(2026, 7, 8),
+            front_matter={"url": "/blog/lost-state/"},
+            body="Body",
+        )
+
+    @mock.patch.object(syndicate, "find_devto_article_by_canonical")
+    @mock.patch.object(syndicate, "http_post_json")
+    def test_duplicate_canonical_recovers_existing_article(self, post_json, find_article):
+        post_json.side_effect = syndicate.HttpJsonError(
+            "https://dev.to/api/articles",
+            422,
+            '{"error":"Canonical url has already been taken."}',
+        )
+        recovered = {
+            "id": 123,
+            "url": "https://dev.to/codenameone/lost-state-123",
+            "syndicated_at": "2026-07-15T14:58:28+00:00",
+            "recovered": True,
+        }
+        find_article.return_value = recovered
+
+        result = syndicate.publish_to_devto(self.post, "Body", "api-key")
+
+        self.assertEqual(recovered, result)
+        find_article.assert_called_once_with(self.post.canonical_url, "api-key")
+
+    @mock.patch.object(syndicate, "find_devto_article_by_canonical")
+    @mock.patch.object(syndicate, "http_post_json")
+    def test_unrelated_http_error_is_not_hidden(self, post_json, find_article):
+        error = syndicate.HttpJsonError(
+            "https://dev.to/api/articles", 401, '{"error":"unauthorized"}'
+        )
+        post_json.side_effect = error
+
+        with self.assertRaises(syndicate.HttpJsonError) as raised:
+            syndicate.publish_to_devto(self.post, "Body", "api-key")
+
+        self.assertIs(error, raised.exception)
+        find_article.assert_not_called()
+
+    @mock.patch.object(syndicate, "http_get_json")
+    def test_lookup_matches_canonical_url_without_trailing_slash(self, get_json):
+        get_json.side_effect = [
+            [
+                {
+                    "id": 123,
+                    "url": "https://dev.to/codenameone/lost-state-123",
+                    "canonical_url": self.post.canonical_url.rstrip("/"),
+                    "published_at": "2026-07-15T14:58:28+00:00",
+                }
+            ]
+        ]
+
+        result = syndicate.find_devto_article_by_canonical(
+            self.post.canonical_url, "api-key"
+        )
+
+        self.assertEqual(123, result["id"])
+        self.assertTrue(result["recovered"])
+
+
+class StateCommitRaceTest(unittest.TestCase):
+    def git(self, cwd, *args):
+        return subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+
+    def write_state_files(self, repo, state_text="{}\n"):
+        website = repo / "scripts" / "website"
+        website.mkdir(parents=True, exist_ok=True)
+        (website / "syndication-state.json").write_text(state_text, encoding="utf-8")
+        (website / "syndication-queue.json").write_text("{}\n", encoding="utf-8")
+
+    def test_state_commit_rebases_when_default_branch_advanced(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            remote = root / "remote.git"
+            seed = root / "seed"
+            runner = root / "runner"
+            concurrent = root / "concurrent"
+            verify = root / "verify"
+
+            self.git(root, "init", "--bare", "--initial-branch=master", str(remote))
+            self.git(root, "clone", str(remote), str(seed))
+            self.git(seed, "config", "user.name", "Test")
+            self.git(seed, "config", "user.email", "test@example.com")
+            self.write_state_files(seed)
+            (seed / "README.md").write_text("initial\n", encoding="utf-8")
+            self.git(seed, "add", ".")
+            self.git(seed, "commit", "-m", "initial")
+            self.git(seed, "push", "origin", "master")
+
+            self.git(root, "clone", str(remote), str(runner))
+            self.git(root, "clone", str(remote), str(concurrent))
+
+            (concurrent / "README.md").write_text("concurrent\n", encoding="utf-8")
+            self.git(concurrent, "config", "user.name", "Test")
+            self.git(concurrent, "config", "user.email", "test@example.com")
+            self.git(concurrent, "add", "README.md")
+            self.git(concurrent, "commit", "-m", "advance master")
+            self.git(concurrent, "push", "origin", "master")
+
+            self.write_state_files(runner, '{"recorded": true}\n')
+            subprocess.run(
+                ["bash", str(COMMIT_SCRIPT)],
+                cwd=runner,
+                check=True,
+                text=True,
+                capture_output=True,
+                env={
+                    "PATH": os.environ["PATH"],
+                    "GITHUB_REF_NAME": "master",
+                },
+            )
+
+            self.git(root, "clone", str(remote), str(verify))
+            self.assertEqual(
+                "concurrent\n", (verify / "README.md").read_text(encoding="utf-8")
+            )
+            self.assertEqual(
+                '{"recorded": true}\n',
+                (verify / "scripts" / "website" / "syndication-state.json").read_text(
+                    encoding="utf-8"
+                ),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- backfill the DEV state entry lost on July 15 and recover already-published articles by canonical URL
- persist successful syndication state even when a later workflow step fails
- rebase generated state onto the latest default branch and retry raced pushes
- run regression coverage for DEV duplicate recovery and concurrent default-branch updates

## Root cause
The July 15 run published to DEV, then lost the state update when another automation commit advanced `master` before the final push. The next two runs selected the same article and stopped on DEV's duplicate-canonical response.

## Validation
- `python3 scripts/website/test_syndicate_blog_posts.py`
- `python3 scripts/website/syndicate_blog_posts.py --dry-run --today 2026-07-17`
- `python3 scripts/website/queue_browser_syndication.py --dry-run --today 2026-07-17`
- `python3 -m py_compile scripts/website/syndicate_blog_posts.py scripts/website/test_syndicate_blog_posts.py`
- `bash -n scripts/website/commit_syndication_state.sh`
- `git diff --check`