### PR TITLE
Fix JavaScript builds shipping without port.js (Window.current() null NPE on boot)

### DIFF
--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/JavaScriptBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/JavaScriptBuilder.java
@@ -55,6 +55,12 @@ public class JavaScriptBuilder extends Executor {
     private File jsDistDir;
     private File jsOutputZip;
     private File jsDeployableArtifact;
+    // Directory holding the JavaScript-port web assets (port.js, js/, style.css,
+    // ...) for this build. Handed to the translator via the
+    // -Dcodename1.javascriptport.webapp override so it bundles port.js (the
+    // worker-side native bindings) even when the build runs outside a CN1
+    // source checkout. Set by stageJavaScriptPort.
+    private File jsPortWebApp;
 
     @Override
     protected String getDeviceIdCode() {
@@ -237,6 +243,22 @@ public class JavaScriptBuilder extends Executor {
                     fos.close();
                 }
                 unzip(jar, stageClasses, stageClasses, stageClasses);
+                // JavaScriptPort.jar carries the port webapp under webapp/. Move it
+                // OUT of the translate-input tree (stageClasses) so the translator
+                // doesn't re-copy it into the bundle; it is handed to the translator
+                // via -Dcodename1.javascriptport.webapp in runByteCodeTranslator.
+                File stagedWebApp = new File(stageClasses, "webapp");
+                if (stagedWebApp.isDirectory()) {
+                    File dest = new File(tmpDir, "port-webapp");
+                    if (dest.exists()) {
+                        delTree(dest, true);
+                    }
+                    if (!stagedWebApp.renameTo(dest)) {
+                        copyTree(stagedWebApp, dest);
+                        delTree(stagedWebApp, true);
+                    }
+                    jsPortWebApp = dest;
+                }
                 return stageClasses;
             } finally {
                 bundled.close();
@@ -275,6 +297,12 @@ public class JavaScriptBuilder extends Executor {
             throw new BuildException("Failed to compile JavaScript port sources");
         }
         copyTree(portClasses, stageClasses);
+        // Source-checkout build: the webapp sits next to the sources at
+        // src/main/webapp (portSources is src/main/java).
+        File srcWebApp = new File(portSources.getParentFile(), "webapp");
+        if (srcWebApp.isDirectory()) {
+            jsPortWebApp = srcWebApp;
+        }
         return stageClasses;
     }
 
@@ -656,6 +684,15 @@ public class JavaScriptBuilder extends Executor {
                     }
                 }
             }
+        }
+        // Hand the translator the JavaScript-port webapp (port.js, js/, style.css,
+        // ...) so it bundles port.js -- the worker-side native bindings that make
+        // Window.current() etc. resolve. Off-repo builds can't find it via the
+        // translator's own source-tree walk, so we pass the copy staged from
+        // JavaScriptPort.jar. An explicit override in CN1_TRANSLATOR_OPTS wins.
+        if (jsPortWebApp != null && jsPortWebApp.isDirectory()
+                && (translatorOpts == null || !translatorOpts.contains("codename1.javascriptport.webapp"))) {
+            extraOpts.add("-Dcodename1.javascriptport.webapp=" + jsPortWebApp.getAbsolutePath());
         }
         // Default heap; a -Xmx in CN1_TRANSLATOR_OPTS takes precedence (apps
         // that disable tree-shaking, e.g. the Playground, emit a much larger

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/JavaScriptBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/JavaScriptBuilder.java
@@ -230,6 +230,9 @@ public class JavaScriptBuilder extends Executor {
 
     private File stageJavaScriptPort(BuildRequest request, File portSources, File stageClasses, File portClasses)
             throws Exception {
+        // Recompute per build: a reused builder instance must not carry a
+        // previous target's webapp path when this one has none.
+        jsPortWebApp = null;
         // Prefer a pre-built JavaScriptPort.jar bundled as a plugin resource.
         InputStream bundled = getResourceAsStream("/JavaScriptPort.jar");
         if (bundled != null) {
@@ -689,9 +692,17 @@ public class JavaScriptBuilder extends Executor {
         // ...) so it bundles port.js -- the worker-side native bindings that make
         // Window.current() etc. resolve. Off-repo builds can't find it via the
         // translator's own source-tree walk, so we pass the copy staged from
-        // JavaScriptPort.jar. An explicit override in CN1_TRANSLATOR_OPTS wins.
-        if (jsPortWebApp != null && jsPortWebApp.isDirectory()
-                && (translatorOpts == null || !translatorOpts.contains("codename1.javascriptport.webapp"))) {
+        // JavaScriptPort.jar. An explicit override in CN1_TRANSLATOR_OPTS wins --
+        // detected by an actual -D token, not a loose substring match.
+        boolean webAppOverridden = false;
+        for (String opt : extraOpts) {
+            if (opt.startsWith("-Dcodename1.javascriptport.webapp=")
+                    || opt.equals("-Dcodename1.javascriptport.webapp")) {
+                webAppOverridden = true;
+                break;
+            }
+        }
+        if (jsPortWebApp != null && jsPortWebApp.isDirectory() && !webAppOverridden) {
             extraOpts.add("-Dcodename1.javascriptport.webapp=" + jsPortWebApp.getAbsolutePath());
         }
         // Default heap; a -Xmx in CN1_TRANSLATOR_OPTS takes precedence (apps

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/JavaScriptBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/JavaScriptBuilder.java
@@ -252,11 +252,16 @@ public class JavaScriptBuilder extends Executor {
                 // via -Dcodename1.javascriptport.webapp in runByteCodeTranslator.
                 File stagedWebApp = new File(stageClasses, "webapp");
                 if (stagedWebApp.isDirectory()) {
+                    // tmpDir is this build's own work dir, so port-webapp is already
+                    // build-unique; clear any stale copy before moving.
                     File dest = new File(tmpDir, "port-webapp");
                     if (dest.exists()) {
                         delTree(dest, true);
                     }
-                    if (!stagedWebApp.renameTo(dest)) {
+                    try {
+                        Files.move(stagedWebApp.toPath(), dest.toPath());
+                    } catch (IOException moveFailed) {
+                        // e.g. cross-device move: fall back to copy + delete.
                         copyTree(stagedWebApp, dest);
                         delTree(stagedWebApp, true);
                     }
@@ -696,8 +701,9 @@ public class JavaScriptBuilder extends Executor {
         // detected by an actual -D token, not a loose substring match.
         boolean webAppOverridden = false;
         for (String opt : extraOpts) {
-            if (opt.startsWith("-Dcodename1.javascriptport.webapp=")
-                    || opt.equals("-Dcodename1.javascriptport.webapp")) {
+            // Only a -Dkey=value form actually sets the property; a bare -Dkey
+            // does not, so it must NOT suppress the plugin-provided value.
+            if (opt.startsWith("-Dcodename1.javascriptport.webapp=")) {
                 webAppOverridden = true;
                 break;
             }

--- a/maven/parparvm/pom.xml
+++ b/maven/parparvm/pom.xml
@@ -74,6 +74,7 @@
 
         <codename1.javaapi.src.dir>../../vm/JavaAPI/src</codename1.javaapi.src.dir>
         <codename1.javascriptport.src.dir>../../Ports/JavaScriptPort/src/main/java</codename1.javascriptport.src.dir>
+        <codename1.javascriptport.webapp.dir>../../Ports/JavaScriptPort/src/main/webapp</codename1.javascriptport.webapp.dir>
         <javaapi.compiler.source>1.8</javaapi.compiler.source>
         <javaapi.compiler.target>1.8</javaapi.compiler.target>
 
@@ -199,8 +200,24 @@
                                     <fileset dir="${project.build.directory}/api-classes"/>
                                 </zip>
                                 <copy tofile="${project.build.directory}/bundle/parparvm-compiler.jar" file="${project.build.directory}/${project.build.finalName}-jar-with-dependencies.jar"/>
-                                <jar destfile="${project.build.directory}/bundle/JavaScriptPort.jar"
-                                     basedir="${project.build.directory}/javascript-port-classes"/>
+                                <!-- JavaScriptPort.jar carries the compiled port classes AND,
+                                     under webapp/, the JavaScript-port runtime web assets
+                                     (port.js, js/, css/, style.css, sw.js, manifest*, assets/).
+                                     The Maven plugin extracts webapp/ and hands it to the
+                                     translator via -Dcodename1.javascriptport.webapp so that
+                                     builds running OUTSIDE a CN1 source checkout still bundle
+                                     port.js (the worker-side native bindings). Without this,
+                                     JavascriptBundleWriter.locateJavaScriptPortWebApp() finds
+                                     nothing off-repo and the app ships without port.js and
+                                     fails to boot. index.html is emitted by the translator, so
+                                     it (and the servlet-only WEB-INF) are excluded here. -->
+                                <jar destfile="${project.build.directory}/bundle/JavaScriptPort.jar">
+                                    <fileset dir="${project.build.directory}/javascript-port-classes"/>
+                                    <zipfileset dir="${codename1.javascriptport.webapp.dir}" prefix="webapp">
+                                        <exclude name="index.html"/>
+                                        <exclude name="WEB-INF/**"/>
+                                    </zipfileset>
+                                </jar>
                                 <zip destfile="${project.build.directory}/${project.build.finalName}-bundle.jar">
                                     <fileset dir="${project.build.directory}/bundle"/>
                                 </zip>

--- a/maven/parparvm/pom.xml
+++ b/maven/parparvm/pom.xml
@@ -211,6 +211,14 @@
                                      nothing off-repo and the app ships without port.js and
                                      fails to boot. index.html is emitted by the translator, so
                                      it (and the servlet-only WEB-INF) are excluded here. -->
+                                <!-- Fail loudly if the webapp (esp. port.js) is absent rather
+                                     than silently shipping a JavaScriptPort.jar without it --
+                                     that missing-port.js jar is exactly the bug this bundling
+                                     prevents. -->
+                                <available file="${codename1.javascriptport.webapp.dir}/port.js"
+                                           property="cn1.jsport.webapp.present"/>
+                                <fail unless="cn1.jsport.webapp.present"
+                                      message="JavaScript-port webapp not found at ${codename1.javascriptport.webapp.dir} (expected port.js). A full Codename One checkout is required to build the JavaScript port bundle."/>
                                 <jar destfile="${project.build.directory}/bundle/JavaScriptPort.jar">
                                     <fileset dir="${project.build.directory}/javascript-port-classes"/>
                                     <zipfileset dir="${codename1.javascriptport.webapp.dir}" prefix="webapp">

--- a/maven/parparvm/pom.xml
+++ b/maven/parparvm/pom.xml
@@ -211,14 +211,13 @@
                                      nothing off-repo and the app ships without port.js and
                                      fails to boot. index.html is emitted by the translator, so
                                      it (and the servlet-only WEB-INF) are excluded here. -->
-                                <!-- Fail loudly if the webapp (esp. port.js) is absent rather
-                                     than silently shipping a JavaScriptPort.jar without it --
-                                     that missing-port.js jar is exactly the bug this bundling
-                                     prevents. -->
+                                <!-- Fail loudly if the webapp (esp. port.js) is absent instead
+                                     of silently shipping a JavaScriptPort.jar without it; that
+                                     port.js-less jar is exactly the bug this bundling prevents. -->
                                 <available file="${codename1.javascriptport.webapp.dir}/port.js"
                                            property="cn1.jsport.webapp.present"/>
                                 <fail unless="cn1.jsport.webapp.present"
-                                      message="JavaScript-port webapp not found at ${codename1.javascriptport.webapp.dir} (expected port.js). A full Codename One checkout is required to build the JavaScript port bundle."/>
+                                      message="JavaScript-port webapp not found at ${codename1.javascriptport.webapp.dir} (expected port.js). Build from a full Codename One checkout, or point the build at the webapp with -Dcodename1.javascriptport.webapp.dir=/path/to/Ports/JavaScriptPort/src/main/webapp."/>
                                 <jar destfile="${project.build.directory}/bundle/JavaScriptPort.jar">
                                     <fileset dir="${project.build.directory}/javascript-port-classes"/>
                                     <zipfileset dir="${codename1.javascriptport.webapp.dir}" prefix="webapp">


### PR DESCRIPTION
## Problem

A local JavaScript (ParparVM) build produced via the Maven plugin ships a bundle **missing `port.js`** (and the `js/`, `css/`, `style.css` web assets). Because `port.js` installs the worker-side native bindings, `worker.js` never gets `__parparInstallNativeBindings`, native methods keep their Java placeholder bodies, and `com.codename1.html5.js.browser.Window.current()` returns `null`. The app then crashes on boot:

```
HTML5Implementation.<init>:  this.window = Window.current();      // null
                             this.document = this.window.getDocument();  // NPE
```

The app is stuck on the loading splash forever.

## Root cause

`JavascriptBundleWriter.locateJavaScriptPortWebApp()` resolves the JS-port webapp (which contains `port.js`) **only** via:
1. `-Dcodename1.javascriptport.webapp`, or
2. walking **up the current working directory** for `Ports/JavaScriptPort/src/main/webapp`.

That works when the translator runs from inside a CN1 source checkout, but under the Maven plugin the CWD is the *app project*, so it finds nothing and `copyJavaScriptPortWebAppAssets()` silently no-ops. `JavaScriptPort.jar` ships compiled classes only, so `port.js` is on no classpath the plugin uses — the bundle can never include it off-repo.

## Fix

- **`maven/parparvm`**: bundle the JS-port webapp (`port.js`, `js/`, `css/`, `style.css`, `sw.js`, `manifest*`, `assets/`) into `JavaScriptPort.jar` under `webapp/`. `index.html` and `WEB-INF` are excluded — the translator emits its own `index.html`.
- **`codenameone-maven-plugin` `JavaScriptBuilder`**: move that staged `webapp/` out of the translate-input tree (so the translator doesn't re-copy it) and hand it to the forked translator via `-Dcodename1.javascriptport.webapp`. Source-checkout builds point the override at `src/main/webapp`. An explicit override in `CN1_TRANSLATOR_OPTS` still wins.

## Validation

- Packaging: the ant `<jar>` change produces `JavaScriptPort.jar` containing `webapp/port.js`, `webapp/js/*`, `webapp/style.css` and correctly excludes `index.html`/`WEB-INF`.
- Both changed files compile clean.
- **Runtime, end-to-end**: an unchanged real app (the BuildCloud console) was rebuilt with `CN1_TRANSLATOR_OPTS=-Dcodename1.javascriptport.webapp=<repo>/Ports/JavaScriptPort/src/main/webapp` — i.e. exactly the override this PR makes the plugin pass automatically. `port.js` was bundled, `worker.js` gained `importScripts('port.js')`, the boot NPE disappeared, the splash hid, and the app rendered CN1 UI. This PR makes that automatic.

## Note

This adds the webapp (~8 MB, dominated by `assets/` and `js/videojs`) to `JavaScriptPort.jar`. If some of those aren't needed by the base runtime, a follow-up could prune them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)