### PR TITLE
JavaScript port: emit a bundle that is ready to deploy as-is

### DIFF
--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/JavaScriptBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/JavaScriptBuilder.java
@@ -168,7 +168,11 @@ public class JavaScriptBuilder extends Executor {
                         }
                     });
             jsOutputZip = new File(buildDir, request.getMainClass() + "-js.zip");
-            zipDirectory(distDir, jsOutputZip, distDir.getName());
+            // Zip the dist FLAT. The bundle is meant to be unpacked directly
+            // into a web root, so a "<MainClass>-js/" wrapper only forces every
+            // consumer to flatten it first. (The old cloud/TeaVM bundle was flat
+            // too, so this also keeps deployment scripts working across both.)
+            zipDirectory(distDir, jsOutputZip, null);
             log("Wrote browser bundle to " + jsOutputZip);
             return true;
         } catch (BuildException ex) {
@@ -889,7 +893,13 @@ public class JavaScriptBuilder extends Executor {
             return;
         }
         String rel = base.relativize(current.toPath()).toString().replace(File.separatorChar, '/');
-        String entryName = rootEntryName + "/" + rel;
+        // A null/empty root means "no wrapper directory", so the zip unpacks
+        // straight into a web root -- which is what a deployable bundle should
+        // do. Anything else nests the whole app under one directory that every
+        // consumer then has to flatten by hand.
+        String entryName = (rootEntryName == null || rootEntryName.isEmpty())
+                ? rel
+                : rootEntryName + "/" + rel;
         ZipEntry entry = new ZipEntry(entryName);
         zos.putNextEntry(entry);
         FileInputStream fis = new FileInputStream(current);

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/JavaScriptBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/JavaScriptBuilder.java
@@ -202,6 +202,43 @@ public class JavaScriptBuilder extends Executor {
         unzip(sourceZip, stageClasses, stageClasses, stageClasses);
     }
 
+    /**
+     * Strip optional parts of the port webapp from the staged copy, so the
+     * translator never copies them into the app's bundle.
+     *
+     * <p>video.js + RecordRTC (~944KB) are only ever pulled in by
+     * {@code VideoJS.init()}, which {@code HTML5Implementation.captureVideo()}
+     * calls behind a try/catch: without them it logs "VideoJS is not loaded,
+     * using default captureVideo behaviour. Add the javascript.includeVideoJS
+     * build hint..." and falls back. So the hint already described an opt-in
+     * that nothing on the build side implemented -- every app paid for the
+     * library whether or not it captured video. Honour the hint.
+     *
+     * <p>samplerate.min.js (~485KB) is unconditional dead weight: nothing
+     * loads it by path. js/fontmetrics.js only probes for an already-defined
+     * {@code Samplerate} global ("use libsamplerate if it is available"), and
+     * no script tag, ScriptTool call or bridge ever defines one.
+     */
+    private void pruneOptionalPortAssets(File webApp, BuildRequest request) {
+        File js = new File(webApp, "js");
+        if (!js.isDirectory()) {
+            return;
+        }
+        String includeVideoJs = request.getArg("javascript.includeVideoJS", "false");
+        if (!"true".equalsIgnoreCase(includeVideoJs)) {
+            File videojs = new File(js, "videojs");
+            if (videojs.isDirectory()) {
+                delTree(videojs, true);
+                debug("Omitting js/videojs (set the javascript.includeVideoJS "
+                        + "build hint to bundle the video capture libraries)");
+            }
+        }
+        File samplerate = new File(js, "samplerate.min.js");
+        if (samplerate.isFile()) {
+            samplerate.delete();
+        }
+    }
+
     private File locateJavaScriptPortSources(BuildRequest request) {
         String explicit = request.getArg("javascript.portSources", null);
         if (explicit != null && explicit.trim().length() > 0) {
@@ -270,6 +307,7 @@ public class JavaScriptBuilder extends Executor {
                         delTree(stagedWebApp, true);
                     }
                     jsPortWebApp = dest;
+                    pruneOptionalPortAssets(dest, request);
                 }
                 return stageClasses;
             } finally {

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/JavaScriptBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/JavaScriptBuilder.java
@@ -229,13 +229,19 @@ public class JavaScriptBuilder extends Executor {
             File videojs = new File(js, "videojs");
             if (videojs.isDirectory()) {
                 delTree(videojs, true);
-                debug("Omitting js/videojs (set the javascript.includeVideoJS "
-                        + "build hint to bundle the video capture libraries)");
+                if (videojs.exists()) {
+                    log("WARNING: could not delete " + videojs + "; it will ship in the bundle");
+                } else {
+                    debug("Omitting js/videojs (set the javascript.includeVideoJS "
+                            + "build hint to bundle the video capture libraries)");
+                }
             }
         }
         File samplerate = new File(js, "samplerate.min.js");
-        if (samplerate.isFile()) {
-            samplerate.delete();
+        if (samplerate.isFile() && !samplerate.delete()) {
+            // Not fatal -- the bundle just carries a dead 485KB file -- but say
+            // so rather than silently shipping what we claim to have pruned.
+            log("WARNING: could not delete " + samplerate + "; it will ship in the bundle");
         }
     }
 

--- a/maven/parparvm/pom.xml
+++ b/maven/parparvm/pom.xml
@@ -246,6 +246,20 @@
                                         <exclude name="assets/test.json"/>
                                         <exclude name="assets/Page.html"/>
                                         <exclude name="assets/Handlee-Regular.ttf"/>
+                                        <!-- The port test app's own theme (1.4MB). Real apps ship
+                                             their own theme.res at the bundle root, and
+                                             getResourceAsStream() deliberately prefers the root for
+                                             theme.res / CN1Resource.res, so this copy is never read
+                                             (confirmed against a running app: the root theme.res is
+                                             fetched, this one never is). Shipping it also keeps a
+                                             shadowing hazard alive for no benefit. -->
+                                        <exclude name="assets/theme.res"/>
+                                        <!-- No code path returns tzone_theme.res: getNativeTheme()
+                                             only ever yields iOS7Theme / iPhoneTheme /
+                                             iOSModernTheme / android_holo_light /
+                                             AndroidMaterialTheme / androidTheme. The one mention of
+                                             tzone_theme in the port is inside a comment. -->
+                                        <exclude name="assets/tzone_theme.res"/>
                                     </zipfileset>
                                 </jar>
                                 <zip destfile="${project.build.directory}/${project.build.finalName}-bundle.jar">

--- a/maven/parparvm/pom.xml
+++ b/maven/parparvm/pom.xml
@@ -236,10 +236,14 @@
                                              into every JavaScript app's public web root. They stay
                                              in the source tree, so in-repo builds and the
                                              javascript-screenshots suite still see them.
-                                             The system themes assets/ must keep are the ones
-                                             HTML5Implementation.getNativeTheme() resolves:
-                                             iOS7Theme.res, iPhoneTheme.res, iOSModernTheme.res,
-                                             android_holo_light.res and tzone_theme.res. -->
+                                             Kept: the native themes installNativeTheme() can open
+                                             from the bundle. The JS port defaults to the LEGACY
+                                             pair (android_holo_light.res on an Android user agent,
+                                             iOS7Theme.res elsewhere) so existing screenshot
+                                             baselines stay comparable; iPhoneTheme.res is the
+                                             ios.themeMode=legacy opt-in. The modern themes
+                                             (iOSModernTheme.res / AndroidMaterialTheme.res) live in
+                                             Themes/ and are staged per target, not from here. -->
                                         <exclude name="assets/leather.res"/>
                                         <exclude name="assets/chrome.res"/>
                                         <exclude name="assets/video.mp4"/>
@@ -254,11 +258,8 @@
                                              fetched, this one never is). Shipping it also keeps a
                                              shadowing hazard alive for no benefit. -->
                                         <exclude name="assets/theme.res"/>
-                                        <!-- No code path returns tzone_theme.res: getNativeTheme()
-                                             only ever yields iOS7Theme / iPhoneTheme /
-                                             iOSModernTheme / android_holo_light /
-                                             AndroidMaterialTheme / androidTheme. The one mention of
-                                             tzone_theme in the port is inside a comment. -->
+                                        <!-- No theme-resolution path yields tzone_theme.res; the one
+                                             mention of it in the port is inside a comment. -->
                                         <exclude name="assets/tzone_theme.res"/>
                                     </zipfileset>
                                 </jar>

--- a/maven/parparvm/pom.xml
+++ b/maven/parparvm/pom.xml
@@ -261,6 +261,36 @@
                                         <!-- No theme-resolution path yields tzone_theme.res; the one
                                              mention of it in the port is inside a comment. -->
                                         <exclude name="assets/tzone_theme.res"/>
+                                        <!-- The native themes come from Themes/ below instead of
+                                             from these copies, which drift: the webapp's
+                                             iPhoneTheme.res already differs from the Themes/ one. -->
+                                        <exclude name="assets/iOS7Theme.res"/>
+                                        <exclude name="assets/iPhoneTheme.res"/>
+                                        <exclude name="assets/android_holo_light.res"/>
+                                    </zipfileset>
+                                    <!-- Native themes, straight from the single source of truth in
+                                         Themes/ (kept in sync from the CSS sources by
+                                         .github/workflows/native-themes-sync.yml), the same way
+                                         maven/ios folds iOSModernTheme.res into nativeios.jar and
+                                         maven/javase copies the whole set onto its classpath.
+
+                                         All six ship because HTML5Implementation.
+                                         resolveNativeThemeResource() picks between them at RUNTIME
+                                         from the browser user agent plus the ios.themeMode /
+                                         and.themeMode / nativeTheme / javascript.native.theme
+                                         hints, so the build cannot know which one an app will
+                                         need: "modern" resolves to iOSModernTheme.res in an
+                                         iOS-like browser and AndroidMaterialTheme.res everywhere
+                                         else, and "legacy" to iPhoneTheme.res or androidTheme.res.
+                                         Shipping only some of them is why opting in used to fall
+                                         back to the legacy theme instead of applying. -->
+                                    <zipfileset dir="${project.basedir}/../../Themes" prefix="webapp/assets">
+                                        <include name="iOS7Theme.res"/>
+                                        <include name="iPhoneTheme.res"/>
+                                        <include name="iOSModernTheme.res"/>
+                                        <include name="androidTheme.res"/>
+                                        <include name="android_holo_light.res"/>
+                                        <include name="AndroidMaterialTheme.res"/>
                                     </zipfileset>
                                 </jar>
                                 <zip destfile="${project.build.directory}/${project.build.finalName}-bundle.jar">

--- a/maven/parparvm/pom.xml
+++ b/maven/parparvm/pom.xml
@@ -218,11 +218,34 @@
                                            property="cn1.jsport.webapp.present"/>
                                 <fail unless="cn1.jsport.webapp.present"
                                       message="JavaScript-port webapp not found at ${codename1.javascriptport.webapp.dir} (expected port.js). Build from a full Codename One checkout, or point the build at the webapp with -Dcodename1.javascriptport.webapp.dir=/path/to/Ports/JavaScriptPort/src/main/webapp."/>
+                                <!-- Ant's jar task treats an existing archive as up to date when
+                                     it is newer than every input file, so on an incremental build
+                                     a change to the include/exclude list below is silently
+                                     ignored and a stale jar ships. Delete it first. -->
+                                <delete file="${project.build.directory}/bundle/JavaScriptPort.jar" quiet="true"/>
                                 <jar destfile="${project.build.directory}/bundle/JavaScriptPort.jar">
                                     <fileset dir="${project.build.directory}/javascript-port-classes"/>
                                     <zipfileset dir="${codename1.javascriptport.webapp.dir}" prefix="webapp">
                                         <exclude name="index.html"/>
                                         <exclude name="WEB-INF/**"/>
+                                        <!-- Demo/test fixtures used by the port's own in-repo test
+                                             app. They are NOT referenced by any port or core class,
+                                             yet the translator copies webapp/assets into every app
+                                             it builds, so shipping them here put ~3.6MB of dead
+                                             weight (a 2.1MB leather theme, a 666KB sample video)
+                                             into every JavaScript app's public web root. They stay
+                                             in the source tree, so in-repo builds and the
+                                             javascript-screenshots suite still see them.
+                                             The system themes assets/ must keep are the ones
+                                             HTML5Implementation.getNativeTheme() resolves:
+                                             iOS7Theme.res, iPhoneTheme.res, iOSModernTheme.res,
+                                             android_holo_light.res and tzone_theme.res. -->
+                                        <exclude name="assets/leather.res"/>
+                                        <exclude name="assets/chrome.res"/>
+                                        <exclude name="assets/video.mp4"/>
+                                        <exclude name="assets/test.json"/>
+                                        <exclude name="assets/Page.html"/>
+                                        <exclude name="assets/Handlee-Regular.ttf"/>
                                     </zipfileset>
                                 </jar>
                                 <zip destfile="${project.build.directory}/${project.build.finalName}-bundle.jar">

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeTranslator.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeTranslator.java
@@ -112,7 +112,7 @@ public class ByteCodeTranslator {
                 if(f.getName().endsWith(".class")) {
                     Parser.parse(f);
                 } else {
-                    if(!f.isDirectory()) {
+                    if(!f.isDirectory() && !isBuildMetadata(f.getName())) {
                         // copy the file to the dest dir
                         copy(Files.newInputStream(f.toPath()), Files.newOutputStream(new File(outputDir, f.getName()).toPath()));
                     }
@@ -1212,6 +1212,20 @@ public class ByteCodeTranslator {
      * @param i source
      * @param o destination
      */
+    /**
+     * Build descriptors that ride along inside an application jar's META-INF
+     * but are not application resources. Every non-class input file is copied
+     * into the output by basename, so without this filter a Maven-built app
+     * leaks its pom.xml (dependency list and all), pom.properties and
+     * MANIFEST.MF into the bundle -- and for the JavaScript target that bundle
+     * IS a public document root.
+     */
+    private static boolean isBuildMetadata(String name) {
+        return "pom.xml".equals(name)
+                || "pom.properties".equals(name)
+                || "MANIFEST.MF".equals(name);
+    }
+
     public static void copy(InputStream i, OutputStream o) throws IOException {
         copy(i, o, 8192);
     }

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeTranslator.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeTranslator.java
@@ -112,7 +112,7 @@ public class ByteCodeTranslator {
                 if(f.getName().endsWith(".class")) {
                     Parser.parse(f);
                 } else {
-                    if(!f.isDirectory() && !isBuildMetadata(f.getName())) {
+                    if(!f.isDirectory() && !isBuildMetadata(f)) {
                         // copy the file to the dest dir
                         copy(Files.newInputStream(f.toPath()), Files.newOutputStream(new File(outputDir, f.getName()).toPath()));
                     }
@@ -1206,26 +1206,39 @@ public class ByteCodeTranslator {
     
 
     /**
+     * Build descriptors that ride along inside an application jar's
+     * {@code META-INF} but are not application resources. Every non-class input
+     * file is copied into the output by basename, so without this filter a
+     * Maven-built app leaks its pom.xml (dependency list and all),
+     * pom.properties and MANIFEST.MF into the bundle -- and for the JavaScript
+     * target that bundle IS a public document root.
+     *
+     * <p>The check is path-aware on purpose: an app is free to ship a resource
+     * of its own that happens to be called pom.xml, and only the copies living
+     * under META-INF are jar metadata.
+     */
+    private static boolean isBuildMetadata(File f) {
+        String name = f.getName();
+        if (!"pom.xml".equals(name)
+                && !"pom.properties".equals(name)
+                && !"MANIFEST.MF".equals(name)) {
+            return false;
+        }
+        for (File parent = f.getParentFile(); parent != null; parent = parent.getParentFile()) {
+            if ("META-INF".equals(parent.getName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Copy the input stream into the output stream, closes both streams when finishing or in
      *  the case of an exception
      * 
      * @param i source
      * @param o destination
      */
-    /**
-     * Build descriptors that ride along inside an application jar's META-INF
-     * but are not application resources. Every non-class input file is copied
-     * into the output by basename, so without this filter a Maven-built app
-     * leaks its pom.xml (dependency list and all), pom.properties and
-     * MANIFEST.MF into the bundle -- and for the JavaScript target that bundle
-     * IS a public document root.
-     */
-    private static boolean isBuildMetadata(String name) {
-        return "pom.xml".equals(name)
-                || "pom.properties".equals(name)
-                || "MANIFEST.MF".equals(name);
-    }
-
     public static void copy(InputStream i, OutputStream o) throws IOException {
         copy(i, o, 8192);
     }

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/JavascriptBundleWriter.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/JavascriptBundleWriter.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
 package com.codename1.tools.translator;
 
 import java.io.File;
@@ -49,11 +72,15 @@ final class JavascriptBundleWriter {
     }
 
     /**
-     * {@code -Dparparvm.js.diagnostics=1} re-enables the developer-only
-     * artifacts alongside the bundle.
+     * {@code -Dparparvm.js.diagnostics=1} (or {@code =true}) re-enables the
+     * developer-only artifacts alongside the bundle. The value is parsed rather
+     * than merely tested for presence, so an explicit {@code =0} / {@code
+     * =false} still keeps them out of what is, for this target, a public web
+     * root.
      */
     static boolean emitDiagnostics() {
-        return System.getProperty("parparvm.js.diagnostics") != null;
+        String v = System.getProperty("parparvm.js.diagnostics");
+        return "1".equals(v) || "true".equalsIgnoreCase(v);
     }
 
     /**

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/JavascriptBundleWriter.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/JavascriptBundleWriter.java
@@ -34,8 +34,26 @@ final class JavascriptBundleWriter {
         writeWorker(outputDirectory);
         writeBrowserBridge(outputDirectory);
         writeIndex(outputDirectory);
-        writeProtocol(outputDirectory);
-        writeJsoBridgeManifest(outputDirectory, classes);
+        // vm_protocol.md and jso-bridge-dispatch-ids.txt are developer
+        // artifacts, and this output directory becomes the app's PUBLIC web
+        // root. vm_protocol.md documents the worker boundary and is checked in
+        // at vm/ByteCodeTranslator/src/javascript/vm_protocol.md, so copying it
+        // into every deployed app just published documentation that nobody
+        // reads from there. jso-bridge-dispatch-ids.txt is a sidecar for the
+        // OPT-IN dispatch-id mangler (-Dparparvm.js.manglesigs=1) and nothing
+        // reads the emitted file at all. Emit both only when asked.
+        if (emitDiagnostics()) {
+            writeProtocol(outputDirectory);
+            writeJsoBridgeManifest(outputDirectory, classes);
+        }
+    }
+
+    /**
+     * {@code -Dparparvm.js.diagnostics=1} re-enables the developer-only
+     * artifacts alongside the bundle.
+     */
+    static boolean emitDiagnostics() {
+        return System.getProperty("parparvm.js.diagnostics") != null;
     }
 
     /**

--- a/vm/tests/src/test/java/com/codename1/tools/translator/JavascriptCn1CoreCompletenessTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/JavascriptCn1CoreCompletenessTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
 package com.codename1.tools.translator;
 
 import org.junit.jupiter.api.Test;

--- a/vm/tests/src/test/java/com/codename1/tools/translator/JavascriptCn1CoreCompletenessTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/JavascriptCn1CoreCompletenessTest.java
@@ -32,8 +32,10 @@ class JavascriptCn1CoreCompletenessTest {
         Path distDir = translateCn1CoreSlice(config);
         assertTrue(Files.exists(distDir.resolve("translated_app.js")),
                 "Translator should emit translated JS for the Codename One core slice");
-        assertTrue(Files.exists(distDir.resolve("vm_protocol.md")),
-                "Translator should emit the VM protocol artifact for the Codename One core slice");
+        // vm_protocol.md is a developer artifact and is no longer written into
+        // the bundle by default (it would ship into the app's public web root);
+        // -Dparparvm.js.diagnostics brings it back. "Did the translator run"
+        // is already covered by translated_app.js above.
 
         String translatedApp = new String(Files.readAllBytes(distDir.resolve("translated_app.js")), StandardCharsets.UTF_8);
         assertTrue(translatedApp.contains("JsCodenameOneCoreSliceApp"),

--- a/vm/tests/src/test/java/com/codename1/tools/translator/JavascriptTargetIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/JavascriptTargetIntegrationTest.java
@@ -56,7 +56,20 @@ class JavascriptTargetIntegrationTest {
         compileAgainstJavaApi(config, sourceDir, classesDir, javaApiDir);
 
         Path outputDir = Files.createTempDirectory("js-target-output");
-        runJavascriptTranslator(classesDir, outputDir, "JsHello");
+        // vm_protocol.md is a developer artifact and is no longer written into
+        // the bundle by default -- the bundle is an app's public web root. The
+        // assertions below still cover it, so ask for it explicitly.
+        String prevDiagnostics = System.getProperty("parparvm.js.diagnostics");
+        System.setProperty("parparvm.js.diagnostics", "1");
+        try {
+            runJavascriptTranslator(classesDir, outputDir, "JsHello");
+        } finally {
+            if (prevDiagnostics == null) {
+                System.clearProperty("parparvm.js.diagnostics");
+            } else {
+                System.setProperty("parparvm.js.diagnostics", prevDiagnostics);
+            }
+        }
 
         Path distDir = outputDir.resolve("dist").resolve("JsHello-js");
         assertTrue(Files.exists(distDir.resolve("index.html")), "Translator should emit a minimal host page");


### PR DESCRIPTION
Follow-up to #5465 / #5457.

Since #5457, `JavaScriptPort.jar` carries `webapp/` so off-repo builds can find `port.js`, and the translator copies that webapp into every app it builds. That made the port's public web root the *de facto* payload of every JavaScript app — and it turned out to contain the port test app's own fixtures, a video-capture stack no app asked for, developer diagnostics, and the app jar's Maven descriptors.

This PR makes the JavaScript build emit **a tree you can deploy as-is**: nothing in it is there by accident, and the zip unpacks straight into a web root.

Rebuilding a real app (the BuildCloud console) against it: **16 MB → 9.0 MB**, with no change to what the app can do.

---

## 1. Native themes now actually work when you opt in

`HTML5Implementation.resolveNativeThemeResource()` picks a theme **at runtime** from the browser user agent plus the `ios.themeMode` / `and.themeMode` / `nativeTheme` / `javascript.native.theme` hints. The bundle only ever shipped three of the six themes it can resolve, so opting into `modern` silently fell back to the legacy theme instead of applying — the file simply wasn't there.

All six now ship, staged straight from `Themes/` — the single source of truth kept in sync from the CSS sources by `native-themes-sync.yml` — the same way `maven/ios` folds `iOSModernTheme.res` into `nativeios.jar` and `maven/javase` copies the whole set onto its classpath. The webapp's own copies are excluded because they drift: its `iPhoneTheme.res` already differs from the one in `Themes/`.

Defaults are unchanged: with no theme hint the port still lands on `android_holo_light.res` for an Android user agent and `iOS7Theme.res` everywhere else, so existing screenshot baselines stay comparable.

## 2. Demo fixtures stay in the source tree

| file | size |
|---|---|
| `leather.res` | 2.0 MB |
| `theme.res` (the port test app's own) | 1.4 MB |
| `chrome.res` | 760 KB |
| `video.mp4` | 651 KB |
| `Handlee-Regular.ttf` | 38 KB |
| `tzone_theme.res` | 84 KB |
| `Page.html`, `test.json` | ~1.4 KB combined |

None is referenced by any class in the port or in CodenameOne core — I checked every name with fixed-string searches across `Ports/JavaScriptPort/src/main/java` and `CodenameOne/src`; zero hits. (`Handlee-Regular.ttf` appears only inside a Javadoc example in `Font.java`. The single mention of `tzone_theme.res` in the port is inside a comment — no resolution path yields it.)

`assets/theme.res` is worth calling out separately: real apps ship their own `theme.res` at the bundle root, and `getResourceAsStream()` deliberately prefers the root for `theme.res` / `CN1Resource.res`, so the webapp copy was never read (confirmed against a running app — the root one is fetched, this one never is) while keeping a shadowing hazard alive.

They are excluded **from the jar** and stay in the source tree, so in-repo builds and the `javascript-screenshots` suite still see them.

## 3. The media stack is opt-in, as its own error message always claimed

`VideoJS.init()` is called by `HTML5Implementation.captureVideo()` behind a try/catch that logs:

> VideoJS is not loaded, using default captureVideo behaviour. Add the `javascript.includeVideoJS` build hint…

…but nothing on the build side ever implemented that hint, so every app paid **944 KB** of video.js + RecordRTC whether or not it captured video. The hint is now honoured (`javascript.includeVideoJS=true` to bundle them).

`samplerate.min.js` (488 KB) is unconditional dead weight and is always dropped: nothing loads it by path. `js/fontmetrics.js` only probes for an already-defined `Samplerate` global ("use libsamplerate if it is available"), and no script tag, `ScriptTool` call or bridge ever defines one.

Reachability analysis can't gate either of these — `HTML5Implementation` references the media classes itself — which is why it's a build hint.

## 4. Developer diagnostics are behind a flag

`vm_protocol.md` and `jso-bridge-dispatch-ids.txt` were written into the app's **public web root** on every build.

- `vm_protocol.md` is documentation of the worker/main-thread protocol. It is already checked in at `vm/ByteCodeTranslator/src/javascript/`; emitting a copy next to `index.html` publishes it to the app's users.
- `jso-bridge-dispatch-ids.txt` (#4795, #5200) is a sidecar mapping for the **opt-in** `-Dparparvm.js.manglesigs` mangler — a debugging aid for reading mangled dispatch ids. Nothing reads the file at runtime.

Both are now written only under `-Dparparvm.js.diagnostics=1` (or `=true`). `JavascriptTargetIntegrationTest` sets it, so the test that inspects them still does.

## 5. Maven descriptors no longer leak into the web root

The translator copies every non-class file out of the app jar, which included `META-INF/maven/**/pom.xml`, `pom.properties` and `META-INF/MANIFEST.MF` — publishing the app's group/artifact/version and its build metadata at a fetchable URL.

The filter is **path-aware**: it only skips these names when they sit under a `META-INF` directory, so an app resource that happens to be called `pom.xml` is still copied.

## ⚠️ 6. Compatibility change: the zip is now flat

**The output zip no longer contains a top-level `<MainClass>-js/` wrapper directory.** Entries sit at the root, so `unzip -d /var/www/app` produces a working web root instead of one directory containing it.

This is the point of the PR — the previous layout forced every consumer to unwrap the bundle before serving it — but it **will break deployment tooling that expects the wrapper**, e.g. `unzip … && cp -R <MainClass>-js/. dest/`. The fix is to drop the wrapper hop. Flagging it for the release notes.

## Also: force the jar to be recreated

Ant's `<jar>` treats an existing archive as up to date when it is newer than every input file. The include/exclude list lives in the POM, not in the inputs, so on an incremental build a change to it is **silently ignored and a stale jar ships**. This cost a full debugging cycle: the exclusions above appeared to do nothing until I noticed the inner jar was hours old. The task deletes the jar first now.

## Verification

- Jar inspected directly: 0 demo fixtures, all 6 native themes present.
- A real app rebuilt against it (the BuildCloud console): 16 MB → 9.0 MB, renders with icons, theme and material icon font intact, all APIs 200, browser console clean.
- Bundle contents cross-checked against a request log captured from the running console, so "unused" means *observed* unused, not assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
