### PR TITLE
Restore Android clipboard FileProvider handling

### DIFF
--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -8920,7 +8920,10 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
             imageExt = "gif";
         }
         if (imageBytes != null) {
-            File imageFile = new File(getContext().getCacheDir(),
+            // AndroidGradleBuilder exposes cache/intent_files through the app's
+            // FileProvider. Keep generated clipboard payloads inside that root so
+            // FileProvider can safely create a content:// URI for paste targets.
+            File imageFile = new File(new File(getContext().getCacheDir(), "intent_files"),
                     "cn1-clip-image-" + System.currentTimeMillis() + "." + imageExt);
             imageFile.getParentFile().mkdirs();
             OutputStream os = new FileOutputStream(imageFile);
@@ -8954,10 +8957,14 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
                     continue;
                 }
                 Uri u;
-                if (pathOrUri.startsWith("content:") || pathOrUri.startsWith("file:")) {
+                if (pathOrUri.startsWith("content:")) {
                     u = Uri.parse(pathOrUri);
                 } else {
-                    u = Uri.fromFile(new File(pathOrUri));
+                    File file = pathOrUri.startsWith("file:")
+                            ? new File(Uri.parse(pathOrUri).getPath())
+                            : new File(pathOrUri);
+                    u = FileProvider.getUriForFile(getContext(), authority, file);
+                    getContext().grantUriPermission("android", u, Intent.FLAG_GRANT_READ_URI_PERMISSION);
                 }
                 if (clip == null) {
                     clip = new ClipData("Codename One", new String[]{ "text/uri-list" }, new ClipData.Item(u));


### PR DESCRIPTION
## Summary

- restore the configured `cache/intent_files` FileProvider root for generated clipboard images
- convert local file paths and `file:` URIs to `content:` URIs with `FileProvider`
- grant read permission for generated clipboard content while preserving incoming `content:` URIs

## Root cause

PR #5421 reintroduced the pre-#5418 Android clipboard implementation while touching the same file. Generated images were written directly under the cache directory, outside the app's configured FileProvider root, and local files again used `Uri.fromFile(...)`. The current master port-status run consequently failed `ClipboardRoundTripTest` with `Failed to find configured root`.

## Impact

Android clipboard round trips for image and file content work again on modern Android instead of silently falling back to empty clipboard data after URI creation fails.

## Validation

- `./scripts/build-android-port.sh -q -DskipTests`
- `ANDROID_SDK_ROOT=... ANDROID_HOME=... ./scripts/build-android-app.sh -q -DskipTests`
- full `scripts/run-android-instrumentation-tests.sh` run on an API 34 emulator
- normalized `port-status-android.json`: `suite_finished: true`, `ClipboardRoundTripTest: pass`
- instrumentation log contains no `FileProvider`, `FileUriExposedException`, or clipboard assertion failure

The local emulator uses 1080x2209 geometry, so screenshot comparisons against the CI goldens differ; those unrelated visual diffs do not affect the clipboard assertion result.