### PR TITLE
Support debug/release qualified provisioning profiles for app extensions

### DIFF
--- a/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
+++ b/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
@@ -539,7 +539,10 @@ Only supported for App Store builds. See https://www.codenameone.com/developer-g
 |Objective-C code injected at the matching marker comment in the generated Wallet extension sources, for custom behavior at each callback (for example adding fields to the issuer endpoint payload in `generateRequestInject`). See the <<Apple Wallet Extension,Apple Wallet Extension chapter>>.
 
 |ios.appext.NAME.provisioningURL
-|Cloud device builds only. URL of the provisioning profile for a generic app extension dropped into `ios/app_extensions/NAME/`, used when the extension folder doesn't bundle a `.mobileprovision` itself. The profile is installed on the build machine and added to the export options per bundle id.
+|Cloud device builds only. URL of the provisioning profile for a generic app extension dropped into `ios/app_extensions/NAME/` (or a generated extension such as `CN1Widgets`), used when the extension folder doesn't bundle a `.mobileprovision` itself. The profile is installed on the build machine and added to the export options per bundle id. Used for both debug and release builds unless a qualified variant (below) is set.
+
+|ios.debug.appext.NAME.provisioningURL / ios.release.appext.NAME.provisioningURL
+|Cloud device builds only. Build-type-specific variants of `ios.appext.NAME.provisioningURL`: point the `debug` variant at the extension's development profile and the `release` variant at its distribution profile. The Maven build resolves the variant matching the build target (`ios-device` and `ios-on-device-debug` are debug, `ios-device-release` is release) into the unqualified hint before submitting the build; the unqualified hint acts as the fallback. The same qualifiers work for the local-path settings `codename1.ios.debug.appext.NAME.provision` / `codename1.ios.release.appext.NAME.provision`.
 
 |codename1.mac.appid
 |Mac Native cloud builds only. The Mac bundle identifier registered in App Store Connect / Apple Developer. Distinct from `codename1.ios.appid` because Apple treats the iOS and Mac App Store records as separate products. Required for cloud Mac builds.

--- a/docs/developer-guide/Apple-Wallet-Extension.asciidoc
+++ b/docs/developer-guide/Apple-Wallet-Extension.asciidoc
@@ -95,7 +95,7 @@ If you already have Xcode extension targets - from an issuer SDK vendor or an ex
 * `Info.plist` with the `NSExtension` dictionary
 * `MyWalletExtension.entitlements`
 * Optional `buildSettings.properties` with Xcode build settings, one per line (set `IPHONEOS_DEPLOYMENT_TARGET=14.0` for Wallet extensions)
-* Optional `.mobileprovision` for cloud device builds (or supply `ios.appext.MyWalletExtension.provisioningURL`)
+* Optional `.mobileprovision` for cloud device builds (or supply `ios.appext.MyWalletExtension.provisioningURL`; qualify it as `ios.debug.appext.MyWalletExtension.provisioningURL` / `ios.release.appext.MyWalletExtension.provisioningURL` to use different development and distribution profiles per build type)
 
 Each folder becomes an embedded extension target with bundle id `<your package>.<folder name>`. This mechanism isn't Wallet-specific - it embeds any iOS app extension type.
 

--- a/docs/developer-guide/External-Surfaces.asciidoc
+++ b/docs/developer-guide/External-Surfaces.asciidoc
@@ -166,6 +166,13 @@ The build generates a `CN1Widgets` WidgetKit extension target into the Xcode pro
 
 Signing follows the generic app extension rules: the extension needs its own App ID (`<your package>.CN1Widgets`) with the App Groups capability and, for cloud device builds with manual signing, its own provisioning profile. Either place the `.mobileprovision` under `common/src/main/resources` or supply a URL with the `ios.appext.CN1Widgets.provisioningURL` build hint. With automatic (managed) signing and in local `ios-source` builds no extra configuration is needed -- Xcode provisions the extension target as usual.
 
+Like the app itself (`codename1.ios.debug.provision` / `codename1.ios.release.provision`), the extension needs a _development_ profile for debug device builds and a _distribution_ profile for release builds. Qualify any extension provisioning key with `debug` or `release` after the `ios.` segment and the build picks the variant matching the build target, falling back to the unqualified key when no matching variant is set:
+
+* Build hints: `codename1.arg.ios.debug.appext.CN1Widgets.provisioningURL` and `codename1.arg.ios.release.appext.CN1Widgets.provisioningURL`
+* Local profile paths in `codenameone_settings.properties`: `codename1.ios.debug.appext.CN1Widgets.provision` and `codename1.ios.release.appext.CN1Widgets.provision`
+
+The Certificate Wizard populates both `provision` variants automatically when it sets up widget extension signing (the development profile requires at least one registered device). An unqualified key alone still works and is used for both build types.
+
 Widget taps deep link back into the app through the `cn1surface://` URL scheme, which the build registers automatically.
 
 ==== Android
@@ -185,7 +192,8 @@ In a desktop build the app shows a tray icon whose menu pins a floating widget p
 | `ios.surfaces.appGroup` | `group.<package>` | The shared App Group id; the `appGroup` field in `surfaces.json` takes precedence
 | `ios.surfaces.deploymentTarget` | `16.1` | Deployment target of the widget extension (the host app is unaffected)
 | `ios.surfaces.frequentUpdates` | `false` | Adds `NSSupportsLiveActivitiesFrequentUpdates` for high-frequency live activity updates
-| `ios.appext.CN1Widgets.provisioningURL` | | URL of the extension's provisioning profile for cloud manual-signing builds
+| `ios.appext.CN1Widgets.provisioningURL` | | URL of the extension's provisioning profile for cloud manual-signing builds; used for both debug and release builds unless a qualified variant is set
+| `ios.debug.appext.CN1Widgets.provisioningURL` / `ios.release.appext.CN1Widgets.provisioningURL` | | Build-type-specific variants: the development profile URL for debug device builds and the distribution profile URL for release builds. The variant matching the build target overrides the unqualified hint
 | `ios.background_modes` | | Add `fetch` so background fetch can re-publish timelines on device
 | `android.surfaces.exactAlarms` | `false` | Schedule widget timeline entry flips with exact alarms; declares `SCHEDULE_EXACT_ALARM` and falls back to the inexact 30-second window when the user revokes the special app access
 | `windows.msix` | `false` | Wrap the Windows build in an MSIX package with a Widgets Board provider

--- a/docs/developer-guide/External-Surfaces.asciidoc
+++ b/docs/developer-guide/External-Surfaces.asciidoc
@@ -193,7 +193,7 @@ In a desktop build the app shows a tray icon whose menu pins a floating widget p
 | `ios.surfaces.deploymentTarget` | `16.1` | Deployment target of the widget extension (the host app is unaffected)
 | `ios.surfaces.frequentUpdates` | `false` | Adds `NSSupportsLiveActivitiesFrequentUpdates` for high-frequency live activity updates
 | `ios.appext.CN1Widgets.provisioningURL` | | URL of the extension's provisioning profile for cloud manual-signing builds; used for both debug and release builds unless a qualified variant is set
-| `ios.debug.appext.CN1Widgets.provisioningURL` / `ios.release.appext.CN1Widgets.provisioningURL` | | Build-type-specific variants: the development profile URL for debug device builds and the distribution profile URL for release builds. The variant matching the build target overrides the unqualified hint
+| `ios.debug.appext.CN1Widgets.provisioningURL` / `ios.release.appext.CN1Widgets.provisioningURL` | | Build-type-specific variants: the URL of the development profile used by debug device builds and the URL of the distribution profile used by release builds. The variant matching the build target overrides the unqualified hint
 | `ios.background_modes` | | Add `fetch` so background fetch can re-publish timelines on device
 | `android.surfaces.exactAlarms` | `false` | Schedule widget timeline entry flips with exact alarms; declares `SCHEDULE_EXACT_ALARM` and falls back to the inexact 30-second window when the user revokes the special app access
 | `windows.msix` | `false` | Wrap the Windows build in an MSIX package with a Widgets Board provider

--- a/docs/developer-guide/signing.asciidoc
+++ b/docs/developer-guide/signing.asciidoc
@@ -341,6 +341,7 @@ The Codename One build servers read signing assets from `codenameone_settings.pr
 * `codename1.ios.debug.certificate` / `codename1.ios.debug.certificatePassword` / `codename1.ios.debug.provision`: Development P12 and provisioning profile for device/debug builds.
 * `codename1.ios.release.certificate` / `codename1.ios.release.certificatePassword` / `codename1.ios.release.provision`: Distribution P12 and provisioning profile for App Store/TestFlight builds.
 * `codename1.ios.certificate`, `codename1.ios.certificatePassword`, and `codename1.ios.provision`: Legacy/global defaults. The IDE uses these as fallbacks when the debug/release-specific properties are blank, so keep them aligned with your preferred certificates.
+* `codename1.ios.appext.<Name>.provision`: Provisioning profile for an embedded app extension (for example the generated `CN1Widgets` widget extension), used for both build types. Add `codename1.ios.debug.appext.<Name>.provision` / `codename1.ios.release.appext.<Name>.provision` to use the development profile for device/debug builds and the distribution profile for release builds; the variant matching the build target wins and the unqualified key is the fallback.
 
 Paths may be absolute or relative to the project directory. The passwords must match the values you used when exporting the P12 files from Keychain Access.
 

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/CN1BuildMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/CN1BuildMojo.java
@@ -536,6 +536,40 @@ public class CN1BuildMojo extends AbstractCN1Mojo {
                 || BUILD_TARGET_WINDOWS_NATIVE_PROJECT.equals(buildTarget));
     }
 
+    /**
+     * Collapses build-type-qualified app-extension keys into the unqualified keys the rest
+     * of the build pipeline understands. Like the app's own signing assets
+     * ({@code codename1.ios.debug.provision} vs {@code codename1.ios.release.provision}),
+     * an extension's provisioning profile differs between development and distribution
+     * builds, so both plain settings ({@code codename1.ios.debug.appext.<Name>.provision})
+     * and build hints ({@code codename1.arg.ios.release.appext.<Name>.provisioningURL})
+     * accept a {@code debug}/{@code release} qualifier after the {@code ios.} segment.
+     * The variant matching the build target overrides the unqualified key; both variants
+     * are removed afterwards so the build server only ever sees the resolved value.
+     */
+    static void resolveAppExtensionBuildTypeQualifiers(Properties props, String buildTarget) {
+        String matching = buildTarget != null && buildTarget.contains("release") ? "release" : "debug";
+        for (String key : new ArrayList<String>(props.stringPropertyNames())) {
+            for (String prefix : new String[] {"codename1.arg.ios.", "codename1.ios."}) {
+                String qualifier;
+                if (key.startsWith(prefix + "debug.appext.")) {
+                    qualifier = "debug";
+                } else if (key.startsWith(prefix + "release.appext.")) {
+                    qualifier = "release";
+                } else {
+                    continue;
+                }
+                String value = props.getProperty(key);
+                props.remove(key);
+                if (qualifier.equals(matching) && value != null && value.trim().length() > 0) {
+                    props.setProperty(prefix + "appext."
+                            + key.substring((prefix + qualifier + ".appext.").length()), value);
+                }
+                break;
+            }
+        }
+    }
+
     private void createAntProject() throws IOException, LibraryPropertiesException, MojoExecutionException, MojoFailureException {
         File cn1dir = new File(project.getBuild().getDirectory() + File.separator + "codenameone");
         File antProject = new File(cn1dir, "antProject");
@@ -782,6 +816,10 @@ public class CN1BuildMojo extends AbstractCN1Mojo {
         // file into, so base64-encode its bytes into the ios.appext.<Name>.provisioningData
         // build arg; the daemon decodes it back to <Name>.mobileprovision before signing.
         // Done generically over <Name>, mirroring the daemon's per-extension plumbing.
+        // Extension profiles differ between build types just like the app's own
+        // (development for device/debug builds, distribution for release), so debug/release
+        // qualified keys are collapsed into the unqualified ones first.
+        resolveAppExtensionBuildTypeQualifiers(cn1SettingsProps, buildTarget);
         String appExtPrefix = "codename1.ios.appext.";
         String appExtSuffix = ".provision";
         for (String settingKey : new ArrayList<String>(cn1SettingsProps.stringPropertyNames())) {

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/CN1BuildMojoAppExtProvisioningTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/CN1BuildMojoAppExtProvisioningTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.maven;
+
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+
+public class CN1BuildMojoAppExtProvisioningTest {
+
+    @Test
+    public void debugBuildPicksDebugQualifiedProvisionSetting() {
+        Properties props = new Properties();
+        props.setProperty("codename1.ios.debug.appext.CN1Widgets.provision", "/certs/dev.mobileprovision");
+        props.setProperty("codename1.ios.release.appext.CN1Widgets.provision", "/certs/dist.mobileprovision");
+
+        CN1BuildMojo.resolveAppExtensionBuildTypeQualifiers(props, "ios-device");
+
+        assertEquals("/certs/dev.mobileprovision",
+                props.getProperty("codename1.ios.appext.CN1Widgets.provision"));
+        assertNull(props.getProperty("codename1.ios.debug.appext.CN1Widgets.provision"));
+        assertNull(props.getProperty("codename1.ios.release.appext.CN1Widgets.provision"));
+    }
+
+    @Test
+    public void releaseBuildPicksReleaseQualifiedProvisioningURLHint() {
+        Properties props = new Properties();
+        props.setProperty("codename1.arg.ios.debug.appext.CN1Widgets.provisioningURL", "https://example.com/dev");
+        props.setProperty("codename1.arg.ios.release.appext.CN1Widgets.provisioningURL", "https://example.com/dist");
+
+        CN1BuildMojo.resolveAppExtensionBuildTypeQualifiers(props, "ios-device-release");
+
+        assertEquals("https://example.com/dist",
+                props.getProperty("codename1.arg.ios.appext.CN1Widgets.provisioningURL"));
+        assertNull(props.getProperty("codename1.arg.ios.debug.appext.CN1Widgets.provisioningURL"));
+        assertNull(props.getProperty("codename1.arg.ios.release.appext.CN1Widgets.provisioningURL"));
+    }
+
+    @Test
+    public void onDeviceDebugTargetCountsAsDebug() {
+        Properties props = new Properties();
+        props.setProperty("codename1.arg.ios.debug.appext.CN1Widgets.provisioningURL", "https://example.com/dev");
+
+        CN1BuildMojo.resolveAppExtensionBuildTypeQualifiers(props, "ios-on-device-debug");
+
+        assertEquals("https://example.com/dev",
+                props.getProperty("codename1.arg.ios.appext.CN1Widgets.provisioningURL"));
+    }
+
+    @Test
+    public void qualifiedKeyOverridesUnqualifiedFallback() {
+        Properties props = new Properties();
+        props.setProperty("codename1.ios.appext.CN1Widgets.provision", "/certs/fallback.mobileprovision");
+        props.setProperty("codename1.ios.debug.appext.CN1Widgets.provision", "/certs/dev.mobileprovision");
+
+        CN1BuildMojo.resolveAppExtensionBuildTypeQualifiers(props, "ios-device");
+
+        assertEquals("/certs/dev.mobileprovision",
+                props.getProperty("codename1.ios.appext.CN1Widgets.provision"));
+    }
+
+    @Test
+    public void unqualifiedFallbackSurvivesWhenOnlyOtherBuildTypeIsQualified() {
+        Properties props = new Properties();
+        props.setProperty("codename1.ios.appext.CN1Widgets.provision", "/certs/fallback.mobileprovision");
+        props.setProperty("codename1.ios.release.appext.CN1Widgets.provision", "/certs/dist.mobileprovision");
+
+        CN1BuildMojo.resolveAppExtensionBuildTypeQualifiers(props, "ios-device");
+
+        assertEquals("/certs/fallback.mobileprovision",
+                props.getProperty("codename1.ios.appext.CN1Widgets.provision"));
+        assertNull(props.getProperty("codename1.ios.release.appext.CN1Widgets.provision"));
+    }
+
+    @Test
+    public void blankQualifiedValueFallsBackToUnqualified() {
+        Properties props = new Properties();
+        props.setProperty("codename1.ios.appext.CN1Widgets.provision", "/certs/fallback.mobileprovision");
+        props.setProperty("codename1.ios.debug.appext.CN1Widgets.provision", "  ");
+
+        CN1BuildMojo.resolveAppExtensionBuildTypeQualifiers(props, "ios-device");
+
+        assertEquals("/certs/fallback.mobileprovision",
+                props.getProperty("codename1.ios.appext.CN1Widgets.provision"));
+        assertFalse(props.containsKey("codename1.ios.debug.appext.CN1Widgets.provision"));
+    }
+
+    @Test
+    public void unrelatedKeysAreLeftAlone() {
+        Properties props = new Properties();
+        props.setProperty("codename1.ios.debug.provision", "/certs/app-dev.mobileprovision");
+        props.setProperty("codename1.arg.ios.debug.teamId", "TEAM123");
+        props.setProperty("codename1.arg.ios.appext.CN1Widgets.provisioningURL", "https://example.com/single");
+
+        CN1BuildMojo.resolveAppExtensionBuildTypeQualifiers(props, "ios-device-release");
+
+        assertEquals("/certs/app-dev.mobileprovision", props.getProperty("codename1.ios.debug.provision"));
+        assertEquals("TEAM123", props.getProperty("codename1.arg.ios.debug.teamId"));
+        assertEquals("https://example.com/single",
+                props.getProperty("codename1.arg.ios.appext.CN1Widgets.provisioningURL"));
+    }
+
+    @Test
+    public void worksGenericallyForAnyExtensionNameAndArg() {
+        Properties props = new Properties();
+        props.setProperty("codename1.arg.ios.release.appext.MyWalletExtension.provisioningURL",
+                "https://example.com/wallet-dist");
+
+        CN1BuildMojo.resolveAppExtensionBuildTypeQualifiers(props, "ios-device-release");
+
+        assertEquals("https://example.com/wallet-dist",
+                props.getProperty("codename1.arg.ios.appext.MyWalletExtension.provisioningURL"));
+    }
+}

--- a/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/CertificateWizard.java
+++ b/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/CertificateWizard.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.certificatewizard;
 
 import com.codename1.certificatewizard.api.CloudSigningService;

--- a/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/CertificateWizard.java
+++ b/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/CertificateWizard.java
@@ -1367,57 +1367,98 @@ public class CertificateWizard extends Lifecycle {
 
     private void createWidgetExtensionProfile(String appName, ProjectDefaults defaults, String extIdentifier,
             Runnable next) {
-        SigningState.Profile existing = findProfile(extIdentifier, PROFILE_APP_STORE);
+        // The extension needs a distribution profile for release builds and a development
+        // profile for debug device builds, mirroring codename1.ios.release.provision /
+        // codename1.ios.debug.provision on the app itself. The App Store profile is
+        // required; the development profile is skipped gracefully when no development
+        // certificate or registered device is available.
+        ensureWidgetExtensionProfile(appName, extIdentifier, PROFILE_APP_STORE, releasePath ->
+                ensureWidgetExtensionProfile(appName, extIdentifier, PROFILE_DEVELOPMENT, debugPath ->
+                        installWidgetExtensionSigning(defaults, releasePath, debugPath, next)));
+    }
+
+    private void ensureWidgetExtensionProfile(String appName, String extIdentifier, String profileType,
+            com.codename1.util.OnComplete<String> onPath) {
+        SigningState.Profile existing = findProfile(extIdentifier, profileType);
         if (existing != null) {
-            downloadWidgetExtensionProfile(defaults, existing, next);
+            downloadWidgetExtensionProfile(existing, profileType, onPath);
             return;
         }
         SigningState.BundleId ext = findBundleByIdentifier(extIdentifier, "IOS");
-        List<SigningState.Certificate> compatible = WizardDecisions.compatibleCertificates(state, PROFILE_APP_STORE);
+        List<SigningState.Certificate> compatible = WizardDecisions.compatibleCertificates(state, profileType);
+        boolean development = PROFILE_DEVELOPMENT.equals(profileType);
         if (ext == null || compatible.isEmpty()) {
+            if (development) {
+                onPath.completed(null);
+                return;
+            }
             showPageMessage("No distribution certificate was available for the widget extension profile.", true);
             return;
         }
         List<String> certs = new ArrayList<String>();
         certs.add(compatible.get(0).appleCertId());
-        String profileName = appName + " Widgets App Store";
-        showPageMessage("Creating widget extension provisioning profile...", false);
-        service.createProfile(profileName, PROFILE_APP_STORE, ext.id(), certs, new ArrayList<String>(), r -> {
+        List<String> devices = deviceIdsFor(profileType);
+        if (!WizardDecisions.canCreateProfile(profileType, ext.id(), certs, devices, appName)) {
+            showPageMessage("Skipped the widget extension development profile: register a device to create development signing assets.", true);
+            onPath.completed(null);
+            return;
+        }
+        String profileName = appName + " Widgets " + (development ? "Development" : "App Store");
+        showPageMessage("Creating widget extension provisioning profile " + profileName + "...", false);
+        service.createProfile(profileName, profileType, ext.id(), certs, devices, r -> {
             if (!r.ok) {
                 showPageMessage(r.message, true);
+                // A failed development profile shouldn't drop the App Store profile that
+                // was already downloaded -- continue and install what we have.
+                if (development) {
+                    onPath.completed(null);
+                }
                 return;
             }
             refreshForAutoSetup(() -> {
-                SigningState.Profile created = findProfile(extIdentifier, PROFILE_APP_STORE);
+                SigningState.Profile created = findProfile(extIdentifier, profileType);
                 if (created == null) {
                     showPageMessage("Widget extension profile was created but could not be found after refresh.", true);
+                    if (development) {
+                        onPath.completed(null);
+                    }
                     return;
                 }
-                downloadWidgetExtensionProfile(defaults, created, next);
+                downloadWidgetExtensionProfile(created, profileType, onPath);
             });
         });
     }
 
-    private void downloadWidgetExtensionProfile(ProjectDefaults defaults, SigningState.Profile profile,
-            Runnable next) {
-        service.downloadProfile(profile.id(), "CN1Widgets.mobileprovision", r -> {
+    private void downloadWidgetExtensionProfile(SigningState.Profile profile, String profileType,
+            com.codename1.util.OnComplete<String> onPath) {
+        String fileName = PROFILE_DEVELOPMENT.equals(profileType)
+                ? "CN1Widgets_Development.mobileprovision" : "CN1Widgets.mobileprovision";
+        service.downloadProfile(profile.id(), fileName, r -> {
             if (!r.ok) {
                 showPageMessage(r.message, true);
+                if (PROFILE_DEVELOPMENT.equals(profileType)) {
+                    onPath.completed(null);
+                }
                 return;
             }
-            try {
-                String groupId = resolveAppGroupIdentifier(defaults);
-                SigningAssetInstaller.applyWidgetExtensionSigning(binding.settings(), groupId, r.value);
-                clearPageMessage();
-                ToastBar.showMessage("Widget extension signing installed", FontImage.MATERIAL_CHECK);
-                if (next != null) {
-                    next.run();
-                }
-            } catch (Exception ex) {
-                Log.e(ex);
-                showPageMessage("Failed to update widget extension settings: " + friendlyMessage(ex), true);
-            }
+            onPath.completed(r.value);
         });
+    }
+
+    private void installWidgetExtensionSigning(ProjectDefaults defaults, String releasePath, String debugPath,
+            Runnable next) {
+        try {
+            String groupId = resolveAppGroupIdentifier(defaults);
+            SigningAssetInstaller.applyWidgetExtensionSigning(binding.settings(), groupId, releasePath, debugPath);
+            clearPageMessage();
+            ToastBar.showMessage("Widget extension signing installed", FontImage.MATERIAL_CHECK);
+            if (next != null) {
+                next.run();
+            }
+        } catch (Exception ex) {
+            Log.e(ex);
+            showPageMessage("Failed to update widget extension settings: " + friendlyMessage(ex), true);
+        }
     }
 
     private void generateAndroidKeystore(String alias, String password, String dname) {

--- a/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/project/SigningAssetInstaller.java
+++ b/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/project/SigningAssetInstaller.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.certificatewizard.project;
 
 import com.codename1.io.FileSystemStorage;

--- a/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/project/SigningAssetInstaller.java
+++ b/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/project/SigningAssetInstaller.java
@@ -57,13 +57,20 @@ public final class SigningAssetInstaller {
     }
 
     public static void applyWidgetExtensionSigning(String settingsPath, String appGroupIdentifier,
-                                                   String extensionProfilePath) throws IOException {
+                                                   String releaseProfilePath, String debugProfilePath)
+            throws IOException {
         Map<String, String> updates = new HashMap<String, String>();
         if (appGroupIdentifier != null) {
             updates.put("codename1.arg.ios.surfaces.appGroup", appGroupIdentifier);
         }
-        if (extensionProfilePath != null) {
-            updates.put("codename1.ios.appext.CN1Widgets.provision", extensionProfilePath);
+        if (releaseProfilePath != null) {
+            // The unqualified key stays populated with the distribution profile so builds
+            // through tooling that predates the debug/release split keep working.
+            updates.put("codename1.ios.appext.CN1Widgets.provision", releaseProfilePath);
+            updates.put("codename1.ios.release.appext.CN1Widgets.provision", releaseProfilePath);
+        }
+        if (debugProfilePath != null) {
+            updates.put("codename1.ios.debug.appext.CN1Widgets.provision", debugProfilePath);
         }
         if (updates.isEmpty()) {
             return;

--- a/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/project/SigningAssetInstaller.java
+++ b/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/project/SigningAssetInstaller.java
@@ -90,8 +90,13 @@ public final class SigningAssetInstaller {
             // through tooling that predates the debug/release split keep working.
             updates.put("codename1.ios.appext.CN1Widgets.provision", releaseProfilePath);
             updates.put("codename1.ios.release.appext.CN1Widgets.provision", releaseProfilePath);
-        }
-        if (debugProfilePath != null) {
+            // Blank rather than skip the debug key when no development profile was
+            // produced: a stale path left by an earlier wizard run would otherwise keep
+            // overriding the unqualified fallback for debug device builds. A blank
+            // qualified key is dropped during build-type resolution.
+            updates.put("codename1.ios.debug.appext.CN1Widgets.provision",
+                    debugProfilePath == null ? "" : debugProfilePath);
+        } else if (debugProfilePath != null) {
             updates.put("codename1.ios.debug.appext.CN1Widgets.provision", debugProfilePath);
         }
         if (updates.isEmpty()) {

--- a/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardModelTest.java
+++ b/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardModelTest.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.certificatewizard;
 
 import com.codename1.certificatewizard.api.MockSigningService;

--- a/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardModelTest.java
+++ b/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardModelTest.java
@@ -211,24 +211,59 @@ class CertificateWizardModelTest {
         certs.add(dist.get(0).appleCertId());
         service.createProfile("My App Widgets App Store", "IOS_APP_STORE", extAppleId, certs,
                 new ArrayList<String>(), r -> assertTrue(r.ok));
+        List<SigningState.Certificate> dev = WizardDecisions.compatibleCertificates(state[0], "IOS_APP_DEVELOPMENT");
+        assertFalse(dev.isEmpty());
+        List<String> devCerts = new ArrayList<String>();
+        devCerts.add(dev.get(0).appleCertId());
+        List<String> deviceIds = new ArrayList<String>();
+        for (SigningState.Device d : state[0].devices) {
+            deviceIds.add(d.id());
+        }
+        assertTrue(WizardDecisions.canCreateProfile("IOS_APP_DEVELOPMENT", extAppleId, devCerts, deviceIds,
+                "My App Widgets Development"));
+        service.createProfile("My App Widgets Development", "IOS_APP_DEVELOPMENT", extAppleId, devCerts,
+                deviceIds, r -> assertTrue(r.ok));
         service.refresh(r -> state[0] = r.value);
-        boolean extProfile = false;
+        boolean extStoreProfile = false;
+        boolean extDevProfile = false;
         for (SigningState.Profile p : state[0].profiles) {
             if (extId.equals(p.bundleId()) && "IOS_APP_STORE".equals(p.profileType())) {
-                extProfile = true;
+                extStoreProfile = true;
+            }
+            if (extId.equals(p.bundleId()) && "IOS_APP_DEVELOPMENT".equals(p.profileType())) {
+                extDevProfile = true;
             }
         }
-        assertTrue(extProfile);
+        assertTrue(extStoreProfile);
+        assertTrue(extDevProfile);
 
         Path settings = Files.createTempFile("cn1-settings", ".properties");
         Files.writeString(settings, "codename1.packageName=com.example.app\n", StandardCharsets.UTF_8);
         SigningAssetInstaller.applyWidgetExtensionSigning(settings.toString(), groupId,
-                "/tmp/CN1Widgets.mobileprovision");
+                "/tmp/CN1Widgets.mobileprovision", "/tmp/CN1Widgets_Development.mobileprovision");
         String written = Files.readString(settings, StandardCharsets.UTF_8);
         assertTrue(written.contains("codename1.arg.ios.surfaces.appGroup=group.com.example.app"));
         assertTrue(written.contains(
                 "codename1.ios.appext.CN1Widgets.provision=/tmp/CN1Widgets.mobileprovision"));
+        assertTrue(written.contains(
+                "codename1.ios.release.appext.CN1Widgets.provision=/tmp/CN1Widgets.mobileprovision"));
+        assertTrue(written.contains(
+                "codename1.ios.debug.appext.CN1Widgets.provision=/tmp/CN1Widgets_Development.mobileprovision"));
         assertTrue(written.contains("codename1.packageName=com.example.app"));
+    }
+
+    @Test
+    void widgetExtensionSigningWithoutDevelopmentProfileOmitsDebugKey() throws Exception {
+        Path settings = Files.createTempFile("cn1-settings", ".properties");
+        Files.writeString(settings, "codename1.packageName=com.example.app\n", StandardCharsets.UTF_8);
+        SigningAssetInstaller.applyWidgetExtensionSigning(settings.toString(), "group.com.example.app",
+                "/tmp/CN1Widgets.mobileprovision", null);
+        String written = Files.readString(settings, StandardCharsets.UTF_8);
+        assertTrue(written.contains(
+                "codename1.ios.appext.CN1Widgets.provision=/tmp/CN1Widgets.mobileprovision"));
+        assertTrue(written.contains(
+                "codename1.ios.release.appext.CN1Widgets.provision=/tmp/CN1Widgets.mobileprovision"));
+        assertFalse(written.contains("codename1.ios.debug.appext.CN1Widgets.provision"));
     }
 
     @Test

--- a/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardModelTest.java
+++ b/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardModelTest.java
@@ -275,9 +275,11 @@ class CertificateWizardModelTest {
     }
 
     @Test
-    void widgetExtensionSigningWithoutDevelopmentProfileOmitsDebugKey() throws Exception {
+    void widgetExtensionSigningWithoutDevelopmentProfileClearsStaleDebugKey() throws Exception {
         Path settings = Files.createTempFile("cn1-settings", ".properties");
-        Files.writeString(settings, "codename1.packageName=com.example.app\n", StandardCharsets.UTF_8);
+        Files.writeString(settings, "codename1.packageName=com.example.app\n"
+                + "codename1.ios.debug.appext.CN1Widgets.provision=/tmp/stale-dev.mobileprovision\n",
+                StandardCharsets.UTF_8);
         SigningAssetInstaller.applyWidgetExtensionSigning(settings.toString(), "group.com.example.app",
                 "/tmp/CN1Widgets.mobileprovision", null);
         String written = Files.readString(settings, StandardCharsets.UTF_8);
@@ -285,7 +287,8 @@ class CertificateWizardModelTest {
                 "codename1.ios.appext.CN1Widgets.provision=/tmp/CN1Widgets.mobileprovision"));
         assertTrue(written.contains(
                 "codename1.ios.release.appext.CN1Widgets.provision=/tmp/CN1Widgets.mobileprovision"));
-        assertFalse(written.contains("codename1.ios.debug.appext.CN1Widgets.provision"));
+        assertFalse(written.contains("stale-dev.mobileprovision"));
+        assertTrue(written.contains("codename1.ios.debug.appext.CN1Widgets.provision=\n"));
     }
 
     @Test

--- a/scripts/developer-guide/run_languagetool.py
+++ b/scripts/developer-guide/run_languagetool.py
@@ -73,6 +73,12 @@ SKIP_ELEMENT_ATTRS = {
     # Footer / header metadata blocks rarely contain prose worth checking.
     ("div", "id", "footer"),
     ("div", "id", "footer-text"),
+    # The document-header byline: author list plus the revision line built
+    # from the -a revnumber attribute. CI passes the git branch name as the
+    # revision, so any branch whose name isn't a dictionary word (e.g.
+    # "claude/surfaces-feature-issue-zm044b") produced a spurious
+    # MORFOLOGIK_RULE_EN_US match. None of it is prose.
+    ("div", "class", "details"),
 }
 
 


### PR DESCRIPTION
## Summary

Add support for build-type-qualified provisioning profiles for iOS app extensions (like CN1Widgets), mirroring the existing debug/release qualification system for the main app. This allows extensions to use development profiles for debug device builds and distribution profiles for release builds.

## Key Changes

- **CN1BuildMojo**: Added `resolveAppExtensionBuildTypeQualifiers()` method to collapse build-type-qualified app extension keys (`debug`/`release`) into unqualified keys that the build pipeline understands. Integrated this into the build process before extension provisioning data is encoded.

- **CertificateWizard**: Refactored widget extension profile creation to support both development and distribution profiles:
  - Split `createWidgetExtensionProfile()` into `ensureWidgetExtensionProfile()` to handle both profile types generically
  - Development profiles are created when possible but gracefully skipped if no development certificate or registered device is available
  - Both profiles are downloaded and passed to the signing installer

- **SigningAssetInstaller**: Updated `applyWidgetExtensionSigning()` to accept both release and debug profile paths, writing them to both unqualified and build-type-qualified settings keys for backward compatibility.

- **Documentation**: Updated signing and advanced topics guides to document the new debug/release qualification syntax for extension provisioning profiles and build hints.

- **Tests**: Added comprehensive test suite (`CN1BuildMojoAppExtProvisioningTest`) covering qualifier resolution logic and updated existing certificate wizard tests to verify both profile types are created and installed correctly.

## Implementation Details

- Qualified keys follow the pattern: `codename1.arg.ios.{debug|release}.appext.<Name>.provisioningURL` and `codename1.ios.{debug|release}.appext.<Name>.provision`
- The build target determines which variant is selected (release builds use `release` qualifier, debug/device builds use `debug`)
- Unqualified keys serve as fallback when no matching variant is set
- The resolution happens early in the Maven build to ensure the build server only sees the resolved value
- Development profile creation is optional and doesn't fail the overall signing setup if unavailable

https://claude.ai/code/session_01JjqoJvk1f5LhYUACPRAM8p