### PR TITLE
Add simulator network timeout mode

### DIFF
--- a/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
@@ -987,6 +987,34 @@ public class JavaSEPort extends CodenameOneImplementation {
 
     private boolean slowConnectionMode;
     private boolean disconnectedMode;
+    private int connectionStatus;
+
+    static final int CONNECTION_STATUS_REGULAR = 0;
+    static final int CONNECTION_STATUS_SLOW = 1;
+    static final int CONNECTION_STATUS_DISCONNECTED = 2;
+    static final int CONNECTION_STATUS_TIMEOUT = 3;
+
+    void setConnectionStatus(int status) {
+        if (status < CONNECTION_STATUS_REGULAR || status > CONNECTION_STATUS_TIMEOUT) {
+            status = CONNECTION_STATUS_REGULAR;
+        }
+        connectionStatus = status;
+        slowConnectionMode = status == CONNECTION_STATUS_SLOW;
+        disconnectedMode = status == CONNECTION_STATUS_DISCONNECTED;
+    }
+
+    static IOException getSimulatedNetworkError(int status, String url) {
+        if (url == null || !url.toLowerCase().startsWith("http")) {
+            return null;
+        }
+        if (status == CONNECTION_STATUS_DISCONNECTED) {
+            return new IOException("Unreachable");
+        }
+        if (status == CONNECTION_STATUS_TIMEOUT) {
+            return new IOException("The request timed out.");
+        }
+        return null;
+    }
 
     private static boolean exposeFilesystem;
 
@@ -5836,9 +5864,8 @@ public class JavaSEPort extends CodenameOneImplementation {
         regularConnection.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent ae) {
-                slowConnectionMode = false;
-                disconnectedMode = false;
-                pref.putInt("connectionStatus", 0);
+                setConnectionStatus(CONNECTION_STATUS_REGULAR);
+                pref.putInt("connectionStatus", CONNECTION_STATUS_REGULAR);
             }
         });
         networkDebug.add(regularConnection);
@@ -5847,9 +5874,8 @@ public class JavaSEPort extends CodenameOneImplementation {
         slowConnection.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent ae) {
-                slowConnectionMode = true;
-                disconnectedMode = false;
-                pref.putInt("connectionStatus", 1);
+                setConnectionStatus(CONNECTION_STATUS_SLOW);
+                pref.putInt("connectionStatus", CONNECTION_STATUS_SLOW);
             }
         });
         networkDebug.add(slowConnection);
@@ -5858,29 +5884,46 @@ public class JavaSEPort extends CodenameOneImplementation {
         disconnected.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent ae) {
-                slowConnectionMode = false;
-                disconnectedMode = true;
-                pref.putInt("connectionStatus", 2);
+                setConnectionStatus(CONNECTION_STATUS_DISCONNECTED);
+                pref.putInt("connectionStatus", CONNECTION_STATUS_DISCONNECTED);
             }
         });
         networkDebug.add(disconnected);
+
+        JRadioButtonMenuItem timedOut = new JRadioButtonMenuItem("Timed Out");
+        timedOut.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent ae) {
+                setConnectionStatus(CONNECTION_STATUS_TIMEOUT);
+                pref.putInt("connectionStatus", CONNECTION_STATUS_TIMEOUT);
+            }
+        });
+        networkDebug.add(timedOut);
 
         ButtonGroup connectionGroup = new ButtonGroup();
         connectionGroup.add(regularConnection);
         connectionGroup.add(slowConnection);
         connectionGroup.add(disconnected);
+        connectionGroup.add(timedOut);
 
-        switch(pref.getInt("connectionStatus", 0)) {
-            case 0:
+        int connectionStatus = pref.getInt("connectionStatus", CONNECTION_STATUS_REGULAR);
+        setConnectionStatus(connectionStatus);
+        switch(connectionStatus) {
+            case CONNECTION_STATUS_REGULAR:
                 regularConnection.setSelected(true);
                 break;
-            case 1:
+            case CONNECTION_STATUS_SLOW:
                 slowConnection.setSelected(true);
-                slowConnectionMode = true;
                 break;
-            case 2:
+            case CONNECTION_STATUS_DISCONNECTED:
                 disconnected.setSelected(true);
-                disconnectedMode = true;
+                break;
+            case CONNECTION_STATUS_TIMEOUT:
+                timedOut.setSelected(true);
+                break;
+            default:
+                setConnectionStatus(CONNECTION_STATUS_REGULAR);
+                regularConnection.setSelected(true);
                 break;
         }
 
@@ -13696,8 +13739,9 @@ public class JavaSEPort extends CodenameOneImplementation {
      * @inheritDoc
      */
     public Object connect(String url, boolean read, boolean write, int timeout) throws IOException {
-        if(disconnectedMode && url.toLowerCase().startsWith("http")) {
-            throw new IOException("Unreachable");
+        IOException simulatedNetworkError = getSimulatedNetworkError(connectionStatus, url);
+        if(simulatedNetworkError != null) {
+            throw simulatedNetworkError;
         }
         if(url.toLowerCase().startsWith("http:"))  {
             if(!warnAboutHttpChecked) {

--- a/maven/javase/src/test/java/com/codename1/impl/javase/JavaSEPortNetworkModeTest.java
+++ b/maven/javase/src/test/java/com/codename1/impl/javase/JavaSEPortNetworkModeTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if
+ * you need additional information or have any questions.
+ */
+package com.codename1.impl.javase;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JavaSEPortNetworkModeTest {
+
+    @Test
+    public void timeoutModeProducesExpectedIOExceptionForHttpRequests() {
+        IOException error = JavaSEPort.getSimulatedNetworkError(
+                JavaSEPort.CONNECTION_STATUS_TIMEOUT,
+                "https://example.invalid/parse");
+
+        assertEquals("The request timed out.", error.getMessage());
+    }
+
+    @Test
+    public void disconnectedModeStillProducesUnreachableIOException() {
+        IOException error = JavaSEPort.getSimulatedNetworkError(
+                JavaSEPort.CONNECTION_STATUS_DISCONNECTED,
+                "https://example.invalid/parse");
+
+        assertEquals("Unreachable", error.getMessage());
+    }
+}


### PR DESCRIPTION
## Summary

- add a `Network > Timed Out` mode to the JavaSE simulator
- persist the selection alongside the existing regular, slow, and disconnected modes
- fail HTTP and HTTPS requests deterministically with `IOException("The request timed out.")`
- add regression coverage for the timeout and disconnected failure messages

## Motivation

The simulator could previously model a slow connection or an immediate disconnection, but it could not reproduce the timeout reported in [Discussion #5405](https://github.com/codenameone/CodenameOne/discussions/5405). `Disconnected` produces `IOException("Unreachable")`, which exercises a different failure path in applications that distinguish network errors.

The new mode injects the timeout before opening the connection, so reproduction is immediate and does not depend on an external proxy or a deliberately stalled server.

## User impact

Developers can select `Network > Timed Out` and run the same application request that failed in production. HTTP and HTTPS requests then take the application's normal exception path with the reported timeout message. Other URL schemes are unaffected.

## Validation

- `JAVA_HOME=/Users/shai/Library/Java/JavaVirtualMachines/azul-1.8.0_372/Contents/Home /opt/homebrew/bin/mvn -pl javase -Dtest=JavaSEPortNetworkModeTest -DargLine=-Djava.awt.headless=true -Dmaven.javadoc.skip=true -Plocal-dev-javase test`
  - 2 tests passed, 0 failures
- `git diff --check`