### PR TITLE
Document rich copy and paste support in weekly posts

### DIFF
--- a/docs/website/content/blog/javascript-free-open-source.md
+++ b/docs/website/content/blog/javascript-free-open-source.md
@@ -22,7 +22,7 @@ The Codename One JavaScript port is now open source and available on every plan,
 - [ParparVM garbage collection](#issue-5425-dave-was-right-about-our-collector): A real application exposed a benchmark gap, redundant collection cycles, and a broken first fix.
 - [Calendar](#calendar-api-local-calendars-cloud-sync-and-conflicts): The new API covers device and cloud calendars, recurrence, tasks, incremental sync, offline mutations, and conflict handling.
 - [Bluetooth](#bluetooth-is-now-part-of-the-core): Bluetooth moved into the core with BLE, GATT, L2CAP, RFCOMM, Web Bluetooth, desktop radios, and a scriptable simulator.
-- [Text editing](#pure-codename-one-text-editing): `EditField`, `RichTextArea`, and `CodeEditor` can edit and paint text without placing a native field over the component.
+- [Text editing](#pure-codename-one-text-editing): `EditField`, `RichTextArea`, and `CodeEditor` can edit and paint text without placing a native field over the component. The new clipboard model carries rich text, images, and file references alongside a plain-text fallback.
 - [Rich text](#lightweight-rich-text-without-a-web-view): `RichTextComponent` renders HTML, Markdown, AsciiDoc, RTF, and styled Java runs without a web view.
 - [Compact strings](#compact-strings-in-parparvm): Strings now use a `byte[]` when every character fits, cutting their character storage in half without adding a second backing-array pointer.
 - [Account, website, and videos](#account-website-and-video-updates): The authorization migration is complete, the redesigned site is live, and the weekly posts now generate explainer videos.
@@ -190,7 +190,11 @@ notes.setRows(5);
 form.add(notes);
 ```
 
-[PR #5386](https://github.com/codenameone/CodenameOne/pull/5386) adds the port bindings and portable editor engine. {{< post-link path="/blog/text-input-without-native-overlay" text="Read the text-input article for composition, UTF-16 offsets, bidirectional hit testing, and the native-overlay tradeoff." >}}
+This work also replaces the text-only clipboard assumption. A `ClipboardContent` can carry several representations of one item: plain text, HTML, RTF, Markdown, AsciiDoc, PNG, JPEG, GIF, and file references. The port publishes the formats its system clipboard supports while retaining plain text for older code and applications that do not understand the richer payload.
+
+`RichTextArea` uses that negotiation directly. Copying a formatted selection publishes plain text, HTML, RTF, Markdown, and AsciiDoc together. Pasting chooses the richest text representation it understands, while a clipboard image becomes an inline image instead of a filename or discarded payload.
+
+[PR #5386](https://github.com/codenameone/CodenameOne/pull/5386) adds the port bindings and portable editor engine. {{< post-link path="/blog/text-input-without-native-overlay" text="Read the text-input article for composition, UTF-16 offsets, bidirectional hit testing, rich clipboard negotiation, and the native-overlay tradeoff." >}}
 
 ## Lightweight rich text without a web view
 

--- a/docs/website/content/blog/text-input-without-native-overlay.md
+++ b/docs/website/content/blog/text-input-without-native-overlay.md
@@ -4,8 +4,8 @@ slug: text-input-without-native-overlay
 url: /blog/text-input-without-native-overlay/
 date: '2026-07-27'
 author: Shai Almog
-description: "Codename One can now edit text inside its lightweight component layer through a semantic text-input contract. EditField, RichTextArea, and CodeEditor keep painting, selection, bidirectional layout, and document state portable while the OS supplies keyboard and IME events."
-feed_html: '<img src="https://www.codenameone.com/blog/text-input-without-native-overlay.jpg" alt="Pure Codename One text editing driven by a platform input method" /> A semantic port contract lets Codename One own text painting, selection, rich editing, and bidirectional layout while the platform supplies keyboard and IME operations.'
+description: "Codename One can now edit text inside its lightweight component layer through a semantic text-input contract. EditField, RichTextArea, and CodeEditor keep painting, selection, bidirectional layout, rich clipboard data, and document state portable while the OS supplies keyboard and IME events."
+feed_html: '<img src="https://www.codenameone.com/blog/text-input-without-native-overlay.jpg" alt="Pure Codename One text editing driven by a platform input method" /> A semantic port contract lets Codename One own text painting, selection, rich editing, clipboard formats, and bidirectional layout while the platform supplies keyboard and IME operations.'
 series: ["release-2026-07-24"]
 ---
 
@@ -67,6 +67,27 @@ form.show();
 ![Rich text and code editors painted by the lightweight editing engine](/blog/text-input-without-native-overlay/editors-overview.png)
 
 Text input is now a port-level capability that does not require a visible native field.
+
+## The clipboard carries several representations at once
+
+The old clipboard API usually moved a `String`. That remains valid, but it cannot preserve formatting or describe an image or file.
+
+`ClipboardContent` represents one clipboard item through several MIME types. Include plain text as the fallback, then add the richer forms you can produce:
+
+```java
+ClipboardContent content = new ClipboardContent()
+        .setData(ClipboardContent.MIME_TEXT, "Codename One")
+        .setData(ClipboardContent.MIME_HTML, "<b>Codename One</b>")
+        .setData(ClipboardContent.MIME_MARKDOWN, "**Codename One**");
+
+Display.getInstance().copyToClipboard(content);
+```
+
+The same container supports RTF, AsciiDoc, PNG, JPEG, GIF, and local file references. Each port maps the representations its system clipboard exposes. Code that still calls `copyToClipboard("text")` or expects plain text continues to work.
+
+`RichTextArea` publishes five text representations when you copy a formatted selection: plain text, HTML, RTF, Markdown, and AsciiDoc. On paste, it selects the richest format it understands and imports the formatting into its document model. If the clipboard contains PNG, JPEG, or GIF bytes, the editor inserts the image inline as a self-contained data URI.
+
+This is format negotiation, not a private editor clipboard. Other applications can paste the native formats a port publishes, and application code can inspect the available types through `Display.getInstance().getClipboardContent()`.
 
 ## Bidirectional text uses one layout for paint and hit testing
 


### PR DESCRIPTION
## Summary

- add rich clipboard support to the July 24 weekly release summary and text-editing section
- add a dedicated clipboard section and `ClipboardContent` example to the text-editing deep dive
- document rich text negotiation, image and file payloads, and compatibility with string-only clipboard calls

## Why

The weekly release post and the text-editing deep dive covered the new lightweight editor architecture but omitted the multi-format clipboard work that shipped with it. These edits describe the user-visible behavior and the underlying MIME-based negotiation model.

## Validation

- `python3 scripts/website/blog_prose_gate.py --base-ref origin/master --no-languagetool docs/website/content/blog/javascript-free-open-source.md docs/website/content/blog/text-input-without-native-overlay.md`
- `vale --config docs/website/.vale.ini --minAlertLevel=suggestion docs/website/content/blog/javascript-free-open-source.md docs/website/content/blog/text-input-without-native-overlay.md`
- `hugo --source docs/website --buildFuture --environment production --minify`
- `git diff --check`

LanguageTool was unavailable locally because its snapshot host could not be resolved; CI can run that stage.