### PR TITLE
Preserve scaled simulator mouse routing

### DIFF
--- a/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
@@ -19149,30 +19149,45 @@ public class JavaSEPort extends CodenameOneImplementation {
 
    /**
     * Returns whether the glass pane should handle a mouse event at the given point.
-    * Swing popup menus are placed above the content pane in the root layered pane,
-    * so testing only whether the point overlaps the canvas would steal their events.
+    * The geometric canvas check must remain the default because native peers can be
+    * siblings of the canvas in the AppFrame hierarchy, and their HiDPI coordinates
+    * still need to pass through the glass-pane dispatcher. Swing menus are the one
+    * exception because lightweight popup menus can overlap the canvas.
     */
    static boolean shouldGlassPaneInterceptMouseEvent(JComponent glassPane,
            java.awt.Component canvas, int x, int y) {
+        if (!(canvas instanceof JComponent)) {
+            return false;
+        }
+        Point canvasPoint = SwingUtilities.convertPoint(
+                glassPane, new Point(x, y), canvas);
+        if (!((JComponent) canvas).getVisibleRect().contains(canvasPoint)) {
+            return false;
+        }
+
         JRootPane rootPane = SwingUtilities.getRootPane(glassPane);
         if (rootPane == null) {
-            return false;
+            return true;
         }
         JLayeredPane layeredPane = rootPane.getLayeredPane();
         Point layeredPoint = SwingUtilities.convertPoint(
                 glassPane, new Point(x, y), layeredPane);
         java.awt.Component component = SwingUtilities.getDeepestComponentAt(
                 layeredPane, layeredPoint.x, layeredPoint.y);
-        return component != null
-                && (canvas == component || containsInHierarchy(canvas, component));
+        return !isSwingMenuComponent(component);
    }
-   
-   private static boolean containsInHierarchy(java.awt.Component parent, java.awt.Component cmp) {
-        Container p = cmp.getParent();
-        while (p != parent && p != null) {
-            p = p.getParent();
+
+   private static boolean isSwingMenuComponent(java.awt.Component component) {
+        java.awt.Component current = component;
+        while (current != null) {
+            if (current instanceof JMenuBar
+                    || current instanceof JPopupMenu
+                    || current instanceof JMenuItem) {
+                return true;
+            }
+            current = current.getParent();
         }
-        return p == parent;
+        return false;
     }
     
    /**

--- a/maven/javase/src/test/java/com/codename1/impl/javase/JavaSEPortGlassPaneMenuTest.java
+++ b/maven/javase/src/test/java/com/codename1/impl/javase/JavaSEPortGlassPaneMenuTest.java
@@ -147,6 +147,43 @@ public class JavaSEPortGlassPaneMenuTest {
         rethrow(failure.get());
     }
 
+    @Test
+    public void glassPaneStillInterceptsNativePeerOverCanvas() throws Exception {
+        final AtomicReference<Throwable> failure = new AtomicReference<Throwable>();
+        SwingUtilities.invokeAndWait(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    Fixture fixture = new Fixture();
+                    JPanel nativePeer = new JPanel();
+                    fixture.contentPane.add(nativePeer, 0);
+                    nativePeer.setBounds(50, 50, 120, 80);
+
+                    Point point = SwingUtilities.convertPoint(
+                            nativePeer, 10, 10, fixture.glassPane);
+                    Point canvasPoint = SwingUtilities.convertPoint(
+                            fixture.glassPane, point, fixture.canvas);
+                    Point layeredPoint = SwingUtilities.convertPoint(
+                            fixture.glassPane, point, fixture.rootPane.getLayeredPane());
+
+                    assertTrue(fixture.canvas.getVisibleRect().contains(canvasPoint),
+                            "the native peer must overlap the nested simulator canvas");
+                    assertSame(nativePeer, SwingUtilities.getDeepestComponentAt(
+                            fixture.rootPane.getLayeredPane(), layeredPoint.x, layeredPoint.y),
+                            "the native peer must be the topmost Swing component");
+
+                    assertTrue(JavaSEPort.shouldGlassPaneInterceptMouseEvent(
+                            fixture.glassPane, fixture.canvas, point.x, point.y),
+                            "the HiDPI glass pane must keep intercepting native peers "
+                                    + "over the canvas so it can transform their coordinates");
+                } catch (Throwable t) {
+                    failure.set(t);
+                }
+            }
+        });
+        rethrow(failure.get());
+    }
+
     private static void rethrow(Throwable failure) throws Exception {
         if (failure == null) {
             return;
@@ -172,13 +209,15 @@ public class JavaSEPortGlassPaneMenuTest {
             }
         };
         private final JPanel contentPane = new JPanel(null);
+        private final JPanel canvasHost = new JPanel(null);
         private final JComponent glassPane = new JComponent() {
         };
         private final JMenu deviceMenu = new JMenu("Device");
         private final JMenuBar menuBar = new JMenuBar();
 
         private Fixture() {
-            contentPane.add(canvas);
+            canvasHost.add(canvas);
+            contentPane.add(canvasHost);
             rootPane.setContentPane(contentPane);
 
             menuBar.add(deviceMenu);
@@ -193,6 +232,7 @@ public class JavaSEPortGlassPaneMenuTest {
             rootPane.setSize(400, 400);
             rootPane.getLayeredPane().setBounds(0, 0, 400, 400);
             contentPane.setBounds(0, 24, 400, 376);
+            canvasHost.setBounds(0, 0, 400, 376);
             canvas.setBounds(0, 0, 400, 376);
             menuBar.setBounds(0, 0, 400, 24);
             deviceMenu.setBounds(0, 0, 80, 24);


### PR DESCRIPTION
## Summary

- preserve the geometric canvas hit test introduced for scaled/HiDPI AppFrame input
- exempt only Swing menu hierarchies from glass-pane interception
- add regression coverage for a native-peer-style component above a nested simulator canvas

## Root cause

PR #5431 fixed Windows menu clicks by requiring the topmost Swing component to be the simulator canvas or one of its descendants. That was too broad a change.

Commit `098439e6a4` deliberately replaced that rule in 2022 while fixing retina/AppFrame glitches. Native peers can be siblings of the nested canvas and still need the glass-pane dispatcher in the input path. The merged rule returned `false` when such a peer was topmost, restoring the scaled-input regression.

This follow-up retains the 2022 geometric rule for all points over the visible canvas, but returns `false` when the topmost component is in a `JMenuBar`, `JPopupMenu`, or `JMenuItem` hierarchy. Thus popup items over the canvas remain clickable without changing native-peer routing.

## Regression coverage

`JavaSEPortGlassPaneMenuTest` now verifies all of these cases:

- embedded Swing menu clicks bypass the glass pane
- popup menu items over the canvas bypass the glass pane
- ordinary canvas clicks use the glass pane
- native-peer-style siblings above a nested canvas still use the glass pane

The new peer test fails against merged `master`, while the popup test fails with the unqualified 2022 coordinate-only implementation.

## Validation

- focused Java 8 test: 4 tests, 0 failures, 0 errors
- complete JavaSE Java 8 suite: 85 tests, 0 failures, 0 errors, 22 skipped
- `git diff --check`

Follow-up to #5431.
