### PR TITLE
Fix Settings/desktop window left black after a canvas surface swap (#5443)

### DIFF
--- a/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
@@ -2944,6 +2944,7 @@ public class JavaSEPort extends CodenameOneImplementation {
         }
         
         private BufferedImage updateBufferSize(BufferedImage buffer) {
+            BufferedImage previous = buffer;
             if (getScreenCoordinates() == null) {
                 java.awt.Dimension d = getSize();
                 if (buffer == null || buffer.getWidth() != (int)(d.width * retinaScale) || buffer.getHeight() != (int)(d.height*retinaScale)) {
@@ -2955,9 +2956,39 @@ public class JavaSEPort extends CodenameOneImplementation {
                     buffer = createBufferedImage();
                 }
             }
+            if (previous != null && buffer != previous) {
+                invalidateScreenAfterSurfaceSwap();
+            }
             return buffer;
         }
-        
+
+        /**
+         * A replacement buffer starts out blank - TYPE_INT_RGB, so literally
+         * black - and nothing else marks the form dirty. The next
+         * {@code paintDirty()} only refills the components that happen to be in
+         * the dirty list, so unless something coincidentally repaints the whole
+         * form the window is left as an unpainted black surface with a stray
+         * component or two floating in it (issue #5443). Nothing on the screen
+         * survived the swap, so everything is dirty: say so.
+         *
+         * <p>Queued rather than repainted inline because this runs in the
+         * middle of acquiring the paint graphics - the EDT may be iterating the
+         * dirty list right now - and from the AWT thread inside blit().</p>
+         */
+        private void invalidateScreenAfterSurfaceSwap() {
+            if (!Display.isInitialized()) {
+                return;
+            }
+            Display.getInstance().callSerially(new Runnable() {
+                public void run() {
+                    Form f = getCurrentForm();
+                    if (f != null) {
+                        f.repaint();
+                    }
+                }
+            });
+        }
+
         private void updateEdtBufferSize() {
             edtBuffer = updateBufferSize(edtBuffer);
         }

--- a/docs/demos/common/src/main/snippets/developer-guide/maven-appendix-control-center.sh
+++ b/docs/demos/common/src/main/snippets/developer-guide/maven-appendix-control-center.sh
@@ -3,3 +3,7 @@
 // tag::maven-appendix-control-center-bash-001[]
 mvn cn1:settings
 // end::maven-appendix-control-center-bash-001[]
+
+// tag::maven-appendix-control-center-bash-002[]
+mvn cn1:settings -Dsettings.diagnostics=cn1-settings-diagnostics.txt
+// end::maven-appendix-control-center-bash-002[]

--- a/docs/developer-guide/Maven-Getting-Started.adoc
+++ b/docs/developer-guide/Maven-Getting-Started.adoc
@@ -337,7 +337,7 @@ Settings is a Codename One app hosted in a native window, so a window that opens
 
 [source,shell]
 ----
-mvn cn1:settings -Dsettings.diagnostics=cn1-settings-diagnostics.txt
+include::../demos/common/src/main/snippets/developer-guide/maven-appendix-control-center.sh[tag=maven-appendix-control-center-bash-002,indent=0]
 ----
 
 The file records the OS and JDK, the HiDPI scale the JVM reports, the window and canvas geometry, the size Codename One laid the form out at, and the colours and font metrics resolved for the theme. Add `-Dsettings.screenshot=shot.png` to also write the window contents; a second `shot.onscreen.png` captures the pixels actually on screen, which can differ from the offscreen paint. The launch log is at `~/.codenameoneSettings/settings.log`.

--- a/docs/developer-guide/Maven-Getting-Started.adoc
+++ b/docs/developer-guide/Maven-Getting-Started.adoc
@@ -330,6 +330,18 @@ Settings shields you from the details of how it installs extensions. For extensi
 You shouldn't need to worry about this, as it happens seamlessly. If you're curious, you can look at the `<dependencies>` section of your common/pom.xml file to see the added `<dependency>` tag after you install an extension.
 ****
 
+[#settings-window-renders-nothing]
+===== If the Settings window opens blank
+
+Settings is a Codename One app hosted in a native window, so a window that opens but shows nothing can come from the window layer, the display scale, the theme, or font loading. Capture the render state and attach it to a bug report rather than guessing:
+
+[source,shell]
+----
+mvn cn1:settings -Dsettings.diagnostics=cn1-settings-diagnostics.txt
+----
+
+The file records the OS and JDK, the HiDPI scale the JVM reports, the window and canvas geometry, the size Codename One laid the form out at, and the colours and font metrics resolved for the theme. Add `-Dsettings.screenshot=shot.png` to also write the window contents; a second `shot.onscreen.png` captures the pixels actually on screen, which can differ from the offscreen paint. The launch log is at `~/.codenameoneSettings/settings.log`.
+
 ==== Installing legacy cn1libs
 
 The recommended approach for installing add-ons is to use <<managing-addons-in-control-center,Codename One Settings>> or <<maven-dependency-example,add the Maven dependency to `common/pom.xml`>>. In some situations neither method is available. For example, you might have a legacy cn1lib file that isn't listed in the extension catalog or deployed to Maven Central.

--- a/maven/javase/src/test/java/com/codename1/impl/javase/CanvasSurfaceSwapRepaintTest.java
+++ b/maven/javase/src/test/java/com/codename1/impl/javase/CanvasSurfaceSwapRepaintTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.impl.javase;
+
+import com.codename1.testing.junit.CodenameOneTest;
+import com.codename1.ui.Display;
+import com.codename1.ui.Form;
+import com.codename1.ui.Graphics;
+import com.codename1.ui.Label;
+import com.codename1.ui.layouts.BorderLayout;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+import java.awt.GraphicsEnvironment;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+/**
+ * Regression test for the black desktop window of issue #5443.
+ *
+ * The canvas paints into a {@code TYPE_INT_RGB} buffer, and that buffer is
+ * thrown away and reallocated whenever the surface geometry changes. The
+ * replacement starts out blank - black - but nothing marked the form dirty, so
+ * the following {@code paintDirty()} refilled only whatever happened to be in
+ * the dirty list. A window that was up and correct became a black rectangle
+ * with a stray component or two still painted in it, and stayed that way: the
+ * only thing that healed it was an AWT-initiated paint, which a settled desktop
+ * window with no native peers may never get.
+ *
+ * Swapping the surface has to invalidate the whole form.
+ */
+@CodenameOneTest
+@DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
+public class CanvasSurfaceSwapRepaintTest {
+
+    /** Counts whole-form paints; a partial repaint of a child never gets here. */
+    private static final class CountingForm extends Form {
+        final AtomicInteger fullPaints = new AtomicInteger();
+
+        CountingForm() {
+            super("surface swap", new BorderLayout());
+        }
+
+        @Override
+        public void paint(Graphics g) {
+            fullPaints.incrementAndGet();
+            super.paint(g);
+        }
+    }
+
+    @Test
+    public void replacingTheCanvasSurfaceRepaintsTheWholeForm() throws Exception {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "needs a display");
+
+        final CountingForm form = new CountingForm();
+        final Label child = new Label("child");
+        runOnCn1AndWait(new Runnable() {
+            @Override
+            public void run() {
+                form.add(BorderLayout.NORTH, child);
+                form.show();
+            }
+        });
+        settle();
+
+        int fullPaintsBeforeSwap = form.fullPaints.get();
+        assertTrue(fullPaintsBeforeSwap > 0, "the form must paint at least once before the swap");
+
+        // Force exactly one surface swap with no size-change event behind it:
+        // the buffer is sized from the canvas bounds times the retina scale, so
+        // moving the scale invalidates the buffer geometry on its own. This is
+        // the isolated form of what a HiDPI window resize does in the wild.
+        double originalScale = JavaSEPort.retinaScale;
+        try {
+            JavaSEPort.retinaScale = originalScale == 1.0 ? 2.0 : 1.0;
+            // Only one small component is dirty. Before the fix this was the
+            // only thing repainted into the fresh black buffer.
+            runOnCn1AndWait(new Runnable() {
+                @Override
+                public void run() {
+                    child.repaint();
+                }
+            });
+            settle();
+        } finally {
+            JavaSEPort.retinaScale = originalScale;
+        }
+
+        assertTrue(form.fullPaints.get() > fullPaintsBeforeSwap,
+                "replacing the canvas buffer must invalidate the whole form - otherwise the new"
+                + " blank surface keeps whatever the dirty list happened to hold and the window"
+                + " reads as black (issue #5443)");
+        settle();
+    }
+
+    // ---- helpers ----
+
+    /** Lets a few paint cycles run so queued repaints reach the surface. */
+    private void settle() throws Exception {
+        for (int iter = 0; iter < 5; iter++) {
+            runOnCn1AndWait(new Runnable() {
+                @Override
+                public void run() {
+                }
+            });
+            Thread.sleep(60);
+        }
+    }
+
+    private void runOnCn1AndWait(final Runnable r) throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<Throwable> err = new AtomicReference<Throwable>();
+        Display.getInstance().callSerially(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    r.run();
+                } catch (Throwable t) {
+                    err.set(t);
+                } finally {
+                    latch.countDown();
+                }
+            }
+        });
+        assertTrue(latch.await(15, TimeUnit.SECONDS), "Codename One EDT work timed out");
+        if (err.get() != null) {
+            throw new RuntimeException(err.get());
+        }
+    }
+}

--- a/scripts/run-windows-tooling-tests.sh
+++ b/scripts/run-windows-tooling-tests.sh
@@ -94,6 +94,109 @@ if [ -f "$HOME/.codenameoneSettings/settings.log" ]; then
 fi
 
 # ---------------------------------------------------------------------------
+# 1b. Settings render matrix.
+#     The mojo run above covers the launch path on the runner's own desktop:
+#     100% scale, light mode, en-US. Real Windows 11 desktops are routinely
+#     none of those, and issue #5443 survived a fix that this single
+#     configuration was green for. The matrix drives the launcher directly
+#     (same binding file the mojo writes) so each run can vary the JVM's HiDPI
+#     scale, dark mode and locale, and captures the on-screen pixels plus a
+#     render-state dump next to every screenshot.
+# ---------------------------------------------------------------------------
+SETTINGS_CP_DIR="$TEMP_BASE/cn1-windows-settings-cp"
+mkdir -p "$SETTINGS_CP_DIR"
+cat > "$SETTINGS_CP_DIR/cp-pom.xml" <<EOF
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.codename1.demos</groupId>
+  <artifactId>windows-settings-classpath</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>com.codenameone</groupId>
+      <artifactId>codenameone-settings</artifactId>
+      <version>$CN1_VERSION</version>
+    </dependency>
+    <dependency>
+      <groupId>com.codenameone</groupId>
+      <artifactId>codenameone-core</artifactId>
+      <version>$CN1_VERSION</version>
+    </dependency>
+    <dependency>
+      <groupId>com.codenameone</groupId>
+      <artifactId>codenameone-javase</artifactId>
+      <version>$CN1_VERSION</version>
+    </dependency>
+  </dependencies>
+</project>
+EOF
+mvn -B -q -f "$(winpath "$SETTINGS_CP_DIR/cp-pom.xml")" dependency:build-classpath \
+  "-Dmdep.outputFile=$(winpath "$SETTINGS_CP_DIR/cp.txt")"
+SETTINGS_CP="$(cat "$SETTINGS_CP_DIR/cp.txt")"
+
+BINDING_FILE="$SETTINGS_CP_DIR/settings.input"
+WORK_DIR_W="$(winpath "$WORK_DIR")"
+cat > "$BINDING_FILE" <<EOF
+# Codename One Settings project binding
+projectDir=$WORK_DIR_W
+settings=$WORK_DIR_W\\codenameone_settings.properties
+pom=$WORK_DIR_W\\pom.xml
+multimoduleRoot=$WORK_DIR_W
+EOF
+
+MATRIX_FAILURES=()
+
+# run_settings_scenario <name> [extra jvm args...]
+run_settings_scenario() {
+  local name="$1"; shift
+  local png="$ARTIFACTS_DIR/settings-$name.png"
+  local diag="$ARTIFACTS_DIR/settings-$name.txt"
+  wt_log "Settings render scenario: $name ($*)"
+  if ! "$JAVA_BIN" "$@" \
+      -Djava.awt.headless=false \
+      "-Dsettings.input=$(winpath "$BINDING_FILE")" \
+      "-Dsettings.screenshot=$(winpath "$png")" \
+      "-Dsettings.diagnostics=$(winpath "$diag")" \
+      -Dsettings.screenshot.delay=8000 \
+      -cp "$SETTINGS_CP" \
+      com.codename1.settings.CodenameOneSettingsLauncher \
+      > "$ARTIFACTS_DIR/settings-$name.log" 2>&1; then
+    wt_log "  scenario $name: launcher exited non-zero"
+    MATRIX_FAILURES+=("$name (launcher)")
+    return 0
+  fi
+  # The window the user looks at is the one that has to be right, so the
+  # on-screen grab is the gate; the offscreen paint is kept for comparison
+  # because a disagreement between the two is itself a finding.
+  local onscreen="$ARTIFACTS_DIR/settings-$name.onscreen.png"
+  local gate="$onscreen"
+  if [ ! -s "$gate" ]; then
+    wt_log "  scenario $name: no on-screen capture, falling back to offscreen paint"
+    gate="$png"
+  fi
+  # Deliberately loose bounds: the runner desktop is 1024x768, so a scaled
+  # window is legitimately small. The colour/flatness checks are the signal.
+  if ! "$JAVA_BIN" "$SANITY_SRC_W" "$(winpath "$gate")" 300 200; then
+    MATRIX_FAILURES+=("$name")
+  fi
+}
+
+run_settings_scenario baseline
+run_settings_scenario dark -Dsettings.darkMode=true
+run_settings_scenario hidpi125 -Dsun.java2d.uiScale=1.25
+run_settings_scenario hidpi150 -Dsun.java2d.uiScale=1.5
+run_settings_scenario hidpi175 -Dsun.java2d.uiScale=1.75
+run_settings_scenario hidpi150-dark -Dsun.java2d.uiScale=1.5 -Dsettings.darkMode=true
+run_settings_scenario locale-es -Duser.language=es -Duser.country=ES
+
+if [ ${#MATRIX_FAILURES[@]} -gt 0 ]; then
+  wt_log "Settings render matrix failed for: ${MATRIX_FAILURES[*]}" >&2
+  exit 1
+fi
+wt_log "Settings render matrix passed"
+
+# ---------------------------------------------------------------------------
 # 2. JavaSE simulator smoke via the shared verifier harness.
 # ---------------------------------------------------------------------------
 BUILD_DIR="$TEMP_BASE/cn1-windows-sim"

--- a/scripts/settings/javase/src/desktop/java/com/codename1/settings/CodenameOneSettingsStub.java
+++ b/scripts/settings/javase/src/desktop/java/com/codename1/settings/CodenameOneSettingsStub.java
@@ -260,6 +260,14 @@ public class CodenameOneSettingsStub implements Runnable, WindowListener {
             return;
         }
         try {
+            // A grab of a window that is not on screen yet captures whatever
+            // is behind it, which reads as an empty window rather than as a
+            // missing capture. Better to write nothing and let the caller say
+            // so than to write a misleading image.
+            if (!frm.isShowing()) {
+                System.err.println("On-screen capture skipped: window is not showing");
+                return;
+            }
             Rectangle bounds = frm.getBounds();
             if (bounds.width <= 0 || bounds.height <= 0) {
                 return;

--- a/scripts/settings/javase/src/desktop/java/com/codename1/settings/CodenameOneSettingsStub.java
+++ b/scripts/settings/javase/src/desktop/java/com/codename1/settings/CodenameOneSettingsStub.java
@@ -31,6 +31,8 @@ import java.awt.GraphicsEnvironment;
 import java.awt.Graphics2D;
 import java.awt.Image;
 import java.awt.KeyboardFocusManager;
+import java.awt.Rectangle;
+import java.awt.Robot;
 import java.awt.Taskbar;
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
@@ -41,6 +43,8 @@ import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import javax.imageio.ImageIO;
 import javax.swing.ImageIcon;
@@ -256,11 +260,11 @@ public class CodenameOneSettingsStub implements Runnable, WindowListener {
             return;
         }
         try {
-            java.awt.Rectangle bounds = frm.getBounds();
+            Rectangle bounds = frm.getBounds();
             if (bounds.width <= 0 || bounds.height <= 0) {
                 return;
             }
-            BufferedImage image = new java.awt.Robot().createScreenCapture(bounds);
+            BufferedImage image = new Robot().createScreenCapture(bounds);
             ImageIO.write(image, "png", new File(onScreenPath(screenshot)));
         } catch (Throwable ex) {
             System.err.println("On-screen capture unavailable: " + ex);
@@ -284,7 +288,7 @@ public class CodenameOneSettingsStub implements Runnable, WindowListener {
         // handoff in this direction can deadlock. A timeout is not a failure
         // to report - a wedged EDT is exactly the kind of thing this dump
         // exists to catch, so say so in the file.
-        final java.util.concurrent.CountDownLatch done = new java.util.concurrent.CountDownLatch(1);
+        final CountDownLatch done = new CountDownLatch(1);
         Display.getInstance().callSerially(() -> {
             try {
                 SettingsDiagnostics.write(target, frm);
@@ -293,7 +297,7 @@ public class CodenameOneSettingsStub implements Runnable, WindowListener {
             }
         });
         try {
-            if (!done.await(10, java.util.concurrent.TimeUnit.SECONDS)) {
+            if (!done.await(10, TimeUnit.SECONDS)) {
                 SettingsDiagnostics.writeUnresponsiveEdt(target, frm);
             }
         } catch (InterruptedException ex) {

--- a/scripts/settings/javase/src/desktop/java/com/codename1/settings/CodenameOneSettingsStub.java
+++ b/scripts/settings/javase/src/desktop/java/com/codename1/settings/CodenameOneSettingsStub.java
@@ -45,6 +45,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.imageio.ImageIO;
 import javax.swing.ImageIcon;
@@ -296,18 +297,33 @@ public class CodenameOneSettingsStub implements Runnable, WindowListener {
         // handoff in this direction can deadlock. A timeout is not a failure
         // to report - a wedged EDT is exactly the kind of thing this dump
         // exists to catch, so say so in the file.
+        //
+        // Exactly one of the two writers may touch the file. A merely slow EDT
+        // can run its probe after the timeout has already written the fallback,
+        // and overwriting it would throw away the stack dump naming whatever
+        // the EDT was stuck on - the reason the fallback exists.
         final CountDownLatch done = new CountDownLatch(1);
+        final AtomicBoolean claimed = new AtomicBoolean(false);
         Display.getInstance().callSerially(() -> {
             try {
-                SettingsDiagnostics.write(target, frm);
+                if (claimed.compareAndSet(false, true)) {
+                    SettingsDiagnostics.write(target, frm);
+                }
             } finally {
                 done.countDown();
             }
         });
         try {
-            if (!done.await(10, TimeUnit.SECONDS)) {
-                SettingsDiagnostics.writeUnresponsiveEdt(target, frm);
+            if (done.await(10, TimeUnit.SECONDS)) {
+                return;
             }
+            if (!claimed.compareAndSet(false, true)) {
+                // The EDT claimed the report just as we timed out and is still
+                // writing it; let it finish rather than racing it to the file.
+                done.await(10, TimeUnit.SECONDS);
+                return;
+            }
+            SettingsDiagnostics.writeUnresponsiveEdt(target, frm);
         } catch (InterruptedException ex) {
             Thread.currentThread().interrupt();
         }

--- a/scripts/settings/javase/src/desktop/java/com/codename1/settings/CodenameOneSettingsStub.java
+++ b/scripts/settings/javase/src/desktop/java/com/codename1/settings/CodenameOneSettingsStub.java
@@ -186,7 +186,10 @@ public class CodenameOneSettingsStub implements Runnable, WindowListener {
 
     private static void scheduleScreenshotIfRequested() {
         String screenshot = System.getProperty("settings.screenshot");
-        if (screenshot == null || screenshot.length() == 0) {
+        String diagnostics = System.getProperty("settings.diagnostics");
+        boolean wantsScreenshot = screenshot != null && screenshot.length() > 0;
+        boolean wantsDiagnostics = diagnostics != null && diagnostics.length() > 0;
+        if (!wantsScreenshot && !wantsDiagnostics) {
             return;
         }
         // CI runners paint the first frame much slower than dev machines;
@@ -194,22 +197,108 @@ public class CodenameOneSettingsStub implements Runnable, WindowListener {
         int delay = Integer.getInteger("settings.screenshot.delay", 1200);
         Timer timer = new Timer(delay, e -> {
             try {
-                BufferedImage image = new BufferedImage(frm.getContentPane().getWidth(),
-                        frm.getContentPane().getHeight(), BufferedImage.TYPE_INT_ARGB);
-                Graphics2D graphics = image.createGraphics();
-                frm.getContentPane().paint(graphics);
-                graphics.dispose();
-                ImageIO.write(image, "png", new File(screenshot));
+                if (wantsScreenshot) {
+                    captureOffscreen(new File(screenshot));
+                    captureOnScreen(screenshot);
+                }
             } catch (Exception ex) {
                 ex.printStackTrace();
-            } finally {
-                if (!"false".equals(System.getProperty("settings.screenshot.exit"))) {
-                    Display.getInstance().exitApplication();
-                }
             }
+            if (!wantsDiagnostics) {
+                exitAfterCapture();
+                return;
+            }
+            // The diagnostics probe waits on the Codename One EDT, and the
+            // Codename One EDT waits on this thread inside blit()'s
+            // SwingUtilities.invokeAndWait - so the wait has to happen off the
+            // AWT thread or the two deadlock and every report reads as a
+            // wedged EDT.
+            Thread worker = new Thread(() -> {
+                try {
+                    captureDiagnostics(new File(diagnostics));
+                } finally {
+                    exitAfterCapture();
+                }
+            }, "cn1-settings-diagnostics");
+            worker.setDaemon(true);
+            worker.start();
         });
         timer.setRepeats(false);
         timer.start();
+    }
+
+    private static void exitAfterCapture() {
+        if (!"false".equals(System.getProperty("settings.screenshot.exit"))) {
+            Display.getInstance().exitApplication();
+        }
+    }
+
+    private static void captureOffscreen(File target) throws Exception {
+        BufferedImage image = new BufferedImage(frm.getContentPane().getWidth(),
+                frm.getContentPane().getHeight(), BufferedImage.TYPE_INT_ARGB);
+        Graphics2D graphics = image.createGraphics();
+        frm.getContentPane().paint(graphics);
+        graphics.dispose();
+        ImageIO.write(image, "png", target);
+    }
+
+    /**
+     * Grabs the composited desktop pixels behind the window alongside the
+     * offscreen paint. The two can disagree: {@code contentPane.paint()} drives
+     * a fresh Swing paint pass, so it can look healthy while the window the
+     * user is actually staring at shows a stale or unpainted surface - which is
+     * the shape of issue #5443. Written next to the screenshot as
+     * {@code <name>.onscreen.png}; a Robot grab is best effort (locked-down or
+     * headless sessions deny it) and never fails the capture.
+     */
+    private static void captureOnScreen(String screenshot) {
+        if (!Boolean.parseBoolean(System.getProperty("settings.screenshot.onscreen", "true"))) {
+            return;
+        }
+        try {
+            java.awt.Rectangle bounds = frm.getBounds();
+            if (bounds.width <= 0 || bounds.height <= 0) {
+                return;
+            }
+            BufferedImage image = new java.awt.Robot().createScreenCapture(bounds);
+            ImageIO.write(image, "png", new File(onScreenPath(screenshot)));
+        } catch (Throwable ex) {
+            System.err.println("On-screen capture unavailable: " + ex);
+        }
+    }
+
+    static String onScreenPath(String screenshot) {
+        int dot = screenshot.lastIndexOf('.');
+        int separator = Math.max(screenshot.lastIndexOf('/'), screenshot.lastIndexOf('\\'));
+        if (dot > separator) {
+            return screenshot.substring(0, dot) + ".onscreen" + screenshot.substring(dot);
+        }
+        return screenshot + ".onscreen.png";
+    }
+
+    private static void captureDiagnostics(File target) {
+        // The UIID/theme probes read live Codename One state, so they run on
+        // the Codename One EDT. We wait on a latch rather than
+        // callSeriallyAndWait: this runs on the AWT thread, and blit() blocks
+        // the Codename One EDT on SwingUtilities.invokeAndWait, so a blocking
+        // handoff in this direction can deadlock. A timeout is not a failure
+        // to report - a wedged EDT is exactly the kind of thing this dump
+        // exists to catch, so say so in the file.
+        final java.util.concurrent.CountDownLatch done = new java.util.concurrent.CountDownLatch(1);
+        Display.getInstance().callSerially(() -> {
+            try {
+                SettingsDiagnostics.write(target, frm);
+            } finally {
+                done.countDown();
+            }
+        });
+        try {
+            if (!done.await(10, java.util.concurrent.TimeUnit.SECONDS)) {
+                SettingsDiagnostics.writeUnresponsiveEdt(target, frm);
+            }
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+        }
     }
 
     private static void applyApplicationIcon(JFrame frame) {

--- a/scripts/settings/javase/src/desktop/java/com/codename1/settings/SettingsDiagnostics.java
+++ b/scripts/settings/javase/src/desktop/java/com/codename1/settings/SettingsDiagnostics.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.settings;
+
+import com.codename1.impl.javase.JavaSEPort;
+import com.codename1.ui.CN;
+import com.codename1.ui.Component;
+import com.codename1.ui.Container;
+import com.codename1.ui.Display;
+import com.codename1.ui.Font;
+import com.codename1.ui.Form;
+import com.codename1.ui.plaf.Style;
+import com.codename1.ui.plaf.UIManager;
+
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsEnvironment;
+import java.awt.Toolkit;
+import java.awt.geom.AffineTransform;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import javax.swing.JFrame;
+
+/**
+ * Dumps the desktop render state of the Settings tool to a text file.
+ *
+ * The Control Center is a Codename One app hosted in a Swing frame, so "it
+ * opened but painted nothing" (issue #5443) can come from the window layer,
+ * the HiDPI scale, the theme, or font loading - and a screenshot alone cannot
+ * tell those apart. This dump records all four in one place so a user report
+ * or a CI artifact is actionable without a round trip:
+ *
+ * <pre>mvn cn1:settings -Dsettings.diagnostics=cn1-settings-diag.txt</pre>
+ *
+ * Everything here is best effort: a diagnostic dump must never be the reason
+ * the tool fails to start, so every probe degrades to a marker string.
+ */
+final class SettingsDiagnostics {
+    /**
+     * UIIDs sampled from the loaded theme. If the CSS theme did not load these
+     * all fall back to the built-in {@link Style} defaults (white background,
+     * black text), which is itself the diagnosis.
+     */
+    static final String[] SAMPLED_UIIDS = {
+        "SettingsForm", "SettingsFormDark",
+        "SettingsChrome", "SettingsChromeDark",
+        "SettingsPage", "SettingsPageDark",
+        "SettingsPageTitle", "SettingsPageTitleDark",
+        "SettingsField", "SettingsFieldDark"
+    };
+
+    private SettingsDiagnostics() {
+    }
+
+    /**
+     * Renders the report. Call on the Codename One EDT: the UIID and current
+     * form probes read live component state.
+     */
+    static String describe(JFrame frame) {
+        StringBuilder out = new StringBuilder();
+        out.append("# Codename One Settings diagnostics\n");
+        out.append("edt.responsive=true\n");
+        appendEnvironment(out);
+        appendDisplayScale(out);
+        appendWindow(out, frame);
+        appendCodenameOne(out);
+        appendTheme(out);
+        return out.toString();
+    }
+
+    /**
+     * Fallback report for when the Codename One EDT never ran the probe. The
+     * EDT-independent sections still describe the window and the scale, and
+     * the thread dump names whatever the EDT is stuck on.
+     */
+    static void writeUnresponsiveEdt(File target, JFrame frame) {
+        StringBuilder out = new StringBuilder();
+        out.append("# Codename One Settings diagnostics\n");
+        out.append("edt.responsive=false\n");
+        try {
+            appendEnvironment(out);
+            appendDisplayScale(out);
+            appendWindow(out, frame);
+        } catch (Throwable err) {
+            out.append("diagnostics.failed=").append(err).append('\n');
+        }
+        appendEdtStack(out);
+        writeReport(target, out.toString());
+    }
+
+    private static void appendEdtStack(StringBuilder out) {
+        out.append("\n[edt-stack]\n");
+        try {
+            for (java.util.Map.Entry<Thread, StackTraceElement[]> entry
+                    : Thread.getAllStackTraces().entrySet()) {
+                String name = entry.getKey().getName();
+                if (!name.contains("EDT") && !name.startsWith("AWT-EventQueue")) {
+                    continue;
+                }
+                out.append("thread=").append(name)
+                        .append(" state=").append(entry.getKey().getState()).append('\n');
+                for (StackTraceElement frame : entry.getValue()) {
+                    out.append("    at ").append(frame).append('\n');
+                }
+            }
+        } catch (Throwable err) {
+            out.append("edt-stack.failed=").append(err).append('\n');
+        }
+    }
+
+    static void write(File target, JFrame frame) {
+        String report;
+        try {
+            report = describe(frame);
+        } catch (Throwable err) {
+            report = "# Codename One Settings diagnostics\ndiagnostics.failed=" + err + "\n";
+        }
+        writeReport(target, report);
+    }
+
+    private static void writeReport(File target, String report) {
+        try {
+            File parent = target.getAbsoluteFile().getParentFile();
+            if (parent != null) {
+                parent.mkdirs();
+            }
+            Files.write(target.toPath(), report.getBytes(StandardCharsets.UTF_8));
+        } catch (IOException err) {
+            System.err.println("Failed to write Settings diagnostics to " + target + ": " + err);
+        }
+    }
+
+    private static void appendEnvironment(StringBuilder out) {
+        out.append("\n[environment]\n");
+        prop(out, "os.name");
+        prop(out, "os.version");
+        prop(out, "os.arch");
+        prop(out, "java.version");
+        prop(out, "java.vm.name");
+        prop(out, "java.home");
+        prop(out, "user.language");
+        prop(out, "user.country");
+        prop(out, "file.encoding");
+        prop(out, "sun.java2d.uiScale");
+        prop(out, "sun.java2d.d3d");
+        prop(out, "sun.java2d.opengl");
+        prop(out, "cn1.retinaScale");
+        kv(out, "settings.version", System.getProperty("settings.version", "?"));
+        kv(out, "headless", String.valueOf(GraphicsEnvironment.isHeadless()));
+    }
+
+    private static void appendDisplayScale(StringBuilder out) {
+        out.append("\n[display]\n");
+        try {
+            Toolkit toolkit = Toolkit.getDefaultToolkit();
+            kv(out, "toolkit.screenResolutionDpi", String.valueOf(toolkit.getScreenResolution()));
+            GraphicsConfiguration config = GraphicsEnvironment.getLocalGraphicsEnvironment()
+                    .getDefaultScreenDevice().getDefaultConfiguration();
+            AffineTransform tx = config.getDefaultTransform();
+            kv(out, "graphicsConfig.scaleX", String.valueOf(tx.getScaleX()));
+            kv(out, "graphicsConfig.scaleY", String.valueOf(tx.getScaleY()));
+            kv(out, "graphicsConfig.bounds", String.valueOf(config.getBounds()));
+        } catch (Throwable err) {
+            kv(out, "display.failed", String.valueOf(err));
+        }
+        kv(out, "javase.retinaScale", String.valueOf(JavaSEPort.getRetinaScale()));
+        kv(out, "javase.defaultPixelMilliRatio", String.valueOf(JavaSEPort.getDefaultPixelMilliRatio()));
+    }
+
+    private static void appendWindow(StringBuilder out, JFrame frame) {
+        out.append("\n[window]\n");
+        if (frame == null) {
+            kv(out, "frame", "null");
+            return;
+        }
+        kv(out, "frame.bounds", String.valueOf(frame.getBounds()));
+        kv(out, "frame.visible", String.valueOf(frame.isVisible()));
+        kv(out, "frame.contentPaneSize", String.valueOf(frame.getContentPane().getSize()));
+        kv(out, "frame.contentPaneComponents", String.valueOf(frame.getContentPane().getComponentCount()));
+        try {
+            java.awt.Component canvas = frame.getContentPane().getComponentCount() > 0
+                    ? frame.getContentPane().getComponent(0) : null;
+            kv(out, "canvas.class", canvas == null ? "null" : canvas.getClass().getName());
+            kv(out, "canvas.bounds", canvas == null ? "null" : String.valueOf(canvas.getBounds()));
+        } catch (Throwable err) {
+            kv(out, "canvas.failed", String.valueOf(err));
+        }
+    }
+
+    private static void appendCodenameOne(StringBuilder out) {
+        out.append("\n[codenameone]\n");
+        if (!Display.isInitialized()) {
+            kv(out, "display.initialized", "false");
+            return;
+        }
+        Display display = Display.getInstance();
+        kv(out, "display.initialized", "true");
+        kv(out, "display.isEdt", String.valueOf(display.isEdt()));
+        kv(out, "display.size", display.getDisplayWidth() + "x" + display.getDisplayHeight());
+        kv(out, "display.density", String.valueOf(display.getDeviceDensity()));
+        kv(out, "display.convertToPixels12mm", String.valueOf(display.convertToPixels(12f)));
+        kv(out, "display.darkMode", String.valueOf(display.isDarkMode()));
+        Form current = display.getCurrent();
+        kv(out, "form", current == null ? "null" : current.getClass().getName());
+        if (current != null) {
+            kv(out, "form.uiid", current.getUIID());
+            kv(out, "form.size", current.getWidth() + "x" + current.getHeight());
+            kv(out, "form.componentCount", String.valueOf(current.getContentPane().getComponentCount()));
+            describeStyle(out, "form.style", current.getStyle());
+            kv(out, "form.paintedLeafCount", String.valueOf(countVisibleLeaves(current.getContentPane())));
+        }
+        Font system = Font.getDefaultFont();
+        kv(out, "font.default.height", system == null ? "null" : String.valueOf(system.getHeight()));
+        kv(out, "font.default.width.M", system == null ? "null" : String.valueOf(system.stringWidth("M")));
+        Font main = safeNativeFont();
+        kv(out, "font.nativeMainRegular.height", main == null ? "null" : String.valueOf(main.getHeight()));
+        kv(out, "font.nativeMainRegular.width.M", main == null ? "null" : String.valueOf(main.stringWidth("M")));
+    }
+
+    private static void appendTheme(StringBuilder out) {
+        out.append("\n[theme]\n");
+        kv(out, "theme.resourcePresent",
+                String.valueOf(SettingsDiagnostics.class.getResource("/theme.res") != null));
+        kv(out, "nativeTheme.resourcePresent",
+                String.valueOf(SettingsDiagnostics.class.getResource("/NativeTheme.res") != null));
+        if (!Display.isInitialized()) {
+            return;
+        }
+        for (String uiid : SAMPLED_UIIDS) {
+            try {
+                describeStyle(out, "uiid." + uiid, UIManager.getInstance().getComponentStyle(uiid));
+            } catch (Throwable err) {
+                kv(out, "uiid." + uiid, "failed: " + err);
+            }
+        }
+    }
+
+    private static void describeStyle(StringBuilder out, String prefix, Style style) {
+        if (style == null) {
+            kv(out, prefix, "null");
+            return;
+        }
+        Font font = style.getFont();
+        kv(out, prefix, "bg=#" + hex(style.getBgColor())
+                + " fg=#" + hex(style.getFgColor())
+                + " bgTransparency=" + (style.getBgTransparency() & 0xff)
+                + " opacity=" + style.getOpacity()
+                + " fontHeight=" + (font == null ? "null" : String.valueOf(font.getHeight()))
+                + " fontWidthM=" + (font == null ? "null" : String.valueOf(font.stringWidth("M"))));
+    }
+
+    /**
+     * Counts components that would actually put ink on the screen. A collapsed
+     * layout (every text component measuring zero) and a healthy one are hard
+     * to tell apart from a colour histogram but differ sharply here.
+     */
+    private static int countVisibleLeaves(Container root) {
+        int count = 0;
+        for (int iter = 0; iter < root.getComponentCount(); iter++) {
+            Component child = root.getComponentAt(iter);
+            if (child instanceof Container) {
+                count += countVisibleLeaves((Container) child);
+            } else if (child.getWidth() > 0 && child.getHeight() > 0) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static Font safeNativeFont() {
+        try {
+            return Font.createTrueTypeFont(CN.NATIVE_MAIN_REGULAR, CN.NATIVE_MAIN_REGULAR);
+        } catch (Throwable err) {
+            return null;
+        }
+    }
+
+    private static String hex(int color) {
+        String value = Integer.toHexString(color & 0xffffff);
+        while (value.length() < 6) {
+            value = "0" + value;
+        }
+        return value;
+    }
+
+    private static void prop(StringBuilder out, String key) {
+        kv(out, key, System.getProperty(key, "<unset>"));
+    }
+
+    private static void kv(StringBuilder out, String key, String value) {
+        out.append(key).append('=').append(value == null ? "null" : value).append('\n');
+    }
+}

--- a/scripts/settings/javase/src/desktop/java/com/codename1/settings/SettingsDiagnostics.java
+++ b/scripts/settings/javase/src/desktop/java/com/codename1/settings/SettingsDiagnostics.java
@@ -272,17 +272,25 @@ final class SettingsDiagnostics {
     }
 
     /**
-     * Counts components that would actually put ink on the screen. A collapsed
-     * layout (every text component measuring zero) and a healthy one are hard
-     * to tell apart from a colour histogram but differ sharply here.
+     * Counts leaf components that would actually put ink on the screen -
+     * visible and occupying a non-empty rectangle. A collapsed layout (every
+     * text component measuring zero) and a healthy one are hard to tell apart
+     * from a colour histogram but differ sharply here, so the count is only
+     * worth reading if hidden and zero-sized components stay out of it.
+     *
+     * A container that is hidden or has collapsed to nothing takes its whole
+     * subtree with it: its children cannot paint through it.
      */
     private static int countVisibleLeaves(Container root) {
         int count = 0;
         for (int iter = 0; iter < root.getComponentCount(); iter++) {
             Component child = root.getComponentAt(iter);
+            if (!child.isVisible() || child.getWidth() <= 0 || child.getHeight() <= 0) {
+                continue;
+            }
             if (child instanceof Container) {
                 count += countVisibleLeaves((Container) child);
-            } else if (child.getWidth() > 0 && child.getHeight() > 0) {
+            } else {
                 count++;
             }
         }

--- a/scripts/settings/javase/src/test/java/com/codename1/settings/SettingsDiagnosticsTest.java
+++ b/scripts/settings/javase/src/test/java/com/codename1/settings/SettingsDiagnosticsTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.settings;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SettingsDiagnosticsTest {
+
+    @Test
+    public void onScreenCaptureSitsBesideTheScreenshot() {
+        assertEquals("out.onscreen.png", CodenameOneSettingsStub.onScreenPath("out.png"));
+        assertEquals("/tmp/a.b/shot.onscreen.png",
+                CodenameOneSettingsStub.onScreenPath("/tmp/a.b/shot.png"));
+        assertEquals("C:\\Users\\Me\\a.b\\shot.onscreen.png",
+                CodenameOneSettingsStub.onScreenPath("C:\\Users\\Me\\a.b\\shot.png"));
+    }
+
+    /**
+     * A directory component containing a dot must not be mistaken for the
+     * screenshot's extension - the suffix has to land on the file name.
+     */
+    @Test
+    public void onScreenCaptureHandlesExtensionlessNames() {
+        assertEquals("shot.onscreen.png", CodenameOneSettingsStub.onScreenPath("shot"));
+        assertEquals("/tmp/a.b/shot.onscreen.png",
+                CodenameOneSettingsStub.onScreenPath("/tmp/a.b/shot"));
+    }
+
+    /**
+     * The unresponsive-EDT fallback is the report that matters most in a bug
+     * report, so it must produce a usable file with no Codename One Display
+     * booted at all.
+     */
+    @Test
+    public void unresponsiveEdtReportIsWrittenWithoutADisplay(@TempDir Path dir) throws Exception {
+        File target = dir.resolve("diag.txt").toFile();
+        SettingsDiagnostics.writeUnresponsiveEdt(target, null);
+        assertTrue(target.isFile(), "the fallback report must still be written");
+        String report = new String(Files.readAllBytes(target.toPath()), StandardCharsets.UTF_8);
+        assertTrue(report.contains("edt.responsive=false"), report);
+        assertTrue(report.contains("[environment]"), report);
+        assertTrue(report.contains("os.name="), report);
+        assertTrue(report.contains("[edt-stack]"), report);
+    }
+
+    @Test
+    public void sampledUiidsCoverBothThemeVariants() {
+        for (String uiid : SettingsDiagnostics.SAMPLED_UIIDS) {
+            if (uiid.endsWith("Dark")) {
+                continue;
+            }
+            boolean hasDark = false;
+            for (String candidate : SettingsDiagnostics.SAMPLED_UIIDS) {
+                hasDark |= candidate.equals(uiid + "Dark");
+            }
+            assertTrue(hasDark, "dark variant missing for sampled UIID " + uiid);
+        }
+    }
+}

--- a/scripts/windows/ScreenshotSanity.java
+++ b/scripts/windows/ScreenshotSanity.java
@@ -82,9 +82,70 @@ public class ScreenshotSanity {
             fail("screenshot is " + (dominant * 100 / sampled)
                     + "% a single color - window likely rendered nothing: " + file);
         }
+
+        int coverage = contentCoveragePercent(image);
+        if (coverage < MIN_COVERAGE_PERCENT) {
+            fail("screenshot has content in only " + coverage + "% of the window ("
+                    + "expected at least " + MIN_COVERAGE_PERCENT + "%) - the window is mostly"
+                    + " an unpainted surface: " + file);
+        }
         System.out.println("[screenshot-sanity] OK " + file + " " + image.getWidth() + "x"
                 + image.getHeight() + " colors=" + histogram.size()
-                + " dominant=" + (dominant * 100 / sampled) + "%");
+                + " dominant=" + (dominant * 100 / sampled) + "%"
+                + " coverage=" + coverage + "%");
+    }
+
+    /**
+     * Minimum share of the window that must carry something other than a flat
+     * fill. Measured values: a healthy Settings window covers 63-72%, a healthy
+     * simulator 89-95%, and the black window from issue #5443 covers 16-18%.
+     */
+    private static final int MIN_COVERAGE_PERCENT = 35;
+
+    private static final int GRID_COLUMNS = 24;
+    private static final int GRID_ROWS = 16;
+
+    /**
+     * Percentage of grid cells that contain more than one color.
+     *
+     * The whole-image histogram is not enough on its own: the #5443 window is
+     * an unpainted black surface with one app icon drawn into it, which is
+     * enough color variety and low enough single-color dominance to sail
+     * through both checks above. What actually distinguishes a rendered UI is
+     * that the detail is spread across the window rather than pooled in one
+     * corner.
+     */
+    private static int contentCoveragePercent(BufferedImage image) {
+        int populated = 0;
+        for (int row = 0; row < GRID_ROWS; row++) {
+            for (int column = 0; column < GRID_COLUMNS; column++) {
+                if (cellHasContent(image, column, row)) {
+                    populated++;
+                }
+            }
+        }
+        return populated * 100 / (GRID_COLUMNS * GRID_ROWS);
+    }
+
+    private static boolean cellHasContent(BufferedImage image, int column, int row) {
+        int x0 = column * image.getWidth() / GRID_COLUMNS;
+        int x1 = (column + 1) * image.getWidth() / GRID_COLUMNS;
+        int y0 = row * image.getHeight() / GRID_ROWS;
+        int y1 = (row + 1) * image.getHeight() / GRID_ROWS;
+        int stepX = Math.max(1, (x1 - x0) / 8);
+        int stepY = Math.max(1, (y1 - y0) / 8);
+        int first = -1;
+        for (int y = y0; y < y1; y += stepY) {
+            for (int x = x0; x < x1; x += stepX) {
+                int rgb = image.getRGB(x, y) & 0xffffff;
+                if (first == -1) {
+                    first = rgb;
+                } else if (first != rgb) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private static void fail(String message) {


### PR DESCRIPTION
Follow-up to #5445, which did not fix issue #5443 — the reporter still sees the black Control Center on 7.0.261.

## What the screenshots actually say

The reported window is pure `#000000`. That matches neither the light (`#F3F4F7`) nor the dark (`#071B4D`) `SettingsForm` background, so it is not a theme that failed to load — it is the raw `TYPE_INT_RGB` canvas buffer with nothing painted into it. The one thing drawn is the project's icon preview, at its correct pixel size, and it survives the reporter resizing the window between their two screenshots.

## Root cause

`JavaSEPort.C.updateBufferSize()` discards and reallocates the paint buffer whenever the surface geometry changes. The replacement is blank, but nothing marked the form dirty, so the next `paintDirty()` refilled only whatever happened to be in the dirty list. Everything else stayed at the buffer's initial black. The only thing that healed it was an AWT-initiated paint (`paintComponent` queues a full `f.repaint()`), which a settled desktop window with no native peers may never receive.

Replacing the buffer now invalidates the whole form. The repaint is queued rather than run inline: the swap happens both while the EDT is acquiring paint graphics (it may be iterating the dirty list) and from the AWT thread inside `blit()`.

`CanvasSurfaceSwapRepaintTest` drives a real port — shows a form, forces a surface swap with no size-change event behind it, marks a single child dirty, and asserts the form repaints in full. It fails without the fix.

## Why CI did not catch this

The `windows-tooling` gate added in #5445 **accepts the exact screenshot from the issue**: 63 distinct colours and 89% single-colour dominance both pass. `ScreenshotSanity` gains a coverage check — the share of grid cells holding more than one colour. Healthy Settings windows measure 63–72% and the simulator 89–95%; the reported black window measures 16–18%. The gate now rejects both screenshots from the issue and passes every healthy capture with margin.

The job also only ever ran the runner's own desktop: 100% scale, light mode, en-US. It now runs a render matrix over HiDPI scale (125/150/175%), dark mode and locale, and captures the real on-screen pixels next to the offscreen paint, since `contentPane.paint()` can look healthy while the window shows something else. All seven scenarios pass on Windows — which is what ruled those variables out and pointed at the surface swap.

## Diagnostics

`mvn cn1:settings -Dsettings.diagnostics=diag.txt` dumps the environment, the HiDPI scale the JVM reports, window/canvas geometry, the size Codename One laid the form out at, and the resolved theme colours and font metrics — plus an EDT stack trace if the EDT is wedged. Documented in the Maven getting-started guide so the next report of this failure class arrives actionable in one round trip.

## Honest scope

The mechanism is confirmed by a test that fails without the fix, and it is the only mechanism consistent with the reported pixels. What triggers the surface swap on the reporter's specific machine is not reproduced here — CI is green across the whole matrix — so this fixes the failure rather than a demonstrated trigger. If a blank window survives this, the diagnostics dump will say why.

## Verification

- `CanvasSurfaceSwapRepaintTest` fails before the change, passes after
- full `codenameone-javase` suite: 175 tests, 0 failures
- `cn1-settings` suite: 34 tests, 0 failures
- Settings tool verified end to end on macOS, including under a rapid resize storm

🤖 Generated with [Claude Code](https://claude.com/claude-code)