### PR TITLE
Fix GC storm on retained large-array loads (issue 5425, final Dtest shape)

### DIFF
--- a/.github/workflows/linux-build-run.yml
+++ b/.github/workflows/linux-build-run.yml
@@ -452,7 +452,7 @@ jobs:
               # they live in the app log, not the job log.
               if [ -f "$raw/app-output.log" ]; then
                 echo "[linux-gtk-$arch] ---- CN1SS diagnostics from app-output.log ----"
-                grep -n "CN1SS:WARN\|CN1SS:ERR\|CN1SS:INFO:test=ToastBar\|timed out\|TIMEOUT\|watchdog" "$raw/app-output.log" | tail -80 || true
+                grep -nE "CN1SS:WARN|CN1SS:ERR|CN1SS:INFO:test=ToastBar|timed out|TIMEOUT|watchdog" "$raw/app-output.log" | tail -80 || true
                 echo "[linux-gtk-$arch] ---- last 40 app log lines ----"
                 tail -40 "$raw/app-output.log" || true
               fi

--- a/.github/workflows/linux-build-run.yml
+++ b/.github/workflows/linux-build-run.yml
@@ -446,6 +446,16 @@ jobs:
             set -e
             if [ "$gate_rc" -ne 0 ]; then
               echo "[linux-gtk-$arch] FATAL: screenshot gate failed (rc=$gate_rc)"; fail=1
+              # Surface the app's own per-test diagnostics for the failure triage:
+              # a missing screenshot means a test never emitted -- its CN1SS:WARN/ERR
+              # lines (and any test the runner aborted) are the only evidence, and
+              # they live in the app log, not the job log.
+              if [ -f "$raw/app-output.log" ]; then
+                echo "[linux-gtk-$arch] ---- CN1SS diagnostics from app-output.log ----"
+                grep -n "CN1SS:WARN\|CN1SS:ERR\|CN1SS:INFO:test=ToastBar\|timed out\|TIMEOUT\|watchdog" "$raw/app-output.log" | tail -80 || true
+                echo "[linux-gtk-$arch] ---- last 40 app log lines ----"
+                tail -40 "$raw/app-output.log" || true
+              fi
             fi
             # A streamed screenshot with no committed golden keeps the baselines out
             # of sync; the central gate treats it as "extra" and ignores it, so fail here.

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/ToastBarTopPositionScreenshotTest.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/ToastBarTopPositionScreenshotTest.java
@@ -133,7 +133,7 @@ public class ToastBarTopPositionScreenshotTest extends BaseTest {
         // times this test out with the screenshot never emitted; these probes
         // (1/s + every state reset) show which wait the choreography dies in.
         // CN1SS:WARN prefix so the Linux gate's failure dump surfaces them.
-        if ((waitedMs % 1000) == 0) {
+        if (waitedMs > 0 && (waitedMs % 1000) == 0) {
             System.out.println("CN1SS:WARN:test=ToastBarTopPosition probe phase=await-shown"
                     + " waitedMs=" + waitedMs + " shown=" + shown
                     + " tbc=" + (tbc == null ? "null" : "present")
@@ -194,7 +194,7 @@ public class ToastBarTopPositionScreenshotTest extends BaseTest {
                 return;
             }
             boolean rendered = containsRenderedToastBar(screen);
-            if ((waitedMs % 1000) == 0) {
+            if (waitedMs > 0 && (waitedMs % 1000) == 0) {
                 System.out.println("CN1SS:WARN:test=ToastBarTopPosition probe phase=await-render"
                         + " waitedMs=" + waitedMs + " rendered=" + rendered
                         + " imgW=" + screen.getWidth() + " imgH=" + screen.getHeight());

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/ToastBarTopPositionScreenshotTest.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/ToastBarTopPositionScreenshotTest.java
@@ -107,6 +107,18 @@ public class ToastBarTopPositionScreenshotTest extends BaseTest {
         Form f = Display.getInstance().getCurrent();
         Object tbc = (f != null) ? f.getClientProperty("ToastBarComponent") : null;
         boolean shown = isToastComponentShown(tbc);
+        // Diagnostic trace for the Linux GTK CI miss (issue 5425 PR): the suite
+        // times this test out with the screenshot never emitted; these probes
+        // (1/s + every state reset) show which wait the choreography dies in.
+        // CN1SS:WARN prefix so the Linux gate's failure dump surfaces them.
+        if ((waitedMs % 1000) == 0) {
+            System.out.println("CN1SS:WARN:test=ToastBarTopPosition probe phase=await-shown"
+                    + " waitedMs=" + waitedMs + " shown=" + shown
+                    + " tbc=" + (tbc == null ? "null" : "present")
+                    + " y=" + (tbc instanceof Component ? ((Component) tbc).getY() : -1)
+                    + " h=" + (tbc instanceof Component ? ((Component) tbc).getHeight() : -1)
+                    + " stable=" + stableGeometryPolls);
+        }
         if (shown) {
             Component c = (Component) tbc;
             if (c.getY() == lastToastY && c.getHeight() == lastToastH) {
@@ -127,6 +139,8 @@ public class ToastBarTopPositionScreenshotTest extends BaseTest {
         }
         if (!shown && waitedMs > 0 && (waitedMs % 3000) == 0) {
             // the show did not take (toast left at height 0) -> re-issue it
+            System.out.println("CN1SS:WARN:test=ToastBarTopPosition probe phase=await-shown RESET"
+                    + " waitedMs=" + waitedMs + " (re-issuing showToast)");
             showToast();
         }
         UITimer.timer(250, false, parent, () -> awaitToastShown(parent, waitedMs + 250));
@@ -158,6 +172,11 @@ public class ToastBarTopPositionScreenshotTest extends BaseTest {
                 return;
             }
             boolean rendered = containsRenderedToastBar(screen);
+            if ((waitedMs % 1000) == 0) {
+                System.out.println("CN1SS:WARN:test=ToastBarTopPosition probe phase=await-render"
+                        + " waitedMs=" + waitedMs + " rendered=" + rendered
+                        + " imgW=" + screen.getWidth() + " imgH=" + screen.getHeight());
+            }
             if (rendered || waitedMs >= 12000) {
                 if (!rendered) {
                     System.out.println("CN1SS:WARN:test=ToastBarTopPosition rendered toast not detected at capture bound");
@@ -167,6 +186,8 @@ public class ToastBarTopPositionScreenshotTest extends BaseTest {
             }
             screen.dispose();
             if (waitedMs > 0 && (waitedMs % 3000) == 0 && !isToastComponentShown(tbc)) {
+                System.out.println("CN1SS:WARN:test=ToastBarTopPosition probe phase=await-render RESET"
+                        + " waitedMs=" + waitedMs + " (toast vanished; re-showing + restarting waits)");
                 showToast();
                 awaitToastShown(parent, 0);
                 return;

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/ToastBarTopPositionScreenshotTest.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/ToastBarTopPositionScreenshotTest.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codenameone.examples.hellocodenameone.tests;
 
 import com.codename1.components.ToastBar;

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -1010,14 +1010,19 @@ void codenameOneGCMark() {
     // per collection cycle. Costs one cached getenv when disabled. Used by
     // LargeArrayGcIntegrationTest to assert the issue-5425 fix deterministically
     // (cycle COUNT is load-independent, unlike wall-clock phase timings) and
-    // generally useful for diagnosing trigger storms on device. DELIBERATELY
-    // outside the CN1_DISABLE_BIBOP guard: -DCN1_DISABLE_BIBOP A/B builds need
-    // the same observable so cycle counts can be compared across both collector
-    // shapes; with the env var unset this is behavior-identical either way.
+    // generally useful for diagnosing trigger storms on device.
     {
-        static int cn1LogCycles = -1;
-        if(cn1LogCycles < 0) cn1LogCycles = getenv("CN1_GC_LOG_CYCLES") ? 1 : 0;
-        if(cn1LogCycles) {
+        // -1 = uninitialized. Lazy init is race-free in practice (collection
+        // cycles run on the GC thread only), but keep the gate atomic so the
+        // idempotent getenv probe is well-defined C even if a future caller
+        // runs a cycle from another thread.
+        static _Atomic int cn1LogCycles = -1;
+        int logCycles = atomic_load_explicit(&cn1LogCycles, memory_order_relaxed);
+        if(logCycles < 0) {
+            logCycles = getenv("CN1_GC_LOG_CYCLES") ? 1 : 0;
+            atomic_store_explicit(&cn1LogCycles, logCycles, memory_order_relaxed);
+        }
+        if(logCycles) {
             fprintf(stderr, "[GC-CYCLE] %d\n", currentGcMarkValue);
         }
     }
@@ -1813,7 +1818,7 @@ long long cn1_instr_allocCount = 0;
 #ifndef CN1_LEGACY_GC_TRIGGER_BYTES
 #define CN1_LEGACY_GC_TRIGGER_BYTES (24*1024*1024)
 #endif
-static _Atomic long cn1LegacyBytesSinceGc = 0;
+_Atomic long cn1LegacyBytesSinceGc = 0;
 #endif
 
 JAVA_BOOLEAN java_lang_System_isHighFrequencyGC___R_boolean(CODENAME_ONE_THREAD_STATE) {
@@ -2067,10 +2072,7 @@ void cn1BibopBeginGcCycle(void) {
                                                          memory_order_acq_rel);
     // Same charge-to-next-cycle rule for the legacy byte counter (large arrays
     // and anything above CN1_BIBOP_MAX_OBJECT): see cn1LegacyBytesSinceGc.
-    // Same atomic-exchange idiom as the BiBOP reset above: a racing
-    // fetch_add lands either before the swap (covered by the cycle that is
-    // starting) or after it (charged to the next cycle) -- never dropped.
-    (void)atomic_exchange_explicit(&cn1LegacyBytesSinceGc, 0, memory_order_acq_rel);
+    atomic_store_explicit(&cn1LegacyBytesSinceGc, 0, memory_order_relaxed);
 #ifdef CN1_GRACE_AUDIT
     // QA builds only: snapshot every page's cursor at mark start. Slots below the
     // snapshot existed before the grace pass ran, so a complete grace pass must
@@ -3945,30 +3947,10 @@ JAVA_OBJECT codenameOneGcMalloc(CODENAME_ONE_THREAD_STATE, int size, struct claz
     // asynchronous (sets forceGc + notifies the GC thread) exactly as in the
     // BiBOP path. nativeAllocationMode save/restore matches cn1BibopMaybeGc:
     // we may already be inside a caller's native-allocation bracket.
-    // EDGE-triggered on the threshold crossing: level-triggering here would
-    // call System.gc() (a lock+notify) on EVERY legacy allocation between the
-    // crossing and the cycle start that resets the counter -- avoidable
-    // overhead that is itself a mini-storm on large-array churn. At most one
-    // schedule per cycle window; a crossing that lands while a cycle is
-    // already running just sets forceGc for the GC thread's next loop pass
-    // (which is why there is deliberately no !gcCurrentlyRunning suppression:
-    // suppressing would LOSE the edge and delay collection up to the 30s
-    // idle wait).
-    long __prevLegacyBytes = atomic_fetch_add_explicit(&cn1LegacyBytesSinceGc, (long)size,
-                                                       memory_order_relaxed);
-    if(__prevLegacyBytes <= CN1_LEGACY_GC_TRIGGER_BYTES
-       && __prevLegacyBytes + (long)size > CN1_LEGACY_GC_TRIGGER_BYTES
-       && constantPoolObjects != 0
-#ifndef CN1_CONSERVATIVE_GC_ROOTS
-       // Mirror cn1BibopMaybeGc's gate exactly: without conservative roots a
-       // thread inside a native-allocation bracket must not trigger a cycle
-       // (its half-built objects aren't rooted). Under conservative roots the
-       // native C locals ARE scanned, and gating unconditionally would starve
-       // the trigger on workloads whose large allocations all happen inside
-       // natives (the same starvation the BiBOP comment documents).
-       && !threadStateData->nativeAllocationMode
-#endif
-       ) {
+    long __legacyBytes = atomic_fetch_add_explicit(&cn1LegacyBytesSinceGc, (long)size,
+                                                   memory_order_relaxed) + (long)size;
+    if(__legacyBytes > CN1_LEGACY_GC_TRIGGER_BYTES && !gcCurrentlyRunning
+       && constantPoolObjects != 0) {
         JAVA_BOOLEAN wasNam = threadStateData->nativeAllocationMode;
         threadStateData->nativeAllocationMode = JAVA_TRUE;
         java_lang_System_gc__(threadStateData);

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -3945,9 +3945,19 @@ JAVA_OBJECT codenameOneGcMalloc(CODENAME_ONE_THREAD_STATE, int size, struct claz
     // asynchronous (sets forceGc + notifies the GC thread) exactly as in the
     // BiBOP path. nativeAllocationMode save/restore matches cn1BibopMaybeGc:
     // we may already be inside a caller's native-allocation bracket.
-    long __legacyBytes = atomic_fetch_add_explicit(&cn1LegacyBytesSinceGc, (long)size,
-                                                   memory_order_relaxed) + (long)size;
-    if(__legacyBytes > CN1_LEGACY_GC_TRIGGER_BYTES && !gcCurrentlyRunning
+    // EDGE-triggered on the threshold crossing: level-triggering here would
+    // call System.gc() (a lock+notify) on EVERY legacy allocation between the
+    // crossing and the cycle start that resets the counter -- avoidable
+    // overhead that is itself a mini-storm on large-array churn. At most one
+    // schedule per cycle window; a crossing that lands while a cycle is
+    // already running just sets forceGc for the GC thread's next loop pass
+    // (which is why there is deliberately no !gcCurrentlyRunning suppression:
+    // suppressing would LOSE the edge and delay collection up to the 30s
+    // idle wait).
+    long __prevLegacyBytes = atomic_fetch_add_explicit(&cn1LegacyBytesSinceGc, (long)size,
+                                                       memory_order_relaxed);
+    if(__prevLegacyBytes <= CN1_LEGACY_GC_TRIGGER_BYTES
+       && __prevLegacyBytes + (long)size > CN1_LEGACY_GC_TRIGGER_BYTES
        && constantPoolObjects != 0
 #ifndef CN1_CONSERVATIVE_GC_ROOTS
        // Mirror cn1BibopMaybeGc's gate exactly: without conservative roots a

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -1818,7 +1818,7 @@ long long cn1_instr_allocCount = 0;
 #ifndef CN1_LEGACY_GC_TRIGGER_BYTES
 #define CN1_LEGACY_GC_TRIGGER_BYTES (24*1024*1024)
 #endif
-_Atomic long cn1LegacyBytesSinceGc = 0;
+static _Atomic long cn1LegacyBytesSinceGc = 0;
 #endif
 
 JAVA_BOOLEAN java_lang_System_isHighFrequencyGC___R_boolean(CODENAME_ONE_THREAD_STATE) {
@@ -2072,7 +2072,10 @@ void cn1BibopBeginGcCycle(void) {
                                                          memory_order_acq_rel);
     // Same charge-to-next-cycle rule for the legacy byte counter (large arrays
     // and anything above CN1_BIBOP_MAX_OBJECT): see cn1LegacyBytesSinceGc.
-    atomic_store_explicit(&cn1LegacyBytesSinceGc, 0, memory_order_relaxed);
+    // Same atomic-exchange idiom as the BiBOP reset above: a racing fetch_add
+    // lands either before the swap (covered by the cycle that is starting) or
+    // after it (charged to the next cycle) -- never dropped.
+    (void)atomic_exchange_explicit(&cn1LegacyBytesSinceGc, 0, memory_order_acq_rel);
 #ifdef CN1_GRACE_AUDIT
     // QA builds only: snapshot every page's cursor at mark start. Slots below the
     // snapshot existed before the grace pass ran, so a complete grace pass must
@@ -3947,10 +3950,30 @@ JAVA_OBJECT codenameOneGcMalloc(CODENAME_ONE_THREAD_STATE, int size, struct claz
     // asynchronous (sets forceGc + notifies the GC thread) exactly as in the
     // BiBOP path. nativeAllocationMode save/restore matches cn1BibopMaybeGc:
     // we may already be inside a caller's native-allocation bracket.
-    long __legacyBytes = atomic_fetch_add_explicit(&cn1LegacyBytesSinceGc, (long)size,
-                                                   memory_order_relaxed) + (long)size;
-    if(__legacyBytes > CN1_LEGACY_GC_TRIGGER_BYTES && !gcCurrentlyRunning
-       && constantPoolObjects != 0) {
+    // EDGE-triggered on the threshold crossing: level-triggering here would
+    // call System.gc() (a lock+notify) on EVERY legacy allocation between the
+    // crossing and the cycle start that resets the counter -- avoidable
+    // overhead that is itself a mini-storm on large-array churn. At most one
+    // schedule per cycle window; a crossing that lands while a cycle is
+    // already running just sets forceGc for the GC thread's next loop pass
+    // (which is why there is deliberately no !gcCurrentlyRunning suppression:
+    // suppressing would LOSE the edge and delay collection up to the 30s
+    // idle wait).
+    long prevLegacyBytes = atomic_fetch_add_explicit(&cn1LegacyBytesSinceGc, (long)size,
+                                                     memory_order_relaxed);
+    if(prevLegacyBytes <= CN1_LEGACY_GC_TRIGGER_BYTES
+       && prevLegacyBytes + (long)size > CN1_LEGACY_GC_TRIGGER_BYTES
+       && constantPoolObjects != 0
+#ifndef CN1_CONSERVATIVE_GC_ROOTS
+       // Mirror cn1BibopMaybeGc's gate exactly: without conservative roots a
+       // thread inside a native-allocation bracket must not trigger a cycle
+       // (its half-built objects aren't rooted). Under conservative roots the
+       // native C locals ARE scanned, and gating unconditionally would starve
+       // the trigger on workloads whose large allocations all happen inside
+       // natives (the same starvation the BiBOP comment documents).
+       && !threadStateData->nativeAllocationMode
+#endif
+       ) {
         JAVA_BOOLEAN wasNam = threadStateData->nativeAllocationMode;
         threadStateData->nativeAllocationMode = JAVA_TRUE;
         java_lang_System_gc__(threadStateData);

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -1010,7 +1010,10 @@ void codenameOneGCMark() {
     // per collection cycle. Costs one cached getenv when disabled. Used by
     // LargeArrayGcIntegrationTest to assert the issue-5425 fix deterministically
     // (cycle COUNT is load-independent, unlike wall-clock phase timings) and
-    // generally useful for diagnosing trigger storms on device.
+    // generally useful for diagnosing trigger storms on device. DELIBERATELY
+    // outside the CN1_DISABLE_BIBOP guard: -DCN1_DISABLE_BIBOP A/B builds need
+    // the same observable so cycle counts can be compared across both collector
+    // shapes; with the env var unset this is behavior-identical either way.
     {
         static int cn1LogCycles = -1;
         if(cn1LogCycles < 0) cn1LogCycles = getenv("CN1_GC_LOG_CYCLES") ? 1 : 0;
@@ -1810,7 +1813,7 @@ long long cn1_instr_allocCount = 0;
 #ifndef CN1_LEGACY_GC_TRIGGER_BYTES
 #define CN1_LEGACY_GC_TRIGGER_BYTES (24*1024*1024)
 #endif
-_Atomic long cn1LegacyBytesSinceGc = 0;
+static _Atomic long cn1LegacyBytesSinceGc = 0;
 #endif
 
 JAVA_BOOLEAN java_lang_System_isHighFrequencyGC___R_boolean(CODENAME_ONE_THREAD_STATE) {

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -1818,7 +1818,9 @@ long long cn1_instr_allocCount = 0;
 #ifndef CN1_LEGACY_GC_TRIGGER_BYTES
 #define CN1_LEGACY_GC_TRIGGER_BYTES (24*1024*1024)
 #endif
-static _Atomic long cn1LegacyBytesSinceGc = 0;
+// long long, NOT long: on the Windows LLP64 target long is 32-bit and this
+// counter accumulates raw allocation bytes between cycle resets.
+static _Atomic long long cn1LegacyBytesSinceGc = 0;
 #endif
 
 JAVA_BOOLEAN java_lang_System_isHighFrequencyGC___R_boolean(CODENAME_ONE_THREAD_STATE) {
@@ -3959,10 +3961,11 @@ JAVA_OBJECT codenameOneGcMalloc(CODENAME_ONE_THREAD_STATE, int size, struct claz
     // (which is why there is deliberately no !gcCurrentlyRunning suppression:
     // suppressing would LOSE the edge and delay collection up to the 30s
     // idle wait).
-    long prevLegacyBytes = atomic_fetch_add_explicit(&cn1LegacyBytesSinceGc, (long)size,
-                                                     memory_order_relaxed);
+    long long prevLegacyBytes = atomic_fetch_add_explicit(&cn1LegacyBytesSinceGc,
+                                                          (long long)size,
+                                                          memory_order_relaxed);
     if(prevLegacyBytes <= CN1_LEGACY_GC_TRIGGER_BYTES
-       && prevLegacyBytes + (long)size > CN1_LEGACY_GC_TRIGGER_BYTES
+       && prevLegacyBytes + (long long)size > CN1_LEGACY_GC_TRIGGER_BYTES
        && constantPoolObjects != 0
 #ifndef CN1_CONSERVATIVE_GC_ROOTS
        // Mirror cn1BibopMaybeGc's gate exactly: without conservative roots a

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -2064,7 +2064,10 @@ void cn1BibopBeginGcCycle(void) {
                                                          memory_order_acq_rel);
     // Same charge-to-next-cycle rule for the legacy byte counter (large arrays
     // and anything above CN1_BIBOP_MAX_OBJECT): see cn1LegacyBytesSinceGc.
-    atomic_store_explicit(&cn1LegacyBytesSinceGc, 0, memory_order_relaxed);
+    // Same atomic-exchange idiom as the BiBOP reset above: a racing
+    // fetch_add lands either before the swap (covered by the cycle that is
+    // starting) or after it (charged to the next cycle) -- never dropped.
+    (void)atomic_exchange_explicit(&cn1LegacyBytesSinceGc, 0, memory_order_acq_rel);
 #ifdef CN1_GRACE_AUDIT
     // QA builds only: snapshot every page's cursor at mark start. Slots below the
     // snapshot existed before the grace pass ran, so a complete grace pass must
@@ -3942,7 +3945,17 @@ JAVA_OBJECT codenameOneGcMalloc(CODENAME_ONE_THREAD_STATE, int size, struct claz
     long __legacyBytes = atomic_fetch_add_explicit(&cn1LegacyBytesSinceGc, (long)size,
                                                    memory_order_relaxed) + (long)size;
     if(__legacyBytes > CN1_LEGACY_GC_TRIGGER_BYTES && !gcCurrentlyRunning
-       && constantPoolObjects != 0) {
+       && constantPoolObjects != 0
+#ifndef CN1_CONSERVATIVE_GC_ROOTS
+       // Mirror cn1BibopMaybeGc's gate exactly: without conservative roots a
+       // thread inside a native-allocation bracket must not trigger a cycle
+       // (its half-built objects aren't rooted). Under conservative roots the
+       // native C locals ARE scanned, and gating unconditionally would starve
+       // the trigger on workloads whose large allocations all happen inside
+       // natives (the same starvation the BiBOP comment documents).
+       && !threadStateData->nativeAllocationMode
+#endif
+       ) {
         JAVA_BOOLEAN wasNam = threadStateData->nativeAllocationMode;
         threadStateData->nativeAllocationMode = JAVA_TRUE;
         java_lang_System_gc__(threadStateData);

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -1006,6 +1006,18 @@ static JAVA_BOOLEAN cn1SweepRemoving;
 void codenameOneGCMark() {
     currentGcMarkValue++;
     atomic_store_explicit(&gcMarkOverflowSeen, JAVA_FALSE, memory_order_relaxed);
+    // Env-gated cycle tracer (same pattern as CN1_LEGACY_DEBUG): one stderr line
+    // per collection cycle. Costs one cached getenv when disabled. Used by
+    // LargeArrayGcIntegrationTest to assert the issue-5425 fix deterministically
+    // (cycle COUNT is load-independent, unlike wall-clock phase timings) and
+    // generally useful for diagnosing trigger storms on device.
+    {
+        static int cn1LogCycles = -1;
+        if(cn1LogCycles < 0) cn1LogCycles = getenv("CN1_GC_LOG_CYCLES") ? 1 : 0;
+        if(cn1LogCycles) {
+            fprintf(stderr, "[GC-CYCLE] %d\n", currentGcMarkValue);
+        }
+    }
 #ifndef CN1_DISABLE_BIBOP
     cn1BibopBeginGcCycle();
 #endif
@@ -1783,10 +1795,42 @@ long long allocationsSinceLastGC = 0;
 long long totalAllocations = 0;
 long long cn1_instr_allocCount = 0;
 
+#ifndef CN1_DISABLE_BIBOP
+// BYTES allocated through the LEGACY (non-BiBOP) path since the last cycle:
+// large arrays and anything above CN1_BIBOP_MAX_OBJECT. These allocations never
+// feed bibopBytesSinceGc, so before this counter existed the ONLY byte-based
+// signal they produced was the 1MB isHighFrequencyGC re-arm below -- a
+// threshold tuned for the pre-BiBOP collector, 24x more aggressive than the
+// BiBOP trigger. On the issue-5425 workload (~800 retained 10K byte[] blocks
+// over a ~500K-object survivor set) that kept the collector in back-to-back
+// 200ms cycles for an allocation phase that produced NO garbage at all.
+// Instead, mirror the BiBOP design: an event-driven System.gc() when legacy
+// volume since the last cycle crosses the same modern budget (reset in
+// cn1BibopBeginGcCycle alongside bibopBytesSinceGc).
+#ifndef CN1_LEGACY_GC_TRIGGER_BYTES
+#define CN1_LEGACY_GC_TRIGGER_BYTES (24*1024*1024)
+#endif
+_Atomic long cn1LegacyBytesSinceGc = 0;
+#endif
+
 JAVA_BOOLEAN java_lang_System_isHighFrequencyGC___R_boolean(CODENAME_ONE_THREAD_STATE) {
     long long alloc = allocationsSinceLastGC;
     allocationsSinceLastGC = 0;
-    return alloc > CN1_HIGH_FREQUENCY_ALLOCATION_THRESHOLD && totalAllocations > CN1_HIGH_FREQUENCY_ALLOCATION_ACTIVATED_THRESHOLD;
+    long long threshold = CN1_HIGH_FREQUENCY_ALLOCATION_THRESHOLD;
+#ifndef CN1_DISABLE_BIBOP
+    // Align the 200ms re-arm with the adaptive BiBOP trigger: collection
+    // SCHEDULING is event-driven (cn1BibopMaybeGc for BiBOP bytes, the legacy
+    // trigger in codenameOneGcMalloc for legacy bytes), so the high-frequency
+    // loop only needs to re-arm when allocation volume since the last cycle
+    // would have crossed the trigger anyway. The old fixed 1MB re-arm predates
+    // BiBOP and turned a small retained large-array load into a continuous GC
+    // storm over the whole live set (issue 5425, final Dtest shape).
+    long adaptive = atomic_load_explicit(&bibopGcTriggerBytes, memory_order_relaxed);
+    if(adaptive > threshold) {
+        threshold = adaptive;
+    }
+#endif
+    return alloc > threshold && totalAllocations > CN1_HIGH_FREQUENCY_ALLOCATION_ACTIVATED_THRESHOLD;
 }
 
 JAVA_INT java_lang_System_identityHashCode___java_lang_Object_R_int(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT __cn1Arg1) {
@@ -2018,6 +2062,9 @@ void cn1BibopBeginGcCycle(void) {
     // sustained allocator.
     bibopCycleAllocatedBytes = atomic_exchange_explicit(&bibopBytesSinceGc, 0,
                                                          memory_order_acq_rel);
+    // Same charge-to-next-cycle rule for the legacy byte counter (large arrays
+    // and anything above CN1_BIBOP_MAX_OBJECT): see cn1LegacyBytesSinceGc.
+    atomic_store_explicit(&cn1LegacyBytesSinceGc, 0, memory_order_relaxed);
 #ifdef CN1_GRACE_AUDIT
     // QA builds only: snapshot every page's cursor at mark start. Slots below the
     // snapshot existed before the grace pass ran, so a complete grace pass must
@@ -3881,6 +3928,27 @@ JAVA_OBJECT codenameOneGcMalloc(CODENAME_ONE_THREAD_STATE, int size, struct claz
     }
     threadStateData->pendingHeapAllocations[threadStateData->heapAllocationSize] = o;
     threadStateData->heapAllocationSize++;
+#ifndef CN1_DISABLE_BIBOP
+    // Event-driven trigger for LEGACY allocation volume, mirroring
+    // cn1BibopMaybeGc's simple self-triggering branch: without it, raising the
+    // isHighFrequencyGC re-arm above 1MB would let a legacy-churn workload
+    // (transient large arrays) accumulate uncollected garbage for up to the GC
+    // thread's 30s idle wait, bounded only by the per-thread pending-table
+    // count triggers above. The object is already registered in
+    // pendingHeapAllocations, so triggering here is safe; System.gc() is
+    // asynchronous (sets forceGc + notifies the GC thread) exactly as in the
+    // BiBOP path. nativeAllocationMode save/restore matches cn1BibopMaybeGc:
+    // we may already be inside a caller's native-allocation bracket.
+    long __legacyBytes = atomic_fetch_add_explicit(&cn1LegacyBytesSinceGc, (long)size,
+                                                   memory_order_relaxed) + (long)size;
+    if(__legacyBytes > CN1_LEGACY_GC_TRIGGER_BYTES && !gcCurrentlyRunning
+       && constantPoolObjects != 0) {
+        JAVA_BOOLEAN wasNam = threadStateData->nativeAllocationMode;
+        threadStateData->nativeAllocationMode = JAVA_TRUE;
+        java_lang_System_gc__(threadStateData);
+        threadStateData->nativeAllocationMode = wasNam;
+    }
+#endif
     return o;
 }
 

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -1821,6 +1821,15 @@ long long cn1_instr_allocCount = 0;
 // long long, NOT long: on the Windows LLP64 target long is 32-bit and this
 // counter accumulates raw allocation bytes between cycle resets.
 static _Atomic long long cn1LegacyBytesSinceGc = 0;
+// One-shot per-cycle latch for the legacy volume trigger. The trigger is
+// LEVEL-triggered on the counter -- so a crossing that lands while the
+// allocating thread is inside a native-allocation bracket (skipped below when
+// conservative roots are off) is simply retried by the next out-of-bracket
+// legacy allocation on ANY thread, instead of being lost until the GC thread's
+// idle wake -- but LATCHED so the async System.gc() (a lock+notify) is
+// scheduled at most once per cycle window, not on every allocation after the
+// crossing. Cleared in cn1BibopBeginGcCycle after the counter reset.
+static _Atomic int cn1LegacyGcScheduled = 0;
 #endif
 
 JAVA_BOOLEAN java_lang_System_isHighFrequencyGC___R_boolean(CODENAME_ONE_THREAD_STATE) {
@@ -2078,6 +2087,10 @@ void cn1BibopBeginGcCycle(void) {
     // lands either before the swap (covered by the cycle that is starting) or
     // after it (charged to the next cycle) -- never dropped.
     (void)atomic_exchange_explicit(&cn1LegacyBytesSinceGc, 0, memory_order_acq_rel);
+    // Latch AFTER the counter: an allocator racing between the two exchanges
+    // still sees the old latch and skips, so the fresh latch can never be
+    // consumed by bytes just charged to the cycle that is starting.
+    (void)atomic_exchange_explicit(&cn1LegacyGcScheduled, 0, memory_order_acq_rel);
 #ifdef CN1_GRACE_AUDIT
     // QA builds only: snapshot every page's cursor at mark start. Slots below the
     // snapshot existed before the grace pass ran, so a complete grace pass must
@@ -3952,20 +3965,21 @@ JAVA_OBJECT codenameOneGcMalloc(CODENAME_ONE_THREAD_STATE, int size, struct claz
     // asynchronous (sets forceGc + notifies the GC thread) exactly as in the
     // BiBOP path. nativeAllocationMode save/restore matches cn1BibopMaybeGc:
     // we may already be inside a caller's native-allocation bracket.
-    // EDGE-triggered on the threshold crossing: level-triggering here would
-    // call System.gc() (a lock+notify) on EVERY legacy allocation between the
-    // crossing and the cycle start that resets the counter -- avoidable
-    // overhead that is itself a mini-storm on large-array churn. At most one
-    // schedule per cycle window; a crossing that lands while a cycle is
-    // already running just sets forceGc for the GC thread's next loop pass
-    // (which is why there is deliberately no !gcCurrentlyRunning suppression:
-    // suppressing would LOSE the edge and delay collection up to the 30s
-    // idle wait).
+    // LEVEL-triggered on volume, LATCHED to one schedule per cycle window
+    // (cn1LegacyGcScheduled, cleared at cycle begin). Level-triggering means a
+    // crossing suppressed by the native-bracket gate below is retried by the
+    // next out-of-bracket legacy allocation on any thread -- a pure edge
+    // trigger would lose that crossing permanently (prev already above the
+    // threshold forever after) and delay collection up to the GC thread's 30s
+    // idle wait. The latch supplies what edge-triggering was buying: no
+    // per-allocation System.gc() (lock+notify) spam after the crossing. A
+    // crossing that lands while a cycle is already running just sets forceGc
+    // for the GC thread's next loop pass (deliberately no !gcCurrentlyRunning
+    // suppression -- the latch makes it redundant anyway).
     long long prevLegacyBytes = atomic_fetch_add_explicit(&cn1LegacyBytesSinceGc,
                                                           (long long)size,
                                                           memory_order_relaxed);
-    if(prevLegacyBytes <= CN1_LEGACY_GC_TRIGGER_BYTES
-       && prevLegacyBytes + (long long)size > CN1_LEGACY_GC_TRIGGER_BYTES
+    if(prevLegacyBytes + (long long)size > CN1_LEGACY_GC_TRIGGER_BYTES
        && constantPoolObjects != 0
 #ifndef CN1_CONSERVATIVE_GC_ROOTS
        // Mirror cn1BibopMaybeGc's gate exactly: without conservative roots a
@@ -3976,11 +3990,16 @@ JAVA_OBJECT codenameOneGcMalloc(CODENAME_ONE_THREAD_STATE, int size, struct claz
        // natives (the same starvation the BiBOP comment documents).
        && !threadStateData->nativeAllocationMode
 #endif
-       ) {
-        JAVA_BOOLEAN wasNam = threadStateData->nativeAllocationMode;
-        threadStateData->nativeAllocationMode = JAVA_TRUE;
-        java_lang_System_gc__(threadStateData);
-        threadStateData->nativeAllocationMode = wasNam;
+       && atomic_load_explicit(&cn1LegacyGcScheduled, memory_order_relaxed) == 0) {
+        int expectedLatch = 0;
+        if(atomic_compare_exchange_strong_explicit(&cn1LegacyGcScheduled, &expectedLatch, 1,
+                                                   memory_order_acq_rel,
+                                                   memory_order_relaxed)) {
+            JAVA_BOOLEAN wasNam = threadStateData->nativeAllocationMode;
+            threadStateData->nativeAllocationMode = JAVA_TRUE;
+            java_lang_System_gc__(threadStateData);
+            threadStateData->nativeAllocationMode = wasNam;
+        }
     }
 #endif
     return o;

--- a/vm/ByteCodeTranslator/src/cn1_win_compat.c
+++ b/vm/ByteCodeTranslator/src/cn1_win_compat.c
@@ -263,13 +263,12 @@ int usleep(unsigned int usec) {
 long long cn1_monotonic_micros(void) {
     /* QPC is Win32's monotonic clock. The divide is split so ticks * 1e6
        cannot overflow 64 bits at multi-GHz tick rates over long uptimes.
-       The lazy freq init is benignly racy: every writer stores the same
-       boot-constant value. */
-    static LARGE_INTEGER freq;
+       No cached static for the frequency: QueryPerformanceFrequency is a
+       cheap userspace read of a boot constant, and a lazily-written shared
+       static would be a formal C data race across concurrent sleepers. */
+    LARGE_INTEGER freq;
     LARGE_INTEGER count;
-    if(freq.QuadPart == 0) {
-        QueryPerformanceFrequency(&freq);
-    }
+    QueryPerformanceFrequency(&freq);
     QueryPerformanceCounter(&count);
     return (count.QuadPart / freq.QuadPart) * 1000000LL
          + ((count.QuadPart % freq.QuadPart) * 1000000LL) / freq.QuadPart;

--- a/vm/ByteCodeTranslator/src/cn1_win_compat.c
+++ b/vm/ByteCodeTranslator/src/cn1_win_compat.c
@@ -238,6 +238,21 @@ int usleep(unsigned int usec) {
     return 0;
 }
 
+long long cn1_monotonic_micros(void) {
+    /* QPC is Win32's monotonic clock. The divide is split so ticks * 1e6
+       cannot overflow 64 bits at multi-GHz tick rates over long uptimes.
+       The lazy freq init is benignly racy: every writer stores the same
+       boot-constant value. */
+    static LARGE_INTEGER freq;
+    LARGE_INTEGER count;
+    if(freq.QuadPart == 0) {
+        QueryPerformanceFrequency(&freq);
+    }
+    QueryPerformanceCounter(&count);
+    return (count.QuadPart / freq.QuadPart) * 1000000LL
+         + ((count.QuadPart % freq.QuadPart) * 1000000LL) / freq.QuadPart;
+}
+
 int gettimeofday(struct timeval* tv, void* tz) {
     FILETIME ft;
     ULARGE_INTEGER li;

--- a/vm/ByteCodeTranslator/src/cn1_win_compat.c
+++ b/vm/ByteCodeTranslator/src/cn1_win_compat.c
@@ -1,4 +1,26 @@
 /*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+/*
  * Win32 implementation of the minimal POSIX surface declared in
  * cn1_win_compat.h. See that header for the rationale. Entirely gated on
  * _WIN32 so this is an empty translation unit on every other platform (it is

--- a/vm/ByteCodeTranslator/src/cn1_win_compat.h
+++ b/vm/ByteCodeTranslator/src/cn1_win_compat.h
@@ -116,6 +116,11 @@ int pthread_setschedparam(pthread_t thread, int policy, const struct sched_param
 int usleep(unsigned int usec);
 int gettimeofday(struct timeval* tv, void* tz);
 
+/* Monotonic microsecond clock (QueryPerformanceCounter), immune to wall-clock
+   adjustments. Used for Thread.sleep deadline arithmetic, where a stepped
+   system clock must not stretch or cut the remaining sleep. */
+long long cn1_monotonic_micros(void);
+
 /* --- environment / time.h POSIX helpers absent from MSVC ---
    Thin static-inline wrappers over the MSVC equivalents; used by the date /
    timezone runtime in nativeMethods. */

--- a/vm/ByteCodeTranslator/src/cn1_win_compat.h
+++ b/vm/ByteCodeTranslator/src/cn1_win_compat.h
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 #ifndef CN1_WIN_COMPAT_H
 #define CN1_WIN_COMPAT_H
 

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/JavascriptNativeRegistry.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/JavascriptNativeRegistry.java
@@ -134,6 +134,7 @@ final class JavascriptNativeRegistry {
             "cn1_java_lang_Thread_releaseThreadNativeResources_long",
             "cn1_java_lang_Thread_setPriorityImpl_int",
             "cn1_java_lang_Thread_sleep_long",
+            "cn1_java_lang_Thread_sleepImpl_long",
             "cn1_java_lang_Thread_start",
             "cn1_java_lang_Throwable_fillInStack",
             "cn1_java_lang_Throwable_getStack_R_java_lang_String",

--- a/vm/ByteCodeTranslator/src/javascript/parparvm_runtime.js
+++ b/vm/ByteCodeTranslator/src/javascript/parparvm_runtime.js
@@ -5274,7 +5274,11 @@ bindNative(["cn1_java_lang_Thread_currentThread_R_java_lang_Thread", "cn1_java_l
   }
   return jvm.mainThreadObject || null;
 });
-bindNative(["cn1_java_lang_Thread_sleep_long", "cn1_java_lang_Thread_sleep___long"], function*(millis) {
+// sleepImpl is the current native (Thread.sleep(long) became a Java wrapper
+// that adds the negative-millis IllegalArgumentException guard); the plain
+// sleep aliases stay bound for previously-translated bundles.
+bindNative(["cn1_java_lang_Thread_sleepImpl_long", "cn1_java_lang_Thread_sleepImpl___long",
+            "cn1_java_lang_Thread_sleep_long", "cn1_java_lang_Thread_sleep___long"], function*(millis) {
   const resumed = yield { op: "sleep", millis: millis || 0 };
   if (resumed && resumed.interrupted) {
     yield* throwInterruptedException();

--- a/vm/ByteCodeTranslator/src/nativeMethods.m
+++ b/vm/ByteCodeTranslator/src/nativeMethods.m
@@ -2066,13 +2066,13 @@ JAVA_VOID java_lang_Thread_releaseThreadNativeResources___long(CODENAME_ONE_THRE
     }
 }
 
-// Monotonic microsecond clock for the sleep deadline (wall clock on the MSVC /
-// clang-cl target, which lacks clock_gettime -- same fallback as nanoTime above).
+// Monotonic microsecond clock for the sleep deadline. Monotonic on BOTH
+// targets: the MSVC / clang-cl side goes through the QueryPerformanceCounter
+// shim in cn1_win_compat (gettimeofday here would tie the deadline to the
+// wall clock, so a system time step would stretch or cut a sleep-in-progress).
 static JAVA_LONG cn1SleepNowMicros(void) {
 #ifdef _WIN32
-    struct timeval time;
-    gettimeofday(&time, NULL);
-    return (((JAVA_LONG)time.tv_sec) * 1000000LL) + (JAVA_LONG)time.tv_usec;
+    return (JAVA_LONG)cn1_monotonic_micros();
 #else
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);

--- a/vm/ByteCodeTranslator/src/nativeMethods.m
+++ b/vm/ByteCodeTranslator/src/nativeMethods.m
@@ -2109,7 +2109,9 @@ JAVA_VOID java_lang_Thread_sleep___long(CODENAME_ONE_THREAD_STATE, JAVA_LONG mil
         if(remainMicros > 500000) {
             remainMicros = 500000;
         }
-        usleep((useconds_t)remainMicros);
+        // JAVA_INT cast, not useconds_t: the MSVC/clang-cl target's cn1_win_compat
+        // usleep shim has no useconds_t typedef (same reason the old code cast here)
+        usleep((JAVA_INT)remainMicros);
     }
     while(threadStateData->threadBlockedByGC) {
         usleep(1000);

--- a/vm/ByteCodeTranslator/src/nativeMethods.m
+++ b/vm/ByteCodeTranslator/src/nativeMethods.m
@@ -2094,9 +2094,12 @@ JAVA_VOID java_lang_Thread_sleep___long(CODENAME_ONE_THREAD_STATE, JAVA_LONG mil
     // (issue-5425 PR, ToastBarTopPosition CI failure). Sleep on a monotonic
     // deadline and resume across early wakeups. Chunked below 1s because POSIX
     // allows usleep() to reject arguments >= 1000000 outright (EINVAL on musl),
-    // which silently turned long sleeps into no-ops on those libcs. Honors the
-    // interrupt flag so interrupt() now actually shortens a sleep instead of
-    // relying on an accidental EINTR.
+    // which silently turned long sleeps into no-ops on those libcs.
+    // INTERRUPT SEMANTICS UNCHANGED: this VM has never delivered
+    // InterruptedException from sleep (interrupt() only sets the flag), so the
+    // resume loop deliberately does NOT exit early on it -- waking without the
+    // exception would be a third behavior, neither historical nor Java's.
+    // Proper interrupt delivery is a separate change.
     // Saturate instead of overflowing: Thread.sleep(Long.MAX_VALUE) is a real
     // "park this thread" idiom, and millis * 1000 would wrap negative and make
     // it return immediately.
@@ -2105,9 +2108,6 @@ JAVA_VOID java_lang_Thread_sleep___long(CODENAME_ONE_THREAD_STATE, JAVA_LONG mil
     JAVA_LONG deltaMicros = (millis > maxMicros / 1000) ? maxMicros : millis * 1000;
     JAVA_LONG deadline = (deltaMicros > maxMicros - now) ? maxMicros : now + deltaMicros;
     for(;;) {
-        if(threadStateData->interrupted) {
-            break;
-        }
         JAVA_LONG remainMicros = deadline - cn1SleepNowMicros();
         if(remainMicros <= 0) {
             break;

--- a/vm/ByteCodeTranslator/src/nativeMethods.m
+++ b/vm/ByteCodeTranslator/src/nativeMethods.m
@@ -2066,9 +2066,51 @@ JAVA_VOID java_lang_Thread_releaseThreadNativeResources___long(CODENAME_ONE_THRE
     }
 }
 
+// Monotonic microsecond clock for the sleep deadline (wall clock on the MSVC /
+// clang-cl target, which lacks clock_gettime -- same fallback as nanoTime above).
+static JAVA_LONG cn1SleepNowMicros(void) {
+#ifdef _WIN32
+    struct timeval time;
+    gettimeofday(&time, NULL);
+    return (((JAVA_LONG)time.tv_sec) * 1000000LL) + (JAVA_LONG)time.tv_usec;
+#else
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (((JAVA_LONG)ts.tv_sec) * 1000000LL) + (JAVA_LONG)(ts.tv_nsec / 1000);
+#endif
+}
+
 JAVA_VOID java_lang_Thread_sleep___long(CODENAME_ONE_THREAD_STATE, JAVA_LONG millis) {
     threadStateData->threadActive = JAVA_FALSE;
-    usleep((JAVA_INT)(millis * 1000));
+    // usleep()/nanosleep() return EINTR when any signal lands, and POSIX never
+    // restarts them (SA_RESTART explicitly excludes them). The conservative-roots
+    // collector SIGNAL-STOPS sleeping threads every cycle to scan their native
+    // stacks (a sleeper has no cooperative park capture), so the old single
+    // usleep() call effectively slept only until the next collection or any other
+    // process signal: Thread.sleep(600000) was measured returning after ~20ms on
+    // the Linux port under allocation churn. java.util.Timer schedules through
+    // Thread.sleep, so every TimerTask fired almost immediately -- observed as
+    // ToastBar's "practically unexpiring" status dismissing itself mid-test
+    // (issue-5425 PR, ToastBarTopPosition CI failure). Sleep on a monotonic
+    // deadline and resume across early wakeups. Chunked below 1s because POSIX
+    // allows usleep() to reject arguments >= 1000000 outright (EINVAL on musl),
+    // which silently turned long sleeps into no-ops on those libcs. Honors the
+    // interrupt flag so interrupt() now actually shortens a sleep instead of
+    // relying on an accidental EINTR.
+    JAVA_LONG deadline = cn1SleepNowMicros() + millis * 1000;
+    for(;;) {
+        if(threadStateData->interrupted) {
+            break;
+        }
+        JAVA_LONG remainMicros = deadline - cn1SleepNowMicros();
+        if(remainMicros <= 0) {
+            break;
+        }
+        if(remainMicros > 500000) {
+            remainMicros = 500000;
+        }
+        usleep((useconds_t)remainMicros);
+    }
     while(threadStateData->threadBlockedByGC) {
         usleep(1000);
     }

--- a/vm/ByteCodeTranslator/src/nativeMethods.m
+++ b/vm/ByteCodeTranslator/src/nativeMethods.m
@@ -2097,7 +2097,13 @@ JAVA_VOID java_lang_Thread_sleep___long(CODENAME_ONE_THREAD_STATE, JAVA_LONG mil
     // which silently turned long sleeps into no-ops on those libcs. Honors the
     // interrupt flag so interrupt() now actually shortens a sleep instead of
     // relying on an accidental EINTR.
-    JAVA_LONG deadline = cn1SleepNowMicros() + millis * 1000;
+    // Saturate instead of overflowing: Thread.sleep(Long.MAX_VALUE) is a real
+    // "park this thread" idiom, and millis * 1000 would wrap negative and make
+    // it return immediately.
+    JAVA_LONG now = cn1SleepNowMicros();
+    JAVA_LONG maxMicros = 0x7fffffffffffffffLL;
+    JAVA_LONG deltaMicros = (millis > maxMicros / 1000) ? maxMicros : millis * 1000;
+    JAVA_LONG deadline = (deltaMicros > maxMicros - now) ? maxMicros : now + deltaMicros;
     for(;;) {
         if(threadStateData->interrupted) {
             break;

--- a/vm/ByteCodeTranslator/src/nativeMethods.m
+++ b/vm/ByteCodeTranslator/src/nativeMethods.m
@@ -2080,7 +2080,10 @@ static JAVA_LONG cn1SleepNowMicros(void) {
 #endif
 }
 
-JAVA_VOID java_lang_Thread_sleep___long(CODENAME_ONE_THREAD_STATE, JAVA_LONG millis) {
+// Bound to Thread.sleepImpl: the public Thread.sleep(long) is Java code that
+// throws IllegalArgumentException for negative millis (per the JDK contract)
+// before delegating here, so millis is always >= 0 at this point.
+JAVA_VOID java_lang_Thread_sleepImpl___long(CODENAME_ONE_THREAD_STATE, JAVA_LONG millis) {
     // Park per the CN1_YIELD_THREAD contract (cn1_globals.h): capture SP +
     // callee-saved registers FIRST, then publish threadActive=FALSE. Under
     // CN1_CONSERVATIVE_GC_ROOTS this lets the collector scan the sleeper's

--- a/vm/ByteCodeTranslator/src/nativeMethods.m
+++ b/vm/ByteCodeTranslator/src/nativeMethods.m
@@ -2081,6 +2081,13 @@ static JAVA_LONG cn1SleepNowMicros(void) {
 }
 
 JAVA_VOID java_lang_Thread_sleep___long(CODENAME_ONE_THREAD_STATE, JAVA_LONG millis) {
+    // Park per the CN1_YIELD_THREAD contract (cn1_globals.h): capture SP +
+    // callee-saved registers FIRST, then publish threadActive=FALSE. Under
+    // CN1_CONSERVATIVE_GC_ROOTS this lets the collector scan the sleeper's
+    // native stack cooperatively; on Windows there is NO signal-stop fallback,
+    // so without the capture a sleeping thread's native-stack roots would go
+    // unscanned for the cycle. No-op when conservative roots are off.
+    CN1_GC_PARK_CAPTURE(threadStateData);
     threadStateData->threadActive = JAVA_FALSE;
     // usleep()/nanosleep() return EINTR when any signal lands, and POSIX never
     // restarts them (SA_RESTART explicitly excludes them). The conservative-roots
@@ -2123,6 +2130,11 @@ JAVA_VOID java_lang_Thread_sleep___long(CODENAME_ONE_THREAD_STATE, JAVA_LONG mil
         usleep(1000);
     }
     threadStateData->threadActive = JAVA_TRUE;
+#ifdef CN1_CONSERVATIVE_GC_ROOTS
+    // Mirror CN1_RESUME_THREAD: drop the capture so a stale SP can never
+    // satisfy the scanner's cooperative path after this frame unwinds.
+    threadStateData->gcParkCaptured = JAVA_FALSE;
+#endif
 }
 
 JAVA_OBJECT java_lang_Thread_currentThread___R_java_lang_Thread(CODENAME_ONE_THREAD_STATE) {

--- a/vm/JavaAPI/src/java/lang/Thread.java
+++ b/vm/JavaAPI/src/java/lang/Thread.java
@@ -247,7 +247,14 @@ public class Thread implements java.lang.Runnable{
     /**
      * Causes the currently executing thread to sleep (temporarily cease execution) for the specified number of milliseconds. The thread does not lose ownership of any monitors.
      */
-    public static native void sleep(long millis) throws java.lang.InterruptedException;
+    public static void sleep(long millis) throws java.lang.InterruptedException {
+        if (millis < 0) {
+            throw new IllegalArgumentException("timeout value is negative");
+        }
+        sleepImpl(millis);
+    }
+
+    private static native void sleepImpl(long millis);
 
     public static void sleep(long millis, int nanos) throws java.lang.InterruptedException {
         if (millis < 0) {

--- a/vm/benchmarks/README.md
+++ b/vm/benchmarks/README.md
@@ -122,6 +122,15 @@ The fresh-page-stack grace scheme this audit was written against reported
 `gcAllocedSinceSweep`-pruned registry walk reports zero doomed across the
 suite. `StormAB` (sustained single-thread storm) and `LoadLoop` (repeated
 dictionary build/drop) are the matching wall-time/RSS A/B drivers.
+`LargeArrayLoad` models the FINAL issue-5425 Dtest shape -- a persistent
+small-object survivor set plus a retained LARGE (>CN1_BIBOP_MAX_OBJECT,
+legacy-path) byte[] phase that produces no garbage -- and guards the
+legacy-allocation GC-trigger storm (its CI twin is
+`LargeArrayGcIntegrationTest` in `vm/tests`). Run it with
+`CN1_GC_LOG_CYCLES=1` and count `[GC-CYCLE]` stderr lines: collection must be
+volume-driven (~6 cycles on this workload), not re-armed at wall-clock
+cadence by the pre-BiBOP 1MB high-frequency threshold (15 cycles when
+regressed).
 
 `ClinitThrow` is a standalone liveness reproducer (not byte-identical to the
 host JVM by design — ParparVM's initialization-failure semantics differ): a

--- a/vm/benchmarks/README.md
+++ b/vm/benchmarks/README.md
@@ -122,6 +122,12 @@ The fresh-page-stack grace scheme this audit was written against reported
 `gcAllocedSinceSweep`-pruned registry walk reports zero doomed across the
 suite. `StormAB` (sustained single-thread storm) and `LoadLoop` (repeated
 dictionary build/drop) are the matching wall-time/RSS A/B drivers.
+`TimerLatency` is the sleep/timer fidelity probe for the Thread.sleep
+signal-truncation defect (a single usleep was EINTR'd by the collector's
+sleeping-thread stop signal, cutting Thread.sleep(3000) to ~20ms and firing
+every java.util.Timer task almost immediately): it must print
+`TIMER_LATENCY_OK` -- max_early_ms > 50 or a truncated min_sleep1500_ms
+means the regression is back.
 `LargeArrayLoad` models the FINAL issue-5425 Dtest shape -- a persistent
 small-object survivor set plus a retained LARGE (>CN1_BIBOP_MAX_OBJECT,
 legacy-path) byte[] phase that produces no garbage -- and guards the

--- a/vm/benchmarks/README.md
+++ b/vm/benchmarks/README.md
@@ -126,8 +126,8 @@ dictionary build/drop) are the matching wall-time/RSS A/B drivers.
 signal-truncation defect (a single usleep was EINTR'd by the collector's
 sleeping-thread stop signal, cutting Thread.sleep(3000) to ~20ms and firing
 every java.util.Timer task almost immediately): it must print
-`TIMER_LATENCY_OK` -- max_early_ms > 50 or a truncated min_sleep1500_ms
-means the regression is back.
+`TIMER_LATENCY_OK`. If `max_early_ms` exceeds 50 or `min_sleep1500_ms` comes
+out truncated, the regression is back.
 `LargeArrayLoad` models the FINAL issue-5425 Dtest shape -- a persistent
 small-object survivor set plus a retained LARGE (>CN1_BIBOP_MAX_OBJECT,
 legacy-path) byte[] phase that produces no garbage -- and guards the

--- a/vm/benchmarks/src/com/bench/LargeArrayLoad.java
+++ b/vm/benchmarks/src/com/bench/LargeArrayLoad.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.bench;
+
+import java.util.Hashtable;
+
+/**
+ * Models the FINAL issue-5425 Dtest shape (the one from the last round of
+ * comments, after the reporter removed all transient garbage): pass 1 builds a
+ * persistent survivor set of SMALL (BiBOP-resident) objects, pass 2 then
+ * allocates ONLY LARGE (>CN1_BIBOP_MAX_OBJECT, legacy-path) retained byte[]
+ * blocks -- the reporter's volume shape, producing NO garbage.
+ *
+ * Each pass is stretched to a fixed WALL duration with allocation-free
+ * compute, because the regression being guarded is a TRIGGER-CADENCE bug: the
+ * pre-BiBOP 1MB isHighFrequencyGC re-arm keeps a full collection cycle
+ * starting every re-arm window for as long as >1MB is allocated per interval
+ * -- "allocating the large arrays is triggering a global multiple times" --
+ * while the fixed VM (24MB budget, event-driven legacy trigger) collects only
+ * when allocation VOLUME demands it. Run with CN1_GC_LOG_CYCLES=1 and count
+ * [GC-CYCLE] stderr lines: the cycle count is the load-independent observable
+ * (measured on this workload: unfixed 15 cycles, fixed 6, stable across
+ * runs; wall-clock phase times only inflate when cycles contend with the
+ * mutator, which depends on core count and machine load).
+ */
+public class LargeArrayLoad {
+    static Hashtable dict;      // survivor set for the current round
+    static byte[][] blocks;     // retained large arrays for the current round
+
+    // Spin without allocating until the phase has lasted stretchMs, so the
+    // number of 200ms GC re-arm windows per phase is machine-independent.
+    private static long stretch(long phaseStart, long stretchMs, long seed) {
+        long v = seed;
+        while (System.currentTimeMillis() - phaseStart < stretchMs) {
+            for (int i = 0; i < 5000; i++) {
+                v = v * 6364136223846793005L + 1442695040888963407L;
+            }
+        }
+        return v;
+    }
+
+    public static void main(String[] args) {
+        int rounds = 12;
+        int smallCount = 15000;
+        int blockCount = 400;      // ~4MB of 10K blocks per round: above the old
+        int blockSize = 10240;     // 1MB re-arm, well below the 24MB budget
+        long stretchMs = 400;
+        long checksum = 0;
+        StringBuilder sb = new StringBuilder();
+        String[] probeKeys = new String[smallCount >> 9];
+        for (int round = 0; round < rounds; round++) {
+            long t0 = System.currentTimeMillis();
+            // Pass 1: persistent small objects (Hashtable nodes, keys, tiny
+            // byte[] defs) -- BiBOP-sized, ~100% survival for the round.
+            Hashtable h = new Hashtable();
+            for (int i = 0; i < smallCount; i++) {
+                sb.setLength(0);
+                sb.append("word");
+                sb.append(i);
+                String key = sb.toString();
+                byte[] def = new byte[16 + (i & 31)];
+                def[0] = (byte) i;
+                def[def.length - 1] = (byte) (i >> 8);
+                h.put(key, def);
+                if ((i & 511) == 0 && (i >> 9) < probeKeys.length) {
+                    probeKeys[i >> 9] = key;
+                }
+            }
+            dict = h;
+            checksum += stretch(t0, stretchMs, round);
+            long t1 = System.currentTimeMillis();
+            // Pass 2: ONLY large retained arrays -- the legacy allocation
+            // path. No garbage is produced here at all.
+            byte[][] b = new byte[blockCount][];
+            for (int i = 0; i < blockCount; i++) {
+                byte[] blk = new byte[blockSize];
+                for (int j = 0; j < blockSize; j += 512) {
+                    blk[j] = (byte) (i + j);
+                }
+                b[i] = blk;
+            }
+            blocks = b;
+            checksum += stretch(t1, stretchMs, round + 31);
+            long t2 = System.currentTimeMillis();
+            // Pass 3: allocation-free lookups -- models the app using the
+            // loaded dictionary.
+            long probe = 0;
+            for (int rep = 0; rep < 40; rep++) {
+                for (int i = 0; i < probeKeys.length; i++) {
+                    byte[] def = (byte[]) h.get(probeKeys[i]);
+                    probe += def[0];
+                }
+            }
+            long t3 = System.currentTimeMillis();
+            checksum += probe + b[blockCount - 1][512];
+            System.out.println("round " + round
+                    + " small_ms=" + (t1 - t0)
+                    + " large_ms=" + (t2 - t1)
+                    + " settle_ms=" + (t3 - t2));
+        }
+        // The stretch() return values feed checksum, so RESULT would differ
+        // between VMs/machines; keep the comparable part separate.
+        long comparable = 0;
+        for (int i = 0; i < probeKeys.length; i++) {
+            byte[] def = (byte[]) dict.get(probeKeys[i]);
+            comparable += def[0] + def[def.length - 1];
+        }
+        comparable += blocks[blockCount - 1][512] + blocks.length;
+        if (checksum == Long.MIN_VALUE) {
+            System.out.println("(unreachable sink " + checksum + ")");
+        }
+        System.out.println("RESULT=" + comparable);
+        System.out.println("LARGE_ARRAY_LOAD_DONE");
+    }
+}

--- a/vm/benchmarks/src/com/bench/LargeArrayLoad.java
+++ b/vm/benchmarks/src/com/bench/LargeArrayLoad.java
@@ -43,6 +43,14 @@ import java.util.Hashtable;
  * (measured on this workload: unfixed 15 cycles, fixed 6, stable across
  * runs; wall-clock phase times only inflate when cycles contend with the
  * mutator, which depends on core count and machine load).
+ *
+ * KEEP IN SYNC with the CI twin: vm/tests/src/test/resources/com/codename1/
+ * tools/translator/LargeArrayGcApp.java is this workload verbatim (default
+ * package, plus a completion marker line). Any change to the workload shape
+ * or checksum here must be mirrored there; both must keep printing the same
+ * RESULT= value (currently 1099), which the integration test asserts against
+ * a host JVM run, so a one-sided edit shows up as a parity break rather than
+ * silently weakening the guard.
  */
 public class LargeArrayLoad {
     static Hashtable dict;      // survivor set for the current round

--- a/vm/benchmarks/src/com/bench/SleepEdge.java
+++ b/vm/benchmarks/src/com/bench/SleepEdge.java
@@ -49,8 +49,17 @@ public class SleepEdge {
         parked.start();
         Thread.sleep(300);
         boolean stillParked = parked.isAlive();
-        System.out.println("small_elapsed=" + elapsed + " parkedAlive=" + stillParked);
-        System.out.println(elapsed >= 50 && elapsed < 2000 && stillParked
+        // Negative millis must throw IllegalArgumentException (JDK contract),
+        // not return immediately or park.
+        boolean negativeThrew = false;
+        try {
+            Thread.sleep(-1);
+        } catch (IllegalArgumentException e) {
+            negativeThrew = true;
+        }
+        System.out.println("small_elapsed=" + elapsed + " parkedAlive=" + stillParked
+                + " negativeThrew=" + negativeThrew);
+        System.out.println(elapsed >= 50 && elapsed < 2000 && stillParked && negativeThrew
                 ? "SLEEP_EDGE_OK" : "SLEEP_EDGE_FAIL");
         System.exit(0);
     }

--- a/vm/benchmarks/src/com/bench/SleepEdge.java
+++ b/vm/benchmarks/src/com/bench/SleepEdge.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.bench;
+
+/** Thread.sleep edge cases: tiny, zero, and saturating-huge with interrupt. */
+public class SleepEdge {
+    public static void main(String[] args) throws Exception {
+        long t0 = System.currentTimeMillis();
+        Thread.sleep(0);
+        Thread.sleep(1);
+        Thread.sleep(50);
+        long elapsed = System.currentTimeMillis() - t0;
+        final Thread parked = new Thread(new Runnable() {
+            public void run() {
+                try {
+                    Thread.sleep(Long.MAX_VALUE);
+                } catch (InterruptedException e) {
+                }
+                System.out.println("PARKED_WOKE");
+            }
+        });
+        parked.start();
+        Thread.sleep(300);
+        if (!parked.isAlive()) {
+            System.out.println("SLEEP_EDGE_FAIL huge sleep returned immediately");
+            System.exit(1);
+        }
+        parked.interrupt();
+        parked.join(5000);
+        System.out.println("small_elapsed=" + elapsed + " parkedAlive=" + parked.isAlive());
+        System.out.println(elapsed >= 50 && elapsed < 2000 && !parked.isAlive()
+                ? "SLEEP_EDGE_OK" : "SLEEP_EDGE_FAIL");
+    }
+}

--- a/vm/benchmarks/src/com/bench/SleepEdge.java
+++ b/vm/benchmarks/src/com/bench/SleepEdge.java
@@ -22,7 +22,15 @@
  */
 package com.bench;
 
-/** Thread.sleep edge cases: tiny, zero, and saturating-huge with interrupt. */
+/**
+ * Thread.sleep edge cases: tiny sleeps stay accurate and a
+ * Thread.sleep(Long.MAX_VALUE) "park this thread" idiom must not return
+ * immediately (the saturating-deadline guard -- an overflowing deadline
+ * wrapped negative and made huge sleeps no-ops). Interrupt semantics are
+ * deliberately NOT asserted: this VM has never delivered
+ * InterruptedException from sleep, and the process exit reaps the parked
+ * daemon-equivalent thread.
+ */
 public class SleepEdge {
     public static void main(String[] args) throws Exception {
         long t0 = System.currentTimeMillis();
@@ -36,19 +44,14 @@ public class SleepEdge {
                     Thread.sleep(Long.MAX_VALUE);
                 } catch (InterruptedException e) {
                 }
-                System.out.println("PARKED_WOKE");
             }
         });
         parked.start();
         Thread.sleep(300);
-        if (!parked.isAlive()) {
-            System.out.println("SLEEP_EDGE_FAIL huge sleep returned immediately");
-            System.exit(1);
-        }
-        parked.interrupt();
-        parked.join(5000);
-        System.out.println("small_elapsed=" + elapsed + " parkedAlive=" + parked.isAlive());
-        System.out.println(elapsed >= 50 && elapsed < 2000 && !parked.isAlive()
+        boolean stillParked = parked.isAlive();
+        System.out.println("small_elapsed=" + elapsed + " parkedAlive=" + stillParked);
+        System.out.println(elapsed >= 50 && elapsed < 2000 && stillParked
                 ? "SLEEP_EDGE_OK" : "SLEEP_EDGE_FAIL");
+        System.exit(0);
     }
 }

--- a/vm/benchmarks/src/com/bench/TimerLatency.java
+++ b/vm/benchmarks/src/com/bench/TimerLatency.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.bench;
+
+/**
+ * Sleep/timer fidelity probe under allocation churn. Guards the
+ * Thread.sleep signal-truncation defect found via issue 5425's PR CI: the
+ * conservative-roots collector signal-stops SLEEPING threads to scan their
+ * stacks, and usleep()/nanosleep() return EINTR without ever being
+ * restarted (SA_RESTART excludes them), so a single-usleep Thread.sleep
+ * was measured sleeping ~20ms of a requested 3000ms on the Linux port --
+ * every java.util.Timer task (ToastBar show/expiry among them) fired
+ * almost immediately. Deviations are SIGNED: the broken behavior is EARLY
+ * fire, which a max(late, 0) metric silently clamps away.
+ */
+public class TimerLatency {
+    static final Object lock = new Object();
+    static int fired;
+    static long[] deviation = new long[30];
+    static volatile boolean stop;
+
+    public static void main(String[] args) throws Exception {
+        Thread churn = new Thread(new Runnable() {
+            public void run() {
+                java.util.Vector<Object> keep = new java.util.Vector<Object>();
+                int i = 0;
+                while (!stop) {
+                    byte[] b = new byte[4096];
+                    b[0] = (byte) i;
+                    if ((i++ & 127) == 0) {
+                        keep.clear();
+                    }
+                    keep.addElement(b);
+                    if ((i & 1023) == 0) {
+                        try { Thread.sleep(1); } catch (Exception e) { }
+                    }
+                }
+            }
+        });
+        churn.start();
+        for (int i = 0; i < 30; i++) {
+            final long scheduled = System.currentTimeMillis();
+            final long delay = 100 + (i % 5) * 100;
+            final int slot = i;
+            new java.util.Timer().schedule(new java.util.TimerTask() {
+                public void run() {
+                    long d = System.currentTimeMillis() - scheduled - delay;
+                    synchronized (lock) {
+                        deviation[slot] = d;
+                        fired++;
+                        lock.notifyAll();
+                    }
+                }
+            }, delay);
+            Thread.sleep(40);
+        }
+        long deadline = System.currentTimeMillis() + 20000;
+        synchronized (lock) {
+            while (fired < 30 && System.currentTimeMillis() < deadline) {
+                lock.wait(500);
+            }
+        }
+        // direct sleep-truncation probe: the broken VM returned in ~20ms
+        long minSleep = Long.MAX_VALUE;
+        for (int i = 0; i < 3; i++) {
+            long t0 = System.currentTimeMillis();
+            Thread.sleep(1500);
+            minSleep = Math.min(minSleep, System.currentTimeMillis() - t0);
+        }
+        stop = true;
+        long maxLate = 0, maxEarly = 0;
+        for (long d : deviation) {
+            maxLate = Math.max(maxLate, d);
+            maxEarly = Math.min(maxEarly, d);
+        }
+        System.out.println("fired=" + fired
+                + " max_late_ms=" + maxLate
+                + " max_early_ms=" + (-maxEarly)
+                + " min_sleep1500_ms=" + minSleep);
+        boolean healthy = fired == 30 && maxEarly > -50 && minSleep >= 1400;
+        System.out.println(healthy ? "TIMER_LATENCY_OK" : "TIMER_LATENCY_DEGRADED");
+        System.out.println("TIMER_LATENCY_DONE");
+        System.exit(0);
+    }
+}

--- a/vm/benchmarks/src/com/bench/TimerLatency.java
+++ b/vm/benchmarks/src/com/bench/TimerLatency.java
@@ -63,6 +63,11 @@ public class TimerLatency {
             final long scheduled = System.currentTimeMillis();
             final long delay = 100 + (i % 5) * 100;
             final int slot = i;
+            // One Timer per task is intentional, not an oversight: ParparVM's
+            // java.util.Timer spawns a dedicated thread per schedule() call
+            // anyway (see JavaAPI Timer.T), so a shared Timer would not reduce
+            // thread count -- and per-thread Thread.sleep is exactly the code
+            // path under test.
             new java.util.Timer().schedule(new java.util.TimerTask() {
                 public void run() {
                     long d = System.currentTimeMillis() - scheduled - delay;

--- a/vm/tests/src/test/java/com/codename1/tools/translator/JavascriptOpcodeCoverageTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/JavascriptOpcodeCoverageTest.java
@@ -54,6 +54,8 @@ class JavascriptOpcodeCoverageTest {
                 "Runtime should expose notifyAll() native support");
         assertTrue(runtime.contains("cn1_java_lang_Thread_sleep_long") || runtime.contains("cn1_java_lang_Thread_sleep___long"),
                 "Runtime should expose sleep() native support");
+        assertTrue(runtime.contains("cn1_java_lang_Thread_sleepImpl_long") || runtime.contains("cn1_java_lang_Thread_sleepImpl___long"),
+                "Runtime should expose sleepImpl() native support (Thread.sleep is now a Java wrapper over it)");
     }
 
     @Test

--- a/vm/tests/src/test/java/com/codename1/tools/translator/JavascriptOpcodeCoverageTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/JavascriptOpcodeCoverageTest.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.tools.translator;
 
 import org.junit.jupiter.api.Test;

--- a/vm/tests/src/test/java/com/codename1/tools/translator/LargeArrayGcIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/LargeArrayGcIntegrationTest.java
@@ -198,15 +198,28 @@ class LargeArrayGcIntegrationTest {
         if (root == null || !Files.exists(root)) {
             return;
         }
+        // Best effort -- a locked file must not fail the test -- but not silent:
+        // the translated build tree is large, so leaked roots on a self-hosted
+        // runner need a breadcrumb for triage. One line per root, first failure.
+        final java.io.IOException[] firstFailure = new java.io.IOException[1];
         try (java.util.stream.Stream<Path> walk = Files.walk(root)) {
             walk.sorted(java.util.Comparator.reverseOrder()).forEach(p -> {
                 try {
                     Files.deleteIfExists(p);
-                } catch (java.io.IOException ignore) {
-                    // best effort -- a locked file must not fail the test
+                } catch (java.io.IOException e) {
+                    if (firstFailure[0] == null) {
+                        firstFailure[0] = e;
+                    }
                 }
             });
-        } catch (java.io.IOException ignore) {
+        } catch (java.io.IOException e) {
+            if (firstFailure[0] == null) {
+                firstFailure[0] = e;
+            }
+        }
+        if (firstFailure[0] != null) {
+            System.err.println("LargeArrayGcIntegrationTest: temp cleanup incomplete under "
+                    + root + " (first failure: " + firstFailure[0] + ")");
         }
     }
 

--- a/vm/tests/src/test/java/com/codename1/tools/translator/LargeArrayGcIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/LargeArrayGcIntegrationTest.java
@@ -73,9 +73,25 @@ class LargeArrayGcIntegrationTest {
     void largeArrayLoadStaysFlatAcrossRounds() throws Exception {
         Parser.cleanup();
 
+        List<Path> tempDirs = new ArrayList<>();
+        try {
+            runLargeArrayLoad(tempDirs);
+        } finally {
+            // The translated CMake build tree is large; don't let repeated runs
+            // accumulate it on self-hosted runners.
+            for (Path dir : tempDirs) {
+                deleteRecursively(dir);
+            }
+        }
+    }
+
+    private void runLargeArrayLoad(List<Path> tempDirs) throws Exception {
         Path sourceDir = Files.createTempDirectory("large-array-gc-sources");
         Path classesDir = Files.createTempDirectory("large-array-gc-classes");
         Path javaApiDir = Files.createTempDirectory("large-array-gc-javaapi");
+        tempDirs.add(sourceDir);
+        tempDirs.add(classesDir);
+        tempDirs.add(javaApiDir);
 
         Path source = sourceDir.resolve("LargeArrayGcApp.java");
         Files.write(source, loadAppSource().getBytes(StandardCharsets.UTF_8));
@@ -117,6 +133,7 @@ class LargeArrayGcIntegrationTest {
         CompilerHelper.copyDirectory(javaApiDir, classesDir);
 
         Path outputDir = Files.createTempDirectory("large-array-gc-output");
+        tempDirs.add(outputDir);
         CleanTargetIntegrationTest.runTranslator(classesDir, outputDir, "LargeArrayGcApp");
 
         Path distDir = outputDir.resolve("dist");
@@ -175,6 +192,22 @@ class LargeArrayGcIntegrationTest {
         System.err.println("[LargeArrayGcIntegrationTest] cycles=" + cycles);
         System.err.println("[LargeArrayGcIntegrationTest] JavaSE\n" + javaOutput);
         System.err.println("[LargeArrayGcIntegrationTest] ParparVM\n" + vmOutput);
+    }
+
+    private static void deleteRecursively(Path root) {
+        if (root == null || !Files.exists(root)) {
+            return;
+        }
+        try (java.util.stream.Stream<Path> walk = Files.walk(root)) {
+            walk.sorted(java.util.Comparator.reverseOrder()).forEach(p -> {
+                try {
+                    Files.deleteIfExists(p);
+                } catch (java.io.IOException ignore) {
+                    // best effort -- a locked file must not fail the test
+                }
+            });
+        } catch (java.io.IOException ignore) {
+        }
     }
 
     private String loadAppSource() throws Exception {

--- a/vm/tests/src/test/java/com/codename1/tools/translator/LargeArrayGcIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/LargeArrayGcIntegrationTest.java
@@ -1,0 +1,259 @@
+package com.codename1.tools.translator;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Regression guard for the issue-5425 large-array GC storm (final Dtest shape).
+ *
+ * <p>Large arrays (above CN1_BIBOP_MAX_OBJECT) always take the legacy
+ * allocation path. Before the fix, their allocation volume re-armed the GC
+ * thread's 200ms high-frequency loop through the pre-BiBOP 1MB threshold, so a
+ * workload that retains a few hundred 10K byte[] blocks -- creating NO garbage
+ * -- kept full collection cycles starting at wall-clock cadence over the whole
+ * survivor set for the entire run. The fixed VM collects only when allocation
+ * VOLUME demands it (24MB budget on both the BiBOP and legacy paths).</p>
+ *
+ * <p>The guard counts collection CYCLES (the VM's env-gated CN1_GC_LOG_CYCLES
+ * tracer, one [GC-CYCLE] stderr line per cycle) rather than phase wall times:
+ * cycle count is deterministic and load-independent, while wall-time inflation
+ * only appears when cycles contend with the mutator, which depends on core
+ * count and runner load. Measured on this workload: unfixed 15 cycles, fixed
+ * 6, exactly stable across runs -- the gate is 10. The app's phases are
+ * stretched to fixed wall durations so the number of re-arm windows is
+ * machine-independent; the fixed VM's count is volume-driven and therefore
+ * also machine-independent. Correctness is pinned by comparing RESULT=
+ * against the same program on the host JVM.</p>
+ */
+@Tag("benchmark")
+class LargeArrayGcIntegrationTest {
+
+    /** Cycle budget: fixed VM measures 6 (volume-driven), unfixed 15+ (cadence-driven). */
+    private static final int MAX_GC_CYCLES = 10;
+
+    @Test
+    void largeArrayLoadStaysFlatAcrossRounds() throws Exception {
+        Parser.cleanup();
+
+        Path sourceDir = Files.createTempDirectory("large-array-gc-sources");
+        Path classesDir = Files.createTempDirectory("large-array-gc-classes");
+        Path javaApiDir = Files.createTempDirectory("large-array-gc-javaapi");
+
+        Path source = sourceDir.resolve("LargeArrayGcApp.java");
+        Files.write(source, loadAppSource().getBytes(StandardCharsets.UTF_8));
+
+        CompilerHelper.CompilerConfig config = selectCompiler();
+        if (config == null) {
+            fail("No compatible compiler available for large-array GC integration test");
+        }
+
+        assertTrue(CompilerHelper.isJavaApiCompatible(config),
+                "JDK " + config.jdkVersion + " must target matching bytecode level for JavaAPI");
+
+        CompilerHelper.compileJavaAPI(javaApiDir, config);
+
+        List<String> compileArgs = new ArrayList<>();
+        compileArgs.add("-source");
+        compileArgs.add(config.targetVersion);
+        compileArgs.add("-target");
+        compileArgs.add(config.targetVersion);
+        if (CompilerHelper.useClasspath(config)) {
+            compileArgs.add("-classpath");
+            compileArgs.add(javaApiDir.toString());
+        } else {
+            compileArgs.add("-bootclasspath");
+            compileArgs.add(javaApiDir.toString());
+            compileArgs.add("-Xlint:-options");
+        }
+        compileArgs.add("-d");
+        compileArgs.add(classesDir.toString());
+        compileArgs.add(source.toString());
+
+        int compileResult = CompilerHelper.compile(config.jdkHome, compileArgs);
+        assertEquals(0, compileResult, "LargeArrayGcApp should compile. " + CompilerHelper.getLastErrorLog());
+
+        String javaOutput = runJavaMain(config, classesDir, javaApiDir);
+        String javaResult = extractLine(javaOutput, "RESULT=");
+        assertTrue(javaResult.startsWith("RESULT="), "JavaSE should produce RESULT=. Output: " + javaOutput);
+
+        CompilerHelper.copyDirectory(javaApiDir, classesDir);
+
+        Path outputDir = Files.createTempDirectory("large-array-gc-output");
+        CleanTargetIntegrationTest.runTranslator(classesDir, outputDir, "LargeArrayGcApp");
+
+        Path distDir = outputDir.resolve("dist");
+        Path cmakeLists = distDir.resolve("CMakeLists.txt");
+        assertTrue(Files.exists(cmakeLists), "Translator should emit a CMake project");
+
+        CleanTargetIntegrationTest.replaceLibraryWithExecutableTarget(cmakeLists, "LargeArrayGcApp-src");
+
+        Path buildDir = distDir.resolve("build");
+        Files.createDirectories(buildDir);
+
+        CleanTargetIntegrationTest.runCommand(Arrays.asList(
+                "cmake",
+                "-S", distDir.toString(),
+                "-B", buildDir.toString(),
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DCMAKE_C_COMPILER=clang",
+                "-DCMAKE_OBJC_COMPILER=clang"
+        ), distDir);
+
+        CleanTargetIntegrationTest.runCommand(Arrays.asList("cmake", "--build", buildDir.toString()), distDir);
+
+        Path executable = buildDir.resolve("LargeArrayGcApp");
+        assertTrue(Files.exists(executable), "ParparVM build should produce a runnable executable");
+        String vmOutput = runVmBenchmarkWithRetry(executable, buildDir);
+        String vmResult = extractLine(vmOutput, "RESULT=");
+        assertEquals(javaResult, vmResult,
+                "JavaSE and ParparVM should produce identical RESULT signatures\n"
+                        + "--- JavaSE output ---\n" + javaOutput
+                        + "\n--- ParparVM output ---\n" + vmOutput);
+        assertTrue(vmOutput.contains("LARGE_ARRAY_GC_DONE"),
+                "ParparVM run should complete all rounds. Output: " + vmOutput);
+
+        // Storm detector: count collection cycles over the whole run. On the
+        // fixed VM, collection is volume-driven -- this workload's ~7MB/round
+        // crosses the 24MB budget about every third round (6 cycles measured).
+        // On the regressed VM the pre-BiBOP 1MB re-arm keeps cycles starting at
+        // wall-clock cadence for the entire run (15 measured). Cycle count is
+        // deterministic and independent of runner speed and load.
+        int cycles = 0;
+        for (String line : vmOutput.split("\\R")) {
+            if (line.contains("[GC-CYCLE]")) {
+                cycles++;
+            }
+        }
+        assertTrue(cycles > 0,
+                "Expected at least one [GC-CYCLE] line -- CN1_GC_LOG_CYCLES tracer "
+                        + "did not fire; the guard cannot observe the collector. Output: " + vmOutput);
+        assertTrue(cycles <= MAX_GC_CYCLES,
+                "GC ran " + cycles + " cycles over the large-array load (budget " + MAX_GC_CYCLES
+                        + "). This is the issue-5425 storm signature: legacy/large allocations "
+                        + "re-arming continuous collection cycles through the pre-BiBOP 1MB "
+                        + "isHighFrequencyGC threshold instead of the 24MB volume budget."
+                        + "\n--- ParparVM output ---\n" + vmOutput);
+
+        System.err.println("[LargeArrayGcIntegrationTest] cycles=" + cycles);
+        System.err.println("[LargeArrayGcIntegrationTest] JavaSE\n" + javaOutput);
+        System.err.println("[LargeArrayGcIntegrationTest] ParparVM\n" + vmOutput);
+    }
+
+    private String loadAppSource() throws Exception {
+        java.io.InputStream in = LargeArrayGcIntegrationTest.class.getResourceAsStream("/com/codename1/tools/translator/LargeArrayGcApp.java");
+        assertNotNull(in, "LargeArrayGcApp.java test resource should exist");
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
+            return reader.lines().collect(Collectors.joining("\n")) + "\n";
+        }
+    }
+
+    private String runJavaMain(CompilerHelper.CompilerConfig config, Path classesDir, Path javaApiDir) throws Exception {
+        String javaExe = config.jdkHome.resolve("bin").resolve("java").toString();
+        if (System.getProperty("os.name").toLowerCase().contains("win")) {
+            javaExe += ".exe";
+        }
+
+        ProcessBuilder pb = new ProcessBuilder(
+                javaExe,
+                "-cp",
+                classesDir + System.getProperty("path.separator") + javaApiDir,
+                "LargeArrayGcApp"
+        );
+        pb.redirectErrorStream(true);
+
+        Process process = pb.start();
+        String output;
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+            output = reader.lines().collect(Collectors.joining("\n"));
+        }
+
+        int exitCode = process.waitFor();
+        assertEquals(0, exitCode, "JVM run should exit cleanly. Output: " + output);
+        return output;
+    }
+
+    private String extractLine(String output, String prefix) {
+        for (String line : output.split("\\R")) {
+            if (line.startsWith(prefix)) {
+                return line.trim();
+            }
+        }
+        return "";
+    }
+
+    private CompilerHelper.CompilerConfig selectCompiler() {
+        String[] preferredTargets = {"11", "17", "21", "25", "1.8"};
+        for (String target : preferredTargets) {
+            List<CompilerHelper.CompilerConfig> configs = CompilerHelper.getAvailableCompilers(target);
+            for (CompilerHelper.CompilerConfig config : configs) {
+                if (CompilerHelper.isJavaApiCompatible(config)) {
+                    return config;
+                }
+            }
+        }
+        return null;
+    }
+
+    private String runVmBenchmarkWithRetry(Path executable, Path workingDir) throws Exception {
+        final int maxAttempts = 4;
+        AssertionFailedError lastSegfaultFailure = null;
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                return runWithCycleTracer(executable, workingDir);
+            } catch (AssertionFailedError failure) {
+                if (!looksLikeSegmentationFault(failure)) {
+                    throw failure;
+                }
+                lastSegfaultFailure = failure;
+                if (attempt < maxAttempts) {
+                    Thread.sleep(100L * attempt);
+                }
+            }
+        }
+        throw lastSegfaultFailure;
+    }
+
+    /**
+     * Like CleanTargetIntegrationTest.runCommand, but with CN1_GC_LOG_CYCLES=1 in
+     * the environment so the VM emits one [GC-CYCLE] stderr line per collection
+     * cycle (stderr is merged into the returned output).
+     */
+    private String runWithCycleTracer(Path executable, Path workingDir) throws Exception {
+        ProcessBuilder builder = new ProcessBuilder(executable.toString());
+        builder.directory(workingDir.toFile());
+        builder.environment().put("CN1_GC_LOG_CYCLES", "1");
+        builder.redirectErrorStream(true);
+        Process process = builder.start();
+        String output;
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+            output = reader.lines().collect(Collectors.joining("\n"));
+        }
+        int exit = process.waitFor();
+        assertEquals(0, exit, "Command failed: " + executable + "\nOutput:\n" + output);
+        return output;
+    }
+
+    private boolean looksLikeSegmentationFault(AssertionFailedError failure) {
+        String message = failure.getMessage();
+        if (message == null) {
+            return false;
+        }
+        return message.contains("but was: <139>") || message.contains("Segmentation fault");
+    }
+}

--- a/vm/tests/src/test/java/com/codename1/tools/translator/LargeArrayGcIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/LargeArrayGcIntegrationTest.java
@@ -267,7 +267,12 @@ class LargeArrayGcIntegrationTest {
             output = reader.lines().collect(Collectors.joining("\n"));
         }
         int exit = process.waitFor();
-        assertEquals(0, exit, "Command failed: " + executable + "\nOutput:\n" + output);
+        if (exit != 0) {
+            // Controlled message: the retry logic keys on the VM_RUN_EXIT marker
+            // instead of JUnit's assertion-message format, which is not a stable API.
+            throw new AssertionFailedError(
+                    "VM_RUN_EXIT(" + exit + ") for " + executable + "\nOutput:\n" + output);
+        }
         return output;
     }
 
@@ -276,6 +281,8 @@ class LargeArrayGcIntegrationTest {
         if (message == null) {
             return false;
         }
-        return message.contains("but was: <139>") || message.contains("Segmentation fault");
+        // 139 = 128+SIGSEGV from the shell-style exit code the JVM reports for a
+        // crashed child process.
+        return message.contains("VM_RUN_EXIT(139)") || message.contains("Segmentation fault");
     }
 }

--- a/vm/tests/src/test/java/com/codename1/tools/translator/LargeArrayGcIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/LargeArrayGcIntegrationTest.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.tools.translator;
 
 import org.junit.jupiter.api.Tag;

--- a/vm/tests/src/test/resources/com/codename1/tools/translator/LargeArrayGcApp.java
+++ b/vm/tests/src/test/resources/com/codename1/tools/translator/LargeArrayGcApp.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 import java.util.Hashtable;
 
 /**

--- a/vm/tests/src/test/resources/com/codename1/tools/translator/LargeArrayGcApp.java
+++ b/vm/tests/src/test/resources/com/codename1/tools/translator/LargeArrayGcApp.java
@@ -1,0 +1,109 @@
+import java.util.Hashtable;
+
+/**
+ * Models the FINAL issue-5425 Dtest shape (see com.bench.LargeArrayLoad in
+ * vm/benchmarks, which this mirrors): pass 1 builds a persistent survivor set
+ * of SMALL (BiBOP-resident) objects, pass 2 allocates ONLY LARGE
+ * (>CN1_BIBOP_MAX_OBJECT, legacy-path) retained byte[] blocks -- the
+ * reporter's volume shape, producing NO garbage. Each pass is stretched to a
+ * fixed WALL duration with allocation-free compute, so the number of 200ms GC
+ * re-arm windows per phase is machine-independent.
+ *
+ * Guards the legacy-allocation GC-trigger regression: through the pre-BiBOP
+ * 1MB isHighFrequencyGC threshold, this workload kept a full collection cycle
+ * starting every re-arm window for the entire run ("allocating the large
+ * arrays is triggering a global multiple times"), while the fixed VM (24MB
+ * budget, event-driven legacy trigger) collects only when allocation VOLUME
+ * demands it. The harness runs this with CN1_GC_LOG_CYCLES=1 and counts
+ * [GC-CYCLE] stderr lines -- the load-independent observable (measured:
+ * unfixed 15 cycles, fixed 6, stable across runs).
+ */
+public class LargeArrayGcApp {
+    static Hashtable dict;      // survivor set for the current round
+    static byte[][] blocks;     // retained large arrays for the current round
+
+    // Spin without allocating until the phase has lasted stretchMs.
+    private static long stretch(long phaseStart, long stretchMs, long seed) {
+        long v = seed;
+        while (System.currentTimeMillis() - phaseStart < stretchMs) {
+            for (int i = 0; i < 5000; i++) {
+                v = v * 6364136223846793005L + 1442695040888963407L;
+            }
+        }
+        return v;
+    }
+
+    public static void main(String[] args) {
+        int rounds = 12;
+        int smallCount = 15000;
+        int blockCount = 400;      // ~4MB of 10K blocks per round: above the old
+        int blockSize = 10240;     // 1MB re-arm, well below the 24MB budget
+        long stretchMs = 400;
+        long checksum = 0;
+        StringBuilder sb = new StringBuilder();
+        String[] probeKeys = new String[smallCount >> 9];
+        for (int round = 0; round < rounds; round++) {
+            long t0 = System.currentTimeMillis();
+            // Pass 1: persistent small objects (Hashtable nodes, keys, tiny
+            // byte[] defs) -- BiBOP-sized, ~100% survival for the round.
+            Hashtable h = new Hashtable();
+            for (int i = 0; i < smallCount; i++) {
+                sb.setLength(0);
+                sb.append("word");
+                sb.append(i);
+                String key = sb.toString();
+                byte[] def = new byte[16 + (i & 31)];
+                def[0] = (byte) i;
+                def[def.length - 1] = (byte) (i >> 8);
+                h.put(key, def);
+                if ((i & 511) == 0 && (i >> 9) < probeKeys.length) {
+                    probeKeys[i >> 9] = key;
+                }
+            }
+            dict = h;
+            checksum += stretch(t0, stretchMs, round);
+            long t1 = System.currentTimeMillis();
+            // Pass 2: ONLY large retained arrays -- the legacy allocation
+            // path. No garbage is produced here at all.
+            byte[][] b = new byte[blockCount][];
+            for (int i = 0; i < blockCount; i++) {
+                byte[] blk = new byte[blockSize];
+                for (int j = 0; j < blockSize; j += 512) {
+                    blk[j] = (byte) (i + j);
+                }
+                b[i] = blk;
+            }
+            blocks = b;
+            checksum += stretch(t1, stretchMs, round + 31);
+            long t2 = System.currentTimeMillis();
+            // Pass 3: allocation-free lookups -- models the app using the
+            // loaded dictionary.
+            long probe = 0;
+            for (int rep = 0; rep < 40; rep++) {
+                for (int i = 0; i < probeKeys.length; i++) {
+                    byte[] def = (byte[]) h.get(probeKeys[i]);
+                    probe += def[0];
+                }
+            }
+            long t3 = System.currentTimeMillis();
+            checksum += probe + b[blockCount - 1][512];
+            System.out.println("round " + round
+                    + " small_ms=" + (t1 - t0)
+                    + " large_ms=" + (t2 - t1)
+                    + " settle_ms=" + (t3 - t2));
+        }
+        // The stretch() return values feed checksum, so it would differ
+        // between machines; keep the comparable part separate.
+        long comparable = 0;
+        for (int i = 0; i < probeKeys.length; i++) {
+            byte[] def = (byte[]) dict.get(probeKeys[i]);
+            comparable += def[0] + def[def.length - 1];
+        }
+        comparable += blocks[blockCount - 1][512] + blocks.length;
+        if (checksum == Long.MIN_VALUE) {
+            System.out.println("(unreachable sink " + checksum + ")");
+        }
+        System.out.println("RESULT=" + comparable);
+        System.out.println("LARGE_ARRAY_GC_DONE");
+    }
+}

--- a/vm/tests/src/test/resources/com/codename1/tools/translator/LargeArrayGcApp.java
+++ b/vm/tests/src/test/resources/com/codename1/tools/translator/LargeArrayGcApp.java
@@ -39,6 +39,12 @@ import java.util.Hashtable;
  * demands it. The harness runs this with CN1_GC_LOG_CYCLES=1 and counts
  * [GC-CYCLE] stderr lines -- the load-independent observable (measured:
  * unfixed 15 cycles, fixed 6, stable across runs).
+ *
+ * KEEP IN SYNC with com.bench.LargeArrayLoad (vm/benchmarks): this file is
+ * that workload verbatim, differing only in package/class name and the
+ * LARGE_ARRAY_GC_DONE marker. Edit both together; the shared RESULT= value
+ * (currently 1099) is host-JVM-asserted by LargeArrayGcIntegrationTest, so a
+ * one-sided edit surfaces as a parity break instead of silent drift.
  */
 public class LargeArrayGcApp {
     static Hashtable dict;      // survivor set for the current round


### PR DESCRIPTION
Fixes the remaining slowdown in #5425 (final Dtest shape from the last comments: a persistent survivor set plus a pass that retains only large 10K `byte[]` blocks and produces **no garbage**, yet took 450s on iOS vs 4s on Android, with the reporter observing "allocating the large arrays is triggering a global multiple times"). Along the way, CI validation surfaced and this PR also fixes a second long-standing VM defect: `Thread.sleep` truncation by signals.

## Fix 1: GC trigger asymmetry for large/legacy allocations

**Root cause:** arrays above `CN1_BIBOP_MAX_OBJECT` (512 bytes) always take the legacy allocation path. That path's only byte-based GC signal was the pre-BiBOP **1MB** `isHighFrequencyGC` re-arm, which keeps the GC thread starting a full mark/sweep cycle every 200ms wait interval for as long as ≥1MB was allocated since the last cycle. BiBOP allocations got a modern 24MB (adaptive up to 192MB) trigger, but the legacy path was never re-tuned — it re-armed **24× more aggressively**, keeping full collections running at wall-clock cadence over the whole survivor set.

**Change** (behavioral pieces `#ifndef CN1_DISABLE_BIBOP`):
1. `cn1LegacyBytesSinceGc` — per-cycle byte counter (64-bit; `long` is 32-bit on the Windows LLP64 target) for legacy allocations, reset in `cn1BibopBeginGcCycle` (same atomic-exchange idiom as `bibopBytesSinceGc`).
2. Level-triggered, per-cycle-latched async `System.gc()` in `codenameOneGcMalloc`'s legacy tail when legacy volume crosses `CN1_LEGACY_GC_TRIGGER_BYTES` (24MB, `-D` overridable): the latch (`cn1LegacyGcScheduled`, cleared at cycle begin) bounds it to one schedule per cycle window, while level-triggering means a crossing suppressed by the native-bracket gate (mirrored from `cn1BibopMaybeGc`, applied when conservative roots are off) is retried by the next out-of-bracket legacy allocation instead of being lost.
3. `isHighFrequencyGC` re-arms at `max(1MB, bibopGcTriggerBytes)` — collection scheduling is event-driven on both paths, so the 200ms loop only re-arms when volume would have crossed the trigger anyway.
4. `CN1_GC_LOG_CYCLES` env-gated cycle tracer in `codenameOneGCMark` (deliberately available in `CN1_DISABLE_BIBOP` A/B builds too; behavior-identical when unset).

**Measured:** cycle count over the guarded workload — unfixed **15** (wall-clock cadence) vs fixed **6** (volume-driven), exactly stable across runs. On the fast-loop shape the storm showed as 10–15× inflated `large_ms` rounds and 4–8× higher sys CPU.

## Fix 2: Thread.sleep truncated by signals (found via this PR's CI)

The quieter GC exposed a deterministic Linux-suite failure (`ToastBarTopPosition` missing on both arches, 5/5 rounds). Local reproduction on the translated GTK port showed **`Thread.sleep(3000)` returning after ~20ms**: `usleep`/`nanosleep` return `EINTR` on any signal and POSIX never restarts them (`SA_RESTART` excludes them), while the conservative-roots collector signal-stops sleeping threads every cycle to scan their stacks. `java.util.Timer` schedules through `Thread.sleep`, so every `TimerTask` fired almost immediately — ToastBar's 10-minute expiry dismissed the toast mid-test, which is exactly the observed re-show/poll loop timeout.

**Change:** `Thread.sleep` now sleeps on a monotonic deadline (QueryPerformanceCounter via the `cn1_win_compat` shim on the MSVC target) and resumes across early wakeups, chunked <1s (POSIX allows `usleep(>=1e6)` to fail with `EINVAL` on musl — long sleeps were silent no-ops there). The deadline saturates instead of overflowing for `Long.MAX_VALUE`-style arguments, negative millis throw `IllegalArgumentException` per the JDK contract (guarded in Java; the native is now `sleepImpl`), and the sleeper parks with `CN1_GC_PARK_CAPTURE` per the `CN1_YIELD_THREAD` contract so its native-stack roots are scannable on Windows, which has no signal-stop fallback. Interrupt semantics are deliberately unchanged: ParparVM's `Thread.interrupt()` has always been flag-only (`sleep` never threw `InterruptedException` and never woke early by design), and the resume loop preserves exactly that — it neither delivers the exception nor invents a silent early wake.

**Measured** on the translated Linux port under Xvfb: `Thread.sleep(3000)` → 3000/3000/3001/3000/3000ms (was 19–26ms); the ToastBar show/poll choreography runs to completion.

## Benchmark + CI regression guard

- `vm/benchmarks/src/com/bench/LargeArrayLoad.java` — models the final Dtest (persistent small survivors; retained large arrays only; allocation-free lookups; wall-stretched phases).
- `vm/tests/.../LargeArrayGcIntegrationTest.java` (+ app resource, `@Tag("benchmark")`) — asserts `RESULT=` parity with the host JVM and gates on **collection cycle count** (≤10) via the tracer; load-independent, unlike wall-time assertions (verified flaky and rejected).
- The Linux screenshot gate now dumps app-side `CN1SS` diagnostics on failure, and `ToastBarTopPositionScreenshotTest` traces its poll state during extended waits — both were what made the sleep defect findable.

## Validation

- Integration test passes on the fixed VM and fails on the unfixed VM (6 vs 15 cycles).
- Full local gauntlet green after **both** fixes: MapTorture, SbTorture, StrCmp, FusedTest, IbpTest, ExcTest, ThreadChurn, SoeTest, TaggedSync, LoadLoop byte-identical to the host JVM; GcStress ×10 + MtStress ×6 across cooperative and `CN1_GC_SIGNAL_STOP=1` stop modes; `RESULT=` parity across host JVM / fixed / unfixed.
- Deeper structural GC costs identified during the audit (adoption densifying the legacy table, per-cycle extent qsort, `placeObjectInHeapCollection` NULL-slot scans) are intentionally untouched — tracked by the existing TODO in the extent-snapshot section of `cn1_globals.m`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133QDXUjHwX9uprkupEgB29