### PR TITLE
Fix Windows Settings black screen and add Windows tooling CI

### DIFF
--- a/.github/workflows/windows-tooling.yml
+++ b/.github/workflows/windows-tooling.yml
@@ -1,0 +1,104 @@
+name: Windows simulator and tooling screenshot smoke
+
+# Runs the JavaSE simulator and the desktop tooling (cn1:settings / Control
+# Center) on a real Windows desktop runner and gates on basic screenshot
+# sanity (window rendered actual content, not the black screen of issue
+# #5443). Windows was previously the only desktop platform with zero
+# simulator/tooling coverage, which is exactly where that regression shipped.
+#
+# Pixel-exact golden comparison is deliberately not attempted here - font
+# rasterization differs per OS; the sanity gate catches the
+# opened-but-rendered-nothing failure class.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/windows-tooling.yml'
+      - 'scripts/run-windows-tooling-tests.sh'
+      - 'scripts/windows/**'
+      - 'scripts/javase/lib/**'
+      - 'scripts/settings/**'
+      - 'Ports/JavaSE/**'
+      - '!Ports/JavaSE/**/*.md'
+      - 'maven/javase/**'
+      - 'maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/OpenSettingsMojo.java'
+      - 'maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/OpenCertificateWizardMojo.java'
+  push:
+    branches: [ master ]
+    paths:
+      - '.github/workflows/windows-tooling.yml'
+      - 'scripts/run-windows-tooling-tests.sh'
+      - 'scripts/windows/**'
+      - 'scripts/javase/lib/**'
+      - 'scripts/settings/**'
+      - 'Ports/JavaSE/**'
+      - '!Ports/JavaSE/**/*.md'
+      - 'maven/javase/**'
+      - 'maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/OpenSettingsMojo.java'
+      - 'maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/OpenCertificateWizardMojo.java'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  windows-tooling:
+    runs-on: windows-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v6
+
+      # JDK 17 first, JDK 8 last: each setup-java call prepends itself to
+      # PATH and exports JAVA_HOME_<ver>_X64; the build steps below pick the
+      # JDK explicitly via JAVA_HOME.
+      - name: Setup JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup JDK 8
+        uses: actions/setup-java@v5
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Cache simulator skins
+        uses: actions/cache@v5
+        with:
+          path: ${{ runner.temp }}/cn1-windows-skins
+          key: ${{ runner.os }}-cn1-skins-v1
+
+      - name: Build Codename One Maven artifacts (JDK 8)
+        shell: bash
+        env:
+          JAVA_HOME: ${{ env.JAVA_HOME_8_X64 }}
+        run: |
+          cd maven
+          mvn -B install -Plocal-dev-javase -DskipTests -Darchetype.test.skip=true -Dmaven.javadoc.skip=true
+
+      - name: Build standalone Settings tool (JDK 17)
+        shell: bash
+        env:
+          JAVA_HOME: ${{ env.JAVA_HOME_17_X64 }}
+        run: |
+          cd scripts/settings
+          mvn -B install -Pexecutable-jar -Dcodename1.platform=javase -Dmaven.test.skip=true
+
+      - name: Run Windows simulator and tooling screenshot tests
+        shell: bash
+        env:
+          JAVA_HOME: ${{ env.JAVA_HOME_17_X64 }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./scripts/run-windows-tooling-tests.sh
+
+      - name: Upload Windows tooling artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-tooling-tests
+          path: artifacts/windows-tooling-tests
+          if-no-files-found: warn
+          retention-days: 14

--- a/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
@@ -14663,30 +14663,45 @@ public class JavaSEPort extends CodenameOneImplementation {
             }
         } else {
             if(file.indexOf("%") > 0) {
-                // this is an encoded file URL convert it to a regular file
+                // likely an encoded file URL; decode it when it parses, but fall
+                // back to plain prefix stripping for paths that merely contain a
+                // literal % (or spaces/backslashes that java.net.URI rejects)
+                // instead of throwing and killing the caller
                 try {
-                    File f = new File(new URI(file));
-                    return f.getAbsolutePath();
+                    return new File(new URI(file)).getAbsolutePath();
                 } catch(Exception err) {
-                    Log.e(err);
-                    throw new RuntimeException(err);
+                    // not a parseable encoded URL - treat as a plain path below
                 }
             }
         }
-        
+
         if(file.startsWith("file://home")) {
             return System.getProperty("user.home").replace('\\', '/') + File.separator + appHomeDir + file.substring(11).replace('/', File.separatorChar);
         }
         if (file.startsWith("file:///")) {
-            return file.substring(7);
+            return stripWindowsDriveSlash(file.substring(7));
         }
         if (file.startsWith("file://")) {
-            return file.substring(6);
+            return stripWindowsDriveSlash(file.substring(6));
         }
         if (file.startsWith("file:/")) {
-            return file.substring(5);
+            return stripWindowsDriveSlash(file.substring(5));
         }
         return file;
+    }
+
+    /**
+     * A file URL for a Windows path (file:///C:/Users/...) strips to
+     * /C:/Users/...; java.io.File treats the leading slash as drive-relative,
+     * resolving to C:\C:\Users\... - drop it so drive-letter paths survive the
+     * URL round trip. No-op for Unix paths and everything else.
+     */
+    static String stripWindowsDriveSlash(String path) {
+        if (path.length() > 2 && path.charAt(0) == '/' && path.charAt(2) == ':'
+                && Character.isLetter(path.charAt(1))) {
+            return path.substring(1);
+        }
+        return path;
     }
 
     /**

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/OpenCertificateWizardMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/OpenCertificateWizardMojo.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.maven;
 
@@ -193,7 +211,6 @@ public class OpenCertificateWizardMojo extends AbstractCN1Mojo {
         pb.directory(projectDir);
         pb.redirectErrorStream(true);
         pb.redirectOutput(ProcessBuilder.Redirect.appendTo(log));
-        configureLauncherEnvironment(pb);
         try {
             pb.start();
             getLog().info("Certificate Wizard launched in the background. Log: " + log.getAbsolutePath());
@@ -210,14 +227,11 @@ public class OpenCertificateWizardMojo extends AbstractCN1Mojo {
     File namedJavaLauncher(File runtimeDir) {
         File java = new File(javaExecutable());
         if (isWindows()) {
-            File launcher = new File(runtimeDir, "CertificateWizard.exe");
-            try {
-                FileUtils.copyFile(java, launcher);
-                return launcher;
-            } catch (IOException ex) {
-                getLog().debug("Unable to create Certificate Wizard launcher executable: " + ex.getMessage());
-                return java;
-            }
+            // Never copy javaw.exe out of the JDK: a copied launcher loses the JDK's
+            // bin directory as its DLL search anchor, so dependent native libraries
+            // can bind to wrong DLLs from System32/PATH and break rendering
+            // (issue #5443). Launch the real javaw.exe instead.
+            return java;
         }
         File launcher = new File(runtimeDir, "Certificate Wizard");
         try {
@@ -228,16 +242,6 @@ public class OpenCertificateWizardMojo extends AbstractCN1Mojo {
             getLog().debug("Unable to create Certificate Wizard launcher symlink: " + ex.getMessage());
             return java;
         }
-    }
-
-    private void configureLauncherEnvironment(ProcessBuilder pb) {
-        if (!isWindows()) {
-            return;
-        }
-        String javaBin = new File(System.getProperty("java.home"), "bin").getAbsolutePath();
-        String path = pb.environment().get("PATH");
-        pb.environment().put("PATH", path == null || path.length() == 0
-                ? javaBin : javaBin + File.pathSeparator + path);
     }
 
     List<String> desktopIdentityArgs(File jar, File runtimeDir) {

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/OpenSettingsMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/OpenSettingsMojo.java
@@ -1,6 +1,24 @@
 /*
- * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.maven;
 
@@ -71,7 +89,29 @@ public class OpenSettingsMojo extends AbstractCN1Mojo {
         java.createClasspath().setPath(joinClasspath(toolClasspath.files));
         configureDesktopIdentity(java, toolClasspath.primaryJar, runtimeDir);
         java.createJvmarg().setValue("-Dsettings.input=" + inputFile.getAbsolutePath());
+        for (String arg : forwardedSettingsProperties()) {
+            java.createJvmarg().setValue(arg);
+        }
         java.executeJava();
+    }
+
+    /**
+     * Forwards {@code settings.*} system properties (screenshot capture, forced
+     * section/dark-mode, etc.) from the Maven invocation to the spawned Settings
+     * JVM so {@code mvn cn1:settings -Dsettings.screenshot=out.png} works. The
+     * {@code settings.input} binding and {@code settings.spawn} launch flag are
+     * owned by this mojo and never forwarded.
+     */
+    List<String> forwardedSettingsProperties() {
+        List<String> args = new ArrayList<String>();
+        for (String key : System.getProperties().stringPropertyNames()) {
+            if (key.startsWith("settings.")
+                    && !key.equals("settings.input")
+                    && !key.equals("settings.spawn")) {
+                args.add("-D" + key + "=" + System.getProperty(key));
+            }
+        }
+        return args;
     }
 
     @Override
@@ -109,6 +149,7 @@ public class OpenSettingsMojo extends AbstractCN1Mojo {
         command.add(namedJavaLauncher(runtimeDir).getAbsolutePath());
         command.addAll(desktopIdentityArgs(toolClasspath.primaryJar, runtimeDir));
         command.add("-Dsettings.input=" + inputFile.getAbsolutePath());
+        command.addAll(forwardedSettingsProperties());
         command.add("-cp");
         command.add(joinClasspath(toolClasspath.files));
         command.add("com.codename1.settings.CodenameOneSettingsLauncher");
@@ -116,7 +157,6 @@ public class OpenSettingsMojo extends AbstractCN1Mojo {
         pb.directory(projectDir);
         pb.redirectErrorStream(true);
         pb.redirectOutput(ProcessBuilder.Redirect.appendTo(log));
-        configureLauncherEnvironment(pb);
         try {
             pb.start();
             getLog().info("Codename One Settings launched in the background. Log: " + log.getAbsolutePath());
@@ -154,14 +194,12 @@ public class OpenSettingsMojo extends AbstractCN1Mojo {
     File namedJavaLauncher(File runtimeDir) {
         File java = new File(javaExecutable());
         if (isWindows()) {
-            File launcher = new File(runtimeDir, "CodenameOneSettings.exe");
-            try {
-                FileUtils.copyFile(java, launcher);
-                return launcher;
-            } catch (IOException ex) {
-                getLog().debug("Unable to create Settings launcher executable: " + ex.getMessage());
-                return java;
-            }
+            // Never copy javaw.exe out of the JDK: a copied launcher loses the JDK's
+            // bin directory as its DLL search anchor, so dependent native libraries
+            // (fontmanager/freetype and friends) can bind to wrong DLLs from
+            // System32/PATH and break rendering (issue #5443). The cosmetic Task
+            // Manager name is not worth a broken JVM - launch the real javaw.exe.
+            return java;
         }
         File launcher = new File(runtimeDir, "Codename One Settings");
         try {
@@ -189,16 +227,6 @@ public class OpenSettingsMojo extends AbstractCN1Mojo {
             getLog().debug("Unable to extract Settings dock icon: " + ex.getMessage());
             return null;
         }
-    }
-
-    private void configureLauncherEnvironment(ProcessBuilder pb) {
-        if (!isWindows()) {
-            return;
-        }
-        String javaBin = new File(System.getProperty("java.home"), "bin").getAbsolutePath();
-        String path = pb.environment().get("PATH");
-        pb.environment().put("PATH", path == null || path.length() == 0
-                ? javaBin : javaBin + File.pathSeparator + path);
     }
 
     void writeBinding(File inputFile, File projectDir) throws MojoExecutionException {

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/OpenCertificateWizardMojoTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/OpenCertificateWizardMojoTest.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.maven;
 
 import org.apache.maven.project.MavenProject;
@@ -95,12 +117,16 @@ public class OpenCertificateWizardMojoTest {
     }
 
     @Test
-    public void namedJavaLauncherUsesCertificateWizardProcessName() throws Exception {
+    public void namedJavaLauncherNeverCopiesTheWindowsJvmLauncher() throws Exception {
         File runtimeDir = tmp.newFolder("runtime");
         File launcher = new OpenCertificateWizardMojo().namedJavaLauncher(runtimeDir);
 
         if (OpenCertificateWizardMojo.isWindows()) {
-            assertEquals("CertificateWizard.exe", launcher.getName());
+            // A javaw.exe copied out of the JDK loses its DLL search anchor and
+            // breaks font/native rendering (issue #5443) - the real launcher
+            // must be used and nothing may be materialized in the runtime dir.
+            assertEquals("javaw.exe", launcher.getName());
+            assertFalse(new File(runtimeDir, "CertificateWizard.exe").exists());
         } else {
             assertEquals("Certificate Wizard", launcher.getName());
             assertTrue(Files.isSymbolicLink(launcher.toPath()) || launcher.exists());

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/OpenSettingsMojoTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/OpenSettingsMojoTest.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.maven;
 
 import org.apache.maven.project.MavenProject;
@@ -49,14 +71,41 @@ public class OpenSettingsMojoTest {
     }
 
     @Test
-    public void namedJavaLauncherUsesSettingsProcessName() throws Exception {
-        File launcher = new OpenSettingsMojo().namedJavaLauncher(tmp.newFolder("runtime"));
+    public void namedJavaLauncherNeverCopiesTheWindowsJvmLauncher() throws Exception {
+        File runtimeDir = tmp.newFolder("runtime");
+        File launcher = new OpenSettingsMojo().namedJavaLauncher(runtimeDir);
 
         if (OpenSettingsMojo.isWindows()) {
-            assertEquals("CodenameOneSettings.exe", launcher.getName());
+            // A javaw.exe copied out of the JDK loses its DLL search anchor and
+            // breaks font/native rendering (issue #5443) - the real launcher
+            // must be used and nothing may be materialized in the runtime dir.
+            assertEquals("javaw.exe", launcher.getName());
+            assertFalse(new File(runtimeDir, "CodenameOneSettings.exe").exists());
         } else {
             assertEquals("Codename One Settings", launcher.getName());
             assertTrue(Files.isSymbolicLink(launcher.toPath()) || launcher.exists());
+        }
+    }
+
+    @Test
+    public void forwardsSettingsSystemPropertiesButNotLaunchInternals() {
+        System.setProperty("settings.screenshot", "/tmp/out.png");
+        System.setProperty("settings.screenshot.delay", "5000");
+        System.setProperty("settings.input", "/tmp/should-not-forward.input");
+        System.setProperty("settings.spawn", "false");
+        try {
+            List<String> args = new OpenSettingsMojo().forwardedSettingsProperties();
+            assertTrue(args.contains("-Dsettings.screenshot=/tmp/out.png"));
+            assertTrue(args.contains("-Dsettings.screenshot.delay=5000"));
+            for (String arg : args) {
+                assertFalse(arg.startsWith("-Dsettings.input="));
+                assertFalse(arg.startsWith("-Dsettings.spawn="));
+            }
+        } finally {
+            System.clearProperty("settings.screenshot");
+            System.clearProperty("settings.screenshot.delay");
+            System.clearProperty("settings.input");
+            System.clearProperty("settings.spawn");
         }
     }
 

--- a/maven/javase/src/test/java/com/codename1/impl/javase/JavaSEPortFileUrlTest.java
+++ b/maven/javase/src/test/java/com/codename1/impl/javase/JavaSEPortFileUrlTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.impl.javase;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The Settings tool (and every desktop tool binding files through
+ * FileSystemStorage) round-trips native paths through file:// URLs. On Windows
+ * the stripped form used to keep a leading slash before the drive letter
+ * (/C:\Users\...), which java.io.File resolves drive-relative (C:\C:\...) so
+ * every read silently failed (#5443). These tests pin the tolerant decoding.
+ */
+public class JavaSEPortFileUrlTest {
+
+    private JavaSEPort originalInstance;
+    private boolean originalExposeFilesystem;
+    private JavaSEPort port;
+
+    @BeforeEach
+    public void captureInstance() {
+        // The port constructor overwrites the global JavaSEPort.instance which
+        // other test classes reach through; capture and restore it so this
+        // test can't cause order-dependent failures.
+        originalInstance = JavaSEPort.instance;
+        originalExposeFilesystem = JavaSEPort.isExposeFilesystem();
+        port = new JavaSEPort();
+        JavaSEPort.setExposeFilesystem(true);
+    }
+
+    @AfterEach
+    public void restoreInstance() {
+        JavaSEPort.instance = originalInstance;
+        JavaSEPort.setExposeFilesystem(originalExposeFilesystem);
+    }
+
+    @Test
+    public void stripsLeadingSlashFromWindowsDrivePaths() {
+        assertEquals("C:/Users/dev/app", JavaSEPort.stripWindowsDriveSlash("/C:/Users/dev/app"));
+        assertEquals("C:\\Users\\dev\\app", JavaSEPort.stripWindowsDriveSlash("/C:\\Users\\dev\\app"));
+        assertEquals("c:/temp", JavaSEPort.stripWindowsDriveSlash("/c:/temp"));
+    }
+
+    @Test
+    public void leavesUnixPathsUntouched() {
+        assertEquals("/Users/dev/app", JavaSEPort.stripWindowsDriveSlash("/Users/dev/app"));
+        assertEquals("/tmp", JavaSEPort.stripWindowsDriveSlash("/tmp"));
+        assertEquals("", JavaSEPort.stripWindowsDriveSlash(""));
+    }
+
+    @Test
+    public void unfileHandlesWindowsDriveLetterUrls() {
+        assertEquals("C:/Users/dev/app", port.unfile("file:///C:/Users/dev/app"));
+        assertEquals("C:\\Users\\dev\\app", port.unfile("file://C:\\Users\\dev\\app"));
+    }
+
+    @Test
+    public void unfileHandlesUnixUrls() {
+        assertEquals("/Users/dev/app", port.unfile("file:///Users/dev/app"));
+        assertEquals("/Users/dev/app", port.unfile("file:/Users/dev/app"));
+    }
+
+    @Test
+    public void unfileToleratesSpacesAndLiteralPercent() {
+        // Spaces are common in Windows user directories; a literal % (not an
+        // encoded escape) used to make the URI-decode branch throw a
+        // RuntimeException that killed the caller.
+        assertEquals("C:/Users/John Smith/My App",
+                port.unfile("file:///C:/Users/John Smith/My App"));
+        assertEquals("C:/Users/100% dev/app",
+                port.unfile("file:///C:/Users/100% dev/app"));
+    }
+
+    @Test
+    public void unfileStillDecodesProperlyEncodedUrls() {
+        // getAbsolutePath prepends the current drive on Windows, so only pin
+        // the decoded tail of the path.
+        String decoded = port.unfile("file:///tmp/some%20dir/file.txt");
+        assertTrue(decoded.replace('\\', '/').endsWith("/tmp/some dir/file.txt"),
+                "expected decoded path, got: " + decoded);
+    }
+}

--- a/scripts/run-windows-tooling-tests.sh
+++ b/scripts/run-windows-tooling-tests.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# Windows simulator + tooling screenshot smoke tests.
+#
+# Runs under Git Bash on a windows-latest GitHub runner (which has a real
+# desktop session, so no xvfb equivalent is needed). Prerequisites, provided
+# by .github/workflows/windows-tooling.yml:
+#   - the maven/ reactor installed to the local repo (JDK 8 build)
+#   - the scripts/settings tool installed to the local repo (JDK 17 build)
+#   - JAVA_HOME pointing at JDK 17 for the runtime below
+#
+# Coverage:
+#   1. cn1:settings end-to-end through the REAL mojo launch path (javaw.exe
+#      launcher, binding file, file:// URL round trip) against a project in a
+#      directory WITH SPACES, asserting the captured window isn't the black
+#      screen from issue #5443.
+#   2. The JavaSE simulator (single + multi window) via the shared
+#      SimulatorWindowModeVerifier harness, which self-validates content.
+set -euo pipefail
+
+wt_log() { echo "[run-windows-tooling-tests] $1"; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+if ! command -v cygpath >/dev/null 2>&1; then
+  wt_log "cygpath not found - this script must run under Git Bash on Windows" >&2
+  exit 2
+fi
+
+winpath() { cygpath -w "$1"; }
+
+JAVA_BIN="${JAVA_HOME:?JAVA_HOME (JDK 17+) must be set}/bin/java"
+JAVAC_BIN="$JAVA_HOME/bin/javac"
+
+CN1_VERSION=$(awk -F'[<>]' '/<version>/{print $3; exit}' maven/pom.xml)
+wt_log "Codename One version: $CN1_VERSION"
+
+ARTIFACTS_BASE="${ARTIFACTS_DIR:-${GITHUB_WORKSPACE:-$REPO_ROOT}/artifacts}"
+ARTIFACTS_DIR="$ARTIFACTS_BASE/windows-tooling-tests"
+mkdir -p "$ARTIFACTS_DIR"
+ARTIFACTS_W="$(winpath "$ARTIFACTS_DIR")"
+
+SANITY_SRC_W="$(winpath "$SCRIPT_DIR/windows/ScreenshotSanity.java")"
+
+# ---------------------------------------------------------------------------
+# 1. Settings tool (Control Center) through the real cn1:settings mojo.
+#    The directory deliberately contains spaces on both levels: Windows user
+#    dirs commonly do, and the file://-URL round trip must survive them.
+# ---------------------------------------------------------------------------
+WORK_DIR="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/cn1 tooling tests/Demo App"
+rm -rf "$WORK_DIR"
+mkdir -p "$WORK_DIR"
+
+cat > "$WORK_DIR/codenameone_settings.properties" <<'EOF'
+codename1.displayName=WindowsToolingDemo
+codename1.packageName=com.codename1.demos.windows
+codename1.mainName=WindowsToolingDemo
+codename1.version=1.0
+codename1.vendor=Codename One
+codename1.icon=icon.png
+EOF
+
+cat > "$WORK_DIR/pom.xml" <<EOF
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.codename1.demos</groupId>
+  <artifactId>windows-tooling-demo</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+</project>
+EOF
+
+SETTINGS_PNG="$ARTIFACTS_DIR/settings.png"
+wt_log "Launching cn1:settings against '$WORK_DIR' (screenshot mode)"
+mvn -B -f "$(winpath "$WORK_DIR/pom.xml")" \
+  "com.codenameone:codenameone-maven-plugin:$CN1_VERSION:settings" \
+  -Dsettings.spawn=false \
+  "-Dsettings.screenshot=$(winpath "$SETTINGS_PNG")" \
+  -Dsettings.screenshot.delay=8000
+
+wt_log "Validating settings screenshot"
+"$JAVA_BIN" "$SANITY_SRC_W" "$(winpath "$SETTINGS_PNG")" 800 400
+
+# The settings log is the primary diagnostic for launch failures - keep it
+# with the artifacts either way.
+if [ -f "$HOME/.codenameoneSettings/settings.log" ]; then
+  cp "$HOME/.codenameoneSettings/settings.log" "$ARTIFACTS_DIR/settings.log" || true
+fi
+
+# ---------------------------------------------------------------------------
+# 2. JavaSE simulator smoke via the shared verifier harness.
+# ---------------------------------------------------------------------------
+BUILD_DIR="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/cn1-windows-sim"
+mkdir -p "$BUILD_DIR"
+
+wt_log "Resolving simulator classpath from maven artifacts"
+cat > "$BUILD_DIR/cp-pom.xml" <<EOF
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.codename1.demos</groupId>
+  <artifactId>windows-sim-classpath</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>com.codenameone</groupId>
+      <artifactId>codenameone-core</artifactId>
+      <version>$CN1_VERSION</version>
+    </dependency>
+    <dependency>
+      <groupId>com.codenameone</groupId>
+      <artifactId>codenameone-javase</artifactId>
+      <version>$CN1_VERSION</version>
+    </dependency>
+  </dependencies>
+</project>
+EOF
+mvn -B -q -f "$(winpath "$BUILD_DIR/cp-pom.xml")" dependency:build-classpath \
+  "-Dmdep.outputFile=$(winpath "$BUILD_DIR/cp.txt")"
+SIM_CP="$(cat "$BUILD_DIR/cp.txt")"
+
+CLASS_DIR="$BUILD_DIR/classes"
+mkdir -p "$CLASS_DIR"
+wt_log "Compiling simulator verifier harness"
+"$JAVAC_BIN" -cp "$SIM_CP" -d "$(winpath "$CLASS_DIR")" \
+  "$(winpath "$SCRIPT_DIR/javase/lib/SimulatorModeTestApp.java")" \
+  "$(winpath "$SCRIPT_DIR/javase/lib/SimulatorWindowModeVerifier.java")"
+
+SKIN_CACHE_DIR="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/cn1-windows-skins"
+mkdir -p "$SKIN_CACHE_DIR"
+SKIN_ARCHIVE="$SKIN_CACHE_DIR/skins.tar.gz"
+SKIN_EXTRACT_DIR="$SKIN_CACHE_DIR/extracted"
+if [ ! -s "$SKIN_ARCHIVE" ]; then
+  wt_log "Resolving simulator skin from codenameone-skins release"
+  AUTH_ARGS=()
+  if [ -n "${GITHUB_TOKEN:-${GH_TOKEN:-}}" ]; then
+    AUTH_ARGS=(-H "Authorization: Bearer ${GITHUB_TOKEN:-${GH_TOKEN:-}}")
+  fi
+  SKIN_URL="$(curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors "${AUTH_ARGS[@]}" \
+    -H 'Accept: application/vnd.github+json' \
+    https://api.github.com/repos/codenameone/codenameone-skins/releases/latest \
+    | jq -r '.assets[0].browser_download_url')"
+  if [ -z "$SKIN_URL" ] || [ "$SKIN_URL" = "null" ]; then
+    wt_log "Failed to resolve codenameone-skins release asset URL" >&2
+    exit 2
+  fi
+  curl -fL --retry 5 --retry-delay 5 --retry-all-errors -o "$SKIN_ARCHIVE" "$SKIN_URL"
+fi
+if [ ! -d "$SKIN_EXTRACT_DIR" ]; then
+  mkdir -p "$SKIN_EXTRACT_DIR"
+  tar -xzf "$SKIN_ARCHIVE" -C "$SKIN_EXTRACT_DIR"
+fi
+SIM_SKIN_PATH="$(find "$SKIN_EXTRACT_DIR" -type f -name 'Nexus5X.skin' | head -n 1 || true)"
+if [ -z "$SIM_SKIN_PATH" ]; then
+  SIM_SKIN_PATH="$(find "$SKIN_EXTRACT_DIR" -type f -name '*.skin' | head -n 1 || true)"
+fi
+if [ -z "$SIM_SKIN_PATH" ]; then
+  wt_log "Unable to locate a simulator skin file" >&2
+  exit 2
+fi
+wt_log "Using simulator skin: $SIM_SKIN_PATH"
+
+FULL_SIM_CP="$SIM_CP;$(winpath "$CLASS_DIR")"
+for mode in single multi; do
+  png="$ARTIFACTS_DIR/simulator-$mode-window.png"
+  wt_log "Running simulator verification for mode=$mode"
+  "$JAVA_BIN" -Djava.awt.headless=false \
+    -cp "$FULL_SIM_CP" \
+    com.codenameone.examples.javase.tests.SimulatorWindowModeVerifier \
+    --mode "$mode" \
+    --scenario default \
+    --sim-classpath "$FULL_SIM_CP" \
+    --skin "$(winpath "$SIM_SKIN_PATH")" \
+    --screenshot "$(winpath "$png")"
+  wt_log "Validating simulator screenshot for mode=$mode"
+  "$JAVA_BIN" "$SANITY_SRC_W" "$(winpath "$png")" 800 600
+done
+
+wt_log "All Windows tooling and simulator smoke tests passed"

--- a/scripts/run-windows-tooling-tests.sh
+++ b/scripts/run-windows-tooling-tests.sh
@@ -30,13 +30,18 @@ fi
 
 winpath() { cygpath -w "$1"; }
 
+# Keep every path the shell tools touch in POSIX form: GNU tar (and friends)
+# treat the colon in D:\a\_temp as a remote-host separator. Windows form is
+# produced via winpath only at java/maven argument boundaries.
+TEMP_BASE="$(cygpath -u "${RUNNER_TEMP:-${TMPDIR:-/tmp}}")"
+
 JAVA_BIN="${JAVA_HOME:?JAVA_HOME (JDK 17+) must be set}/bin/java"
 JAVAC_BIN="$JAVA_HOME/bin/javac"
 
 CN1_VERSION=$(awk -F'[<>]' '/<version>/{print $3; exit}' maven/pom.xml)
 wt_log "Codename One version: $CN1_VERSION"
 
-ARTIFACTS_BASE="${ARTIFACTS_DIR:-${GITHUB_WORKSPACE:-$REPO_ROOT}/artifacts}"
+ARTIFACTS_BASE="$(cygpath -u "${ARTIFACTS_DIR:-${GITHUB_WORKSPACE:-$REPO_ROOT}/artifacts}")"
 ARTIFACTS_DIR="$ARTIFACTS_BASE/windows-tooling-tests"
 mkdir -p "$ARTIFACTS_DIR"
 ARTIFACTS_W="$(winpath "$ARTIFACTS_DIR")"
@@ -48,7 +53,7 @@ SANITY_SRC_W="$(winpath "$SCRIPT_DIR/windows/ScreenshotSanity.java")"
 #    The directory deliberately contains spaces on both levels: Windows user
 #    dirs commonly do, and the file://-URL round trip must survive them.
 # ---------------------------------------------------------------------------
-WORK_DIR="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/cn1 tooling tests/Demo App"
+WORK_DIR="$TEMP_BASE/cn1 tooling tests/Demo App"
 rm -rf "$WORK_DIR"
 mkdir -p "$WORK_DIR"
 
@@ -91,7 +96,7 @@ fi
 # ---------------------------------------------------------------------------
 # 2. JavaSE simulator smoke via the shared verifier harness.
 # ---------------------------------------------------------------------------
-BUILD_DIR="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/cn1-windows-sim"
+BUILD_DIR="$TEMP_BASE/cn1-windows-sim"
 mkdir -p "$BUILD_DIR"
 
 wt_log "Resolving simulator classpath from maven artifacts"
@@ -127,7 +132,7 @@ wt_log "Compiling simulator verifier harness"
   "$(winpath "$SCRIPT_DIR/javase/lib/SimulatorModeTestApp.java")" \
   "$(winpath "$SCRIPT_DIR/javase/lib/SimulatorWindowModeVerifier.java")"
 
-SKIN_CACHE_DIR="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/cn1-windows-skins"
+SKIN_CACHE_DIR="$TEMP_BASE/cn1-windows-skins"
 mkdir -p "$SKIN_CACHE_DIR"
 SKIN_ARCHIVE="$SKIN_CACHE_DIR/skins.tar.gz"
 SKIN_EXTRACT_DIR="$SKIN_CACHE_DIR/extracted"

--- a/scripts/settings/common/src/main/java/com/codename1/settings/project/ProjectIO.java
+++ b/scripts/settings/common/src/main/java/com/codename1/settings/project/ProjectIO.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.settings.project;
 
 import com.codename1.io.FileSystemStorage;
@@ -41,6 +63,14 @@ public final class ProjectIO {
         if (path.startsWith("file://") || path.indexOf("://") > 0) {
             return path;
         }
-        return "file://" + path;
+        String normalized = path.replace('\\', '/');
+        if (normalized.length() > 1 && normalized.charAt(1) == ':') {
+            // Windows drive-letter path (C:\Users\...): a file URL needs a slash
+            // before the drive letter, otherwise stripping the file:// prefix
+            // yields a drive-relative path like /C:\... that resolves to
+            // C:\C:\... and silently breaks every project-file read.
+            return "file:///" + normalized;
+        }
+        return "file://" + normalized;
     }
 }

--- a/scripts/settings/common/src/test/java/com/codename1/settings/ProjectIOTest.java
+++ b/scripts/settings/common/src/test/java/com/codename1/settings/ProjectIOTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.settings;
+
+import com.codename1.settings.project.ProjectBinding;
+import com.codename1.settings.project.ProjectIO;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class ProjectIOTest {
+    @Test
+    public void unixPathsGetTheStandardFileUrlPrefix() {
+        assertEquals("file:///Users/dev/app", ProjectIO.fsUrl("/Users/dev/app"));
+    }
+
+    @Test
+    public void windowsDriveLetterPathsGetASlashBeforeTheDrive() {
+        // Without the extra slash, stripping file:// on the consumer side
+        // yields /C:\... which java.io.File resolves drive-relative
+        // (C:\C:\...) and every project-file read silently fails (#5443).
+        assertEquals("file:///C:/Users/dev/app", ProjectIO.fsUrl("C:\\Users\\dev\\app"));
+        assertEquals("file:///C:/Users/dev/app", ProjectIO.fsUrl("C:/Users/dev/app"));
+    }
+
+    @Test
+    public void windowsPathsWithSpacesSurviveTheUrlRoundTrip() {
+        assertEquals("file:///C:/Users/John Smith/My App",
+                ProjectIO.fsUrl("C:\\Users\\John Smith\\My App"));
+    }
+
+    @Test
+    public void existingUrlsPassThroughUntouched() {
+        assertEquals("file:///C:/Users/dev/app", ProjectIO.fsUrl("file:///C:/Users/dev/app"));
+        assertEquals("jar://something", ProjectIO.fsUrl("jar://something"));
+        assertNull(ProjectIO.fsUrl(null));
+    }
+
+    @Test
+    public void bindingParserKeepsWindowsBackslashesVerbatim() {
+        ProjectBinding b = ProjectBinding.parse(
+                "projectDir=C:\\Users\\John Smith\\My App\n"
+                + "settings=C:\\Users\\John Smith\\My App\\codenameone_settings.properties\n");
+        assertEquals("C:\\Users\\John Smith\\My App", b.projectDir());
+        assertEquals("C:\\Users\\John Smith\\My App\\codenameone_settings.properties", b.settings());
+    }
+}

--- a/scripts/settings/javase/src/desktop/java/com/codename1/settings/CodenameOneSettingsStub.java
+++ b/scripts/settings/javase/src/desktop/java/com/codename1/settings/CodenameOneSettingsStub.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.settings;
 
 import com.codename1.impl.javase.JavaSEPort;
@@ -167,7 +189,10 @@ public class CodenameOneSettingsStub implements Runnable, WindowListener {
         if (screenshot == null || screenshot.length() == 0) {
             return;
         }
-        Timer timer = new Timer(1200, e -> {
+        // CI runners paint the first frame much slower than dev machines;
+        // settings.screenshot.delay lets automation wait for a settled UI.
+        int delay = Integer.getInteger("settings.screenshot.delay", 1200);
+        Timer timer = new Timer(delay, e -> {
             try {
                 BufferedImage image = new BufferedImage(frm.getContentPane().getWidth(),
                         frm.getContentPane().getHeight(), BufferedImage.TYPE_INT_ARGB);

--- a/scripts/windows/ScreenshotSanity.java
+++ b/scripts/windows/ScreenshotSanity.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.imageio.ImageIO;
+
+/**
+ * Basic screenshot sanity gate for the Windows tooling CI job. Pixel-exact
+ * golden comparison is deliberately out of scope (font rasterization differs
+ * per OS); this catches the failure class from issue #5443 instead: a window
+ * that opened but rendered (near-)nothing - a black/blank canvas, a
+ * single-color frame, or a truncated capture.
+ *
+ * Usage: java ScreenshotSanity.java &lt;file.png&gt; [minWidth] [minHeight]
+ * Exits non-zero with a diagnostic when the capture fails a check.
+ */
+public class ScreenshotSanity {
+    public static void main(String[] args) throws Exception {
+        if (args.length < 1) {
+            fail("usage: ScreenshotSanity <file.png> [minWidth] [minHeight]");
+        }
+        File file = new File(args[0]);
+        int minWidth = args.length > 1 ? Integer.parseInt(args[1]) : 400;
+        int minHeight = args.length > 2 ? Integer.parseInt(args[2]) : 300;
+
+        if (!file.isFile() || file.length() == 0) {
+            fail("screenshot was not produced: " + file);
+        }
+        BufferedImage image = ImageIO.read(file);
+        if (image == null) {
+            fail("file is not a decodable image: " + file);
+        }
+        if (image.getWidth() < minWidth || image.getHeight() < minHeight) {
+            fail("screenshot is unexpectedly small: " + image.getWidth() + "x" + image.getHeight()
+                    + " (expected at least " + minWidth + "x" + minHeight + "): " + file);
+        }
+
+        Map<Integer, Integer> histogram = new HashMap<Integer, Integer>();
+        int sampled = 0;
+        int stepX = Math.max(1, image.getWidth() / 64);
+        int stepY = Math.max(1, image.getHeight() / 64);
+        for (int y = 0; y < image.getHeight(); y += stepY) {
+            for (int x = 0; x < image.getWidth(); x += stepX) {
+                int rgb = image.getRGB(x, y) & 0xffffff;
+                Integer count = histogram.get(rgb);
+                histogram.put(rgb, count == null ? 1 : count + 1);
+                sampled++;
+            }
+        }
+        int dominant = 0;
+        for (Integer count : histogram.values()) {
+            dominant = Math.max(dominant, count);
+        }
+        if (histogram.size() < 16) {
+            fail("screenshot appears blank/flat: only " + histogram.size()
+                    + " distinct colors sampled in " + file);
+        }
+        if (dominant > sampled * 97 / 100) {
+            fail("screenshot is " + (dominant * 100 / sampled)
+                    + "% a single color - window likely rendered nothing: " + file);
+        }
+        System.out.println("[screenshot-sanity] OK " + file + " " + image.getWidth() + "x"
+                + image.getHeight() + " colors=" + histogram.size()
+                + " dominant=" + (dominant * 100 / sampled) + "%");
+    }
+
+    private static void fail(String message) {
+        System.err.println("[screenshot-sanity] FAIL " + message);
+        System.exit(1);
+    }
+}


### PR DESCRIPTION
Fixes the #5443 failure class: the Control Center opened on Windows 11 as a black window while working fine on macOS.

## Root causes fixed

**Copied `javaw.exe` launcher.** `cn1:settings` / `cn1:certificatewizard` copied `javaw.exe` out of the JDK into the runtime dir (for a cosmetic Task Manager process name) and prepended the JDK bin to `PATH` so the stray copy could find `jvm.dll`. A copied JVM launcher loses the JDK `bin` directory as its DLL search anchor — Windows searches System32 *before* `PATH` for dependent DLLs such as freetype/fontmanager — which breaks font/native rendering while the window itself still opens. Both mojos now launch the real `javaw.exe` (macOS keeps its safe symlink); the `PATH` hack is deleted.

**Broken Windows file-URL round trip.** `ProjectIO.fsUrl` prefixed `file://` onto `C:\Users\...` paths and `JavaSEPort.unfile` stripped that back to `/C:\Users\...`, which `java.io.File` resolves drive-relative (`C:\C:\...`) — every project-file read silently failed. `fsUrl` now emits `file:///C:/...` for drive-letter paths, `unfile` strips the stray leading slash before a drive letter, and `unfile` no longer throws on paths containing spaces or a literal `%` (it falls back to plain prefix stripping instead of a `RuntimeException`).

**Screenshot automation plumbing.** The settings mojo now forwards `settings.*` system properties (except `settings.input`/`settings.spawn`) to the spawned tool, and the stub honors `settings.screenshot.delay`, so `mvn cn1:settings -Dsettings.spawn=false -Dsettings.screenshot=out.png` works for CI and for reproducing user reports.

## New Windows CI

Windows was the only desktop platform with zero simulator/tooling coverage — exactly where this regression shipped. The new `windows-tooling` workflow runs on a real Windows desktop runner (no xvfb equivalent needed) and gates on screenshot **sanity** (blank/flat/single-color detection via the new `scripts/windows/ScreenshotSanity.java`) rather than pixel goldens, since font rasterization differs per OS:

1. `cn1:settings` end-to-end through the **real mojo launch path** (javaw launcher, binding file, file-URL round trip) against a project in a directory **containing spaces on two levels**.
2. The JavaSE simulator in single- and multi-window modes via the shared `SimulatorWindowModeVerifier` harness, which self-validates rendered content.

## Testing

- Plugin suite 269/269, new `JavaSEPortFileUrlTest` 6/6, settings reactor 30/30, copyright headers pass.
- End-to-end on macOS: real mojo → spaced project dir → settings UI screenshot showing the bound project; sanity gate passes (90 colors, dominant 52%); a #5443-style black window fails it.
- The workflow's first actual Windows run happens on this PR; it is also `workflow_dispatch`-able.

Note: the reporter on 7.0.260 stays broken until the next 7.0.x release ships the plugin + settings tool with these fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)