### PR TITLE
JS port: let Display.execute navigate the current page instead of prompting

### DIFF
--- a/CodenameOne/src/com/codename1/ui/CN.java
+++ b/CodenameOne/src/com/codename1/ui/CN.java
@@ -664,6 +664,11 @@ public class CN extends CN1Constants {
     /// }
     /// ```
     ///
+    /// On the JavaScript port this can open a new tab, navigate the current page
+    /// or show a confirmation `Sheet`, depending on the
+    /// `javascript.execute.target` property. See [Display#execute(String)] for
+    /// the details.
+    ///
     /// #### Parameters
     ///
     /// - `url`: the url to execute

--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -4082,6 +4082,33 @@ public final class Display extends CN1Constants {
     /// `simulator-hooks.properties` format and the positional `itemN` / `labelN`
     /// conventions.
     ///
+    /// #### JavaScript port
+    ///
+    /// Browsers only let a page open a new window/tab from inside a live user
+    /// gesture, and Codename One dispatches events on its own EDT so by the time
+    /// your listener calls this method the browser no longer considers a gesture
+    /// to be in progress. The JavaScript port therefore resolves the
+    /// `javascript.execute.target` property to decide what to do:
+    ///
+    /// - `auto` (the default) opens a new tab when the page still has user
+    ///   activation and otherwise navigates the page the app is running in. No
+    ///   confirmation prompt is ever shown, but note that navigating the current
+    ///   page unloads the app.
+    /// - `_blank` only ever opens a new tab. When the browser would block it the
+    ///   port shows a confirmation `Sheet` whose OK button supplies the missing
+    ///   gesture. This was the behavior before the property existed.
+    /// - `_self` always navigates the page the app is running in.
+    ///
+    /// Set it before the call, for example in your `init` method:
+    ///
+    /// ```java
+    /// Display.getInstance().setProperty("javascript.execute.target", "_self");
+    /// ```
+    ///
+    /// The property is ignored on every other platform, and on all targets a
+    /// `javascript:` URL, a `data:` URL or a path to a local file keeps its
+    /// existing meaning.
+    ///
     /// #### Parameters
     ///
     /// - `url`: the url to execute

--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -4105,9 +4105,11 @@ public final class Display extends CN1Constants {
     /// Display.getInstance().setProperty("javascript.execute.target", "_self");
     /// ```
     ///
-    /// The property is ignored on every other platform, and on all targets a
-    /// `javascript:` URL, a `data:` URL or a path to a local file keeps its
-    /// existing meaning.
+    /// The property applies to any URL carrying a URI scheme the browser can
+    /// hand off, custom deep links like the `imdb:///find` example above
+    /// included. It is ignored on every other platform, and on all targets a
+    /// `javascript:` URL, a `data:` URL, a `file:` URL or a path into local
+    /// storage keeps its existing meaning.
     ///
     /// #### Parameters
     ///

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -7020,9 +7020,9 @@ public class HTML5Implementation extends CodenameOneImplementation {
         // trusted looking path> reads as one over-long authority and the tail
         // rule below would show the attacker's suffix instead of the host.
         boolean special;
-        if (url.startsWith("//")) {
-            // Protocol relative. isExternalUrl() accepts these, so they reach
-            // the Sheet and carry an authority that needs the same parsing --
+        if (startsWithAuthorityMarker(url)) {
+            // Scheme relative. isExternalUrl() accepts these, so they reach the
+            // Sheet and carry an authority that needs the same parsing --
             // indexOf("://") does not find one. The page's own scheme applies,
             // which for a served app is http(s), so treat it as special.
             rest = url.substring(2);
@@ -7233,6 +7233,27 @@ public class HTML5Implementation extends CodenameOneImplementation {
     }
 
     /**
+     * True when the string opens with two path separators, which makes it
+     * scheme relative: the browser reads what follows as an authority.
+     *
+     * <p>Any combination of {@code /} and {@code \\} counts, because a special
+     * base URL -- and an app served over http(s) always has one -- treats them
+     * alike. So {@code \\\\host/p}, {@code \\/host/p} and {@code /\\host/p} all
+     * navigate to {@code host} exactly as {@code //host/p} does.</p>
+     *
+     * <p>Shared by every place that has to agree on where an authority starts:
+     * classification, the storage gate and the confirmation display. Answering
+     * this question separately in each is what let earlier authority shapes be
+     * fixed in one and missed in another.</p>
+     */
+    private static boolean startsWithAuthorityMarker(String url) {
+        return url.length() >= 2
+                && (url.charAt(0) == '/' || url.charAt(0) == '\\')
+                && (url.charAt(1) == '/' || url.charAt(1) == '\\');
+    }
+
+    /**
+     * True when {@code url} carries exactly {@code scheme}, compared without    /**
      * True when {@code url} carries exactly {@code scheme}, compared without
      * regard to case since URI schemes are case-insensitive. Guards the
      * {@code javascript:} and {@code data:} branches of {@link #execute(String)},
@@ -7271,7 +7292,7 @@ public class HTML5Implementation extends CodenameOneImplementation {
      * unambiguous and skip the lookup that would have found it.</p>
      */
     private static boolean isUnambiguousBrowserUrl(String url) {
-        if (url.startsWith("//")) {
+        if (startsWithAuthorityMarker(url)) {
             return true;
         }
         int sep = url.indexOf("://");
@@ -7300,8 +7321,8 @@ public class HTML5Implementation extends CodenameOneImplementation {
      * scheme at all, it names local content.</p>
      */
     private static boolean isExternalUrl(String url) {
-        if (url.startsWith("//")) {
-            // Protocol relative -- the page's own scheme applies.
+        if (startsWithAuthorityMarker(url)) {
+            // Scheme relative -- the page's own scheme applies.
             return true;
         }
         int colon = url.indexOf(':');

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -7004,6 +7004,19 @@ public class HTML5Implementation extends CodenameOneImplementation {
     private boolean popupReservedForGesture;
 
     /**
+     * True when {@code url} carries exactly {@code scheme}, compared without
+     * regard to case since URI schemes are case-insensitive. Guards the
+     * {@code javascript:} and {@code data:} branches of {@link #execute(String)},
+     * which would otherwise let {@code JavaScript:} slip through to the
+     * external-link path.
+     */
+    private static boolean hasScheme(String url, String scheme) {
+        return url.length() > scheme.length()
+                && url.charAt(scheme.length()) == ':'
+                && url.regionMatches(true, 0, scheme, 0, scheme.length());
+    }
+
+    /**
      * True when the URL names something the browser itself can hand off, as
      * opposed to a path into local storage that {@link #execute(String)} is
      * expected to turn into a download. Only these get the
@@ -7017,19 +7030,6 @@ public class HTML5Implementation extends CodenameOneImplementation {
      * URLs. {@code file:} is the exception: like the bare paths that carry no
      * scheme at all, it names local content.</p>
      */
-    /**
-     * True when {@code url} carries exactly {@code scheme}, compared without
-     * regard to case since URI schemes are case-insensitive. Guards the
-     * {@code javascript:} and {@code data:} branches of {@link #execute(String)},
-     * which would otherwise let {@code JavaScript:} slip through to the
-     * external-link path.
-     */
-    private static boolean hasScheme(String url, String scheme) {
-        return url.length() > scheme.length()
-                && url.charAt(scheme.length()) == ':'
-                && url.regionMatches(true, 0, scheme, 0, scheme.length());
-    }
-
     private static boolean isExternalUrl(String url) {
         if (url.startsWith("//")) {
             // Protocol relative -- the page's own scheme applies.
@@ -7106,9 +7106,10 @@ public class HTML5Implementation extends CodenameOneImplementation {
             addBacksideHook(new JSRunnable() {
                 @Override
                 public void run() {
-                    if (!openUrlOnMainThread(url, false, false)) {
-                        _log("execute(): popup blocked for " + url);
-                    }
+                    // openUrlOnMainThread reports the reason on failure --
+                    // popup blocked or no page-side channel -- so do not
+                    // second-guess it with a duplicate line here.
+                    openUrlOnMainThread(url, false, false);
                 }
             });
             return;
@@ -7129,14 +7130,13 @@ public class HTML5Implementation extends CodenameOneImplementation {
                     @Override
                     public void run() {
                         if (!openUrlOnMainThread(url, false, false)) {
-                            // The user confirmed and we still could not open.
-                            // Only reachable on a host bundle with no
-                            // eval-on-main handler, where the worker has no
-                            // page-side channel at all -- there is nothing
-                            // further to fall back to, and re-showing the Sheet
-                            // would just loop. Say so plainly in the log.
-                            _log("execute(): confirmed open failed, no page-side"
-                                    + " channel available for " + url);
+                            // The user confirmed and it still did not open.
+                            // openUrlOnMainThread has already logged why; note
+                            // only that this was the confirmed attempt, which
+                            // is the end of the line -- re-showing the Sheet
+                            // from here would just loop.
+                            _log("execute(): confirmed open did not succeed for "
+                                    + url);
                         }
                     }
                 });

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -6876,16 +6876,41 @@ public class HTML5Implementation extends CodenameOneImplementation {
     }
 
     /**
-     * True when the URL names something the browser itself can navigate to, as
+     * True when the URL names something the browser itself can hand off, as
      * opposed to a path into local storage that {@link #execute(String)} is
      * expected to turn into a download. Only these get the
      * {@code javascript.execute.target} treatment -- pointing the current page
      * at a storage path would unload the app and land on nothing.
+     *
+     * <p>Anything carrying a URI scheme qualifies, whatever its case. That
+     * deliberately includes custom deep links such as the {@code imdb:///find}
+     * example in {@code Display.execute}'s javadoc, which the browser passes to
+     * a registered handler, and it includes protocol-relative {@code //host/path}
+     * URLs. {@code file:} is the exception: like the bare paths that carry no
+     * scheme at all, it names local content.</p>
      */
     private static boolean isExternalUrl(String url) {
-        return url.startsWith("http:") || url.startsWith("https:")
-                || url.startsWith("mailto:") || url.startsWith("tel:")
-                || url.startsWith("sms:");
+        if (url.startsWith("//")) {
+            // Protocol relative -- the page's own scheme applies.
+            return true;
+        }
+        int colon = url.indexOf(':');
+        // A single character before the colon is a Windows drive letter rather
+        // than a URI scheme; every scheme worth handing off is longer.
+        if (colon < 2) {
+            return false;
+        }
+        // scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ), per RFC 3986. A
+        // path that merely happens to contain a colon fails this.
+        for (int i = 0; i < colon; i++) {
+            char c = url.charAt(i);
+            boolean alpha = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+            boolean extra = i > 0 && ((c >= '0' && c <= '9') || c == '+' || c == '-' || c == '.');
+            if (!alpha && !extra) {
+                return false;
+            }
+        }
+        return !"file".equals(url.substring(0, colon).toLowerCase());
     }
 
     /**
@@ -6950,7 +6975,10 @@ public class HTML5Implementation extends CodenameOneImplementation {
         String fileName = null;
         boolean useBlobHandler = false;
         Button nativeButton = new Button();
-        if (!isExternalUrl(url) && !url.startsWith("data:")) {
+        // Only a local path can name storage content to wrap in a Blob. A
+        // data: URL carries its own payload and is handled further down;
+        // isExternalUrl already excludes it, since it has a scheme.
+        if (!isExternalUrl(url)) {
             if (exists(url)) {
                 try {
                     Blob blob = openFileAsBlob(url);

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -669,11 +669,19 @@ public class HTML5Implementation extends CodenameOneImplementation {
      */
     private void addGestureOnlyHook(JSRunnable r, Runnable superseded) {
         // Backstop against unbounded growth: a hook whose interaction is long
-        // past can no longer be drained, which only happens if the EDT took
-        // longer than the whole 5s drain burst to reach us.
+        // past can no longer be drained. Eight generations is only about four
+        // rapid clicks, since press and release each advance one, so this is
+        // reachable in ordinary use -- drop the hook, but hand it to its
+        // fallback rather than losing the request. Silently discarding it left
+        // an execute() with no popup, no Sheet and no trace.
         for (int i = gestureOnlyHooks.size() - 1; i >= 0; i--) {
-            if (gestureGeneration - gestureOnlyHooks.get(i).generation > 8) {
+            GestureHook stale = gestureOnlyHooks.get(i);
+            if (gestureGeneration - stale.generation > 8) {
                 gestureOnlyHooks.remove(i);
+                _log("execute(): a queued open aged out before its drain ran");
+                if (stale.superseded != null) {
+                    callSerially(stale.superseded);
+                }
             }
         }
         gestureOnlyHooks.add(new GestureHook(gestureGeneration, r, superseded));

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -7116,33 +7116,38 @@ public class HTML5Implementation extends CodenameOneImplementation {
     }
 
     /**
-     * True for schemes that unambiguously address the browser, so offering the
-     * string to local storage first would be pointless.
+     * True when the string cannot plausibly be a storage key, so the storage
+     * lookup in {@link #execute(String)} can be skipped.
      *
-     * <p>Everything else is offered to storage first, because a stored key can
-     * be scheme-shaped: {@code report:2026.pdf} is a file, not a URI, and was
-     * downloadable before {@link #isExternalUrl(String)} began classifying by
-     * grammar. Custom deep links pass through unharmed -- {@code imdb:///find}
-     * simply is not in storage, so the lookup misses and classification
-     * proceeds.</p>
+     * <p>That means it opens with {@code //}, or with a SPECIAL scheme followed
+     * by {@code //}. Nobody names a stored file {@code https://example.com/x},
+     * and those are the overwhelming majority of links, so the common path pays
+     * nothing. Every other shape is offered to storage first -- slashless forms
+     * like {@code https:report.pdf} and {@code report:2026.pdf}, which a browser
+     * would happily parse as URLs but which a caller may just as legitimately
+     * have stored under that name, and also {@code file:///x} and custom
+     * {@code myapp://x}, which named local content or could be a key. Storage
+     * only wins if the key actually exists; a miss falls through to
+     * classification, so deep links are unaffected.</p>
+     *
+     * <p>Deciding this by scheme allowlist instead was wrong twice over: it
+     * regressed {@code report:2026.pdf}, then still regressed
+     * {@code https:report.pdf}. Ambiguity is a property of the shape, not of
+     * the scheme name.</p>
      */
-    private static boolean isBrowserOnlyScheme(String url) {
+    private static boolean isUnambiguousBrowserUrl(String url) {
         if (url.startsWith("//")) {
             return true;
         }
-        int colon = url.indexOf(':');
-        if (colon < 1) {
+        int sep = url.indexOf("://");
+        if (sep < 1) {
             return false;
         }
-        String scheme = url.substring(0, colon);
-        return isSpecialScheme(scheme)
-                || "mailto".equalsIgnoreCase(scheme)
-                || "tel".equalsIgnoreCase(scheme)
-                || "sms".equalsIgnoreCase(scheme)
-                || "data".equalsIgnoreCase(scheme)
-                || "blob".equalsIgnoreCase(scheme)
-                || "about".equalsIgnoreCase(scheme)
-                || "javascript".equalsIgnoreCase(scheme);
+        // Special schemes only. file:///x names local content, and a custom
+        // myapp://x could be a key as easily as a deep link; both were reaching
+        // the lookup before this branch and still should. What this skips is
+        // ordinary web links, which are the volume and are never keys.
+        return isSpecialScheme(url.substring(0, sep));
     }
 
     /**
@@ -7316,14 +7321,14 @@ public class HTML5Implementation extends CodenameOneImplementation {
         String fileName = null;
         boolean useBlobHandler = false;
         Button nativeButton = new Button();
-        // Storage wins for anything that could name a key. Classifying by
-        // scheme grammar alone would skip the lookup for a stored file called
-        // report:2026.pdf, which is scheme-shaped but is a file; only the
-        // unambiguously browser-bound schemes skip it, so an ordinary link does
-        // not pay for a storage round trip. Looked up under the path exactly as
-        // given, since a key may legitimately open or close with a space and
-        // nothing here is parsed by the browser.
-        if (!isBrowserOnlyScheme(url) && exists(rawUrl)) {
+        // Storage wins for anything that could name a key -- a stored file may
+        // be called report:2026.pdf or https:report.pdf, both of which a
+        // browser would read as URLs. Only shapes that cannot be a key skip the
+        // lookup, since exists() costs up to two IndexedDB reads and ordinary
+        // https://... links should not pay for them. Looked up under the path
+        // exactly as given: a key may legitimately open or close with a space,
+        // and nothing here is parsed by the browser.
+        if (!isUnambiguousBrowserUrl(url) && exists(rawUrl)) {
             try {
                 Blob blob = openFileAsBlob(rawUrl);
                 char sep = getFileSystemSeparator();

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -7162,7 +7162,7 @@ public class HTML5Implementation extends CodenameOneImplementation {
                 rest = url.substring(schemeEnd + 3);
                 special = isSpecialScheme(url.substring(0, schemeEnd));
             } else {
-                int colon = url.indexOf(':');
+                int colon = schemeColon(url);
                 if (colon > 0 && isSpecialScheme(url.substring(0, colon))) {
                     // A special scheme tolerates missing slashes: browsers parse
                     // http:host/path, and even http:/host/path, with host as the
@@ -7195,9 +7195,24 @@ public class HTML5Implementation extends CodenameOneImplementation {
                     // Only reached when the scheme is special; the separator
                     // skip below covers http:/host as well as http:host.
                     special = true;
-                } else {
-                    // No authority to protect (mailto:, tel:, a bare path).
+                } else if (colon > 0) {
+                    // A scheme we do not parse an authority for (mailto:, tel:).
                     return ellipsizeTail(url);
+                } else {
+                    // No scheme at all, so the browser resolves it against the
+                    // page: the destination host is the page's own, and the
+                    // text is a path under it. Returning the text alone invited
+                    // reading "evil.example" as a host when the link goes to
+                    // <page host>/evil.example.
+                    String host = mainLocationPart("host");
+                    if (host == null || host.length() == 0) {
+                        return ellipsizeTail(url);
+                    }
+                    String path = url.startsWith("/") ? url : "/" + url;
+                    String combined = host + path;
+                    return combined.length() <= MAX_DISPLAY_URL_LENGTH
+                            ? combined
+                            : host + "/" + DISPLAY_URL_ELLIPSIS;
                 }
             }
         }
@@ -7248,6 +7263,32 @@ public class HTML5Implementation extends CodenameOneImplementation {
     }
 
     /**
+     * Index of the colon terminating a syntactically valid scheme, or -1 when
+     * the string carries none.
+     *
+     * <p>Shared so "does this have a scheme" is answered once. A colon inside a
+     * path -- {@code /host:8443/p}, {@code ./user:pw@host} -- is not one, and
+     * treating it as one made those read as unparsed schemes rather than as the
+     * page-relative references they are.</p>
+     */
+    private static int schemeColon(String url) {
+        int colon = url.indexOf(':');
+        if (colon < 1) {
+            return -1;
+        }
+        // scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ), per RFC 3986.
+        for (int i = 0; i < colon; i++) {
+            char c = url.charAt(i);
+            boolean alpha = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+            boolean extra = i > 0 && ((c >= '0' && c <= '9') || c == '+' || c == '-' || c == '.');
+            if (!alpha && !extra) {
+                return -1;
+            }
+        }
+        return colon;
+    }
+
+    /**
      * The page's own scheme, without the trailing colon, or null if unreadable.
      */
     private static String pageScheme() {
@@ -7273,7 +7314,12 @@ public class HTML5Implementation extends CodenameOneImplementation {
                 || "https".equalsIgnoreCase(scheme)
                 || "ws".equalsIgnoreCase(scheme)
                 || "wss".equalsIgnoreCase(scheme)
-                || "ftp".equalsIgnoreCase(scheme);
+                || "ftp".equalsIgnoreCase(scheme)
+                // Special for PARSING, which is all this governs. Routing still
+                // sends file: to storage -- see isExternalUrl() -- but when one
+                // does reach the Sheet, file:\\\\host/p carries a real authority
+                // and must be read as one.
+                || "file".equalsIgnoreCase(scheme);
     }
 
     /**
@@ -7453,24 +7499,12 @@ public class HTML5Implementation extends CodenameOneImplementation {
             // Scheme relative -- the page's own scheme applies.
             return true;
         }
-        int colon = url.indexOf(':');
         // RFC 3986 allows a single ALPHA scheme, so x:payload is a legitimate
-        // deep link. The usual reason to demand two characters is to avoid
-        // reading a Windows drive letter as a scheme, which cannot arise here:
-        // getFileSystemSeparator() is '/' on this port, so no storage path it
-        // hands us is drive qualified.
+        // deep link. A colon inside a path is not a scheme -- schemeColon()
+        // holds that grammar for every caller.
+        int colon = schemeColon(url);
         if (colon < 1) {
             return false;
-        }
-        // scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ), per RFC 3986. A
-        // path that merely happens to contain a colon fails this.
-        for (int i = 0; i < colon; i++) {
-            char c = url.charAt(i);
-            boolean alpha = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
-            boolean extra = i > 0 && ((c >= '0' && c <= '9') || c == '+' || c == '-' || c == '.');
-            if (!alpha && !extra) {
-                return false;
-            }
         }
         // equalsIgnoreCase rather than toLowerCase(): case folding a scheme
         // through the default locale turns "FILE" into "fIle" under a Turkish

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -7232,11 +7232,17 @@ public class HTML5Implementation extends CodenameOneImplementation {
 
     @Override
     public void execute(String rawUrl) {
-        // Everything below -- classification, the Sheet's display, and the
-        // string handed to the page -- works from this one normalized form.
+        // Normalization exists to make classification, the Sheet's display and
+        // the string handed to the page agree on what the BROWSER will parse.
+        // It is therefore only applied to those: a javascript: payload and a
+        // storage path are consumed verbatim below, since stripping their tabs
+        // and newlines would change a program's meaning and a key's identity.
         final String url = normalizeUrlForParsing(rawUrl);
         if (hasScheme(url, "javascript")) {
-            String cmd = url.substring(url.indexOf(":")+1);
+            // Payload taken from the raw string. Normalizing it would splice
+            // out newlines that terminate a // comment and tabs that separate
+            // tokens, silently changing what the caller asked to run.
+            String cmd = rawUrl.substring(rawUrl.indexOf(":")+1);
             eval_(cmd);
             return;
         }
@@ -7250,11 +7256,14 @@ public class HTML5Implementation extends CodenameOneImplementation {
         // true, data: included -- that carries its own payload and is claimed
         // by its own branch further down.
         if (!isExternalUrl(url)) {
-            if (exists(url)) {
+            // Looked up under the path exactly as given: a storage key may
+            // legitimately open or close with a space, and nothing here is
+            // parsed by the browser.
+            if (exists(rawUrl)) {
                 try {
-                    Blob blob = openFileAsBlob(url);
+                    Blob blob = openFileAsBlob(rawUrl);
                     char sep = getFileSystemSeparator();
-                    fileName = url;
+                    fileName = rawUrl;
                     if (fileName.indexOf(sep) >=0) {
                         fileName = fileName.substring(fileName.lastIndexOf(sep)+1);
                     }

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -6924,9 +6924,12 @@ public class HTML5Implementation extends CodenameOneImplementation {
             return true;
         }
         int colon = url.indexOf(':');
-        // A single character before the colon is a Windows drive letter rather
-        // than a URI scheme; every scheme worth handing off is longer.
-        if (colon < 2) {
+        // RFC 3986 allows a single ALPHA scheme, so x:payload is a legitimate
+        // deep link. The usual reason to demand two characters is to avoid
+        // reading a Windows drive letter as a scheme, which cannot arise here:
+        // getFileSystemSeparator() is '/' on this port, so no storage path it
+        // hands us is drive qualified.
+        if (colon < 1) {
             return false;
         }
         // scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ), per RFC 3986. A

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -6778,19 +6778,29 @@ public class HTML5Implementation extends CodenameOneImplementation {
      */
     private boolean openUrlOnMainThread(String url, boolean sameWindow, boolean fallBackToSameWindow) {
         String literal = toJavaScriptStringLiteral(url);
+        // When the host bundle predates the __cn1_eval_on_main__ handler,
+        // port.js degrades to evaluating the script inside the worker. Opening
+        // fails loudly there (no window.open), but a same-window navigation
+        // would NOT: assigning to the worker's read-only location is a silent
+        // no-op in non-strict eval code, so execute() would appear to succeed
+        // and do nothing. Assert we are on the page so every variant fails
+        // detectably and the caller can degrade.
+        String guard = "if (typeof document === 'undefined') {"
+                + " throw new Error('cn1: not running on the page'); }";
         String script;
         if (sameWindow) {
-            script = "window.location.href = " + literal + ";";
+            script = guard + "window.location.href = " + literal + ";";
         } else if (fallBackToSameWindow) {
             // Only attempt the popup while the page still has transient user
             // activation -- otherwise the browser blocks it and shows its
             // "popup blocked" indicator before we navigate anyway. Browsers
             // without navigator.userActivation just try and let !cn1w decide.
-            script = "var cn1a = window.navigator && window.navigator.userActivation;"
+            script = guard
+                    + "var cn1a = window.navigator && window.navigator.userActivation;"
                     + "var cn1w = (!cn1a || cn1a.isActive) ? window.open(" + literal + ", '_blank') : null;"
                     + "if (!cn1w) { window.location.href = " + literal + "; }";
         } else {
-            script = "window.open(" + literal + ", '_blank');";
+            script = guard + "window.open(" + literal + ", '_blank');";
         }
         try {
             eval_(script);
@@ -6866,20 +6876,35 @@ public class HTML5Implementation extends CodenameOneImplementation {
     }
 
     /**
+     * True when the URL names something the browser itself can navigate to, as
+     * opposed to a path into local storage that {@link #execute(String)} is
+     * expected to turn into a download. Only these get the
+     * {@code javascript.execute.target} treatment -- pointing the current page
+     * at a storage path would unload the app and land on nothing.
+     */
+    private static boolean isExternalUrl(String url) {
+        return url.startsWith("http:") || url.startsWith("https:")
+                || url.startsWith("mailto:") || url.startsWith("tel:")
+                || url.startsWith("sms:");
+    }
+
+    /**
      * Opens a URL, or asks the user to, honoring the
      * {@code javascript.execute.target} property. See {@link #execute(String)}.
      */
     private void openExternalUrl(final String url) {
         String target = executeTarget();
-        if (EXECUTE_TARGET_SELF.equals(target)) {
-            openUrlOnMainThread(url, true, false);
+        if (EXECUTE_TARGET_SELF.equals(target)
+                && openUrlOnMainThread(url, true, false)) {
             return;
         }
         if (EXECUTE_TARGET_AUTO.equals(target)
                 && openUrlOnMainThread(url, false, true)) {
             return;
         }
-        // _blank, or auto on a host bundle without the eval-on-main handler:
+        // _blank, or _self / auto whose page-side script never ran because the
+        // host bundle predates the eval-on-main handler -- degrade rather than
+        // leave execute() with no effect at all:
         // a popup only survives inside a live user gesture, so ride the backside
         // hook when one is pending and otherwise ask the user, whose tap on the
         // Sheet becomes the gesture.
@@ -6925,10 +6950,7 @@ public class HTML5Implementation extends CodenameOneImplementation {
         String fileName = null;
         boolean useBlobHandler = false;
         Button nativeButton = new Button();
-        if (!url.startsWith("http:") &&
-                !url.startsWith("http:") &&
-                !url.startsWith("mailto:") &&
-                !url.startsWith("data:")) {
+        if (!isExternalUrl(url) && !url.startsWith("data:")) {
             if (exists(url)) {
                 try {
                     Blob blob = openFileAsBlob(url);
@@ -6964,8 +6986,19 @@ public class HTML5Implementation extends CodenameOneImplementation {
             nativeButton.setText(buttonText);
             nativeButton.setMaterialIcon(FontImage.MATERIAL_SAVE);
             //icon = "save-file";
-        } else {
+        } else if (isExternalUrl(url)) {
             openExternalUrl(furl);
+            return;
+        } else {
+            // A local/storage path we could not turn into a Blob: exists() said
+            // no, or openFileAsBlob() threw (see downloadBytesAsFile above on
+            // how readily the storage round trip fails on this port). Keep it
+            // off the external-link target policy -- under auto or _self that
+            // would point the page at a path the server does not serve and
+            // unload the app instead of downloading anything. Best effort in a
+            // new window, which is what this port did before.
+            _log("execute(): no downloadable content for " + furl);
+            openUrlOnMainThread(furl, false, false);
             return;
         }
         final Runnable startDownload = new Runnable() {

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -6698,16 +6698,22 @@ public class HTML5Implementation extends CodenameOneImplementation {
     private static final String EXECUTE_TARGET_SELF = "_self";
 
     /**
-     * Resolves the {@code javascript.execute.target} property, accepting the
-     * target names with or without the leading underscore.
+     * Resolves the {@code javascript.execute.target} property to one of the
+     * three documented values, falling back to {@code auto}. An unrecognized
+     * value is logged rather than silently accepted, so a typo is diagnosable
+     * instead of looking like the default was chosen deliberately.
      */
     private String executeTarget() {
         String target = Display.getInstance().getProperty("javascript.execute.target", EXECUTE_TARGET_AUTO);
-        if (EXECUTE_TARGET_SELF.equals(target) || "self".equals(target)) {
+        if (EXECUTE_TARGET_SELF.equals(target)) {
             return EXECUTE_TARGET_SELF;
         }
-        if (EXECUTE_TARGET_BLANK.equals(target) || "blank".equals(target) || "new".equals(target)) {
+        if (EXECUTE_TARGET_BLANK.equals(target)) {
             return EXECUTE_TARGET_BLANK;
+        }
+        if (!EXECUTE_TARGET_AUTO.equals(target)) {
+            _log("javascript.execute.target: unrecognized value '" + target
+                    + "', expected auto, _blank or _self. Using auto.");
         }
         return EXECUTE_TARGET_AUTO;
     }
@@ -6942,7 +6948,10 @@ public class HTML5Implementation extends CodenameOneImplementation {
                 return false;
             }
         }
-        return !"file".equals(url.substring(0, colon).toLowerCase());
+        // equalsIgnoreCase rather than toLowerCase(): case folding a scheme
+        // through the default locale turns "FILE" into "fIle" under a Turkish
+        // locale and would classify a file: URL as external.
+        return !"file".equalsIgnoreCase(url.substring(0, colon));
     }
 
     /**
@@ -7045,7 +7054,6 @@ public class HTML5Implementation extends CodenameOneImplementation {
         
         String buttonText = null;
         //String icon = null;
-        final String furl = url;
         if (useBlobHandler) {
             //popover.setContents("<button style='white-space:nowrap' onclick='window.cn1SaveBlobHandler();'><span style='font-size:3em;vertical-align:text-bottom;' class='glyphicon glyphicon-download'/><span style='font-size:2em;vertical-align:top;'> Download "+(fileName!=null?fileName:"File")+"</span></button>");
             buttonText = "Click to Download "+(fileName!=null?fileName:"File");
@@ -7063,7 +7071,7 @@ public class HTML5Implementation extends CodenameOneImplementation {
             // isExternalUrl() is true for data: as well -- it does carry a
             // scheme -- so that branch MUST stay ahead of this one or data:
             // URLs would navigate instead of downloading.
-            openExternalUrl(furl);
+            openExternalUrl(url);
             return;
         } else {
             // A local/storage path we could not turn into a Blob: exists() said
@@ -7073,8 +7081,8 @@ public class HTML5Implementation extends CodenameOneImplementation {
             // would point the page at a path the server does not serve and
             // unload the app instead of downloading anything. Best effort in a
             // new window, which is what this port did before.
-            _log("execute(): no downloadable content for " + furl);
-            openUrlOnMainThread(furl, false, false);
+            _log("execute(): no downloadable content for " + url);
+            openUrlOnMainThread(url, false, false);
             return;
         }
         final Runnable startDownload = new Runnable() {
@@ -7084,7 +7092,7 @@ public class HTML5Implementation extends CodenameOneImplementation {
                     fireSaveBlobHandler();
                 } else {
                     _log("Opening URL in new window");
-                    openUrlOnMainThread(furl, false, false);
+                    openUrlOnMainThread(url, false, false);
                 }
             }
         };

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -7012,7 +7012,69 @@ public class HTML5Implementation extends CodenameOneImplementation {
     }
 
     /**
-     * A raw URL has no spaces for {@code SpanLabel} to wrap on, so putting one    /**
+     * Downloads a {@code data:} URL by clicking a generated anchor on the page.
+     *
+     * <p>The same technique {@code browser_bridge.js} uses, run from here so it
+     * happens exactly ONCE and at a moment we choose. Its
+     * {@code __cn1_register_save_blob_dataurl__} fires the click eagerly and
+     * stashes a copy for a later retry, which is only resolvable by knowing
+     * whether the eager click was allowed -- and {@code a.click()} reports that
+     * to nobody. Doing it ourselves sidesteps the question: there is no eager
+     * click to duplicate, and no stash left unfired.</p>
+     */
+    private boolean downloadDataUrlOnMainThread(String dataUrl, String fileName) {
+        String script = "if (typeof document === 'undefined') {"
+                + " throw new Error('cn1: not running on the page'); }"
+                + "var cn1a = document.createElement('a');"
+                + "cn1a.href = " + toJavaScriptStringLiteral(dataUrl) + ";"
+                + "cn1a.download = " + toJavaScriptStringLiteral(fileName) + ";"
+                + "document.body.appendChild(cn1a);"
+                + "cn1a.click();"
+                + "document.body.removeChild(cn1a);";
+        try {
+            eval_(script);
+            return true;
+        } catch (Throwable t) {
+            _log("Failed to download a data: URL on the main thread: " + t);
+            return false;
+        }
+    }
+
+    /**
+     * Runs a {@code data:} download once, riding a pending hook when there is
+     * one and otherwise asking, so a blocked attempt still has a user-driven
+     * retry. Uses the shared hook queue: a download is gated on engagement
+     * rather than transient activation, exactly as the Blob leg is.
+     */
+    private void downloadDataUrl(final String dataUrl, final String fileName) {
+        if (!isMainThreadBridgeAvailable()) {
+            // No page-side channel of our own, so the bridge's register handler
+            // -- whose eager click is its own trigger -- is all that is left.
+            // One attempt and no retry, which is what this bundle can manage.
+            _log("execute(): no page-side channel, leaving the data: download to the bridge");
+            registerSaveBlobHandlerDataUrl(fileName, dataUrl);
+            return;
+        }
+        final JSRunnable click = new JSRunnable() {
+            @Override
+            public void run() {
+                downloadDataUrlOnMainThread(dataUrl, fileName);
+            }
+        };
+        if (isBacksideHookAvailable()) {
+            addBacksideHook(click);
+            return;
+        }
+        createConfirmationSheet("Download file", "Download " + fileName + " now?",
+                null, new Runnable() {
+            @Override
+            public void run() {
+                addBacksideHook(click);
+            }
+        }).show();
+    }
+
+    /**
      * A raw URL has no spaces for {@code SpanLabel} to wrap on, so putting one
      * in the confirmation Sheet blew the content pane's preferred width past the
      * screen and pushed the buttons out of reach. Shorten it for display; the
@@ -7261,7 +7323,6 @@ public class HTML5Implementation extends CodenameOneImplementation {
     }
 
     /**
-     * True when {@code url} carries exactly {@code scheme}, compared without    /**
      * True when {@code url} carries exactly {@code scheme}, compared without
      * regard to case since URI schemes are case-insensitive. Guards the
      * {@code javascript:} and {@code data:} branches of {@link #execute(String)},
@@ -7557,15 +7618,7 @@ public class HTML5Implementation extends CodenameOneImplementation {
             // download's payload, not something we are only classifying. Same
             // rule as the javascript: payload and the storage key -- normalize
             // what the browser parses, never what it carries.
-            registerSaveBlobHandlerDataUrl(fileName == null ? "download":fileName, rawUrl);
-            // Registration IS the download: browser_bridge.js's
-            // __cn1_register_save_blob_dataurl__ clicks the anchor immediately
-            // and only stashes a copy in case that click was blocked. So return
-            // here. Firing the stash as well downloads the file twice, and the
-            // old behavior of falling through to window.open() on the data: URL
-            // opened a spurious tab the browser then blocked. Nothing further
-            // to do on this path.
-            _log("execute(): data: URL handed to the download handler");
+            downloadDataUrl(rawUrl, fileName == null ? "download" : fileName);
             return;
         } else if (isExternalUrl(url)) {
             // Reached only by URLs the data: branch above did not claim.

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -6812,6 +6812,15 @@ public class HTML5Implementation extends CodenameOneImplementation {
     }
 
     /**
+     * Longest URL the confirmation Sheet shows before it is ellipsized. Chosen
+     * to stay inside a narrow phone viewport at the default font.
+     */
+    private static final int MAX_DISPLAY_URL_LENGTH = 40;
+
+    /** Marker appended to a URL shortened for the confirmation Sheet. */
+    private static final String DISPLAY_URL_ELLIPSIS = "...";
+
+    /**
      * A raw URL has no spaces for {@code SpanLabel} to wrap on, so putting one
      * in the confirmation Sheet blew the content pane's preferred width past the
      * screen and pushed the buttons out of reach. Shorten it for display; the
@@ -6826,12 +6835,14 @@ public class HTML5Implementation extends CodenameOneImplementation {
         if (schemeEnd >= 0) {
             shortened = shortened.substring(schemeEnd + 3);
         }
-        if (shortened.length() > 40) {
+        if (shortened.length() > MAX_DISPLAY_URL_LENGTH) {
             int slash = shortened.indexOf('/');
-            if (slash > 0 && slash <= 40) {
-                shortened = shortened.substring(0, slash) + "/...";
+            if (slash > 0 && slash <= MAX_DISPLAY_URL_LENGTH) {
+                // Host fits: keep it whole and stand in for the path.
+                shortened = shortened.substring(0, slash) + "/" + DISPLAY_URL_ELLIPSIS;
             } else {
-                shortened = shortened.substring(0, 37) + "...";
+                shortened = shortened.substring(0, MAX_DISPLAY_URL_LENGTH - DISPLAY_URL_ELLIPSIS.length())
+                        + DISPLAY_URL_ELLIPSIS;
             }
         }
         return shortened;
@@ -6957,7 +6968,16 @@ public class HTML5Implementation extends CodenameOneImplementation {
                 addBacksideHook(new JSRunnable() {
                     @Override
                     public void run() {
-                        openUrlOnMainThread(url, false, false);
+                        if (!openUrlOnMainThread(url, false, false)) {
+                            // The user confirmed and we still could not open.
+                            // Only reachable on a host bundle with no
+                            // eval-on-main handler, where the worker has no
+                            // page-side channel at all -- there is nothing
+                            // further to fall back to, and re-showing the Sheet
+                            // would just loop. Say so plainly in the log.
+                            _log("execute(): confirmed open failed, no page-side"
+                                    + " channel available for " + url);
+                        }
                     }
                 });
             }

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -7168,6 +7168,21 @@ public class HTML5Implementation extends CodenameOneImplementation {
                     // http:host/path, and even http:/host/path, with host as the
                     // authority. Without this the slashless form would skip the
                     // parsing below and display its leading user info.
+                    //
+                    // UNLESS the scheme matches the page's own. Then it is a
+                    // relative reference, not an authority: on an https page
+                    // https:example.com/p resolves under the page's host, with
+                    // example.com as the start of the PATH. Naming example.com
+                    // as the destination would be simply false.
+                    String scheme = url.substring(0, colon);
+                    String page = pageScheme();
+                    if (page != null && page.equalsIgnoreCase(scheme)) {
+                        String host = mainLocationPart("host");
+                        if (host != null && host.length() > 0) {
+                            return host + "/" + DISPLAY_URL_ELLIPSIS;
+                        }
+                        return ellipsizeTail(url);
+                    }
                     rest = url.substring(colon + 1);
                     // Only reached when the scheme is special; the separator
                     // skip below covers http:/host as well as http:host.
@@ -7222,6 +7237,23 @@ public class HTML5Implementation extends CodenameOneImplementation {
         // A lone trailing "/" is not worth an ellipsis.
         boolean hasPath = rest.length() - authorityEnd > 1;
         return hasPath ? authority + "/" + DISPLAY_URL_ELLIPSIS : authority;
+    }
+
+    /**
+     * The page's own scheme, without the trailing colon, or null if unreadable.
+     */
+    private static String pageScheme() {
+        try {
+            String protocol = mainLocationPart("protocol");
+            if (protocol == null) {
+                return null;
+            }
+            return protocol.endsWith(":")
+                    ? protocol.substring(0, protocol.length() - 1)
+                    : protocol;
+        } catch (Throwable t) {
+            return null;
+        }
     }
 
     /**

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -6770,6 +6770,19 @@ public class HTML5Implementation extends CodenameOneImplementation {
     }
 
     /**
+     * Severs {@code window.opener} on a window we just opened, so the page in
+     * it cannot navigate the app's own page (reverse tabnabbing).
+     *
+     * <p>Deliberately not the {@code noopener} window feature: that makes
+     * {@code window.open()} return null in every browser, which would destroy
+     * the only signal available for telling a blocked popup from a successful
+     * one. Clearing the property gets the same protection while keeping the
+     * handle. Wrapped, since the assignment can throw once the new window has
+     * navigated cross-origin.</p>
+     */
+    private static final String SEVER_OPENER = "try { cn1w.opener = null; } catch (e) {}";
+
+    /**
      * Hands a URL to the page's main thread for opening. {@code window} and
      * {@code window.open} do not exist inside the Web Worker the app runs in, so
      * this routes through the eval-on-main host bridge (see the
@@ -6807,13 +6820,14 @@ public class HTML5Implementation extends CodenameOneImplementation {
             script = guard
                     + "var cn1a = window.navigator && window.navigator.userActivation;"
                     + "var cn1w = (!cn1a || cn1a.isActive) ? window.open(" + literal + ", '_blank') : null;"
-                    + "if (!cn1w) { window.location.href = " + literal + "; }";
+                    + "if (!cn1w) { window.location.href = " + literal + "; } else { " + SEVER_OPENER + " }";
         } else {
             // Report a blocked popup instead of returning as if it opened. The
             // page-side null is the only evidence available -- there is no
             // callback -- so turn it into a throw the host call propagates.
             script = guard + "var cn1w = window.open(" + literal + ", '_blank');"
-                    + "if (!cn1w) { throw new Error('cn1: popup blocked'); }";
+                    + "if (!cn1w) { throw new Error('cn1: popup blocked'); }"
+                    + SEVER_OPENER;
         }
         try {
             eval_(script);
@@ -7028,6 +7042,40 @@ public class HTML5Implementation extends CodenameOneImplementation {
     private int popupReservedForGeneration = -1;
 
     /**
+     * Applies the cleanup a browser performs before it parses a URL: strip
+     * leading and trailing C0 controls and spaces, then remove every tab and
+     * newline wherever they appear.
+     *
+     * <p>Applied once at the top of {@link #execute(String)} so classification,
+     * the confirmation Sheet's display and the URL actually handed to the page
+     * all see the same string. Parsing the raw input separately in each place is
+     * what let " https:host@evil.example/" be classified and displayed off a
+     * scheme of {@code " https"} while the browser navigated to
+     * {@code evil.example}.</p>
+     */
+    static String normalizeUrlForParsing(String url) {
+        if (url == null) {
+            return null;
+        }
+        int start = 0;
+        int end = url.length();
+        while (start < end && url.charAt(start) <= ' ') {
+            start++;
+        }
+        while (end > start && url.charAt(end - 1) <= ' ') {
+            end--;
+        }
+        StringBuilder sb = new StringBuilder(end - start);
+        for (int i = start; i < end; i++) {
+            char c = url.charAt(i);
+            if (c != '\t' && c != '\n' && c != '\r') {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
      * True when {@code url} carries exactly {@code scheme}, compared without
      * regard to case since URI schemes are case-insensitive. Guards the
      * {@code javascript:} and {@code data:} branches of {@link #execute(String)},
@@ -7183,7 +7231,10 @@ public class HTML5Implementation extends CodenameOneImplementation {
     }
 
     @Override
-    public void execute(String url) {
+    public void execute(String rawUrl) {
+        // Everything below -- classification, the Sheet's display, and the
+        // string handed to the page -- works from this one normalized form.
+        final String url = normalizeUrlForParsing(rawUrl);
         if (hasScheme(url, "javascript")) {
             String cmd = url.substring(url.indexOf(":")+1);
             eval_(cmd);
@@ -7193,10 +7244,11 @@ public class HTML5Implementation extends CodenameOneImplementation {
         String fileName = null;
         boolean useBlobHandler = false;
         Button nativeButton = new Button();
-        // Only a local path can name storage content to wrap in a Blob.
-        // isExternalUrl() is false for exactly those, and true for everything
-        // with a scheme -- data: included, which carries its own payload and is
-        // claimed by its own branch further down.
+        // Only local content can name storage to wrap in a Blob, which is
+        // what isExternalUrl() is false for: bare paths, and file: URLs, whose
+        // scheme names local content too. Everything else with a scheme is
+        // true, data: included -- that carries its own payload and is claimed
+        // by its own branch further down.
         if (!isExternalUrl(url)) {
             if (exists(url)) {
                 try {

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -674,7 +674,24 @@ public class HTML5Implementation extends CodenameOneImplementation {
             }
         }
         gestureOnlyHooks.add(new GestureHook(gestureGeneration, r));
+        if (pendingGestureDrains <= 0) {
+            // Generation matching keeps an older drain from taking this hook,
+            // but only a drain of THIS interaction will run it -- and there may
+            // be none left. Safari schedules a single 75/300ms drain, so an EDT
+            // slower than that would strand the hook forever and the confirmed
+            // link would do nothing at all. Schedule one. The activation is
+            // probably gone by now, but an attempt that reports failure beats
+            // silence: the caller logs it, or falls back to the Sheet.
+            runBacksideHooksInTimeout(0);
+        }
     }
+
+    /**
+     * Drains still scheduled for {@link #gestureGeneration}. Reset when a new
+     * interaction begins, since an older interaction's drains cannot run this
+     * one's hooks.
+     */
+    private int pendingGestureDrains;
 
     private void runGestureOnlyHooks(int generation) {
         // Collected before running: a hook may queue another one, and mutating
@@ -719,10 +736,14 @@ public class HTML5Implementation extends CodenameOneImplementation {
         // Remember which interaction scheduled this drain, so it only runs the
         // activation-dependent hooks that same interaction queued.
         final int generation = gestureGeneration;
+        pendingGestureDrains++;
         Window.setTimeout(new TimerHandler() {
             @Override
             public void onTimer() {
                 backsideHooksSemaphore--;
+                if (generation == gestureGeneration) {
+                    pendingGestureDrains--;
+                }
                 //_log("Decrementing backsideHooksSemaphore: "+backsideHooksSemaphore);
                 // This drain descends from a real interaction, so it may run
                 // that interaction's activation-dependent hooks -- and only
@@ -807,8 +828,10 @@ public class HTML5Implementation extends CodenameOneImplementation {
     
     private void installBacksideHooksInUserInteraction() {
         // A distinct interaction, so a popup reserved against the previous one
-        // no longer applies -- see popupReservedForGeneration.
+        // no longer applies -- see popupReservedForGeneration -- and the
+        // previous one's outstanding drains cannot serve this one's hooks.
         gestureGeneration++;
+        pendingGestureDrains = 0;
         if (isIOS() || isSafari()) {
             debugLog("Installing backside hooks with delay "+safariBacksideHookDelay());
             runBacksideHooksInTimeout(safariBacksideHookDelay());

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -7048,89 +7048,26 @@ public class HTML5Implementation extends CodenameOneImplementation {
         sheet.show();
     }
 
-    /**
-     * Queues a hook on the shared queue and makes sure something will drain it.
-     *
-     * <p>Unlike {@link #addGestureOnlyHook(JSRunnable, Runnable)}, plain
-     * {@link #addBacksideHook(JSRunnable)} schedules nothing: the hook waits for
-     * a drain that may already have run. Safari schedules a single 75/300ms
-     * drain per interaction, so an EDT slower than that arrives with none left
-     * and the hook sits forever. Callers that have no other attempt to fall
-     * back on need this.</p>
-     */
-    private void addBacksideHookEnsuringDrain(JSRunnable r) {
-        addBacksideHook(r);
-        if (pendingGestureDrains <= 0 && backsideHooksIntervalHandle == 0) {
-            runBacksideHooksInTimeout(0, false);
-        }
-    }
 
     /**
-     * Downloads a {@code data:} URL by clicking a generated anchor on the page.
+     * Hands a {@code data:} download to the bridge's structured handler.
      *
-     * <p>The same technique {@code browser_bridge.js} uses, run from here so it
-     * happens exactly ONCE and at a moment we choose. Its
-     * {@code __cn1_register_save_blob_dataurl__} fires the click eagerly and
-     * stashes a copy for a later retry, which is only resolvable by knowing
-     * whether the eager click was allowed -- and {@code a.click()} reports that
-     * to nobody. Doing it ourselves sidesteps the question: there is no eager
-     * click to duplicate, and no stash left unfired.</p>
+     * <p>Three constraints apply and the current bridge can satisfy only two.
+     * The download must happen once; a blocked attempt should be retryable; and
+     * the payload must not be copied more than necessary. Registering fires the
+     * click eagerly, so re-firing the stash duplicates it. Clicking the anchor
+     * ourselves through eval-on-main avoids that and restores the retry, but
+     * escapes a multi-megabyte base64 string into JavaScript source, builds
+     * several payload-sized copies of it and makes the page parse it as code.</p>
+     *
+     * <p>So: register and return. One download, and the payload travels once as
+     * structured host-call data rather than as source text. The retry is what is
+     * given up, and recovering it needs a bridge-side change --
+     * {@code __cn1_register_save_blob_dataurl__} would have to accept a
+     * no-eager-fire flag -- which lives in the translator, not here.</p>
      */
-    private boolean downloadDataUrlOnMainThread(String dataUrl, String fileName) {
-        String script = "if (typeof document === 'undefined') {"
-                + " throw new Error('cn1: not running on the page'); }"
-                + "var cn1a = document.createElement('a');"
-                + "cn1a.href = " + toJavaScriptStringLiteral(dataUrl) + ";"
-                + "cn1a.download = " + toJavaScriptStringLiteral(fileName) + ";"
-                + "document.body.appendChild(cn1a);"
-                + "cn1a.click();"
-                + "document.body.removeChild(cn1a);";
-        try {
-            // Function-scoped for the same reason as the open scripts: indirect
-            // eval would otherwise leak cn1a onto the page's globals.
-            eval_("(function(){" + script + "})();");
-            return true;
-        } catch (Throwable t) {
-            _log("Failed to download a data: URL on the main thread: " + t);
-            return false;
-        }
-    }
-
-    /**
-     * Runs a {@code data:} download once, riding a pending hook when there is
-     * one and otherwise asking, so a blocked attempt still has a user-driven
-     * retry. Uses the shared hook queue: a download is gated on engagement
-     * rather than transient activation, exactly as the Blob leg is.
-     */
-    private void downloadDataUrl(final String dataUrl, final String fileName) {
-        if (!isMainThreadBridgeAvailable()) {
-            // No page-side channel of our own, so the bridge's register handler
-            // -- whose eager click is its own trigger -- is all that is left.
-            // One attempt and no retry, which is what this bundle can manage.
-            _log("execute(): no page-side channel, leaving the data: download to the bridge");
-            registerSaveBlobHandlerDataUrl(fileName, dataUrl);
-            return;
-        }
-        final JSRunnable click = new JSRunnable() {
-            @Override
-            public void run() {
-                downloadDataUrlOnMainThread(dataUrl, fileName);
-            }
-        };
-        if (isBacksideHookAvailable()) {
-            addBacksideHookEnsuringDrain(click);
-            return;
-        }
-        createConfirmationSheet("Download file", "Download " + fileName + " now?",
-                null, new Runnable() {
-            @Override
-            public void run() {
-                // Ensuring a drain matters most here: the user confirmed, and
-                // removing the bridge's eager click left no earlier attempt to
-                // rescue a hook that never runs.
-                addBacksideHookEnsuringDrain(click);
-            }
-        }).show();
+    private void downloadDataUrl(String dataUrl, String fileName) {
+        registerSaveBlobHandlerDataUrl(fileName, dataUrl);
     }
 
     /**

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -663,6 +663,12 @@ public class HTML5Implementation extends CodenameOneImplementation {
             public void onTimer() {
                 backsideHooksSemaphore--;
                 //_log("Decrementing backsideHooksSemaphore: "+backsideHooksSemaphore);
+                if (backsideHooksSemaphore <= 0) {
+                    // Every delayed drain scheduled off that interaction has
+                    // run, so whatever activation it granted is spent. The next
+                    // popup has to earn a gesture of its own.
+                    popupReservedForGesture = false;
+                }
                 runBacksideHooks();
             }
         }, timeout);
@@ -6981,16 +6987,21 @@ public class HTML5Implementation extends CodenameOneImplementation {
     }
 
     /**
-     * Popup opens queued on a backside hook but not yet drained.
+     * Whether the gesture currently represented by {@link #backsideHooksSemaphore}
+     * has already had a popup queued against it.
      *
      * <p>The semaphore counts pending drains, not unconsumed popup
-     * authorization. One gesture authorizes ONE {@code window.open()}: the
-     * first consumes the transient activation, so a second queued behind the
-     * same gesture drains in the same batch and is blocked. Only ever reserve a
-     * pending gesture for a single popup and send the rest to the Sheet, which
-     * earns them a gesture of their own.</p>
+     * authorization. One gesture authorizes ONE {@code window.open()} -- the
+     * first consumes the transient activation -- yet
+     * {@code installBacksideHooksInUserInteraction()} schedules three drains
+     * (300ms, 1500ms, 5000ms) off a single interaction. Releasing the
+     * reservation when the first of those runs would let a later execute() read
+     * one of the remaining drains as a fresh gesture and queue a popup whose
+     * activation is already spent. So hold the reservation until the whole burst
+     * has expired, i.e. the semaphore falls back to zero, and send everything
+     * else to the Sheet, which earns a gesture of its own.</p>
      */
-    private int pendingPopupOpens;
+    private boolean popupReservedForGesture;
 
     /**
      * True when the URL names something the browser itself can hand off, as
@@ -7087,17 +7098,16 @@ public class HTML5Implementation extends CodenameOneImplementation {
      * worse than the Sheet.</p>
      */
     private void openInNewWindowWithConfirmation(final String url, String prompt) {
-        if (isGestureBackedHookAvailable() && pendingPopupOpens == 0) {
-            pendingPopupOpens++;
+        if (isGestureBackedHookAvailable() && !popupReservedForGesture) {
+            // Held until the gesture's whole drain burst expires -- see the
+            // field. Not released here, where the first drain would free it
+            // while later drains from the same interaction are still pending.
+            popupReservedForGesture = true;
             addBacksideHook(new JSRunnable() {
                 @Override
                 public void run() {
-                    try {
-                        if (!openUrlOnMainThread(url, false, false)) {
-                            _log("execute(): popup blocked for " + url);
-                        }
-                    } finally {
-                        pendingPopupOpens--;
+                    if (!openUrlOnMainThread(url, false, false)) {
+                        _log("execute(): popup blocked for " + url);
                     }
                 }
             });

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -632,6 +632,30 @@ public class HTML5Implementation extends CodenameOneImplementation {
     public void addBacksideHook(JSRunnable r) {
         backSideHooks.push(r);
     }
+
+    /**
+     * Hooks that only a gesture-backed drain may run.
+     *
+     * <p>{@link #backSideHooks} is also drained by the
+     * {@code platformHint.javascript.backsideHooksInterval} timer, which
+     * carries no transient activation. That is fine for media, but a
+     * {@code window.open()} drained from the polling timer is simply blocked --
+     * so a popup queued there can lose the race to the gesture's own timeout
+     * and never open. Anything needing activation goes here instead, where only
+     * {@link #runBacksideHooksInTimeout(int)} reaches it.</p>
+     */
+    private JSArray gestureOnlyHooks = JSArray.create();
+
+    private void addGestureOnlyHook(JSRunnable r) {
+        gestureOnlyHooks.push(r);
+    }
+
+    private void runGestureOnlyHooks() {
+        while (gestureOnlyHooks.getLength() > 0) {
+            JSRunnable r = (JSRunnable)gestureOnlyHooks.shift();
+            r.run();
+        }
+    }
     
     // Count the number of backside hook calls that are queued up
     private int backsideHooksSemaphore = 0;
@@ -663,6 +687,9 @@ public class HTML5Implementation extends CodenameOneImplementation {
             public void onTimer() {
                 backsideHooksSemaphore--;
                 //_log("Decrementing backsideHooksSemaphore: "+backsideHooksSemaphore);
+                // This drain descends from a real interaction, so it is the
+                // only one allowed to run activation-dependent hooks.
+                runGestureOnlyHooks();
                 runBacksideHooks();
             }
         }, timeout);
@@ -7205,7 +7232,7 @@ public class HTML5Implementation extends CodenameOneImplementation {
             // field. Never cleared; the next interaction simply carries a
             // different generation.
             popupReservedForGeneration = gestureGeneration;
-            addBacksideHook(new JSRunnable() {
+            addGestureOnlyHook(new JSRunnable() {
                 @Override
                 public void run() {
                     // openUrlOnMainThread reports the reason on failure --
@@ -7240,9 +7267,11 @@ public class HTML5Implementation extends CodenameOneImplementation {
                 // very thing the Sheet exists to recover from. That tap did
                 // install a backside hook though (pointer handling calls
                 // installBacksideHooksInUserInteraction), so queue the open on
-                // it and let the drain perform it inside the gesture. Same
-                // shape as the download confirmation in execute().
-                addBacksideHook(new JSRunnable() {
+                // it and let the drain perform it inside the gesture. On the
+                // gesture-only queue, or the polling interval could drain it
+                // first with no activation and block the link the user just
+                // confirmed.
+                addGestureOnlyHook(new JSRunnable() {
                     @Override
                     public void run() {
                         if (!openUrlOnMainThread(url, false, false)) {
@@ -7368,24 +7397,40 @@ public class HTML5Implementation extends CodenameOneImplementation {
                 ? isBacksideHookAvailable()
                 : isGestureBackedHookAvailable();
         if (hookAvailable) {
-            addBacksideHook(new JSRunnable() {
+            JSRunnable hook = new JSRunnable() {
                 @Override
                 public void run() {
                     startDownload.run();
                 }
-            });
+            };
+            if (fuseBlobHandler) {
+                addBacksideHook(hook);
+            } else {
+                // The no-blob leg opens a popup, so it needs the activation
+                // only a gesture-backed drain carries -- same reason its gate
+                // above is the stricter one.
+                addGestureOnlyHook(hook);
+            }
 
         } else {
             String dlName = fileName == null ? "file" : fileName;
             createConfirmationSheet("Download file", "Download " + dlName + " now?", null, new Runnable() {
                 @Override
                 public void run() {
-                    addBacksideHook(new JSRunnable() {
+                    JSRunnable confirmed = new JSRunnable() {
                         @Override
                         public void run() {
                             startDownload.run();
                         }
-                    });
+                    };
+                    // Same split as the unconfirmed path above: the popup leg
+                    // needs the activation the OK tap just granted, which the
+                    // polling interval would not carry.
+                    if (fuseBlobHandler) {
+                        addBacksideHook(confirmed);
+                    } else {
+                        addGestureOnlyHook(confirmed);
+                    }
                 }
             }).show();
         }

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -7267,6 +7267,13 @@ public class HTML5Implementation extends CodenameOneImplementation {
         // It is therefore only applied to those: a javascript: payload and a
         // storage path are consumed verbatim below, since stripping their tabs
         // and newlines would change a program's meaning and a key's identity.
+        if (rawUrl == null) {
+            // Pre-existing behavior was an NPE off the first startsWith. There
+            // is nothing to open, so say so and return rather than crash the
+            // caller's EDT.
+            _log("execute(): ignoring null URL");
+            return;
+        }
         final String url = normalizeUrlForParsing(rawUrl);
         if (hasScheme(url, "javascript")) {
             // Payload taken from the raw string. Normalizing it would splice

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -7012,6 +7012,23 @@ public class HTML5Implementation extends CodenameOneImplementation {
     }
 
     /**
+     * Queues a hook on the shared queue and makes sure something will drain it.
+     *
+     * <p>Unlike {@link #addGestureOnlyHook(JSRunnable, Runnable)}, plain
+     * {@link #addBacksideHook(JSRunnable)} schedules nothing: the hook waits for
+     * a drain that may already have run. Safari schedules a single 75/300ms
+     * drain per interaction, so an EDT slower than that arrives with none left
+     * and the hook sits forever. Callers that have no other attempt to fall
+     * back on need this.</p>
+     */
+    private void addBacksideHookEnsuringDrain(JSRunnable r) {
+        addBacksideHook(r);
+        if (pendingGestureDrains <= 0 && backsideHooksIntervalHandle == 0) {
+            runBacksideHooksInTimeout(0);
+        }
+    }
+
+    /**
      * Downloads a {@code data:} URL by clicking a generated anchor on the page.
      *
      * <p>The same technique {@code browser_bridge.js} uses, run from here so it
@@ -7062,14 +7079,17 @@ public class HTML5Implementation extends CodenameOneImplementation {
             }
         };
         if (isBacksideHookAvailable()) {
-            addBacksideHook(click);
+            addBacksideHookEnsuringDrain(click);
             return;
         }
         createConfirmationSheet("Download file", "Download " + fileName + " now?",
                 null, new Runnable() {
             @Override
             public void run() {
-                addBacksideHook(click);
+                // Ensuring a drain matters most here: the user confirmed, and
+                // removing the bridge's eager click left no earlier attempt to
+                // rescue a hook that never runs.
+                addBacksideHookEnsuringDrain(click);
             }
         }).show();
     }

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -7176,7 +7176,15 @@ public class HTML5Implementation extends CodenameOneImplementation {
                     // as the destination would be simply false.
                     String scheme = url.substring(0, colon);
                     String page = pageScheme();
-                    if (page != null && page.equalsIgnoreCase(scheme)) {
+                    // ...and only when fewer than two separators follow the
+                    // colon. Two of them, in any mix of "/" and "\\", are an
+                    // authority marker that outranks the same-scheme rule:
+                    // https:\\\\evil.example/p navigates to evil.example even
+                    // from an https page, so claiming the app's own host there
+                    // would name a destination the browser is not going to.
+                    boolean authorityFollows =
+                            startsWithAuthorityMarker(url.substring(colon + 1));
+                    if (!authorityFollows && page != null && page.equalsIgnoreCase(scheme)) {
                         String host = mainLocationPart("host");
                         if (host != null && host.length() > 0) {
                             return host + "/" + DISPLAY_URL_ELLIPSIS;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -6887,6 +6887,24 @@ public class HTML5Implementation extends CodenameOneImplementation {
     }
 
     /**
+     * True when a backside-hook drain is pending because of an actual user
+     * gesture, rather than merely because the polling interval enabled by
+     * {@code platformHint.javascript.backsideHooksInterval} is running.
+     *
+     * <p>{@link #isBacksideHookAvailable()} accepts either, which is right for
+     * media -- browsers relax autoplay once the page has engagement -- but not
+     * for a popup. The interval drains from {@code Window.setInterval}, which
+     * grants no transient activation, so a {@code window.open()} queued on it
+     * can be blocked with nothing shown to the user. The semaphore, in
+     * contrast, is only raised by
+     * {@code installBacksideHooksInUserInteraction()} off a real pointer or key
+     * event.</p>
+     */
+    private boolean isGestureBackedHookAvailable() {
+        return backsideHooksSemaphore > 0;
+    }
+
+    /**
      * True when the URL names something the browser itself can hand off, as
      * opposed to a path into local storage that {@link #execute(String)} is
      * expected to turn into a download. Only these get the
@@ -6942,9 +6960,12 @@ public class HTML5Implementation extends CodenameOneImplementation {
         // host bundle predates the eval-on-main handler -- degrade rather than
         // leave execute() with no effect at all:
         // a popup only survives inside a live user gesture, so ride the backside
-        // hook when one is pending and otherwise ask the user, whose tap on the
-        // Sheet becomes the gesture.
-        if (isBacksideHookAvailable()) {
+        // hook when a gesture-backed one is pending and otherwise ask the user,
+        // whose tap on the Sheet becomes the gesture. Note this deliberately
+        // ignores an interval-only hook: draining from a timer would let the
+        // browser block the popup with nothing shown, which is worse than the
+        // Sheet that _blank promises.
+        if (isGestureBackedHookAvailable()) {
             addBacksideHook(new JSRunnable() {
                 @Override
                 public void run() {

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -6953,7 +6953,58 @@ public class HTML5Implementation extends CodenameOneImplementation {
     /** Marker appended to a URL shortened for the confirmation Sheet. */
     private static final String DISPLAY_URL_ELLIPSIS = "...";
 
+    /** 0 unknown, 1 reachable, -1 not reachable. */
+    private int mainThreadBridgeState;
+
     /**
+     * Whether scripts can reach the page at all, cached after one probe.
+     *
+     * <p>A host bundle predating the {@code __cn1_eval_on_main__} handler leaves
+     * the worker with no page-side channel, so every open fails. Knowing that
+     * up front matters because the recovery for a blocked popup -- ask the user
+     * -- is worthless here: the Sheet would promise something no button on it
+     * can deliver.</p>
+     */
+    private boolean isMainThreadBridgeAvailable() {
+        if (mainThreadBridgeState == 0) {
+            try {
+                // A no-op that asserts page context, nothing else.
+                eval_("if (typeof document === 'undefined') {"
+                        + " throw new Error('cn1: not running on the page'); }");
+                mainThreadBridgeState = 1;
+            } catch (Throwable t) {
+                mainThreadBridgeState = -1;
+            }
+        }
+        return mainThreadBridgeState == 1;
+    }
+
+    /**
+     * Tells the user a link cannot be opened, for the one case where no
+     * confirmation could help. Informational, so a single dismiss button.
+     */
+    private void showCannotOpenMessage(String url) {
+        final Sheet sheet = new Sheet(null, "Open Link");
+        SpanLabel message = new SpanLabel(
+                "This app cannot open links. Its web runtime is out of date.");
+        Button close = new Button("Close");
+        close.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent evt) {
+                sheet.back();
+            }
+        });
+        sheet.getContentPane().setLayout(BoxLayout.y());
+        sheet.getContentPane().add(message);
+        Label detail = new Label(shortenUrlForDisplay(url));
+        detail.setEndsWith3Points(true);
+        sheet.getContentPane().add(detail);
+        sheet.getContentPane().add(FlowLayout.encloseCenter(close));
+        sheet.show();
+    }
+
+    /**
+     * A raw URL has no spaces for {@code SpanLabel} to wrap on, so putting one    /**
      * A raw URL has no spaces for {@code SpanLabel} to wrap on, so putting one
      * in the confirmation Sheet blew the content pane's preferred width past the
      * screen and pushed the buttons out of reach. Shorten it for display; the
@@ -7300,6 +7351,13 @@ public class HTML5Implementation extends CodenameOneImplementation {
         // Sheet is a compatibility fallback the caller never requested, so
         // promising a new window there would describe behavior they did not
         // choose.
+        if (!isMainThreadBridgeAvailable()) {
+            // No page-side channel at all, so no button could make this work.
+            // Say so instead of showing a confirmation that cannot succeed.
+            _log("execute(): no page-side channel on this host bundle, cannot open " + url);
+            showCannotOpenMessage(url);
+            return;
+        }
         openInNewWindowWithConfirmation(url, EXECUTE_TARGET_BLANK.equals(target)
                 ? "Open this link in a new window?"
                 : "Open this link?");

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -2525,7 +2525,7 @@ public class HTML5Implementation extends CodenameOneImplementation {
                 JavaScriptKeyboardInteractionAdapter.handleKeyUp(new JavaScriptKeyboardInteractionAdapter.BacksideHooks() {
                     @Override
                     public void installBacksideHooksInUserInteraction() {
-                        HTML5Implementation.this.installBacksideHooksInUserInteraction();
+                        HTML5Implementation.this.installBacksideHooksInUserInteraction(false);
                     }
                 }, new JavaScriptKeyboardInteractionAdapter.KeyDispatch() {
                     @Override
@@ -2606,7 +2606,7 @@ public class HTML5Implementation extends CodenameOneImplementation {
                 }, new JavaScriptKeyboardInteractionAdapter.BacksideHooks() {
                     @Override
                     public void installBacksideHooksInUserInteraction() {
-                        HTML5Implementation.this.installBacksideHooksInUserInteraction();
+                        HTML5Implementation.this.installBacksideHooksInUserInteraction(false);
                     }
                 }, new JavaScriptKeyboardInteractionAdapter.KeyDispatch() {
                     @Override
@@ -6976,7 +6976,12 @@ public class HTML5Implementation extends CodenameOneImplementation {
                     + SEVER_OPENER;
         }
         try {
-            eval_(script);
+            // Wrapped in a function: __cn1_eval_on_main__ runs this through
+            // indirect eval, so a bare "var cn1w" would land on the page's
+            // global object -- clobbering an identically named global of the
+            // embedding page, and throwing outright against a top-level let or
+            // const of that name, which would break the default popup path.
+            eval_("(function(){" + script + "})();");
             return true;
         } catch (Throwable t) {
             _log("Failed to open URL on the main thread: " + t);
@@ -7081,7 +7086,9 @@ public class HTML5Implementation extends CodenameOneImplementation {
                 + "cn1a.click();"
                 + "document.body.removeChild(cn1a);";
         try {
-            eval_(script);
+            // Function-scoped for the same reason as the open scripts: indirect
+            // eval would otherwise leak cn1a onto the page's globals.
+            eval_("(function(){" + script + "})();");
             return true;
         } catch (Throwable t) {
             _log("Failed to download a data: URL on the main thread: " + t);

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -6836,22 +6836,55 @@ public class HTML5Implementation extends CodenameOneImplementation {
         if (url == null) {
             return "";
         }
-        String shortened = url;
-        int schemeEnd = shortened.indexOf("://");
-        if (schemeEnd >= 0) {
-            shortened = shortened.substring(schemeEnd + 3);
+        int schemeEnd = url.indexOf("://");
+        if (schemeEnd < 0) {
+            // No authority to protect (mailto:, tel:, a bare storage path).
+            return ellipsizeTail(url);
         }
-        if (shortened.length() > MAX_DISPLAY_URL_LENGTH) {
-            int slash = shortened.indexOf('/');
-            if (slash > 0 && slash <= MAX_DISPLAY_URL_LENGTH) {
-                // Host fits: keep it whole and stand in for the path.
-                shortened = shortened.substring(0, slash) + "/" + DISPLAY_URL_ELLIPSIS;
-            } else {
-                shortened = shortened.substring(0, MAX_DISPLAY_URL_LENGTH - DISPLAY_URL_ELLIPSIS.length())
-                        + DISPLAY_URL_ELLIPSIS;
+        String rest = url.substring(schemeEnd + 3);
+        int authorityEnd = rest.length();
+        for (int i = 0; i < rest.length(); i++) {
+            char c = rest.charAt(i);
+            if (c == '/' || c == '?' || c == '#') {
+                authorityEnd = i;
+                break;
             }
         }
-        return shortened;
+        String authority = rest.substring(0, authorityEnd);
+        // Everything before the last '@' is user info. An attacker picks it
+        // freely and can spell it to read like a trusted host, so showing it --
+        // or truncating the display in the middle of it -- would let
+        // https://www.paypal.com@evil.example/ be confirmed as "www.paypal.com".
+        // What confirming actually opens is the host, so show only that.
+        int at = authority.lastIndexOf('@');
+        if (at >= 0) {
+            authority = authority.substring(at + 1);
+        }
+        if (authority.length() == 0) {
+            // Scheme-relative or path-only, e.g. imdb:///find?q=godfather.
+            return ellipsizeTail(rest);
+        }
+        if (authority.length() > MAX_DISPLAY_URL_LENGTH) {
+            // Keep the END of an over-long host: the registrable domain is the
+            // rightmost labels, so dropping the front is what preserves the
+            // part that decides where the link goes.
+            authority = DISPLAY_URL_ELLIPSIS + authority.substring(
+                    authority.length() - (MAX_DISPLAY_URL_LENGTH - DISPLAY_URL_ELLIPSIS.length()));
+        }
+        // A lone trailing "/" is not worth an ellipsis.
+        boolean hasPath = rest.length() - authorityEnd > 1;
+        return hasPath ? authority + "/" + DISPLAY_URL_ELLIPSIS : authority;
+    }
+
+    /**
+     * Trims a string with no authority to protect down to the display cap.
+     */
+    private static String ellipsizeTail(String value) {
+        if (value.length() <= MAX_DISPLAY_URL_LENGTH) {
+            return value;
+        }
+        return value.substring(0, MAX_DISPLAY_URL_LENGTH - DISPLAY_URL_ELLIPSIS.length())
+                + DISPLAY_URL_ELLIPSIS;
     }
 
     /**
@@ -6924,6 +6957,19 @@ public class HTML5Implementation extends CodenameOneImplementation {
      * URLs. {@code file:} is the exception: like the bare paths that carry no
      * scheme at all, it names local content.</p>
      */
+    /**
+     * True when {@code url} carries exactly {@code scheme}, compared without
+     * regard to case since URI schemes are case-insensitive. Guards the
+     * {@code javascript:} and {@code data:} branches of {@link #execute(String)},
+     * which would otherwise let {@code JavaScript:} slip through to the
+     * external-link path.
+     */
+    private static boolean hasScheme(String url, String scheme) {
+        return url.length() > scheme.length()
+                && url.charAt(scheme.length()) == ':'
+                && url.regionMatches(true, 0, scheme, 0, scheme.length());
+    }
+
     private static boolean isExternalUrl(String url) {
         if (url.startsWith("//")) {
             // Protocol relative -- the page's own scheme applies.
@@ -6986,7 +7032,14 @@ public class HTML5Implementation extends CodenameOneImplementation {
             });
             return;
         }
-        createConfirmationSheet("Open Link", "Open this link in a new window?",
+        // Only _blank actually asked for a new window. Under auto or _self the
+        // Sheet is a compatibility fallback the caller never requested, so
+        // promising a new window there would describe behavior they did not
+        // choose.
+        String prompt = EXECUTE_TARGET_BLANK.equals(target)
+                ? "Open this link in a new window?"
+                : "Open this link?";
+        createConfirmationSheet("Open Link", prompt,
                 shortenUrlForDisplay(url), new Runnable() {
             @Override
             public void run() {
@@ -7019,7 +7072,7 @@ public class HTML5Implementation extends CodenameOneImplementation {
 
     @Override
     public void execute(String url) {
-        if (url.startsWith("javascript:")) {
+        if (hasScheme(url, "javascript")) {
             String cmd = url.substring(url.indexOf(":")+1);
             eval_(cmd);
             return;
@@ -7028,9 +7081,10 @@ public class HTML5Implementation extends CodenameOneImplementation {
         String fileName = null;
         boolean useBlobHandler = false;
         Button nativeButton = new Button();
-        // Only a local path can name storage content to wrap in a Blob. A
-        // data: URL carries its own payload and is handled further down;
-        // isExternalUrl already excludes it, since it has a scheme.
+        // Only a local path can name storage content to wrap in a Blob.
+        // isExternalUrl() is false for exactly those, and true for everything
+        // with a scheme -- data: included, which carries its own payload and is
+        // claimed by its own branch further down.
         if (!isExternalUrl(url)) {
             if (exists(url)) {
                 try {
@@ -7059,7 +7113,7 @@ public class HTML5Implementation extends CodenameOneImplementation {
             buttonText = "Click to Download "+(fileName!=null?fileName:"File");
             nativeButton.setText(buttonText);
             nativeButton.setMaterialIcon(FontImage.MATERIAL_SAVE);
-        } else if (url.startsWith("data:")) {
+        } else if (hasScheme(url, "data")) {
             registerSaveBlobHandlerDataUrl(fileName == null ? "download":fileName, url);
             //popover.setContents("<button style='white-space:nowrap' onclick='window.cn1SaveBlobHandler();'><span style='font-size:3em;vertical-align:text-bottom;' class='glyphicon glyphicon-download; font-size: '/><span style='font-size:2em;vertical-align:top;'> Download "+(fileName!=null?fileName:"File")+"</span></button>");
             buttonText = "Click to Download "+(fileName!=null?fileName:"File");
@@ -7096,7 +7150,16 @@ public class HTML5Implementation extends CodenameOneImplementation {
                 }
             }
         };
-        if (isBacksideHookAvailable()) {
+        // Firing the registered blob handler is a download, which browsers gate
+        // on engagement rather than transient activation, so an interval-only
+        // hook is good enough for it. The no-blob-handler leg opens a popup
+        // instead, and that does need a real gesture -- draining it from a timer
+        // would let the browser block it with no Sheet shown. Pick the gate that
+        // matches the leg this run will actually take.
+        boolean hookAvailable = fuseBlobHandler
+                ? isBacksideHookAvailable()
+                : isGestureBackedHookAvailable();
+        if (hookAvailable) {
             addBacksideHook(new JSRunnable() {
                 @Override
                 public void run() {

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -7196,6 +7196,11 @@ public class HTML5Implementation extends CodenameOneImplementation {
      * regressed {@code report:2026.pdf}, then still regressed
      * {@code https:report.pdf}. Ambiguity is a property of the shape, not of
      * the scheme name.</p>
+     *
+     * <p>Takes the RAW string, the same one the lookup uses. Judging the
+     * normalized form would let {@code " https://example.com/report "} -- a
+     * perfectly legal key, since keys may carry surrounding whitespace -- look
+     * unambiguous and skip the lookup that would have found it.</p>
      */
     private static boolean isUnambiguousBrowserUrl(String url) {
         if (url.startsWith("//")) {
@@ -7342,13 +7347,29 @@ public class HTML5Implementation extends CodenameOneImplementation {
                     @Override
                     public void run() {
                         if (!openUrlOnMainThread(url, false, false)) {
-                            // The user confirmed and it still did not open.
-                            // openUrlOnMainThread has already logged why; note
-                            // only that this was the confirmed attempt, which
-                            // is the end of the line -- re-showing the Sheet
-                            // from here would just loop.
+                            // The user confirmed and it still did not open --
+                            // a browser setting, an extension, or an activation
+                            // that expired before this drain. Do not stop at a
+                            // log: they acted and deserve a way through. Offer
+                            // the current tab, which needs no activation and so
+                            // cannot be blocked in turn. Not a loop -- that
+                            // path is a navigation, not another popup.
                             _log("execute(): confirmed open did not succeed for "
                                     + url);
+                            callSerially(new Runnable() {
+                                @Override
+                                public void run() {
+                                    createConfirmationSheet("Open Link",
+                                            "Your browser blocked the new window."
+                                                    + " Open this link in the current tab instead?",
+                                            shortenUrlForDisplay(url), new Runnable() {
+                                        @Override
+                                        public void run() {
+                                            openUrlOnMainThread(url, true, false);
+                                        }
+                                    }).show();
+                                }
+                            });
                         }
                     }
                 });
@@ -7387,10 +7408,16 @@ public class HTML5Implementation extends CodenameOneImplementation {
         // be called report:2026.pdf or https:report.pdf, both of which a
         // browser would read as URLs. Only shapes that cannot be a key skip the
         // lookup, since exists() costs up to two IndexedDB reads and ordinary
-        // https://... links should not pay for them. Looked up under the path
-        // exactly as given: a key may legitimately open or close with a space,
-        // and nothing here is parsed by the browser.
-        if (!isUnambiguousBrowserUrl(url) && exists(rawUrl)) {
+        // https://... links should not pay for them. Both the decision and the
+        // lookup read rawUrl: a key may legitimately open or close with a
+        // space, so judging the normalized form would skip the lookup for keys
+        // the lookup would have found.
+        // ...and only when normalization left the string untouched. If it
+        // changed anything, the raw form is not what the browser would parse,
+        // so it can still be a key in its own right -- "https://x/y\n" among
+        // them, which the shape test alone would wave through.
+        boolean cannotBeStorageKey = isUnambiguousBrowserUrl(rawUrl) && rawUrl.equals(url);
+        if (!cannotBeStorageKey && exists(rawUrl)) {
             try {
                 Blob blob = openFileAsBlob(rawUrl);
                 char sep = getFileSystemSeparator();

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -6869,15 +6869,25 @@ public class HTML5Implementation extends CodenameOneImplementation {
                     // authority. Without this the slashless form would skip the
                     // parsing below and display its leading user info.
                     rest = url.substring(colon + 1);
-                    while (rest.startsWith("/") || rest.startsWith("\\")) {
-                        rest = rest.substring(1);
-                    }
-                    // Only reached when the scheme is special.
+                    // Only reached when the scheme is special; the separator
+                    // skip below covers http:/host as well as http:host.
                     special = true;
                 } else {
                     // No authority to protect (mailto:, tel:, a bare path).
                     return ellipsizeTail(url);
                 }
+            }
+        }
+        if (special) {
+            // Browsers ignore any number of separators after the scheme, so
+            // https:////host and https:/\\/host both open host. Skip them, or
+            // the scan below stops on the leftover separator, reads an empty
+            // authority and falls back to showing the raw prefix.
+            while (rest.startsWith("/") || rest.startsWith("\\")) {
+                rest = rest.substring(1);
+            }
+            if (rest.length() == 0) {
+                return ellipsizeTail(url);
             }
         }
         int authorityEnd = rest.length();
@@ -7111,7 +7121,7 @@ public class HTML5Implementation extends CodenameOneImplementation {
      * timer would let the browser block the popup with nothing shown, which is
      * worse than the Sheet.</p>
      */
-    private void openInNewWindowWithConfirmation(final String url, String prompt) {
+    private void openInNewWindowWithConfirmation(final String url, final String prompt) {
         if (isGestureBackedHookAvailable() && popupReservedForGeneration != gestureGeneration) {
             // Tied to the interaction rather than to any drain of it -- see the
             // field. Never cleared; the next interaction simply carries a
@@ -7123,7 +7133,21 @@ public class HTML5Implementation extends CodenameOneImplementation {
                     // openUrlOnMainThread reports the reason on failure --
                     // popup blocked or no page-side channel -- so do not
                     // second-guess it with a duplicate line here.
-                    openUrlOnMainThread(url, false, false);
+                    if (!openUrlOnMainThread(url, false, false)) {
+                        // A browser setting, an extension or an activation that
+                        // expired before the drain can still block the one
+                        // reserved attempt. Fall back to asking rather than
+                        // leaving the caller with a dead click. Re-entering is
+                        // safe and cannot loop: this generation's reservation is
+                        // already spent, so it lands on the Sheet. Hop to the
+                        // EDT first -- this runs on a hook drain.
+                        callSerially(new Runnable() {
+                            @Override
+                            public void run() {
+                                openInNewWindowWithConfirmation(url, prompt);
+                            }
+                        });
+                    }
                 }
             });
             return;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -852,11 +852,26 @@ public class HTML5Implementation extends CodenameOneImplementation {
     private native static int _safariBacksideHookDelay();
     
     private void installBacksideHooksInUserInteraction() {
-        // A distinct interaction, so a popup reserved against the previous one
-        // no longer applies -- see popupReservedForGeneration -- and the
-        // previous one's outstanding drains cannot serve this one's hooks.
-        gestureGeneration++;
-        pendingGestureDrains = 0;
+        installBacksideHooksInUserInteraction(true);
+    }
+
+    /**
+     * @param newInteraction true for a press or key down, which begins a new
+     *   interaction; false for the matching release, which belongs to the
+     *   interaction already in progress. A release refreshes the window's
+     *   activation and schedules more drains, but it is not a new gesture: a
+     *   press-time execute() tagged with the current generation must still be
+     *   servable by the release's drain, and a click shorter than the 300ms
+     *   delay -- the normal case -- always releases first.
+     */
+    private void installBacksideHooksInUserInteraction(boolean newInteraction) {
+        if (newInteraction) {
+            // A distinct interaction, so a popup reserved against the previous
+            // one no longer applies -- see popupReservedForGeneration -- and the
+            // previous one's outstanding drains cannot serve this one's hooks.
+            gestureGeneration++;
+            pendingGestureDrains = 0;
+        }
         if (isIOS() || isSafari()) {
             debugLog("Installing backside hooks with delay "+safariBacksideHookDelay());
             runBacksideHooksInTimeout(safariBacksideHookDelay());
@@ -1906,7 +1921,7 @@ public class HTML5Implementation extends CodenameOneImplementation {
                 pointerState.setMouseDown(false);
 
                 pointerState.setLastTouchUpPosition(x, y);
-                installBacksideHooksInUserInteraction();
+                installBacksideHooksInUserInteraction(false);
                 applyMouseMetadata(me);
 
                 final Runnable releaseDispatch = new Runnable() {
@@ -2067,7 +2082,7 @@ public class HTML5Implementation extends CodenameOneImplementation {
                 pointerState.setGrabbedDrag(false);
                 
                 TouchEvent me = (TouchEvent)evt;
-                installBacksideHooksInUserInteraction();
+                installBacksideHooksInUserInteraction(false);
                 nativeCallSerially(new Runnable() {
                     @Override
                     public void run() {

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -7059,6 +7059,10 @@ public class HTML5Implementation extends CodenameOneImplementation {
             nativeButton.setMaterialIcon(FontImage.MATERIAL_SAVE);
             //icon = "save-file";
         } else if (isExternalUrl(url)) {
+            // Reached only by URLs the data: branch above did not claim.
+            // isExternalUrl() is true for data: as well -- it does carry a
+            // scheme -- so that branch MUST stay ahead of this one or data:
+            // URLs would navigate instead of downloading.
             openExternalUrl(furl);
             return;
         } else {

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -7089,6 +7089,36 @@ public class HTML5Implementation extends CodenameOneImplementation {
     }
 
     /**
+     * True for schemes that unambiguously address the browser, so offering the
+     * string to local storage first would be pointless.
+     *
+     * <p>Everything else is offered to storage first, because a stored key can
+     * be scheme-shaped: {@code report:2026.pdf} is a file, not a URI, and was
+     * downloadable before {@link #isExternalUrl(String)} began classifying by
+     * grammar. Custom deep links pass through unharmed -- {@code imdb:///find}
+     * simply is not in storage, so the lookup misses and classification
+     * proceeds.</p>
+     */
+    private static boolean isBrowserOnlyScheme(String url) {
+        if (url.startsWith("//")) {
+            return true;
+        }
+        int colon = url.indexOf(':');
+        if (colon < 1) {
+            return false;
+        }
+        String scheme = url.substring(0, colon);
+        return isSpecialScheme(scheme)
+                || "mailto".equalsIgnoreCase(scheme)
+                || "tel".equalsIgnoreCase(scheme)
+                || "sms".equalsIgnoreCase(scheme)
+                || "data".equalsIgnoreCase(scheme)
+                || "blob".equalsIgnoreCase(scheme)
+                || "about".equalsIgnoreCase(scheme)
+                || "javascript".equalsIgnoreCase(scheme);
+    }
+
+    /**
      * True when the URL names something the browser itself can hand off, as
      * opposed to a path into local storage that {@link #execute(String)} is
      * expected to turn into a download. Only these get the
@@ -7250,30 +7280,26 @@ public class HTML5Implementation extends CodenameOneImplementation {
         String fileName = null;
         boolean useBlobHandler = false;
         Button nativeButton = new Button();
-        // Only local content can name storage to wrap in a Blob, which is
-        // what isExternalUrl() is false for: bare paths, and file: URLs, whose
-        // scheme names local content too. Everything else with a scheme is
-        // true, data: included -- that carries its own payload and is claimed
-        // by its own branch further down.
-        if (!isExternalUrl(url)) {
-            // Looked up under the path exactly as given: a storage key may
-            // legitimately open or close with a space, and nothing here is
-            // parsed by the browser.
-            if (exists(rawUrl)) {
-                try {
-                    Blob blob = openFileAsBlob(rawUrl);
-                    char sep = getFileSystemSeparator();
-                    fileName = rawUrl;
-                    if (fileName.indexOf(sep) >=0) {
-                        fileName = fileName.substring(fileName.lastIndexOf(sep)+1);
-                    }
-                    registerSaveBlobHandler(fileName, blob);
-                    useBlobHandler = true;
-
-                } catch (Throwable ex) {
-                    // openFileAsBlob failed -- fall through to the no-blob-handler
-                    // branch below which opens the URL in a new window instead.
+        // Storage wins for anything that could name a key. Classifying by
+        // scheme grammar alone would skip the lookup for a stored file called
+        // report:2026.pdf, which is scheme-shaped but is a file; only the
+        // unambiguously browser-bound schemes skip it, so an ordinary link does
+        // not pay for a storage round trip. Looked up under the path exactly as
+        // given, since a key may legitimately open or close with a space and
+        // nothing here is parsed by the browser.
+        if (!isBrowserOnlyScheme(url) && exists(rawUrl)) {
+            try {
+                Blob blob = openFileAsBlob(rawUrl);
+                char sep = getFileSystemSeparator();
+                fileName = rawUrl;
+                if (fileName.indexOf(sep) >= 0) {
+                    fileName = fileName.substring(fileName.lastIndexOf(sep) + 1);
                 }
+                registerSaveBlobHandler(fileName, blob);
+                useBlobHandler = true;
+            } catch (Throwable ex) {
+                // openFileAsBlob failed -- fall through to the no-blob-handler
+                // branch below which opens the URL in a new window instead.
             }
         }
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -7332,13 +7332,6 @@ public class HTML5Implementation extends CodenameOneImplementation {
         // Sheet is a compatibility fallback the caller never requested, so
         // promising a new window there would describe behavior they did not
         // choose.
-        if (!isMainThreadBridgeAvailable()) {
-            // No page-side channel at all, so no button could make this work.
-            // Say so instead of showing a confirmation that cannot succeed.
-            _log("execute(): no page-side channel on this host bundle, cannot open " + url);
-            showCannotOpenMessage(url);
-            return;
-        }
         openInNewWindowWithConfirmation(url, EXECUTE_TARGET_BLANK.equals(target)
                 ? "Open this link in a new window?"
                 : "Open this link?");
@@ -7355,6 +7348,15 @@ public class HTML5Implementation extends CodenameOneImplementation {
      * worse than the Sheet.</p>
      */
     private void openInNewWindowWithConfirmation(final String url, final String prompt) {
+        if (!isMainThreadBridgeAvailable()) {
+            // Guarded here rather than at each caller: every popup path funnels
+            // through this method, and putting it in openExternalUrl() alone
+            // left the local-path fallback and the download legs prompting for
+            // something no button could deliver.
+            _log("execute(): no page-side channel on this host bundle, cannot open " + url);
+            showCannotOpenMessage(url);
+            return;
+        }
         if (isGestureBackedHookAvailable() && popupReservedForGeneration != gestureGeneration) {
             // Tied to the interaction rather than to any drain of it -- see the
             // field. Never cleared; the next interaction simply carries a
@@ -7401,6 +7403,13 @@ public class HTML5Implementation extends CodenameOneImplementation {
      * not run.
      */
     private void showOpenConfirmation(final String url, final String prompt) {
+        if (!isMainThreadBridgeAvailable()) {
+            // Reached directly by the superseded and blocked-popup fallbacks,
+            // which bypass the entry point above.
+            _log("execute(): no page-side channel on this host bundle, cannot open " + url);
+            showCannotOpenMessage(url);
+            return;
+        }
         createConfirmationSheet("Open Link", prompt,
                 shortenUrlForDisplay(url), new Runnable() {
             @Override
@@ -7453,6 +7462,11 @@ public class HTML5Implementation extends CodenameOneImplementation {
      * tab, which needs no activation and so cannot be blocked in turn.
      */
     private void showBlockedPopupFallback(final String url) {
+        if (!isMainThreadBridgeAvailable()) {
+            _log("execute(): no page-side channel on this host bundle, cannot open " + url);
+            showCannotOpenMessage(url);
+            return;
+        }
         createConfirmationSheet("Open Link",
                 "Your browser blocked the new window."
                         + " Open this link in the current tab instead?",

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -7464,7 +7464,13 @@ public class HTML5Implementation extends CodenameOneImplementation {
         // changed anything, the raw form is not what the browser would parse,
         // so it can still be a key in its own right -- "https://x/y\n" among
         // them, which the shape test alone would wave through.
-        boolean cannotBeStorageKey = isUnambiguousBrowserUrl(rawUrl) && rawUrl.equals(url);
+        // data: carries its own payload and is claimed by its own branch
+        // below, so it is never a lookup candidate -- and must not become one:
+        // exists() would push a multi-megabyte base64 string through the host
+        // bridge as a key, twice, blocking the EDT for nothing. The parent
+        // implementation excluded data: here too.
+        boolean cannotBeStorageKey = hasScheme(url, "data")
+                || (isUnambiguousBrowserUrl(rawUrl) && rawUrl.equals(url));
         if (!cannotBeStorageKey && exists(rawUrl)) {
             try {
                 Blob blob = openFileAsBlob(rawUrl);

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -7433,8 +7433,6 @@ public class HTML5Implementation extends CodenameOneImplementation {
             }
         }
 
-        final boolean fuseBlobHandler = useBlobHandler;
-        
         String buttonText = null;
         //String icon = null;
         if (useBlobHandler) {
@@ -7444,6 +7442,12 @@ public class HTML5Implementation extends CodenameOneImplementation {
             nativeButton.setMaterialIcon(FontImage.MATERIAL_SAVE);
         } else if (hasScheme(url, "data")) {
             registerSaveBlobHandlerDataUrl(fileName == null ? "download":fileName, url);
+            // A handler is registered now, exactly as in the Blob case, so the
+            // download path below must FIRE it. Leaving this false sent the
+            // confirmed OK to window.open() on the data: URL instead -- a tab
+            // rather than the download the Sheet advertised, and nothing at all
+            // where the browser blocks top-level data: navigation.
+            useBlobHandler = true;
             //popover.setContents("<button style='white-space:nowrap' onclick='window.cn1SaveBlobHandler();'><span style='font-size:3em;vertical-align:text-bottom;' class='glyphicon glyphicon-download; font-size: '/><span style='font-size:2em;vertical-align:top;'> Download "+(fileName!=null?fileName:"File")+"</span></button>");
             buttonText = "Click to Download "+(fileName!=null?fileName:"File");
             nativeButton.setText(buttonText);
@@ -7470,6 +7474,9 @@ public class HTML5Implementation extends CodenameOneImplementation {
             openInNewWindowWithConfirmation(url, "Open this link?");
             return;
         }
+        // Captured after the chain: the data: branch registers a handler too,
+        // and capturing before it read false for that case.
+        final boolean fuseBlobHandler = useBlobHandler;
         final Runnable startDownload = new Runnable() {
             @Override
             public void run() {

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -6836,12 +6836,20 @@ public class HTML5Implementation extends CodenameOneImplementation {
         if (url == null) {
             return "";
         }
-        int schemeEnd = url.indexOf("://");
-        if (schemeEnd < 0) {
-            // No authority to protect (mailto:, tel:, a bare storage path).
-            return ellipsizeTail(url);
+        String rest;
+        if (url.startsWith("//")) {
+            // Protocol relative. isExternalUrl() accepts these, so they reach
+            // the Sheet and carry an authority that needs the same parsing --
+            // indexOf("://") does not find one.
+            rest = url.substring(2);
+        } else {
+            int schemeEnd = url.indexOf("://");
+            if (schemeEnd < 0) {
+                // No authority to protect (mailto:, tel:, a bare storage path).
+                return ellipsizeTail(url);
+            }
+            rest = url.substring(schemeEnd + 3);
         }
-        String rest = url.substring(schemeEnd + 3);
         int authorityEnd = rest.length();
         for (int i = 0; i < rest.length(); i++) {
             char c = rest.charAt(i);
@@ -7016,13 +7024,28 @@ public class HTML5Implementation extends CodenameOneImplementation {
         }
         // _blank, or _self / auto whose page-side script never ran because the
         // host bundle predates the eval-on-main handler -- degrade rather than
-        // leave execute() with no effect at all:
-        // a popup only survives inside a live user gesture, so ride the backside
-        // hook when a gesture-backed one is pending and otherwise ask the user,
-        // whose tap on the Sheet becomes the gesture. Note this deliberately
-        // ignores an interval-only hook: draining from a timer would let the
-        // browser block the popup with nothing shown, which is worse than the
-        // Sheet that _blank promises.
+        // leave execute() with no effect at all.
+        //
+        // Only _blank actually asked for a new window. Under auto or _self the
+        // Sheet is a compatibility fallback the caller never requested, so
+        // promising a new window there would describe behavior they did not
+        // choose.
+        openInNewWindowWithConfirmation(url, EXECUTE_TARGET_BLANK.equals(target)
+                ? "Open this link in a new window?"
+                : "Open this link?");
+    }
+
+    /**
+     * Opens {@code url} in a new window/tab the gesture-aware way: a popup only
+     * survives inside a live user gesture, so ride a backside hook when a
+     * gesture-backed one is pending and otherwise ask the user, whose tap on the
+     * Sheet becomes the gesture.
+     *
+     * <p>An interval-only hook is deliberately not enough here. Draining from a
+     * timer would let the browser block the popup with nothing shown, which is
+     * worse than the Sheet.</p>
+     */
+    private void openInNewWindowWithConfirmation(final String url, String prompt) {
         if (isGestureBackedHookAvailable()) {
             addBacksideHook(new JSRunnable() {
                 @Override
@@ -7032,13 +7055,6 @@ public class HTML5Implementation extends CodenameOneImplementation {
             });
             return;
         }
-        // Only _blank actually asked for a new window. Under auto or _self the
-        // Sheet is a compatibility fallback the caller never requested, so
-        // promising a new window there would describe behavior they did not
-        // choose.
-        String prompt = EXECUTE_TARGET_BLANK.equals(target)
-                ? "Open this link in a new window?"
-                : "Open this link?";
         createConfirmationSheet("Open Link", prompt,
                 shortenUrlForDisplay(url), new Runnable() {
             @Override
@@ -7050,7 +7066,7 @@ public class HTML5Implementation extends CodenameOneImplementation {
                 // install a backside hook though (pointer handling calls
                 // installBacksideHooksInUserInteraction), so queue the open on
                 // it and let the drain perform it inside the gesture. Same
-                // shape as the download confirmation below.
+                // shape as the download confirmation in execute().
                 addBacksideHook(new JSRunnable() {
                     @Override
                     public void run() {
@@ -7134,9 +7150,11 @@ public class HTML5Implementation extends CodenameOneImplementation {
             // off the external-link target policy -- under auto or _self that
             // would point the page at a path the server does not serve and
             // unload the app instead of downloading anything. Best effort in a
-            // new window, which is what this port did before.
+            // new window, which is what this port did before -- and through the
+            // gesture-aware path, since opening straight from the EDT would let
+            // the browser block the popup with no confirmation shown.
             _log("execute(): no downloadable content for " + url);
-            openUrlOnMainThread(url, false, false);
+            openInNewWindowWithConfirmation(url, "Open this link?");
             return;
         }
         final Runnable startDownload = new Runnable() {

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -644,16 +644,50 @@ public class HTML5Implementation extends CodenameOneImplementation {
      * and never open. Anything needing activation goes here instead, where only
      * {@link #runBacksideHooksInTimeout(int)} reaches it.</p>
      */
-    private JSArray gestureOnlyHooks = JSArray.create();
+    private final java.util.ArrayList<GestureHook> gestureOnlyHooks =
+            new java.util.ArrayList<GestureHook>();
 
-    private void addGestureOnlyHook(JSRunnable r) {
-        gestureOnlyHooks.push(r);
+    /** A hook paired with the interaction that queued it. */
+    private static class GestureHook {
+        final int generation;
+        final JSRunnable runnable;
+
+        GestureHook(int generation, JSRunnable runnable) {
+            this.generation = generation;
+            this.runnable = runnable;
+        }
     }
 
-    private void runGestureOnlyHooks() {
-        while (gestureOnlyHooks.getLength() > 0) {
-            JSRunnable r = (JSRunnable)gestureOnlyHooks.shift();
-            r.run();
+    /**
+     * Queues a hook that only a drain scheduled by the CURRENT interaction may
+     * run. A drain descending from an earlier interaction carries that one's
+     * activation, which is spent or expiring, so letting it consume this hook
+     * would leave the popup blocked.
+     */
+    private void addGestureOnlyHook(JSRunnable r) {
+        // Backstop against unbounded growth: a hook whose interaction is long
+        // past can no longer be drained, which only happens if the EDT took
+        // longer than the whole 5s drain burst to reach us.
+        for (int i = gestureOnlyHooks.size() - 1; i >= 0; i--) {
+            if (gestureGeneration - gestureOnlyHooks.get(i).generation > 8) {
+                gestureOnlyHooks.remove(i);
+            }
+        }
+        gestureOnlyHooks.add(new GestureHook(gestureGeneration, r));
+    }
+
+    private void runGestureOnlyHooks(int generation) {
+        // Collected before running: a hook may queue another one, and mutating
+        // the list mid-iteration would break it.
+        java.util.ArrayList<GestureHook> due = new java.util.ArrayList<GestureHook>();
+        for (int i = 0; i < gestureOnlyHooks.size(); i++) {
+            if (gestureOnlyHooks.get(i).generation == generation) {
+                due.add(gestureOnlyHooks.get(i));
+            }
+        }
+        gestureOnlyHooks.removeAll(due);
+        for (int i = 0; i < due.size(); i++) {
+            due.get(i).runnable.run();
         }
     }
     
@@ -682,14 +716,19 @@ public class HTML5Implementation extends CodenameOneImplementation {
     private void runBacksideHooksInTimeout(int timeout) {
         backsideHooksSemaphore++;
         //_log("Incrementing backsideHooksSemaphore: "+backsideHooksSemaphore);
+        // Remember which interaction scheduled this drain, so it only runs the
+        // activation-dependent hooks that same interaction queued.
+        final int generation = gestureGeneration;
         Window.setTimeout(new TimerHandler() {
             @Override
             public void onTimer() {
                 backsideHooksSemaphore--;
                 //_log("Decrementing backsideHooksSemaphore: "+backsideHooksSemaphore);
-                // This drain descends from a real interaction, so it is the
-                // only one allowed to run activation-dependent hooks.
-                runGestureOnlyHooks();
+                // This drain descends from a real interaction, so it may run
+                // that interaction's activation-dependent hooks -- and only
+                // those: an older drain still pending carries an activation
+                // that is spent or expiring.
+                runGestureOnlyHooks(generation);
                 runBacksideHooks();
             }
         }, timeout);

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -7558,17 +7558,15 @@ public class HTML5Implementation extends CodenameOneImplementation {
             // rule as the javascript: payload and the storage key -- normalize
             // what the browser parses, never what it carries.
             registerSaveBlobHandlerDataUrl(fileName == null ? "download":fileName, rawUrl);
-            // A handler is registered now, exactly as in the Blob case, so the
-            // download path below must FIRE it. Leaving this false sent the
-            // confirmed OK to window.open() on the data: URL instead -- a tab
-            // rather than the download the Sheet advertised, and nothing at all
-            // where the browser blocks top-level data: navigation.
-            useBlobHandler = true;
-            //popover.setContents("<button style='white-space:nowrap' onclick='window.cn1SaveBlobHandler();'><span style='font-size:3em;vertical-align:text-bottom;' class='glyphicon glyphicon-download; font-size: '/><span style='font-size:2em;vertical-align:top;'> Download "+(fileName!=null?fileName:"File")+"</span></button>");
-            buttonText = "Click to Download "+(fileName!=null?fileName:"File");
-            nativeButton.setText(buttonText);
-            nativeButton.setMaterialIcon(FontImage.MATERIAL_SAVE);
-            //icon = "save-file";
+            // Registration IS the download: browser_bridge.js's
+            // __cn1_register_save_blob_dataurl__ clicks the anchor immediately
+            // and only stashes a copy in case that click was blocked. So return
+            // here. Firing the stash as well downloads the file twice, and the
+            // old behavior of falling through to window.open() on the data: URL
+            // opened a spurious tab the browser then blocked. Nothing further
+            // to do on this path.
+            _log("execute(): data: URL handed to the download handler");
+            return;
         } else if (isExternalUrl(url)) {
             // Reached only by URLs the data: branch above did not claim.
             // isExternalUrl() is true for data: as well -- it does carry a

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -7441,7 +7441,12 @@ public class HTML5Implementation extends CodenameOneImplementation {
             nativeButton.setText(buttonText);
             nativeButton.setMaterialIcon(FontImage.MATERIAL_SAVE);
         } else if (hasScheme(url, "data")) {
-            registerSaveBlobHandlerDataUrl(fileName == null ? "download":fileName, url);
+            // The RAW URL, not the normalized one: normalization strips tabs
+            // and newlines anywhere in the string, and this value is the
+            // download's payload, not something we are only classifying. Same
+            // rule as the javascript: payload and the storage key -- normalize
+            // what the browser parses, never what it carries.
+            registerSaveBlobHandlerDataUrl(fileName == null ? "download":fileName, rawUrl);
             // A handler is registered now, exactly as in the Blob case, so the
             // download path below must FIRE it. Leaving this false sent the
             // confirmed OK to window.open() on the data: URL instead -- a tab
@@ -7474,13 +7479,16 @@ public class HTML5Implementation extends CodenameOneImplementation {
             openInNewWindowWithConfirmation(url, "Open this link?");
             return;
         }
-        // Captured after the chain: the data: branch registers a handler too,
-        // and capturing before it read false for that case.
-        final boolean fuseBlobHandler = useBlobHandler;
+        // A final copy of useBlobHandler, needed because the anonymous classes
+        // below cannot capture it -- it is assigned in the branches above and
+        // so is not effectively final. Captured AFTER the chain: the data:
+        // branch registers a handler too, and capturing beforehand read false
+        // for that case and sent the download down the popup leg.
+        final boolean handlerRegistered = useBlobHandler;
         final Runnable startDownload = new Runnable() {
             @Override
             public void run() {
-                if (fuseBlobHandler) {
+                if (handlerRegistered) {
                     fireSaveBlobHandler();
                 } else {
                     _log("Opening URL in new window");
@@ -7494,7 +7502,7 @@ public class HTML5Implementation extends CodenameOneImplementation {
         // instead, and that does need a real gesture -- draining it from a timer
         // would let the browser block it with no Sheet shown. Pick the gate that
         // matches the leg this run will actually take.
-        boolean hookAvailable = fuseBlobHandler
+        boolean hookAvailable = handlerRegistered
                 ? isBacksideHookAvailable()
                 : isGestureBackedHookAvailable();
         if (hookAvailable) {
@@ -7504,7 +7512,7 @@ public class HTML5Implementation extends CodenameOneImplementation {
                     startDownload.run();
                 }
             };
-            if (fuseBlobHandler) {
+            if (handlerRegistered) {
                 addBacksideHook(hook);
             } else {
                 // The no-blob leg opens a popup, so it needs the activation
@@ -7527,7 +7535,7 @@ public class HTML5Implementation extends CodenameOneImplementation {
                     // Same split as the unconfirmed path above: the popup leg
                     // needs the activation the OK tap just granted, which the
                     // polling interval would not carry.
-                    if (fuseBlobHandler) {
+                    if (handlerRegistered) {
                         addBacksideHook(confirmed);
                     } else {
                         addGestureOnlyHook(confirmed);

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -7267,46 +7267,6 @@ public class HTML5Implementation extends CodenameOneImplementation {
     }
 
     /**
-     * True when the string cannot plausibly be a storage key, so the storage
-     * lookup in {@link #execute(String)} can be skipped.
-     *
-     * <p>That means it opens with {@code //}, or with a SPECIAL scheme followed
-     * by {@code //}. Nobody names a stored file {@code https://example.com/x},
-     * and those are the overwhelming majority of links, so the common path pays
-     * nothing. Every other shape is offered to storage first -- slashless forms
-     * like {@code https:report.pdf} and {@code report:2026.pdf}, which a browser
-     * would happily parse as URLs but which a caller may just as legitimately
-     * have stored under that name, and also {@code file:///x} and custom
-     * {@code myapp://x}, which named local content or could be a key. Storage
-     * only wins if the key actually exists; a miss falls through to
-     * classification, so deep links are unaffected.</p>
-     *
-     * <p>Deciding this by scheme allowlist instead was wrong twice over: it
-     * regressed {@code report:2026.pdf}, then still regressed
-     * {@code https:report.pdf}. Ambiguity is a property of the shape, not of
-     * the scheme name.</p>
-     *
-     * <p>Takes the RAW string, the same one the lookup uses. Judging the
-     * normalized form would let {@code " https://example.com/report "} -- a
-     * perfectly legal key, since keys may carry surrounding whitespace -- look
-     * unambiguous and skip the lookup that would have found it.</p>
-     */
-    private static boolean isUnambiguousBrowserUrl(String url) {
-        if (startsWithAuthorityMarker(url)) {
-            return true;
-        }
-        int sep = url.indexOf("://");
-        if (sep < 1) {
-            return false;
-        }
-        // Special schemes only. file:///x names local content, and a custom
-        // myapp://x could be a key as easily as a deep link; both were reaching
-        // the lookup before this branch and still should. What this skips is
-        // ordinary web links, which are the volume and are never keys.
-        return isSpecialScheme(url.substring(0, sep));
-    }
-
-    /**
      * True when the URL names something the browser itself can hand off, as
      * opposed to a path into local storage that {@link #execute(String)} is
      * expected to turn into a download. Only these get the
@@ -7531,26 +7491,22 @@ public class HTML5Implementation extends CodenameOneImplementation {
         String fileName = null;
         boolean useBlobHandler = false;
         Button nativeButton = new Button();
-        // Storage wins for anything that could name a key -- a stored file may
-        // be called report:2026.pdf or https:report.pdf, both of which a
-        // browser would read as URLs. Only shapes that cannot be a key skip the
-        // lookup, since exists() costs up to two IndexedDB reads and ordinary
-        // https://... links should not pay for them. Both the decision and the
-        // lookup read rawUrl: a key may legitimately open or close with a
-        // space, so judging the normalized form would skip the lookup for keys
-        // the lookup would have found.
-        // ...and only when normalization left the string untouched. If it
-        // changed anything, the raw form is not what the browser would parse,
-        // so it can still be a key in its own right -- "https://x/y\n" among
-        // them, which the shape test alone would wave through.
-        // data: carries its own payload and is claimed by its own branch
-        // below, so it is never a lookup candidate -- and must not become one:
-        // exists() would push a multi-megabyte base64 string through the host
-        // bridge as a key, twice, blocking the EDT for nothing. The parent
-        // implementation excluded data: here too.
-        boolean cannotBeStorageKey = hasScheme(url, "data")
-                || (isUnambiguousBrowserUrl(rawUrl) && rawUrl.equals(url));
-        if (!cannotBeStorageKey && exists(rawUrl)) {
+        // Storage names are unrestricted, so NO shape can be ruled out in
+        // advance: report:2026.pdf, https:report.pdf and https://example.com/x
+        // are all legal keys, and three successive attempts to characterize
+        // "cannot be a key" each regressed one of them. Consult storage for
+        // everything and let the miss decide. The parent implementation did
+        // the same for every shape but http:, mailto: and data:.
+        //
+        // data: stays excluded, and it is the only exclusion that holds up:
+        // there the string is the download's payload rather than a name, and
+        // exists() would push a multi-megabyte base64 blob through the host
+        // bridge as a key, twice, for something that can never match.
+        //
+        // Looked up under the path exactly as given -- a key may legitimately
+        // open or close with a space, and nothing here is parsed by the
+        // browser.
+        if (!hasScheme(url, "data") && exists(rawUrl)) {
             try {
                 Blob blob = openFileAsBlob(rawUrl);
                 char sep = getFileSystemSeparator();

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -693,7 +693,7 @@ public class HTML5Implementation extends CodenameOneImplementation {
             // link would do nothing at all. Schedule one. The activation is
             // probably gone by now, but an attempt that reports failure beats
             // silence: the caller logs it, or falls back to the Sheet.
-            runBacksideHooksInTimeout(0);
+            runBacksideHooksInTimeout(0, false);
         }
     }
 
@@ -756,7 +756,22 @@ public class HTML5Implementation extends CodenameOneImplementation {
      * @param timeout 
      */
     private void runBacksideHooksInTimeout(int timeout) {
-        backsideHooksSemaphore++;
+        runBacksideHooksInTimeout(timeout, true);
+    }
+
+    /**
+     * @param fromInteraction true when a real pointer or key event scheduled
+     *   this drain. Only those raise {@link #backsideHooksSemaphore}, because
+     *   that is what {@link #isGestureBackedHookAvailable()} reads to decide a
+     *   popup may be attempted. A drain we schedule ourselves to rescue a
+     *   stranded hook carries no activation, so counting it there would claim a
+     *   gesture that does not exist and send a popup to be blocked instead of
+     *   to the Sheet.
+     */
+    private void runBacksideHooksInTimeout(int timeout, final boolean fromInteraction) {
+        if (fromInteraction) {
+            backsideHooksSemaphore++;
+        }
         //_log("Incrementing backsideHooksSemaphore: "+backsideHooksSemaphore);
         // Remember which interaction scheduled this drain, so it only runs the
         // activation-dependent hooks that same interaction queued.
@@ -765,7 +780,9 @@ public class HTML5Implementation extends CodenameOneImplementation {
         Window.setTimeout(new TimerHandler() {
             @Override
             public void onTimer() {
-                backsideHooksSemaphore--;
+                if (fromInteraction) {
+                    backsideHooksSemaphore--;
+                }
                 if (generation == gestureGeneration) {
                     pendingGestureDrains--;
                 }
@@ -7039,7 +7056,7 @@ public class HTML5Implementation extends CodenameOneImplementation {
     private void addBacksideHookEnsuringDrain(JSRunnable r) {
         addBacksideHook(r);
         if (pendingGestureDrains <= 0 && backsideHooksIntervalHandle == 0) {
-            runBacksideHooksInTimeout(0);
+            runBacksideHooksInTimeout(0, false);
         }
     }
 

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -663,12 +663,6 @@ public class HTML5Implementation extends CodenameOneImplementation {
             public void onTimer() {
                 backsideHooksSemaphore--;
                 //_log("Decrementing backsideHooksSemaphore: "+backsideHooksSemaphore);
-                if (backsideHooksSemaphore <= 0) {
-                    // Every delayed drain scheduled off that interaction has
-                    // run, so whatever activation it granted is spent. The next
-                    // popup has to earn a gesture of its own.
-                    popupReservedForGesture = false;
-                }
                 runBacksideHooks();
             }
         }, timeout);
@@ -746,6 +740,9 @@ public class HTML5Implementation extends CodenameOneImplementation {
     private native static int _safariBacksideHookDelay();
     
     private void installBacksideHooksInUserInteraction() {
+        // A distinct interaction, so a popup reserved against the previous one
+        // no longer applies -- see popupReservedForGeneration.
+        gestureGeneration++;
         if (isIOS() || isSafari()) {
             debugLog("Installing backside hooks with delay "+safariBacksideHookDelay());
             runBacksideHooksInTimeout(safariBacksideHookDelay());
@@ -6847,15 +6844,23 @@ public class HTML5Implementation extends CodenameOneImplementation {
             return "";
         }
         String rest;
+        // Special URLs also accept "\\" wherever they accept "/", so the
+        // authority ends there too -- otherwise https://evil.example\\<long
+        // trusted looking path> reads as one over-long authority and the tail
+        // rule below would show the attacker's suffix instead of the host.
+        boolean special;
         if (url.startsWith("//")) {
             // Protocol relative. isExternalUrl() accepts these, so they reach
             // the Sheet and carry an authority that needs the same parsing --
-            // indexOf("://") does not find one.
+            // indexOf("://") does not find one. The page's own scheme applies,
+            // which for a served app is http(s), so treat it as special.
             rest = url.substring(2);
+            special = true;
         } else {
             int schemeEnd = url.indexOf("://");
             if (schemeEnd >= 0) {
                 rest = url.substring(schemeEnd + 3);
+                special = isSpecialScheme(url.substring(0, schemeEnd));
             } else {
                 int colon = url.indexOf(':');
                 if (colon > 0 && isSpecialScheme(url.substring(0, colon))) {
@@ -6864,9 +6869,11 @@ public class HTML5Implementation extends CodenameOneImplementation {
                     // authority. Without this the slashless form would skip the
                     // parsing below and display its leading user info.
                     rest = url.substring(colon + 1);
-                    while (rest.startsWith("/")) {
+                    while (rest.startsWith("/") || rest.startsWith("\\")) {
                         rest = rest.substring(1);
                     }
+                    // Only reached when the scheme is special.
+                    special = true;
                 } else {
                     // No authority to protect (mailto:, tel:, a bare path).
                     return ellipsizeTail(url);
@@ -6876,7 +6883,7 @@ public class HTML5Implementation extends CodenameOneImplementation {
         int authorityEnd = rest.length();
         for (int i = 0; i < rest.length(); i++) {
             char c = rest.charAt(i);
-            if (c == '/' || c == '?' || c == '#') {
+            if (c == '/' || c == '?' || c == '#' || (special && c == '\\')) {
                 authorityEnd = i;
                 break;
             }
@@ -6987,21 +6994,28 @@ public class HTML5Implementation extends CodenameOneImplementation {
     }
 
     /**
-     * Whether the gesture currently represented by {@link #backsideHooksSemaphore}
-     * has already had a popup queued against it.
-     *
-     * <p>The semaphore counts pending drains, not unconsumed popup
-     * authorization. One gesture authorizes ONE {@code window.open()} -- the
-     * first consumes the transient activation -- yet
-     * {@code installBacksideHooksInUserInteraction()} schedules three drains
-     * (300ms, 1500ms, 5000ms) off a single interaction. Releasing the
-     * reservation when the first of those runs would let a later execute() read
-     * one of the remaining drains as a fresh gesture and queue a popup whose
-     * activation is already spent. So hold the reservation until the whole burst
-     * has expired, i.e. the semaphore falls back to zero, and send everything
-     * else to the Sheet, which earns a gesture of its own.</p>
+     * Identifies the user interaction currently in play. Bumped by
+     * {@link #installBacksideHooksInUserInteraction()}, which runs once per
+     * pointer or key event.
      */
-    private boolean popupReservedForGesture;
+    private int gestureGeneration;
+
+    /**
+     * The {@link #gestureGeneration} that has already had a popup queued
+     * against it, or -1.
+     *
+     * <p>One interaction authorizes ONE {@code window.open()}: the first
+     * consumes the transient activation, so anything else queued behind the
+     * same interaction is blocked. The count of pending drains cannot express
+     * this -- a single interaction schedules three (300ms, 1500ms, 5000ms), and
+     * a second interaction within five seconds raises the shared semaphore
+     * again before the first one's drains have run, so neither "the first drain
+     * ran" nor "the semaphore reached zero" marks a gesture boundary. Comparing
+     * generations does: a genuinely new interaction gets its own popup, while
+     * everything else in the same one goes to the Sheet and earns a gesture of
+     * its own.</p>
+     */
+    private int popupReservedForGeneration = -1;
 
     /**
      * True when {@code url} carries exactly {@code scheme}, compared without
@@ -7098,11 +7112,11 @@ public class HTML5Implementation extends CodenameOneImplementation {
      * worse than the Sheet.</p>
      */
     private void openInNewWindowWithConfirmation(final String url, String prompt) {
-        if (isGestureBackedHookAvailable() && !popupReservedForGesture) {
-            // Held until the gesture's whole drain burst expires -- see the
-            // field. Not released here, where the first drain would free it
-            // while later drains from the same interaction are still pending.
-            popupReservedForGesture = true;
+        if (isGestureBackedHookAvailable() && popupReservedForGeneration != gestureGeneration) {
+            // Tied to the interaction rather than to any drain of it -- see the
+            // field. Never cleared; the next interaction simply carries a
+            // different generation.
+            popupReservedForGeneration = gestureGeneration;
             addBacksideHook(new JSRunnable() {
                 @Override
                 public void run() {

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -6586,10 +6586,6 @@ public class HTML5Implementation extends CodenameOneImplementation {
     }
     
 
-    @JSBody(params={"url", "target"}, script="window.open(url, target)")
-    private native static void windowOpen(String url, String target);
-
-   
     // The original implementations of register/fire SaveBlobHandler ran their
     // scripts inside the worker, where ``document`` doesn't exist -- the
     // generated download <a> element / .click() trick threw the moment the
@@ -6678,7 +6674,233 @@ public class HTML5Implementation extends CodenameOneImplementation {
 
     @JSBody(params={"js"}, script="eval(js)")
     private native static void eval_(String js);
-    
+
+    /**
+     * Value of the {@code javascript.execute.target} property: open in a new
+     * window/tab and silently fall back to navigating the current page when the
+     * browser blocks the popup. This is the default -- it is the only mode that
+     * never needs a confirmation Sheet.
+     */
+    private static final String EXECUTE_TARGET_AUTO = "auto";
+
+    /**
+     * Value of the {@code javascript.execute.target} property: only ever open a
+     * new window/tab. When the browser blocks it (no live user gesture) a
+     * confirmation Sheet is shown so the user's tap on it supplies the gesture.
+     */
+    private static final String EXECUTE_TARGET_BLANK = "_blank";
+
+    /**
+     * Value of the {@code javascript.execute.target} property: always navigate
+     * the page the app is running in. Never blocked, never shows a Sheet, but
+     * it unloads the app.
+     */
+    private static final String EXECUTE_TARGET_SELF = "_self";
+
+    /**
+     * Resolves the {@code javascript.execute.target} property, accepting the
+     * target names with or without the leading underscore.
+     */
+    private String executeTarget() {
+        String target = Display.getInstance().getProperty("javascript.execute.target", EXECUTE_TARGET_AUTO);
+        if (EXECUTE_TARGET_SELF.equals(target) || "self".equals(target)) {
+            return EXECUTE_TARGET_SELF;
+        }
+        if (EXECUTE_TARGET_BLANK.equals(target) || "blank".equals(target) || "new".equals(target)) {
+            return EXECUTE_TARGET_BLANK;
+        }
+        return EXECUTE_TARGET_AUTO;
+    }
+
+    /**
+     * Quotes a string as a JavaScript string literal so it can be embedded in a
+     * script handed to {@link #eval_(String)}.
+     */
+    private static String toJavaScriptStringLiteral(String value) {
+        StringBuilder sb = new StringBuilder(value.length() + 8);
+        sb.append('"');
+        int len = value.length();
+        for (int i = 0; i < len; i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '"':
+                    sb.append("\\\"");
+                    break;
+                case '\\':
+                    sb.append("\\\\");
+                    break;
+                case '\n':
+                    sb.append("\\n");
+                    break;
+                case '\r':
+                    sb.append("\\r");
+                    break;
+                case '\t':
+                    sb.append("\\t");
+                    break;
+                case '<':
+                    // Avoid terminating an enclosing script element early.
+                    sb.append("\\u003c");
+                    break;
+                default:
+                    if (c < ' ' || c > 126) {
+                        String hex = Integer.toHexString(c);
+                        sb.append("\\u");
+                        for (int j = hex.length(); j < 4; j++) {
+                            sb.append('0');
+                        }
+                        sb.append(hex);
+                    } else {
+                        sb.append(c);
+                    }
+                    break;
+            }
+        }
+        sb.append('"');
+        return sb.toString();
+    }
+
+    /**
+     * Hands a URL to the page's main thread for opening. {@code window} and
+     * {@code window.open} do not exist inside the Web Worker the app runs in, so
+     * this routes through the eval-on-main host bridge (see the
+     * {@code eval_} binding in port.js) where the page's real window lives.
+     *
+     * @param url the URL to open
+     * @param sameWindow when true navigate the current page, when false open a
+     *   new window/tab
+     * @param fallBackToSameWindow when opening a new window, navigate the
+     *   current page instead if the browser blocked the popup. The check runs
+     *   inside the page-side script because the popup verdict is only knowable
+     *   there.
+     * @return true if the script reached the page, false if the main-thread
+     *   bridge is unavailable and the caller should degrade
+     */
+    private boolean openUrlOnMainThread(String url, boolean sameWindow, boolean fallBackToSameWindow) {
+        String literal = toJavaScriptStringLiteral(url);
+        String script;
+        if (sameWindow) {
+            script = "window.location.href = " + literal + ";";
+        } else if (fallBackToSameWindow) {
+            // Only attempt the popup while the page still has transient user
+            // activation -- otherwise the browser blocks it and shows its
+            // "popup blocked" indicator before we navigate anyway. Browsers
+            // without navigator.userActivation just try and let !cn1w decide.
+            script = "var cn1a = window.navigator && window.navigator.userActivation;"
+                    + "var cn1w = (!cn1a || cn1a.isActive) ? window.open(" + literal + ", '_blank') : null;"
+                    + "if (!cn1w) { window.location.href = " + literal + "; }";
+        } else {
+            script = "window.open(" + literal + ", '_blank');";
+        }
+        try {
+            eval_(script);
+            return true;
+        } catch (Throwable t) {
+            _log("Failed to open URL on the main thread: " + t);
+            return false;
+        }
+    }
+
+    /**
+     * A raw URL has no spaces for {@code SpanLabel} to wrap on, so putting one
+     * in the confirmation Sheet blew the content pane's preferred width past the
+     * screen and pushed the buttons out of reach. Shorten it for display; the
+     * full URL is never needed to answer "open this link?".
+     */
+    static String shortenUrlForDisplay(String url) {
+        if (url == null) {
+            return "";
+        }
+        String shortened = url;
+        int schemeEnd = shortened.indexOf("://");
+        if (schemeEnd >= 0) {
+            shortened = shortened.substring(schemeEnd + 3);
+        }
+        if (shortened.length() > 40) {
+            int slash = shortened.indexOf('/');
+            if (slash > 0 && slash <= 40) {
+                shortened = shortened.substring(0, slash) + "/...";
+            } else {
+                shortened = shortened.substring(0, 37) + "...";
+            }
+        }
+        return shortened;
+    }
+
+    /**
+     * Builds the "browser blocked this, please confirm" Sheet used by
+     * {@link #execute(String)}. The message, the (shortened) URL and the buttons
+     * each get their own row: the old single-row BorderLayout put the buttons
+     * east of a label whose preferred width was the whole URL, which pushed them
+     * off screen where they could not be tapped.
+     */
+    private Sheet createConfirmationSheet(String title, String message, String detail, final Runnable onConfirm) {
+        final Sheet sheet = new Sheet(null, title);
+        SpanLabel messageLabel = new SpanLabel(message);
+        Button ok = new Button("OK");
+        Button cancel = new Button("Cancel");
+        ok.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent evt) {
+                sheet.back();
+                onConfirm.run();
+            }
+        });
+        cancel.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent evt) {
+                sheet.back();
+            }
+        });
+        sheet.getContentPane().setLayout(BoxLayout.y());
+        sheet.getContentPane().add(messageLabel);
+        if (detail != null && detail.length() > 0) {
+            // A plain Label truncates with an ellipsis when it does not fit,
+            // unlike SpanLabel which would just overflow on an unbreakable URL.
+            Label detailLabel = new Label(detail);
+            detailLabel.setEndsWith3Points(true);
+            sheet.getContentPane().add(detailLabel);
+        }
+        sheet.getContentPane().add(FlowLayout.encloseCenter(cancel, ok));
+        return sheet;
+    }
+
+    /**
+     * Opens a URL, or asks the user to, honoring the
+     * {@code javascript.execute.target} property. See {@link #execute(String)}.
+     */
+    private void openExternalUrl(final String url) {
+        String target = executeTarget();
+        if (EXECUTE_TARGET_SELF.equals(target)) {
+            openUrlOnMainThread(url, true, false);
+            return;
+        }
+        if (EXECUTE_TARGET_AUTO.equals(target)
+                && openUrlOnMainThread(url, false, true)) {
+            return;
+        }
+        // _blank, or auto on a host bundle without the eval-on-main handler:
+        // a popup only survives inside a live user gesture, so ride the backside
+        // hook when one is pending and otherwise ask the user, whose tap on the
+        // Sheet becomes the gesture.
+        if (isBacksideHookAvailable()) {
+            addBacksideHook(new JSRunnable() {
+                @Override
+                public void run() {
+                    openUrlOnMainThread(url, false, false);
+                }
+            });
+            return;
+        }
+        createConfirmationSheet("Open Link", "Open this link in a new window?",
+                shortenUrlForDisplay(url), new Runnable() {
+            @Override
+            public void run() {
+                openUrlOnMainThread(url, false, false);
+            }
+        }).show();
+    }
+
     @Override
     public void execute(String url) {
         if (url.startsWith("javascript:")) {
@@ -6730,80 +6952,43 @@ public class HTML5Implementation extends CodenameOneImplementation {
             nativeButton.setMaterialIcon(FontImage.MATERIAL_SAVE);
             //icon = "save-file";
         } else {
-            //popover.setContents("<a href='"+url+"' target='_blank'>Open URL in New Window</a>");
-            if (isBacksideHookAvailable()) {
-                addBacksideHook(new JSRunnable() {
-                    public void run() {
-                        window.open(furl, "New Window");
-                    }
-                });
-                
-            } else {
-                final Sheet sheet = new Sheet(null, "Open Link");
-                SpanLabel l = new SpanLabel("Open "+url+" in a new window?");
-                Button ok = new Button("OK");
-                Button cancel = new Button("Cancel");
-                ok.addActionListener(new ActionListener() {
-                    public void actionPerformed(ActionEvent evt) {
-                        sheet.back();
-                        CN.execute(furl);
-                    }
-                });
-                cancel.addActionListener(new ActionListener() {
-                    public void actionPerformed(ActionEvent evt) {
-                        sheet.back();
-                    }
-                });
-                sheet.getContentPane().setLayout(BoxLayout.y());
-                sheet.getContentPane().add(BorderLayout.centerEastWest(l, FlowLayout.encloseIn(ok, cancel), null));
-                sheet.show();
-                
-            }
+            openExternalUrl(furl);
             return;
-            
         }
+        final Runnable startDownload = new Runnable() {
+            @Override
+            public void run() {
+                if (fuseBlobHandler) {
+                    fireSaveBlobHandler();
+                } else {
+                    _log("Opening URL in new window");
+                    openUrlOnMainThread(furl, false, false);
+                }
+            }
+        };
         if (isBacksideHookAvailable()) {
             addBacksideHook(new JSRunnable() {
+                @Override
                 public void run() {
-                    if (fuseBlobHandler) {
-                        fireSaveBlobHandler();
-                    } else {
-                        _log("Opening URL in new window");
-                        window.open(furl, "New Window");
-                    }
+                    startDownload.run();
                 }
             });
 
         } else {
-            final Sheet sheet = new Sheet(null, "Download file");
             String dlName = fileName == null ? "file" : fileName;
-            SpanLabel l = new SpanLabel("Download "+dlName+" now?");
-            Button ok = new Button("OK");
-            Button cancel = new Button("Cancel");
-            ok.addActionListener(new ActionListener() {
-                public void actionPerformed(ActionEvent evt) {
-                    sheet.back();
+            createConfirmationSheet("Download file", "Download " + dlName + " now?", null, new Runnable() {
+                @Override
+                public void run() {
                     addBacksideHook(new JSRunnable() {
+                        @Override
                         public void run() {
-                            if (fuseBlobHandler) {
-                                fireSaveBlobHandler();
-                            } else {
-                                window.open(furl, "New Window");
-                            }
+                            startDownload.run();
                         }
                     });
                 }
-            });
-            cancel.addActionListener(new ActionListener() {
-                public void actionPerformed(ActionEvent evt) {
-                    sheet.back();
-                }
-            });
-            sheet.getContentPane().setLayout(BoxLayout.y());
-            sheet.getContentPane().add(BorderLayout.centerEastWest(l, FlowLayout.encloseIn(ok, cancel), null));
-            sheet.show();
+            }).show();
         }
-        
+
     }
 
     

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -6806,7 +6806,11 @@ public class HTML5Implementation extends CodenameOneImplementation {
                     + "var cn1w = (!cn1a || cn1a.isActive) ? window.open(" + literal + ", '_blank') : null;"
                     + "if (!cn1w) { window.location.href = " + literal + "; }";
         } else {
-            script = guard + "window.open(" + literal + ", '_blank');";
+            // Report a blocked popup instead of returning as if it opened. The
+            // page-side null is the only evidence available -- there is no
+            // callback -- so turn it into a throw the host call propagates.
+            script = guard + "var cn1w = window.open(" + literal + ", '_blank');"
+                    + "if (!cn1w) { throw new Error('cn1: popup blocked'); }";
         }
         try {
             eval_(script);
@@ -6844,11 +6848,24 @@ public class HTML5Implementation extends CodenameOneImplementation {
             rest = url.substring(2);
         } else {
             int schemeEnd = url.indexOf("://");
-            if (schemeEnd < 0) {
-                // No authority to protect (mailto:, tel:, a bare storage path).
-                return ellipsizeTail(url);
+            if (schemeEnd >= 0) {
+                rest = url.substring(schemeEnd + 3);
+            } else {
+                int colon = url.indexOf(':');
+                if (colon > 0 && isSpecialScheme(url.substring(0, colon))) {
+                    // A special scheme tolerates missing slashes: browsers parse
+                    // http:host/path, and even http:/host/path, with host as the
+                    // authority. Without this the slashless form would skip the
+                    // parsing below and display its leading user info.
+                    rest = url.substring(colon + 1);
+                    while (rest.startsWith("/")) {
+                        rest = rest.substring(1);
+                    }
+                } else {
+                    // No authority to protect (mailto:, tel:, a bare path).
+                    return ellipsizeTail(url);
+                }
             }
-            rest = url.substring(schemeEnd + 3);
         }
         int authorityEnd = rest.length();
         for (int i = 0; i < rest.length(); i++) {
@@ -6882,6 +6899,18 @@ public class HTML5Implementation extends CodenameOneImplementation {
         // A lone trailing "/" is not worth an ellipsis.
         boolean hasPath = rest.length() - authorityEnd > 1;
         return hasPath ? authority + "/" + DISPLAY_URL_ELLIPSIS : authority;
+    }
+
+    /**
+     * The WHATWG URL "special" schemes, which browsers parse with an authority
+     * even when the {@code //} is missing.
+     */
+    private static boolean isSpecialScheme(String scheme) {
+        return "http".equalsIgnoreCase(scheme)
+                || "https".equalsIgnoreCase(scheme)
+                || "ws".equalsIgnoreCase(scheme)
+                || "wss".equalsIgnoreCase(scheme)
+                || "ftp".equalsIgnoreCase(scheme);
     }
 
     /**
@@ -6950,6 +6979,18 @@ public class HTML5Implementation extends CodenameOneImplementation {
     private boolean isGestureBackedHookAvailable() {
         return backsideHooksSemaphore > 0;
     }
+
+    /**
+     * Popup opens queued on a backside hook but not yet drained.
+     *
+     * <p>The semaphore counts pending drains, not unconsumed popup
+     * authorization. One gesture authorizes ONE {@code window.open()}: the
+     * first consumes the transient activation, so a second queued behind the
+     * same gesture drains in the same batch and is blocked. Only ever reserve a
+     * pending gesture for a single popup and send the rest to the Sheet, which
+     * earns them a gesture of their own.</p>
+     */
+    private int pendingPopupOpens;
 
     /**
      * True when the URL names something the browser itself can hand off, as
@@ -7046,11 +7087,18 @@ public class HTML5Implementation extends CodenameOneImplementation {
      * worse than the Sheet.</p>
      */
     private void openInNewWindowWithConfirmation(final String url, String prompt) {
-        if (isGestureBackedHookAvailable()) {
+        if (isGestureBackedHookAvailable() && pendingPopupOpens == 0) {
+            pendingPopupOpens++;
             addBacksideHook(new JSRunnable() {
                 @Override
                 public void run() {
-                    openUrlOnMainThread(url, false, false);
+                    try {
+                        if (!openUrlOnMainThread(url, false, false)) {
+                            _log("execute(): popup blocked for " + url);
+                        }
+                    } finally {
+                        pendingPopupOpens--;
+                    }
                 }
             });
             return;

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -651,10 +651,13 @@ public class HTML5Implementation extends CodenameOneImplementation {
     private static class GestureHook {
         final int generation;
         final JSRunnable runnable;
+        /** Run on the EDT instead, if a newer interaction supersedes this one. */
+        final Runnable superseded;
 
-        GestureHook(int generation, JSRunnable runnable) {
+        GestureHook(int generation, JSRunnable runnable, Runnable superseded) {
             this.generation = generation;
             this.runnable = runnable;
+            this.superseded = superseded;
         }
     }
 
@@ -664,7 +667,7 @@ public class HTML5Implementation extends CodenameOneImplementation {
      * activation, which is spent or expiring, so letting it consume this hook
      * would leave the popup blocked.
      */
-    private void addGestureOnlyHook(JSRunnable r) {
+    private void addGestureOnlyHook(JSRunnable r, Runnable superseded) {
         // Backstop against unbounded growth: a hook whose interaction is long
         // past can no longer be drained, which only happens if the EDT took
         // longer than the whole 5s drain burst to reach us.
@@ -673,7 +676,7 @@ public class HTML5Implementation extends CodenameOneImplementation {
                 gestureOnlyHooks.remove(i);
             }
         }
-        gestureOnlyHooks.add(new GestureHook(gestureGeneration, r));
+        gestureOnlyHooks.add(new GestureHook(gestureGeneration, r, superseded));
         if (pendingGestureDrains <= 0) {
             // Generation matching keeps an older drain from taking this hook,
             // but only a drain of THIS interaction will run it -- and there may
@@ -703,8 +706,22 @@ public class HTML5Implementation extends CodenameOneImplementation {
             }
         }
         gestureOnlyHooks.removeAll(due);
+        // Transient activation belongs to the WINDOW, not to this generation.
+        // If a newer interaction has since occurred, running these would spend
+        // the activation it just granted -- the newer interaction's own popup
+        // would then be blocked, having done nothing wrong. Hand them to their
+        // fallback instead.
+        boolean superseded = generation != gestureGeneration;
         for (int i = 0; i < due.size(); i++) {
-            due.get(i).runnable.run();
+            GestureHook hook = due.get(i);
+            if (superseded) {
+                _log("execute(): a newer interaction superseded a queued open");
+                if (hook.superseded != null) {
+                    callSerially(hook.superseded);
+                }
+            } else {
+                hook.runnable.run();
+            }
         }
     }
     
@@ -7314,21 +7331,37 @@ public class HTML5Implementation extends CodenameOneImplementation {
                         // A browser setting, an extension or an activation that
                         // expired before the drain can still block the one
                         // reserved attempt. Fall back to asking rather than
-                        // leaving the caller with a dead click. Re-entering is
-                        // safe and cannot loop: this generation's reservation is
-                        // already spent, so it lands on the Sheet. Hop to the
-                        // EDT first -- this runs on a hook drain.
+                        // leaving the caller with a dead click. Hop to the EDT
+                        // first -- this runs on a hook drain.
                         callSerially(new Runnable() {
                             @Override
                             public void run() {
-                                openInNewWindowWithConfirmation(url, prompt);
+                                showOpenConfirmation(url, prompt);
                             }
                         });
                     }
                 }
+            }, new Runnable() {
+                @Override
+                public void run() {
+                    // Superseded by a newer interaction. Ask rather than
+                    // re-queue: queueing again would open this URL off a
+                    // gesture the user made for something else.
+                    showOpenConfirmation(url, prompt);
+                }
             });
             return;
         }
+        showOpenConfirmation(url, prompt);
+    }
+
+    /**
+     * Asks the user whether to open {@code url}, and on OK queues the open
+     * against the tap that answered. Always shows the Sheet -- never queues a
+     * popup on its own -- so it is safe as the fallback for a hook that could
+     * not run.
+     */
+    private void showOpenConfirmation(final String url, final String prompt) {
         createConfirmationSheet("Open Link", prompt,
                 shortenUrlForDisplay(url), new Runnable() {
             @Override
@@ -7359,20 +7392,35 @@ public class HTML5Implementation extends CodenameOneImplementation {
                             callSerially(new Runnable() {
                                 @Override
                                 public void run() {
-                                    createConfirmationSheet("Open Link",
-                                            "Your browser blocked the new window."
-                                                    + " Open this link in the current tab instead?",
-                                            shortenUrlForDisplay(url), new Runnable() {
-                                        @Override
-                                        public void run() {
-                                            openUrlOnMainThread(url, true, false);
-                                        }
-                                    }).show();
+                                    showBlockedPopupFallback(url);
                                 }
                             });
                         }
                     }
+                }, new Runnable() {
+                    @Override
+                    public void run() {
+                        // The confirming tap was superseded before its drain
+                        // ran. Ask again rather than spend the newer gesture.
+                        showOpenConfirmation(url, prompt);
+                    }
                 });
+            }
+        }).show();
+    }
+
+    /**
+     * Last resort after a confirmed open was blocked anyway: offer the current
+     * tab, which needs no activation and so cannot be blocked in turn.
+     */
+    private void showBlockedPopupFallback(final String url) {
+        createConfirmationSheet("Open Link",
+                "Your browser blocked the new window."
+                        + " Open this link in the current tab instead?",
+                shortenUrlForDisplay(url), new Runnable() {
+            @Override
+            public void run() {
+                openUrlOnMainThread(url, true, false);
             }
         }).show();
     }
@@ -7517,8 +7565,14 @@ public class HTML5Implementation extends CodenameOneImplementation {
             } else {
                 // The no-blob leg opens a popup, so it needs the activation
                 // only a gesture-backed drain carries -- same reason its gate
-                // above is the stricter one.
-                addGestureOnlyHook(hook);
+                // above is the stricter one. If a newer interaction supersedes
+                // it, ask rather than spend that interaction's activation.
+                addGestureOnlyHook(hook, new Runnable() {
+                    @Override
+                    public void run() {
+                        showOpenConfirmation(url, "Open this link?");
+                    }
+                });
             }
 
         } else {
@@ -7538,7 +7592,12 @@ public class HTML5Implementation extends CodenameOneImplementation {
                     if (handlerRegistered) {
                         addBacksideHook(confirmed);
                     } else {
-                        addGestureOnlyHook(confirmed);
+                        addGestureOnlyHook(confirmed, new Runnable() {
+                            @Override
+                            public void run() {
+                                showOpenConfirmation(url, "Open this link?");
+                            }
+                        });
                     }
                 }
             }).show();

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -6896,7 +6896,20 @@ public class HTML5Implementation extends CodenameOneImplementation {
                 shortenUrlForDisplay(url), new Runnable() {
             @Override
             public void run() {
-                openUrlOnMainThread(url, false, false);
+                // This callback runs on the EDT, by which point the browser no
+                // longer counts the OK tap as an ongoing gesture -- opening
+                // from here would be discarded by a popup blocker, which is the
+                // very thing the Sheet exists to recover from. That tap did
+                // install a backside hook though (pointer handling calls
+                // installBacksideHooksInUserInteraction), so queue the open on
+                // it and let the drain perform it inside the gesture. Same
+                // shape as the download confirmation below.
+                addBacksideHook(new JSRunnable() {
+                    @Override
+                    public void run() {
+                        openUrlOnMainThread(url, false, false);
+                    }
+                });
             }
         }).show();
     }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/WorkingWithJavascriptJava009Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/WorkingWithJavascriptJava009Snippet.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Codename One in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import java.util.*;
+
+
+class WorkingWithJavascriptJava009Snippet {
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    void snippet() throws Exception {
+        // tag::working-with-javascript-java-009[]
+        // The default. Opens a new tab while the browser still considers a
+        // user gesture to be in progress, and navigates the page the app runs
+        // in when it doesn't. Never shows a confirmation sheet.
+        CN.setProperty("javascript.execute.target", "auto");
+
+        // Always navigate the page the app runs in. Never blocked and never
+        // prompts, but it unloads the app.
+        CN.setProperty("javascript.execute.target", "_self");
+
+        // Only ever open a new tab. When the browser blocks that, the port
+        // shows a confirmation sheet whose OK button supplies the gesture the
+        // browser wanted. This was the behavior before the property existed.
+        CN.setProperty("javascript.execute.target", "_blank");
+
+        CN.execute("https://www.codenameone.com/");
+        // end::working-with-javascript-java-009[]
+    }
+}

--- a/docs/developer-guide/Working-With-Javascript.asciidoc
+++ b/docs/developer-guide/Working-With-Javascript.asciidoc
@@ -609,7 +609,7 @@ NOTE: The Chrome App Launcher lists apps installed both via the Chrome Web Store
 
 People don't like it when the browser automatically starts playing sounds, or opening links without their permission. For this reason, modern browsers restrict your ability to programmatically do these things, unless they're in response to a user action, like a mouse click.
 
-If your app needs to play media (for example, `Media.play()`), or open a link (for example, `Display.execute("...")`) without the user actually interacting physically (for example, key press or pointer press), then it will display a popup dialog confirming that the user actually wants to perform this action.
+If your app needs to play media (for example, `Media.play()`) without the user actually interacting physically (for example, key press or pointer press), then it will display a popup dialog confirming that the user actually wants to perform this action. Opening a link (for example, `Display.execute("...")`) used to do the same, but now defaults to navigating the current page instead of prompting -- see <<opening-links>> below.
 
 Sometimes this dialog may affect the utility of the app. For example, suppose you want to play a video in response to a voice command. Having to press an "OK" button after the command, may be annoying. For such cases, you can use the `platformHint.javascript.backsideHooksInterval` property to *poll* for media play requests on an authorized event.
 
@@ -621,6 +621,36 @@ include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/g
 ----
 
 WARNING: Don't abuse this feature. You should enable this polling when necessary. For example, If your app enables the user to listen for voice commands, enable polling for the period of time that it's listening. When the user wants to stop listening, you should also stop the polling by setting the interval to "0."
+
+[id="opening-links", reftext="Opening links"]
+==== Choosing where a link opens
+
+Opening a link deserves its own note, because the restriction above bites almost every app that calls `Display.execute()`. Codename One dispatches events on its own EDT, so by the time your action listener runs, the browser no longer sees the tap as an ongoing user gesture and refuses to open a new window. Navigating the page the app already runs in has no such restriction: it always works, at the cost of unloading the app.
+
+The port picks between those two with the `javascript.execute.target` property:
+
+[cols="1,4"]
+|===
+|Value |Behavior
+
+|`auto`
+|The default. Opens a new tab while the page still has user activation, and navigates the current page when it doesn't. No confirmation sheet is ever shown.
+
+|`_blank`
+|Only ever opens a new tab. When the browser blocks that, the port shows a confirmation sheet whose OK button supplies the gesture the browser wanted. This was the behavior before the property existed.
+
+|`_self`
+|Always navigates the page the app runs in.
+|===
+
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/WorkingWithJavascriptJava009Snippet.java[tag=working-with-javascript-java-009,indent=0]
+----
+
+NOTE: Under `auto` and `_self` the app is unloaded whenever the current page navigates away, so persist anything you need before you call `execute()`. Pick `_blank` when keeping the app alive matters more than avoiding the sheet.
+
+The property only affects external links. A `javascript:` URL still evaluates on the page, and a `data:` URL or a path to a local file still becomes a download.
 
 [id="browsercomponent-lifecycle", reftext="BrowserComponent Lifecycle"]
 === BrowserComponent lifecycle

--- a/docs/developer-guide/Working-With-Javascript.asciidoc
+++ b/docs/developer-guide/Working-With-Javascript.asciidoc
@@ -650,7 +650,7 @@ include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/g
 
 NOTE: Under `auto` and `_self` the app is unloaded whenever the current page navigates away, so persist anything you need before you call `execute()`. Pick `_blank` when keeping the app alive matters more than avoiding the sheet.
 
-The property only affects external links. A `javascript:` URL still evaluates on the page, and a `data:` URL or a path to a local file still becomes a download.
+The property applies to any URL the browser can hand off, which means anything carrying a URI scheme. Custom deep links such as `imdb:///find?q=godfather` count, and so do protocol-relative `//host/path` URLs. The exceptions keep their existing meaning: a `javascript:` URL still evaluates on the page, and a `data:` URL, a `file:` URL or a path into local storage still becomes a download.
 
 [id="browsercomponent-lifecycle", reftext="BrowserComponent Lifecycle"]
 === BrowserComponent lifecycle


### PR DESCRIPTION
## Problem

Opening a link from the JavaScript port went through a confirmation `Sheet` whenever the browser no longer saw a live user gesture — which is almost always, since Codename One dispatches events on its own EDT, so by the time an action listener calls `Display.execute()` the browser has stopped counting the tap.

Three things were wrong:

1. **The sheet was unusable.** It put the buttons `EAST` of a `SpanLabel` holding the full URL. A URL has no spaces for `SpanLabel` to wrap on, so the label's preferred width blew past the screen and carried the buttons off-edge, where they could not be tapped.
2. **Its OK button recursed.** It called `CN.execute(furl)`, which re-entered `execute()` with still no gesture registered and could show the sheet again indefinitely.
3. **The non-sheet path could never have worked.** Every URL-opening path called `window.open(...)` from inside the Web Worker the app runs in, where `window.open` does not exist — so even the backside-hook path threw.

## Fix

A new `javascript.execute.target` property:

| Value | Behavior |
| --- | --- |
| `auto` | **New default.** Opens a new tab while the page still has user activation (`navigator.userActivation.isActive`), and navigates the current page otherwise. No sheet is ever shown, and no blocked-popup indicator either. |
| `_blank` | New tab only, with the sheet as the fallback. This is the previous behavior. |
| `_self` | Always navigate the page the app runs in. |

URL opening now routes through `eval_()`, which `port.js` already forwards to the `__cn1_eval_on_main__` host bridge (the same channel `Display.execute("javascript:...")` uses). No new host-bridge handler is needed, so this does not require a matching translator change, and a page built against an older `browser_bridge.js` degrades to the sheet instead of failing. The now-dead `windowOpen` native is removed.

Both sheets share a new `createConfirmationSheet()` that stacks message / shortened URL / buttons in `BoxLayout.y()`, so nothing can push the buttons out of reach. The URL is shortened (scheme stripped, host kept, ellipsized) into a `Label` with `setEndsWith3Points(true)`. OK now opens the URL directly rather than recursing.

## Docs

`Display.execute` gets a "JavaScript port" javadoc section explaining why the gesture is lost and listing the three target values; `CN.execute` cross-references it. The developer guide's *Playing media and opening links* section gains a *Choosing where a link opens* subsection with a value table and a snippet fixture — and its opening paragraph is corrected, since it still claimed links always prompt.

## Behavior change to be aware of

Under `auto` and `_self` the app is unloaded whenever the current page navigates away, losing in-memory state. This is documented in both the javadoc and the guide, with `_blank` named as the escape hatch for apps that need to stay alive.

## Verification

JS port sources and both snippet fixtures compile; `validate-guide-snippets.py`, `check-copyright-headers.sh`, Vale, asciidoctor, paragraph-capitalization and LanguageTool (0 matches) all pass locally. Not exercised in a real browser — the `auto` path's behavior against a live popup blocker is reasoned from the API contract rather than observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)