### PR TITLE
Automate same-day LinkedIn posts

### DIFF
--- a/.github/workflows/blog-prose.yml
+++ b/.github/workflows/blog-prose.yml
@@ -68,6 +68,12 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Validate LinkedIn queue inputs
+        if: steps.detect.outputs.has_posts == 'true'
+        run: |
+          python3 scripts/website/test_queue_social_posts.py
+          python3 scripts/website/queue_social_posts.py --validate-only
+
       - name: Install python-markdown
         if: steps.detect.outputs.has_posts == 'true'
         run: pip install --user 'markdown==3.7'

--- a/.github/workflows/blog-syndication.yml
+++ b/.github/workflows/blog-syndication.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Run syndication regression tests
         run: |
           python3 scripts/website/test_syndicate_blog_posts.py
+          python3 scripts/website/test_queue_social_posts.py
           python3 scripts/website/test_syndication_health.py
 
       - name: Run API syndication script
@@ -94,6 +95,11 @@ jobs:
         run: |
           set -euo pipefail
           python3 scripts/website/queue_browser_syndication.py
+
+      - name: Queue scheduled LinkedIn posts
+        run: |
+          set -euo pipefail
+          python3 scripts/website/queue_social_posts.py
 
       - name: Upload syndication screenshots on failure
         if: ${{ always() && hashFiles('docs/website/reports/syndication-screenshots/**/*.png') != '' }}

--- a/docs/website/social/README.md
+++ b/docs/website/social/README.md
@@ -1,0 +1,46 @@
+# LinkedIn social queue
+
+LinkedIn posts live in `docs/website/social/linkedin/`. One Markdown file
+represents one post. Its body is the exact LinkedIn text; the frontmatter tells
+the browser syndication queue when to publish it, which account to use, and
+which blog image to attach.
+
+Every valid artifact merged into the default branch is added to
+`scripts/website/syndication-queue.json`. There is no review or approval-status
+filter. The local browser runner leaves future tasks in the queue until
+`scheduled_at`, then publishes through the requested LinkedIn account with the
+declared image.
+
+`publish_at` must use the source blog post's publication date. LinkedIn is
+same-day distribution; the delayed full-article syndication cadence does not
+apply to it.
+
+## File contract
+
+```yaml
+---
+title: "Internal label"
+slug: 2026-07-20-1200-shai-source-slug
+platform: linkedin
+account: shai # shai or codenameone
+source_slug: source-slug
+publish_at: '2026-07-20T12:00:00'
+timezone: Asia/Jerusalem
+image: /blog/source-slug.jpg
+---
+
+The LinkedIn post body goes here.
+
+Full write-up: {{canonical}}
+```
+
+The IANA timezone keeps the schedule readable and lets the queue convert it to
+an unambiguous UTC instant. Choose a time after the blog is live on that same
+date. `{{canonical}}` is required exactly once and is replaced with the source
+blog post's canonical URL.
+
+Validate artifacts without changing the queue:
+
+```bash
+python3 scripts/website/queue_social_posts.py --validate-only
+```

--- a/docs/website/social/linkedin/2026-07-17-1800-shai-pixel-perfect-is-a-test.md
+++ b/docs/website/social/linkedin/2026-07-17-1800-shai-pixel-perfect-is-a-test.md
@@ -6,8 +6,6 @@ account: shai
 source_slug: pixel-perfect-is-a-test
 publish_at: '2026-07-17T18:00:00'
 timezone: Asia/Jerusalem
-review_by: '2026-07-17'
-status: approved
 image: /blog/pixel-perfect-is-a-test.jpg
 ---
 

--- a/docs/website/social/linkedin/2026-07-18-1200-shai-standalone-codename-one-settings.md
+++ b/docs/website/social/linkedin/2026-07-18-1200-shai-standalone-codename-one-settings.md
@@ -6,8 +6,6 @@ account: shai
 source_slug: standalone-codename-one-settings
 publish_at: '2026-07-18T12:00:00'
 timezone: Asia/Jerusalem
-review_by: '2026-07-17'
-status: approved
 image: /blog/standalone-codename-one-settings.jpg
 ---
 

--- a/docs/website/social/linkedin/2026-07-19-1200-shai-widgets-live-activities-dynamic-island.md
+++ b/docs/website/social/linkedin/2026-07-19-1200-shai-widgets-live-activities-dynamic-island.md
@@ -6,8 +6,6 @@ account: shai
 source_slug: widgets-live-activities-dynamic-island
 publish_at: '2026-07-19T12:00:00'
 timezone: Asia/Jerusalem
-review_by: '2026-07-17'
-status: approved
 image: /blog/widgets-live-activities-dynamic-island.jpg
 ---
 

--- a/docs/website/social/linkedin/2026-07-20-1200-shai-accessibility-semantics.md
+++ b/docs/website/social/linkedin/2026-07-20-1200-shai-accessibility-semantics.md
@@ -6,8 +6,6 @@ account: shai
 source_slug: accessibility-semantics
 publish_at: '2026-07-20T12:00:00'
 timezone: Asia/Jerusalem
-review_by: '2026-07-17'
-status: approved
 image: /blog/accessibility-semantics.jpg
 ---
 

--- a/docs/website/social/linkedin/2026-07-21-1200-shai-codename-one-mcp-server.md
+++ b/docs/website/social/linkedin/2026-07-21-1200-shai-codename-one-mcp-server.md
@@ -6,8 +6,6 @@ account: shai
 source_slug: codename-one-mcp-server
 publish_at: '2026-07-21T12:00:00'
 timezone: Asia/Jerusalem
-review_by: '2026-07-17'
-status: approved
 image: /blog/codename-one-mcp-server.jpg
 ---
 

--- a/docs/website/social/linkedin/2026-07-22-1200-codenameone-tested-port-support.md
+++ b/docs/website/social/linkedin/2026-07-22-1200-codenameone-tested-port-support.md
@@ -6,8 +6,6 @@ account: codenameone
 source_slug: tested-port-support
 publish_at: '2026-07-22T12:00:00'
 timezone: Asia/Jerusalem
-review_by: '2026-07-17'
-status: approved
 image: /blog/tested-port-support.jpg
 ---
 

--- a/docs/website/social/linkedin/2026-07-24-1200-shai-javascript-free-open-source.md
+++ b/docs/website/social/linkedin/2026-07-24-1200-shai-javascript-free-open-source.md
@@ -1,13 +1,11 @@
 ---
 title: "The Codename One JavaScript port is now free and open source"
-slug: 2026-07-27-0300-shai-javascript-free-open-source
+slug: 2026-07-24-1200-shai-javascript-free-open-source
 platform: linkedin
 account: shai
 source_slug: javascript-free-open-source
-publish_at: '2026-07-27T03:00:00'
+publish_at: '2026-07-24T12:00:00'
 timezone: Asia/Jerusalem
-review_by: '2026-07-24'
-status: draft
 image: /blog/javascript-free-open-source.jpg
 ---
 

--- a/docs/website/social/linkedin/2026-07-25-1200-codenameone-calendar-is-not-add-event.md
+++ b/docs/website/social/linkedin/2026-07-25-1200-codenameone-calendar-is-not-add-event.md
@@ -1,13 +1,11 @@
 ---
 title: "Calendar API with local calendars, cloud sync, and conflict handling"
-slug: 2026-07-27-1200-codenameone-calendar-is-not-add-event
+slug: 2026-07-25-1200-codenameone-calendar-is-not-add-event
 platform: linkedin
 account: codenameone
 source_slug: calendar-is-not-add-event
-publish_at: '2026-07-27T12:00:00'
+publish_at: '2026-07-25T12:00:00'
 timezone: Asia/Jerusalem
-review_by: '2026-07-24'
-status: draft
 image: /blog/calendar-is-not-add-event.jpg
 ---
 

--- a/docs/website/social/linkedin/2026-07-26-1200-codenameone-bluetooth-beyond-ble.md
+++ b/docs/website/social/linkedin/2026-07-26-1200-codenameone-bluetooth-beyond-ble.md
@@ -1,13 +1,11 @@
 ---
 title: "Bluetooth support across every Codename One target"
-slug: 2026-07-28-0300-codenameone-bluetooth-beyond-ble
+slug: 2026-07-26-1200-codenameone-bluetooth-beyond-ble
 platform: linkedin
 account: codenameone
 source_slug: bluetooth-beyond-ble
-publish_at: '2026-07-28T03:00:00'
+publish_at: '2026-07-26T12:00:00'
 timezone: Asia/Jerusalem
-review_by: '2026-07-24'
-status: draft
 image: /blog/bluetooth-beyond-ble.jpg
 ---
 

--- a/docs/website/social/linkedin/2026-07-27-1200-shai-text-input-without-native-overlay.md
+++ b/docs/website/social/linkedin/2026-07-27-1200-shai-text-input-without-native-overlay.md
@@ -1,13 +1,11 @@
 ---
 title: "Pure Codename One text editing without a native overlay"
-slug: 2026-07-28-1200-shai-text-input-without-native-overlay
+slug: 2026-07-27-1200-shai-text-input-without-native-overlay
 platform: linkedin
 account: shai
 source_slug: text-input-without-native-overlay
-publish_at: '2026-07-28T12:00:00'
+publish_at: '2026-07-27T12:00:00'
 timezone: Asia/Jerusalem
-review_by: '2026-07-24'
-status: draft
 image: /blog/text-input-without-native-overlay.jpg
 ---
 

--- a/docs/website/social/linkedin/2026-07-28-1200-codenameone-rich-text-without-webview.md
+++ b/docs/website/social/linkedin/2026-07-28-1200-codenameone-rich-text-without-webview.md
@@ -1,13 +1,11 @@
 ---
 title: "A lightweight rich text component without a web view"
-slug: 2026-07-29-0300-codenameone-rich-text-without-webview
+slug: 2026-07-28-1200-codenameone-rich-text-without-webview
 platform: linkedin
 account: codenameone
 source_slug: rich-text-without-webview
-publish_at: '2026-07-29T03:00:00'
+publish_at: '2026-07-28T12:00:00'
 timezone: Asia/Jerusalem
-review_by: '2026-07-24'
-status: draft
 image: /blog/rich-text-without-webview.jpg
 ---
 

--- a/docs/website/social/linkedin/2026-07-29-1200-shai-compact-strings-parparvm.md
+++ b/docs/website/social/linkedin/2026-07-29-1200-shai-compact-strings-parparvm.md
@@ -6,8 +6,6 @@ account: shai
 source_slug: compact-strings-parparvm
 publish_at: '2026-07-29T12:00:00'
 timezone: Asia/Jerusalem
-review_by: '2026-07-24'
-status: draft
 image: /blog/compact-strings-parparvm.jpg
 ---
 

--- a/scripts/website/check_syndication_health.py
+++ b/scripts/website/check_syndication_health.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Report syndication work that has not been processed.
 
-The GitHub workflow queues Medium, DZone, and reviewed LinkedIn work, while a
+The GitHub workflow queues Medium, DZone, and scheduled LinkedIn work, while a
 signed-in browser runner on the maintainer's machine drains that queue.  A
 successful local run removes completed entries.  Anything left beyond its
 grace period therefore needs attention.  DEV, Foojay, and Hashnode do not all

--- a/scripts/website/queue_social_posts.py
+++ b/scripts/website/queue_social_posts.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Validate LinkedIn social posts and append them to the browser queue.
+
+Social posts live under ``docs/website/social/linkedin`` as Markdown with
+YAML-style front matter. Every valid artifact on the default branch enters the
+shared queue. The local browser runner gates publication on ``scheduled_at``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from syndicate_blog_posts import (  # noqa: E402
+    BLOG_DIR,
+    REPO_ROOT,
+    SITE_BASE_URL,
+    STATE_FILE,
+    State,
+    parse_front_matter,
+    parse_post,
+)
+
+
+SOCIAL_DIR = REPO_ROOT / "docs" / "website" / "social" / "linkedin"
+QUEUE_FILE = REPO_ROOT / "scripts" / "website" / "syndication-queue.json"
+STATIC_DIR = REPO_ROOT / "docs" / "website" / "static"
+SUPPORTED_ACCOUNTS = {"codenameone", "shai"}
+CANONICAL_TOKEN = "{{canonical}}"
+
+
+class SocialPostError(ValueError):
+    """Raised when a social-post artifact violates the queue contract."""
+
+
+@dataclass(frozen=True)
+class SocialPost:
+    path: Path
+    slug: str
+    title: str
+    account: str
+    source_slug: str
+    publish_local: dt.datetime
+    publish_utc: dt.datetime
+    timezone: str
+    image_path: str
+    body: str
+    canonical: str
+
+    @property
+    def task_id(self) -> str:
+        return f"linkedin:{self.slug}"
+
+    @property
+    def image_url(self) -> str:
+        return f"{SITE_BASE_URL}{self.image_path}"
+
+    @property
+    def body_text(self) -> str:
+        return self.body.replace(CANONICAL_TOKEN, self.canonical).strip()
+
+
+def _required(fm: dict[str, Any], key: str, path: Path) -> str:
+    value = fm.get(key)
+    if value is None or not str(value).strip():
+        raise SocialPostError(
+            f"{path}: missing required frontmatter field {key!r}"
+        )
+    return str(value).strip()
+
+
+def _parse_local_datetime(
+    value: str, timezone: str, path: Path
+) -> tuple[dt.datetime, dt.datetime]:
+    try:
+        parsed = dt.datetime.fromisoformat(value)
+    except ValueError as err:
+        raise SocialPostError(
+            f"{path}: publish_at must be an ISO date/time: {value!r}"
+        ) from err
+    try:
+        zone = ZoneInfo(timezone)
+    except ZoneInfoNotFoundError as err:
+        raise SocialPostError(
+            f"{path}: unknown IANA timezone: {timezone!r}"
+        ) from err
+
+    if parsed.tzinfo is None:
+        local = parsed.replace(tzinfo=zone)
+    else:
+        local = parsed.astimezone(zone)
+    return local, local.astimezone(dt.timezone.utc)
+
+
+def parse_social_post(
+    path: Path,
+    blog_dir: Path = BLOG_DIR,
+    static_dir: Path = STATIC_DIR,
+) -> SocialPost:
+    raw = path.read_text(encoding="utf-8")
+    try:
+        fm, body = parse_front_matter(raw)
+    except ValueError as err:
+        raise SocialPostError(f"{path}: {err}") from err
+
+    slug = _required(fm, "slug", path)
+    if slug != path.stem:
+        raise SocialPostError(
+            f"{path}: slug must match filename stem ({path.stem!r})"
+        )
+
+    platform = _required(fm, "platform", path).lower()
+    if platform != "linkedin":
+        raise SocialPostError(
+            f"{path}: platform must be 'linkedin' for this queue"
+        )
+
+    account = _required(fm, "account", path).lower()
+    if account not in SUPPORTED_ACCOUNTS:
+        raise SocialPostError(
+            f"{path}: account must be one of "
+            f"{sorted(SUPPORTED_ACCOUNTS)}, got {account!r}"
+        )
+
+    source_slug = _required(fm, "source_slug", path)
+    source_path = blog_dir / f"{source_slug}.md"
+    if not source_path.exists():
+        raise SocialPostError(
+            f"{path}: source blog post does not exist: {source_path}"
+        )
+    source = parse_post(source_path)
+    if source is None:
+        raise SocialPostError(
+            f"{path}: could not parse source blog post: {source_path}"
+        )
+
+    timezone = _required(fm, "timezone", path)
+    publish_local, publish_utc = _parse_local_datetime(
+        _required(fm, "publish_at", path), timezone, path
+    )
+    if publish_local.date() != source.date:
+        raise SocialPostError(
+            f"{path}: publish_at must use the source blog date "
+            f"{source.date.isoformat()}"
+        )
+
+    image_path = _required(fm, "image", path)
+    if not image_path.startswith("/blog/"):
+        raise SocialPostError(f"{path}: image must be a /blog/... path")
+    image_file = static_dir / image_path.lstrip("/")
+    if not image_file.exists():
+        raise SocialPostError(
+            f"{path}: image attachment does not exist: {image_file}"
+        )
+
+    body = body.strip()
+    if not body:
+        raise SocialPostError(f"{path}: LinkedIn post body is empty")
+    canonical = source.canonical_url
+    canonical_references = (
+        body.count(CANONICAL_TOKEN) + body.count(canonical)
+    )
+    if canonical_references != 1:
+        raise SocialPostError(
+            f"{path}: body must contain exactly one canonical link or "
+            f"{CANONICAL_TOKEN} placeholder"
+        )
+    body_text = body.replace(CANONICAL_TOKEN, canonical)
+    if len(body_text) > 3000:
+        raise SocialPostError(
+            f"{path}: LinkedIn body is {len(body_text)} characters; "
+            "maximum is 3000"
+        )
+
+    return SocialPost(
+        path=path,
+        slug=slug,
+        title=_required(fm, "title", path),
+        account=account,
+        source_slug=source_slug,
+        publish_local=publish_local,
+        publish_utc=publish_utc,
+        timezone=timezone,
+        image_path=image_path,
+        body=body,
+        canonical=canonical,
+    )
+
+
+def discover_social_posts(
+    social_dir: Path = SOCIAL_DIR,
+    blog_dir: Path = BLOG_DIR,
+    static_dir: Path = STATIC_DIR,
+) -> list[SocialPost]:
+    if not social_dir.exists():
+        return []
+    posts = [
+        parse_social_post(path, blog_dir=blog_dir, static_dir=static_dir)
+        for path in sorted(social_dir.glob("*.md"))
+        if not path.name.startswith("_")
+    ]
+    posts.sort(
+        key=lambda post: (post.publish_utc, post.account, post.slug)
+    )
+    return posts
+
+
+def build_task(
+    post: SocialPost, queued_at: dt.datetime | None = None
+) -> dict[str, Any]:
+    queued_at = queued_at or dt.datetime.now(dt.timezone.utc)
+    return {
+        "id": post.task_id,
+        "site": "linkedin",
+        "kind": "social",
+        "slug": post.slug,
+        "source_slug": post.source_slug,
+        "account": post.account,
+        "title": post.title,
+        "canonical": post.canonical,
+        "cover_image_url": post.image_url,
+        "body_text": post.body_text,
+        "scheduled_at": post.publish_utc.isoformat(timespec="seconds"),
+        "scheduled_local": post.publish_local.isoformat(
+            timespec="minutes"
+        ),
+        "timezone": post.timezone,
+        "queued_at": queued_at.isoformat(timespec="seconds"),
+    }
+
+
+def _load_queue(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"tasks": []}
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data.get("tasks"), list):
+        raise SocialPostError(f"{path}: queue must contain a tasks list")
+    return data
+
+
+def queue_posts(
+    posts: list[SocialPost],
+    queue: dict[str, Any],
+    state: State,
+    queued_at: dt.datetime | None = None,
+) -> list[dict[str, Any]]:
+    existing_ids = {
+        task.get("id") for task in queue.get("tasks", [])
+    }
+    new_tasks: list[dict[str, Any]] = []
+    for post in posts:
+        if post.task_id in existing_ids:
+            continue
+        if state.is_syndicated(post.slug, "linkedin"):
+            continue
+        task = build_task(post, queued_at=queued_at)
+        new_tasks.append(task)
+        existing_ids.add(post.task_id)
+    return new_tasks
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--social-dir", default=str(SOCIAL_DIR))
+    parser.add_argument("--blog-dir", default=str(BLOG_DIR))
+    parser.add_argument("--static-dir", default=str(STATIC_DIR))
+    parser.add_argument("--state-file", default=str(STATE_FILE))
+    parser.add_argument("--queue-file", default=str(QUEUE_FILE))
+    parser.add_argument("--validate-only", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    try:
+        posts = discover_social_posts(
+            Path(args.social_dir),
+            Path(args.blog_dir),
+            Path(args.static_dir),
+        )
+    except (SocialPostError, json.JSONDecodeError) as err:
+        print(err, file=sys.stderr)
+        return 2
+
+    print(f"Validated {len(posts)} LinkedIn social post artifact(s).")
+    if args.validate_only:
+        return 0
+
+    queue_path = Path(args.queue_file)
+    try:
+        queue = _load_queue(queue_path)
+        state = State.load(Path(args.state_file))
+    except (SocialPostError, json.JSONDecodeError) as err:
+        print(err, file=sys.stderr)
+        return 2
+
+    new_tasks = queue_posts(posts, queue, state)
+    if not new_tasks:
+        print("No new LinkedIn tasks to queue.")
+        return 0
+
+    print(f"Queueing {len(new_tasks)} LinkedIn task(s):")
+    for task in new_tasks:
+        print(
+            f"  + {task['id']} "
+            f"({task['account']}, {task['scheduled_local']})"
+        )
+    if not args.dry_run:
+        queue.setdefault("tasks", []).extend(new_tasks)
+        queue_path.write_text(
+            json.dumps(queue, indent=2) + "\n", encoding="utf-8"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/website/test_queue_social_posts.py
+++ b/scripts/website/test_queue_social_posts.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import datetime as dt
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import queue_social_posts as social
+from syndicate_blog_posts import State
+
+
+BLOG = """---
+title: "Source Post"
+slug: source-post
+url: /blog/source-post/
+date: '2026-07-20'
+author: Shai Almog
+description: Test source.
+---
+
+![Source](/blog/source-post.jpg)
+
+Body.
+"""
+
+
+def artifact(
+    *,
+    status: str | None = None,
+    publish_at: str = "2026-07-20T03:00:00",
+) -> str:
+    status_field = f"status: {status}\n" if status else ""
+    return f"""---
+title: "Personal performance lesson"
+slug: 2026-07-20-0300-shai-source-post
+platform: linkedin
+account: shai
+source_slug: source-post
+publish_at: '{publish_at}'
+timezone: Asia/Jerusalem
+image: /blog/source-post.jpg
+{status_field}---
+
+The useful part of this test is the queue contract.
+
+Full write-up: {{{{canonical}}}}
+"""
+
+
+class SocialQueueTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        root = Path(self.tmp.name)
+        self.blog_dir = root / "blog"
+        self.social_dir = root / "social"
+        self.static_dir = root / "static"
+        self.blog_dir.mkdir()
+        self.social_dir.mkdir()
+        (self.static_dir / "blog").mkdir(parents=True)
+        (self.blog_dir / "source-post.md").write_text(
+            BLOG, encoding="utf-8"
+        )
+        (self.static_dir / "blog" / "source-post.jpg").write_bytes(
+            b"image"
+        )
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def write_artifact(self, text: str) -> Path:
+        path = (
+            self.social_dir
+            / "2026-07-20-0300-shai-source-post.md"
+        )
+        path.write_text(text, encoding="utf-8")
+        return path
+
+    def parse(self, text: str) -> social.SocialPost:
+        return social.parse_social_post(
+            self.write_artifact(text),
+            self.blog_dir,
+            self.static_dir,
+        )
+
+    def test_post_queues_with_time_link_and_image(self):
+        post = self.parse(artifact())
+        now = dt.datetime(
+            2026, 7, 17, 9, tzinfo=dt.timezone.utc
+        )
+        tasks = social.queue_posts(
+            [post],
+            {"tasks": []},
+            State(raw={"posts": {}}),
+            queued_at=now,
+        )
+        self.assertEqual(1, len(tasks))
+        task = tasks[0]
+        self.assertEqual(
+            "2026-07-20T00:00:00+00:00",
+            task["scheduled_at"],
+        )
+        self.assertEqual(
+            "2026-07-20T03:00+03:00",
+            task["scheduled_local"],
+        )
+        self.assertEqual(
+            "https://www.codenameone.com/blog/source-post/",
+            task["canonical"],
+        )
+        self.assertIn(task["canonical"], task["body_text"])
+        self.assertEqual(
+            "https://www.codenameone.com/blog/source-post.jpg",
+            task["cover_image_url"],
+        )
+
+    def test_legacy_draft_status_does_not_block_queueing(self):
+        post = self.parse(artifact(status="draft"))
+        tasks = social.queue_posts(
+            [post],
+            {"tasks": []},
+            State(raw={"posts": {}}),
+        )
+        self.assertEqual(1, len(tasks))
+
+    def test_publish_date_must_match_source_blog_date(self):
+        with self.assertRaisesRegex(
+            social.SocialPostError, "source blog date"
+        ):
+            self.parse(
+                artifact(publish_at="2026-07-21T03:00:00")
+            )
+
+    def test_queue_and_state_deduplicate(self):
+        post = self.parse(artifact())
+        existing = {"tasks": [{"id": post.task_id}]}
+        state = State(raw={"posts": {}})
+        self.assertEqual(
+            [], social.queue_posts([post], existing, state)
+        )
+        state = State(
+            raw={
+                "posts": {
+                    post.slug: {
+                        "linkedin": {
+                            "url": "https://linkedin.example/post"
+                        }
+                    }
+                }
+            }
+        )
+        self.assertEqual(
+            [],
+            social.queue_posts([post], {"tasks": []}, state),
+        )
+
+    def test_image_must_exist(self):
+        (
+            self.static_dir / "blog" / "source-post.jpg"
+        ).unlink()
+        with self.assertRaisesRegex(
+            social.SocialPostError,
+            "image attachment does not exist",
+        ):
+            self.parse(artifact())
+
+    def test_body_requires_one_canonical_reference(self):
+        with self.assertRaisesRegex(
+            social.SocialPostError,
+            "exactly one canonical",
+        ):
+            self.parse(
+                artifact().replace("{{canonical}}", "no-link")
+            )
+
+    def test_existing_canonical_url_is_accepted(self):
+        post = self.parse(
+            artifact().replace(
+                "{{canonical}}",
+                "https://www.codenameone.com/blog/source-post/",
+            )
+        )
+        self.assertEqual(
+            "https://www.codenameone.com/blog/source-post/",
+            post.canonical,
+        )
+
+    def test_main_dry_run_does_not_write_queue(self):
+        self.write_artifact(artifact())
+        root = Path(self.tmp.name)
+        queue = root / "queue.json"
+        state = root / "state.json"
+        queue.write_text(
+            json.dumps({"tasks": []}), encoding="utf-8"
+        )
+        state.write_text(
+            json.dumps({"posts": {}}), encoding="utf-8"
+        )
+        rc = social.main(
+            [
+                "--social-dir",
+                str(self.social_dir),
+                "--blog-dir",
+                str(self.blog_dir),
+                "--static-dir",
+                str(self.static_dir),
+                "--queue-file",
+                str(queue),
+                "--state-file",
+                str(state),
+                "--dry-run",
+            ]
+        )
+        self.assertEqual(0, rc)
+        self.assertEqual(
+            [],
+            json.loads(
+                queue.read_text(encoding="utf-8")
+            )["tasks"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add the repository-backed LinkedIn queue generator and wire it into the blog syndication workflow
- remove the review/status admission filter so every valid default-branch social artifact is queued
- require each LinkedIn `publish_at` date to match its source blog date
- realign the July 24–29 LinkedIn artifacts with the blog posts they discuss
- validate LinkedIn artifacts in the prose workflow and document the queue contract

## Root cause

The LinkedIn artifacts existed, but the queue generator and workflow invocation never reached `master`. The local runner therefore saw an empty queue. The unlanded generator also treated `status: approved` as an admission gate and the current artifacts used a following-week cadence copied from full-article syndication.

LinkedIn is short social distribution, not full-article republication. It should publish on the source blog date; only article syndication keeps the delayed cadence.

## Validation

- `python3 scripts/website/test_queue_social_posts.py` — 8 tests passed
- `python3 scripts/website/test_syndicate_blog_posts.py` — 4 tests passed
- `python3 scripts/website/test_syndication_health.py` — 6 tests passed
- `python3 scripts/website/queue_social_posts.py --validate-only` — 12 artifacts validated
- `python3 scripts/website/queue_social_posts.py --dry-run` — exactly 6 July 24–29 tasks queued
- `git diff --check`