### PR TITLE
Fix JavaDoc full-width layout

### DIFF
--- a/docs/website/assets/css/extended/zz-cn1-design-system.css
+++ b/docs/website/assets/css/extended/zz-cn1-design-system.css
@@ -1268,7 +1268,7 @@ body.dark .cn1-footer-logo {
   margin-left: 12px;
 }
 
-.post-single:not(.cn1-pricing-page):not(.post-single--demo) {
+.post-single:not(.cn1-pricing-page):not(.post-single--demo):not(.post-single--api-javadoc) {
   max-width: 940px;
 }
 


### PR DESCRIPTION
## Summary

- exclude the embedded API JavaDoc page from the new design system's 940px reading-width constraint
- preserve the JavaDoc layout's existing full-width container rules

## Root cause

The generic `.post-single` rule added by the new website design had greater specificity than the JavaDoc page's full-width rule. It constrained the JavaDoc article to 940px while the page-specific zero margin kept it anchored to the left.

## Impact

The `/javadoc/` page once again uses the available viewport width. Regular article, pricing, and demo layouts are unchanged.

## Validation

- built the Hugo site successfully
- verified the generated stylesheet retains the JavaDoc full-width rules and excludes the API JavaDoc layout from the 940px constraint
- `git diff --check`
