### PR TITLE
Fix iOS debugger attach ordering and documentation

### DIFF
--- a/docs/demos/common/src/main/snippets/developer-guide/on-device-debugging.sh
+++ b/docs/demos/common/src/main/snippets/developer-guide/on-device-debugging.sh
@@ -4,7 +4,9 @@
 # Terminal 1 — start the proxy
 mvn cn1:ios-on-device-debugging
 
-# Terminal 2 — attach jdb
+# Launch the app and wait for the proxy to report that it loaded symbols.
+
+# Terminal 2 — attach jdb after the device handshake
 jdb -attach localhost:8000
 // end::on-device-debugging-bash-001[]
 

--- a/docs/developer-guide/On-Device-Debugging-Android.asciidoc
+++ b/docs/developer-guide/On-Device-Debugging-Android.asciidoc
@@ -45,6 +45,10 @@ archetype generated:
 include::../demos/common/src/main/snippets/developer-guide/on-device-debugging-android.properties[tag=on-device-debugging-android-properties-001,indent=0]
 ----
 
+The build hint name is `android.onDeviceDebug`. Entries in
+`codenameone_settings.properties` use the `codename1.arg.` prefix, as
+shown above.
+
 This flips the generated `AndroidManifest.xml` to
 `debuggable="true"` and disables R8/proguard so symbols and locals
 survive the build. Release builds (anything without this hint) are

--- a/docs/developer-guide/On-Device-Debugging.asciidoc
+++ b/docs/developer-guide/On-Device-Debugging.asciidoc
@@ -109,7 +109,7 @@ build hint.
 
 Switch the Run-config dropdown to *CN1 Attach iOS* and click 🐞
 *Debug*. IntelliJ connects to `localhost:8000`, opens a Debug tool
-window, and releases the app after the attach completes.
+window, and releases the app after the debugger connection completes.
 
 Set breakpoints, step, inspect, evaluate expressions, just like a
 normal remote attach. Device output from

--- a/docs/developer-guide/On-Device-Debugging.asciidoc
+++ b/docs/developer-guide/On-Device-Debugging.asciidoc
@@ -97,6 +97,14 @@ before attaching the IDE:
 With `waitForAttach=true`, the app remains on the "Waiting for
 debugger" overlay while you complete the next step.
 
+Attaching the IDE before launching the app is also supported. The
+proxy keeps the JDWP session open and waits for the device to stream
+its symbols. If the device still hasn't connected after ten seconds,
+the proxy prints a checklist for the build hint, `proxyHost`, and the
+device port. You can correct the problem and launch the app without
+restarting the IDE session; rebuild and reinstall first if you change a
+build hint.
+
 ==== 5. Attach the debugger from IntelliJ
 
 Switch the Run-config dropdown to *CN1 Attach iOS* and click 🐞

--- a/docs/developer-guide/On-Device-Debugging.asciidoc
+++ b/docs/developer-guide/On-Device-Debugging.asciidoc
@@ -49,9 +49,13 @@ the archetype generated:
 include::../demos/common/src/main/snippets/developer-guide/on-device-debugging.properties[tag=on-device-debugging-properties-001,indent=0]
 ----
 
+The build hint names start at `ios.onDeviceDebug`. Entries in
+`codenameone_settings.properties` use the `codename1.arg.` prefix, as
+shown above.
+
 For a physical device, set `proxyHost` to the laptop's LAN IP (run
-`ifconfig | grep "inet "`) instead of `127.0.0.1`. The native iOS
-simulator can always use `127.0.0.1`.
+`ipconfig` on Windows or `ifconfig` on macOS and Linux) instead of
+`127.0.0.1`. The native iOS simulator can always use `127.0.0.1`.
 
 ==== 2. Build the app as you normally do
 
@@ -68,32 +72,54 @@ not what you want). The Run tool window opens and shows:
 
 ----
 On-device-debug proxy starting:
-  symbols : .../cn1-symbols.txt
   device  : listening on tcp://0.0.0.0:55333
   jdwp    : listening on tcp://0.0.0.0:8000
+  symbols : streamed from the device on connect (no local file)
 [device] listening on port 55333 for ParparVM app to dial in
 [jdwp] listening on port 8000 for debugger (jdb) to attach
 ----
 
-When the last line appears, the JDWP port is bound and ready.
+When both listener lines appear, the proxy is ready for the app.
 
-==== 4. Attach the debugger from IntelliJ
+==== 4. Launch the app and wait for the device handshake
+
+Launch the iOS app in the native iOS simulator under Xcode or on a
+physical device. The app contains its compressed debug symbol table
+and streams it to the proxy when it connects. Wait for these lines
+before attaching the IDE:
+
+----
+[device] connected from ...
+[device] loaded symbols: ...
+[jdwp] device handshake ...
+----
+
+With `waitForAttach=true`, the app remains on the "Waiting for
+debugger" overlay while you complete the next step.
+
+==== 5. Attach the debugger from IntelliJ
 
 Switch the Run-config dropdown to *CN1 Attach iOS* and click 🐞
-*Debug*. IntelliJ connects to `localhost:8000` and opens a Debug tool
-window.
-
-==== 5. Launch the app
-
-Launch the iOS app (in the native iOS simulator under Xcode, or
-deploy to a tethered device). With `waitForAttach=true` the app boots
-to a "Waiting for debugger" overlay until the proxy's first
-RESUME — set your breakpoints, then let the proxy resume automatically.
+*Debug*. IntelliJ connects to `localhost:8000`, opens a Debug tool
+window, and releases the app after the attach completes.
 
 Set breakpoints, step, inspect, evaluate expressions, just like a
 normal remote attach. Device output from
 `System.out.println` / `Log.p` / `printf` / `NSLog` lands in the
 *CN1 Debug Proxy* Run window prefixed with `[device]`.
+
+=== Attach from NetBeans
+
+NetBeans uses the same proxy and connection order. Start the proxy,
+launch the app, and wait for the device handshake and symbol-loading
+lines shown above. Then choose *Debug > Attach Debugger* in NetBeans.
+Select *Java Debugger (JPDA)* and the *SocketAttach* connector, set
+the host to `localhost` and the port to `8000`, then attach. Keep the
+Codename One project open so NetBeans can resolve your source files
+and breakpoints.
+
+Don't point NetBeans at port `55333`. The iPhone uses `55333` to
+reach the proxy. The IDE uses the proxy's JDWP port, `8000`.
 
 === Quick start (Maven from the command line)
 
@@ -306,7 +332,7 @@ CN1_ON_DEVICE_DEBUG` *without* a leading `//`. If the line is
 still commented out, the build was a release/non-debug build, or
 `ios.onDeviceDebug` wasn't set as a build hint.
 
-==== Make the app wait before running so the IDE can attach first
+==== Make the app wait while the proxy and IDE attach
 
 Set `ios.onDeviceDebug.waitForAttach=true`. The app will block
 at startup until the proxy is connected and the IDE tells the

--- a/docs/website/content/blog/developer-workflow-debug-and-junit.md
+++ b/docs/website/content/blog/developer-workflow-debug-and-junit.md
@@ -120,6 +120,8 @@ Launch the iOS app under the iOS Simulator from Xcode or on the physical device.
 
 With `waitForAttach=true`, the app remains on the "Waiting for debugger" overlay while you complete the next step.
 
+Attaching the IDE before launching the app is also supported. The proxy keeps the JDWP session open and waits for the device to stream its symbols. If the device still hasn't connected after ten seconds, the proxy prints a checklist for the build hint, `proxyHost`, and the device port. You can correct the problem and launch the app without restarting the IDE session; rebuild and reinstall first if you change a build hint.
+
 **5. Attach the debugger.**
 
 Switch the run-config dropdown to **CN1 Attach iOS** and click the 🐞 Debug button. IntelliJ connects to `localhost:8000`, opens its standard Debug tool window, and releases the app after the attach completes. You can set breakpoints anywhere in your Java code or in the framework.

--- a/docs/website/content/blog/developer-workflow-debug-and-junit.md
+++ b/docs/website/content/blog/developer-workflow-debug-and-junit.md
@@ -72,17 +72,17 @@ The Codename One archetype now generates two run configurations under an *On-Dev
 Open `common/codenameone_settings.properties` and uncomment the four lines the archetype generated:
 
 ```
-ios.onDeviceDebug=true
-ios.onDeviceDebug.proxyHost=127.0.0.1
-ios.onDeviceDebug.proxyPort=55333
-ios.onDeviceDebug.waitForAttach=true
+codename1.arg.ios.onDeviceDebug=true
+codename1.arg.ios.onDeviceDebug.proxyHost=127.0.0.1
+codename1.arg.ios.onDeviceDebug.proxyPort=55333
+codename1.arg.ios.onDeviceDebug.waitForAttach=true
 ```
 
-`ios.onDeviceDebug=true` flips the iOS build into the instrumented variant. The other three configure the proxy connection.
+The build hint names start at `ios.onDeviceDebug`. Entries in `codenameone_settings.properties` use the `codename1.arg.` prefix, as shown above. `ios.onDeviceDebug=true` flips the iOS build into the instrumented variant. The other three hints configure the proxy connection.
 
 The fourth hint, `ios.onDeviceDebug.waitForAttach=true`, is the **block-on-load** option, and we recommend leaving it on. With it enabled, the iOS app shows a "Waiting for debugger" overlay at launch and does not progress past `Display.init` until the proxy issues its first resume. The recommendation is mostly about making the on-device-debug variant visible. Without the overlay it is easy to launch an on-device-debug build expecting the debugger to attach and not realize it is silently waiting for a proxy that is not running, and it is also easy to mistake an on-device-debug build for a regular build and then be surprised when it does not perform as smoothly as the release variant. The overlay rules out both of those.
 
-For a physical iPhone the `proxyHost` value should be the laptop's LAN IP (run `ifconfig | grep "inet "` to find it) rather than `127.0.0.1`. The iOS Simulator can always use `127.0.0.1`.
+For a physical iPhone the `proxyHost` value should be the laptop's LAN IP rather than `127.0.0.1`. Run `ipconfig` on Windows or `ifconfig` on macOS and Linux to find it. The iOS Simulator can always use `127.0.0.1`.
 
 **2. Build the iOS app.**
 
@@ -99,24 +99,38 @@ In IntelliJ, pick **CN1 Debug Proxy** from the run-config dropdown and click the
 
 ```
 On-device-debug proxy starting:
-  symbols : .../cn1-symbols.txt
   device  : listening on tcp://0.0.0.0:55333
   jdwp    : listening on tcp://0.0.0.0:8000
+  symbols : streamed from the device on connect (no local file)
 [device] listening on port 55333 for ParparVM app to dial in
 [jdwp]   listening on port 8000 for debugger (jdb) to attach
 ```
 
-When the `[jdwp]` line appears, the proxy is ready.
+When both listener lines appear, the proxy is ready for the app.
 
-**4. Attach the debugger.**
+**4. Launch the app and wait for the device handshake.**
 
-Switch the run-config dropdown to **CN1 Attach iOS** and click the 🐞 Debug button. IntelliJ connects to `localhost:8000` and opens its standard Debug tool window. You can now set breakpoints anywhere in your Java code or in the framework.
+Launch the iOS app under the iOS Simulator from Xcode or on the physical device. The app contains its compressed debug symbol table and streams it to the proxy when it connects. Wait for these lines before attaching the IDE:
 
-**5. Launch the app.**
+```
+[device] connected from ...
+[device] loaded symbols: ...
+[jdwp] device handshake ...
+```
 
-Launch the iOS app under the iOS Simulator (from Xcode) or on the tethered device. With `waitForAttach=true` it pauses at the "Waiting for debugger" overlay until the proxy issues its first resume. Hit Resume on the IntelliJ Debug toolbar; the app proceeds, your breakpoints fire as the app exercises them.
+With `waitForAttach=true`, the app remains on the "Waiting for debugger" overlay while you complete the next step.
+
+**5. Attach the debugger.**
+
+Switch the run-config dropdown to **CN1 Attach iOS** and click the 🐞 Debug button. IntelliJ connects to `localhost:8000`, opens its standard Debug tool window, and releases the app after the attach completes. You can set breakpoints anywhere in your Java code or in the framework.
 
 **The proxy's Run window is also your device console.** Anything the app writes to `System.out`, `Log.p`, `printf`, or `NSLog` from native code is forwarded to the proxy and printed in the **CN1 Debug Proxy** Run window with a `[device]` prefix. This is genuinely useful and is one fewer thing you need Xcode for. The caveat is that the forwarding starts when the proxy connection is established, so output written during the very first millisecond of process launch (before `Display.init`) is not always captured. If you need every byte from `t=0`, attach Xcode's console for that specific run.
+
+### NetBeans + iOS
+
+NetBeans uses the same proxy and the same connection order. Start the proxy, launch the app, and wait for the device handshake and symbol-loading lines shown above. Then choose **Debug > Attach Debugger** in NetBeans. Select **Java Debugger (JPDA)** and the **SocketAttach** connector, set the host to `localhost` and the port to `8000`, then attach. Keep the Codename One project open so NetBeans can resolve your source files and breakpoints.
+
+Don't point NetBeans at port `55333`. The iPhone uses `55333` to reach the proxy. The IDE uses the proxy's JDWP port, `8000`.
 
 ### Tutorial: IntelliJ + Android
 
@@ -127,10 +141,10 @@ Android is simpler because the proxy is not needed. The archetype generates two 
 In `common/codenameone_settings.properties`:
 
 ```
-android.onDeviceDebug=true
+codename1.arg.android.onDeviceDebug=true
 ```
 
-This single hint flips the manifest to `debuggable="true"` and turns R8 / Proguard off for this build. Release builds without the hint are unaffected.
+The build hint name is `android.onDeviceDebug`; the `codename1.arg.` prefix is how you write it in `codenameone_settings.properties`. This hint flips the manifest to `debuggable="true"` and turns R8 / Proguard off for this build. Release builds without the hint are unaffected.
 
 **2. Run CN1 Android On-Device Debug.**
 

--- a/docs/website/content/blog/developer-workflow-debug-and-junit.md
+++ b/docs/website/content/blog/developer-workflow-debug-and-junit.md
@@ -124,7 +124,7 @@ Attaching the IDE before launching the app is also supported. The proxy keeps th
 
 **5. Attach the debugger.**
 
-Switch the run-config dropdown to **CN1 Attach iOS** and click the 🐞 Debug button. IntelliJ connects to `localhost:8000`, opens its standard Debug tool window, and releases the app after the attach completes. You can set breakpoints anywhere in your Java code or in the framework.
+Switch the run-config dropdown to **CN1 Attach iOS** and click the 🐞 Debug button. IntelliJ connects to `localhost:8000`, opens its standard Debug tool window, and releases the app after the debugger connection completes. You can set breakpoints anywhere in your Java code or in the framework.
 
 **The proxy's Run window is also your device console.** Anything the app writes to `System.out`, `Log.p`, `printf`, or `NSLog` from native code is forwarded to the proxy and printed in the **CN1 Debug Proxy** Run window with a `[device]` prefix. This is genuinely useful and is one fewer thing you need Xcode for. The caveat is that the forwarding starts when the proxy connection is established, so output written during the very first millisecond of process launch (before `Display.init`) is not always captured. If you need every byte from `t=0`, attach Xcode's console for that specific run.
 

--- a/maven/cn1-debug-proxy/pom.xml
+++ b/maven/cn1-debug-proxy/pom.xml
@@ -18,6 +18,14 @@
         ParparVM-built iOS app's custom debug protocol on another.
     </description>
 
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/DeviceConnection.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/DeviceConnection.java
@@ -39,7 +39,7 @@ public final class DeviceConnection implements AutoCloseable {
         /**
          * The device's symbol table, fetched over the wire and inflated,
          * delivered before {@link #onHello} so downstream JDWP handling can
-         * rely on it. Replaces the old local cn1-symbols.txt sidecar.
+         * rely on it. Replaces the old local symbol sidecar.
          */
         void onSymbols(SymbolTable symbols);
         void onHello(int version);

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/DeviceConnection.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/DeviceConnection.java
@@ -6,6 +6,19 @@
  * published by the Free Software Foundation.  Codename One designates this
  * particular file as subject to the "Classpath" exception as provided
  * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.debug.proxy;
 

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
@@ -6,6 +6,19 @@
  * published by the Free Software Foundation.  Codename One designates this
  * particular file as subject to the "Classpath" exception as provided
  * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.debug.proxy;
 

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
@@ -78,11 +78,13 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
     private static final int SP_ALL          = 2;
 
     private final int port;
+    private final int devicePort;
     // Delivered by the device over the wire (CMD_GET_SYMBOLS), not a local
-    // file. Null until the device dials in and streams its table. VM_START is
-    // gated on this being set, and JDWP clients don't enumerate classes until
-    // they see VM_START — so symbol-dependent handlers never run against null.
+    // file. Null until the device dials in and streams its table. Some JDWP
+    // clients query classes before VM_START, so an IDE-first connection waits
+    // on symbolsLock before dispatching any commands.
     private volatile SymbolTable symbols;
+    private final Object symbolsLock = new Object();
     private volatile DeviceConnection device;
 
     private Socket socket;
@@ -141,7 +143,12 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
     }
 
     public JdwpServer(int port) {
+        this(port, 55333);
+    }
+
+    public JdwpServer(int port, int devicePort) {
         this.port = port;
+        this.devicePort = devicePort;
     }
 
     public void setDevice(DeviceConnection device) {
@@ -150,12 +157,14 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
 
     /**
      * Receives the symbol table streamed off the device, just before onHello.
-     * onHello then fires VM_START (if an IDE is attached), which is the signal
-     * JDWP clients wait for before enumerating classes — so by the time any
-     * symbol-dependent query arrives, {@link #symbols} is set.
+     * Wakes an IDE that attached before the device so its queued JDWP requests
+     * can continue against a complete table.
      */
     @Override public void onSymbols(SymbolTable symbols) {
-        this.symbols = symbols;
+        synchronized (symbolsLock) {
+            this.symbols = symbols;
+            symbolsLock.notifyAll();
+        }
     }
 
     public void acceptAndServe() throws IOException {
@@ -178,28 +187,15 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                     continue;
                 }
                 System.out.println("[jdwp] handshake complete");
-                // If the device already streamed its symbols (it connected
-                // before this IDE attach), fire VM_START now. Otherwise onHello
-                // will fire it once the device dials in and delivers symbols.
-                // Gating VM_START on symbols!=null means the IDE won't
-                // enumerate classes until the table is present. Idempotent, so
-                // onHello racing this is harmless.
-                if (symbols != null) {
-                    sendVmStart();
-                }
-                // Auto-release the device-side waitForAttach gate after a
-                // short delay. The delay gives the IDE time to register
-                // breakpoints via EventRequest.Set so the device doesn't race
-                // past them when it resumes. Most JDWP debuggers (IntelliJ,
-                // VS Code) don't auto-send VM.Resume on attach, so without
-                // this nudge the app would sit on the waiting overlay forever.
-                Thread autoResume = new Thread(() -> {
-                    try { Thread.sleep(500); } catch (InterruptedException ignore) {}
-                    try { if (device != null) device.resumeAll(); }
-                    catch (IOException ignore) {}
-                }, "cn1-debug-auto-resume");
-                autoResume.setDaemon(true);
-                autoResume.start();
+
+                // NetBeans queries classes immediately after the JDWP
+                // handshake, before VM_START. Wait here instead of dispatching
+                // those commands against a null symbol table. Commands already
+                // sent by the IDE remain buffered on the socket and are handled
+                // after the device connects.
+                waitForSymbols();
+                sendVmStart();
+                scheduleAutoResume();
 
                 try {
                     packetLoop();
@@ -211,6 +207,51 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 System.out.println("[jdwp] debugger session ended; listening for the next attach");
             }
         }
+    }
+
+    private SymbolTable waitForSymbols() throws IOException {
+        SymbolTable current = symbols;
+        if (current != null) {
+            return current;
+        }
+
+        System.out.println("[jdwp] debugger attached before the iOS app; waiting for device symbols");
+        System.out.println("[jdwp] launch the app now; this debugger session will continue when it connects");
+        boolean troubleshootingShown = false;
+        synchronized (symbolsLock) {
+            while ((current = symbols) == null) {
+                try {
+                    symbolsLock.wait(10000L);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("Interrupted while waiting for device symbols", e);
+                }
+                if (symbols == null && !troubleshootingShown) {
+                    System.err.println("[jdwp] still waiting for the iOS app on device port " + devicePort);
+                    System.err.println("[jdwp] verify the installed build uses "
+                            + "codename1.arg.ios.onDeviceDebug=true, proxyHost is this computer's "
+                            + "LAN IP, and the firewall allows TCP " + devicePort);
+                    troubleshootingShown = true;
+                }
+            }
+        }
+        System.out.println("[jdwp] device symbols received; continuing debugger session");
+        return current;
+    }
+
+    /**
+     * Releases the device-side waitForAttach gate only after both sides are
+     * connected. The delay gives the IDE time to register breakpoints. Most
+     * JDWP debuggers don't send VM.Resume automatically on attach.
+     */
+    private void scheduleAutoResume() {
+        Thread autoResume = new Thread(() -> {
+            try { Thread.sleep(500); } catch (InterruptedException ignore) {}
+            try { if (device != null) device.resumeAll(); }
+            catch (IOException ignore) {}
+        }, "cn1-debug-auto-resume");
+        autoResume.setDaemon(true);
+        autoResume.start();
     }
 
     private void closeJdwpSession() {

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/ProxyMain.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/ProxyMain.java
@@ -57,7 +57,7 @@ public final class ProxyMain {
             listener = new LoggingListener();
             jdwpServer = null;
         } else {
-            jdwpServer = new JdwpServer(jdwpPort);
+            jdwpServer = new JdwpServer(jdwpPort, devicePort);
             listener = jdwpServer;
             final JdwpServer js = jdwpServer;
             Thread t = new Thread(() -> {

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/ProxyMain.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/ProxyMain.java
@@ -6,6 +6,19 @@
  * published by the Free Software Foundation.  Codename One designates this
  * particular file as subject to the "Classpath" exception as provided
  * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.debug.proxy;
 

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/WireProtocol.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/WireProtocol.java
@@ -6,6 +6,19 @@
  * published by the Free Software Foundation.  Codename One designates this
  * particular file as subject to the "Classpath" exception as provided
  * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.debug.proxy;
 

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/WireProtocol.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/WireProtocol.java
@@ -41,7 +41,7 @@ public final class WireProtocol {
     // Pull the symbol table off the device. Payload: offset(4) maxLen(4).
     // The device replies with EVT_SYMBOLS carrying one chunk; the proxy
     // loops until it has assembled totalLen bytes. This replaces the old
-    // cn1-symbols.txt sidecar so a cloud-built app (Windows/Linux, where the
+    // legacy local symbol sidecar so a cloud-built app (Windows/Linux, where the
     // translator ran on the build server) still yields symbols locally.
     public static final int CMD_GET_SYMBOLS       = 0x11;
 

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpServerTest.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpServerTest.java
@@ -6,6 +6,19 @@
  * published by the Free Software Foundation.  Codename One designates this
  * particular file as subject to the "Classpath" exception as provided
  * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.debug.proxy;
 

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpServerTest.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpServerTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ */
+package com.codename1.debug.proxy;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class JdwpServerTest {
+
+    private static final byte[] HANDSHAKE = "JDWP-Handshake".getBytes(StandardCharsets.US_ASCII);
+
+    @Test
+    public void debuggerCanAttachAndQueryBeforeDeviceStreamsSymbols() throws Exception {
+        int port = freePort();
+        JdwpServer server = new JdwpServer(port);
+        Thread serverThread = new Thread(() -> {
+            try {
+                server.acceptAndServe();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }, "jdwp-server-test");
+        serverThread.setDaemon(true);
+        serverThread.start();
+
+        try (Socket client = connect(port)) {
+            DataInputStream in = new DataInputStream(client.getInputStream());
+            DataOutputStream out = new DataOutputStream(client.getOutputStream());
+            out.write(HANDSHAKE);
+            out.flush();
+            byte[] handshakeReply = new byte[HANDSHAKE.length];
+            in.readFully(handshakeReply);
+            assertEquals("JDWP-Handshake", new String(handshakeReply, StandardCharsets.US_ASCII));
+
+            int requestId = 41;
+            byte[] signature = "Lcom/example/Test;".getBytes(StandardCharsets.UTF_8);
+            out.writeInt(11 + 4 + signature.length);
+            out.writeInt(requestId);
+            out.writeByte(0);
+            out.writeByte(1); // VirtualMachine command set
+            out.writeByte(2); // ClassesBySignature
+            out.writeInt(signature.length);
+            out.write(signature);
+            out.flush();
+
+            client.setSoTimeout(250);
+            try {
+                in.readInt();
+                fail("Class query should wait until the device streams symbols");
+            } catch (SocketTimeoutException expected) {
+                // Expected: the request remains queued instead of throwing.
+            }
+
+            String table = "version\t1\nclass\t0\tcom_example_Test\tTest.java\t-1\n";
+            server.onSymbols(SymbolTable.load(new ByteArrayInputStream(
+                    table.getBytes(StandardCharsets.UTF_8))));
+            server.onHello(1);
+
+            client.setSoTimeout(2000);
+            Reply reply = readReply(in, requestId);
+            assertEquals(0, reply.errorCode);
+            DataInputStream body = new DataInputStream(new ByteArrayInputStream(reply.body));
+            assertEquals(1, body.readInt());
+            assertEquals(1, body.readUnsignedByte());
+            assertEquals(1L, body.readLong());
+            assertEquals(7, body.readInt());
+        }
+    }
+
+    private static int freePort() throws Exception {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+
+    private static Socket connect(int port) throws Exception {
+        Exception last = null;
+        for (int i = 0; i < 50; i++) {
+            try {
+                return new Socket("127.0.0.1", port);
+            } catch (Exception e) {
+                last = e;
+                Thread.sleep(20);
+            }
+        }
+        throw last;
+    }
+
+    private static Reply readReply(DataInputStream in, int requestId) throws Exception {
+        while (true) {
+            int length = in.readInt();
+            int id = in.readInt();
+            int flags = in.readUnsignedByte();
+            if ((flags & 0x80) != 0) {
+                int errorCode = in.readUnsignedShort();
+                byte[] body = new byte[length - 11];
+                in.readFully(body);
+                if (id == requestId) {
+                    return new Reply(errorCode, body);
+                }
+            } else {
+                in.readUnsignedByte();
+                in.readUnsignedByte();
+                byte[] body = new byte[length - 11];
+                in.readFully(body);
+            }
+        }
+    }
+
+    private static final class Reply {
+        final int errorCode;
+        final byte[] body;
+
+        Reply(int errorCode, byte[] body) {
+            this.errorCode = errorCode;
+            this.body = body;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- keep an IDE-first JDWP session alive until the iOS device streams its symbol table
- buffer early NetBeans class queries instead of dispatching them against a missing table
- print an actionable troubleshooting message after ten seconds, including the exact build hint and configured device port
- release `waitForAttach` only after the IDE and device are both connected
- add a regression test for attaching and querying from the IDE before the device connects
- update the iOS debugging documentation, build-hint notation, and NetBeans instructions
- remove the obsolete local symbol filename from documentation and explanatory source comments

## Root cause and behavior

The proxy assumed JDWP clients would wait for `VM_START` before querying classes. NetBeans sends `VirtualMachine.ClassesBySignature` immediately after the JDWP handshake, so an IDE-first attach reached symbol-dependent handlers while the device symbol table was still null.

The proxy now completes the JDWP handshake and waits for the device symbol stream before dispatching queued IDE commands. Device-first attach remains unchanged. With IDE-first attach, the same session continues automatically once the app connects. If no app connects within ten seconds, the proxy explains how to verify `codename1.arg.ios.onDeviceDebug`, `proxyHost`, the firewall, and the actual device port instead of throwing a null-pointer exception.

The docs still recommend device-first attach because its log checkpoints make configuration mistakes easier to identify, but both orders now work.

This addresses the runtime bug and documentation gaps reported in #5333 and discussion #5332.

## Validation

- Java 8: `mvn -pl cn1-debug-proxy -Dmaven.javadoc.skip=true verify`
- `vale --config docs/developer-guide/.vale.ini --minAlertLevel=suggestion docs/developer-guide`
- `asciidoctor --failure-level WARN --verbose --trace -o /dev/null docs/developer-guide/developer-guide.asciidoc`
- `python3 scripts/developer-guide/validate-guide-snippets.py`
- `ruby scripts/developer-guide/check_paragraph_capitalization.rb docs/developer-guide/developer-guide.asciidoc`
- `python3 scripts/website/blog_prose_gate.py --base-ref origin/master --no-languagetool docs/website/content/blog/developer-workflow-debug-and-junit.md`
- `hugo --source docs/website --renderToMemory`
- verified the obsolete filename no longer appears in tracked files
