### PR TITLE
Alert on stalled syndication

### DIFF
--- a/.github/workflows/blog-syndication.yml
+++ b/.github/workflows/blog-syndication.yml
@@ -38,7 +38,9 @@ jobs:
           python-version: '3.12'
 
       - name: Run syndication regression tests
-        run: python3 scripts/website/test_syndicate_blog_posts.py
+        run: |
+          python3 scripts/website/test_syndicate_blog_posts.py
+          python3 scripts/website/test_syndication_health.py
 
       - name: Run API syndication script
         id: syndicate_api

--- a/.github/workflows/syndication-health.yml
+++ b/.github/workflows/syndication-health.yml
@@ -1,0 +1,211 @@
+name: Syndication Health
+
+on:
+  workflow_run:
+    workflows:
+      - Syndicate Blog Posts
+    types:
+      - completed
+  schedule:
+    # Catch a silent/stalled local browser runner within a few hours.
+    - cron: '17 */4 * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+
+concurrency:
+  group: syndication-health
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out default branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Inspect local-runner queue
+        id: queue_health
+        continue-on-error: true
+        run: |
+          python3 scripts/website/check_syndication_health.py \
+            --output "${RUNNER_TEMP}/syndication-health.json"
+
+      - name: Open, update, or close syndication alert
+        uses: actions/github-script@v8
+        env:
+          HEALTH_REPORT: ${{ runner.temp }}/syndication-health.json
+          # Assign Shai directly so this is harder to miss than an Actions-only
+          # failure. A repository variable can override the recipient later.
+          ALERT_ASSIGNEE: ${{ vars.SYNDICATION_ALERT_ASSIGNEE || 'shai-almog' }}
+        with:
+          script: |
+            const fs = require('fs');
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const title = 'Syndication pipeline needs attention';
+            const marker = '<!-- syndication-health -->';
+            const reminderMarker = '<!-- syndication-health-reminder -->';
+            const problems = new Map();
+            const addProblem = (key, text) => problems.set(key, text);
+
+            let report;
+            try {
+              report = JSON.parse(fs.readFileSync(process.env.HEALTH_REPORT, 'utf8'));
+            } catch (error) {
+              report = { overdue: [], invalid: [], platform_overdue: [] };
+              addProblem('queue-report', `Queue health report could not be read: ${error.message}`);
+            }
+
+            for (const task of report.overdue || []) {
+              addProblem(
+                `overdue:${task.id}`,
+                `Queued task \`${task.id}\` is ${task.overdue_hours} hours beyond its processing grace period (deadline ${task.deadline}).`
+              );
+            }
+            for (const task of report.invalid || []) {
+              addProblem(
+                `invalid:${task.id}`,
+                `Queued task \`${task.id}\` cannot be monitored: ${task.reason}.`
+              );
+            }
+            for (const task of report.platform_overdue || []) {
+              addProblem(
+                `platform:${task.id}`,
+                `Eligible article \`${task.id}\` is ${task.overdue_hours} hours beyond the daily-platform grace period (deadline ${task.deadline}).`
+              );
+            }
+
+            if (context.eventName === 'workflow_run') {
+              const run = context.payload.workflow_run;
+              if (run.conclusion !== 'success') {
+                addProblem(
+                  'blog-run',
+                  `The blog syndication workflow concluded with **${run.conclusion || 'unknown'}**: ${run.html_url}`
+                );
+              }
+            }
+
+            const workflowRuns = await github.rest.actions.listWorkflowRuns({
+              owner,
+              repo,
+              workflow_id: 'blog-syndication.yml',
+              branch: context.payload.repository.default_branch,
+              per_page: 10,
+            });
+            const latest = workflowRuns.data.workflow_runs.find(run => run.status === 'completed');
+            if (!latest) {
+              addProblem('missing-blog-run', 'No completed blog syndication workflow run was found.');
+            } else {
+              const ageHours = (Date.now() - Date.parse(latest.updated_at)) / 3600000;
+              if (latest.conclusion !== 'success') {
+                addProblem(
+                  'blog-run',
+                  `The latest blog syndication workflow concluded with **${latest.conclusion || 'unknown'}**: ${latest.html_url}`
+                );
+              } else if (ageHours > 30) {
+                addProblem(
+                  'stale-blog-run',
+                  `The last successful blog syndication workflow is ${ageHours.toFixed(1)} hours old: ${latest.html_url}`
+                );
+              }
+            }
+
+            const issueList = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            });
+            let issue = issueList.find(candidate =>
+              !candidate.pull_request && candidate.title === title && (candidate.body || '').includes(marker)
+            );
+
+            if (problems.size === 0) {
+              await core.summary.addHeading('Syndication health').addRaw('Healthy').write();
+              if (issue) {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  body: `${reminderMarker}\nRecovered at ${new Date().toISOString()}. The workflow is succeeding and no queue entries are overdue.`,
+                });
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+              }
+              return;
+            }
+
+            const lines = Array.from(problems.values()).map(problem => `- ${problem}`);
+            const body = [
+              marker,
+              'The syndication watchdog found work that needs attention.',
+              '',
+              ...lines,
+              '',
+              `Last checked: ${new Date().toISOString()}`,
+              '',
+              'The GitHub workflow publishes DEV/Foojay and creates queue tasks. The signed-in local runner publishes Medium, DZone, Hashnode, and LinkedIn. This issue stays open until both paths recover.',
+            ].join('\n');
+
+            const assignees = process.env.ALERT_ASSIGNEE ? [process.env.ALERT_ASSIGNEE] : undefined;
+            if (!issue) {
+              const created = await github.rest.issues.create({
+                owner,
+                repo,
+                title,
+                body,
+                assignees,
+              });
+              issue = created.data;
+            } else {
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: issue.number,
+                body,
+                assignees,
+              });
+
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: issue.number,
+                per_page: 100,
+              });
+              const reminders = comments.filter(comment => (comment.body || '').includes(reminderMarker));
+              const lastReminder = reminders.at(-1);
+              const reminderAge = lastReminder
+                ? (Date.now() - Date.parse(lastReminder.created_at)) / 3600000
+                : Infinity;
+              if (reminderAge >= 24) {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  body: `${reminderMarker}\nStill failing as of ${new Date().toISOString()}. See the updated issue body for the current blockers.`,
+                });
+              }
+            }
+
+            await core.summary
+              .addHeading('Syndication health failure')
+              .addList(Array.from(problems.values()))
+              .addLink(`Tracking issue #${issue.number}`, issue.html_url)
+              .write();
+            core.setFailed(`Syndication is unhealthy; tracking issue #${issue.number}`);

--- a/scripts/website/check_syndication_health.py
+++ b/scripts/website/check_syndication_health.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Report syndication work that has not been processed.
+
+The GitHub workflow queues Medium, DZone, and reviewed LinkedIn work, while a
+signed-in browser runner on the maintainer's machine drains that queue.  A
+successful local run removes completed entries.  Anything left beyond its
+grace period therefore needs attention.  DEV, Foojay, and Hashnode do not all
+use that queue, so eligible articles are also checked against platform state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+
+from syndicate_blog_posts import (
+    BLOG_DIR,
+    ELIGIBILITY_FLOOR,
+    MIN_AGE_DAYS,
+    STATE_FILE,
+    discover_posts,
+)
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_QUEUE_FILE = SCRIPT_DIR / "syndication-queue.json"
+
+
+def parse_timestamp(value: object) -> dt.datetime:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("timestamp is missing")
+    parsed = dt.datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("timestamp has no timezone")
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def inspect_queue(
+    queue: dict,
+    now: dt.datetime,
+    social_grace: dt.timedelta,
+    browser_grace: dt.timedelta,
+) -> dict:
+    if now.tzinfo is None:
+        raise ValueError("now must include a timezone")
+    now = now.astimezone(dt.timezone.utc)
+    overdue: list[dict] = []
+    invalid: list[dict] = []
+
+    tasks = queue.get("tasks", [])
+    if not isinstance(tasks, list):
+        tasks = []
+        invalid.append({"id": "<queue>", "reason": "tasks must be a list"})
+
+    for index, task in enumerate(tasks):
+        if not isinstance(task, dict):
+            invalid.append({"id": f"<task {index}>", "reason": "task must be an object"})
+            continue
+
+        task_id = str(task.get("id") or f"<task {index}>")
+        site = str(task.get("site") or "unknown")
+        is_social = task.get("kind") == "social" or site == "linkedin"
+        timestamp_field = "scheduled_at" if is_social else "queued_at"
+        grace = social_grace if is_social else browser_grace
+
+        try:
+            base_time = parse_timestamp(task.get(timestamp_field))
+        except (TypeError, ValueError) as error:
+            invalid.append(
+                {
+                    "id": task_id,
+                    "site": site,
+                    "reason": f"invalid {timestamp_field}: {error}",
+                }
+            )
+            continue
+
+        deadline = base_time + grace
+        if now > deadline:
+            overdue.append(
+                {
+                    "id": task_id,
+                    "site": site,
+                    "deadline": deadline.isoformat(timespec="seconds"),
+                    "overdue_hours": round((now - deadline).total_seconds() / 3600, 1),
+                }
+            )
+
+    return {
+        "healthy": not overdue and not invalid,
+        "checked_at": now.isoformat(timespec="seconds"),
+        "pending_count": len(tasks),
+        "overdue": overdue,
+        "invalid": invalid,
+    }
+
+
+def inspect_platform_state(
+    posts: list,
+    state: dict,
+    now: dt.datetime,
+    grace: dt.timedelta,
+) -> list[dict]:
+    """Find eligible direct-publish articles missing their platform state."""
+    if now.tzinfo is None:
+        raise ValueError("now must include a timezone")
+    now = now.astimezone(dt.timezone.utc)
+    state_posts = state.get("posts", {})
+    if not isinstance(state_posts, dict):
+        state_posts = {}
+
+    overdue: list[dict] = []
+    for post in posts:
+        eligible_at = dt.datetime.combine(
+            post.date + dt.timedelta(days=MIN_AGE_DAYS),
+            dt.time.min,
+            tzinfo=dt.timezone.utc,
+        )
+        deadline = eligible_at + grace
+        if now <= deadline:
+            continue
+
+        expected_platforms = ["devto", "hashnode"]
+        if post.date.weekday() == 4:  # Foojay takes the Friday digest only.
+            expected_platforms.append("foojay")
+
+        recorded = state_posts.get(post.slug, {})
+        if not isinstance(recorded, dict):
+            recorded = {}
+        for platform in expected_platforms:
+            platform_state = recorded.get(platform, {})
+            if isinstance(platform_state, dict) and platform_state.get("url"):
+                continue
+            overdue.append(
+                {
+                    "id": f"{platform}:{post.slug}",
+                    "site": platform,
+                    "deadline": deadline.isoformat(timespec="seconds"),
+                    "overdue_hours": round((now - deadline).total_seconds() / 3600, 1),
+                }
+            )
+    return overdue
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--queue-file", default=str(DEFAULT_QUEUE_FILE))
+    parser.add_argument("--state-file", default=str(STATE_FILE))
+    parser.add_argument("--blog-dir", default=str(BLOG_DIR))
+    parser.add_argument("--output", help="Write the JSON report to this path.")
+    parser.add_argument("--now", help="Override the current UTC time for testing.")
+    parser.add_argument("--social-grace-hours", type=float, default=2.0)
+    parser.add_argument("--browser-grace-hours", type=float, default=8.0)
+    parser.add_argument("--platform-grace-hours", type=float, default=36.0)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    queue_path = Path(args.queue_file)
+    try:
+        queue = json.loads(queue_path.read_text(encoding="utf-8"))
+        state = json.loads(Path(args.state_file).read_text(encoding="utf-8"))
+        posts = [
+            post
+            for post in discover_posts(Path(args.blog_dir))
+            if post.date > ELIGIBILITY_FLOOR
+        ]
+    except (OSError, json.JSONDecodeError, ValueError) as error:
+        print(f"Unable to read syndication inputs: {error}", file=sys.stderr)
+        return 2
+
+    now = parse_timestamp(args.now) if args.now else dt.datetime.now(dt.timezone.utc)
+    report = inspect_queue(
+        queue,
+        now,
+        dt.timedelta(hours=args.social_grace_hours),
+        dt.timedelta(hours=args.browser_grace_hours),
+    )
+    report["platform_overdue"] = inspect_platform_state(
+        posts,
+        state,
+        now,
+        dt.timedelta(hours=args.platform_grace_hours),
+    )
+    report["healthy"] = report["healthy"] and not report["platform_overdue"]
+    rendered = json.dumps(report, indent=2) + "\n"
+    if args.output:
+        Path(args.output).write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+    return 0 if report["healthy"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/website/test_syndication_health.py
+++ b/scripts/website/test_syndication_health.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import datetime as dt
+import unittest
+from types import SimpleNamespace
+
+from check_syndication_health import inspect_platform_state, inspect_queue
+
+
+UTC = dt.timezone.utc
+
+
+class SyndicationHealthTest(unittest.TestCase):
+    def inspect(self, tasks: list[object], now: dt.datetime) -> dict:
+        return inspect_queue(
+            {"tasks": tasks},
+            now,
+            social_grace=dt.timedelta(hours=2),
+            browser_grace=dt.timedelta(hours=8),
+        )
+
+    def test_future_linkedin_task_is_healthy(self) -> None:
+        report = self.inspect(
+            [
+                {
+                    "id": "linkedin:future",
+                    "site": "linkedin",
+                    "kind": "social",
+                    "scheduled_at": "2026-07-18T09:00:00+00:00",
+                }
+            ],
+            dt.datetime(2026, 7, 18, 8, 0, tzinfo=UTC),
+        )
+        self.assertTrue(report["healthy"])
+        self.assertEqual([], report["overdue"])
+
+    def test_linkedin_task_is_flagged_after_grace_period(self) -> None:
+        report = self.inspect(
+            [
+                {
+                    "id": "linkedin:stuck",
+                    "site": "linkedin",
+                    "kind": "social",
+                    "scheduled_at": "2026-07-18T09:00:00Z",
+                }
+            ],
+            dt.datetime(2026, 7, 18, 12, 30, tzinfo=UTC),
+        )
+        self.assertFalse(report["healthy"])
+        self.assertEqual("linkedin:stuck", report["overdue"][0]["id"])
+        self.assertEqual(1.5, report["overdue"][0]["overdue_hours"])
+
+    def test_browser_task_is_flagged_when_local_runner_does_not_drain_it(self) -> None:
+        report = self.inspect(
+            [
+                {
+                    "id": "medium:stuck",
+                    "site": "medium",
+                    "queued_at": "2026-07-17T13:00:00+00:00",
+                }
+            ],
+            dt.datetime(2026, 7, 17, 22, 0, tzinfo=UTC),
+        )
+        self.assertFalse(report["healthy"])
+        self.assertEqual("medium:stuck", report["overdue"][0]["id"])
+
+    def test_missing_or_naive_timestamp_is_invalid(self) -> None:
+        report = self.inspect(
+            [
+                {"id": "linkedin:missing", "site": "linkedin", "kind": "social"},
+                {
+                    "id": "medium:naive",
+                    "site": "medium",
+                    "queued_at": "2026-07-17T13:00:00",
+                },
+            ],
+            dt.datetime(2026, 7, 17, 14, 0, tzinfo=UTC),
+        )
+        self.assertFalse(report["healthy"])
+        self.assertEqual(2, len(report["invalid"]))
+
+    def test_missing_direct_platform_is_flagged_after_daily_grace(self) -> None:
+        post = SimpleNamespace(slug="stuck-post", date=dt.date(2026, 7, 8))
+        state = {
+            "posts": {
+                "stuck-post": {
+                    "devto": {"url": "https://dev.to/example"},
+                    "hashnode": {},
+                }
+            }
+        }
+        overdue = inspect_platform_state(
+            [post],
+            state,
+            dt.datetime(2026, 7, 17, 13, 0, tzinfo=UTC),
+            grace=dt.timedelta(hours=36),
+        )
+        self.assertEqual(["hashnode:stuck-post"], [item["id"] for item in overdue])
+
+    def test_foojay_is_expected_only_for_friday_posts(self) -> None:
+        thursday = SimpleNamespace(slug="thursday", date=dt.date(2026, 7, 9))
+        friday = SimpleNamespace(slug="friday", date=dt.date(2026, 7, 10))
+        state = {
+            "posts": {
+                slug: {
+                    "devto": {"url": "https://dev.to/example"},
+                    "hashnode": {"url": "https://hashnode.com/example"},
+                }
+                for slug in ("thursday", "friday")
+            }
+        }
+        overdue = inspect_platform_state(
+            [thursday, friday],
+            state,
+            dt.datetime(2026, 7, 20, 0, 0, tzinfo=UTC),
+            grace=dt.timedelta(hours=36),
+        )
+        self.assertEqual(["foojay:friday"], [item["id"] for item in overdue])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a watchdog triggered after blog syndication runs and every four hours
- open and assign a persistent GitHub issue when the workflow fails or syndication work stalls
- detect overdue local Medium, DZone, LinkedIn, Hashnode, DEV, and Foojay work
- remind daily while unhealthy and close the issue automatically after recovery

## Validation
- `python3 scripts/website/test_syndication_health.py`
- `python3 scripts/website/test_syndicate_blog_posts.py`
- parsed both workflow YAML files with Ruby/Psych
- `git diff --check`