### PR TITLE
Fix dashboard link on mobile

### DIFF
--- a/docs/website/assets/css/extended/zz-cn1-design-system.css
+++ b/docs/website/assets/css/extended/zz-cn1-design-system.css
@@ -149,6 +149,10 @@ body:not(.dark) .cn1-brand-logo {
   display: none;
 }
 
+.cn1-header #menu > .cn1-mobile-dashboard-item {
+  display: none;
+}
+
 .cn1-header #menu > li > a,
 .cn1-header #menu > li > .cn1-menu-trigger {
   color: var(--cn1-text);
@@ -229,6 +233,7 @@ body:not(.dark) .cn1-brand-logo {
 
 .cn1-menu-search-link svg,
 .cn1-theme-toggle-btn svg,
+.cn1-dashboard-link svg,
 .cn1-create-project-link svg,
 .cn1-action svg,
 .cn1-nav-toggle-btn svg {
@@ -273,6 +278,9 @@ body:not(.dark) .cn1-brand-logo {
 }
 
 .cn1-header .cn1-dashboard-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   margin: 0;
   padding: 0 5px;
   border: 0;
@@ -280,6 +288,10 @@ body:not(.dark) .cn1-brand-logo {
   font-size: 14px;
   font-weight: 600;
   line-height: 38px;
+}
+
+.cn1-header .cn1-dashboard-link svg {
+  display: none;
 }
 
 .cn1-header .cn1-dashboard-link:hover {
@@ -1326,7 +1338,21 @@ body.dark .cn1-footer-logo {
   }
 
   .cn1-header .cn1-dashboard-link {
+    width: 40px;
+    height: 40px;
+    padding: 0;
+    border: 1px solid var(--cn1-border);
+    border-radius: 8px;
+    color: var(--cn1-text);
+    line-height: 1;
+  }
+
+  .cn1-header .cn1-dashboard-link span {
     display: none;
+  }
+
+  .cn1-header .cn1-dashboard-link svg {
+    display: block;
   }
 
   .cn1-v2-hero {
@@ -1392,6 +1418,14 @@ body.dark .cn1-footer-logo {
 
   .cn1-header #menu {
     display: block;
+  }
+
+  .cn1-header #menu > .cn1-mobile-dashboard-item {
+    display: block;
+  }
+
+  .cn1-header .cn1-dashboard-link {
+    display: none;
   }
 
   .cn1-header #menu > li > a,

--- a/docs/website/layouts/partials/header.html
+++ b/docs/website/layouts/partials/header.html
@@ -56,8 +56,8 @@
         <div class="cn1-nav-links" id="cn1-primary-menu">
             <ul id="menu">
                 {{- range site.Menus.main }}
-                {{- if and (not .Parent) (ne .Identifier "dashboard") (ne .Identifier "create-project") }}
-                <li class="{{ if .HasChildren }}has-children{{ end }}">
+                {{- if and (not .Parent) (ne .Identifier "create-project") }}
+                <li class="{{ if eq .Identifier "dashboard" }}cn1-mobile-dashboard-item{{ else if .HasChildren }}has-children{{ end }}">
                     {{- if .HasChildren }}
                     <button class="cn1-menu-trigger" type="button" aria-expanded="false" aria-haspopup="true">
                         <span>{{- .Name -}}</span>
@@ -94,8 +94,9 @@
         </div>
         {{- range site.Menus.main }}
         {{- if eq .Identifier "dashboard" }}
-        <a class="cn1-dashboard-link" href="{{ .URL }}" title="{{ .Title | default .Name }}">
+        <a class="cn1-dashboard-link" href="{{ .URL }}" title="{{ .Title | default .Name }}" aria-label="{{ .Title | default .Name }}">
             <span>{{- .Name -}}</span>
+            <svg viewBox="0 0 24 24" aria-hidden="true"><rect x="4" y="4" width="6" height="6" rx="1"/><rect x="14" y="4" width="6" height="6" rx="1"/><rect x="4" y="14" width="6" height="6" rx="1"/><rect x="14" y="14" width="6" height="6" rx="1"/></svg>
         </a>
         {{- end }}
         {{- end }}


### PR DESCRIPTION
## Summary

- keep the Dashboard link visible as a compact icon when the desktop navigation gets tight
- include Dashboard in the collapsible navigation menu on mobile
- add an accessible label to the icon-only Dashboard link

## Root cause

The responsive stylesheet hid the standalone Dashboard link below 1120px, while the header template explicitly excluded Dashboard from the primary menu. Once the mobile menu took over, neither rendering path exposed the link.

## Validation

- `hugo --source docs/website --destination /tmp/cn1-website-dashboard.nXg8sk --cleanDestinationDir --logLevel error`
- `git diff --check`
- inspected the generated home page and compiled stylesheet for both responsive Dashboard renderings
