### PR TITLE
Fix iOS debugger breakpoints in inner classes

### DIFF
--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/LoggingListener.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/LoggingListener.java
@@ -6,6 +6,19 @@
  * published by the Free Software Foundation.  Codename One designates this
  * particular file as subject to the "Classpath" exception as provided
  * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.debug.proxy;
 
@@ -91,7 +104,7 @@ public final class LoggingListener implements DeviceConnection.DeviceListener {
         SymbolTable.MethodInfo m = symbols.methodById(methodId);
         if (m == null) return "method=" + methodId + " line=" + line;
         SymbolTable.ClassInfo c = symbols.classById(m.classId);
-        String cls = c != null ? c.name.replace('_', '.') : "?";
+        String cls = c != null ? c.jvmName.replace('/', '.') : "?";
         return cls + "." + m.name + m.descriptor + ":" + line;
     }
 

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/SymbolTable.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/SymbolTable.java
@@ -6,6 +6,19 @@
  * published by the Free Software Foundation.  Codename One designates this
  * particular file as subject to the "Classpath" exception as provided
  * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.debug.proxy;
 
@@ -36,6 +49,7 @@ public final class SymbolTable {
     public static final class ClassInfo {
         public final int classId;
         public final String name;        // e.g. "java_lang_String" (translator convention)
+        public final String jvmName;     // e.g. "java/lang/String$CaseInsensitiveComparator"
         public final String sourceFile;
         /** Superclass classId, or -1 if java.lang.Object / unknown. */
         public int superId = -1;
@@ -48,15 +62,16 @@ public final class SymbolTable {
          */
         public final List<FieldInfo> instanceFields = new ArrayList<>();
 
-        ClassInfo(int classId, String name, String sourceFile) {
+        ClassInfo(int classId, String name, String sourceFile, String jvmName) {
             this.classId = classId;
             this.name = name;
             this.sourceFile = sourceFile;
+            this.jvmName = jvmName;
         }
 
-        /** JVM-style signature: "Ljava/lang/String;" derived from the underscore-separated name. */
+        /** JVM-style signature retaining inner-class markers and literal underscores. */
         public String jvmSignature() {
-            return "L" + name.replace('_', '/') + ";";
+            return "L" + jvmName + ";";
         }
     }
 
@@ -159,7 +174,13 @@ public final class SymbolTable {
                     case "class": {
                         if (parts.length < 4) continue;
                         int id = Integer.parseInt(parts[1]);
-                        ClassInfo c = new ClassInfo(id, parts[2], parts[3]);
+                        // New tables carry the original JVM internal name in
+                        // column 6. Older tables only contain ParparVM's
+                        // underscore-mangled identifier, so retain the legacy
+                        // best-effort reconstruction for compatibility.
+                        String jvmName = parts.length >= 6 && !parts[5].isEmpty()
+                                ? parts[5] : parts[2].replace('_', '/');
+                        ClassInfo c = new ClassInfo(id, parts[2], parts[3], jvmName);
                         if (parts.length >= 5) {
                             try { c.superId = Integer.parseInt(parts[4]); }
                             catch (NumberFormatException ignore) {}
@@ -233,7 +254,9 @@ public final class SymbolTable {
      */
     public MethodInfo methodCoveringLine(String className, int line) {
         ClassInfo c = classesById.values().stream()
-                .filter(ci -> ci.name.equals(className) || ci.name.replace('_', '.').equals(className))
+                .filter(ci -> ci.name.equals(className)
+                        || ci.jvmName.equals(className)
+                        || ci.jvmName.replace('/', '.').equals(className))
                 .findFirst().orElse(null);
         if (c == null) return null;
         for (MethodInfo m : c.methods) {

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpServerTest.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpServerTest.java
@@ -63,7 +63,7 @@ public class JdwpServerTest {
             assertEquals("JDWP-Handshake", new String(handshakeReply, StandardCharsets.US_ASCII));
 
             int requestId = 41;
-            byte[] signature = "Lcom/example/Test;".getBytes(StandardCharsets.UTF_8);
+            byte[] signature = "Lcom/example/Test$1;".getBytes(StandardCharsets.UTF_8);
             out.writeInt(11 + 4 + signature.length);
             out.writeInt(requestId);
             out.writeByte(0);
@@ -81,7 +81,8 @@ public class JdwpServerTest {
                 // Expected: the request remains queued instead of throwing.
             }
 
-            String table = "version\t1\nclass\t0\tcom_example_Test\tTest.java\t-1\n";
+            String table = "version\t1\n"
+                    + "class\t0\tcom_example_Test_1\tTest.java\t-1\tcom/example/Test$1\n";
             server.onSymbols(SymbolTable.load(new ByteArrayInputStream(
                     table.getBytes(StandardCharsets.UTF_8))));
             server.onHello(1);

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/SymbolTableTest.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/SymbolTableTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.debug.proxy;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+public class SymbolTableTest {
+
+    @Test
+    public void originalJvmNamePreservesInnerClassesAndUnderscores() throws Exception {
+        SymbolTable table = load(
+                "version\t1\n"
+                        + "class\t17\tcom_example_my_app_Main_1\tMain.java\t-1\tcom/example/my_app/Main$1\n"
+        );
+
+        SymbolTable.ClassInfo inner = table.classById(17);
+        assertNotNull(inner);
+        assertEquals("com/example/my_app/Main$1", inner.jvmName);
+        assertEquals("Lcom/example/my_app/Main$1;", inner.jvmSignature());
+        assertSame(inner, table.classByJvmSignature("Lcom/example/my_app/Main$1;"));
+        assertNull(table.classByJvmSignature("Lcom/example/my/app/Main/1;"));
+    }
+
+    @Test
+    public void legacyRowsRetainBestEffortSignatureConversion() throws Exception {
+        SymbolTable table = load(
+                "version\t1\n"
+                        + "class\t3\tjava_lang_String\tString.java\t-1\n"
+        );
+
+        assertEquals("Ljava/lang/String;", table.classById(3).jvmSignature());
+    }
+
+    private SymbolTable load(String text) throws Exception {
+        return SymbolTable.load(new ByteArrayInputStream(text.getBytes(StandardCharsets.UTF_8)));
+    }
+}

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/Parser.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/Parser.java
@@ -265,7 +265,7 @@ public class Parser extends ClassVisitor {
      * The uncompressed payload is the same line-based ASCII the proxy's
      * SymbolTable parses:
      *   version &lt;n&gt;
-     *   class   &lt;classId&gt; &lt;clsName&gt; &lt;sourceFile&gt; &lt;superId&gt;
+     *   class   &lt;classId&gt; &lt;clsName&gt; &lt;sourceFile&gt; &lt;superId&gt; &lt;jvmName&gt;
      *   method  &lt;methodId&gt; &lt;classId&gt; &lt;methodName&gt; &lt;desc&gt; &lt;isStatic&gt;
      *   line    &lt;methodId&gt; &lt;sourceLine&gt;
      *   var     &lt;methodId&gt; &lt;slot&gt; &lt;name&gt; &lt;desc&gt;
@@ -280,15 +280,7 @@ public class Parser extends ClassVisitor {
                 if (src == null) {
                     src = "";
                 }
-                // Extended class row: id, name, sourceFile, superId.
-                // Older proxies (4-column form) ignore the trailing
-                // column since the parser tolerates extras.
-                int superId = -1;
-                if (bc.getBaseClassObject() != null) {
-                    superId = bc.getBaseClassObject().getClassOffset();
-                }
-                w.write("class\t" + bc.getClassOffset() + "\t" + bc.getClsName()
-                        + "\t" + src + "\t" + superId + "\n");
+                w.write(classSymbolRow(bc, src));
             }
             // Emit instance-field metadata so the proxy can answer JDWP
             // ClassType.Fields / FieldsWithGeneric without a device round-trip,
@@ -391,6 +383,28 @@ public class Parser extends ClassVisitor {
             System.out.println("Wrote on-device-debug symbol blob: " + f.getAbsolutePath()
                     + " (" + gz.length + " gz bytes, " + raw.size() + " raw)");
         }
+    }
+
+    /**
+     * Builds a symbol-table class row while retaining both ParparVM's mangled
+     * identifier and the original JVM internal name. The latter is required
+     * for JDWP signatures because mangling maps both {@code '/'} and
+     * {@code '$'} to {@code '_'}, making anonymous and inner classes
+     * impossible to reconstruct reliably in the debugger proxy.
+     */
+    static String classSymbolRow(ByteCodeClass bc, String sourceFile) {
+        int superId = -1;
+        if (bc.getBaseClassObject() != null) {
+            superId = bc.getBaseClassObject().getClassOffset();
+        }
+        String jvmName = bc.getOriginalClassName();
+        if (jvmName == null || jvmName.isEmpty()) {
+            // Defensive compatibility for synthetic ByteCodeClass instances
+            // that predate original-name tracking.
+            jvmName = bc.getClsName().replace('_', '/');
+        }
+        return "class\t" + bc.getClassOffset() + "\t" + bc.getClsName()
+                + "\t" + sourceFile + "\t" + superId + "\t" + jvmName + "\n";
     }
     
     private static void appendClassOffset(ByteCodeClass bc, List<Integer> clsIds) {

--- a/vm/tests/src/test/java/com/codename1/tools/translator/ParserTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/ParserTest.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.tools.translator;
 
 import com.codename1.tools.translator.bytecodes.Instruction;
@@ -99,6 +121,20 @@ class ParserTest {
         assertTrue(cls.isIsInterface(), "Annotations should be treated as interfaces");
         assertTrue(readPrivateBoolean(cls, "isAnnotation"));
         assertFalse(readPrivateBoolean(cls, "isSynthetic"));
+    }
+
+    @Test
+    void symbolClassRowsPreserveOriginalJvmNames() {
+        ByteCodeClass cls = new ByteCodeClass(
+                "com_example_my_app_Main_1",
+                "com/example/my_app/Main$1"
+        );
+        cls.setClassOffset(17);
+
+        assertEquals(
+                "class\t17\tcom_example_my_app_Main_1\tMain.java\t-1\tcom/example/my_app/Main$1\n",
+                Parser.classSymbolRow(cls, "Main.java")
+        );
     }
 
     @Test


### PR DESCRIPTION
## Summary

- preserve the original JVM internal class name in the embedded iOS debugger symbol table
- use that name for JDWP signatures and diagnostic output while retaining legacy symbol-table compatibility
- add translator, symbol-table, and JDWP regression coverage for anonymous classes and literal underscores

## Root cause

ParparVM mangles both `/` and `$` to `_` for generated C identifiers. The debugger proxy tried to reconstruct JVM names by converting every `_` back to `/`, so an anonymous listener such as `MyApp$1` was advertised to the IDE as `MyApp/1`. NetBeans could bind breakpoints in the outer class but not inside the listener.

The symbol table now includes the original JVM internal name as an optional trailing class field. New proxies use it when present and retain the prior best-effort conversion for older app binaries.

This addresses the final breakpoint report in #5333. A new debug IPA is required because the symbol table is embedded in the app.

## Validation

- `mvn -DunitTests=true -pl cn1-debug-proxy test` (Java 8): 3 tests passed
- `mvn -pl tests -am -Dtest=ParserTest -Dsurefire.failIfNoSpecifiedTests=false test` from `vm` (Java 8): 11 tests passed
- `./scripts/check-copyright-headers.sh`: 6 files passed
- `git diff --check`