### PR TITLE
Fix ParparVM scalar replacement folding a field read shared by two paths (#5461)

### DIFF
--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeTranslator.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeTranslator.java
@@ -83,11 +83,24 @@ public class ByteCodeTranslator {
         }
     }
     
+    private static void sortByName(File[] files) {
+        if (files != null) {
+            java.util.Arrays.sort(files, (a, b) -> a.getName().compareTo(b.getName()));
+        }
+    }
+
     void execute(File sourceDir, File outputDir) throws Exception {
         File[] directoryList = sourceDir.listFiles(pathname ->
                 !pathname.isHidden() && !pathname.getName().startsWith(".") && pathname.isDirectory());
         File[] fileList = sourceDir.listFiles(pathname ->
                 !pathname.isHidden() && !pathname.getName().startsWith(".") && !pathname.isDirectory());
+        // listFiles() returns whatever order the filesystem hands back, which can
+        // differ between two builds of the same input (the app classes are
+        // re-extracted per build). Parse order is observable in the output --
+        // cross-class analyses see either the raw or the already-optimized form of
+        // another class -- so sort it and keep builds reproducible.
+        sortByName(directoryList);
+        sortByName(fileList);
         if(fileList != null) {
             for(File f : fileList) {
                 if (f.getName().equals("module-info.class")) {

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
@@ -1292,13 +1292,20 @@ public class BytecodeMethod implements SignatureSet {
     // looks this up at emit time -- decoupling the analysis (raw, deterministic) from
     // the cross-class emission order. null == not an inlinable ctor.
     private com.codename1.tools.translator.bytecodes.InlinableConstructor inlinableCtorPlan;
-    private boolean inlinableCtorComputed;
+    private boolean rawPlansComputed;
 
-    public void computeInlinableConstructorPlan() {
-        if (inlinableCtorComputed) {
+    /**
+     * Snapshots every analysis whose answer must be read off the RAW instruction
+     * list. Called from Parser.MethodVisitorWrapper.visitEnd, before any
+     * optimize() folds opcodes into custom instructions -- so that a pass running
+     * over one class cannot get a different answer about another class depending
+     * on which of the two was optimized first.
+     */
+    public void computeRawMethodPlans() {
+        if (rawPlansComputed) {
             return;
         }
-        inlinableCtorComputed = true;
+        rawPlansComputed = true;
         if (constructor) {
             inlinableCtorPlan = com.codename1.tools.translator.bytecodes.InlinableConstructor.analyzeRaw(this, desc);
             // FUSED OBJECTS: snapshot the fused-construction plan from the same RAW
@@ -3600,8 +3607,8 @@ public class BytecodeMethod implements SignatureSet {
      *
      * The instruction-shape half runs at PARSE time (see
      * {@link #analyzeScalarConstructorRaw()}) because optimize() folds the
-     * ALOAD/xLOAD/PUTFIELD groups into opaque CustomIntructions -- reading the
-     * ctor's live list here would make the answer depend on whether X had
+     * ALOAD/xLOAD/PUTFIELD groups into opaque custom instructions -- reading
+     * the ctor's live list here would make the answer depend on whether X had
      * already been optimized, i.e. on class processing order. Only the
      * class-level bijection check, which needs the resolved field list, is
      * left for here.
@@ -3639,7 +3646,7 @@ public class BytecodeMethod implements SignatureSet {
     }
 
     // Shape half of srAnalyzeCtor, snapshotted from the RAW instruction list at
-    // parse time (called from computeInlinableConstructorPlan, exactly like the
+    // parse time (called from computeRawMethodPlans, exactly like the
     // InlinableConstructor / FusedConstructor plans next to it).
     private String[] srCtorMembers;
     private char[] srCtorQuals;
@@ -3809,7 +3816,7 @@ public class BytecodeMethod implements SignatureSet {
      *
      *  The shape itself is recognized at parse time ({@link #analyzeTrivialGetterRaw()}): by the
      *  time this call site is optimized the getter's own list may already have been folded into
-     *  CustomIntructions, and matching against that would make the decision depend on class
+     *  custom instructions, and matching against that would make the decision depend on class
      *  processing order. */
     private Field srTrivialGetterField(Invoke inv, ByteCodeClass x) {
         int op = inv.getOpcode();

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
@@ -1305,7 +1305,13 @@ public class BytecodeMethod implements SignatureSet {
             // list (the class-level @Fused gate is applied by the users of the plan;
             // the shape analysis is cheap and most ctors bail on the first check).
             fusedCtorPlan = com.codename1.tools.translator.bytecodes.FusedConstructor.analyzeRaw(this, desc);
+            // SCALAR REPLACEMENT: same reason, same RAW list -- see srAnalyzeCtor.
+            analyzeScalarConstructorRaw();
         }
+        // SCALAR REPLACEMENT: trivial getters are folded into a struct member read
+        // at their CALL sites, in other classes. Same rule as the plans above --
+        // recognize the shape on the raw list, never on the live one.
+        analyzeTrivialGetterRaw();
     }
 
     public com.codename1.tools.translator.bytecodes.InlinableConstructor getInlinableConstructorPlan() {
@@ -2675,6 +2681,39 @@ public class BytecodeMethod implements SignatureSet {
         return s.replace('.', '_').replace('/', '_').replace('$', '_');
     }
 
+    /**
+     * Like {@link #srNextReal(int)} but a control-flow join ends the lookahead.
+     *
+     * Every scalar-replacement match is a claim about two ADJACENT instructions
+     * ("this ALOAD feeds that GETFIELD", "this NEW feeds that DUP"). srNextReal
+     * skips every LabelInstruction, including the ones that are jump targets --
+     * so it happily pairs instructions that are not on a common path. javac
+     * emits exactly that for {@code (c ? p : q).x}:
+     *
+     *     ALOAD p ; GOTO L ; [L1:] ALOAD q ; [L:] GETFIELD x
+     *
+     * Folding "ALOAD q ; GETFIELD x" into a read of q's scalar struct rewrites
+     * the GETFIELD that the {@code p} path also branches into, so that path
+     * silently reads q's field (and leaks its own receiver on the operand
+     * stack). Stopping at the join leaves the whole site alone.
+     */
+    private int srNextRealNoJoin(int from) {
+        for (int i = from; i < instructions.size(); i++) {
+            Instruction in = instructions.get(i);
+            if (in instanceof LabelInstruction) {
+                if (LabelInstruction.isJumpTarget(((LabelInstruction) in).getLabel())) {
+                    return -1;
+                }
+                continue;
+            }
+            if (in instanceof LineNumber || in instanceof LocalVariable) {
+                continue;
+            }
+            return i;
+        }
+        return -1;
+    }
+
     /** Next index of a non-trivia instruction at or after {@code from}, or -1. */
     private int srNextReal(int from) {
         for (int i = from; i < instructions.size(); i++) {
@@ -2817,7 +2856,7 @@ public class BytecodeMethod implements SignatureSet {
             }
 
             // DUP must immediately follow the NEW.
-            int dupIdx = srNextReal(idx + 1);
+            int dupIdx = srNextRealNoJoin(idx + 1);
             if (dupIdx < 0 || instructions.get(dupIdx).getOpcode() != Opcodes.DUP) {
                 continue;
             }
@@ -2827,7 +2866,7 @@ public class BytecodeMethod implements SignatureSet {
             // or any control flow -- those break the simple receiver-at-bottom shape.
             int invIdx = -1;
             boolean bail = false;
-            for (int j = srNextReal(dupIdx + 1); j >= 0; j = srNextReal(j + 1)) {
+            for (int j = srNextRealNoJoin(dupIdx + 1); j >= 0; j = srNextRealNoJoin(j + 1)) {
                 Instruction c = instructions.get(j);
                 int op = c.getOpcode();
                 if (c instanceof Invoke && op == Opcodes.INVOKESPECIAL
@@ -2859,7 +2898,7 @@ public class BytecodeMethod implements SignatureSet {
             Invoke initInv = (Invoke) instructions.get(invIdx);
 
             // ASTORE n must immediately follow the constructor call.
-            int storeIdx = srNextReal(invIdx + 1);
+            int storeIdx = srNextRealNoJoin(invIdx + 1);
             if (storeIdx < 0) {
                 continue;
             }
@@ -2874,7 +2913,7 @@ public class BytecodeMethod implements SignatureSet {
             char[] quals = new char[0];
             String[][] mapOut = new String[1][];
             char[][] qualOut = new char[1][];
-            if (!srAnalyzeCtor(x, initInv, saType, mapOut, qualOut)) {
+            if (!srAnalyzeCtor(x, initInv, mapOut, qualOut)) {
                 continue;
             }
             members = mapOut[0];
@@ -3555,18 +3594,67 @@ public class BytecodeMethod implements SignatureSet {
     }
 
     /**
-     * Verifies X.<init> is exactly Object.<init> + param->field PUTFIELD groups,
+     * Verifies X.&lt;init&gt; is exactly Object.&lt;init&gt; + param-&gt;field PUTFIELD groups,
      * each ctor param consumed once, every instance field of X assigned once.
      * On success fills membersOut[0] / qualsOut[0] indexed by ctor-arg position.
+     *
+     * The instruction-shape half runs at PARSE time (see
+     * {@link #analyzeScalarConstructorRaw()}) because optimize() folds the
+     * ALOAD/xLOAD/PUTFIELD groups into opaque CustomIntructions -- reading the
+     * ctor's live list here would make the answer depend on whether X had
+     * already been optimized, i.e. on class processing order. Only the
+     * class-level bijection check, which needs the resolved field list, is
+     * left for here.
      */
-    private boolean srAnalyzeCtor(ByteCodeClass x, Invoke initInv, String saType,
+    private boolean srAnalyzeCtor(ByteCodeClass x, Invoke initInv,
                                   String[][] membersOut, char[][] qualsOut) {
         String desc = initInv.getDesc();
+        BytecodeMethod ctor = null;
+        for (BytecodeMethod m : x.getMethods()) {
+            if ("__INIT__".equals(m.getMethodName()) && desc.equals(m.getSignature())) {
+                ctor = m;
+                break;
+            }
+        }
+        if (ctor == null || !ctor.srCtorShapeOk) {
+            return false;
+        }
+        // every instance field of X must be assigned exactly once (definite init)
+        int instanceFieldCount = 0;
+        for (ByteCodeField bf : x.getFields()) {
+            if (!bf.isStaticField()) {
+                instanceFieldCount++;
+                if (!ctor.srCtorAssigned.contains(srMangle(x.getClsName()) + "_" + bf.getFieldName())) {
+                    return false;
+                }
+            }
+        }
+        if (instanceFieldCount != ctor.srCtorAssigned.size()) {
+            return false;
+        }
+
+        membersOut[0] = ctor.srCtorMembers;
+        qualsOut[0] = ctor.srCtorQuals;
+        return true;
+    }
+
+    // Shape half of srAnalyzeCtor, snapshotted from the RAW instruction list at
+    // parse time (called from computeInlinableConstructorPlan, exactly like the
+    // InlinableConstructor / FusedConstructor plans next to it).
+    private String[] srCtorMembers;
+    private char[] srCtorQuals;
+    private java.util.Set<String> srCtorAssigned;
+    private boolean srCtorShapeOk;
+
+    private void analyzeScalarConstructorRaw() {
+        srCtorShapeOk = false;
+        srCtorAssigned = java.util.Collections.emptySet();
         List<ByteCodeMethodArg> args = Util.getMethodArgs(desc);
         int n = args.size();
         if (n == 0) {
-            return false; // empty ctor leaves fields uninitialized under scalar repl
+            return; // empty ctor leaves fields uninitialized under scalar repl
         }
+        String saType = srMangle(clsName);
         // ctor-arg local-slot layout (this=0; long/double take two slots)
         Map<Integer, Integer> slotToParam = new HashMap<Integer, Integer>();
         int slot = 1;
@@ -3575,19 +3663,8 @@ public class BytecodeMethod implements SignatureSet {
             slot += args.get(i).isDoubleOrLong() ? 2 : 1;
         }
 
-        BytecodeMethod ctor = null;
-        for (BytecodeMethod m : x.getMethods()) {
-            if ("__INIT__".equals(m.getMethodName()) && desc.equals(m.getSignature())) {
-                ctor = m;
-                break;
-            }
-        }
-        if (ctor == null) {
-            return false;
-        }
-
         List<Instruction> body = new ArrayList<Instruction>();
-        for (Instruction in : ctor.getInstructions()) {
+        for (Instruction in : instructions) {
             if (in instanceof LineNumber || in instanceof LabelInstruction || in instanceof LocalVariable) {
                 continue;
             }
@@ -3603,7 +3680,7 @@ public class BytecodeMethod implements SignatureSet {
                 && "<init>".equals(((Invoke) body.get(i + 1)).getName())) {
             Invoke sup = (Invoke) body.get(i + 1);
             if (!"java/lang/Object".equals(sup.getOwner()) || !"()V".equals(sup.getDesc())) {
-                return false;
+                return;
             }
             i += 2;
         }
@@ -3615,73 +3692,61 @@ public class BytecodeMethod implements SignatureSet {
             Instruction a = body.get(i);
             if (a.getOpcode() == Opcodes.RETURN) {
                 if (i != body.size() - 1) {
-                    return false; // trailing instructions after the void return
+                    return; // trailing instructions after the void return
                 }
                 break;
             }
             if (i + 2 >= body.size()) {
-                return false;
+                return;
             }
             Instruction l0 = body.get(i), l1 = body.get(i + 1), l2 = body.get(i + 2);
             if (!(l0 instanceof VarOp) || l0.getOpcode() != Opcodes.ALOAD || ((VarOp) l0).getIndex() != 0) {
-                return false;
+                return;
             }
             if (!(l1 instanceof VarOp)) {
-                return false;
+                return;
             }
             int lop = l1.getOpcode();
             if (lop != Opcodes.ILOAD && lop != Opcodes.LLOAD && lop != Opcodes.FLOAD && lop != Opcodes.DLOAD) {
-                return false; // object load -> not a primitive param store
+                return; // object load -> not a primitive param store
             }
             Integer pi = slotToParam.get(((VarOp) l1).getIndex());
             if (pi == null) {
-                return false; // not loading a ctor param exactly
+                return; // not loading a ctor param exactly
             }
             if (!(l2 instanceof Field) || l2.getOpcode() != Opcodes.PUTFIELD) {
-                return false;
+                return;
             }
             Field f = (Field) l2;
             if (f.isObject() || !srMangle(f.getOwner()).equals(saType)) {
-                return false;
+                return;
             }
             char q = args.get(pi).getQualifier();
             if (q != srQualifierOfDesc(f.getDesc())) {
-                return false; // ctor param type must match field type
+                return; // ctor param type must match field type
             }
             if (members[pi] != null) {
-                return false; // param stored into two fields
+                return; // param stored into two fields
             }
             String member = srMangle(f.getOwner()) + "_" + f.getFieldName();
             if (!assigned.add(member)) {
-                return false; // field assigned twice
+                return; // field assigned twice
             }
             members[pi] = member;
             quals[pi] = q;
             i += 3;
         }
 
-        for (int k = 0; k < n; k++) {
-            if (members[k] == null) {
-                return false; // some ctor param never stored
+        for (String member : members) {
+            if (member == null) {
+                return; // some ctor param never stored
             }
-        }
-        // every instance field of X must be assigned exactly once (definite init)
-        int instanceFieldCount = 0;
-        for (ByteCodeField bf : x.getFields()) {
-            if (!bf.isStaticField()) {
-                instanceFieldCount++;
-                if (!assigned.contains(srMangle(x.getClsName()) + "_" + bf.getFieldName())) {
-                    return false;
-                }
-            }
-        }
-        if (instanceFieldCount != assigned.size()) {
-            return false;
         }
 
-        membersOut[0] = members;
-        qualsOut[0] = quals;
-        return true;
+        srCtorMembers = members;
+        srCtorQuals = quals;
+        srCtorAssigned = assigned;
+        srCtorShapeOk = true;
     }
 
     private static char srQualifierOfDesc(String desc) {
@@ -3716,9 +3781,9 @@ public class BytecodeMethod implements SignatureSet {
                 if (i < storeIdx) {
                     return false; // read before the construction
                 }
-                int g = srNextReal(i + 1);
+                int g = srNextRealNoJoin(i + 1);
                 if (g < 0) {
-                    return false;
+                    return false; // nothing usable, or a control-flow join in between
                 }
                 Instruction nxt = instructions.get(g);
                 // Accept a direct field read OR a trivial-getter call (the receiver is a `new x()`,
@@ -3740,38 +3805,62 @@ public class BytecodeMethod implements SignatureSet {
     /** If {@code inv} calls a trivial getter (body exactly {@code ALOAD 0; GETFIELD f; xRETURN})
      *  declared on {@code x}, returns that field, else null. The receiver at the call is a
      *  {@code new x()}, so dispatch is deterministically x's own method -- folding it to a field
-     *  read is sound regardless of any subclass overrides. */
+     *  read is sound regardless of any subclass overrides.
+     *
+     *  The shape itself is recognized at parse time ({@link #analyzeTrivialGetterRaw()}): by the
+     *  time this call site is optimized the getter's own list may already have been folded into
+     *  CustomIntructions, and matching against that would make the decision depend on class
+     *  processing order. */
     private Field srTrivialGetterField(Invoke inv, ByteCodeClass x) {
         int op = inv.getOpcode();
         if (op != Opcodes.INVOKEVIRTUAL && op != Opcodes.INVOKESPECIAL && op != Opcodes.INVOKEINTERFACE) {
             return null;
         }
         for (BytecodeMethod m : x.getMethods()) {
-            if (!inv.getName().equals(m.getMethodName())) {
+            // name AND descriptor: an overload set shares the name, and binding the
+            // wrong member of it would fold the read to the wrong field.
+            if (!inv.getName().equals(m.getMethodName()) || !inv.getDesc().equals(m.getSignature())) {
                 continue;
             }
-            Instruction a = null, b = null, c = null;
-            int count = 0;
-            for (Instruction bi : m.getInstructions()) {
-                if (bi instanceof LineNumber || bi instanceof LabelInstruction || bi instanceof LocalVariable) {
-                    continue;
-                }
-                count++;
-                if (count == 1) { a = bi; } else if (count == 2) { b = bi; } else if (count == 3) { c = bi; } else { return null; }
-            }
-            if (count != 3
-                    || !(a instanceof VarOp) || a.getOpcode() != Opcodes.ALOAD || ((VarOp) a).getIndex() != 0
-                    || !(b instanceof Field) || b.getOpcode() != Opcodes.GETFIELD) {
-                return null;
-            }
-            int rc = c.getOpcode();
-            if (rc != Opcodes.IRETURN && rc != Opcodes.LRETURN && rc != Opcodes.FRETURN
-                    && rc != Opcodes.DRETURN && rc != Opcodes.ARETURN) {
-                return null;
-            }
-            return (Field) b;
+            return m.trivialGetterField;
         }
         return null;
+    }
+
+    // The GETFIELD a trivial getter returns, snapshotted from the RAW instruction list at parse
+    // time; null when this method is not a trivial getter. Only the field's owner/name/descriptor
+    // are ever read from it, and those are fixed at construction.
+    private Field trivialGetterField;
+
+    private void analyzeTrivialGetterRaw() {
+        Instruction a = null, b = null, c = null;
+        int count = 0;
+        for (Instruction bi : instructions) {
+            if (bi instanceof LineNumber || bi instanceof LabelInstruction || bi instanceof LocalVariable) {
+                continue;
+            }
+            count++;
+            if (count == 1) {
+                a = bi;
+            } else if (count == 2) {
+                b = bi;
+            } else if (count == 3) {
+                c = bi;
+            } else {
+                return;
+            }
+        }
+        if (count != 3
+                || !(a instanceof VarOp) || a.getOpcode() != Opcodes.ALOAD || ((VarOp) a).getIndex() != 0
+                || !(b instanceof Field) || b.getOpcode() != Opcodes.GETFIELD) {
+            return;
+        }
+        int rc = c.getOpcode();
+        if (rc != Opcodes.IRETURN && rc != Opcodes.LRETURN && rc != Opcodes.FRETURN
+                && rc != Opcodes.DRETURN && rc != Opcodes.ARETURN) {
+            return;
+        }
+        trivialGetterField = (Field) b;
     }
 
     /**
@@ -3788,7 +3877,10 @@ public class BytecodeMethod implements SignatureSet {
                     || ((VarOp) in).getIndex() != localN) {
                 continue;
             }
-            int g = srNextReal(i + 1);
+            int g = srNextRealNoJoin(i + 1);
+            if (g < 0) {
+                continue; // cannot happen for a validated local; never rewrite blind
+            }
             Instruction gi = instructions.get(g);
             // Either an immediate GETFIELD or a trivial-getter call (validated above); both fold to
             // the same scalar member read, replacing the second instruction and dropping the ALOAD.

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/Parser.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/Parser.java
@@ -1333,9 +1333,9 @@ public class Parser extends ClassVisitor {
         @Override
         public void visitEnd() {
             super.visitEnd();
-            // LEVER B: snapshot the inlinable-constructor plan from the RAW instruction
+            // LEVER B: snapshot the plans that must be read off the RAW instruction
             // list now, before optimize() (run later, per-class) folds the PUTFIELDs.
-            mtd.computeInlinableConstructorPlan();
+            mtd.computeRawMethodPlans();
             resolveDupForms(dupAnalysisOwner, dupAnalysisNode, mtd);
         }
 

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/InlinableConstructor.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/InlinableConstructor.java
@@ -238,7 +238,7 @@ public final class InlinableConstructor {
             // NB: a ctor's methodName is rewritten to "__INIT__" in the BytecodeMethod
             // ctor, so match on isConstructor() + the (untouched) descriptor.
             if (m.isConstructor() && desc.equals(m.getSignature())) {
-                m.computeInlinableConstructorPlan(); // idempotent; normally already done
+                m.computeRawMethodPlans(); // idempotent; normally already done
                 return m.getInlinableConstructorPlan();
             }
         }

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/LabelInstruction.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/LabelInstruction.java
@@ -132,16 +132,22 @@ public class LabelInstruction extends Instruction {
     }
 
     /**
-     * True when {@code l} is referenced by a jump, a switch or an exception
-     * handler range -- in other words when it marks a control-flow join.
+     * True when {@code l} is branched to: the target of a jump, a switch case
+     * or default, or the entry of a catch handler -- in other words when it
+     * marks a control-flow join.
      *
      * Peephole passes that match ADJACENT instruction pairs must not look
      * through such a label: the instruction after it can also be reached from
      * a predecessor that never executed the instruction before it, so folding
-     * the pair changes what the other predecessors do. The registration side
-     * of this map is populated while the method is parsed (Jump, CustomJump,
-     * SwitchInstruction and TryCatch all call labelIsUsed in their
-     * constructors), so it is already complete by the time optimize() runs.
+     * the pair changes what the other predecessors do.
+     *
+     * Every one of those registrations happens in a constructor (Jump,
+     * CustomJump, SwitchInstruction, TryCatch), i.e. while the method is being
+     * parsed, so the answer is already final by the time optimize() runs. Try
+     * RANGE boundaries are not included -- addTryBeginLabel/addTryEndLabel run
+     * later, during emission -- but a try range start or end is not branched
+     * to, so it is not a join either. The handler is, and that one is
+     * registered at parse time.
      */
     public static boolean isJumpTarget(Label l) {
         return usedLabels.get(l) != null;

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/LabelInstruction.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/LabelInstruction.java
@@ -130,7 +130,24 @@ public class LabelInstruction extends Instruction {
             usedLabels.put(l,l);
         }
     }
-        
+
+    /**
+     * True when {@code l} is referenced by a jump, a switch or an exception
+     * handler range -- in other words when it marks a control-flow join.
+     *
+     * Peephole passes that match ADJACENT instruction pairs must not look
+     * through such a label: the instruction after it can also be reached from
+     * a predecessor that never executed the instruction before it, so folding
+     * the pair changes what the other predecessors do. The registration side
+     * of this map is populated while the method is parsed (Jump, CustomJump,
+     * SwitchInstruction and TryCatch all call labelIsUsed in their
+     * constructors), so it is already complete by the time optimize() runs.
+     */
+    public static boolean isJumpTarget(Label l) {
+        return usedLabels.get(l) != null;
+    }
+
+
     @Override
     public void appendInstruction(StringBuilder b) {
         if(usedLabels.get(parent)==null) {

--- a/vm/tests/src/test/java/com/codename1/tools/translator/ScalarReplacementTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/ScalarReplacementTest.java
@@ -163,10 +163,10 @@ class ScalarReplacementTest {
     /** The text of the first generated C function whose name contains {@code marker}. */
     private String cFunctionBody(String code, String marker) {
         int nameAt = code.indexOf(marker);
-        assertTrue(nameAt > 0, "generated code has no function matching " + marker + ":\n" + code);
+        assertTrue(nameAt >= 0, "generated code has no function matching " + marker + ":\n" + code);
         int start = code.indexOf('{', nameAt);
-        int end = code.indexOf("\n}", start);
-        assertTrue(start > 0 && end > start, "could not delimit the body of " + marker);
+        int end = code.indexOf("\n}", start + 1);
+        assertTrue(start >= 0 && end > start, "could not delimit the body of " + marker);
         return code.substring(start, end);
     }
 

--- a/vm/tests/src/test/java/com/codename1/tools/translator/ScalarReplacementTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/ScalarReplacementTest.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.tools.translator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Scalar replacement folds a non-escaping primitive-only object into a C struct
+ * local and rewrites its field reads into direct member accesses. Both halves of
+ * that rewrite are pattern matches over an instruction list, and both used to be
+ * matched in ways that ignored where the instructions actually sit:
+ *
+ * <ul>
+ *   <li>the ALOAD/GETFIELD lookahead skipped every label, including branch
+ *       targets, so a field read shared by two paths (a ternary receiver) was
+ *       folded into one path's struct -- the other path then read the wrong
+ *       object and left its receiver on the operand stack;</li>
+ *   <li>the constructor and trivial-getter shape checks read another method's
+ *       LIVE instruction list, which optimize() folds, so the decision depended
+ *       on the order the classes happened to be parsed in.</li>
+ * </ul>
+ */
+class ScalarReplacementTest {
+    private static final String VALUE_CLASS = "com/example/SrValue";
+    private static final String HOST_CLASS = "com/example/SrHost";
+
+    @BeforeEach
+    void cleanParser() {
+        Parser.cleanup();
+    }
+
+    /**
+     * {@code (c ? p : q).x} puts a branch target between "ALOAD q" and the
+     * GETFIELD both paths run. That GETFIELD must survive as a real field read.
+     */
+    @Test
+    void sharedFieldReadBehindAJoinIsNotFoldedIntoOneObject() throws Exception {
+        for (boolean valueClassFirst : new boolean[]{true, false}) {
+            Parser.cleanup();
+            String ternary = cFunctionBody(translateHost(valueClassFirst), "_ternary___");
+            assertTrue(ternary.contains("get_field_com_example_SrValue_x"),
+                    "the field read shared by both ternary arms must stay a real GETFIELD, was:\n" + ternary);
+            assertFalse(ternary.contains("scalar-replaced GETFIELD"),
+                    "a GETFIELD reachable from two paths must not be folded into one path's struct, was:\n" + ternary);
+        }
+    }
+
+    /**
+     * Guards the test above against passing for the wrong reason: the pass must
+     * still fire on the straight-line shapes it exists for, through a direct
+     * field read and through a trivial getter.
+     */
+    @Test
+    void straightLineAllocationsAreStillScalarReplaced() throws Exception {
+        for (boolean valueClassFirst : new boolean[]{true, false}) {
+            Parser.cleanup();
+            String hostCode = translateHost(valueClassFirst);
+            assertTrue(cFunctionBody(hostCode, "_simple___").contains("scalar-replaced GETFIELD"),
+                    "a non-escaping allocation read through a field access should still be scalar replaced");
+            assertTrue(cFunctionBody(hostCode, "_viaGetter___").contains("scalar-replaced GETFIELD"),
+                    "a non-escaping allocation read through a trivial getter should still be scalar replaced");
+        }
+    }
+
+    /**
+     * The value class carries the constructor and the getter whose shapes decide
+     * whether the host's allocations are scalar replaced. Parsing it after the
+     * host means it has already been optimized by the time the host is, so a
+     * matcher that reads its live instruction list produces different output --
+     * the same sources translating differently between two builds.
+     */
+    @Test
+    void translationIsIndependentOfClassParseOrder() throws Exception {
+        String valueFirst = translateHost(true);
+        Parser.cleanup();
+        String hostFirst = translateHost(false);
+
+        assertEquals(withoutLabelNames(valueFirst), withoutLabelNames(hostFirst),
+                "generated C must not depend on the order the classes were parsed in");
+    }
+
+    /**
+     * Emitted C label names are derived from the ASM {@code Label} identity hash, so
+     * they differ between two runs of the same input and carry no meaning. Everything
+     * else in the output does.
+     */
+    private String withoutLabelNames(String code) {
+        return code.replaceAll("label_L\\w+", "label_L");
+    }
+
+    /**
+     * Parses the two classes in the requested order and returns the generated C
+     * for the host class.
+     */
+    private String translateHost(boolean valueClassFirst) throws Exception {
+        Path valueFile = writeValueClass();
+        Path hostFile = writeHostClass();
+        if (valueClassFirst) {
+            Parser.parse(valueFile.toFile());
+            Parser.parse(hostFile.toFile());
+        } else {
+            Parser.parse(hostFile.toFile());
+            Parser.parse(valueFile.toFile());
+        }
+
+        ByteCodeClass objectClass = new ByteCodeClass("java_lang_Object", "java/lang/Object");
+        ByteCodeClass value = Parser.getClassObject("com_example_SrValue");
+        ByteCodeClass host = Parser.getClassObject("com_example_SrHost");
+        for (ByteCodeClass cls : Arrays.asList(value, host)) {
+            cls.setBaseClassObject(objectClass);
+            cls.setBaseInterfacesObject(Collections.<ByteCodeClass>emptyList());
+            cls.updateAllDependencies();
+        }
+
+        // generateCCode is what runs optimize(), so emitting in parse order is what
+        // decides whether the host sees SrValue's ctor and getter raw or already
+        // folded -- exactly the ordering the real translator walks.
+        List<ByteCodeClass> classes = Arrays.asList(objectClass, value, host);
+        if (valueClassFirst) {
+            value.generateCCode(classes);
+            return host.generateCCode(classes);
+        }
+        String hostCode = host.generateCCode(classes);
+        value.generateCCode(classes);
+        return hostCode;
+    }
+
+    /** The text of the first generated C function whose name contains {@code marker}. */
+    private String cFunctionBody(String code, String marker) {
+        int nameAt = code.indexOf(marker);
+        assertTrue(nameAt > 0, "generated code has no function matching " + marker + ":\n" + code);
+        int start = code.indexOf('{', nameAt);
+        int end = code.indexOf("\n}", start);
+        assertTrue(start > 0 && end > start, "could not delimit the body of " + marker);
+        return code.substring(start, end);
+    }
+
+    /** {@code final class SrValue { final int x; SrValue(int) ; int getX(); }} */
+    private Path writeValueClass() throws Exception {
+        ClassWriter cw = new ClassWriter(0);
+        cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL | Opcodes.ACC_SUPER,
+                VALUE_CLASS, null, "java/lang/Object", null);
+        cw.visitField(Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL, "x", "I", null, null).visitEnd();
+
+        MethodVisitor init = cw.visitMethod(Opcodes.ACC_PUBLIC, "<init>", "(I)V", null, null);
+        init.visitCode();
+        init.visitVarInsn(Opcodes.ALOAD, 0);
+        init.visitMethodInsn(Opcodes.INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+        init.visitVarInsn(Opcodes.ALOAD, 0);
+        init.visitVarInsn(Opcodes.ILOAD, 1);
+        init.visitFieldInsn(Opcodes.PUTFIELD, VALUE_CLASS, "x", "I");
+        init.visitInsn(Opcodes.RETURN);
+        init.visitMaxs(2, 2);
+        init.visitEnd();
+
+        MethodVisitor getX = cw.visitMethod(Opcodes.ACC_PUBLIC, "getX", "()I", null, null);
+        getX.visitCode();
+        getX.visitVarInsn(Opcodes.ALOAD, 0);
+        getX.visitFieldInsn(Opcodes.GETFIELD, VALUE_CLASS, "x", "I");
+        getX.visitInsn(Opcodes.IRETURN);
+        getX.visitMaxs(1, 1);
+        getX.visitEnd();
+
+        cw.visitEnd();
+        return writeClassFile(VALUE_CLASS, cw);
+    }
+
+    /**
+     * {@code simple(v)} and {@code viaGetter(v)} are the straight-line shapes the
+     * pass targets; {@code ternary(c)} is javac's lowering of
+     * {@code return (c ? new SrValue(1) : new SrValue(2)).x;} -- the GETFIELD sits
+     * behind a join both arms branch into.
+     */
+    private Path writeHostClass() throws Exception {
+        ClassWriter cw = new ClassWriter(0);
+        cw.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL | Opcodes.ACC_SUPER,
+                HOST_CLASS, null, "java/lang/Object", null);
+
+        MethodVisitor simple = cw.visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC,
+                "simple", "(I)I", null, null);
+        simple.visitCode();
+        newValue(simple, Opcodes.ILOAD, 0);
+        simple.visitVarInsn(Opcodes.ASTORE, 1);
+        simple.visitVarInsn(Opcodes.ALOAD, 1);
+        simple.visitFieldInsn(Opcodes.GETFIELD, VALUE_CLASS, "x", "I");
+        simple.visitInsn(Opcodes.IRETURN);
+        simple.visitMaxs(3, 2);
+        simple.visitEnd();
+
+        MethodVisitor viaGetter = cw.visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC,
+                "viaGetter", "(I)I", null, null);
+        viaGetter.visitCode();
+        newValue(viaGetter, Opcodes.ILOAD, 0);
+        viaGetter.visitVarInsn(Opcodes.ASTORE, 1);
+        viaGetter.visitVarInsn(Opcodes.ALOAD, 1);
+        viaGetter.visitMethodInsn(Opcodes.INVOKEVIRTUAL, VALUE_CLASS, "getX", "()I", false);
+        viaGetter.visitInsn(Opcodes.IRETURN);
+        viaGetter.visitMaxs(3, 2);
+        viaGetter.visitEnd();
+
+        MethodVisitor ternary = cw.visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC,
+                "ternary", "(Z)I", null, null);
+        Label elseArm = new Label();
+        Label join = new Label();
+        ternary.visitCode();
+        newValueConst(ternary, Opcodes.ICONST_1);
+        ternary.visitVarInsn(Opcodes.ASTORE, 1);
+        newValueConst(ternary, Opcodes.ICONST_2);
+        ternary.visitVarInsn(Opcodes.ASTORE, 2);
+        ternary.visitVarInsn(Opcodes.ILOAD, 0);
+        ternary.visitJumpInsn(Opcodes.IFEQ, elseArm);
+        ternary.visitVarInsn(Opcodes.ALOAD, 1);
+        ternary.visitJumpInsn(Opcodes.GOTO, join);
+        ternary.visitLabel(elseArm);
+        ternary.visitVarInsn(Opcodes.ALOAD, 2);
+        ternary.visitLabel(join);
+        ternary.visitFieldInsn(Opcodes.GETFIELD, VALUE_CLASS, "x", "I");
+        ternary.visitInsn(Opcodes.IRETURN);
+        ternary.visitMaxs(3, 3);
+        ternary.visitEnd();
+
+        cw.visitEnd();
+        return writeClassFile(HOST_CLASS, cw);
+    }
+
+    private void newValue(MethodVisitor mv, int loadOpcode, int slot) {
+        mv.visitTypeInsn(Opcodes.NEW, VALUE_CLASS);
+        mv.visitInsn(Opcodes.DUP);
+        mv.visitVarInsn(loadOpcode, slot);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, VALUE_CLASS, "<init>", "(I)V", false);
+    }
+
+    private void newValueConst(MethodVisitor mv, int constOpcode) {
+        mv.visitTypeInsn(Opcodes.NEW, VALUE_CLASS);
+        mv.visitInsn(Opcodes.DUP);
+        mv.visitInsn(constOpcode);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, VALUE_CLASS, "<init>", "(I)V", false);
+    }
+
+    private Path writeClassFile(String internalName, ClassWriter cw) throws Exception {
+        Path outputDir = Files.createTempDirectory("parparvm-scalar-replacement");
+        Path classFile = outputDir.resolve(internalName + ".class");
+        Files.createDirectories(classFile.getParent());
+        Files.write(classFile, cw.toByteArray());
+        return classFile;
+    }
+}


### PR DESCRIPTION
Fixes #5461.

## What broke

`7.0.261` was the first cloud release where scalar replacement runs without the `@StackAllocate` opt-in gate (#5421), so it now applies to every primitive-only direct-`Object` subclass in the app and the framework. Two latent defects in the pass became reachable across all iOS builds.

**The lookahead skips control-flow joins.** `srNextReal` skips every `LabelInstruction`, including branch targets, so "ALOAD n" and "GETFIELD f" were paired even with a join between them. javac emits exactly that for `(c ? p : q).x`. The pass then deleted `q`'s ALOAD and rewrote the *shared* GETFIELD into a read of `q`'s struct, so the `p` path read the wrong object and leaked its own receiver on the operand stack.

Reduced from the report, translated with `clean` output and run:

```java
static int ternary(boolean c) {
    P p = new P(1);
    P q = new P(2);
    return (c ? p : q).x;      // must be 1 when c == true
}
```

```c
    /* NEW scalar-replaced (__cn1sr_0) */
    __cn1sr_0.SrBug_P_x = 2 /* ICONST_2 */;
    if (ilocals_0_==0) goto label_L780237624;
    BC_ALOAD(1);                      // pushes p
    goto label_L205797316;
label_L780237624:
label_L205797316:
    PUSH_INT(__cn1sr_0.SrBug_P_x);    /* scalar-replaced GETFIELD */  <- always q
```

**Cross-method shape checks read live instruction lists.** `srAnalyzeCtor` and `srTrivialGetterField` matched against another method's *current* instructions, which `optimize()` folds into `CustomIntruction`s. So whether a site was scalar-replaced depended on whether that class had been optimized yet -- i.e. on the order `ByteCodeTranslator.execute` happened to enumerate class files in. Same input, same jar, only the enumeration order differs:

```
A (SrBug$P parsed first): 6 6 1 2   <- correct
B (SrBug parsed first):   6 6 2 2   <- wrong
```

That is why the reporter saw it come and go across rebuilds with no source change.

## The fix

- `LabelInstruction.isJumpTarget` exposes the `usedLabels` map that `Jump` / `CustomJump` / `SwitchInstruction` / `TryCatch` already populate at parse time; a new `srNextRealNoJoin` stops there, so no scalar-replacement match spans a join. The other passes keep the old lookahead.
- The constructor and trivial-getter shapes are recognized at parse time from the raw list and cached on the `BytecodeMethod`, matching what `InlinableConstructor` / `FusedConstructor` already do for the same reason.
- `listFiles()` results are sorted, so parse order is stable regardless.
- `srTrivialGetterField` now compares the descriptor as well as the name, so an overload set cannot bind the wrong field. (Unproven in the wild, but unsound as written.)

Coverage is not reduced. On the JavaAPI corpus the pass now fires on sites it previously reached only by luck of enumeration order; after the fix the ternary shape is the only thing it declines, and `simple` / `viaGetter` still emit `scalar-replaced GETFIELD`.

## Testing

`ScalarReplacementTest` (new, `vm/tests`) builds the two classes with ASM and asserts:

1. the field read shared by both ternary arms stays a real `GETFIELD`, in both parse orders;
2. straight-line allocations -- read through a field access and through a trivial getter -- are still scalar replaced, in both parse orders;
3. the generated C is identical for both parse orders.

All three fail on `master` and pass here. Also run green locally: `ParserTest`, `BytecodeInstructionIntegrationTest` (40), `CleanTargetIntegrationTest` (24), `LambdaIntegrationTest`, `StreamApiIntegrationTest`.

## Note for whoever cuts the next release

`CN1_DISABLE_SCALAR_REPLACE=true` remains available as a server-side kill switch if a build needs to opt out before this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)