### PR TITLE
Fix simulator menu clicks on Windows

### DIFF
--- a/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
@@ -19142,10 +19142,29 @@ public class JavaSEPort extends CodenameOneImplementation {
             // would go to Canvas.  If we don't do this, then the glasspane will 
             // intercept all events, even those destined for the menu items - and
             // that causes all hell to break loose on Windows.
-            Point p = SwingUtilities.convertPoint(this, new Point(x, y), instance.canvas);
-            return instance.canvas.getVisibleRect().contains(p);
+            return shouldGlassPaneInterceptMouseEvent(this, instance.canvas, x, y);
 
         }
+   }
+
+   /**
+    * Returns whether the glass pane should handle a mouse event at the given point.
+    * Swing popup menus are placed above the content pane in the root layered pane,
+    * so testing only whether the point overlaps the canvas would steal their events.
+    */
+   static boolean shouldGlassPaneInterceptMouseEvent(JComponent glassPane,
+           java.awt.Component canvas, int x, int y) {
+        JRootPane rootPane = SwingUtilities.getRootPane(glassPane);
+        if (rootPane == null) {
+            return false;
+        }
+        JLayeredPane layeredPane = rootPane.getLayeredPane();
+        Point layeredPoint = SwingUtilities.convertPoint(
+                glassPane, new Point(x, y), layeredPane);
+        java.awt.Component component = SwingUtilities.getDeepestComponentAt(
+                layeredPane, layeredPoint.x, layeredPoint.y);
+        return component != null
+                && (canvas == component || containsInHierarchy(canvas, component));
    }
    
    private static boolean containsInHierarchy(java.awt.Component parent, java.awt.Component cmp) {

--- a/maven/javase/src/test/java/com/codename1/impl/javase/JavaSEPortGlassPaneMenuTest.java
+++ b/maven/javase/src/test/java/com/codename1/impl/javase/JavaSEPortGlassPaneMenuTest.java
@@ -88,11 +88,12 @@ public class JavaSEPortGlassPaneMenuTest {
                     JPopupMenu popup = new JPopupMenu();
                     JMenuItem item = new JMenuItem("Rotate");
                     popup.add(item);
-                    popup.setBounds(0, 24, 140, 30);
-                    item.setBounds(1, 1, 138, 28);
                     fixture.rootPane.getLayeredPane().add(
                             popup, JLayeredPane.POPUP_LAYER);
                     popup.setVisible(true);
+                    fixture.applyBounds();
+                    popup.setBounds(0, 24, 140, 30);
+                    item.setBounds(1, 1, 138, 28);
 
                     Point point = SwingUtilities.convertPoint(
                             item, 10, 10, fixture.glassPane);
@@ -164,29 +165,32 @@ public class JavaSEPortGlassPaneMenuTest {
                 return new Rectangle(0, 0, getWidth(), getHeight());
             }
         };
+        private final JPanel contentPane = new JPanel(null);
         private final JComponent glassPane = new JComponent() {
         };
         private final JMenu deviceMenu = new JMenu("Device");
+        private final JMenuBar menuBar = new JMenuBar();
 
         private Fixture() {
-            rootPane.setSize(400, 400);
-            rootPane.getLayeredPane().setSize(400, 400);
-
-            JPanel contentPane = new JPanel(null);
-            contentPane.setBounds(0, 24, 400, 376);
-            canvas.setBounds(0, 0, 400, 376);
             contentPane.add(canvas);
             rootPane.setContentPane(contentPane);
 
-            JMenuBar menuBar = new JMenuBar();
-            menuBar.setBounds(0, 0, 400, 24);
-            deviceMenu.setBounds(0, 0, 80, 24);
             menuBar.add(deviceMenu);
             rootPane.setJMenuBar(menuBar);
 
             rootPane.setGlassPane(glassPane);
-            glassPane.setBounds(0, 0, 400, 400);
             glassPane.setVisible(true);
+            applyBounds();
+        }
+
+        private void applyBounds() {
+            rootPane.setSize(400, 400);
+            rootPane.getLayeredPane().setBounds(0, 0, 400, 400);
+            contentPane.setBounds(0, 24, 400, 376);
+            canvas.setBounds(0, 0, 400, 376);
+            menuBar.setBounds(0, 0, 400, 24);
+            deviceMenu.setBounds(0, 0, 80, 24);
+            glassPane.setBounds(0, 0, 400, 400);
         }
     }
 }

--- a/maven/javase/src/test/java/com/codename1/impl/javase/JavaSEPortGlassPaneMenuTest.java
+++ b/maven/javase/src/test/java/com/codename1/impl/javase/JavaSEPortGlassPaneMenuTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.impl.javase;
+
+import java.awt.Point;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.swing.JComponent;
+import javax.swing.JLayeredPane;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
+import javax.swing.JRootPane;
+import javax.swing.SwingUtilities;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression coverage for simulator menu mouse routing through the HiDPI glass pane:
+ * <a href="https://github.com/codenameone/CodenameOne/issues/2686">#2686</a> and
+ * <a href="https://github.com/codenameone/CodenameOne/issues/5430">#5430</a>.
+ */
+public class JavaSEPortGlassPaneMenuTest {
+
+    @Test
+    public void glassPaneDoesNotInterceptEmbeddedMenuBar() throws Exception {
+        final AtomicReference<Throwable> failure = new AtomicReference<Throwable>();
+        SwingUtilities.invokeAndWait(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    Fixture fixture = new Fixture();
+                    Point point = SwingUtilities.convertPoint(
+                            fixture.deviceMenu, 10, 10, fixture.glassPane);
+                    Point layeredPoint = SwingUtilities.convertPoint(
+                            fixture.glassPane, point, fixture.rootPane.getLayeredPane());
+
+                    assertSame(fixture.deviceMenu, SwingUtilities.getDeepestComponentAt(
+                            fixture.rootPane.getLayeredPane(), layeredPoint.x, layeredPoint.y),
+                            "the regression fixture must target the embedded JMenu");
+
+                    assertFalse(JavaSEPort.shouldGlassPaneInterceptMouseEvent(
+                            fixture.glassPane, fixture.canvas, point.x, point.y),
+                            "the HiDPI glass pane must leave embedded JMenu clicks to Swing");
+                } catch (Throwable t) {
+                    failure.set(t);
+                }
+            }
+        });
+        rethrow(failure.get());
+    }
+
+    @Test
+    public void glassPaneDoesNotInterceptPopupItemOverCanvas() throws Exception {
+        final AtomicReference<Throwable> failure = new AtomicReference<Throwable>();
+        SwingUtilities.invokeAndWait(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    Fixture fixture = new Fixture();
+                    JPopupMenu popup = new JPopupMenu();
+                    JMenuItem item = new JMenuItem("Rotate");
+                    popup.add(item);
+                    popup.setBounds(0, 24, 140, 30);
+                    item.setBounds(1, 1, 138, 28);
+                    fixture.rootPane.getLayeredPane().add(
+                            popup, JLayeredPane.POPUP_LAYER);
+                    popup.setVisible(true);
+
+                    Point point = SwingUtilities.convertPoint(
+                            item, 10, 10, fixture.glassPane);
+                    Point canvasPoint = SwingUtilities.convertPoint(
+                            fixture.glassPane, point, fixture.canvas);
+                    Point layeredPoint = SwingUtilities.convertPoint(
+                            fixture.glassPane, point, fixture.rootPane.getLayeredPane());
+
+                    assertTrue(fixture.canvas.getVisibleRect().contains(canvasPoint),
+                            "the regression fixture must place the popup item geometrically over the canvas");
+                    assertSame(item, SwingUtilities.getDeepestComponentAt(
+                            fixture.rootPane.getLayeredPane(), layeredPoint.x, layeredPoint.y),
+                            "the regression fixture must target the popup JMenuItem above the canvas");
+
+                    assertFalse(JavaSEPort.shouldGlassPaneInterceptMouseEvent(
+                            fixture.glassPane, fixture.canvas, point.x, point.y),
+                            "a popup JMenuItem over the canvas must receive its own click");
+                } catch (Throwable t) {
+                    failure.set(t);
+                }
+            }
+        });
+        rethrow(failure.get());
+    }
+
+    @Test
+    public void glassPaneStillInterceptsCanvasEvents() throws Exception {
+        final AtomicReference<Throwable> failure = new AtomicReference<Throwable>();
+        SwingUtilities.invokeAndWait(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    Fixture fixture = new Fixture();
+                    Point point = SwingUtilities.convertPoint(
+                            fixture.canvas, 200, 200, fixture.glassPane);
+
+                    assertTrue(JavaSEPort.shouldGlassPaneInterceptMouseEvent(
+                            fixture.glassPane, fixture.canvas, point.x, point.y),
+                            "ordinary simulator-canvas events must still pass through the HiDPI dispatcher");
+                } catch (Throwable t) {
+                    failure.set(t);
+                }
+            }
+        });
+        rethrow(failure.get());
+    }
+
+    private static void rethrow(Throwable failure) throws Exception {
+        if (failure == null) {
+            return;
+        }
+        if (failure instanceof Exception) {
+            throw (Exception) failure;
+        }
+        if (failure instanceof Error) {
+            throw (Error) failure;
+        }
+        throw new RuntimeException(failure);
+    }
+
+    private static final class Fixture {
+        private final JRootPane rootPane = new JRootPane();
+        private final JPanel canvas = new JPanel();
+        private final JComponent glassPane = new JComponent() {
+        };
+        private final JMenu deviceMenu = new JMenu("Device");
+
+        private Fixture() {
+            rootPane.setSize(400, 400);
+            rootPane.getLayeredPane().setSize(400, 400);
+
+            JPanel contentPane = new JPanel(null);
+            contentPane.setBounds(0, 24, 400, 376);
+            canvas.setBounds(0, 0, 400, 376);
+            contentPane.add(canvas);
+            rootPane.setContentPane(contentPane);
+
+            JMenuBar menuBar = new JMenuBar();
+            menuBar.setBounds(0, 0, 400, 24);
+            deviceMenu.setBounds(0, 0, 80, 24);
+            menuBar.add(deviceMenu);
+            rootPane.setJMenuBar(menuBar);
+
+            rootPane.setGlassPane(glassPane);
+            glassPane.setBounds(0, 0, 400, 400);
+            glassPane.setVisible(true);
+        }
+    }
+}

--- a/maven/javase/src/test/java/com/codename1/impl/javase/JavaSEPortGlassPaneMenuTest.java
+++ b/maven/javase/src/test/java/com/codename1/impl/javase/JavaSEPortGlassPaneMenuTest.java
@@ -85,12 +85,18 @@ public class JavaSEPortGlassPaneMenuTest {
             public void run() {
                 try {
                     Fixture fixture = new Fixture();
-                    JPopupMenu popup = new JPopupMenu();
+                    JPopupMenu popup = new JPopupMenu() {
+                        @Override
+                        public boolean isVisible() {
+                            // Keep this synthetic popup in the root layered pane instead of
+                            // invoking the platform PopupFactory for an unattached hierarchy.
+                            return true;
+                        }
+                    };
                     JMenuItem item = new JMenuItem("Rotate");
                     popup.add(item);
                     fixture.rootPane.getLayeredPane().add(
                             popup, JLayeredPane.POPUP_LAYER);
-                    popup.setVisible(true);
                     fixture.applyBounds();
                     popup.setBounds(0, 24, 140, 30);
                     item.setBounds(1, 1, 138, 28);

--- a/maven/javase/src/test/java/com/codename1/impl/javase/JavaSEPortGlassPaneMenuTest.java
+++ b/maven/javase/src/test/java/com/codename1/impl/javase/JavaSEPortGlassPaneMenuTest.java
@@ -23,6 +23,7 @@
 package com.codename1.impl.javase;
 
 import java.awt.Point;
+import java.awt.Rectangle;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.swing.JComponent;
@@ -154,7 +155,15 @@ public class JavaSEPortGlassPaneMenuTest {
 
     private static final class Fixture {
         private final JRootPane rootPane = new JRootPane();
-        private final JPanel canvas = new JPanel();
+        private final JPanel canvas = new JPanel() {
+            @Override
+            public Rectangle getVisibleRect() {
+                // The production canvas is showing when the glass pane is active. This
+                // fixture is intentionally not attached to a native window so it remains
+                // headless; model the production visibility explicitly and consistently.
+                return new Rectangle(0, 0, getWidth(), getHeight());
+            }
+        };
         private final JComponent glassPane = new JComponent() {
         };
         private final JMenu deviceMenu = new JMenu("Device");


### PR DESCRIPTION
## Summary

- route simulator glass-pane mouse interception using the actual topmost Swing component in the root layered pane
- leave embedded menu-bar and popup-menu item clicks to Swing while preserving canvas event interception
- add headless regression coverage for both #2686 and #5430

## Root cause

On HiDPI displays, the simulator installs a visible glass pane to transform canvas input. Its hit test only checked whether a pointer coordinate geometrically overlapped the simulator canvas. A lightweight `JPopupMenu` is layered over that canvas, so Windows delivered the click to the glass pane, which then redispatched it to the underlying content pane instead of the `JMenuItem`.

The revised hit test resolves the topmost component in the `JRootPane` layered pane and only intercepts the event when that component is the simulator canvas or one of its descendants.

## Validation

- Java 8 focused test: `JavaSEPortGlassPaneMenuTest` — 3 tests passed
- Java 8 complete JavaSE module: 84 tests, 0 failures, 0 errors, 22 skipped
- mutation check: restoring the coordinate-only hit test makes the popup-over-canvas regression test fail
- `git diff --check`

Fixes #5430.
