### PR TITLE
Fix Android port status and CI gating

### DIFF
--- a/.github/workflows/scripts-android.yml
+++ b/.github/workflows/scripts-android.yml
@@ -116,6 +116,11 @@ jobs:
       # so the GoogleWebMap screenshot test renders a live Google map; absent
       # (e.g. fork PRs with no access to the secret) the test skips.
       GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+      # The device runner reports logical test failures through CN1SS log
+      # markers, not through the launcher instrumentation test. Make the
+      # normalized report authoritative so a red port-status test cannot leave
+      # the Android workflow green and then be published from master.
+      CN1SS_FAIL_ON_TEST_FAILURE: '1'
     steps:
       - uses: actions/checkout@v6
       - name: Set TMPDIR

--- a/.github/workflows/scripts-android.yml
+++ b/.github/workflows/scripts-android.yml
@@ -120,7 +120,7 @@ jobs:
       # markers, not through the launcher instrumentation test. Make the
       # normalized report authoritative so a red port-status test cannot leave
       # the Android workflow green and then be published from master.
-      CN1SS_FAIL_ON_TEST_FAILURE: '1'
+      CN1SS_FAIL_ON_TEST_PROBLEMS: '1'
     steps:
       - uses: actions/checkout@v6
       - name: Set TMPDIR

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
@@ -83,11 +83,17 @@ import org.xeustechnologies.jtar.TarOutputStream;
  */
 public class AndroidGradleBuilder extends Executor {
 
+    private static final String GRADLE_8_VERSION = "8.13";
+    private static final String ANDROID_GRADLE_PLUGIN_8_VERSION = "8.13.2";
+    private static final String DESUGAR_JDK_LIBS_VERSION = "2.1.5";
+    private static final String GRADLE_8_DISTRIBUTION_URL =
+            "https://services.gradle.org/distributions/gradle-" + GRADLE_8_VERSION + "-bin.zip";
+
     private String minimumGradleVersion = "6";
 
     private String gradleDistributionUrl = "https://services.gradle.org/distributions/gradle-6.8.3-bin.zip";
 
-    private String gradle8DistributionUrl = "https://services.gradle.org/distributions/gradle-8.13-bin.zip";
+    private String gradle8DistributionUrl = GRADLE_8_DISTRIBUTION_URL;
     public boolean PREFER_MANAGED_GRADLE=true;
 
     private boolean rootCheck = false;
@@ -607,7 +613,7 @@ public class AndroidGradleBuilder extends Executor {
         }
         if (useGradle8) {
             getGradleJavaHome(); // will throw build exception if JAVA17_HOME is not set
-            minimumGradleVersion = "8.13";
+            minimumGradleVersion = GRADLE_8_VERSION;
             gradleDistributionUrl = gradle8DistributionUrl;
             if (!useJava8SourceLevel) {
                 log("NOTICE: Enabling Java 8 source level for Gradle 8 build because RetroLambda is not supported on Java 17, which is required for gradle 8.");
@@ -4872,7 +4878,8 @@ public class AndroidGradleBuilder extends Executor {
             }else if (gradleVersionInt < 8) {
                 gradleDependency = "classpath 'com.android.tools.build:gradle:4.1.1'\n";
             } else {
-                gradleDependency = "classpath 'com.android.tools.build:gradle:8.13.2'\n";
+                gradleDependency = "classpath 'com.android.tools.build:gradle:" +
+                        ANDROID_GRADLE_PLUGIN_8_VERSION + "'\n";
             }
         }
         boolean hasKotlinSources = hasSourceFileWithExtension(new File(projectDir, "src/main/java"), ".kt");
@@ -4921,7 +4928,8 @@ public class AndroidGradleBuilder extends Executor {
                 && !additionalDependencies.contains("com.android.tools:desugar_jdk_libs")
                 && !request.getArg("android.gradleDep", "").contains("com.android.tools:desugar_jdk_libs")) {
             coreLibraryDesugaringDependency =
-                    "    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'\n";
+                    "    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:" +
+                            DESUGAR_JDK_LIBS_VERSION + "'\n";
         }
 
         String mavenCentral = "";

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
@@ -88,6 +88,10 @@ public class AndroidGradleBuilder extends Executor {
     private static final String DESUGAR_JDK_LIBS_VERSION = "2.1.5";
     private static final String GRADLE_8_DISTRIBUTION_URL =
             "https://services.gradle.org/distributions/gradle-" + GRADLE_8_VERSION + "-bin.zip";
+    private static final int GRADLE_DOWNLOAD_ATTEMPTS = 3;
+    private static final long GRADLE_DOWNLOAD_RETRY_DELAY_MS = 2000L;
+    private static final int GRADLE_DOWNLOAD_CONNECT_TIMEOUT_MS = 30000;
+    private static final int GRADLE_DOWNLOAD_READ_TIMEOUT_MS = 300000;
 
     private String minimumGradleVersion = "6";
 
@@ -941,15 +945,7 @@ public class AndroidGradleBuilder extends Executor {
                     delTree(managedGradleHome);
                 }
                 File gradleZip = new File(managedGradleHome+".zip");
-                if (gradleZip.exists()) {
-                    gradleZip.delete();
-                }
-                try {
-                    log("Downloading gradle distribution from "+gradleDistributionUrl);
-                    FileUtils.copyURLToFile(new URL(gradleDistributionUrl), gradleZip);
-                } catch (Exception ex) {
-                    throw new BuildException("Failed to download gradle distribution from URL "+gradleDistributionUrl, ex);
-                }
+                downloadGradleDistribution(gradleZip);
                 try {
                     ZipFile gradleZipFile = new ZipFile(gradleZip);
                     File extracted = new File(path(gradleZip.getAbsolutePath()+"-extracted"));
@@ -5555,6 +5551,46 @@ public class AndroidGradleBuilder extends Executor {
         } catch (Exception e) {
             e.printStackTrace();
         }
+    }
+
+    private void downloadGradleDistribution(File gradleZip) throws BuildException {
+        File partialGradleZip = new File(gradleZip.getAbsolutePath() + ".part");
+        Exception lastFailure = null;
+        for (int attempt = 1; attempt <= GRADLE_DOWNLOAD_ATTEMPTS; attempt++) {
+            if (partialGradleZip.exists() && !partialGradleZip.delete()) {
+                throw new BuildException("Failed to remove partial gradle distribution at " + partialGradleZip);
+            }
+            if (gradleZip.exists() && !gradleZip.delete()) {
+                throw new BuildException("Failed to remove existing gradle distribution at " + gradleZip);
+            }
+            try {
+                log("Downloading gradle distribution from " + gradleDistributionUrl
+                        + " (attempt " + attempt + " of " + GRADLE_DOWNLOAD_ATTEMPTS + ")");
+                FileUtils.copyURLToFile(new URL(gradleDistributionUrl), partialGradleZip,
+                        GRADLE_DOWNLOAD_CONNECT_TIMEOUT_MS, GRADLE_DOWNLOAD_READ_TIMEOUT_MS);
+                FileUtils.moveFile(partialGradleZip, gradleZip);
+                return;
+            } catch (Exception ex) {
+                lastFailure = ex;
+                if (partialGradleZip.exists() && !partialGradleZip.delete()) {
+                    partialGradleZip.deleteOnExit();
+                }
+                if (gradleZip.exists() && !gradleZip.delete()) {
+                    gradleZip.deleteOnExit();
+                }
+                if (attempt < GRADLE_DOWNLOAD_ATTEMPTS) {
+                    log("Gradle distribution download failed: " + ex.getMessage() + ". Retrying...");
+                    try {
+                        Thread.sleep(GRADLE_DOWNLOAD_RETRY_DELAY_MS * attempt);
+                    } catch (InterruptedException interrupted) {
+                        Thread.currentThread().interrupt();
+                        throw new BuildException("Interrupted while retrying gradle distribution download", interrupted);
+                    }
+                }
+            }
+        }
+        throw new BuildException("Failed to download gradle distribution from URL "
+                + gradleDistributionUrl + " after " + GRADLE_DOWNLOAD_ATTEMPTS + " attempts", lastFailure);
     }
 
     public void extractAAR(InputStream source, File dir, String sdkPath) throws IOException {

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
@@ -83,11 +83,11 @@ import org.xeustechnologies.jtar.TarOutputStream;
  */
 public class AndroidGradleBuilder extends Executor {
 
-    private float MIN_GRADLE_VERSION=6;
+    private String minimumGradleVersion = "6";
 
     private String gradleDistributionUrl = "https://services.gradle.org/distributions/gradle-6.8.3-bin.zip";
 
-    private String gradle8DistributionUrl = "https://services.gradle.org/distributions/gradle-8.1-bin.zip";
+    private String gradle8DistributionUrl = "https://services.gradle.org/distributions/gradle-8.13-bin.zip";
     public boolean PREFER_MANAGED_GRADLE=true;
 
     private boolean rootCheck = false;
@@ -607,7 +607,7 @@ public class AndroidGradleBuilder extends Executor {
         }
         if (useGradle8) {
             getGradleJavaHome(); // will throw build exception if JAVA17_HOME is not set
-            MIN_GRADLE_VERSION = 8;
+            minimumGradleVersion = "8.13";
             gradleDistributionUrl = gradle8DistributionUrl;
             if (!useJava8SourceLevel) {
                 log("NOTICE: Enabling Java 8 source level for Gradle 8 build because RetroLambda is not supported on Java 17, which is required for gradle 8.");
@@ -615,7 +615,7 @@ public class AndroidGradleBuilder extends Executor {
             }
         }
         if (newFirebaseMessaging && !useGradle8) {
-            throw new BuildException("android.newFirebaseMessaging requires gradle version 8.1 or higher.  Please remove the android.gradleVersion build hint");
+            throw new BuildException("android.newFirebaseMessaging requires Gradle 8.13 or higher. Please remove the android.gradleVersion build hint");
         }
         debug("Request Args: ");
         debug("-----------------");
@@ -918,7 +918,7 @@ public class AndroidGradleBuilder extends Executor {
         debug("FOUND gradleVersion "+gradleVersion);
         int gradleVersionInt = parseVersionStringAsInt(gradleVersion);
         debug("Found gradleVersionInt="+gradleVersionInt);
-        if (gradleVersionInt <  MIN_GRADLE_VERSION) {
+        if (compareVersions(gradleVersion, minimumGradleVersion) < 0) {
             // The minimum version is too low.
             if (managedGradleHome.exists()) {
                 gradleExe = new File(managedGradleHome, path("bin", "gradle"+bat)).getAbsolutePath();
@@ -930,7 +930,7 @@ public class AndroidGradleBuilder extends Executor {
                 gradleVersionInt = parseVersionStringAsInt(gradleVersion);
 
             }
-            if (gradleVersionInt < MIN_GRADLE_VERSION) {
+            if (compareVersions(gradleVersion, minimumGradleVersion) < 0) {
                 if (managedGradleHome.exists()) {
                     delTree(managedGradleHome);
                 }
@@ -991,8 +991,8 @@ public class AndroidGradleBuilder extends Executor {
                     throw new BuildException("Failed to get gradle version even after downloading it from "+gradleDistributionUrl+".  Something must have gone wrong with the gradle installation.");
                 }
                 gradleVersionInt = parseVersionStringAsInt(gradleVersion);
-                if (gradleVersionInt < MIN_GRADLE_VERSION) {
-                    throw new BuildException("Required gradle version is "+MIN_GRADLE_VERSION+" but found version "+gradleVersion);
+                if (compareVersions(gradleVersion, minimumGradleVersion) < 0) {
+                    throw new BuildException("Required Gradle version is "+minimumGradleVersion+" but found version "+gradleVersion);
                 }
             }
         }
@@ -4872,7 +4872,7 @@ public class AndroidGradleBuilder extends Executor {
             }else if (gradleVersionInt < 8) {
                 gradleDependency = "classpath 'com.android.tools.build:gradle:4.1.1'\n";
             } else {
-                gradleDependency = "classpath 'com.android.tools.build:gradle:8.1.0'\n";
+                gradleDependency = "classpath 'com.android.tools.build:gradle:8.13.2'\n";
             }
         }
         boolean hasKotlinSources = hasSourceFileWithExtension(new File(projectDir, "src/main/java"), ".kt");
@@ -4898,17 +4898,30 @@ public class AndroidGradleBuilder extends Executor {
         String compileSdkVersion = "'android-21'";
 
         int projectJavaVersion = parseVersionStringAsInt(request.getArg("java.version", "8"));
+        String coreLibraryDesugaringOption = useGradle8
+                ? "        coreLibraryDesugaringEnabled true\n"
+                : "";
         String javaCompileOptions = "";
         if (projectJavaVersion >= 17 && useGradle8) {
             javaCompileOptions = "    compileOptions {\n" +
+                    coreLibraryDesugaringOption +
                     "        sourceCompatibility JavaVersion.toVersion(17)\n" +
                     "        targetCompatibility JavaVersion.toVersion(17)\n" +
                     "    }\n";
         } else if(useJava8SourceLevel) {
             javaCompileOptions = "    compileOptions {\n" +
+                    coreLibraryDesugaringOption +
                     "        sourceCompatibility JavaVersion.VERSION_1_8\n" +
                     "        targetCompatibility JavaVersion.VERSION_1_8\n" +
                     "    }\n";
+        }
+
+        String coreLibraryDesugaringDependency = "";
+        if (useGradle8
+                && !additionalDependencies.contains("com.android.tools:desugar_jdk_libs")
+                && !request.getArg("android.gradleDep", "").contains("com.android.tools:desugar_jdk_libs")) {
+            coreLibraryDesugaringDependency =
+                    "    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'\n";
         }
 
         String mavenCentral = "";
@@ -5113,6 +5126,7 @@ public class AndroidGradleBuilder extends Executor {
                 + "}\n"
                 + "\n"
                 + "dependencies {\n"
+                + coreLibraryDesugaringDependency
                 + "    "+compile+" fileTree(dir: 'libs', include: ['*.jar'])\n"
                 + request.getArg("android.supportv4Dep",supportV4Default) + "\n"
                 + kotlinRuntimeDependency
@@ -5195,7 +5209,6 @@ public class AndroidGradleBuilder extends Executor {
         Integer compileSdkInt = parseSdkInt(compileSdkVersion);
         if (compileSdkInt != null && compileSdkInt >= 35) {
             gradlePropertiesObject.setProperty("android.suppressUnsupportedCompileSdk", String.valueOf(compileSdkInt));
-            gradlePropertiesObject.setProperty("android.experimental.androidTest.useUnifiedTestPlatform", "false");
         }
 
         // Configure R8 optimization mode to prevent reflection issues
@@ -5912,7 +5925,7 @@ public class AndroidGradleBuilder extends Executor {
         return String.valueOf(Math.max(Integer.parseInt(a), Integer.parseInt(b)));
     }
 
-    private static int compareVersions(String v1, String v2) {
+    static int compareVersions(String v1, String v2) {
         String v1p1 = v1.indexOf(".") == -1 ? v1 : v1.substring(0, v1.indexOf("."));
         String v2p1 = v2.indexOf(".") == -1 ? v2 : v2.substring(0, v2.indexOf("."));
         int i1 = Integer.parseInt(v1p1);

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/AndroidGradleBuilderVersionTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/AndroidGradleBuilderVersionTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided by
+ * Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.builders;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AndroidGradleBuilderVersionTest {
+
+    @Test
+    void comparesMinorVersionsInsteadOfOnlyTheMajorVersion() {
+        assertTrue(AndroidGradleBuilder.compareVersions("8.1", "8.13") < 0);
+        assertEquals(0, AndroidGradleBuilder.compareVersions("8.13", "8.13"));
+        assertTrue(AndroidGradleBuilder.compareVersions("8.13.2", "8.13") > 0);
+    }
+}

--- a/scripts/build-android-app.sh
+++ b/scripts/build-android-app.sh
@@ -149,7 +149,6 @@ GRADLE_PROPS="$GRADLE_PROJECT_DIR/gradle.properties"
 grep -q '^android.useAndroidX=' "$GRADLE_PROPS" 2>/dev/null || echo 'android.useAndroidX=true' >> "$GRADLE_PROPS"
 grep -q '^android.enableJetifier=' "$GRADLE_PROPS" 2>/dev/null || echo 'android.enableJetifier=true' >> "$GRADLE_PROPS"
 grep -q '^android.suppressUnsupportedCompileSdk=' "$GRADLE_PROPS" 2>/dev/null || echo 'android.suppressUnsupportedCompileSdk=36' >> "$GRADLE_PROPS"
-grep -q '^android.experimental.androidTest.useUnifiedTestPlatform=' "$GRADLE_PROPS" 2>/dev/null || echo 'android.experimental.androidTest.useUnifiedTestPlatform=false' >> "$GRADLE_PROPS"
 
 APP_BUILD_GRADLE="$GRADLE_PROJECT_DIR/app/build.gradle"
 ROOT_BUILD_GRADLE="$GRADLE_PROJECT_DIR/build.gradle"

--- a/scripts/hellocodenameone/conformance/port_status.py
+++ b/scripts/hellocodenameone/conformance/port_status.py
@@ -24,6 +24,7 @@ RUNNER = REPO_ROOT / (
     "examples/hellocodenameone/tests/Cn1ssDeviceRunner.java"
 )
 COMMON_SOURCES = REPO_ROOT / "scripts/hellocodenameone/common/src/main"
+STRICT_GATE_FAILED = 10
 
 START_RE = re.compile(r"suite starting test=([A-Za-z0-9_]+)")
 FINISH_RE = re.compile(r"suite finished test=([A-Za-z0-9_]+)")
@@ -526,8 +527,20 @@ def strict_report_errors(report: dict) -> list[str]:
     if not report.get("suite_finished"):
         errors.append("suite did not emit its completion marker")
     summary = report.get("summary", {})
-    failed = int(summary.get("fail", 0))
-    not_run = int(summary.get("not-run", 0))
+    if not isinstance(summary, dict):
+        raise ContractError("Expected report summary to be an object")
+
+    counts: dict[str, int] = {}
+    for key in ("fail", "not-run"):
+        value = summary.get(key, 0)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ContractError(
+                f"Expected report summary {key!r} to be a non-negative integer"
+            )
+        counts[key] = value
+
+    failed = counts["fail"]
+    not_run = counts["not-run"]
     if failed:
         errors.append(f"{failed} test(s) failed")
     if not_run:
@@ -597,7 +610,7 @@ def main() -> int:
                     "port-status strict gate: " + "; ".join(strict_errors),
                     file=sys.stderr,
                 )
-                return 2
+                return STRICT_GATE_FAILED
         return 0
     except ContractError as exc:
         print(f"port-status: {exc}", file=sys.stderr)

--- a/scripts/hellocodenameone/conformance/port_status.py
+++ b/scripts/hellocodenameone/conformance/port_status.py
@@ -526,13 +526,15 @@ def strict_report_errors(report: dict) -> list[str]:
     errors: list[str] = []
     if not report.get("suite_finished"):
         errors.append("suite did not emit its completion marker")
-    summary = report.get("summary", {})
+    summary = report.get("summary")
     if not isinstance(summary, dict):
         raise ContractError("Expected report summary to be an object")
 
     counts: dict[str, int] = {}
-    for key in ("fail", "not-run"):
-        value = summary.get(key, 0)
+    for key in ("pass", "fail", "skip", "not-run"):
+        if key not in summary:
+            raise ContractError(f"Report summary is missing required count {key!r}")
+        value = summary[key]
         if isinstance(value, bool) or not isinstance(value, int) or value < 0:
             raise ContractError(
                 f"Expected report summary {key!r} to be a non-negative integer"
@@ -569,7 +571,7 @@ def build_parser() -> argparse.ArgumentParser:
     normalize_parser.add_argument("--generated-at", default=utc_now())
     normalize_parser.add_argument("--binary-size", type=int)
     normalize_parser.add_argument(
-        "--fail-on-test-failure",
+        "--fail-on-test-problems",
         action="store_true",
         help="return nonzero after writing the report if tests fail, do not run, or the suite is incomplete",
     )
@@ -603,7 +605,7 @@ def main() -> int:
             f"Wrote {args.output}: "
             + ", ".join(f"{key}={value}" for key, value in report["summary"].items())
         )
-        if args.fail_on_test_failure:
+        if args.fail_on_test_problems:
             strict_errors = strict_report_errors(report)
             if strict_errors:
                 print(

--- a/scripts/hellocodenameone/conformance/port_status.py
+++ b/scripts/hellocodenameone/conformance/port_status.py
@@ -521,6 +521,20 @@ def normalize(
     return report
 
 
+def strict_report_errors(report: dict) -> list[str]:
+    errors: list[str] = []
+    if not report.get("suite_finished"):
+        errors.append("suite did not emit its completion marker")
+    summary = report.get("summary", {})
+    failed = int(summary.get("fail", 0))
+    not_run = int(summary.get("not-run", 0))
+    if failed:
+        errors.append(f"{failed} test(s) failed")
+    if not_run:
+        errors.append(f"{not_run} test(s) did not run")
+    return errors
+
+
 def utc_now() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
@@ -541,6 +555,11 @@ def build_parser() -> argparse.ArgumentParser:
     normalize_parser.add_argument("--commit", default=os.environ.get("GITHUB_SHA", ""))
     normalize_parser.add_argument("--generated-at", default=utc_now())
     normalize_parser.add_argument("--binary-size", type=int)
+    normalize_parser.add_argument(
+        "--fail-on-test-failure",
+        action="store_true",
+        help="return nonzero after writing the report if tests fail, do not run, or the suite is incomplete",
+    )
     return parser
 
 
@@ -571,6 +590,14 @@ def main() -> int:
             f"Wrote {args.output}: "
             + ", ".join(f"{key}={value}" for key, value in report["summary"].items())
         )
+        if args.fail_on_test_failure:
+            strict_errors = strict_report_errors(report)
+            if strict_errors:
+                print(
+                    "port-status strict gate: " + "; ".join(strict_errors),
+                    file=sys.stderr,
+                )
+                return 2
         return 0
     except ContractError as exc:
         print(f"port-status: {exc}", file=sys.stderr)

--- a/scripts/hellocodenameone/conformance/test_port_status.py
+++ b/scripts/hellocodenameone/conformance/test_port_status.py
@@ -135,11 +135,28 @@ class PortStatusTest(unittest.TestCase):
     def test_strict_report_errors_rejects_malformed_summary_counts(self):
         report = {
             "suite_finished": True,
-            "summary": {"fail": None, "not-run": 0},
+            "summary": {"pass": 0, "fail": None, "skip": 0, "not-run": 0},
         }
         with self.assertRaisesRegex(
             port_status.ContractError,
             "Expected report summary 'fail' to be a non-negative integer",
+        ):
+            port_status.strict_report_errors(report)
+
+    def test_strict_report_errors_requires_complete_summary(self):
+        with self.assertRaisesRegex(
+            port_status.ContractError,
+            "Expected report summary to be an object",
+        ):
+            port_status.strict_report_errors({"suite_finished": True})
+
+        report = {
+            "suite_finished": True,
+            "summary": {"pass": 10, "fail": 0, "not-run": 0},
+        }
+        with self.assertRaisesRegex(
+            port_status.ContractError,
+            "Report summary is missing required count 'skip'",
         ):
             port_status.strict_report_errors(report)
 
@@ -155,7 +172,7 @@ class PortStatusTest(unittest.TestCase):
                 str(output_path),
                 "--generated-at",
                 "2026-07-24T00:00:00Z",
-                "--fail-on-test-failure",
+                "--fail-on-test-problems",
             ]
             with patch.object(port_status.sys, "argv", argv):
                 exit_code = port_status.main()

--- a/scripts/hellocodenameone/conformance/test_port_status.py
+++ b/scripts/hellocodenameone/conformance/test_port_status.py
@@ -4,6 +4,7 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 import port_status
 
@@ -130,6 +131,40 @@ class PortStatusTest(unittest.TestCase):
             "summary": {"pass": 10, "fail": 0, "skip": 1, "not-run": 0},
         }
         self.assertEqual([], port_status.strict_report_errors(report))
+
+    def test_strict_report_errors_rejects_malformed_summary_counts(self):
+        report = {
+            "suite_finished": True,
+            "summary": {"fail": None, "not-run": 0},
+        }
+        with self.assertRaisesRegex(
+            port_status.ContractError,
+            "Expected report summary 'fail' to be a non-negative integer",
+        ):
+            port_status.strict_report_errors(report)
+
+    def test_cli_strict_gate_writes_report_before_returning_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_path = Path(tmp) / "report.json"
+            argv = [
+                "port_status.py",
+                "normalize",
+                "--port",
+                "android",
+                "--output",
+                str(output_path),
+                "--generated-at",
+                "2026-07-24T00:00:00Z",
+                "--fail-on-test-failure",
+            ]
+            with patch.object(port_status.sys, "argv", argv):
+                exit_code = port_status.main()
+
+            self.assertEqual(port_status.STRICT_GATE_FAILED, exit_code)
+            self.assertTrue(output_path.is_file())
+            report = json.loads(output_path.read_text(encoding="utf-8"))
+            self.assertFalse(report["suite_finished"])
+            self.assertGreater(report["summary"]["not-run"], 0)
 
 
 if __name__ == "__main__":

--- a/scripts/hellocodenameone/conformance/test_port_status.py
+++ b/scripts/hellocodenameone/conformance/test_port_status.py
@@ -110,6 +110,27 @@ class PortStatusTest(unittest.TestCase):
         self.assertEqual("fail", report["tests"]["StringApiTest"]["status"])
         self.assertEqual(["suite-error"], report["tests"]["StringApiTest"]["reasons"])
 
+    def test_strict_report_errors_reject_failures_missing_tests_and_incomplete_suite(self):
+        report = {
+            "suite_finished": False,
+            "summary": {"pass": 10, "fail": 2, "skip": 1, "not-run": 3},
+        }
+        self.assertEqual(
+            [
+                "suite did not emit its completion marker",
+                "2 test(s) failed",
+                "3 test(s) did not run",
+            ],
+            port_status.strict_report_errors(report),
+        )
+
+    def test_strict_report_errors_allows_complete_report_with_skips(self):
+        report = {
+            "suite_finished": True,
+            "summary": {"pass": 10, "fail": 0, "skip": 1, "not-run": 0},
+        }
+        self.assertEqual([], port_status.strict_report_errors(report))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/lib/cn1ss.sh
+++ b/scripts/lib/cn1ss.sh
@@ -438,8 +438,8 @@ cn1ss_generate_port_status() {
   if [ -n "$binary_size" ]; then
     args+=(--binary-size "$binary_size")
   fi
-  if [ "${CN1SS_FAIL_ON_TEST_FAILURE:-0}" = "1" ]; then
-    args+=(--fail-on-test-failure)
+  if [ "${CN1SS_FAIL_ON_TEST_PROBLEMS:-0}" = "1" ]; then
+    args+=(--fail-on-test-problems)
   fi
   if ! "$python_bin" "${args[@]}"; then
     cn1ss_log "FATAL: Failed to generate normalized port status for $CN1SS_PORT_ID"

--- a/scripts/lib/cn1ss.sh
+++ b/scripts/lib/cn1ss.sh
@@ -438,6 +438,9 @@ cn1ss_generate_port_status() {
   if [ -n "$binary_size" ]; then
     args+=(--binary-size "$binary_size")
   fi
+  if [ "${CN1SS_FAIL_ON_TEST_FAILURE:-0}" = "1" ]; then
+    args+=(--fail-on-test-failure)
+  fi
   if ! "$python_bin" "${args[@]}"; then
     cn1ss_log "FATAL: Failed to generate normalized port status for $CN1SS_PORT_ID"
     return 19


### PR DESCRIPTION
## Summary

- enable Android core-library desugaring with `desugar_jdk_libs` 2.1.5 so API 36 uses the corrected `java.time` implementation
- update the managed Android toolchain to Gradle 8.13 and Android Gradle Plugin 8.13.2, including correct minor-version enforcement
- make the normalized Android port-status report fail CI when tests fail, do not run, or the suite completion marker is missing
- keep writing and uploading the report on failure, while continuing to allow explicit skips
- remove the obsolete unified test platform workaround and add focused regression coverage

## Root cause

`TimeApiTest` failed on API 36 because the platform implementation parsed `Duration.parse("PT-0.5S")` as positive 500 ms. Core-library desugaring fixes that behavior. Enabling it with the existing AGP 8.1 toolchain failed during JaCoCo-instrumented builds, so the managed toolchain also needed the compatible Gradle/AGP update.

The workflow had a second problem: the launcher instrumentation test could finish successfully even when the Codename One suite reported logical failures through its log markers. As a result, a red normalized port-status report could leave the workflow green. The report is now an explicit CI gate.

## Validation

- `python3 scripts/hellocodenameone/conformance/test_port_status.py` — 5 tests passed
- Java 8 focused Maven test: `AndroidGradleBuilderVersionTest` — 1 test passed
- workflow YAML parsing, shell syntax checks, and `git diff --check` passed
- a freshly generated Android project used Gradle 8.13, AGP 8.13.2, and `desugar_jdk_libs` 2.1.5 and built successfully with JaCoCo instrumentation
- API 36 device run emitted the suite completion marker and `TimeApiTest` passed
- the strict gate returned nonzero for local ARM screenshot mismatches against the Linux/x86 references, confirming logical report failures can no longer leave CI green

A full Java 8 reactor rerun on this Mac stopped in the JavaSE module because that local JDK lacks JavaFX; it did not reach or fail the changed plugin module.