### PR TITLE
Remove website JavaScript build login

### DIFF
--- a/.github/workflows/website-docs.yml
+++ b/.github/workflows/website-docs.yml
@@ -141,8 +141,8 @@ jobs:
         env:
           WEBSITE_INCLUDE_JAVADOCS: "true"
           WEBSITE_INCLUDE_DEVGUIDE: "true"
-          WEBSITE_INCLUDE_INITIALIZR: "auto"
-          WEBSITE_INCLUDE_PLAYGROUND: "auto"
+          WEBSITE_INCLUDE_INITIALIZR: "true"
+          WEBSITE_INCLUDE_PLAYGROUND: "true"
           # The Initializr's JavaScript app is built with the local ParparVM
           # target, whose builder lives in the repo (8.0-SNAPSHOT) plugin rather
           # than the pinned release. Bootstrap the local snapshot artifacts so
@@ -157,8 +157,6 @@ jobs:
           # (push to master) keep the default so future posts only appear
           # on their actual date.
           HUGO_BUILD_FUTURE: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
-          CN1_USER: ${{ secrets.CN1_USER }}
-          CN1_TOKEN: ${{ secrets.CN1_TOKEN }}
 
       - name: Validate Port Status page output
         run: |
@@ -181,28 +179,10 @@ jobs:
           test -f docs/website/public/playground/index.html
 
       - name: Validate Initializr JS bundle output
-        run: |
-          set -euo pipefail
-          if [ -n "${CN1_USER}" ] && [ -n "${CN1_TOKEN}" ]; then
-            test -f docs/website/public/initializr-app/index.html
-          else
-            echo "CN1 credentials not configured; skipping Initializr JS bundle output validation."
-          fi
-        env:
-          CN1_USER: ${{ secrets.CN1_USER }}
-          CN1_TOKEN: ${{ secrets.CN1_TOKEN }}
+        run: test -f docs/website/public/initializr-app/index.html
 
       - name: Validate Playground JS bundle output
-        run: |
-          set -euo pipefail
-          if [ -n "${CN1_USER}" ] && [ -n "${CN1_TOKEN}" ]; then
-            test -f docs/website/public/playground-app/index.html
-          else
-            echo "CN1 credentials not configured; skipping Playground JS bundle output validation."
-          fi
-        env:
-          CN1_USER: ${{ secrets.CN1_USER }}
-          CN1_TOKEN: ${{ secrets.CN1_TOKEN }}
+        run: test -f docs/website/public/playground-app/index.html
 
       - name: Validate redirects against local Pages runtime
         run: |

--- a/scripts/website/build.sh
+++ b/scripts/website/build.sh
@@ -33,15 +33,9 @@ WEBSITE_INCLUDE_SKINDESIGNER="${WEBSITE_INCLUDE_SKINDESIGNER:-true}"
 WEBSITE_BOOTSTRAP_CN1_SNAPSHOTS="${WEBSITE_BOOTSTRAP_CN1_SNAPSHOTS:-auto}"
 WEBSITE_REFRESH_PORT_STATUS="${WEBSITE_REFRESH_PORT_STATUS:-false}"
 WEBSITE_CN1_VERSION="${WEBSITE_CN1_VERSION:-auto}"
-CN1_USER="${CN1_USER:-}"
-CN1_TOKEN="${CN1_TOKEN:-}"
 
 if [ "${WEBSITE_INCLUDE_INITIALIZR}" = "auto" ]; then
-  if [ -n "${CN1_USER}" ] && [ -n "${CN1_TOKEN}" ]; then
-    WEBSITE_INCLUDE_INITIALIZR="true"
-  else
-    WEBSITE_INCLUDE_INITIALIZR="false"
-  fi
+  WEBSITE_INCLUDE_INITIALIZR="true"
 fi
 
 bootstrap_local_cn1_snapshots() {
@@ -82,11 +76,7 @@ activate_bootstrapped_java17() {
 }
 
 if [ "${WEBSITE_INCLUDE_PLAYGROUND}" = "auto" ]; then
-  if [ -n "${CN1_USER}" ] && [ -n "${CN1_TOKEN}" ]; then
-    WEBSITE_INCLUDE_PLAYGROUND="true"
-  else
-    WEBSITE_INCLUDE_PLAYGROUND="false"
-  fi
+  WEBSITE_INCLUDE_PLAYGROUND="true"
 fi
 
 if [ "${WEBSITE_INCLUDE_SKINDESIGNER}" = "auto" ]; then
@@ -104,62 +94,6 @@ if [ "${WEBSITE_CN1_VERSION}" = "auto" ]; then
     exit 1
   fi
 fi
-
-set_cn1_user_token() {
-  local project_dir="$1"
-
-  if [ -n "${CN1_USER}" ] && [ -n "${CN1_TOKEN}" ]; then
-    # CN1_TOKEN holds the account *password*, not a build token. The build
-    # sends whatever is stored in the prefs "token" slot as an
-    # "Authorization: Bearer" header; the cloud server parses that as a JWT,
-    # so seeding the raw password makes every cloud call 401 and the build
-    # falls back to an interactive browser login that hangs in CI
-    # ("Waiting for login..."). Exchange the password for a short-lived
-    # Keycloak access token (OAuth2 direct grant on the public cn1cloudapp
-    # client) and seed THAT instead.
-    local cn1_access_token=""
-    cn1_access_token="$(curl -fsS -m 20 \
-      -d 'grant_type=password' \
-      -d 'client_id=cn1cloudapp' \
-      --data-urlencode "username=${CN1_USER}" \
-      --data-urlencode "password=${CN1_TOKEN}" \
-      'https://auth.codenameone.com/auth/realms/Realm/protocol/openid-connect/token' \
-      | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')" || true
-    if [ -z "${cn1_access_token}" ]; then
-      echo "Failed to obtain a Codename One access token from CN1_USER/CN1_TOKEN — check the credentials (the secret must be the account password)." >&2
-      return 1
-    fi
-
-    if ! sh ./mvnw -q -U -pl javascript -am \
-      cn1:set-user-token \
-      -Dcodename1.platform=javascript \
-      -Duser="${CN1_USER}" \
-      -Dtoken="${cn1_access_token}"; then
-      echo "cn1:set-user-token is unavailable in this plugin version for ${project_dir}; writing CN1 credentials directly to Java preferences." >&2
-      local tmp_dir
-      tmp_dir="$(mktemp -d)"
-      cat > "${tmp_dir}/SetCn1Prefs.java" <<'JAVA'
-import java.util.prefs.Preferences;
-
-public class SetCn1Prefs {
-    public static void main(String[] args) {
-        if (args.length != 2) {
-            throw new IllegalArgumentException("Usage: SetCn1Prefs <user> <token>");
-        }
-        Preferences prefs = Preferences.userRoot().node("/com/codename1/ui");
-        prefs.put("user", args[0]);
-        prefs.put("token", args[1]);
-    }
-}
-JAVA
-      javac "${tmp_dir}/SetCn1Prefs.java"
-      java -cp "${tmp_dir}" SetCn1Prefs "${CN1_USER}" "${cn1_access_token}"
-      rm -rf "${tmp_dir}"
-    fi
-  else
-    echo "CN1_USER/CN1_TOKEN not provided; building ${project_dir} JavaScript without setting token." >&2
-  fi
-}
 
 build_javadocs_for_site() {
   if [ "${WEBSITE_INCLUDE_JAVADOCS}" != "true" ]; then
@@ -636,8 +570,6 @@ build_initializr_for_site() {
       -Dcodename1.platform=javascript \
       install
 
-    set_cn1_user_token "Initializr"
-
     run_initializr_mvn -q -U -pl javascript -am \
       "${initializr_workspace_args[@]}" \
       -DskipTests \
@@ -710,7 +642,6 @@ build_playground_for_site() {
       fi
     }
 
-    set_cn1_user_token "Playground"
     local playground_workspace_args=()
     if [ "${WEBSITE_BOOTSTRAP_CN1_SNAPSHOTS}" = "true" ]; then
       playground_workspace_args+=(-Dcn1.localWorkspace=true)
@@ -799,7 +730,6 @@ build_skindesigner_for_site() {
       fi
     }
 
-    set_cn1_user_token "Skin Designer"
     local skindesigner_workspace_args=()
     if [ "${WEBSITE_BOOTSTRAP_CN1_SNAPSHOTS}" = "true" ]; then
       skindesigner_workspace_args+=(-Dcn1.localWorkspace=true)


### PR DESCRIPTION
## Summary

- remove the obsolete Keycloak token exchange and Java preference seeding from website JavaScript builds
- build Initializr and Playground unconditionally through the free local ParparVM target in website CI
- validate both generated JavaScript bundles without depending on `CN1_USER` or `CN1_TOKEN` secrets

## Root cause

The website workflow still attempted to log in before building its JavaScript apps. Keycloak has been taken down, so that stale request now fails with HTTP 522 even though ParparVM JavaScript builds are free and no longer require authentication.

## Impact

Website builds no longer depend on the retired authentication service. Initializr, Playground, and Skin Designer use the existing local ParparVM build path without credentials.

## Validation

- `bash -n scripts/website/build.sh`
- parsed `.github/workflows/website-docs.yml` with Ruby YAML
- `git diff --check`
- confirmed no Keycloak, `CN1_USER`/`CN1_TOKEN`, or token-seeding references remain in the website build path
- full website build delegated to this PR's CI as requested