### PR TITLE
Separate repository and traffic tokens in OSS snapshot

### DIFF
--- a/.github/workflows/oss-traction.yml
+++ b/.github/workflows/oss-traction.yml
@@ -27,10 +27,10 @@ jobs:
 
       - name: Capture GitHub metrics
         env:
-          # Repository traffic needs Administration read access. The ordinary
-          # workflow token still captures public stars and engagement if this
-          # optional fine-grained token has not been configured.
-          GH_TOKEN: ${{ secrets.OSS_TRACTION_TOKEN || github.token }}
+          # Keep repository reads on the installation token. The fine-grained
+          # token has Administration read access solely for traffic endpoints.
+          GITHUB_TOKEN: ${{ github.token }}
+          OSS_TRACTION_TOKEN: ${{ secrets.OSS_TRACTION_TOKEN }}
         run: |
           python3 scripts/website/capture_oss_traction.py \
             --output "${RUNNER_TEMP}/oss-traction.json" \

--- a/scripts/website/capture_oss_traction.py
+++ b/scripts/website/capture_oss_traction.py
@@ -103,6 +103,16 @@ def optional_rest(path: str, token: str) -> dict:
         return {"available": False, "error": str(error)}
 
 
+def collect_traffic(repository: str, token: str) -> dict:
+    return {
+        "views": optional_rest(f"/repos/{repository}/traffic/views", token),
+        "clones": optional_rest(f"/repos/{repository}/traffic/clones", token),
+        "referrers": optional_rest(
+            f"/repos/{repository}/traffic/popular/referrers", token
+        ),
+    }
+
+
 def collect_discussions(owner: str, name: str, token: str, cutoff: dt.datetime) -> list[dict]:
     query = """
       query($owner: String!, $name: String!, $cursor: String) {
@@ -141,16 +151,21 @@ def collect_discussions(owner: str, name: str, token: str, cutoff: dt.datetime) 
         cursor = connection["pageInfo"]["endCursor"]
 
 
-def collect_snapshot(repository: str, token: str, now: dt.datetime) -> dict:
+def collect_snapshot(
+    repository: str,
+    repository_token: str,
+    now: dt.datetime,
+    traffic_token: str | None = None,
+) -> dict:
     try:
         owner, name = repository.split("/", 1)
     except ValueError as error:
         raise ValueError("repository must use owner/name format") from error
     cutoff = now - dt.timedelta(days=28)
-    metadata = api_request(f"{API_ROOT}/repos/{repository}", token)
+    metadata = api_request(f"{API_ROOT}/repos/{repository}", repository_token)
 
     stargazers = paged_rest(
-        f"/repos/{repository}/stargazers", token, accept=STAR_ACCEPT
+        f"/repos/{repository}/stargazers", repository_token, accept=STAR_ACCEPT
     )
     star_times = [
         parse_timestamp(item["starred_at"])
@@ -163,14 +178,15 @@ def collect_snapshot(repository: str, token: str, now: dt.datetime) -> dict:
         + repository
         + "/issues?state=all&since="
         + urllib.parse.quote(cutoff.isoformat()),
-        token,
+        repository_token,
     )
     new_issues = [
         item
         for item in issue_candidates
         if "pull_request" not in item and parse_timestamp(item["created_at"]) >= cutoff
     ]
-    discussions = collect_discussions(owner, name, token, cutoff)
+    discussions = collect_discussions(owner, name, repository_token, cutoff)
+    traffic = collect_traffic(repository, traffic_token or repository_token)
 
     return {
         "schema_version": 1,
@@ -190,13 +206,7 @@ def collect_snapshot(repository: str, token: str, now: dt.datetime) -> dict:
             "discussions_created": len(discussions),
             "unique_discussion_authors": unique_logins(discussions, "author"),
         },
-        "traffic_last_14_days": {
-            "views": optional_rest(f"/repos/{repository}/traffic/views", token),
-            "clones": optional_rest(f"/repos/{repository}/traffic/clones", token),
-            "referrers": optional_rest(
-                f"/repos/{repository}/traffic/popular/referrers", token
-            ),
-        },
+        "traffic_last_14_days": traffic,
     }
 
 
@@ -250,15 +260,23 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def resolve_tokens(environ: dict[str, str]) -> tuple[str | None, str | None]:
+    repository_token = environ.get("GITHUB_TOKEN") or environ.get("GH_TOKEN")
+    traffic_token = environ.get("OSS_TRACTION_TOKEN") or repository_token
+    return repository_token, traffic_token
+
+
 def main(argv: list[str]) -> int:
     args = parse_args(argv)
-    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
-    if not token:
+    repository_token, traffic_token = resolve_tokens(os.environ)
+    if not repository_token:
         print("Set GH_TOKEN or GITHUB_TOKEN before capturing a snapshot.", file=sys.stderr)
         return 2
     now = parse_timestamp(args.now) if args.now else dt.datetime.now(dt.timezone.utc)
     try:
-        report = collect_snapshot(args.repository, token, now)
+        report = collect_snapshot(
+            args.repository, repository_token, now, traffic_token=traffic_token
+        )
     except (GitHubApiError, KeyError, TypeError, ValueError) as error:
         print(f"Unable to capture OSS traction: {error}", file=sys.stderr)
         return 1

--- a/scripts/website/test_capture_oss_traction.py
+++ b/scripts/website/test_capture_oss_traction.py
@@ -2,6 +2,7 @@
 
 import datetime as dt
 import unittest
+from unittest import mock
 
 import capture_oss_traction as traction
 
@@ -52,6 +53,43 @@ class CaptureOssTractionTest(unittest.TestCase):
             {},
         ]
         self.assertEqual(traction.unique_logins(items, "user"), 2)
+
+    def test_resolve_tokens_keeps_traffic_token_separate(self):
+        self.assertEqual(
+            traction.resolve_tokens(
+                {
+                    "GITHUB_TOKEN": "repository-token",
+                    "OSS_TRACTION_TOKEN": "traffic-token",
+                }
+            ),
+            ("repository-token", "traffic-token"),
+        )
+
+    def test_resolve_tokens_falls_back_to_repository_token(self):
+        self.assertEqual(
+            traction.resolve_tokens({"GH_TOKEN": "repository-token"}),
+            ("repository-token", "repository-token"),
+        )
+
+    def test_collect_traffic_uses_only_traffic_token(self):
+        with mock.patch.object(
+            traction,
+            "optional_rest",
+            return_value={"available": True, "data": {}},
+        ) as request:
+            traction.collect_traffic("owner/repository", "traffic-token")
+
+        self.assertEqual(
+            request.call_args_list,
+            [
+                mock.call("/repos/owner/repository/traffic/views", "traffic-token"),
+                mock.call("/repos/owner/repository/traffic/clones", "traffic-token"),
+                mock.call(
+                    "/repos/owner/repository/traffic/popular/referrers",
+                    "traffic-token",
+                ),
+            ],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- keep repository metadata, stargazers, issues, and discussions on the workflow's built-in `GITHUB_TOKEN`
- pass `OSS_TRACTION_TOKEN` separately and use it only for traffic views, clones, and referrers
- add regression tests for token resolution and traffic-only routing

## Root cause

[Workflow run 29673546923](https://github.com/codenameone/CodenameOne/actions/runs/29673546923) failed on the first stargazers request with:

```text
403 Resource not accessible by personal access token
```

The workflow selected `OSS_TRACTION_TOKEN || github.token` and then used that single token for every GitHub API request. The fine-grained PAT has Administration read access for repository traffic, but it cannot serve as the repository installation token for the stargazer listing.

## Fix

The workflow now exports both tokens:

- `GITHUB_TOKEN`: ordinary repository reads
- `OSS_TRACTION_TOKEN`: traffic endpoints only

If the optional traffic token is absent, the script falls back to the repository token and reports traffic as unavailable without failing the snapshot.

## Validation

- `python3 scripts/website/test_capture_oss_traction.py` — 6 tests pass
- Python compilation
- workflow YAML parsing
- `git diff --check`
- live snapshot with an intentionally invalid traffic token completed repository metrics and marked only traffic unavailable
- live snapshot with an authorized traffic token returned views, clones, and referrers