### PR TITLE
Fix CSS watcher leak on simulator reload

### DIFF
--- a/Ports/JavaSE/src/com/codename1/impl/javase/CSSWatcher.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/CSSWatcher.java
@@ -52,8 +52,9 @@ public class CSSWatcher implements Runnable {
     private int simulatorReloadVersion = Integer.parseInt(System.getProperty("reload.simulator.count", "0"));
     private Thread watchThread, pulseThread;
     private ServerSocket pulseSocket;
-    private Process childProcess;
-    private boolean closing;
+    private volatile Process childProcess;
+    private volatile boolean closing;
+    private final Thread shutdownHook;
     private static final int MIN_DESIGNER_VERSION=6;
 
     private final String themePrefix;
@@ -64,7 +65,7 @@ public class CSSWatcher implements Runnable {
 
     public CSSWatcher(String themePrefix) {
         this.themePrefix = themePrefix;
-        Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+        shutdownHook = new Thread(new Runnable() {
 
             @Override
             public void run() {
@@ -75,8 +76,9 @@ public class CSSWatcher implements Runnable {
                     } catch (Throwable t){}
                 }
             }
-            
-        }));
+
+        });
+        Runtime.getRuntime().addShutdownHook(shutdownHook);
     }
 
     public void stop() {
@@ -90,6 +92,11 @@ public class CSSWatcher implements Runnable {
             try {
                 pulseSocket.close();
             } catch (Exception ex){}
+        }
+        try {
+            Runtime.getRuntime().removeShutdownHook(shutdownHook);
+        } catch (Throwable t) {
+            // The JVM is already shutting down, or the hook was already removed.
         }
     }
     
@@ -231,6 +238,9 @@ public class CSSWatcher implements Runnable {
     }
 
     private void watch() throws IOException {
+        if (closing) {
+            return;
+        }
         if (pulseSocket == null || pulseSocket.isClosed()) {
             // If the the Simulator is killed then the shutdown hook doesn't run
             // so we need an alternative way for the ResourceEditorApp to know that
@@ -333,16 +343,23 @@ public class CSSWatcher implements Runnable {
             args.add("-Dprism.order=sw");
         }
         System.out.println("Running CSS watch with args " + args);
-        
-        
-        Process p = pb.start();
-        
-        if (childProcess != null) {
+
+        if (closing) {
+            stop();
+            return;
+        }
+        Process previousProcess = childProcess;
+        if (previousProcess != null && previousProcess.isAlive()) {
             try {
-                childProcess.destroyForcibly();
+                previousProcess.destroyForcibly();
             } catch (Throwable t){}
         }
+        Process p = pb.start();
         childProcess = p;
+        if (closing) {
+            stop();
+            return;
+        }
         String line;
        
         OutputStream stdin = p.getOutputStream();
@@ -388,8 +405,10 @@ public class CSSWatcher implements Runnable {
                 String l = reader.readLine();
                 if (l == null) {
                     if (!p.isAlive()) {
-                        watchThread = null;
-                        start();
+                        if (!closing) {
+                            watchThread = null;
+                            start();
+                        }
                         break;
                     }
                 }
@@ -427,8 +446,10 @@ public class CSSWatcher implements Runnable {
                 t.printStackTrace();
                 
                 if (!p.isAlive()) {
-                    watchThread = null;
-                    start();
+                    if (!closing) {
+                        watchThread = null;
+                        start();
+                    }
                     break;
                 }
             }
@@ -448,8 +469,8 @@ public class CSSWatcher implements Runnable {
         }
     }
     
-    public void start() {
-        if (watchThread == null) {
+    public synchronized void start() {
+        if (!closing && watchThread == null) {
             watchThread = new Thread(this);
             watchThread.setDaemon(true);
             watchThread.start(); 

--- a/Ports/JavaSE/src/com/codename1/impl/javase/CSSWatcher.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/CSSWatcher.java
@@ -50,7 +50,8 @@ import java.util.logging.Logger;
  */
 public class CSSWatcher implements Runnable {
     private int simulatorReloadVersion = Integer.parseInt(System.getProperty("reload.simulator.count", "0"));
-    private Thread watchThread, pulseThread;
+    private volatile Thread watchThread;
+    private Thread pulseThread;
     private ServerSocket pulseSocket;
     private volatile Process childProcess;
     private volatile boolean closing;

--- a/Ports/JavaSE/src/com/codename1/impl/javase/Executor.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/Executor.java
@@ -287,24 +287,28 @@ public class Executor {
                                 // Delay the starting of the CSS watcher to avoid compiling the CSS file while the theme is being loaded.
                                 final int simulatorReloadVersion = Integer.parseInt(System.getProperty("reload.simulator.count", "0"));
                                 for (final String themePrefix : CSSWatcher.scanForThemePrefixes()) {
-                                    Timer t = new Timer(true);
+                                    final Timer timer = new Timer(true);
                                     TimerTask tt = new TimerTask() {
                                         @Override
                                         public void run() {
-                                            int currentReloadVersion = Integer.parseInt(System.getProperty("reload.simulator.count", "0"));
-                                            if (currentReloadVersion != simulatorReloadVersion) {
-                                                return;
+                                            try {
+                                                int currentReloadVersion = Integer.parseInt(System.getProperty("reload.simulator.count", "0"));
+                                                if (currentReloadVersion != simulatorReloadVersion) {
+                                                    return;
+                                                }
+                                                System.out.println("Starting CSS Watcher for prefix " + themePrefix);
+                                                CSSWatcher cssWatcher = new CSSWatcher(themePrefix);
+                                                if (!registerCSSWatcher(cssWatcher, simulatorReloadVersion)) {
+                                                    cssWatcher.stop();
+                                                    return;
+                                                }
+                                                cssWatcher.start();
+                                            } finally {
+                                                timer.cancel();
                                             }
-                                            System.out.println("Starting CSS Watcher for prefix " + themePrefix);
-                                            CSSWatcher cssWatcher = new CSSWatcher(themePrefix);
-                                            if (!registerCSSWatcher(cssWatcher, simulatorReloadVersion)) {
-                                                cssWatcher.stop();
-                                                return;
-                                            }
-                                            cssWatcher.start();
                                         }
                                     };
-                                    t.schedule(tt, 2000);
+                                    timer.schedule(tt, 2000);
                                 }
 
                             }

--- a/Ports/JavaSE/src/com/codename1/impl/javase/Executor.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/Executor.java
@@ -38,6 +38,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.*;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.Timer;
@@ -67,6 +68,7 @@ public class Executor {
     // when combined with Hotswap Agent.
     // https://github.com/HotswapProjects/HotswapAgent
     private static SourceChangeWatcher sourceWatcher;
+    private static final List<CSSWatcher> cssWatchers = new ArrayList<CSSWatcher>();
     
     private final static boolean IS_MAC;
     private final static boolean isWindows;
@@ -283,13 +285,22 @@ public class Executor {
                             Display.init(null);
                             if (CSSWatcher.isSupported()) {
                                 // Delay the starting of the CSS watcher to avoid compiling the CSS file while the theme is being loaded.
+                                final int simulatorReloadVersion = Integer.parseInt(System.getProperty("reload.simulator.count", "0"));
                                 for (final String themePrefix : CSSWatcher.scanForThemePrefixes()) {
-                                    Timer t = new Timer();
+                                    Timer t = new Timer(true);
                                     TimerTask tt = new TimerTask() {
                                         @Override
                                         public void run() {
+                                            int currentReloadVersion = Integer.parseInt(System.getProperty("reload.simulator.count", "0"));
+                                            if (currentReloadVersion != simulatorReloadVersion) {
+                                                return;
+                                            }
                                             System.out.println("Starting CSS Watcher for prefix " + themePrefix);
                                             CSSWatcher cssWatcher = new CSSWatcher(themePrefix);
+                                            if (!registerCSSWatcher(cssWatcher, simulatorReloadVersion)) {
+                                                cssWatcher.stop();
+                                                return;
+                                            }
                                             cssWatcher.start();
                                         }
                                     };
@@ -424,6 +435,32 @@ public class Executor {
             } catch (Exception ex) {
                 ex.printStackTrace();
             } 
+        }
+    }
+
+    static boolean registerCSSWatcher(CSSWatcher cssWatcher, int simulatorReloadVersion) {
+        synchronized (cssWatchers) {
+            int currentReloadVersion = Integer.parseInt(System.getProperty("reload.simulator.count", "0"));
+            if (currentReloadVersion != simulatorReloadVersion) {
+                return false;
+            }
+            cssWatchers.add(cssWatcher);
+            return true;
+        }
+    }
+
+    public static void cleanupForSimulatorReload() {
+        List<CSSWatcher> watchersToStop;
+        synchronized (cssWatchers) {
+            watchersToStop = new ArrayList<CSSWatcher>(cssWatchers);
+            cssWatchers.clear();
+        }
+        for (CSSWatcher cssWatcher : watchersToStop) {
+            cssWatcher.stop();
+        }
+        if (sourceWatcher != null) {
+            sourceWatcher.stop();
+            sourceWatcher = null;
         }
     }
 

--- a/Ports/JavaSE/src/com/codename1/impl/javase/Simulator.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/Simulator.java
@@ -261,7 +261,7 @@ public class Simulator {
         
         final ClassLoader fLdr = ldr;
         Thread.currentThread().setContextClassLoader(fLdr);
-        Class c = Class.forName("com.codename1.impl.javase.Executor", true, ldr);
+        final Class c = Class.forName("com.codename1.impl.javase.Executor", true, ldr);
         Method m = c.getDeclaredMethod("main", String[].class);
         m.invoke(null, new Object[]{argv});
         new Thread() {
@@ -277,6 +277,12 @@ public class Simulator {
                         System.setProperty("reload.simulator", "");
                         int version = Integer.parseInt(System.getProperty("reload.simulator.count", "0"));
                         System.setProperty("reload.simulator.count", String.valueOf(version+1));
+                        try {
+                            Method cleanup = c.getDeclaredMethod("cleanupForSimulatorReload");
+                            cleanup.invoke(null);
+                        } catch (Exception ex) {
+                            ex.printStackTrace();
+                        }
                         try {
                             main(argv);
                         } catch (Exception ex) {

--- a/maven/javase/src/test/java/com/codename1/impl/javase/CSSWatcherTest.java
+++ b/maven/javase/src/test/java/com/codename1/impl/javase/CSSWatcherTest.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.impl.javase;
 
 import org.junit.jupiter.api.Test;

--- a/maven/javase/src/test/java/com/codename1/impl/javase/CSSWatcherTest.java
+++ b/maven/javase/src/test/java/com/codename1/impl/javase/CSSWatcherTest.java
@@ -10,9 +10,20 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CSSWatcherTest {
+
+    private static class TrackingCSSWatcher extends CSSWatcher {
+        private int stopCount;
+
+        @Override
+        public void stop() {
+            stopCount++;
+            super.stop();
+        }
+    }
 
     @Test
     void addsLocalizationArgumentForProjectL10nDirectory(@TempDir Path tempDir) throws Exception {
@@ -52,6 +63,39 @@ class CSSWatcherTest {
             assertEquals(l10nDir.toFile().getAbsolutePath(), args.get(args.indexOf("-l") + 1));
         } finally {
             System.setProperty("user.dir", oldUserDir);
+        }
+    }
+
+    @Test
+    void simulatorReloadStopsEachRegisteredCSSWatcherOnce() {
+        TrackingCSSWatcher first = new TrackingCSSWatcher();
+        TrackingCSSWatcher second = new TrackingCSSWatcher();
+        int simulatorReloadVersion = Integer.parseInt(System.getProperty("reload.simulator.count", "0"));
+        assertTrue(Executor.registerCSSWatcher(first, simulatorReloadVersion));
+        assertTrue(Executor.registerCSSWatcher(second, simulatorReloadVersion));
+
+        Executor.cleanupForSimulatorReload();
+        Executor.cleanupForSimulatorReload();
+
+        assertEquals(1, first.stopCount);
+        assertEquals(1, second.stopCount);
+    }
+
+    @Test
+    void staleSimulatorGenerationCannotRegisterDelayedCSSWatcher() {
+        String oldReloadVersion = System.getProperty("reload.simulator.count");
+        int simulatorReloadVersion = Integer.parseInt(System.getProperty("reload.simulator.count", "0"));
+        TrackingCSSWatcher watcher = new TrackingCSSWatcher();
+        System.setProperty("reload.simulator.count", String.valueOf(simulatorReloadVersion + 1));
+        try {
+            assertFalse(Executor.registerCSSWatcher(watcher, simulatorReloadVersion));
+        } finally {
+            watcher.stop();
+            if (oldReloadVersion == null) {
+                System.clearProperty("reload.simulator.count");
+            } else {
+                System.setProperty("reload.simulator.count", oldReloadVersion);
+            }
         }
     }
 }

--- a/maven/javase/src/test/java/com/codename1/impl/javase/CSSWatcherTest.java
+++ b/maven/javase/src/test/java/com/codename1/impl/javase/CSSWatcherTest.java
@@ -105,19 +105,12 @@ class CSSWatcherTest {
 
     @Test
     void staleSimulatorGenerationCannotRegisterDelayedCSSWatcher() {
-        String oldReloadVersion = System.getProperty("reload.simulator.count");
         int simulatorReloadVersion = Integer.parseInt(System.getProperty("reload.simulator.count", "0"));
         TrackingCSSWatcher watcher = new TrackingCSSWatcher();
-        System.setProperty("reload.simulator.count", String.valueOf(simulatorReloadVersion + 1));
         try {
-            assertFalse(Executor.registerCSSWatcher(watcher, simulatorReloadVersion));
+            assertFalse(Executor.registerCSSWatcher(watcher, simulatorReloadVersion + 1));
         } finally {
             watcher.stop();
-            if (oldReloadVersion == null) {
-                System.clearProperty("reload.simulator.count");
-            } else {
-                System.setProperty("reload.simulator.count", oldReloadVersion);
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- stop the active CSS watcher and source watcher before a simulator generation reloads
- reject delayed CSS watcher tasks that belong to an older simulator generation
- make CSS watcher shutdown race-safe and remove obsolete JVM shutdown hooks
- add regression coverage for watcher cleanup and stale-generation registration

## Root cause

Each hot reload created a new simulator classloader and scheduled a new CSS watcher. The previous watcher could remain blocked while reading its child process, so it was never explicitly stopped. Its shutdown hook also retained the old watcher and classloader. Repeating hot reload therefore accumulated `theme-css -watch` Java processes.

The simulator now advances its generation, explicitly cleans up the old generation, and only then starts the replacement. This stops the previous compiler process instead of trying to reuse a watcher tied to the old classloader.

Addresses https://github.com/codenameone/CodenameOne/discussions/5455

## Validation

- `JAVA_HOME=/Users/shai/Library/Java/JavaVirtualMachines/azul-1.8.0_372/Contents/Home mvn -pl javase -Dtest=CSSWatcherTest -Dmaven.javadoc.skip=true -Plocal-dev-javase test`
  - 4 tests passed
- JavaSE `verify` with tests skipped passed and built the module artifacts
- `git diff --check` passed

The complete JavaSE suite was also attempted. It is currently blocked on this macOS host by unrelated native failures: Java 8 aborts in AWT UI/font tests, and FFmpeg VideoToolbox cannot create a hardware compression session.
