### PR TITLE
Fix asymmetric border radius rendering in RTL

### DIFF
--- a/CodenameOne/src/com/codename1/ui/plaf/RoundRectBorder.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/RoundRectBorder.java
@@ -686,13 +686,13 @@ public final class RoundRectBorder extends Border {
                         for (int iter = shadowSpreadL - 1; iter >= 0; iter--) {
                             tg.translate(iter, iter);
                             int iterOpacity = Math.max(0, Math.min(255, (int) (shadowOpacity * (shadowSpreadL - iter) / (float) shadowSpreadL)));
-                            drawShape(tg, shadowColor, shadowOpacity - iterOpacity, w - (iter * 2), h - (iter * 2));
+                            drawShape(tg, shadowColor, shadowOpacity - iterOpacity, w - (iter * 2), h - (iter * 2), c.isRTL());
                             tg.translate(-iter, -iter);
                         }
                     }
                     tg.translate(shapeX, shapeY);
 
-                    GeneralPath gp = createShape(shapeW, shapeH);
+                    GeneralPath gp = createShape(shapeW, shapeH, c.isRTL());
                     Style s = c.getStyle();
                     if (s.getBgImage() == null) {
                         byte type = s.getBackgroundType();
@@ -757,7 +757,7 @@ public final class RoundRectBorder extends Border {
             for (int iter = shadowSpreadL - 1; iter >= 0; iter--) {
                 tg.translate(iter, iter);
                 int iterOpacity = Math.max(0, Math.min(255, (int) (shadowOpacity * (shadowSpreadL - iter) / (float) shadowSpreadL)));
-                drawShape(tg, shadowColor, shadowOpacity - iterOpacity, w - (iter * 2), h - (iter * 2));
+                drawShape(tg, shadowColor, shadowOpacity - iterOpacity, w - (iter * 2), h - (iter * 2), c.isRTL());
                 tg.translate(-iter, -iter);
             }
 
@@ -771,7 +771,7 @@ public final class RoundRectBorder extends Border {
         }
         tg.translate(shapeX, shapeY);
 
-        GeneralPath gp = createShape(shapeW, shapeH);
+        GeneralPath gp = createShape(shapeW, shapeH, c.isRTL());
         Style s = c.getStyle();
         if (s.getBgImage() == null) {
             byte type = s.getBackgroundType();
@@ -882,7 +882,7 @@ public final class RoundRectBorder extends Border {
                 if (s.getBgImage() == null) {
                     byte type = s.getBackgroundType();
                     if (type == Style.BACKGROUND_IMAGE_SCALED || type == Style.BACKGROUND_NONE) {
-                        GeneralPath gp = createShape(w, h);
+                        GeneralPath gp = createShape(w, h, c.isRTL());
                         byte bgt = c.getStyle().getBgTransparency();
                         if (bgt != 0) {
                             int a = g.getAlpha();
@@ -926,7 +926,7 @@ public final class RoundRectBorder extends Border {
                         int shapeW = w - inset * 2;
                         int shapeH = h - inset * 2;
                         if (shapeW > 0 && shapeH > 0) {
-                            GeneralPath gp = createShape(shapeW, shapeH);
+                            GeneralPath gp = createShape(shapeW, shapeH, c.isRTL());
                             int dx = Math.round((shadowX - 0.5f) * blurPx);
                             int dy = Math.max(1, Math.round((shadowY * 0.5f + 0.25f) * blurPx));
                             g.translate(x + inset, y + inset);
@@ -976,13 +976,17 @@ public final class RoundRectBorder extends Border {
         }
     }
 
-    private GeneralPath createShape(int shapeW, int shapeH) {
+    private GeneralPath createShape(int shapeW, int shapeH, boolean rtl) {
         GeneralPath gp = new GeneralPath();
         float radius = Display.getInstance().convertToPixels(cornerRadius);
         float x = 0;
         float y = 0;
         float widthF = shapeW;
         float heightF = shapeH;
+        boolean roundTopLeft = rtl ? topRight : topLeft;
+        boolean roundTopRight = rtl ? topLeft : topRight;
+        boolean roundBottomLeft = rtl ? bottomRight : bottomLeft;
+        boolean roundBottomRight = rtl ? bottomLeft : bottomRight;
 
         if (getTrackComponent() != null || trackComponentSide >= 0) {
             int ah = CN.convertToPixels(arrowSize);
@@ -1019,7 +1023,7 @@ public final class RoundRectBorder extends Border {
 
         }
 
-        if (topLeft) {
+        if (roundTopLeft) {
             gp.moveTo(x + radius, y);
         } else {
             gp.moveTo(x, y);
@@ -1037,7 +1041,7 @@ public final class RoundRectBorder extends Border {
             gp.lineTo(x + widthF - radius, y);
             gp.quadTo(x + widthF, y, x + widthF, y + radius);
         } else {
-            if (topRight) {
+            if (roundTopRight) {
                 gp.lineTo(x + widthF - radius, y);
                 gp.quadTo(x + widthF, y, x + widthF, y + radius);
             } else {
@@ -1045,7 +1049,7 @@ public final class RoundRectBorder extends Border {
             }
         }
 
-        if (bottomRight) {
+        if (roundBottomRight) {
             gp.lineTo(x + widthF, y + heightF - radius);
             gp.quadTo(x + widthF, y + heightF, x + widthF - radius, y + heightF);
         } else {
@@ -1066,7 +1070,7 @@ public final class RoundRectBorder extends Border {
             gp.lineTo(x + radius, y + heightF);
             gp.quadTo(x, y + heightF, x, y + heightF - radius);
         } else {
-            if (bottomLeft) {
+            if (roundBottomLeft) {
                 gp.lineTo(x + radius, y + heightF);
                 gp.quadTo(x, y + heightF, x, y + heightF - radius);
             } else {
@@ -1075,7 +1079,7 @@ public final class RoundRectBorder extends Border {
         }
 
 
-        if (topLeft) {
+        if (roundTopLeft) {
             gp.lineTo(x, y + radius);
             gp.quadTo(x, y, x + radius, y);
         } else {
@@ -1123,10 +1127,10 @@ public final class RoundRectBorder extends Border {
         return Display.getInstance().convertToPixels(shadowSpread) + Display.getInstance().convertToPixels(cornerRadius) * 2;
     }
 
-    private void drawShape(Graphics g, int color, int opacity, int width, int height) {
+    private void drawShape(Graphics g, int color, int opacity, int width, int height, boolean rtl) {
         g.setColor(color);
         g.setAlpha(opacity);
-        GeneralPath gp = createShape(width, height);
+        GeneralPath gp = createShape(width, height, rtl);
         if (stroke1 == null) {
             stroke1 = new Stroke(1f, Stroke.CAP_ROUND, Stroke.JOIN_MITER, 1f);
         }

--- a/CodenameOne/src/com/codename1/ui/plaf/RoundRectBorder.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/RoundRectBorder.java
@@ -665,6 +665,7 @@ public final class RoundRectBorder extends Border {
             public void paint(Graphics g) {
                 super.paint(g);
                 try {
+                    boolean rtl = c.isRTL();
                     g.translate(getX(), getY());
                     int shapeX = 0;
                     int shapeY = 0;
@@ -686,13 +687,13 @@ public final class RoundRectBorder extends Border {
                         for (int iter = shadowSpreadL - 1; iter >= 0; iter--) {
                             tg.translate(iter, iter);
                             int iterOpacity = Math.max(0, Math.min(255, (int) (shadowOpacity * (shadowSpreadL - iter) / (float) shadowSpreadL)));
-                            drawShape(tg, shadowColor, shadowOpacity - iterOpacity, w - (iter * 2), h - (iter * 2), c.isRTL());
+                            drawShape(tg, shadowColor, shadowOpacity - iterOpacity, w - (iter * 2), h - (iter * 2), rtl);
                             tg.translate(-iter, -iter);
                         }
                     }
                     tg.translate(shapeX, shapeY);
 
-                    GeneralPath gp = createShape(shapeW, shapeH, c.isRTL());
+                    GeneralPath gp = createShape(shapeW, shapeH, rtl);
                     Style s = c.getStyle();
                     if (s.getBgImage() == null) {
                         byte type = s.getBackgroundType();
@@ -735,6 +736,7 @@ public final class RoundRectBorder extends Border {
         if (!useCache) {
             return createTargetComponentImage(c, w, h);
         }
+        boolean rtl = c.isRTL();
         Image target = ImageFactory.createImage(c, w, h, 0);
 
         int shapeX = 0;
@@ -757,7 +759,7 @@ public final class RoundRectBorder extends Border {
             for (int iter = shadowSpreadL - 1; iter >= 0; iter--) {
                 tg.translate(iter, iter);
                 int iterOpacity = Math.max(0, Math.min(255, (int) (shadowOpacity * (shadowSpreadL - iter) / (float) shadowSpreadL)));
-                drawShape(tg, shadowColor, shadowOpacity - iterOpacity, w - (iter * 2), h - (iter * 2), c.isRTL());
+                drawShape(tg, shadowColor, shadowOpacity - iterOpacity, w - (iter * 2), h - (iter * 2), rtl);
                 tg.translate(-iter, -iter);
             }
 
@@ -771,7 +773,7 @@ public final class RoundRectBorder extends Border {
         }
         tg.translate(shapeX, shapeY);
 
-        GeneralPath gp = createShape(shapeW, shapeH, c.isRTL());
+        GeneralPath gp = createShape(shapeW, shapeH, rtl);
         Style s = c.getStyle();
         if (s.getBgImage() == null) {
             byte type = s.getBackgroundType();
@@ -872,6 +874,7 @@ public final class RoundRectBorder extends Border {
 
         final int w = c.getWidth();
         final int h = c.getHeight();
+        boolean rtl = c.isRTL();
         int x = c.getX();
         int y = c.getY();
         boolean antiAliased = g.isAntiAliased();
@@ -882,7 +885,7 @@ public final class RoundRectBorder extends Border {
                 if (s.getBgImage() == null) {
                     byte type = s.getBackgroundType();
                     if (type == Style.BACKGROUND_IMAGE_SCALED || type == Style.BACKGROUND_NONE) {
-                        GeneralPath gp = createShape(w, h, c.isRTL());
+                        GeneralPath gp = createShape(w, h, rtl);
                         byte bgt = c.getStyle().getBgTransparency();
                         if (bgt != 0) {
                             int a = g.getAlpha();
@@ -926,7 +929,7 @@ public final class RoundRectBorder extends Border {
                         int shapeW = w - inset * 2;
                         int shapeH = h - inset * 2;
                         if (shapeW > 0 && shapeH > 0) {
-                            GeneralPath gp = createShape(shapeW, shapeH, c.isRTL());
+                            GeneralPath gp = createShape(shapeW, shapeH, rtl);
                             int dx = Math.round((shadowX - 0.5f) * blurPx);
                             int dy = Math.max(1, Math.round((shadowY * 0.5f + 0.25f) * blurPx));
                             g.translate(x + inset, y + inset);

--- a/maven/core-unittests/src/test/java/com/codename1/ui/plaf/BorderAndPlafTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/plaf/BorderAndPlafTest.java
@@ -8,6 +8,7 @@ import com.codename1.ui.Graphics;
 import com.codename1.ui.Image;
 import com.codename1.ui.Label;
 import com.codename1.ui.Stroke;
+import com.codename1.ui.geom.PathIterator;
 import com.codename1.ui.plaf.StyleParser.BorderInfo;
 import com.codename1.ui.plaf.StyleParser.FontInfo;
 import com.codename1.ui.plaf.StyleParser.ImageInfo;
@@ -116,6 +117,40 @@ class BorderAndPlafTest extends UITestBase {
         assertEquals(1.5f, bounds[1], 0.001f);
         assertEquals(17f, bounds[2], 0.001f);
         assertEquals(7f, bounds[3], 0.001f);
+    }
+
+    @FormTest
+    void testRoundRectBorderMirrorsAsymmetricCornersInRTL() {
+        RoundRectBorder border = RoundRectBorder.create()
+                .cornerRadius(4f)
+                .topLeftMode(false)
+                .bottomLeftMode(false)
+                .topRightMode(true)
+                .bottomRightMode(true);
+
+        Label label = new Label();
+        label.setRTL(true);
+        label.setWidth(30);
+        label.setHeight(20);
+        label.getStyle().setBackgroundType(Style.BACKGROUND_NONE);
+        label.getStyle().setBgTransparency(0xff);
+        label.getStyle().setBgColor(0);
+        label.getStyle().setBorder(border);
+
+        implementation.setShapeSupported(true);
+        implementation.resetShapeTracking();
+        border.paintBorderBackground(Image.createImage(30, 20).getGraphics(), label);
+
+        assertTrue(implementation.wasFillShapeInvoked());
+        PathIterator path = implementation.getLastFillShape().getPathIterator();
+        float[] coordinates = new float[6];
+        assertEquals(PathIterator.SEG_MOVETO, path.currentSegment(coordinates));
+        assertTrue(coordinates[0] > 0,
+                "RTL should start after the mirrored rounded top-left corner");
+        path.next();
+        assertEquals(PathIterator.SEG_LINETO, path.currentSegment(coordinates));
+        assertEquals(30f, coordinates[0], 0.001f,
+                "RTL should mirror the square top-left corner to the top-right");
     }
 
     @FormTest

--- a/maven/core-unittests/src/test/java/com/codename1/ui/plaf/BorderAndPlafTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/plaf/BorderAndPlafTest.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.ui.plaf;
 
 import com.codename1.junit.FormTest;
@@ -144,10 +166,12 @@ class BorderAndPlafTest extends UITestBase {
         assertTrue(implementation.wasFillShapeInvoked());
         PathIterator path = implementation.getLastFillShape().getPathIterator();
         float[] coordinates = new float[6];
+        assertFalse(path.isDone(), "RTL shape should contain a move-to segment");
         assertEquals(PathIterator.SEG_MOVETO, path.currentSegment(coordinates));
         assertTrue(coordinates[0] > 0,
                 "RTL should start after the mirrored rounded top-left corner");
         path.next();
+        assertFalse(path.isDone(), "RTL shape should contain a top-edge line segment");
         assertEquals(PathIterator.SEG_LINETO, path.currentSegment(coordinates));
         assertEquals(30f, coordinates[0], 0.001f,
                 "RTL should mirror the square top-left corner to the top-right");


### PR DESCRIPTION
## Summary

- mirror asymmetric `RoundRectBorder` corner modes for RTL components
- apply the mirrored shape consistently to direct, cached-image, component-image, GPU-shadow, and fallback-shadow rendering paths
- add a regression test that verifies the rounded and square corners swap horizontally in RTL

## Root cause

The CSS compiler represents the simple asymmetric `border-radius` case from [discussion #5453](https://github.com/codenameone/CodenameOne/discussions/5453) as a `RoundRectBorder`. Its shape builder always used the configured physical corner flags, even when the component was RTL, while the surrounding layout and side-specific spacing were mirrored. This left the rounded edge on the wrong side.

## Validation

Ran with Java 8:

```text
mvn -pl core-unittests -am -DunitTests=true -Dmaven.javadoc.skip=true -Plocal-dev-javase -Dtest=BorderAndPlafTest,RoundRectBorderTestTest,CSSThemeCompilerTest -Dsurefire.failIfNoSpecifiedTests=false test
```

Result: 22 tests passed, 0 failures, 0 errors.