### PR TITLE
Fix JCEF HiDPI callbacks and JavaSE runtime provisioning

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -31,10 +31,10 @@ jobs:
     - name: Free disk space for desktop runtime dependencies
       run: |
         # This Java-only job does not use the preinstalled Android, .NET, or
-        # Haskell toolchains. cn1-binaries-javase intentionally resolves large
-        # cross-platform JCEF and FFmpeg artifacts, then integration tests copy
-        # them into generated applications, so the stock runner otherwise runs
-        # out of disk while duplicating those artifacts.
+        # Haskell toolchains. cn1-binaries-javase resolves the large cross-
+        # platform FFmpeg artifacts, then integration tests copy them into
+        # generated applications, so the stock runner otherwise runs out of
+        # disk while duplicating those artifacts.
         sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
         df -h /
     - name: Set up JDK 8

--- a/.github/workflows/javase-cef-ffmpeg-smoke.yml
+++ b/.github/workflows/javase-cef-ffmpeg-smoke.yml
@@ -50,7 +50,9 @@ jobs:
       - name: Cache Maven dependencies
         uses: actions/cache@v4
         with:
-          path: .m2/repository
+          path: |
+            .m2/repository
+            ~/.codenameone/jcef
           key: ${{ runner.os }}-javase-smoke-m2-${{ hashFiles('maven/**/*.xml', 'maven/**/*.pom', 'maven/tests/javase-cef-ffmpeg-smoke/**') }}
           restore-keys: |
             ${{ runner.os }}-javase-smoke-m2-

--- a/CodenameOneDesigner/src/com/codename1/designer/css/CN1CSSCLI.java
+++ b/CodenameOneDesigner/src/com/codename1/designer/css/CN1CSSCLI.java
@@ -621,8 +621,8 @@ public class CN1CSSCLI {
             System.out.println("                    The compile fails listing offending rules instead of falling back.");
             System.out.println("                    Used by the framework native-themes build.");
             System.out.println("\nSystem Properties:");
-            System.out.println(" cef.dir            The path to the CEF directory.");
-            System.out.println("                    Required for generation of image borders.");
+            System.out.println(" cn1.jcef.installDir  Optional JCEF Maven installation directory.");
+            System.out.println(" cn1.jcef.mirrors     Optional comma-separated JCEF download mirrors.");
             System.out.println(" parent.port        The port number to connect to the parent process for watch mode so that it knows ");
             System.out.println("                    to exit if the parent process ends.");
             return;

--- a/Ports/JavaSE/nbproject/project.properties
+++ b/Ports/JavaSE/nbproject/project.properties
@@ -43,7 +43,13 @@ endorsed.classpath=
 # the Ant simulator and gets the real GPU backend in the Maven simulator.
 excludes=com/codename1/testing/junit/**,com/codename1/impl/javase/JavaSEJoglSurface.java,com/codename1/impl/javase/JavaSEGLDevice.java
 file.reference.Filters.jar=../../../cn1-binaries/javase/Filters.jar
+file.reference.commons-codec.jar=../../../cn1-binaries/javase/commons-codec.jar
+file.reference.commons-compress.jar=../../../cn1-binaries/javase/commons-compress.jar
+file.reference.commons-io.jar=../../../cn1-binaries/javase/commons-io.jar
+file.reference.commons-lang3.jar=../../../cn1-binaries/javase/commons-lang3.jar
+file.reference.gson.jar=../../../cn1-binaries/javase/gson.jar
 file.reference.jcef.jar=../../../cn1-binaries/javase/jcef.jar
+file.reference.jcefmaven.jar=../../../cn1-binaries/javase/jcefmaven.jar
 file.reference.jmf-2.1.1e.jar=../../../cn1-binaries/javase/jmf-2.1.1e.jar
 file.reference.jfxrt.jar=../../../cn1-binaries/jfxrt.jar
 file.reference.sqlite-jdbc-3.46.1.0.jar=../../../cn1-binaries/javase/sqlite-jdbc-3.46.1.0.jar
@@ -54,7 +60,13 @@ javac.classpath=\
     ${reference.CodenameOne.jar}:\
     ${file.reference.sqlite-jdbc-3.46.1.0.jar}:\
     ${file.reference.Filters.jar}:\
+    ${file.reference.commons-codec.jar}:\
+    ${file.reference.commons-compress.jar}:\
+    ${file.reference.commons-io.jar}:\
+    ${file.reference.commons-lang3.jar}:\
+    ${file.reference.gson.jar}:\
     ${file.reference.jcef.jar}:\
+    ${file.reference.jcefmaven.jar}:\
     ${file.reference.jmf-2.1.1e.jar}:\
     ${file.reference.jfxrt.jar}
 # Space-separated list of extra javac options

--- a/Ports/JavaSE/src/com/codename1/impl/javase/CN1Bootstrap.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/CN1Bootstrap.java
@@ -27,11 +27,12 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
+import org.cef.CN1JcefRuntime;
 
 /**
- * A utility class which will dynamically add CEF to the classpath if it is available.  This is
- * used by the CSS compiler, and should also be used by other desktop CN1 apps that need to use
- * CEF.
+ * Bootstraps the reloadable JavaSE classpath while keeping native-backed
+ * libraries such as JCEF in the parent classloader. This is used by the CSS
+ * compiler and desktop Codename One applications.
  * @author shannah
  */
 public class CN1Bootstrap {
@@ -59,6 +60,21 @@ public class CN1Bootstrap {
             return true;
         } catch (Throwable ex){}
         return false;
+    }
+
+    /**
+     * Checks whether JCEF Maven provides a native runtime for this platform.
+     * The runtime itself is installed lazily when the first BrowserComponent
+     * is created.
+     *
+     * @return true if JCEF is available for this platform
+     */
+    public static boolean isCEFSupported() {
+        try {
+            return CN1JcefRuntime.isSupported();
+        } catch (Throwable ex) {
+            return false;
+        }
     }
 
     private static boolean hasFFmpeg() {
@@ -89,9 +105,9 @@ public class CN1Bootstrap {
     }
     
     /**
-     * <p>Run the given mainclass with a bootstrapped classpath (i.e. it will first attempt to 
-     * add CEF to the classpath, and then run the main() method of the given class using the
-     * bootstrapped classloader.</p>
+     * <p>Run the given main class with a bootstrapped classpath, keeping JCEF
+     * in the parent classloader and running the main method with the reloadable
+     * child classloader.</p>
      * 
      * <p>NOTE: This will only execute the main class if bootstrapping had not already occurred.  This is
      * is to allow you to call this method inside your class's main() method without infinite recursion, as follows:</p>
@@ -163,30 +179,7 @@ public class CN1Bootstrap {
             fxSupported = true;
         } catch (Throwable ex) {}
         boolean fxOnSystemPath = fxSupported;
-        File cef = System.getProperty("cef.dir") != null ? new File(System.getProperty("cef.dir")) : new File(System.getProperty("user.home") + File.separator + ".codenameone" + File.separator + "cef");
-        //File cef = new File(System.getProperty("user.home") + File.separator + ".codenameone" + File.separator + "cef");
-        if (cef.exists()) {
-            if (isUnix && !is64Bit) {
-                System.out.println("Found CEF, but not using because CEF is only supported on 64 bit platforms.  Try running inside a 64 bit JVM");
-            } else {
-                
-            
-                cefSupported = true;
-                System.out.println("Adding CEF to classpath " + cef);
-                String cn1LibPath = System.getProperty("cn1.library.path", ".");
-                String bitSuffix = is64Bit ? "64" : "32";
-                String nativeDir = isMac ? "macos64" : isWindows ? ("lib" + File.separator + "win"+bitSuffix) : ("lib" + File.separator + "linux"+bitSuffix);
-                System.setProperty("cn1.library.path", cn1LibPath + File.pathSeparator + cef.getAbsolutePath() + File.separator + nativeDir);
-
-                // Necessary to modify java.libary.path property on windows as it is used by CefApp to locate jcef_helper.exe
-                System.setProperty("java.library.path", cef.getAbsolutePath()+File.separator+nativeDir+File.pathSeparator+System.getProperty("java.library.path", "."));
-                for (File jar : cef.listFiles()) {
-                    if (jar.getName().endsWith(".jar")) {
-                        files.add(jar);
-                    }
-                }
-            }
-        }
+        cefSupported = isCEFSupported();
         
         File jmf = new File(System.getProperty("user.home") + File.separator + ".codenameone" + File.separator + "jmf-2.1.1e.jar");
         if (jmf.exists()) {
@@ -199,7 +192,8 @@ public class CN1Bootstrap {
         
         if (implementation.equalsIgnoreCase("cef") && !cefSupported) {
             // We will use CEF
-            System.err.println("cn1.javase.implementation=cef but CEF was not found.  Please update your Codename One libraries and try again.\nAlternatively, you can try using a different implementation.");
+            System.err.println("cn1.javase.implementation=cef but JCEF Maven does not support "
+                    + "this platform. Please try a different JavaSE implementation.");
             System.exit(1);
         }
         if (implementation.equalsIgnoreCase("fx") && !fxSupported) {
@@ -237,6 +231,7 @@ public class CN1Bootstrap {
             
         }
         ((ClassPathLoader)ldr).addExclude("org.cef.");
+        ((ClassPathLoader)ldr).addExclude("me.friwi.jcefmaven.");
         
         final ClassLoader fLdr = ldr;
         Class c = Class.forName(mainClass, true, ldr);
@@ -251,27 +246,4 @@ public class CN1Bootstrap {
     private static boolean isWindows = (OS.indexOf("win") >= 0);
     
 
-    private static boolean isMac =  (OS.indexOf("mac") >= 0);
-    private static final String ARCH = System.getProperty("os.arch");
-
-    private static boolean isUnix = (OS.indexOf("nux") >= 0);
-    private static final boolean is64Bit = is64Bit();
-    private static final boolean is64Bit() {
-        
-        String model = System.getProperty("sun.arch.data.model",
-                                          System.getProperty("com.ibm.vm.bitmode"));
-        if (model != null) {
-            return "64".equals(model);
-        }
-        if ("x86-64".equals(ARCH)
-            || "ia64".equals(ARCH)
-            || "ppc64".equals(ARCH) || "ppc64le".equals(ARCH)
-            || "sparcv9".equals(ARCH)
-            || "mips64".equals(ARCH) || "mips64el".equals(ARCH)
-            || "amd64".equals(ARCH)
-            || "aarch64".equals(ARCH)) {
-            return true;
-        }
-        return false;
-    }
 }

--- a/Ports/JavaSE/src/com/codename1/impl/javase/CSSWatcher.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/CSSWatcher.java
@@ -289,13 +289,10 @@ public class CSSWatcher implements Runnable {
                         + "(which both fetches the right designer into m2 and pins it via -Dcodename1.designer.jar).");
             }
         }
-        String cefDir = System.getProperty("cef.dir", cn1Home + File.separator + "cef");
-        
         //List<String> args = new ArrayList<String>();
         ProcessBuilder pb = new ProcessBuilder(
                 javaBin.getAbsolutePath(),
                 "-jar", "-Dcli=true", 
-                "-Dcef.dir="+cefDir, 
                 "-Dparent.port="+pulseSocket.getLocalPort(), 
                 designerJar.getAbsolutePath(), 
                 "-css"    

--- a/Ports/JavaSE/src/com/codename1/impl/javase/CSSWatcher.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/CSSWatcher.java
@@ -1,7 +1,24 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.javase;
 

--- a/Ports/JavaSE/src/com/codename1/impl/javase/ClassPathLoader.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/ClassPathLoader.java
@@ -52,6 +52,8 @@ class ClassPathLoader extends ClassLoader {
         excludes.add("netscape.javascript");
         excludes.add("javafx");
         excludes.add("org.sqlite");
+        excludes.add("org.cef.");
+        excludes.add("me.friwi.jcefmaven.");
         excludes.add("org.w3c");
     }
     private List<String> includes = new ArrayList<String>();

--- a/Ports/JavaSE/src/com/codename1/impl/javase/Simulator.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/Simulator.java
@@ -192,28 +192,11 @@ public class Simulator {
         } catch (Throwable ex) {}
         boolean fxOnSystemPath = fxSupported;
         
-        File cef = System.getProperty("cef.dir") != null ? new File(System.getProperty("cef.dir")) : new File(System.getProperty("user.home") + File.separator + ".codenameone" + File.separator + "cef");
-        if (cef.exists()) {
-            if (isUnix && !is64Bit) {
-                System.out.println("Found CEF, but not using because CEF is only supported on 64 bit platforms.  Try running inside a 64 bit JVM");
-            } else {
-                
-            
-                cefSupported = true;
-                System.out.println("Adding CEF to classpath");
-                String cn1LibPath = System.getProperty("cn1.library.path", ".");
-                String bitSuffix = is64Bit ? "64" : "32";
-                String nativeDir = isMac ? "macos64" : isWindows ? ("lib" + File.separator + "win"+bitSuffix) : ("lib" + File.separator + "linux"+bitSuffix);
-                System.setProperty("cn1.library.path", cn1LibPath + File.pathSeparator + cef.getAbsolutePath() + File.separator + nativeDir);
-
-                // Necessary to modify java.libary.path property on windows as it is used by CefApp to locate jcef_helper.exe
-                System.setProperty("java.library.path", cef.getAbsolutePath()+File.separator+nativeDir+File.pathSeparator+System.getProperty("java.library.path", "."));
-                for (File jar : cef.listFiles()) {
-                    if (jar.getName().endsWith(".jar") && !jar.getName().endsWith("-tests.jar")) {
-                        files.add(jar.getAbsoluteFile());
-                    }
-                }
-            }
+        try {
+            Class cefRuntime = Class.forName("org.cef.CN1JcefRuntime");
+            cefSupported = Boolean.TRUE.equals(cefRuntime.getMethod("isSupported").invoke(null));
+        } catch (Throwable ex) {
+            cefSupported = false;
         }
         
         File jmf = new File(System.getProperty("user.home") + File.separator + ".codenameone" + File.separator + "jmf-2.1.1e.jar");
@@ -227,7 +210,8 @@ public class Simulator {
         
         if (implementation.equalsIgnoreCase("cef") && !cefSupported) {
             // We will use CEF
-            System.err.println("cn1.javase.implementation=cef but CEF was not found.  Please update your Codename One libraries and try again.\nAlternatively, you can try using a different implementation.");
+            System.err.println("cn1.javase.implementation=cef but JCEF Maven does not support "
+                    + "this platform. Please try a different JavaSE implementation.");
             System.exit(1);
         }
         if (implementation.equalsIgnoreCase("fx") && !fxSupported) {
@@ -273,6 +257,7 @@ public class Simulator {
         }
         System.setProperty("cn1.classPathLoader.Path", filesPath.toString());
         ((ClassPathLoader)ldr).addExclude("org.cef.");
+        ((ClassPathLoader)ldr).addExclude("me.friwi.jcefmaven.");
         
         final ClassLoader fLdr = ldr;
         Thread.currentThread().setContextClassLoader(fLdr);
@@ -361,30 +346,6 @@ public class Simulator {
     private static boolean isWindows = (OS.indexOf("win") >= 0);
     
 
-    private static boolean isMac =  (OS.indexOf("mac") >= 0);
-    private static final String ARCH = System.getProperty("os.arch");
-
-    private static boolean isUnix = (OS.indexOf("nux") >= 0);
-    private static final boolean is64Bit = is64Bit();
-    private static final boolean is64Bit() {
-        
-        String model = System.getProperty("sun.arch.data.model",
-                                          System.getProperty("com.ibm.vm.bitmode"));
-        if (model != null) {
-            return "64".equals(model);
-        }
-        if ("x86-64".equals(ARCH)
-            || "ia64".equals(ARCH)
-            || "ppc64".equals(ARCH) || "ppc64le".equals(ARCH)
-            || "sparcv9".equals(ARCH)
-            || "mips64".equals(ARCH) || "mips64el".equals(ARCH)
-            || "amd64".equals(ARCH)
-            || "aarch64".equals(ARCH)) {
-            return true;
-        }
-        return false;
-    }
-    
     /**
      * Encapsulates the hotswap-agent.properties file that is used when running with HotswapAgent.
      * See https://github.com/HotswapProjects/HotswapAgent

--- a/Ports/JavaSE/src/com/codename1/impl/javase/cef/AppHandler.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/cef/AppHandler.java
@@ -6,17 +6,17 @@ package com.codename1.impl.javase.cef;
 
 import java.util.HashMap;
 import java.util.Map;
+import me.friwi.jcefmaven.MavenCefAppHandlerAdapter;
 import org.cef.CefApp;
 import org.cef.CefApp.CefAppState;
 import org.cef.browser.CefBrowser;
 import org.cef.browser.CefFrame;
 import org.cef.callback.CefSchemeHandlerFactory;
 import org.cef.callback.CefSchemeRegistrar;
-import org.cef.handler.CefAppHandlerAdapter;
 import org.cef.handler.CefResourceHandler;
 import org.cef.network.CefRequest;
 
-public class AppHandler extends CefAppHandlerAdapter  {
+public class AppHandler extends MavenCefAppHandlerAdapter  {
     
    
     
@@ -25,8 +25,8 @@ public class AppHandler extends CefAppHandlerAdapter  {
     // We're registering our own schemes to demonstrate how to use
     // CefAppHandler.onRegisterCustomSchemes() in combination with
     // CefApp.registerSchemeHandlerFactory().
-    public AppHandler(String[] args) {
-        super(args);
+    public AppHandler() {
+        super();
     }
     
     

--- a/Ports/JavaSE/src/com/codename1/impl/javase/cef/AppHandler.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/cef/AppHandler.java
@@ -1,6 +1,25 @@
-// Copyright (c) 2014 The Chromium Embedded Framework Authors. All rights
-// reserved. Use of this source code is governed by a BSD-style license that
-// can be found in the LICENSE file.
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 
 package com.codename1.impl.javase.cef;
 

--- a/Ports/JavaSE/src/com/codename1/impl/javase/cef/BrowserPanel.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/cef/BrowserPanel.java
@@ -37,8 +37,10 @@ import java.lang.ref.WeakReference;
 import java.net.ServerSocket;
 import javax.swing.JButton;
 import javax.swing.SwingUtilities;
+import me.friwi.jcefmaven.CefAppBuilder;
 import org.cef.CefApp;
 import org.cef.CefClient;
+import org.cef.CN1JcefRuntime;
 import org.cef.CefSettings;
 import org.cef.OS;
 import org.cef.browser.CN1CefBrowser;
@@ -179,7 +181,13 @@ public abstract class BrowserPanel extends CN1JPanel {
             //    application arguments to it, if you want to handle any
             //    chromium or CEF related switches/attributes in
             //    the native world.
-           CefSettings settings = new CefSettings();
+            CefAppBuilder builder;
+            try {
+                builder = CN1JcefRuntime.createBuilder(args);
+            } catch (Exception ex) {
+                throw new RuntimeException("Failed to configure JCEF", ex);
+            }
+            CefSettings settings = builder.getCefSettings();
             //settings.log_severity = CefSettings.LogSeverity.LOGSEVERITY_VERBOSE;
             //settings.log_file = "/tmp/cef.log";
             
@@ -199,7 +207,12 @@ public abstract class BrowserPanel extends CN1JPanel {
             
             settings.remote_debugging_port = port;
             JavaSEPort.instance.setChromeDebugPort(port);
-            myApp = CefApp.getInstance(args, settings);
+            builder.setAppHandler(new AppHandler());
+            try {
+                myApp = CN1JcefRuntime.build(builder);
+            } catch (Exception ex) {
+                throw new RuntimeException("Failed to install or initialize JCEF", ex);
+            }
 
             CefApp.CefVersion version = myApp.getVersion();
             System.out.println("Using:\n" + version);
@@ -212,7 +225,6 @@ public abstract class BrowserPanel extends CN1JPanel {
             
             
             
-            CefApp.addAppHandler(new AppHandler(args));
         } else {
             myApp = CefApp.getInstance(args);
         }

--- a/Ports/JavaSE/src/com/codename1/impl/javase/cef/CEFBrowserComponent.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/cef/CEFBrowserComponent.java
@@ -15,14 +15,11 @@ import com.codename1.ui.events.ActionEvent;
 import com.codename1.ui.events.BrowserNavigationCallback;
 import java.awt.EventQueue;
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import javax.swing.JFrame;
-import org.cef.CefApp;
-import org.cef.CefSettings;
 
 /**
  *
@@ -35,26 +32,6 @@ public class CEFBrowserComponent extends Peer implements IBrowserComponent  {
     private static final boolean isWindows = isWindows();
     private static final boolean isMac = isMac();
     private static final boolean isUnix = isUnix();
-    private static final boolean is64Bit = is64Bit();
-    private static final String ARCH = System.getProperty("os.arch");
-    private static final boolean is64Bit() {
-        
-        String model = System.getProperty("sun.arch.data.model",
-                                          System.getProperty("com.ibm.vm.bitmode"));
-        if (model != null) {
-            return "64".equals(model);
-        }
-        if ("x86-64".equals(ARCH)
-            || "ia64".equals(ARCH)
-            || "ppc64".equals(ARCH) || "ppc64le".equals(ARCH)
-            || "sparcv9".equals(ARCH)
-            || "mips64".equals(ARCH) || "mips64el".equals(ARCH)
-            || "amd64".equals(ARCH)
-            || "aarch64".equals(ARCH)) {
-            return true;
-        }
-        return false;
-    }
     private static boolean isWindows() {
         return (OS.indexOf("win") >= 0);
     }
@@ -121,45 +98,9 @@ public class CEFBrowserComponent extends Peer implements IBrowserComponent  {
     
     
     
-    private static String getLibPath() {
-        String out = System.getProperty("cef.libPath", null);
-        if (out != null) {
-            return out;
-        }
-        
-        if (isMac) {
-            String cefRoot = System.getProperty("cef.dir",
-                    System.getProperty("user.home")+File.separator+".codenameone"+File.separator+"cef")+File.separator;
-
-            return cefRoot + "macos64";
-        } else if (isWindows) {
-            String bitSuffix = is64Bit ? "64" : "32";
-            String cefRoot = System.getProperty("cef.dir",
-                    System.getProperty("user.home")+File.separator+".codenameone"+File.separator+"cef")+File.separator+"lib"+File.separator;
-            return cefRoot + "win"+bitSuffix;
-        } else if (isUnix && is64Bit) {
-            
-            String bitSuffix = is64Bit ? "64" : "32";
-            String cefRoot = System.getProperty("cef.dir",
-                    System.getProperty("user.home")+File.separator+".codenameone"+File.separator+"cef")+File.separator+"lib"+File.separator;
-            return cefRoot + "linux"+bitSuffix;
-        }else {
-            throw new UnsupportedOperationException("CEF Not implemented on this platform yet");
-        }
-    }
-    
     private static String[] createArgs() {
         List<String> args = new ArrayList<String>();
         if (isMac) {
-
-            if (!"true".equals(System.getProperty("cn1.cef.bundled"))) {
-                // The cn1.cef.bundled flag is set in SEWrapper to indicate that CEF is bundled in the .app
-                // Otherwise it needs to get CEF from the central location specified 
-                args.add(String.format("--framework-dir-path=%s/Chromium Embedded Framework.framework", getLibPath()));
-                args.add(String.format("--main-bundle-path=%s/jcef Helper.app", getLibPath()));
-                args.add(String.format("--browser-subprocess-path=%s/jcef Helper.app/Contents/MacOS/jcef Helper", getLibPath()));
-            }
-            
             args.add("--disable-gpu");
         } else if (isWindows) {
             // no extra stuff here
@@ -196,19 +137,7 @@ public class CEFBrowserComponent extends Peer implements IBrowserComponent  {
         return create(null, parent);
     }
     public static CEFBrowserComponent create(final String startingURL, final CEFBrowserComponentListener parent) {
-        CefSettings settings = new CefSettings();
-        
         String[] args = createArgs();
-        // Perform startup initialization on platforms that require it.
-        if (!"true".equals(System.getProperty("cef.started", "false"))) {
-            if (!CefApp.startup(args)) {
-                System.err.println("CEFStartup initialization failed");
-                throw new RuntimeException("CEF Startup initialization failed!");
-
-            }
-            System.setProperty("cef.started", "true");
-        }
-        
 
         // OSR mode is enabled by default on Linux.
         // and disabled by default on Windows and Mac OS X.

--- a/Ports/JavaSE/src/com/codename1/impl/javase/cef/CEFBrowserComponent.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/cef/CEFBrowserComponent.java
@@ -1,7 +1,24 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.impl.javase.cef;
 

--- a/Ports/JavaSE/src/org/cef/CN1JcefRuntime.java
+++ b/Ports/JavaSE/src/org/cef/CN1JcefRuntime.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package org.cef;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.util.ArrayList;
+import java.util.List;
+import me.friwi.jcefmaven.CefAppBuilder;
+import me.friwi.jcefmaven.CefBuildInfo;
+import me.friwi.jcefmaven.CefInitializationException;
+import me.friwi.jcefmaven.EnumPlatform;
+import me.friwi.jcefmaven.UnsupportedPlatformException;
+
+/**
+ * Owns the JCEF Maven runtime used by the JavaSE port.
+ *
+ * <p>This class is deliberately in the {@code org.cef} package.  The
+ * simulator keeps that package in its parent class loader so JCEF and its
+ * native libraries are initialized exactly once while application classes
+ * can still be reloaded.</p>
+ */
+public final class CN1JcefRuntime {
+    public static final String INSTALL_DIR_PROPERTY = "cn1.jcef.installDir";
+    public static final String MIRRORS_PROPERTY = "cn1.jcef.mirrors";
+
+    private static CefApp instance;
+
+    private CN1JcefRuntime() {
+    }
+
+    /**
+     * Returns whether JCEF Maven supports the current operating system and
+     * architecture.
+     *
+     * @return true if a native JCEF distribution is available
+     */
+    public static boolean isSupported() {
+        try {
+            EnumPlatform.getCurrentPlatform();
+            CefBuildInfo.fromClasspath();
+            return true;
+        } catch (Throwable ex) {
+            return false;
+        }
+    }
+
+    /**
+     * Creates a builder configured with Codename One's shared, versioned JCEF
+     * cache and optional download mirrors.
+     *
+     * @param args Chromium command-line arguments
+     * @return the configured builder
+     * @throws IOException if the JCEF build metadata cannot be read
+     * @throws UnsupportedPlatformException if the current platform is unsupported
+     */
+    public static CefAppBuilder createBuilder(String[] args) throws IOException, UnsupportedPlatformException {
+        CefAppBuilder builder = new CefAppBuilder();
+        builder.setInstallDir(getInstallDir());
+        if (args != null) {
+            builder.addJcefArgs(args);
+        }
+        List<String> mirrors = getConfiguredMirrors();
+        if (!mirrors.isEmpty()) {
+            builder.setMirrors(mirrors);
+        }
+        return builder;
+    }
+
+    /**
+     * Installs the native runtime, if necessary, and initializes JCEF.  A file
+     * lock protects the shared cache when two simulator or desktop processes
+     * start for the first time concurrently.
+     *
+     * @param builder a configured JCEF Maven builder
+     * @return the process-wide JCEF application
+     * @throws IOException if the runtime cannot be installed
+     * @throws UnsupportedPlatformException if the current platform is unsupported
+     * @throws InterruptedException if initialization is interrupted
+     * @throws CefInitializationException if JCEF cannot be initialized
+     */
+    public static synchronized CefApp build(CefAppBuilder builder)
+            throws IOException, UnsupportedPlatformException, InterruptedException,
+            CefInitializationException {
+        if (instance != null) {
+            return instance;
+        }
+
+        File installDir = getInstallDir();
+        File lockFile = new File(installDir.getParentFile(), installDir.getName() + ".lock");
+        File parent = lockFile.getParentFile();
+        if (!parent.exists() && !parent.mkdirs() && !parent.isDirectory()) {
+            throw new IOException("Could not create JCEF cache directory " + parent);
+        }
+
+        RandomAccessFile lockAccess = new RandomAccessFile(lockFile, "rw");
+        try {
+            FileChannel channel = lockAccess.getChannel();
+            try {
+                FileLock lock = channel.lock();
+                try {
+                    builder.install();
+                } finally {
+                    lock.release();
+                }
+            } finally {
+                channel.close();
+            }
+        } finally {
+            lockAccess.close();
+        }
+
+        instance = builder.build();
+        return instance;
+    }
+
+    static File getInstallDir() throws IOException, UnsupportedPlatformException {
+        String configured = System.getProperty(INSTALL_DIR_PROPERTY);
+        if (configured != null && configured.trim().length() > 0) {
+            File installDir = new File(configured.trim()).getAbsoluteFile();
+            if (installDir.getParentFile() == null
+                    || installDir.getCanonicalFile().equals(
+                            new File(System.getProperty("user.home")).getCanonicalFile())) {
+                throw new IOException(INSTALL_DIR_PROPERTY
+                        + " must point to a dedicated JCEF runtime directory");
+            }
+            return installDir;
+        }
+        CefBuildInfo buildInfo = CefBuildInfo.fromClasspath();
+        String platform = EnumPlatform.getCurrentPlatform().getIdentifier();
+        return new File(new File(new File(System.getProperty("user.home"), ".codenameone"), "jcef"),
+                buildInfo.getReleaseTag() + File.separator + platform).getAbsoluteFile();
+    }
+
+    static List<String> getConfiguredMirrors() {
+        List<String> out = new ArrayList<String>();
+        String configured = System.getProperty(MIRRORS_PROPERTY);
+        if (configured == null) {
+            return out;
+        }
+        String[] parts = configured.split("[,\\r\\n]+");
+        for (String part : parts) {
+            String mirror = part.trim();
+            if (mirror.length() > 0) {
+                out.add(mirror);
+            }
+        }
+        return out;
+    }
+}

--- a/Ports/JavaSE/src/org/cef/browser/CN1CefBrowser.java
+++ b/Ports/JavaSE/src/org/cef/browser/CN1CefBrowser.java
@@ -609,6 +609,21 @@ public class CN1CefBrowser extends CefBrowser_N {
         }
         return true;
     }
+
+    /**
+     * Compatibility entry point used directly by JCEF's native render handler.
+     *
+     * JCEF normally invokes render callbacks on the object returned by
+     * {@link #getRenderHandler()}, but its native GetScreenInfo implementation
+     * invokes this method on the browser object itself.  Keep this exact public
+     * signature even though the Java render handler delegates to
+     * {@link #getScreenInfoImpl(org.cef.browser.CefBrowser, org.cef.handler.CefScreenInfo)}.
+     * Without it JNI raises NoSuchMethodError and CEF never receives the HiDPI
+     * device scale factor.
+     */
+    public boolean getScreenInfo(CefBrowser browser, CefScreenInfo screenInfo) {
+        return getScreenInfoImpl(browser, screenInfo);
+    }
     
     private static double calcRetinaScale() {
         

--- a/docs/demos/javase/pom.xml
+++ b/docs/demos/javase/pom.xml
@@ -445,10 +445,6 @@
                                     the initialize phase. -->
 
 
-                              <!-- The location of CEF.  This property is set in the
-                                  prepare-simulator-classpath goal, and the CEF files are
-                                  managed by maven. -->
-                              <argument>-Dcef.dir=${cef.dir}</argument>
 
                               <!-- The location of the designer jar.  This property is set in the
                                   prepare-simulator-classpath goal, and the file itself is managed
@@ -550,10 +546,6 @@
                                     the initialize phase. -->
 
 
-                              <!-- The location of CEF.  This property is set in the
-                                  prepare-simulator-classpath goal, and the CEF files are
-                                  managed by maven. -->
-                              <argument>-Dcef.dir=${cef.dir}</argument>
 
                               <!-- The location of the designer jar.  This property is set in the
                                   prepare-simulator-classpath goal, and the file itself is managed
@@ -648,10 +640,6 @@
                           <arguments>
                               <argument>-Xmx1024M</argument>
 
-                              <!-- The location of CEF.  This property is set in the
-                                  prepare-simulator-classpath goal, and the CEF files are
-                                  managed by maven. -->
-                              <argument>-Dcef.dir=${cef.dir}</argument>
 
                               <!-- The location of the designer jar.  This property is set in the
                                   prepare-simulator-classpath goal, and the file itself is managed
@@ -759,13 +747,6 @@
                                     are set in the prepare-simulator-classpath goal
                                     of the codenameone-maven-plugin which was run during
                                     the initialize phase. -->
-                              <systemProperty>
-                                  <!-- The location of CEF.  This property is set in the
-                                  prepare-simulator-classpath goal, and the CEF files are
-                                  managed by maven. -->
-                                  <key>cef.dir</key>
-                                  <value>${cef.dir}</value>
-                              </systemProperty>
                               <systemProperty>
                                   <!-- The location of the designer jar.  This property is set in the
                                   prepare-simulator-classpath goal, and the file itself is managed

--- a/maven/cn1-binaries/pom.xml
+++ b/maven/cn1-binaries/pom.xml
@@ -17,40 +17,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>me.friwi</groupId>
-            <artifactId>jcef-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>me.friwi</groupId>
-            <artifactId>jcef-natives-macosx-arm64</artifactId>
-            <version>${jcef.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>me.friwi</groupId>
-            <artifactId>jcef-natives-macosx-amd64</artifactId>
-            <version>${jcef.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>me.friwi</groupId>
-            <artifactId>jcef-natives-linux-amd64</artifactId>
-            <version>${jcef.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>me.friwi</groupId>
-            <artifactId>jcef-natives-linux-arm64</artifactId>
-            <version>${jcef.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>me.friwi</groupId>
-            <artifactId>jcef-natives-windows-amd64</artifactId>
-            <version>${jcef.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>me.friwi</groupId>
-            <artifactId>jcef-natives-windows-arm64</artifactId>
-            <version>${jcef.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.bytedeco</groupId>
             <artifactId>ffmpeg-platform</artifactId>
         </dependency>

--- a/maven/cn1app-archetype/src/main/resources/archetype-resources/javase/pom.xml
+++ b/maven/cn1app-archetype/src/main/resources/archetype-resources/javase/pom.xml
@@ -73,13 +73,9 @@
           <scope>provided</scope>
       </dependency>
       <!--
-        Desktop runtime binaries: the JCEF Java API + per-platform natives (for
-        the BrowserComponent) and bundled ffmpeg (for media). codenameone-javase
-        declares jcef-api as optional, so it is not inherited transitively; this
-        aggregator puts org.cef on the app classpath for every profile (simulator,
-        IntelliJ run, run-desktop, executable-jar). Without it the simulator/desktop
-        app runs but the BrowserComponent fails to initialize CEF. The plugin
-        provisions and extracts the matching native binaries at run/build time.
+        Optional bundled ffmpeg runtime for desktop media. BrowserComponent gets
+        JCEF Maven transitively from codenameone-javase; JCEF Maven downloads and
+        installs the matching native runtime on first use.
       -->
       <dependency>
           <groupId>com.codenameone</groupId>
@@ -436,10 +432,6 @@
                                     the initialize phase. -->
 
 
-                              <!-- The location of CEF.  This property is set in the
-                                  prepare-simulator-classpath goal, and the CEF files are
-                                  managed by maven. -->
-                              <argument>-Dcef.dir=${cef.dir}</argument>
 
                               <!-- The location of the designer jar.  This property is set in the
                                   prepare-simulator-classpath goal, and the file itself is managed
@@ -541,10 +533,6 @@
                                     the initialize phase. -->
 
 
-                              <!-- The location of CEF.  This property is set in the
-                                  prepare-simulator-classpath goal, and the CEF files are
-                                  managed by maven. -->
-                              <argument>-Dcef.dir=${cef.dir}</argument>
 
                               <!-- The location of the designer jar.  This property is set in the
                                   prepare-simulator-classpath goal, and the file itself is managed
@@ -639,10 +627,6 @@
                           <arguments>
                               <argument>-Xmx1024M</argument>
 
-                              <!-- The location of CEF.  This property is set in the
-                                  prepare-simulator-classpath goal, and the CEF files are
-                                  managed by maven. -->
-                              <argument>-Dcef.dir=${cef.dir}</argument>
 
                               <!-- The location of the designer jar.  This property is set in the
                                   prepare-simulator-classpath goal, and the file itself is managed
@@ -750,13 +734,6 @@
                                     are set in the prepare-simulator-classpath goal
                                     of the codenameone-maven-plugin which was run during
                                     the initialize phase. -->
-                              <systemProperty>
-                                  <!-- The location of CEF.  This property is set in the
-                                  prepare-simulator-classpath goal, and the CEF files are
-                                  managed by maven. -->
-                                  <key>cef.dir</key>
-                                  <value>${cef.dir}</value>
-                              </systemProperty>
                               <systemProperty>
                                   <!-- The location of the designer jar.  This property is set in the
                                   prepare-simulator-classpath goal, and the file itself is managed

--- a/maven/cn1app-archetype/src/main/resources/archetype-resources/javase/src/desktop/java/__mainName__Stub.java
+++ b/maven/cn1app-archetype/src/main/resources/archetype-resources/javase/src/desktop/java/__mainName__Stub.java
@@ -76,11 +76,10 @@ public class ${mainName}Stub implements Runnable, WindowListener {
      * @param args the command line arguments
      */
     public static void main(String[] args) {
-        // Bootstrap the classpath/native library path (CEF) the same way the
-        // simulator does before touching any CEF class. This puts the JCEF native
-        // directory (from cef.dir) on java.library.path so chrome_elf/libcef load,
-        // then re-invokes this main() inside the bootstrapped classloader. It is a
-        // no-op (returns false) once bootstrapping has already happened.
+        // Bootstrap through the same parent classloader used by the simulator.
+        // JCEF Maven installs and loads the platform native runtime when the first
+        // BrowserComponent is created. This is a no-op once bootstrapping has
+        // already happened.
         try {
             if (CN1Bootstrap.run(${mainName}Stub.class, args)) {
                 return;
@@ -90,9 +89,9 @@ public class ${mainName}Stub implements Runnable, WindowListener {
             bootstrapError.printStackTrace();
         }
         try {
-            Class.forName("org.cef.CefApp");
-            System.setProperty("cn1.javase.implementation", "cef");
-            //System.setProperty("cn1.cef.bundled", "true");
+            if (CN1Bootstrap.isCEFSupported()) {
+                System.setProperty("cn1.javase.implementation", "cef");
+            }
         } catch (Throwable ex){}
 
         JavaSEPort.setNativeTheme("/NativeTheme.res");

--- a/maven/cn1app-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/maven/cn1app-archetype/src/main/resources/archetype-resources/pom.xml
@@ -61,13 +61,10 @@
                 <version>${cn1.version}</version>
             </dependency>
             <!--
-              Desktop runtime binaries (JCEF for the BrowserComponent + bundled
-              ffmpeg for media). This aggregator carries the jcef-api Java classes,
-              the per-platform jcef-natives, and ffmpeg-platform. jcef-api is
-              declared optional inside codenameone-javase, so it is NOT inherited
-              transitively; the javase module below must depend on this aggregator
-              explicitly or the simulator/desktop app has no org.cef on its
-              classpath and silently runs without a working BrowserComponent.
+              Optional desktop media binaries. BrowserComponent receives JCEF
+              Maven transitively from codenameone-javase and downloads the native
+              runtime for the current platform on first use. This aggregator is
+              retained for the bundled ffmpeg media implementation.
             -->
             <dependency>
                 <groupId>com.codenameone</groupId>

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/AbstractCN1Mojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/AbstractCN1Mojo.java
@@ -16,9 +16,6 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.PathMatcher;
 import java.util.*;
 
 import org.apache.commons.io.FileUtils;
@@ -854,59 +851,7 @@ public abstract class AbstractCN1Mojo extends AbstractMojo {
     }
     protected static String OS = System.getProperty("os.name").toLowerCase();
     protected static boolean isWindows = (OS.indexOf("win") >= 0);
-    
-
-    protected static boolean isMac =  (OS.indexOf("mac") >= 0);
-    protected static final String ARCH = System.getProperty("os.arch");
-
-    protected static boolean isUnix = (OS.indexOf("nux") >= 0);
-    protected static final boolean is64Bit = is64Bit();
-    protected static final boolean is64Bit() {
-        
-        String model = System.getProperty("sun.arch.data.model",
-                                          System.getProperty("com.ibm.vm.bitmode"));
-        if (model != null) {
-            return "64".equals(model);
-        }
-        if ("x86-64".equals(ARCH)
-            || "ia64".equals(ARCH)
-            || "ppc64".equals(ARCH) || "ppc64le".equals(ARCH)
-            || "sparcv9".equals(ARCH)
-            || "mips64".equals(ARCH) || "mips64el".equals(ARCH)
-            || "amd64".equals(ARCH)
-            || "aarch64".equals(ARCH)) {
-            return true;
-        }
-        return false;
-    }
-    
-    protected String getCefPlatform() {
-        if (isMac) return "mac";
-        if (isWindows) return is64Bit ? "win64" : "win32";
-        if (isUnix && is64Bit && ("amd64".equals(ARCH) || "aarch64".equals(ARCH))) return "linux64";
-        return null;
-    }
-
-    protected String getJcefNativeArtifactId() {
-        if (isMac) return "aarch64".equals(ARCH) ? "jcef-natives-macosx-arm64" : "jcef-natives-macosx-amd64";
-        if (isWindows) return "aarch64".equals(ARCH) ? "jcef-natives-windows-arm64" : "jcef-natives-windows-amd64";
-        if (isUnix && is64Bit) return "aarch64".equals(ARCH) ? "jcef-natives-linux-arm64" : "jcef-natives-linux-amd64";
-        return null;
-    }
-
-    protected String getCefRuntimeSubdir() {
-        if (isMac) return "macos64";
-        if (isWindows) return path("lib", is64Bit ? "win64" : "win32");
-        if (isUnix) return path("lib", is64Bit ? "linux64" : "linux32");
-        return null;
-    }
-
-    protected File getCefDir() {
-        String path = System.getProperty("cef.dir", null);
-
-        if (path == null || path.isEmpty()) return null;
-        return new File(path);
-    }
+    protected static boolean isMac = (OS.indexOf("mac") >= 0);
 
     protected File getFFmpegDir() {
         String path = System.getProperty("ffmpeg.dir", null);
@@ -920,180 +865,6 @@ public abstract class AbstractCN1Mojo extends AbstractMojo {
             return false;
         }
         return findExecutable(dir, "ffmpeg") != null && findExecutable(dir, "ffprobe") != null;
-    }
-
-    protected boolean isCefSetup() {
-        File cefDir = getCefDir();
-        if (cefDir == null) return false;
-        return cefDir.exists();
-    }
-
-    private void fixCefPermissions(File cefDir) {
-        getLog().debug("Checking permissions on "+cefDir+" and fixing if necessary");
-        Set<String> patterns = new HashSet<String>();
-        patterns.add("*.dylib");
-        patterns.add("*.so");
-        patterns.add("jcef_helper");
-        patterns.add("*.framework");
-        patterns.add("jcef Helper*");
-        patterns.add("Chromium Embedded Framework");
-        setExecutableRecursive(cefDir, patterns);
-
-        if ("linux64".equals(getCefPlatform())) {
-            getLog().debug("On linux platform.  Checking if we need to workaround issue with libjawt.so");
-            // There is a bug on many versions of linux because libjawt.so isn't in the LD_LIBRARY_PATH
-            // An easy way to fix this is to just copy it into the lib directory
-            File dest = new File(getCefDir(), path("lib", "linux64", "libjawt.so") );
-            File javaHome = new File(System.getProperty("java.home"));
-            File src = new File(javaHome, path("lib", "amd64", "libjawt.so"));
-            if (!src.exists()) {
-                src = new File(javaHome, path("lib", "libjawt.so"));
-            }
-            if (!dest.exists()) {
-                getLog().debug("libjawt.so fix has not been applied yet as "+dest+" does not exist");
-                if (src.exists()) {
-                    getLog().debug("We can attempt to apply libjawt.so fix since "+src+ " was found");
-                } else {
-                    getLog().debug("Cannot attempt to apply libjawt.so fix since "+src+" does not exist");
-                }
-            }
-
-            if (!dest.exists() && src.exists()) {
-                try {
-                    getLog().info("Copying "+src+" to "+dest+" to workaround issue with UnsatisfiedLinkError in CEF related to libjawt.so not being found in LD_LIBRARY_PATH");
-                    FileUtils.copyFile(src, dest);
-                } catch (Exception ex) {
-                    getLog().warn("Failed to copy libjawt.so into CEF lib directory.  There may be problems using the BrowserComponent and media.  If you experience problems try copying the file "+src+" into "+dest, ex);
-
-                }
-            }
-        }
-    }
-
-
-    private boolean match(File file, Collection<String> patterns) {
-        for (String pattern : patterns) {
-            if (pattern.contains("*")) {
-                PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:"+pattern);
-                if (matcher.matches(file.toPath().getFileName())) {
-                    return true;
-                }
-            } else {
-                if (pattern.equals(file.getName())) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    private void setExecutableRecursive(File root, Collection<String> patterns) {
-        if (match(root, patterns)) {
-            if (root.exists()) {
-                root.setExecutable(true, false);
-            }
-        }
-        if (root.isDirectory()) {
-            for (File child : root.listFiles()) {
-                setExecutableRecursive(child, patterns);
-            }
-        }
-
-    }
-
-    private File extractCefBundle(File nativeJar, String version) {
-        File extractedDir = new File(project.getBuild().getDirectory(), "cn1-cef-" + getCefPlatform());
-        File cefRoot = new File(extractedDir, "cef");
-        File runtimeDir = new File(cefRoot, getCefRuntimeSubdir());
-        File tempExtract = new File(extractedDir, "tmp");
-        // The version stamp guards against reusing a stale extraction after a JCEF
-        // upgrade. The native binary and the jcef-api Java classes must match: a
-        // mismatch surfaces at runtime as a native<->Java skew (e.g. a
-        // NoSuchMethodError for getScreenInfo, which also silently breaks HiDPI
-        // scaling). A timestamp check alone misses this because the previously
-        // extracted directory can be newer than a freshly resolved native jar.
-        File versionStamp = new File(cefRoot, ".cn1-jcef-version");
-        boolean versionMatches = version != null && version.equals(readVersionStamp(versionStamp));
-        boolean needsRefresh = !runtimeDir.exists()
-                || extractedDir.lastModified() < nativeJar.lastModified()
-                || !versionMatches;
-        if (isMac) {
-            File chromiumEmbeddedFramework = new File(runtimeDir, "Chromium Embedded Framework.framework/Chromium Embedded Framework");
-            needsRefresh = needsRefresh || !Files.isSymbolicLink(chromiumEmbeddedFramework.toPath());
-        }
-        if (!needsRefresh) {
-            return cefRoot;
-        }
-        if (runtimeDir.exists() && !versionMatches) {
-            getLog().info("Refreshing CEF: extracted JCEF native version does not match "
-                    + (version == null ? "the resolved version" : version));
-        }
-
-        if (extractedDir.exists()) {
-            delTree(extractedDir);
-        }
-        runtimeDir.mkdirs();
-        tempExtract.mkdirs();
-
-        getLog().info("Expanding CEF");
-        Expand expand = (Expand) antProject.createTask("unzip");
-        expand.setDest(tempExtract);
-        expand.setSrc(nativeJar);
-        expand.execute();
-
-        File tarball = findFileBySuffix(tempExtract, ".tar.gz");
-        if (tarball == null) {
-            throw new IllegalStateException("Failed to find native JCEF tarball in " + nativeJar);
-        }
-        ExecTask tar = (ExecTask) antProject.createTask("exec");
-        tar.setExecutable("tar");
-        tar.createArg().setValue("-xzf");
-        tar.createArg().setFile(tarball);
-        tar.createArg().setValue("-C");
-        tar.createArg().setFile(runtimeDir);
-        tar.execute();
-        delTree(tempExtract);
-        writeVersionStamp(versionStamp, version);
-        return cefRoot;
-    }
-
-    private String readVersionStamp(File versionStamp) {
-        if (!versionStamp.exists()) {
-            return null;
-        }
-        try {
-            return new String(Files.readAllBytes(versionStamp.toPath()), "UTF-8").trim();
-        } catch (IOException ex) {
-            getLog().debug("Could not read CEF version stamp " + versionStamp, ex);
-            return null;
-        }
-    }
-
-    private void writeVersionStamp(File versionStamp, String version) {
-        if (version == null) {
-            return;
-        }
-        try {
-            Files.write(versionStamp.toPath(), version.getBytes("UTF-8"));
-        } catch (IOException ex) {
-            getLog().debug("Could not write CEF version stamp " + versionStamp, ex);
-        }
-    }
-
-    private File findFileBySuffix(File root, String suffix) {
-        if (root == null || !root.exists()) {
-            return null;
-        }
-        if (root.isFile()) {
-            return root.getName().endsWith(suffix) ? root : null;
-        }
-        for (File child : root.listFiles()) {
-            File found = findFileBySuffix(child, suffix);
-            if (found != null) {
-                return found;
-            }
-        }
-        return null;
     }
 
     private File findExecutable(File root, String name) {
@@ -1125,34 +896,6 @@ public abstract class AbstractCN1Mojo extends AbstractMojo {
             project.getProperties().setProperty("ffmpeg.dir", getFFmpegDir().getAbsolutePath());
             System.setProperty("ffmpeg.dir", getFFmpegDir().getAbsolutePath());
         }
-    }
-
-    protected void setupCef() {
-        if (isCefSetup()) {
-            fixCefPermissions(getCefDir());
-            return;
-        }
-        String platform = getCefPlatform();
-        if (platform == null) {
-            getLog().warn("CEF not supported on this platform.  Not adding dependency");
-            return;
-        }
-        String artifactId = getJcefNativeArtifactId();
-        if (artifactId == null) {
-            getLog().warn("No upstream JCEF artifact is configured for this platform");
-            return;
-        }
-        Artifact nativeArtifact = getArtifact("me.friwi", artifactId);
-        File nativeJar = nativeArtifact == null ? null : getJar(nativeArtifact);
-        if (nativeJar == null || !nativeJar.exists()) {
-            getLog().warn("Upstream JCEF native bundle " + artifactId + " not found in dependencies. Not adding CEF dependency");
-            return;
-        }
-        File cefDir = extractCefBundle(nativeJar, nativeArtifact.getVersion());
-        project.getProperties().setProperty("cef.dir", cefDir.getAbsolutePath());
-        System.setProperty("cef.dir", cefDir.getAbsolutePath());
-        fixCefPermissions(cefDir);
-        
     }
 
     /**

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/AbstractCN1Mojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/AbstractCN1Mojo.java
@@ -1,7 +1,24 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.maven;
 

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/CompileCSSMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/CompileCSSMojo.java
@@ -1,7 +1,24 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.maven;
 

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/CompileCSSMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/CompileCSSMojo.java
@@ -281,10 +281,7 @@ public class CompileCSSMojo extends AbstractCN1Mojo {
         java.setJar(getDesignerJar());
         java.setFork(true);
         java.setFailonerror(true);
-        setupCef();
-        String cefDir = System.getProperty("cef.dir", System.getProperty("user.home") + File.separator + ".codenameone" + File.separator + "cef");
         java.createJvmarg().setValue("-Dcli=true");
-        java.createJvmarg().setValue("-Dcef.dir="+cefDir);
         java.createArg().setValue("-css");
         java.createArg().setValue("-input");
         java.createArg().setValue(inputs.toString());

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/GenerateDesktopAppWrapperMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/GenerateDesktopAppWrapperMojo.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.maven;
 
 import org.apache.commons.io.IOUtils;

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/GenerateDesktopAppWrapperMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/GenerateDesktopAppWrapperMojo.java
@@ -40,14 +40,6 @@ public class GenerateDesktopAppWrapperMojo extends AbstractCN1Mojo {
 
     @Override
     protected void executeImpl() throws MojoExecutionException, MojoFailureException {
-        // Provision the JCEF natives and set the cef.dir property for the desktop
-        // app the same way the simulator goals do. Without this the desktop run
-        // has the jcef-natives jar on its classpath but the actual native binaries
-        // (e.g. chrome_elf.dll on Windows) are never extracted to disk nor placed
-        // on java.library.path, so opening a BrowserComponent fails with
-        // "no chrome_elf in java.library.path" / "Failed to create CEF browser".
-        // The generated stub boots through CN1Bootstrap, which consumes cef.dir.
-        setupCef();
         generateIcons();
         generateStub();
         registerCustomStubSourceRoot();

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/InstallCn1libsMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/InstallCn1libsMojo.java
@@ -113,8 +113,6 @@ public class InstallCn1libsMojo extends AbstractCN1Mojo {
     
     @Override
     public void executeImpl() throws MojoExecutionException, MojoFailureException {
-        setupCef();
-        
         Exception[] err = new Exception[1];
         List<Artifact> cn1libArtifacts = new ArrayList<>();
         

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/InstallCn1libsMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/InstallCn1libsMojo.java
@@ -1,7 +1,24 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.maven;
 

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/PrepareSimulatorClasspathMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/PrepareSimulatorClasspathMojo.java
@@ -78,18 +78,10 @@ public class PrepareSimulatorClasspathMojo extends AbstractCN1Mojo {
         }
         //props.setProperty("exec.args", properties.getProperty("codename1.packageName")+"."+properties.getProperty("codename1.mainName"));
         project.getModel().addProperty("codename1.mainClass", properties.getProperty("codename1.packageName")+"."+properties.getProperty("codename1.mainName"));
-        // Setup CEF directory
-        if (!isCefSetup()) {
-            getLog().debug("CEF Not set up yet.  Setting it up now");
-            setupCef();
-        } else {
-            getLog().debug("CEF is already set up. cef.dir="+System.getProperty("cef.dir"));
-        }
         if (!isFFmpegSetup()) {
             getLog().debug("FFmpeg not set up yet. Setting it up now");
             setupFFmpeg();
         }
-        project.getProperties().setProperty("cef.dir", System.getProperty("cef.dir"));
         if (System.getProperty("ffmpeg.dir") != null) {
             project.getProperties().setProperty("ffmpeg.dir", System.getProperty("ffmpeg.dir"));
         }
@@ -199,9 +191,6 @@ public class PrepareSimulatorClasspathMojo extends AbstractCN1Mojo {
         } catch (Exception ex){}
 
         try (FileOutputStream fos = new FileOutputStream(simulatorPropertiesFile)) {
-            if (System.getProperty("cef.dir") != null) {
-                simulatorProperties.setProperty("cef.dir", System.getProperty("cef.dir"));
-            }
             if (System.getProperty("ffmpeg.dir") != null) {
                 simulatorProperties.setProperty("ffmpeg.dir", System.getProperty("ffmpeg.dir"));
             }

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/PrepareSimulatorClasspathMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/PrepareSimulatorClasspathMojo.java
@@ -1,7 +1,24 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.maven;
 

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/RunTestsMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/RunTestsMojo.java
@@ -226,10 +226,6 @@ public class RunTestsMojo extends AbstractCN1Mojo {
             }
         }
         cp.add(new Path(antProject, getProjectInternalTmpJar().getAbsolutePath()));
-        if (!isCefSetup()) {
-            setupCef();
-        }
-        java.createJvmarg().setValue("-Dcef.dir="+System.getProperty("cef.dir", System.getProperty("user.home") + File.separator + ".codenameone" + File.separator + "cef"));
         java.setClassname("com.codename1.impl.javase.TestRunner");
         java.createArg().setValue(properties.getProperty("codename1.packageName")+"."+properties.getProperty("codename1.mainName"));
         //java.createArg().setValue("-quietMode");

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/RunTestsMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/RunTestsMojo.java
@@ -1,7 +1,24 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.maven;
 

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/SimulatorMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/SimulatorMojo.java
@@ -1,7 +1,24 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.maven;
 

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/SimulatorMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/SimulatorMojo.java
@@ -201,13 +201,6 @@ private static final String GROUP_ID="com.codenameone";
         Log log = getLog();
         log.debug("Preparing classpath for Simulator");
         Path classpath = java.createClasspath();
-        if (System.getProperty("cef.dir") != null) {
-            Variable v = new Variable();
-            v.setKey("cef.dir");
-            v.setValue(System.getProperty("cef.dir"));
-            java.addSysproperty(v);
-            
-        }
         if (System.getProperty("ffmpeg.dir") != null) {
             Variable v = new Variable();
             v.setKey("ffmpeg.dir");

--- a/maven/codenameone-maven-plugin/src/main/resources/com/codename1/maven/desktop-app-stub-template.java
+++ b/maven/codenameone-maven-plugin/src/main/resources/com/codename1/maven/desktop-app-stub-template.java
@@ -69,11 +69,10 @@ public class __MAIN_NAME__Stub implements Runnable, WindowListener {
     private __MAIN_NAME__ mainApp;
 
     public static void main(String[] args) {
-        // Bootstrap the classpath/native library path (CEF) the same way the
-        // simulator does before touching any CEF class. This puts the JCEF native
-        // directory (from cef.dir) on java.library.path so chrome_elf/libcef load,
-        // then re-invokes this main() inside the bootstrapped classloader. It is a
-        // no-op (returns false) once bootstrapping has already happened.
+        // Bootstrap through the same parent classloader used by the simulator.
+        // JCEF Maven installs and loads the platform native runtime when the first
+        // BrowserComponent is created. This is a no-op once bootstrapping has
+        // already happened.
         try {
             if (CN1Bootstrap.run(__MAIN_NAME__Stub.class, args)) {
                 return;
@@ -83,8 +82,9 @@ public class __MAIN_NAME__Stub implements Runnable, WindowListener {
             bootstrapError.printStackTrace();
         }
         try {
-            Class.forName("org.cef.CefApp");
-            System.setProperty("cn1.javase.implementation", "cef");
+            if (CN1Bootstrap.isCEFSupported()) {
+                System.setProperty("cn1.javase.implementation", "cef");
+            }
         } catch (Throwable ex){}
 
         JavaSEPort.setNativeTheme("/NativeTheme.res");

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/CompileCSSMojoTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/CompileCSSMojoTest.java
@@ -272,11 +272,6 @@ class CompileCSSMojoTest {
         }
 
         @Override
-        protected void setupCef() {
-            // Skip CEF setup during tests.
-        }
-
-        @Override
         protected File getDesignerJar() {
             return designerJar;
         }

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/CompileCSSMojoTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/CompileCSSMojoTest.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.maven;
 
 import org.apache.maven.model.Build;

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/GenerateDesktopAppWrapperMojoTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/GenerateDesktopAppWrapperMojoTest.java
@@ -6,6 +6,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -65,6 +66,10 @@ class GenerateDesktopAppWrapperMojoTest {
                 "default title bar mode must be native");
         assertTrue(src.contains("APP_DESKTOP_INTERACTIVE_SCROLLBARS = true;"),
                 "interactive scrollbars must default on");
+        assertTrue(src.contains("CN1Bootstrap.isCEFSupported()"),
+                "desktop apps must select the JCEF Maven runtime when supported");
+        assertFalse(src.contains("cef.dir"),
+                "desktop apps must not require a pre-extracted CEF directory");
     }
 
     @Test

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/GenerateDesktopAppWrapperMojoTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/GenerateDesktopAppWrapperMojoTest.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.maven;
 
 import org.junit.jupiter.api.Test;

--- a/maven/javase/pom.xml
+++ b/maven/javase/pom.xml
@@ -83,8 +83,21 @@
     <dependencies>
         <dependency>
             <groupId>me.friwi</groupId>
-            <artifactId>jcef-api</artifactId>
-            <optional>true</optional>
+            <artifactId>jcefmaven</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- commons-compress 1.27.1, used by JCEF Maven to extract native
+             bundles, requires BoundedInputStream.builder() from Commons IO
+             2.16.1. The reactor otherwise manages Commons IO at 2.14.0. -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.16.1</version>
         </dependency>
         <dependency>
             <groupId>com.codenameone</groupId>

--- a/maven/javase/src/test/java/com/codename1/impl/javase/ClassPathLoaderTest.java
+++ b/maven/javase/src/test/java/com/codename1/impl/javase/ClassPathLoaderTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.impl.javase;
+
+import java.io.File;
+import me.friwi.jcefmaven.CefAppBuilder;
+import org.cef.CefApp;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class ClassPathLoaderTest {
+
+    @Test
+    public void keepsJcefAndJcefMavenInParentClassLoader() throws Exception {
+        ClassPathLoader loader = new ClassPathLoader(new File[0]);
+
+        assertSame(CefApp.class, loader.loadClass(CefApp.class.getName()));
+        assertSame(CefAppBuilder.class, loader.loadClass(CefAppBuilder.class.getName()));
+    }
+}

--- a/maven/javase/src/test/java/org/cef/CN1JcefRuntimeTest.java
+++ b/maven/javase/src/test/java/org/cef/CN1JcefRuntimeTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package org.cef;
+
+import java.io.File;
+import java.util.Arrays;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class CN1JcefRuntimeTest {
+
+    @AfterEach
+    public void clearProperties() {
+        System.clearProperty(CN1JcefRuntime.INSTALL_DIR_PROPERTY);
+        System.clearProperty(CN1JcefRuntime.MIRRORS_PROPERTY);
+    }
+
+    @Test
+    public void usesConfiguredInstallDirectory() throws Exception {
+        File installDir = new File("target/test-jcef-install").getAbsoluteFile();
+        System.setProperty(CN1JcefRuntime.INSTALL_DIR_PROPERTY, installDir.getPath());
+
+        assertEquals(installDir, CN1JcefRuntime.getInstallDir());
+    }
+
+    @Test
+    public void parsesConfiguredMirrorsInOrder() {
+        System.setProperty(CN1JcefRuntime.MIRRORS_PROPERTY,
+                " https://one.invalid/{platform} ,\nhttps://two.invalid/{tag}\r\n");
+
+        assertEquals(Arrays.asList(
+                "https://one.invalid/{platform}",
+                "https://two.invalid/{tag}"), CN1JcefRuntime.getConfiguredMirrors());
+    }
+
+    @Test
+    public void rejectsHomeDirectoryAsInstallDirectory() {
+        System.setProperty(CN1JcefRuntime.INSTALL_DIR_PROPERTY,
+                new File(System.getProperty("user.home")).getAbsolutePath());
+
+        assertThrows(java.io.IOException.class, CN1JcefRuntime::getInstallDir);
+    }
+}

--- a/maven/javase/src/test/java/org/cef/browser/CN1CefBrowserTest.java
+++ b/maven/javase/src/test/java/org/cef/browser/CN1CefBrowserTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package org.cef.browser;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import org.cef.handler.CefScreenInfo;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CN1CefBrowserTest {
+
+    @Test
+    public void exposesGetScreenInfoCallbackExpectedByJni() throws Exception {
+        Method callback = CN1CefBrowser.class.getMethod(
+                "getScreenInfo", CefBrowser.class, CefScreenInfo.class);
+
+        assertEquals(Boolean.TYPE, callback.getReturnType());
+        assertTrue(Modifier.isPublic(callback.getModifiers()));
+    }
+}

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -329,7 +329,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.14.0</version>
+                <version>2.16.1</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -47,6 +47,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <java-tests.version>11</java-tests.version>
+        <jcefmaven.version>135.0.20</jcefmaven.version>
         <jcef.version>jcef-ca49ada+cef-135.0.20+ge7de5c3+chromium-135.0.7049.85</jcef.version>
         <ffmpeg.version>7.1-1.5.11</ffmpeg.version>
         <rhino.version>1.7.11</rhino.version>
@@ -124,8 +125,8 @@
             </dependency>
             <dependency>
                 <groupId>me.friwi</groupId>
-                <artifactId>jcef-api</artifactId>
-                <version>${jcef.version}</version>
+                <artifactId>jcefmaven</artifactId>
+                <version>${jcefmaven.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.bytedeco</groupId>

--- a/maven/tests/javase-cef-ffmpeg-smoke/javase/pom.xml
+++ b/maven/tests/javase-cef-ffmpeg-smoke/javase/pom.xml
@@ -108,7 +108,6 @@
                             <longClasspath>true</longClasspath>
                             <arguments>
                                 <argument>-Xmx1024M</argument>
-                                <argument>-Dcef.dir=${cef.dir}</argument>
                                 <argument>-Dffmpeg.dir=${ffmpeg.dir}</argument>
                                 <argument>-Dcn1.test.video=${cn1.test.video}</argument>
                                 <argument>-Dcodename1.designer.jar=${codename1.designer.jar}</argument>

--- a/scripts/ci-install-upstream-jcef-jar.sh
+++ b/scripts/ci-install-upstream-jcef-jar.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# Install the upstream me.friwi jcef-api jar (matching maven/pom.xml's
-# jcef.version) as cn1-binaries/javase/jcef.jar, which is what the legacy Ant
-# build of the JavaSE port compiles against. This keeps the Ant build in sync
-# with the Maven build, which consumes the me.friwi artifacts directly. The Ant
-# build only needs the API jar for compilation (CEF natives are not used there).
+# Install the JCEF Maven Java dependencies used by the legacy Ant JavaSE build.
+# The Maven build resolves these transitively from me.friwi:jcefmaven, while the
+# Ant project needs explicit jar files in cn1-binaries/javase. Native JCEF
+# distributions are intentionally not installed here; JCEF Maven downloads or
+# streams the current platform distribution when BrowserComponent is first used.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -14,28 +14,45 @@ if [ ! -d "$binaries_dir" ]; then
     exit 0
 fi
 
-ver="$(grep -oE '<jcef\.version>[^<]+' "$repo_root/maven/pom.xml" | head -1 | sed 's/<jcef\.version>//')"
-if [ -z "$ver" ]; then
+jcef_ver="$(grep -oE '<jcef\.version>[^<]+' "$repo_root/maven/pom.xml" | head -1 | sed 's/<jcef\.version>//')"
+jcefmaven_ver="$(grep -oE '<jcefmaven\.version>[^<]+' "$repo_root/maven/pom.xml" | head -1 | sed 's/<jcefmaven\.version>//')"
+if [ -z "$jcef_ver" ] || [ -z "$jcefmaven_ver" ]; then
     echo "[install-upstream-jcef] could not read jcef.version from maven/pom.xml" >&2
     exit 1
 fi
 
-dest="$binaries_dir/jcef.jar"
-m2_jar="$HOME/.m2/repository/me/friwi/jcef-api/$ver/jcef-api-$ver.jar"
-tmp="$(mktemp)"
+install_artifact() {
+    local group_path="$1"
+    local artifact="$2"
+    local version="$3"
+    local dest_name="$4"
+    local dest="$binaries_dir/$dest_name"
+    local m2_jar="$HOME/.m2/repository/$group_path/$artifact/$version/$artifact-$version.jar"
+    local tmp="$(mktemp)"
+    local enc
+    local url
 
-if [ -f "$m2_jar" ]; then
-    echo "[install-upstream-jcef] using cached $m2_jar"
-    cp "$m2_jar" "$tmp"
-else
-    enc="$(python3 -c 'import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))' "$ver")"
-    url="https://repo1.maven.org/maven2/me/friwi/jcef-api/$enc/jcef-api-$enc.jar"
-    echo "[install-upstream-jcef] downloading $url"
-    curl -fsSL -o "$tmp" "$url"
-fi
+    if [ -f "$m2_jar" ]; then
+        echo "[install-upstream-jcef] using cached $m2_jar"
+        cp "$m2_jar" "$tmp"
+    else
+        enc="$(python3 -c 'import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))' "$version")"
+        url="https://repo1.maven.org/maven2/$group_path/$artifact/$enc/$artifact-$enc.jar"
+        echo "[install-upstream-jcef] downloading $url"
+        curl -fsSL -o "$tmp" "$url"
+    fi
 
-# dest may be a symlink into a shared tree (e.g. /opt/cn1-binaries); remove it
-# first so we replace it with a standalone file rather than writing in place.
-rm -f "$dest"
-mv "$tmp" "$dest"
-echo "[install-upstream-jcef] installed jcef-api $ver -> $dest"
+    # dest may be a symlink into a shared tree (e.g. /opt/cn1-binaries); remove
+    # it first so we replace it instead of writing through the symlink.
+    rm -f "$dest"
+    mv "$tmp" "$dest"
+    echo "[install-upstream-jcef] installed $artifact $version -> $dest"
+}
+
+install_artifact me/friwi jcef-api "$jcef_ver" jcef.jar
+install_artifact me/friwi jcefmaven "$jcefmaven_ver" jcefmaven.jar
+install_artifact org/apache/commons commons-compress 1.27.1 commons-compress.jar
+install_artifact com/google/code/gson gson 2.11.0 gson.jar
+install_artifact commons-codec commons-codec 1.17.1 commons-codec.jar
+install_artifact commons-io commons-io 2.16.1 commons-io.jar
+install_artifact org/apache/commons commons-lang3 3.16.0 commons-lang3.jar

--- a/scripts/cn1playground/javase/pom.xml
+++ b/scripts/cn1playground/javase/pom.xml
@@ -394,10 +394,6 @@
                                     the initialize phase. -->
 
 
-                              <!-- The location of CEF.  This property is set in the
-                                  prepare-simulator-classpath goal, and the CEF files are
-                                  managed by maven. -->
-                              <argument>-Dcef.dir=${cef.dir}</argument>
 
                               <!-- The location of the designer jar.  This property is set in the
                                   prepare-simulator-classpath goal, and the file itself is managed
@@ -499,10 +495,6 @@
                                     the initialize phase. -->
 
 
-                              <!-- The location of CEF.  This property is set in the
-                                  prepare-simulator-classpath goal, and the CEF files are
-                                  managed by maven. -->
-                              <argument>-Dcef.dir=${cef.dir}</argument>
 
                               <!-- The location of the designer jar.  This property is set in the
                                   prepare-simulator-classpath goal, and the file itself is managed
@@ -597,10 +589,6 @@
                           <arguments>
                               <argument>-Xmx1024M</argument>
 
-                              <!-- The location of CEF.  This property is set in the
-                                  prepare-simulator-classpath goal, and the CEF files are
-                                  managed by maven. -->
-                              <argument>-Dcef.dir=${cef.dir}</argument>
 
                               <!-- The location of the designer jar.  This property is set in the
                                   prepare-simulator-classpath goal, and the file itself is managed
@@ -708,13 +696,6 @@
                                     are set in the prepare-simulator-classpath goal
                                     of the codenameone-maven-plugin which was run during
                                     the initialize phase. -->
-                              <systemProperty>
-                                  <!-- The location of CEF.  This property is set in the
-                                  prepare-simulator-classpath goal, and the CEF files are
-                                  managed by maven. -->
-                                  <key>cef.dir</key>
-                                  <value>${cef.dir}</value>
-                              </systemProperty>
                               <systemProperty>
                                   <!-- The location of the designer jar.  This property is set in the
                                   prepare-simulator-classpath goal, and the file itself is managed

--- a/scripts/cn1playground/tools/run-playground-smoke-tests.sh
+++ b/scripts/cn1playground/tools/run-playground-smoke-tests.sh
@@ -40,8 +40,11 @@ mvn -f common/pom.xml -DskipTests org.codehaus.mojo:exec-maven-plugin:3.0.0:java
 mvn -f common/pom.xml -DskipTests org.codehaus.mojo:exec-maven-plugin:3.0.0:java \
   -Dexec.classpathScope=test \
   -Dexec.mainClass=com.codenameone.playground.PlaygroundSyntaxMatrixHarness
+# This harness checks only the native CN1 chrome. Keep its BrowserComponent as
+# a placeholder instead of provisioning a full JCEF runtime during the test.
 mvn -f common/pom.xml -DskipTests org.codehaus.mojo:exec-maven-plugin:3.0.0:java \
   -Dexec.classpathScope=test \
+  -Dcn1.javase.implementation=jmf \
   -Dexec.mainClass=com.codenameone.playground.PlaygroundLayoutHarness
 mvn -f common/pom.xml -DskipTests org.codehaus.mojo:exec-maven-plugin:3.0.0:java \
   -Dexec.classpathScope=test \

--- a/scripts/fidelity-app/javase/pom.xml
+++ b/scripts/fidelity-app/javase/pom.xml
@@ -405,10 +405,6 @@
                                     the initialize phase. -->
 
 
-                              <!-- The location of CEF.  This property is set in the
-                                  prepare-simulator-classpath goal, and the CEF files are
-                                  managed by maven. -->
-                              <argument>-Dcef.dir=${cef.dir}</argument>
 
                               <!-- The location of the designer jar.  This property is set in the
                                   prepare-simulator-classpath goal, and the file itself is managed
@@ -510,10 +506,6 @@
                                     the initialize phase. -->
 
 
-                              <!-- The location of CEF.  This property is set in the
-                                  prepare-simulator-classpath goal, and the CEF files are
-                                  managed by maven. -->
-                              <argument>-Dcef.dir=${cef.dir}</argument>
 
                               <!-- The location of the designer jar.  This property is set in the
                                   prepare-simulator-classpath goal, and the file itself is managed
@@ -608,10 +600,6 @@
                           <arguments>
                               <argument>-Xmx1024M</argument>
 
-                              <!-- The location of CEF.  This property is set in the
-                                  prepare-simulator-classpath goal, and the CEF files are
-                                  managed by maven. -->
-                              <argument>-Dcef.dir=${cef.dir}</argument>
 
                               <!-- The location of the designer jar.  This property is set in the
                                   prepare-simulator-classpath goal, and the file itself is managed
@@ -719,13 +707,6 @@
                                     are set in the prepare-simulator-classpath goal
                                     of the codenameone-maven-plugin which was run during
                                     the initialize phase. -->
-                              <systemProperty>
-                                  <!-- The location of CEF.  This property is set in the
-                                  prepare-simulator-classpath goal, and the CEF files are
-                                  managed by maven. -->
-                                  <key>cef.dir</key>
-                                  <value>${cef.dir}</value>
-                              </systemProperty>
                               <systemProperty>
                                   <!-- The location of the designer jar.  This property is set in the
                                   prepare-simulator-classpath goal, and the file itself is managed

--- a/scripts/hellocodenameone/javase/pom.xml
+++ b/scripts/hellocodenameone/javase/pom.xml
@@ -405,10 +405,6 @@
                                     the initialize phase. -->
 
 
-                              <!-- The location of CEF.  This property is set in the
-                                  prepare-simulator-classpath goal, and the CEF files are
-                                  managed by maven. -->
-                              <argument>-Dcef.dir=${cef.dir}</argument>
 
                               <!-- The location of the designer jar.  This property is set in the
                                   prepare-simulator-classpath goal, and the file itself is managed
@@ -510,10 +506,6 @@
                                     the initialize phase. -->
 
 
-                              <!-- The location of CEF.  This property is set in the
-                                  prepare-simulator-classpath goal, and the CEF files are
-                                  managed by maven. -->
-                              <argument>-Dcef.dir=${cef.dir}</argument>
 
                               <!-- The location of the designer jar.  This property is set in the
                                   prepare-simulator-classpath goal, and the file itself is managed
@@ -608,10 +600,6 @@
                           <arguments>
                               <argument>-Xmx1024M</argument>
 
-                              <!-- The location of CEF.  This property is set in the
-                                  prepare-simulator-classpath goal, and the CEF files are
-                                  managed by maven. -->
-                              <argument>-Dcef.dir=${cef.dir}</argument>
 
                               <!-- The location of the designer jar.  This property is set in the
                                   prepare-simulator-classpath goal, and the file itself is managed
@@ -719,13 +707,6 @@
                                     are set in the prepare-simulator-classpath goal
                                     of the codenameone-maven-plugin which was run during
                                     the initialize phase. -->
-                              <systemProperty>
-                                  <!-- The location of CEF.  This property is set in the
-                                  prepare-simulator-classpath goal, and the CEF files are
-                                  managed by maven. -->
-                                  <key>cef.dir</key>
-                                  <value>${cef.dir}</value>
-                              </systemProperty>
                               <systemProperty>
                                   <!-- The location of the designer jar.  This property is set in the
                                   prepare-simulator-classpath goal, and the file itself is managed

--- a/scripts/initializr/javase/pom.xml
+++ b/scripts/initializr/javase/pom.xml
@@ -411,10 +411,6 @@
                                     the initialize phase. -->
 
 
-                              <!-- The location of CEF.  This property is set in the
-                                  prepare-simulator-classpath goal, and the CEF files are
-                                  managed by maven. -->
-                              <argument>-Dcef.dir=${cef.dir}</argument>
 
                               <!-- The location of the designer jar.  This property is set in the
                                   prepare-simulator-classpath goal, and the file itself is managed
@@ -516,10 +512,6 @@
                                     the initialize phase. -->
 
 
-                              <!-- The location of CEF.  This property is set in the
-                                  prepare-simulator-classpath goal, and the CEF files are
-                                  managed by maven. -->
-                              <argument>-Dcef.dir=${cef.dir}</argument>
 
                               <!-- The location of the designer jar.  This property is set in the
                                   prepare-simulator-classpath goal, and the file itself is managed
@@ -614,10 +606,6 @@
                           <arguments>
                               <argument>-Xmx1024M</argument>
 
-                              <!-- The location of CEF.  This property is set in the
-                                  prepare-simulator-classpath goal, and the CEF files are
-                                  managed by maven. -->
-                              <argument>-Dcef.dir=${cef.dir}</argument>
 
                               <!-- The location of the designer jar.  This property is set in the
                                   prepare-simulator-classpath goal, and the file itself is managed
@@ -725,13 +713,6 @@
                                     are set in the prepare-simulator-classpath goal
                                     of the codenameone-maven-plugin which was run during
                                     the initialize phase. -->
-                              <systemProperty>
-                                  <!-- The location of CEF.  This property is set in the
-                                  prepare-simulator-classpath goal, and the CEF files are
-                                  managed by maven. -->
-                                  <key>cef.dir</key>
-                                  <value>${cef.dir}</value>
-                              </systemProperty>
                               <systemProperty>
                                   <!-- The location of the designer jar.  This property is set in the
                                   prepare-simulator-classpath goal, and the file itself is managed

--- a/scripts/skindesigner/javase/pom.xml
+++ b/scripts/skindesigner/javase/pom.xml
@@ -395,10 +395,6 @@
                                     the initialize phase. -->
 
 
-                              <!-- The location of CEF.  This property is set in the
-                                  prepare-simulator-classpath goal, and the CEF files are
-                                  managed by maven. -->
-                              <argument>-Dcef.dir=${cef.dir}</argument>
 
                               <!-- The location of the designer jar.  This property is set in the
                                   prepare-simulator-classpath goal, and the file itself is managed
@@ -500,10 +496,6 @@
                                     the initialize phase. -->
 
 
-                              <!-- The location of CEF.  This property is set in the
-                                  prepare-simulator-classpath goal, and the CEF files are
-                                  managed by maven. -->
-                              <argument>-Dcef.dir=${cef.dir}</argument>
 
                               <!-- The location of the designer jar.  This property is set in the
                                   prepare-simulator-classpath goal, and the file itself is managed
@@ -598,10 +590,6 @@
                           <arguments>
                               <argument>-Xmx1024M</argument>
 
-                              <!-- The location of CEF.  This property is set in the
-                                  prepare-simulator-classpath goal, and the CEF files are
-                                  managed by maven. -->
-                              <argument>-Dcef.dir=${cef.dir}</argument>
 
                               <!-- The location of the designer jar.  This property is set in the
                                   prepare-simulator-classpath goal, and the file itself is managed
@@ -709,13 +697,6 @@
                                     are set in the prepare-simulator-classpath goal
                                     of the codenameone-maven-plugin which was run during
                                     the initialize phase. -->
-                              <systemProperty>
-                                  <!-- The location of CEF.  This property is set in the
-                                  prepare-simulator-classpath goal, and the CEF files are
-                                  managed by maven. -->
-                                  <key>cef.dir</key>
-                                  <value>${cef.dir}</value>
-                              </systemProperty>
                               <systemProperty>
                                   <!-- The location of the designer jar.  This property is set in the
                                   prepare-simulator-classpath goal, and the file itself is managed


### PR DESCRIPTION
## Summary

- restore the public `getScreenInfo(CefBrowser, CefScreenInfo)` callback that JCEF native code invokes directly on the browser object
- use `me.friwi:jcefmaven:135.0.20` for JavaSE JCEF runtime provisioning in both Simulator and desktop applications
- install platform binaries lazily into a version/platform-scoped cache, or use bundled native artifacts when an application includes them
- remove the manual `cef.dir`, native extraction, version-stamp, and classpath setup from the Maven plugin and project POMs
- retain JavaFX and JMF as fallback browser implementations

## Root causes

### HiDPI scaling

The JCEF 135 migration changed `CN1CefBrowser` from implementing `CefRenderHandler` directly to returning a `CefRenderHandlerAdapter`. During that refactor, `getScreenInfo()` became `getScreenInfoImpl()`.

Most native render callbacks are dispatched to the returned handler, but JCEF native `RenderHandler::GetScreenInfo` uniquely looks up `getScreenInfo()` on the browser object. The missing JNI-visible method raised `NoSuchMethodError`, so CEF never received the display scale factor and rendered undersized on scaled displays.

### Desktop native loading

Codename One previously managed JCEF native archives itself. That required generated POM changes, pre-extraction, and explicit native-library path configuration. A desktop app could therefore have all JAR dependencies present but still fail with `no chrome_elf in java.library.path` if the plugin setup goal had not extracted/configured the runtime before launch.

## Runtime provisioning

`CN1JcefRuntime` now wraps JCEF Maven's `CefAppBuilder`:

- the default cache is `~/.codenameone/jcef/<release>/<platform>`
- `cn1.jcef.installDir` overrides the cache location
- `cn1.jcef.mirrors` supplies alternate download mirrors
- installation is protected by both an in-process monitor and a cross-process file lock
- applications may bundle the matching `jcef-natives-*` dependency; otherwise JCEF Maven downloads it on first use
- JCEF Maven packages stay in the parent classloader with `org.cef`, avoiding split class identity in the Simulator

The JavaSE dependency pins Commons IO 2.16.1 because the JCEF Maven extraction stack requires `BoundedInputStream.builder()`, which is unavailable in the parent POM's older managed version.

## Validation

All Maven checks used Java 8.

- JavaSE JCEF and classloader tests: 5 tests, 0 failures
- Maven plugin desktop/CSS tests: 10 tests, 0 failures
- JavaSE reactor install with `-Plocal-dev-javase`
- application archetype reactor package
- fresh runtime download and extraction into an empty cache
- offline install from a bundled platform-native JAR
- dependency tree verified exact JCEF API, Commons IO 2.16.1, and no default `jcef-natives-*` bundle
- edited POM XML validation, shell syntax validation, and `git diff --check`

The repository's cross-platform JavaSE CEF smoke workflow will run for this PR.
