### PR TITLE
Fix class closure false positive on platform modules

### DIFF
--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/CN1BuildMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/CN1BuildMojo.java
@@ -214,6 +214,11 @@ public class CN1BuildMojo extends AbstractCN1Mojo {
         return buildTarget != null && buildTarget.contains("javascript") && isLocalBuildTarget(buildTarget);
     }
 
+    // A null build target never reaches these from the mojo -- the parameter is
+    // required -- but they are static and package private, so treat an absent
+    // target as "not local": the conservative answer, since it keeps the server
+    // supplied artifacts out of the staged jar rather than throwing.
+
     /**
      * Whether the build itself re-supplies the artifact's classes after they
      * are left out of the staged jar: codenameone-core and java-runtime come
@@ -609,6 +614,9 @@ public class CN1BuildMojo extends AbstractCN1Mojo {
     public static final String BUILD_TARGET_LINUX_NATIVE = Executor.BUILD_TARGET_LINUX_NATIVE;
 
     private static boolean isLocalBuildTarget(String buildTarget) {
+        if (buildTarget == null) {
+            return false;
+        }
         // windows-device (BUILD_TARGET_WINDOWS_NATIVE) is a *cloud* build: it sends
         // a "win32" build to the server (see the windows-device target in
         // buildxml-template.xml), mirroring linux-device. Only the explicit

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/CN1BuildMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/CN1BuildMojo.java
@@ -301,7 +301,7 @@ public class CN1BuildMojo extends AbstractCN1Mojo {
         // scope third party dependency, say -- stays reportable, because nothing
         // puts those classes back before the translators run.
         boolean localJavascriptBuild = isLocalJavascriptBuild(buildTarget);
-        List<File> providedJars = new ArrayList<File>();
+        Set<File> providedJars = new LinkedHashSet<File>();
         for (Artifact artifact : project.getArtifacts()) {
             if (isSuppliedByBuildServer(artifact.getGroupId(), artifact.getArtifactId(), buildTarget)) {
                 File jar = getJar(artifact);
@@ -323,9 +323,7 @@ public class CN1BuildMojo extends AbstractCN1Mojo {
             for (String bundled : BUNDLE_ARTIFACT_ID_BLACKLIST) {
                 File jar = getJar(GROUP_ID, bundled);
                 if (jar != null && jar.isFile()) {
-                    if (!providedJars.contains(jar)) {
-                        providedJars.add(jar);
-                    }
+                    providedJars.add(jar);
                     if ("codenameone-core".equals(bundled)) {
                         coreResolved = true;
                     }
@@ -334,8 +332,11 @@ public class CN1BuildMojo extends AbstractCN1Mojo {
             if (!coreResolved) {
                 // Every application class references the framework, so without its class
                 // list the check cannot tell a stale class from a framework class and would
-                // report false positives. Skipping is the only safe answer.
-                getLog().debug("Skipping the application class closure check because codenameone-core could not be resolved");
+                // report false positives. Skipping is the only safe answer, but say so
+                // loudly: a stale class will now reach the build unreported.
+                getLog().warn("Skipping the application class closure check for build target " + buildTarget
+                        + " because " + GROUP_ID + ":codenameone-core could not be resolved."
+                        + " Stale application classes will not be detected before the build runs.");
                 return;
             }
         }

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/CN1BuildMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/CN1BuildMojo.java
@@ -207,6 +207,45 @@ public class CN1BuildMojo extends AbstractCN1Mojo {
     }
 
     /**
+     * Local JavaScript builds run ParparVM's translator on this machine, so
+     * they keep the classes a server build would have re-supplied.
+     */
+    static boolean isLocalJavascriptBuild(String buildTarget) {
+        return buildTarget != null && buildTarget.contains("javascript") && isLocalBuildTarget(buildTarget);
+    }
+
+    /**
+     * Whether the given artifact is left out of the jar-with-dependencies that
+     * is staged for the build. The build server re-supplies its own copy of
+     * codenameone-core, java-runtime and kotlin-stdlib, and non-compile scopes
+     * are not part of the application in the first place, so references into
+     * them are satisfied even though their classes are not in the jar. Shared
+     * by the jar assembly and the class closure check so the two can never
+     * disagree about what is actually missing.
+     */
+    static boolean isStrippedFromStagedJar(String groupId, String artifactId, String scope, String buildTarget) {
+        if (GROUP_ID.equals(groupId) && contains(artifactId, BUNDLE_ARTIFACT_ID_BLACKLIST)) {
+            // For local JavaScript builds we need codenameone-core and java-runtime classes
+            // in the staged jar - the build server normally re-supplies those, but ParparVM's
+            // ByteCodeTranslator runs locally here and resolves everything from the staged class
+            // directory.
+            return !isLocalJavascriptBuild(buildTarget);
+        }
+        if (!isLocalBuildTarget(buildTarget)
+                && "org.jetbrains.kotlin".equals(groupId)
+                && "kotlin-stdlib".equals(artifactId)) {
+            // When sending to the build server, we'll strip the kotlin-stdlib and the server will
+            // provide it. For local builds, it's easier to just include it.
+            return true;
+        }
+        return !"compile".equals(scope);
+    }
+
+    private boolean isStrippedFromStagedJar(Artifact artifact) {
+        return isStrippedFromStagedJar(artifact.getGroupId(), artifact.getArtifactId(), artifact.getScope(), buildTarget);
+    }
+
+    /**
      * Fails the build when the staged jar-with-dependencies contains an
      * application class that references another application class which is not
      * in the jar. Stale build output causes exactly this -- e.g. an IDE deletes
@@ -241,19 +280,45 @@ public class CN1BuildMojo extends AbstractCN1Mojo {
                 }
             }
         }
-        // Classes stripped from the upload that the build server re-supplies:
+        // Classes stripped from the staged jar that the build server re-supplies:
         // references into them are not missing.
+        boolean localJavascriptBuild = isLocalJavascriptBuild(buildTarget);
         List<File> providedJars = new ArrayList<File>();
         for (Artifact artifact : project.getArtifacts()) {
-            boolean providedByServer = GROUP_ID.equals(artifact.getGroupId())
-                    && contains(artifact.getArtifactId(), BUNDLE_ARTIFACT_ID_BLACKLIST);
-            providedByServer = providedByServer || ("org.jetbrains.kotlin".equals(artifact.getGroupId())
-                    && "kotlin-stdlib".equals(artifact.getArtifactId()));
-            if (providedByServer) {
+            if (isStrippedFromStagedJar(artifact)) {
                 File jar = getJar(artifact);
                 if (jar != null && jar.isFile()) {
                     providedJars.add(jar);
                 }
+            }
+        }
+        if (!localJavascriptBuild) {
+            // codenameone-core and java-runtime are `provided` scope in the app's common
+            // module and `provided` is not transitive, so a platform module (ios, android,
+            // ...) that only depends on common does not see them among its own artifacts.
+            // They still have to count as provided: without them every reference into a
+            // package the app shares with the framework -- a patched framework class, or a
+            // helper deliberately placed in a com.codename1 package to reach package
+            // private API -- makes the whole framework package look like it is missing
+            // from the build. Resolve them from the plugin's own dependencies instead.
+            boolean coreResolved = false;
+            for (String bundled : BUNDLE_ARTIFACT_ID_BLACKLIST) {
+                File jar = getJar(GROUP_ID, bundled);
+                if (jar != null && jar.isFile()) {
+                    if (!providedJars.contains(jar)) {
+                        providedJars.add(jar);
+                    }
+                    if ("codenameone-core".equals(bundled)) {
+                        coreResolved = true;
+                    }
+                }
+            }
+            if (!coreResolved) {
+                // Every application class references the framework, so without its class
+                // list the check cannot tell a stale class from a framework class and would
+                // report false positives. Skipping is the only safe answer.
+                getLog().debug("Skipping the application class closure check because codenameone-core could not be resolved");
+                return;
             }
         }
         Map<String, Set<String>> missing;
@@ -524,7 +589,7 @@ public class CN1BuildMojo extends AbstractCN1Mojo {
     public static final String BUILD_TARGET_MAC_NATIVE = Executor.BUILD_TARGET_MAC_NATIVE;
     public static final String BUILD_TARGET_LINUX_NATIVE = Executor.BUILD_TARGET_LINUX_NATIVE;
 
-    private boolean isLocalBuildTarget(String buildTarget) {
+    private static boolean isLocalBuildTarget(String buildTarget) {
         // windows-device (BUILD_TARGET_WINDOWS_NATIVE) is a *cloud* build: it sends
         // a "win32" build to the server (see the windows-device target in
         // buildxml-template.xml), mirroring linux-device. Only the explicit
@@ -652,34 +717,14 @@ public class CN1BuildMojo extends AbstractCN1Mojo {
             // in the staged jar — the build server normally re-supplies those, but ParparVM's
             // ByteCodeTranslator runs locally here and resolves everything from the staged class
             // directory.
-            boolean localJsBuild = buildTarget.contains("javascript") && isLocalBuildTarget(buildTarget);
+            boolean localJsBuild = isLocalJavascriptBuild(buildTarget);
             for (Artifact artifact : project.getArtifacts()) {
-                boolean addToBlacklist = false;
-                if (artifact.getGroupId().equals("com.codenameone") && contains(artifact.getArtifactId(), BUNDLE_ARTIFACT_ID_BLACKLIST)) {
-                    if (!localJsBuild) {
-                        addToBlacklist = true;
-                    }
-                }
-                if (!addToBlacklist && !isLocalBuildTarget(buildTarget)) {
-                    // When sending to the build server, we'll strip the kotlin-stdlib and the server will provide it
-                    // for local builds, it's easier to just include it.
-                    if (artifact.getGroupId().equals("org.jetbrains.kotlin") && artifact.getArtifactId().equals("kotlin-stdlib")) {
-                        addToBlacklist = true;
-                        serverMustProvideKotlinVersion = artifact.getVersion();
-                        getLog().debug("Adding kotlin-stdlib to blacklist.  Server will provide this:" + artifact);
-                    }
-                }
-                if (!addToBlacklist && !"compile".equals(artifact.getScope())) {
-                    // Local JS builds need codenameone-core / java-runtime even though they are
-                    // marked `provided` in the user's POM — the build server normally re-supplies
-                    // them, but locally we have to bundle them so ParparVM's translator can see
-                    // every referenced class.
-                    boolean keepForLocalJs = localJsBuild
-                            && "com.codenameone".equals(artifact.getGroupId())
-                            && contains(artifact.getArtifactId(), BUNDLE_ARTIFACT_ID_BLACKLIST);
-                    if (!keepForLocalJs) {
-                        addToBlacklist = true;
-                    }
+                boolean addToBlacklist = isStrippedFromStagedJar(artifact);
+                if (addToBlacklist && !isLocalBuildTarget(buildTarget)
+                        && "org.jetbrains.kotlin".equals(artifact.getGroupId())
+                        && "kotlin-stdlib".equals(artifact.getArtifactId())) {
+                    serverMustProvideKotlinVersion = artifact.getVersion();
+                    getLog().debug("Adding kotlin-stdlib to blacklist.  Server will provide this:" + artifact);
                 }
                 if (addToBlacklist) {
                     File jar = getJar(artifact);

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/CN1BuildMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/CN1BuildMojo.java
@@ -215,13 +215,29 @@ public class CN1BuildMojo extends AbstractCN1Mojo {
     }
 
     /**
+     * Whether the build itself re-supplies the artifact's classes after they
+     * are left out of the staged jar: codenameone-core and java-runtime come
+     * from the build server (or, for a local JavaScript build, stay in the jar
+     * so ParparVM's translator can see them), and kotlin-stdlib comes from the
+     * build server too. This is deliberately narrower than
+     * {@link #isStrippedFromStagedJar}: a reference into anything else that is
+     * left out really is a reference to a class nobody will supply.
+     */
+    static boolean isSuppliedByBuildServer(String groupId, String artifactId, String buildTarget) {
+        if (GROUP_ID.equals(groupId) && contains(artifactId, BUNDLE_ARTIFACT_ID_BLACKLIST)) {
+            return !isLocalJavascriptBuild(buildTarget);
+        }
+        return !isLocalBuildTarget(buildTarget)
+                && "org.jetbrains.kotlin".equals(groupId)
+                && "kotlin-stdlib".equals(artifactId);
+    }
+
+    /**
      * Whether the given artifact is left out of the jar-with-dependencies that
-     * is staged for the build. The build server re-supplies its own copy of
-     * codenameone-core, java-runtime and kotlin-stdlib, and non-compile scopes
-     * are not part of the application in the first place, so references into
-     * them are satisfied even though their classes are not in the jar. Shared
-     * by the jar assembly and the class closure check so the two can never
-     * disagree about what is actually missing.
+     * is staged for the build, either because the build re-supplies it or
+     * because its scope says it is not part of the application. Shared by the
+     * jar assembly and the class closure check so the two can never disagree
+     * about what is in the jar.
      */
     static boolean isStrippedFromStagedJar(String groupId, String artifactId, String scope, String buildTarget) {
         if (GROUP_ID.equals(groupId) && contains(artifactId, BUNDLE_ARTIFACT_ID_BLACKLIST)) {
@@ -231,14 +247,14 @@ public class CN1BuildMojo extends AbstractCN1Mojo {
             // directory.
             return !isLocalJavascriptBuild(buildTarget);
         }
-        if (!isLocalBuildTarget(buildTarget)
-                && "org.jetbrains.kotlin".equals(groupId)
-                && "kotlin-stdlib".equals(artifactId)) {
+        if (isSuppliedByBuildServer(groupId, artifactId, buildTarget)) {
             // When sending to the build server, we'll strip the kotlin-stdlib and the server will
             // provide it. For local builds, it's easier to just include it.
             return true;
         }
-        return !"compile".equals(scope);
+        // An artifact with no scope was never scoped out of the application, so
+        // keep its classes rather than dropping them from the jar.
+        return scope != null && !"compile".equals(scope);
     }
 
     private boolean isStrippedFromStagedJar(Artifact artifact) {
@@ -280,12 +296,14 @@ public class CN1BuildMojo extends AbstractCN1Mojo {
                 }
             }
         }
-        // Classes stripped from the staged jar that the build server re-supplies:
-        // references into them are not missing.
+        // Classes left out of the staged jar that the build re-supplies: references
+        // into them are not missing. Anything else that was left out -- a `provided`
+        // scope third party dependency, say -- stays reportable, because nothing
+        // puts those classes back before the translators run.
         boolean localJavascriptBuild = isLocalJavascriptBuild(buildTarget);
         List<File> providedJars = new ArrayList<File>();
         for (Artifact artifact : project.getArtifacts()) {
-            if (isStrippedFromStagedJar(artifact)) {
+            if (isSuppliedByBuildServer(artifact.getGroupId(), artifact.getArtifactId(), buildTarget)) {
                 File jar = getJar(artifact);
                 if (jar != null && jar.isFile()) {
                     providedJars.add(jar);

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/ClassClosureVerifier.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/ClassClosureVerifier.java
@@ -36,10 +36,10 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -86,7 +86,7 @@ final class ClassClosureVerifier {
      * @return map of missing class internal name to the internal names of the
      *         classes that reference it, empty when the closure is consistent
      */
-    static Map<String, Set<String>> findMissingProjectReferences(File stagedJar, List<File> projectClassRoots, List<File> providedJars) throws IOException {
+    static Map<String, Set<String>> findMissingProjectReferences(File stagedJar, Collection<File> projectClassRoots, Collection<File> providedJars) throws IOException {
         Set<String> projectPackages = new HashSet<String>();
         for (File root : projectClassRoots) {
             if (root.isDirectory()) {

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/CN1BuildMojoTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/CN1BuildMojoTest.java
@@ -91,6 +91,8 @@ public class CN1BuildMojoTest {
     @Test
     public void stripsKotlinStdlibOnlyForServerBuilds() {
         assertTrue(CN1BuildMojo.isStrippedFromStagedJar("org.jetbrains.kotlin", "kotlin-stdlib", "compile", "ios-device"));
+        // ios-source generates the Xcode project on this machine, so it is a local
+        // target and bundling kotlin-stdlib is simpler than having it re-supplied.
         assertFalse(CN1BuildMojo.isStrippedFromStagedJar("org.jetbrains.kotlin", "kotlin-stdlib", "compile", "ios-source"));
     }
 

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/CN1BuildMojoTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/CN1BuildMojoTest.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Method;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -49,5 +50,32 @@ public class CN1BuildMojoTest {
         } catch (InvocationTargetException ex) {
             assertTrue(ex.getCause().getMessage().contains("Property codename1.arg.test has a conflict"));
         }
+    }
+
+    @Test
+    public void stripsTheFrameworkTheServerReSupplies() {
+        assertTrue(CN1BuildMojo.isStrippedFromStagedJar("com.codenameone", "codenameone-core", "provided", "ios-device"));
+        assertTrue(CN1BuildMojo.isStrippedFromStagedJar("com.codenameone", "codenameone-core", "provided", "ios-source"));
+        assertTrue(CN1BuildMojo.isStrippedFromStagedJar("com.codenameone", "java-runtime", "provided", "android-device"));
+    }
+
+    @Test
+    public void keepsTheFrameworkForLocalJavascriptBuilds() {
+        // ParparVM translates locally for these, so it needs every class in the jar.
+        assertFalse(CN1BuildMojo.isStrippedFromStagedJar("com.codenameone", "codenameone-core", "provided", "local-javascript"));
+        assertFalse(CN1BuildMojo.isStrippedFromStagedJar("com.codenameone", "java-runtime", "provided", "local-javascript"));
+    }
+
+    @Test
+    public void stripsKotlinStdlibOnlyForServerBuilds() {
+        assertTrue(CN1BuildMojo.isStrippedFromStagedJar("org.jetbrains.kotlin", "kotlin-stdlib", "compile", "ios-device"));
+        assertFalse(CN1BuildMojo.isStrippedFromStagedJar("org.jetbrains.kotlin", "kotlin-stdlib", "compile", "ios-source"));
+    }
+
+    @Test
+    public void keepsTheApplicationsOwnCompileDependencies() {
+        assertFalse(CN1BuildMojo.isStrippedFromStagedJar("com.mycompany", "myproject-common", "compile", "ios-source"));
+        assertFalse(CN1BuildMojo.isStrippedFromStagedJar("com.codenameone", "cn1-admob-lib", "compile", "ios-device"));
+        assertTrue(CN1BuildMojo.isStrippedFromStagedJar("org.junit.jupiter", "junit-jupiter", "test", "ios-device"));
     }
 }

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/CN1BuildMojoTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/CN1BuildMojoTest.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2021, 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.maven;
 
 import com.codename1.ant.SortedProperties;
@@ -77,5 +99,23 @@ public class CN1BuildMojoTest {
         assertFalse(CN1BuildMojo.isStrippedFromStagedJar("com.mycompany", "myproject-common", "compile", "ios-source"));
         assertFalse(CN1BuildMojo.isStrippedFromStagedJar("com.codenameone", "cn1-admob-lib", "compile", "ios-device"));
         assertTrue(CN1BuildMojo.isStrippedFromStagedJar("org.junit.jupiter", "junit-jupiter", "test", "ios-device"));
+    }
+
+    @Test
+    public void keepsArtifactsWithoutAScope() {
+        // A null scope is not a statement that the artifact is outside the application.
+        assertFalse(CN1BuildMojo.isStrippedFromStagedJar("com.mycompany", "some-lib", null, "ios-device"));
+    }
+
+    @Test
+    public void onlyTheFrameworkCountsAsSuppliedByTheBuildServer() {
+        assertTrue(CN1BuildMojo.isSuppliedByBuildServer("com.codenameone", "codenameone-core", "ios-device"));
+        assertTrue(CN1BuildMojo.isSuppliedByBuildServer("com.codenameone", "java-runtime", "ios-source"));
+        assertTrue(CN1BuildMojo.isSuppliedByBuildServer("org.jetbrains.kotlin", "kotlin-stdlib", "ios-device"));
+        assertFalse(CN1BuildMojo.isSuppliedByBuildServer("com.codenameone", "codenameone-core", "local-javascript"));
+        // A `provided` scope third party dependency is stripped from the jar but nobody
+        // puts it back, so a reference into it stays reportable.
+        assertTrue(CN1BuildMojo.isStrippedFromStagedJar("com.thirdparty", "some-api", "provided", "ios-device"));
+        assertFalse(CN1BuildMojo.isSuppliedByBuildServer("com.thirdparty", "some-api", "ios-device"));
     }
 }

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/CN1BuildMojoTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/CN1BuildMojoTest.java
@@ -110,6 +110,14 @@ public class CN1BuildMojoTest {
     }
 
     @Test
+    public void toleratesAnAbsentBuildTarget() {
+        assertTrue(CN1BuildMojo.isSuppliedByBuildServer("com.codenameone", "codenameone-core", null));
+        assertFalse(CN1BuildMojo.isSuppliedByBuildServer("com.thirdparty", "some-api", null));
+        assertFalse(CN1BuildMojo.isLocalJavascriptBuild(null));
+        assertTrue(CN1BuildMojo.isStrippedFromStagedJar("com.codenameone", "codenameone-core", "provided", null));
+    }
+
+    @Test
     public void onlyTheFrameworkCountsAsSuppliedByTheBuildServer() {
         assertTrue(CN1BuildMojo.isSuppliedByBuildServer("com.codenameone", "codenameone-core", "ios-device"));
         assertTrue(CN1BuildMojo.isSuppliedByBuildServer("com.codenameone", "java-runtime", "ios-source"));


### PR DESCRIPTION
`mvn clean package -Dcodename1.buildTarget=ios-source` (and the cloud iOS/Android targets) fails on a fully clean tree with most of `com.codename1.ui` listed as missing from the build, since #5390:

```
[ERROR] The compiled application classes are inconsistent. The following classes are
[ERROR] referenced by your code but missing from the build:
[ERROR]  - com.codename1.ui.Button (referenced from ...)
[ERROR]  - com.codename1.ui.Form (referenced from ...)
...
```

## Root cause

The check marks a referenced class missing when it is absent from the staged jar-with-dependencies and lives in a package the project owns. Two things collide on a platform module:

1. `codenameone-core` / `java-runtime` are left out of the staged jar because the build re-supplies them, so no framework class is in the jar. This is true for local targets such as `ios-source` too - only a local *JavaScript* build keeps them, because ParparVM then translates on this machine and resolves everything from the staged classes.
2. `verifyApplicationClassClosure` built its "this gets re-supplied" set from `project.getArtifacts()` of the module being built only. Those artifacts are `provided` scope in the app's `common` module and `provided` is not transitive, so an `ios`/`android` module that depends on `common` alone never sees them. The set was always empty there - the same hole the local JavaScript path already documents a few lines below.

The trigger is any application class in a package the framework also owns: a patched framework class, or a helper deliberately placed in a `com.codename1` package to reach package private API. That single class pulls the whole framework package into the project package space, and every framework class the app touches then looks missing.

Reproduced on a stock archetype project: it builds clean, and adding one class under `common/src/main/java/com/codename1/ui/` makes the iOS build fail with `com.codename1.ui.Button/Command/Component/Container/Dialog/Form/Toolbar` reported missing.

## Fix

- Resolve `codenameone-core` / `java-runtime` from the plugin's own dependencies when the module's classpath does not carry them.
- Skip the check when core cannot be resolved at all - without its class list the check cannot tell a stale class from a framework class - and warn that stale classes will go undetected.
- Split the two decisions that were previously one: `isStrippedFromStagedJar` governs what the assembly leaves out, and the narrower `isSuppliedByBuildServer` (codenameone-core, java-runtime, kotlin-stdlib) is what may satisfy a dangling reference. A `provided` scope third party dependency is left out but nobody puts it back, so references into it stay reportable.
- An artifact with a null scope is no longer stripped from the jar: a missing scope is not a statement that the artifact sits outside the application.

## Verification

End to end against a generated app with the patched plugin:

- App with a class in `com.codename1.ui`: BUILD SUCCESS (was the reported failure).
- Genuine stale output (delete a class's source and its `.class`, leave the stale dependent class file): still fails, reporting only the deleted class.
- Unit tests cover the strip matrix and the narrower re-supply set: cloud vs local targets, local-javascript keeping the framework, kotlin-stdlib, null scope, ordinary compile scope dependencies.

Note that the check has been inert on iOS/Android modules since it landed (its provided set was always empty there); this is what makes it work on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)