### PR TITLE
Fix Android clipboard round trip

### DIFF
--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -8920,7 +8920,10 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
             imageExt = "gif";
         }
         if (imageBytes != null) {
-            File imageFile = new File(getContext().getCacheDir(),
+            // AndroidGradleBuilder exposes cache/intent_files through the app's
+            // FileProvider. Keep generated clipboard payloads inside that root so
+            // FileProvider can safely create a content:// URI for paste targets.
+            File imageFile = new File(new File(getContext().getCacheDir(), "intent_files"),
                     "cn1-clip-image-" + System.currentTimeMillis() + "." + imageExt);
             imageFile.getParentFile().mkdirs();
             OutputStream os = new FileOutputStream(imageFile);
@@ -8954,10 +8957,14 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
                     continue;
                 }
                 Uri u;
-                if (pathOrUri.startsWith("content:") || pathOrUri.startsWith("file:")) {
+                if (pathOrUri.startsWith("content:")) {
                     u = Uri.parse(pathOrUri);
                 } else {
-                    u = Uri.fromFile(new File(pathOrUri));
+                    File file = pathOrUri.startsWith("file:")
+                            ? new File(Uri.parse(pathOrUri).getPath())
+                            : new File(pathOrUri);
+                    u = FileProvider.getUriForFile(getContext(), authority, file);
+                    getContext().grantUriPermission("android", u, Intent.FLAG_GRANT_READ_URI_PERMISSION);
                 }
                 if (clip == null) {
                     clip = new ClipData("Codename One", new String[]{ "text/uri-list" }, new ClipData.Item(u));


### PR DESCRIPTION
## Summary

- Store generated clipboard images under the existing cache/intent_files FileProvider root.
- Convert local file paths and file URIs to content URIs before placing them on the Android clipboard.
- Preserve existing content URIs unchanged.

## Root cause

ClipboardRoundTripTest first failed because generated image files were outside the configured FileProvider roots. After correcting that path, the full device suite exposed a second deterministic bug: local files were placed on the clipboard as file URIs, causing FileUriExposedException on modern Android.

## Validation

- Android port build passed with the repository Java 8 and Java 17 toolchains.
- Generated Android application assembled successfully.
- Full API 34 Android instrumentation suite passed on-device.
- The generated port-status artifact records ClipboardRoundTripTest as pass, with no URI exception or test skip.