### PR TITLE
Fix concurrent syndication state updates

### DIFF
--- a/scripts/website/commit_syndication_state.sh
+++ b/scripts/website/commit_syndication_state.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 readonly REMOTE="${SYNDICATION_GIT_REMOTE:-origin}"
 readonly BRANCH="${GITHUB_REF_NAME:-master}"
 readonly MAX_PUSH_ATTEMPTS="${SYNDICATION_PUSH_ATTEMPTS:-3}"
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly MERGE_SCRIPT="$SCRIPT_DIR/merge_syndication_json.py"
 readonly STATE_PATHS=(
     scripts/website/syndication-state.json
     scripts/website/syndication-queue.json
@@ -15,30 +17,69 @@ if git diff --quiet -- "${STATE_PATHS[@]}"; then
     exit 0
 fi
 
+if ! git diff --quiet -- . \
+    ':(exclude)scripts/website/syndication-state.json' \
+    ':(exclude)scripts/website/syndication-queue.json' ||
+    ! git diff --cached --quiet -- . \
+        ':(exclude)scripts/website/syndication-state.json' \
+        ':(exclude)scripts/website/syndication-queue.json'; then
+    echo "Refusing to update syndication state with unrelated tracked changes." >&2
+    exit 1
+fi
+
 git config user.name 'github-actions[bot]'
 git config user.email 'github-actions[bot]@users.noreply.github.com'
 
-# Scheduled workflows run against the commit that was current when GitHub
-# created the run. Master can advance before this final step, so update the
-# checkout while preserving the generated state and queue changes.
-git fetch "$REMOTE" "$BRANCH"
-git rebase --autostash "$REMOTE/$BRANCH"
+readonly SNAPSHOT_DIR="$(mktemp -d)"
+trap 'rm -rf "$SNAPSHOT_DIR"' EXIT
+mkdir -p "$SNAPSHOT_DIR/base" "$SNAPSHOT_DIR/local" "$SNAPSHOT_DIR/merged"
 
-git add "${STATE_PATHS[@]}"
-if git diff --staged --quiet -- "${STATE_PATHS[@]}"; then
-    echo "The latest $BRANCH already contains these state changes."
-    exit 0
-fi
-git commit -m "ci: record blog syndication results"
+for path in "${STATE_PATHS[@]}"; do
+    mkdir -p \
+        "$SNAPSHOT_DIR/base/$(dirname "$path")" \
+        "$SNAPSHOT_DIR/local/$(dirname "$path")" \
+        "$SNAPSHOT_DIR/merged/$(dirname "$path")"
+    git show "HEAD:$path" > "$SNAPSHOT_DIR/base/$path"
+    cp "$path" "$SNAPSHOT_DIR/local/$path"
+    python3 -m json.tool "$SNAPSHOT_DIR/base/$path" >/dev/null
+    python3 -m json.tool "$SNAPSHOT_DIR/local/$path" >/dev/null
+done
+
+# Remove the generated changes before rebasing. Reapply them with a semantic
+# three-way merge so concurrent publishers can update different platform keys
+# under the same post without leaving Git conflict markers in JSON.
+git restore --worktree --staged --source=HEAD -- "${STATE_PATHS[@]}"
 
 attempt=1
-while ! git push "$REMOTE" "HEAD:$BRANCH"; do
+while true; do
+    git fetch "$REMOTE" "$BRANCH"
+    git rebase "$REMOTE/$BRANCH"
+
+    for path in "${STATE_PATHS[@]}"; do
+        python3 "$MERGE_SCRIPT" \
+            --base "$SNAPSHOT_DIR/base/$path" \
+            --local "$SNAPSHOT_DIR/local/$path" \
+            --remote "$path" \
+            --output "$SNAPSHOT_DIR/merged/$path"
+        cp "$SNAPSHOT_DIR/merged/$path" "$path"
+        python3 -m json.tool "$path" >/dev/null
+    done
+
+    git add "${STATE_PATHS[@]}"
+    if git diff --staged --quiet -- "${STATE_PATHS[@]}"; then
+        echo "The latest $BRANCH already contains these state changes."
+        exit 0
+    fi
+    git commit -m "ci: record blog syndication results"
+
+    if git push "$REMOTE" "HEAD:$BRANCH"; then
+        break
+    fi
     if [ "$attempt" -ge "$MAX_PUSH_ATTEMPTS" ]; then
         echo "Failed to push syndication state after $attempt attempts." >&2
         exit 1
     fi
     attempt=$((attempt + 1))
-    echo "The $BRANCH branch advanced; rebasing before push attempt $attempt."
-    git fetch "$REMOTE" "$BRANCH"
-    git rebase "$REMOTE/$BRANCH"
+    echo "The $BRANCH branch advanced; rebuilding state commit for attempt $attempt."
+    git reset --hard HEAD^
 done

--- a/scripts/website/merge_syndication_json.py
+++ b/scripts/website/merge_syndication_json.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Three-way merge JSON state written by concurrent syndication publishers."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import sys
+from pathlib import Path
+
+
+class MergeConflict(ValueError):
+    """Raised when both sides changed the same JSON value differently."""
+
+
+MISSING = object()
+
+
+def display_path(path: tuple[str, ...]) -> str:
+    return ".".join(path) if path else "<root>"
+
+
+def merge_id_list(
+    base: list,
+    local: list,
+    remote: list,
+    path: tuple[str, ...],
+) -> list:
+    def keyed(items: list) -> dict[str, object] | None:
+        result: dict[str, object] = {}
+        for item in items:
+            if not isinstance(item, dict) or not isinstance(item.get("id"), str):
+                return None
+            item_id = item["id"]
+            if item_id in result:
+                raise MergeConflict(
+                    f"duplicate id {item_id!r} at {display_path(path)}"
+                )
+            result[item_id] = item
+        return result
+
+    base_by_id = keyed(base)
+    local_by_id = keyed(local)
+    remote_by_id = keyed(remote)
+    if base_by_id is None or local_by_id is None or remote_by_id is None:
+        raise MergeConflict(f"conflicting list changes at {display_path(path)}")
+
+    order = list(remote_by_id)
+    order.extend(item_id for item_id in local_by_id if item_id not in remote_by_id)
+    merged = []
+    for item_id in order:
+        value = merge_value(
+            base_by_id.get(item_id, MISSING),
+            local_by_id.get(item_id, MISSING),
+            remote_by_id.get(item_id, MISSING),
+            (*path, item_id),
+        )
+        if value is not MISSING:
+            merged.append(value)
+    return merged
+
+
+def merge_value(
+    base: object,
+    local: object,
+    remote: object,
+    path: tuple[str, ...] = (),
+) -> object:
+    if local == remote:
+        return copy.deepcopy(local)
+    if local == base:
+        return copy.deepcopy(remote)
+    if remote == base:
+        return copy.deepcopy(local)
+    if local is MISSING or remote is MISSING:
+        raise MergeConflict(f"conflicting changes at {display_path(path)}")
+
+    dict_values = (base, local, remote)
+    if all(value is MISSING or isinstance(value, dict) for value in dict_values):
+        base_dict = {} if base is MISSING else base
+        local_dict = {} if local is MISSING else local
+        remote_dict = {} if remote is MISSING else remote
+        assert isinstance(base_dict, dict)
+        assert isinstance(local_dict, dict)
+        assert isinstance(remote_dict, dict)
+
+        keys = list(remote_dict)
+        keys.extend(key for key in local_dict if key not in remote_dict)
+        merged = {}
+        for key in keys:
+            value = merge_value(
+                base_dict.get(key, MISSING),
+                local_dict.get(key, MISSING),
+                remote_dict.get(key, MISSING),
+                (*path, key),
+            )
+            if value is not MISSING:
+                merged[key] = value
+        return merged
+
+    if isinstance(base, list) and isinstance(local, list) and isinstance(remote, list):
+        return merge_id_list(base, local, remote, path)
+
+    raise MergeConflict(f"conflicting changes at {display_path(path)}")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--local", required=True)
+    parser.add_argument("--remote", required=True)
+    parser.add_argument("--output", required=True)
+    return parser.parse_args(argv)
+
+
+def load_json(path: str) -> object:
+    with Path(path).open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    try:
+        merged = merge_value(
+            load_json(args.base),
+            load_json(args.local),
+            load_json(args.remote),
+        )
+    except (OSError, json.JSONDecodeError, MergeConflict) as error:
+        print(f"Unable to merge syndication JSON: {error}", file=sys.stderr)
+        return 1
+
+    Path(args.output).write_text(
+        json.dumps(merged, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/website/syndication-state.json
+++ b/scripts/website/syndication-state.json
@@ -1148,7 +1148,6 @@
       }
     },
     "pixel-perfect-is-a-test": {
-<<<<<<< Updated upstream
       "hashnode": {
         "url": "https://hashnode.com/edit/cmrz2ih9400000ahx0rcydwno",
         "published": true,
@@ -1158,7 +1157,7 @@
         "tags_set": true,
         "canonical_set": true,
         "syndicated_at": "2026-07-24T15:01:14+00:00"
-=======
+      },
       "devto": {
         "id": 4225026,
         "url": "https://dev.to/codenameone/own-your-pixels-native-fidelity-on-your-schedule-2gf",
@@ -1171,7 +1170,6 @@
         "featured_media_id": 125062,
         "yoast_meta_set": true,
         "syndicated_at": "2026-07-24T15:28:58+00:00"
->>>>>>> Stashed changes
       }
     }
   }

--- a/scripts/website/test_syndicate_blog_posts.py
+++ b/scripts/website/test_syndicate_blog_posts.py
@@ -2,6 +2,7 @@
 
 import datetime as dt
 import importlib.util
+import json
 import os
 import subprocess
 import sys
@@ -99,11 +100,11 @@ class StateCommitRaceTest(unittest.TestCase):
             capture_output=True,
         )
 
-    def write_state_files(self, repo, state_text="{}\n"):
+    def write_state_files(self, repo, state_text="{}\n", queue_text="{}\n"):
         website = repo / "scripts" / "website"
         website.mkdir(parents=True, exist_ok=True)
         (website / "syndication-state.json").write_text(state_text, encoding="utf-8")
-        (website / "syndication-queue.json").write_text("{}\n", encoding="utf-8")
+        (website / "syndication-queue.json").write_text(queue_text, encoding="utf-8")
 
     def test_state_commit_rebases_when_default_branch_advanced(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -152,10 +153,131 @@ class StateCommitRaceTest(unittest.TestCase):
                 "concurrent\n", (verify / "README.md").read_text(encoding="utf-8")
             )
             self.assertEqual(
-                '{"recorded": true}\n',
+                {"recorded": True},
+                json.loads(
+                    (
+                        verify / "scripts" / "website" / "syndication-state.json"
+                    ).read_text(encoding="utf-8")
+                ),
+            )
+
+    def test_state_commit_merges_concurrent_platform_updates(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            remote = root / "remote.git"
+            seed = root / "seed"
+            runner = root / "runner"
+            concurrent = root / "concurrent"
+            verify = root / "verify"
+
+            self.git(root, "init", "--bare", "--initial-branch=master", str(remote))
+            self.git(root, "clone", str(remote), str(seed))
+            self.git(seed, "config", "user.name", "Test")
+            self.git(seed, "config", "user.email", "test@example.com")
+            self.write_state_files(
+                seed,
+                '{"posts": {"same-post": {}}}\n',
+                '{"tasks": []}\n',
+            )
+            self.git(seed, "add", ".")
+            self.git(seed, "commit", "-m", "initial")
+            self.git(seed, "push", "origin", "master")
+
+            self.git(root, "clone", str(remote), str(runner))
+            self.git(root, "clone", str(remote), str(concurrent))
+
+            self.write_state_files(
+                concurrent,
+                json.dumps(
+                    {
+                        "posts": {
+                            "same-post": {
+                                "hashnode": {
+                                    "url": "https://hashnode.example/same-post"
+                                }
+                            }
+                        }
+                    }
+                )
+                + "\n",
+                json.dumps(
+                    {
+                        "tasks": [
+                            {
+                                "id": "linkedin:same-post",
+                                "site": "linkedin",
+                            }
+                        ]
+                    }
+                )
+                + "\n",
+            )
+            self.git(concurrent, "config", "user.name", "Test")
+            self.git(concurrent, "config", "user.email", "test@example.com")
+            self.git(
+                concurrent,
+                "add",
+                "scripts/website/syndication-state.json",
+                "scripts/website/syndication-queue.json",
+            )
+            self.git(concurrent, "commit", "-m", "record hashnode")
+            self.git(concurrent, "push", "origin", "master")
+
+            self.write_state_files(
+                runner,
+                json.dumps(
+                    {
+                        "posts": {
+                            "same-post": {
+                                "devto": {"url": "https://dev.to/same-post"},
+                                "foojay": {"url": "https://foojay.io/same-post"},
+                            }
+                        }
+                    }
+                )
+                + "\n",
+                json.dumps(
+                    {
+                        "tasks": [
+                            {
+                                "id": "medium:same-post",
+                                "site": "medium",
+                            }
+                        ]
+                    }
+                )
+                + "\n",
+            )
+            subprocess.run(
+                ["bash", str(COMMIT_SCRIPT)],
+                cwd=runner,
+                check=True,
+                text=True,
+                capture_output=True,
+                env={
+                    "PATH": os.environ["PATH"],
+                    "GITHUB_REF_NAME": "master",
+                },
+            )
+
+            self.git(root, "clone", str(remote), str(verify))
+            state = json.loads(
                 (verify / "scripts" / "website" / "syndication-state.json").read_text(
                     encoding="utf-8"
-                ),
+                )
+            )
+            self.assertEqual(
+                {"devto", "foojay", "hashnode"},
+                set(state["posts"]["same-post"]),
+            )
+            queue = json.loads(
+                (verify / "scripts" / "website" / "syndication-queue.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            self.assertEqual(
+                {"linkedin:same-post", "medium:same-post"},
+                {task["id"] for task in queue["tasks"]},
             )
 
 


### PR DESCRIPTION
## What changed

- resolve the committed conflict markers in `syndication-state.json` while preserving the Hashnode, DEV, and Foojay results
- replace `git rebase --autostash` with a validated three-way JSON merge for state and queue updates
- merge queue entries by task ID and fail safely when both publishers change the same value incompatibly
- add an end-to-end regression test for concurrent platform and queue updates

## Root cause

The GitHub publisher and local browser runner updated different platform keys under `pixel-perfect-is-a-test`. `git rebase --autostash` reapplied those changes as a conflict, but the commit script staged and pushed the literal conflict markers. Both Syndication Health and the daily publisher then failed parsing the state file. This addresses #5460.

## Impact

The state file is valid again, existing publication records are retained, and future disjoint publisher updates are merged without committing conflict markers. Genuine same-value conflicts or invalid JSON stop the commit instead of corrupting `master`.

## Validation

- `python3 scripts/website/test_syndicate_blog_posts.py`
- `python3 scripts/website/test_queue_social_posts.py`
- `python3 scripts/website/test_syndication_health.py`
- `python3 scripts/website/syndicate_blog_posts.py --dry-run`
- JSON parsing for state and queue files
- `bash -n scripts/website/commit_syndication_state.sh`
- `git diff --check`

After parsing was restored locally, the health checker correctly exposed two real overdue browser tasks (Medium and DZone) that the local runner still needs to drain.