### PR TITLE
Fix website MCP documentation links

### DIFF
--- a/docs/website/layouts/_default/getting-started.html
+++ b/docs/website/layouts/_default/getting-started.html
@@ -69,7 +69,7 @@
         <p>Java 17 projects include the Codename One authoring skill in the downloaded project. Open the project in Codex or Claude Code so the agent can use the framework-specific build, UI, testing, and screenshot instructions instead of guessing.</p>
         <p>Run the simulator, open its <strong>MCP</strong> menu, and choose <strong>Install in MCP Hosts</strong>. The built-in server lets supported hosts inspect the semantic UI tree, enter text, activate components, and call application tools.</p>
         <div class="cn1-action-row">
-          {{ partial "cn1-cta.html" (dict "label" "Read the MCP guide" "href" "/blog/codename-one-mcp-server/" "variant" "secondary") }}
+          {{ partial "cn1-cta.html" (dict "label" "Read the MCP guide" "href" "/developer-guide/#_mcp_headless_api" "variant" "secondary") }}
         </div>
       </div>
       <aside class="cn1-gs-agent-files" aria-label="Agent resources included with a generated project">

--- a/docs/website/layouts/index.html
+++ b/docs/website/layouts/index.html
@@ -108,7 +108,7 @@ app.show();</code></pre>
       <p>A generated Java 17 project includes Codename One instructions for coding agents. The simulator can expose the running UI to Codex, Claude Code, and other MCP hosts, so the agent can inspect meaning and invoke actions instead of guessing screen coordinates.</p>
       <div class="cn1-action-row">
         {{ partial "cn1-cta.html" (dict "label" "Connect an agent" "href" "/getting-started/#agent" "variant" "secondary") }}
-        {{ partial "cn1-cta.html" (dict "label" "Read the MCP implementation" "href" "/blog/codename-one-mcp-server/" "variant" "text") }}
+        {{ partial "cn1-cta.html" (dict "label" "Read the MCP implementation" "href" "/developer-guide/#_mcp_headless_api" "variant" "text") }}
       </div>
     </div>
     <div class="cn1-v2-agent__grid">


### PR DESCRIPTION
## Summary

- point the homepage MCP implementation CTA to the published Developer Guide MCP section
- point the Getting Started MCP guide CTA to the same published section

## Root cause

The CTAs linked to `/blog/codename-one-mcp-server/`, but that post is dated July 21 and production Hugo builds exclude future-dated content. The resulting missing page caused the website workflow's offline Lychee validation to fail.

## Impact

Production builds no longer contain a broken MCP documentation link before the scheduled blog post publishes. Users are directed to the already-available MCP Headless API section of the Developer Guide.

## Validation

- production-mode website build with `HUGO_BUILD_FUTURE=false` and the Developer Guide included
- Lychee 0.23.0 offline validation of the homepage and Getting Started page: 82 links OK, 0 errors (excluding only the PDF artifact omitted from the reduced local build)
- confirmed the generated target contains `id=_mcp_headless_api`
- `git diff --check`