### PR TITLE
Fix iOS debug proxy dependency resolution

### DIFF
--- a/maven/codenameone-maven-plugin/pom.xml
+++ b/maven/codenameone-maven-plugin/pom.xml
@@ -121,6 +121,12 @@
             <artifactId>codenameone-javase</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>com.codenameone</groupId>
+            <artifactId>cn1-debug-proxy</artifactId>
+            <version>${project.version}</version>
+            <scope>runtime</scope>
+        </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.codehaus.mojo/exec-maven-plugin -->
         <dependency>

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/IosOnDeviceDebuggingMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/IosOnDeviceDebuggingMojo.java
@@ -6,9 +6,23 @@
  * published by the Free Software Foundation.  Codename One designates this
  * particular file as subject to the "Classpath" exception as provided
  * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.maven;
 
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -16,6 +30,8 @@ import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Launches the desktop on-device-debug proxy and prints instructions for
@@ -65,11 +81,7 @@ public class IosOnDeviceDebuggingMojo extends AbstractCN1Mojo {
         getLog().info("  3. Attach a debugger:  jdb -attach localhost:" + jdwpPort);
         getLog().info("");
 
-        ProcessBuilder pb = new ProcessBuilder(
-                javaBinary(),
-                "-jar", jar.getAbsolutePath(),
-                "--device-port=" + devicePort,
-                "--jdwp-port=" + jdwpPort);
+        ProcessBuilder pb = new ProcessBuilder(proxyCommand(jar));
         pb.inheritIO();
         try {
             Process proc = pb.start();
@@ -82,28 +94,38 @@ public class IosOnDeviceDebuggingMojo extends AbstractCN1Mojo {
         }
     }
 
-    private File resolveProxyJar() throws MojoFailureException {
+    File resolveProxyJar() throws MojoFailureException {
         if (proxyJar != null && !proxyJar.isEmpty()) {
             File f = new File(proxyJar);
             if (!f.isFile()) throw new MojoFailureException("Configured proxy jar does not exist: " + f);
             return f;
         }
-        // Try the locally-built standalone shaded jar (developer workflow).
-        String userHome = System.getProperty("user.home", "");
-        File m2 = new File(userHome, ".m2/repository/com/codenameone/cn1-debug-proxy");
-        if (m2.isDirectory()) {
-            File[] versions = m2.listFiles(File::isDirectory);
-            if (versions != null) {
-                for (File v : versions) {
-                    File jar = new File(v, "cn1-debug-proxy-" + v.getName() + "-standalone.jar");
-                    if (jar.isFile()) return jar;
+        if (pluginArtifacts != null) {
+            for (Artifact artifact : pluginArtifacts) {
+                if ("com.codenameone".equals(artifact.getGroupId())
+                        && "cn1-debug-proxy".equals(artifact.getArtifactId())
+                        && artifact.getClassifier() == null) {
+                    File jar = getJar(artifact);
+                    if (jar != null && (jar.isFile() || jar.isDirectory())) {
+                        return jar;
+                    }
                 }
             }
         }
         throw new MojoFailureException(
-                "Could not locate cn1-debug-proxy standalone jar in ~/.m2. "
-                        + "Build it once with 'cd maven/cn1-debug-proxy && mvn install', "
-                        + "or pass -Dcn1.onDeviceDebug.proxyJar=<path>.");
+                "Could not resolve the cn1-debug-proxy bundled with this Codename One Maven plugin. "
+                        + "Reinstall the plugin or pass -Dcn1.onDeviceDebug.proxyJar=<path>.");
+    }
+
+    List<String> proxyCommand(File jar) {
+        List<String> command = new ArrayList<String>();
+        command.add(javaBinary());
+        command.add("-cp");
+        command.add(jar.getAbsolutePath());
+        command.add("com.codename1.debug.proxy.ProxyMain");
+        command.add("--device-port=" + devicePort);
+        command.add("--jdwp-port=" + jdwpPort);
+        return command;
     }
 
     private String javaBinary() {

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/IosOnDeviceDebuggingMojoTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/IosOnDeviceDebuggingMojoTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.maven;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class IosOnDeviceDebuggingMojoTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void resolvesProxyFromPluginDependenciesInsteadOfArbitraryStandaloneVersion() throws Exception {
+        File staleJar = tmp.newFile("cn1-debug-proxy-7.0.259-standalone.jar");
+        File bundledJar = tmp.newFile("cn1-debug-proxy-7.0.260.jar");
+
+        IosOnDeviceDebuggingMojo mojo = new IosOnDeviceDebuggingMojo();
+        mojo.pluginArtifacts = Arrays.asList(
+                artifact("7.0.259", "standalone", staleJar),
+                artifact("7.0.260", null, bundledJar));
+
+        assertEquals(bundledJar, mojo.resolveProxyJar());
+    }
+
+    @Test
+    public void launchesBundledJarByMainClassWithoutRequiringStandaloneManifest() throws Exception {
+        File bundledJar = tmp.newFile("cn1-debug-proxy.jar");
+        IosOnDeviceDebuggingMojo mojo = new IosOnDeviceDebuggingMojo();
+
+        List<String> command = mojo.proxyCommand(bundledJar);
+
+        assertEquals("-cp", command.get(1));
+        assertEquals(bundledJar.getAbsolutePath(), command.get(2));
+        assertEquals("com.codename1.debug.proxy.ProxyMain", command.get(3));
+    }
+
+    private static Artifact artifact(String version, String classifier, File file) {
+        DefaultArtifact artifact = new DefaultArtifact(
+                "com.codenameone", "cn1-debug-proxy", version, "runtime", "jar",
+                classifier, new DefaultArtifactHandler("jar"));
+        artifact.setFile(file);
+        return artifact;
+    }
+}


### PR DESCRIPTION
## Summary

- declare the matching `cn1-debug-proxy` as a runtime dependency of the Codename One Maven plugin
- resolve the proxy from the plugin's artifacts instead of scanning arbitrary versions under `~/.m2`
- launch the regular proxy jar by main class, removing the standalone-manifest requirement
- add regression coverage for stale cached proxy versions and regular-jar launching

## Root cause

`cn1:ios-on-device-debugging` searched every locally cached proxy version and launched the first standalone jar returned by the filesystem. Updating the Maven plugin therefore neither guaranteed that the matching proxy was downloaded nor that it was selected, which led users to manually run `dependency:get`.

With this change, Maven resolves the proxy version pinned to `${project.version}` as part of the plugin itself. Running the debugging goal no longer requires a separate proxy download and cannot silently select an older cached version.

Related to #5333.

## Validation

- Java 8: `mvn -pl cn1-debug-proxy,codenameone-maven-plugin -DunitTests=true -Dmaven.javadoc.skip=true test` — 268 tests passed, 1 skipped
- Java 8 focused package lifecycle for `cn1-debug-proxy` and `codenameone-maven-plugin`
- `git diff --check`
- copyright-header check for both touched Java files