### PR TITLE
Stop padding a Sheet by a CSS corner radius (issue #5488)

### DIFF
--- a/CodenameOne/src/com/codename1/ui/Sheet.java
+++ b/CodenameOne/src/com/codename1/ui/Sheet.java
@@ -122,9 +122,6 @@ public class Sheet extends Container {
     private static final int W = 3;
     private static final int C = 4;
     private static final int DEFAULT_TRANSITION_DURATION = 300;
-    /// The styles a component presents: unselected, selected, pressed and disabled. Caps how many
-    /// content pane insets are kept, see `#recordContentPaneInset`.
-    private static final int CONTENT_PANE_STYLES = 4;
     private final Sheet parentSheet;
     private final Label title = new Label();
     private Component titleComponent = title;
@@ -983,21 +980,24 @@ public class Sheet extends Container {
         return null;
     }
 
-    /// Starts recording an inset for the given style of the content pane, replacing whatever was
-    /// recorded for it before.
+    /// Starts recording an inset for the given style of the content pane, dropping the entry
+    /// recorded for that style before along with any entry there is nothing left to restore for.
+    ///
+    /// Entries are not otherwise evicted. Dropping the oldest once a few have accumulated would be
+    /// wrong, because age does not say whether a style is still attached to the content pane, and
+    /// the alternative of asking the pane for its four styles would create the selected, pressed
+    /// and disabled ones on a pane that never had them, which registers elevation and surface
+    /// state. So an entry for a style that has been replaced is simply carried until the next
+    /// restore, where putting padding back into a detached style costs nothing.
     private ContentPaneInset recordContentPaneInset(Style style) {
         if (contentPaneInsets == null) {
             contentPaneInsets = new ArrayList<ContentPaneInset>();
         }
         for (int iter = contentPaneInsets.size() - 1; iter >= 0; iter--) {
-            if (contentPaneInsets.get(iter).style == style) { //NOPMD CompareObjectsWithEquals
+            ContentPaneInset recorded = contentPaneInsets.get(iter);
+            if (recorded.style == style || !recorded.isIntact()) { //NOPMD CompareObjectsWithEquals
                 contentPaneInsets.remove(iter);
             }
-        }
-        while (contentPaneInsets.size() >= CONTENT_PANE_STYLES) {
-            // A component presents four styles at most, so an older entry than that belongs to a
-            // style that has since been replaced and is no longer attached to the content pane
-            contentPaneInsets.remove(0);
         }
         ContentPaneInset inset = new ContentPaneInset(style);
         contentPaneInsets.add(inset);

--- a/CodenameOne/src/com/codename1/ui/Sheet.java
+++ b/CodenameOne/src/com/codename1/ui/Sheet.java
@@ -351,13 +351,10 @@ public class Sheet extends Container {
     /// Original padding values to prevent accumulation when showing the sheet multiple times.
     /// These are set the first time the sheet is shown and used as the base for safe area calculations.
     private int[] originalPadding = null;
-    /// Padding of the content pane as it was before a hand written `RoundRectBorder` inset it by its
-    /// corner radius, in top, bottom, left, right order and in the units of `#contentPaneInsetUnits`.
-    /// Null while no inset is applied, so restyling the sheet with a border that asks for no inset
-    /// puts the padding back instead of leaving the inset of the previous border behind.
-    private float[] contentPaneInset = null;
-    /// Padding units of the content pane as they were before the inset, null for pixels.
-    private byte[] contentPaneInsetUnits = null;
+    /// The padding a hand written `RoundRectBorder` replaced on the content pane, null while no
+    /// inset is applied. Restyling the sheet with a border that asks for no inset puts this back
+    /// rather than leaving the inset of the previous border behind.
+    private ContentPaneInset contentPaneInset;
     private Form form;
     private final Rectangle sheetBounds = new Rectangle();
     private boolean trackSheetBounds;
@@ -805,8 +802,17 @@ public class Sheet extends Container {
         // CSS asked for, so an inset here is padding the author never wrote, and on an empty
         // content pane it becomes a gap under the title, see issue 5488.
         if (border instanceof RoundRectBorder && !((RoundRectBorder) border).isCssBoxModel()) {
-            rememberContentPanePadding();
+            // The inset pads the current style of the content pane, so that is the style the
+            // padding is taken from and the one it is later put back into
+            Style contentStyle = contentPane.getStyle();
+            if (contentPaneInset == null || !contentPaneInset.isIntact(contentStyle)) {
+                // Nothing was inset yet, or what was inset is gone: a theme refresh replaced
+                // the style, or the padding was changed since. Either way the padding in front of
+                // us now is the one to preserve
+                contentPaneInset = new ContentPaneInset(contentStyle);
+            }
             $(contentPane).setPaddingMillimeters(((RoundRectBorder) border).getCornerRadius());
+            contentPaneInset.recordApplied(contentStyle);
         } else {
             // Restyling the sheet with a border that wants no inset has to take the inset of the
             // previous border back off, otherwise the gap survives the restyle
@@ -939,40 +945,16 @@ public class Sheet extends Container {
         }
     }
 
-    /// Stores the padding of the content pane as it is before the corner radius of a hand written
-    /// border insets it. Only the first inset is recorded, so showing the sheet again does not
-    /// record the inset as if it were the padding of the developer.
-    ///
-    /// The inset is written by the component selector, which pads the current style of the content
-    /// pane rather than all of its styles, so this reads that same style and
-    /// `#restoreContentPanePadding` writes back to it. The selected, pressed and disabled styles
-    /// are never insetted and so have nothing to restore.
-    private void rememberContentPanePadding() {
-        if (contentPaneInset != null) {
-            return;
-        }
-        Style cps = contentPane.getStyle();
-        contentPaneInset = new float[]{
-                cps.getPaddingFloatValue(false, Component.TOP),
-                cps.getPaddingFloatValue(false, Component.BOTTOM),
-                cps.getPaddingFloatValue(false, Component.LEFT),
-                cps.getPaddingFloatValue(false, Component.RIGHT)
-        };
-        byte[] units = cps.getPaddingUnit();
-        contentPaneInsetUnits = units == null ? null : new byte[]{units[0], units[1], units[2], units[3]};
-    }
-
-    /// Puts back the padding `#rememberContentPanePadding` stored, doing nothing when no inset was
-    /// ever applied so a content pane the developer padded is left alone.
+    /// Puts back the padding the corner radius of a hand written border replaced, when that inset
+    /// is still there to take off. Nothing happens when no inset was applied, when the style it was
+    /// applied to has since been replaced, by a theme refresh for instance, or when the padding has
+    /// been changed since, so a content pane padded by the developer is left as they left it.
     private void restoreContentPanePadding() {
         if (contentPaneInset == null) {
             return;
         }
-        Style cps = contentPane.getStyle();
-        cps.setPaddingUnit(contentPaneInsetUnits);
-        cps.setPadding(contentPaneInset[0], contentPaneInset[1], contentPaneInset[2], contentPaneInset[3]);
+        contentPaneInset.restore(contentPane.getStyle());
         contentPaneInset = null;
-        contentPaneInsetUnits = null;
     }
 
     /// Gets the position where the Sheet is to be displayed.
@@ -1487,5 +1469,87 @@ public class Sheet extends Container {
             g.setAlpha(alph);
         }
 
+    }
+
+    /// The padding of the content pane as it was before the corner radius of a hand written
+    /// `RoundRectBorder` replaced it, kept alongside the style that was padded and the padding the
+    /// inset wrote there. Restoring writes the old padding back only into a style that still holds
+    /// exactly what the inset left, so a theme refresh that swaps the style, or a developer padding
+    /// the content pane between two shows, drops the snapshot rather than overwriting their work.
+    ///
+    /// The inset is applied through the component selector, which pads the current style of the
+    /// content pane rather than all of its styles, so only that one style is ever recorded. The
+    /// selected, pressed and disabled styles are not part of the inset and have nothing to restore.
+    private static class ContentPaneInset {
+        private final Style style;
+        private final float[] padding;
+        private final byte[] units;
+        private float[] appliedPadding;
+        private byte[] appliedUnits;
+
+        ContentPaneInset(Style style) {
+            this.style = style;
+            padding = paddingOf(style);
+            units = unitsOf(style);
+        }
+
+        /// Records what the inset left in the style, which is what `#isIntact` looks for later.
+        void recordApplied(Style inset) {
+            appliedPadding = paddingOf(inset);
+            appliedUnits = unitsOf(inset);
+        }
+
+        /// True when the given style is the one that was inset and still holds that inset.
+        boolean isIntact(Style current) {
+            return current == style //NOPMD CompareObjectsWithEquals
+                    && appliedPadding != null
+                    && same(paddingOf(current), appliedPadding)
+                    && same(unitsOf(current), appliedUnits);
+        }
+
+        /// Puts the padding back if the inset it replaced is still in place, otherwise leaves the
+        /// style alone.
+        void restore(Style current) {
+            if (!isIntact(current)) {
+                return;
+            }
+            current.setPaddingUnit(units);
+            current.setPadding(padding[0], padding[1], padding[2], padding[3]);
+        }
+
+        private static float[] paddingOf(Style s) {
+            return new float[]{
+                    s.getPaddingFloatValue(false, Component.TOP),
+                    s.getPaddingFloatValue(false, Component.BOTTOM),
+                    s.getPaddingFloatValue(false, Component.LEFT),
+                    s.getPaddingFloatValue(false, Component.RIGHT)
+            };
+        }
+
+        private static byte[] unitsOf(Style s) {
+            byte[] u = s.getPaddingUnit();
+            return u == null ? null : new byte[]{u[0], u[1], u[2], u[3]};
+        }
+
+        private static boolean same(float[] a, float[] b) {
+            for (int i = 0; i < a.length; i++) {
+                if (a[i] != b[i]) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private static boolean same(byte[] a, byte[] b) {
+            if (a == null || b == null) {
+                return a == b; //NOPMD CompareObjectsWithEquals
+            }
+            for (int i = 0; i < a.length; i++) {
+                if (a[i] != b[i]) {
+                    return false;
+                }
+            }
+            return true;
+        }
     }
 }

--- a/CodenameOne/src/com/codename1/ui/Sheet.java
+++ b/CodenameOne/src/com/codename1/ui/Sheet.java
@@ -810,11 +810,12 @@ public class Sheet extends Container {
             // pads the disabled style. Each style that gets inset is recorded separately
             Style contentStyle = contentPane.getStyle();
             ContentPaneInset inset = contentPaneInsetFor(contentStyle);
-            if (inset == null || !inset.isIntact()) {
-                // Nothing was inset in this style yet, or what was inset is gone because the
-                // padding was changed since. Either way the padding in front of us now is the one
-                // to preserve
+            if (inset == null) {
                 inset = recordContentPaneInset(contentStyle);
+            } else {
+                // A side that no longer holds the inset was padded since, so the padding in front
+                // of us now is the one to preserve for that side
+                inset.rememberChangedSides();
             }
             $(contentPane).setPaddingMillimeters(((RoundRectBorder) border).getCornerRadius());
             inset.recordApplied();
@@ -995,7 +996,7 @@ public class Sheet extends Container {
         }
         for (int iter = contentPaneInsets.size() - 1; iter >= 0; iter--) {
             ContentPaneInset recorded = contentPaneInsets.get(iter);
-            if (recorded.style == style || !recorded.isIntact()) { //NOPMD CompareObjectsWithEquals
+            if (recorded.style == style || !recorded.hasIntactSide()) { //NOPMD CompareObjectsWithEquals
                 contentPaneInsets.remove(iter);
             }
         }
@@ -1520,8 +1521,9 @@ public class Sheet extends Container {
 
     /// The padding of one style of the content pane as it was before the corner radius of a hand
     /// written `RoundRectBorder` replaced it, kept alongside that style and the padding the inset
-    /// wrote into it. Restoring writes the old padding back only while the style still holds
-    /// exactly what the inset left, so padding changed since is not overwritten.
+    /// wrote into it. Each side is tracked on its own: a side is put back only while it still holds
+    /// what the inset wrote there, so padding changed since is not overwritten, and changing one
+    /// side does not strand the inset on the other three.
     ///
     /// The inset is applied through the component selector, which pads the style the content pane
     /// presents at the time rather than all of its styles. Which style that is follows the state of
@@ -1529,74 +1531,102 @@ public class Sheet extends Container {
     /// even if the pane is disabled by the time the sheet is restyled. Hence the style is held
     /// here, and the sheet keeps one of these per style it inset.
     private static class ContentPaneInset {
+        /// The sides of a style, in the order `Style#getPaddingUnit` indexes them.
+        private static final int[] SIDES = {Component.TOP, Component.LEFT, Component.BOTTOM, Component.RIGHT};
         private final Style style;
-        private final float[] padding;
-        private final byte[] units;
+        private final float[] padding = new float[SIDES.length];
+        private final byte[] units = new byte[SIDES.length];
         private float[] appliedPadding;
         private byte[] appliedUnits;
 
         ContentPaneInset(Style style) {
             this.style = style;
-            padding = paddingOf(style);
-            units = unitsOf(style);
+            for (int iter = 0; iter < SIDES.length; iter++) {
+                remember(SIDES[iter]);
+            }
+        }
+
+        /// Takes the padding of the given side as the one to put back.
+        private void remember(int side) {
+            padding[side] = style.getPaddingFloatValue(false, side);
+            units[side] = unitOf(style, side);
+        }
+
+        /// Takes the padding of every side the inset no longer holds as the one to put back. Called
+        /// before insetting again, so a side padded since the last inset keeps the padding it was
+        /// given rather than the one from before that inset.
+        void rememberChangedSides() {
+            if (appliedPadding == null) {
+                return;
+            }
+            for (int iter = 0; iter < SIDES.length; iter++) {
+                if (!isIntact(SIDES[iter])) {
+                    remember(SIDES[iter]);
+                }
+            }
         }
 
         /// Records what the inset left in the style, which is what `#isIntact` looks for later.
         void recordApplied() {
-            appliedPadding = paddingOf(style);
-            appliedUnits = unitsOf(style);
+            appliedPadding = new float[SIDES.length];
+            appliedUnits = new byte[SIDES.length];
+            for (int iter = 0; iter < SIDES.length; iter++) {
+                int side = SIDES[iter];
+                appliedPadding[side] = style.getPaddingFloatValue(false, side);
+                appliedUnits[side] = unitOf(style, side);
+            }
         }
 
-        /// True when the style still holds the inset that was applied to it.
-        boolean isIntact() {
+        /// True when the given side of the style still holds the inset that was applied to it.
+        boolean isIntact(int side) {
             return appliedPadding != null
-                    && same(paddingOf(style), appliedPadding)
-                    && same(unitsOf(style), appliedUnits);
+                    && style.getPaddingFloatValue(false, side) == appliedPadding[side]
+                    && unitOf(style, side) == appliedUnits[side];
         }
 
-        /// Puts the padding back if the inset it replaced is still in place, otherwise leaves the
-        /// style alone.
+        /// True when any side still holds its inset, meaning there is something left to restore.
+        boolean hasIntactSide() {
+            for (int iter = 0; iter < SIDES.length; iter++) {
+                if (isIntact(SIDES[iter])) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// Puts back the padding of every side that still holds its inset, leaving the sides that
+        /// were changed since as they are.
         void restore() {
-            if (!isIntact()) {
-                return;
+            for (int iter = 0; iter < SIDES.length; iter++) {
+                int side = SIDES[iter];
+                if (isIntact(side)) {
+                    setPaddingUnit(style, side, units[side]);
+                    style.setPadding(side, padding[side]);
+                }
             }
-            style.setPaddingUnit(units);
-            style.setPadding(padding[0], padding[1], padding[2], padding[3]);
         }
 
-        private static float[] paddingOf(Style s) {
-            return new float[]{
-                    s.getPaddingFloatValue(false, Component.TOP),
-                    s.getPaddingFloatValue(false, Component.BOTTOM),
-                    s.getPaddingFloatValue(false, Component.LEFT),
-                    s.getPaddingFloatValue(false, Component.RIGHT)
-            };
-        }
-
-        private static byte[] unitsOf(Style s) {
+        private static byte unitOf(Style s, int side) {
             byte[] u = s.getPaddingUnit();
-            return u == null ? null : new byte[]{u[0], u[1], u[2], u[3]};
+            // A style with no units of its own measures in pixels
+            return u == null ? Style.UNIT_TYPE_PIXELS : u[side];
         }
 
-        private static boolean same(float[] a, float[] b) {
-            for (int i = 0; i < a.length; i++) {
-                if (a[i] != b[i]) {
-                    return false;
-                }
+        private static void setPaddingUnit(Style s, int side, byte unit) {
+            switch (side) {
+                case Component.TOP:
+                    s.setPaddingUnitTop(unit);
+                    break;
+                case Component.BOTTOM:
+                    s.setPaddingUnitBottom(unit);
+                    break;
+                case Component.LEFT:
+                    s.setPaddingUnitLeft(unit);
+                    break;
+                default:
+                    s.setPaddingUnitRight(unit);
+                    break;
             }
-            return true;
-        }
-
-        private static boolean same(byte[] a, byte[] b) {
-            if (a == null || b == null) {
-                return a == b; //NOPMD CompareObjectsWithEquals
-            }
-            for (int i = 0; i < a.length; i++) {
-                if (a[i] != b[i]) {
-                    return false;
-                }
-            }
-            return true;
         }
     }
 }

--- a/CodenameOne/src/com/codename1/ui/Sheet.java
+++ b/CodenameOne/src/com/codename1/ui/Sheet.java
@@ -39,6 +39,8 @@ import com.codename1.ui.plaf.UIManager;
 import com.codename1.ui.util.EventDispatcher;
 import com.codename1.util.AsyncResource;
 
+import java.util.ArrayList;
+
 import static com.codename1.ui.ComponentSelector.$;
 
 /// A light-weight dialog that slides up from the bottom of the screen on mobile devices.
@@ -120,6 +122,9 @@ public class Sheet extends Container {
     private static final int W = 3;
     private static final int C = 4;
     private static final int DEFAULT_TRANSITION_DURATION = 300;
+    /// The styles a component presents: unselected, selected, pressed and disabled. Caps how many
+    /// content pane insets are kept, see `#recordContentPaneInset`.
+    private static final int CONTENT_PANE_STYLES = 4;
     private final Sheet parentSheet;
     private final Label title = new Label();
     private Component titleComponent = title;
@@ -351,10 +356,11 @@ public class Sheet extends Container {
     /// Original padding values to prevent accumulation when showing the sheet multiple times.
     /// These are set the first time the sheet is shown and used as the base for safe area calculations.
     private int[] originalPadding = null;
-    /// The padding a hand written `RoundRectBorder` replaced on the content pane, null while no
-    /// inset is applied. Restyling the sheet with a border that asks for no inset puts this back
-    /// rather than leaving the inset of the previous border behind.
-    private ContentPaneInset contentPaneInset;
+    /// The padding a hand written `RoundRectBorder` replaced on the content pane, one entry per
+    /// style it was applied to, null while no inset is applied. Restyling the sheet with a border
+    /// that asks for no inset puts these back rather than leaving the inset of the previous border
+    /// behind.
+    private ArrayList<ContentPaneInset> contentPaneInsets;
     private Form form;
     private final Rectangle sheetBounds = new Rectangle();
     private boolean trackSheetBounds;
@@ -802,17 +808,19 @@ public class Sheet extends Container {
         // CSS asked for, so an inset here is padding the author never wrote, and on an empty
         // content pane it becomes a gap under the title, see issue 5488.
         if (border instanceof RoundRectBorder && !((RoundRectBorder) border).isCssBoxModel()) {
-            // The inset pads the current style of the content pane, so that is the style the
-            // padding is taken from and the one it is later put back into
+            // The inset pads the current style of the content pane, which is not always the same
+            // style: it follows the state of the pane, so a sheet shown while the pane is disabled
+            // pads the disabled style. Each style that gets insetted is recorded separately
             Style contentStyle = contentPane.getStyle();
-            if (contentPaneInset == null || !contentPaneInset.isIntact(contentStyle)) {
-                // Nothing was inset yet, or what was inset is gone: a theme refresh replaced
-                // the style, or the padding was changed since. Either way the padding in front of
-                // us now is the one to preserve
-                contentPaneInset = new ContentPaneInset(contentStyle);
+            ContentPaneInset inset = contentPaneInsetFor(contentStyle);
+            if (inset == null || !inset.isIntact()) {
+                // Nothing was inset in this style yet, or what was inset is gone because the
+                // padding was changed since. Either way the padding in front of us now is the one
+                // to preserve
+                inset = recordContentPaneInset(contentStyle);
             }
             $(contentPane).setPaddingMillimeters(((RoundRectBorder) border).getCornerRadius());
-            contentPaneInset.recordApplied(contentStyle);
+            inset.recordApplied();
         } else {
             // Restyling the sheet with a border that wants no inset has to take the inset of the
             // previous border back off, otherwise the gap survives the restyle
@@ -945,16 +953,55 @@ public class Sheet extends Container {
         }
     }
 
-    /// Puts back the padding the corner radius of a hand written border replaced, when that inset
-    /// is still there to take off. Nothing happens when no inset was applied, when the style it was
-    /// applied to has since been replaced, by a theme refresh for instance, or when the padding has
-    /// been changed since, so a content pane padded by the developer is left as they left it.
+    /// Puts back the padding the corner radius of a hand written border replaced, in every style it
+    /// was applied to rather than only the style the content pane presents right now, which depends
+    /// on the state of the pane and may well be a different one by the time the sheet is restyled.
+    /// A style whose padding has been changed since is left alone, so a content pane padded by the
+    /// developer stays as they left it.
     private void restoreContentPanePadding() {
-        if (contentPaneInset == null) {
+        if (contentPaneInsets == null) {
             return;
         }
-        contentPaneInset.restore(contentPane.getStyle());
-        contentPaneInset = null;
+        for (int iter = 0; iter < contentPaneInsets.size(); iter++) {
+            contentPaneInsets.get(iter).restore();
+        }
+        contentPaneInsets = null;
+    }
+
+    /// The inset recorded for the given style of the content pane, null when that style was never
+    /// insetted.
+    private ContentPaneInset contentPaneInsetFor(Style style) {
+        if (contentPaneInsets == null) {
+            return null;
+        }
+        for (int iter = 0; iter < contentPaneInsets.size(); iter++) {
+            ContentPaneInset inset = contentPaneInsets.get(iter);
+            if (inset.style == style) { //NOPMD CompareObjectsWithEquals
+                return inset;
+            }
+        }
+        return null;
+    }
+
+    /// Starts recording an inset for the given style of the content pane, replacing whatever was
+    /// recorded for it before.
+    private ContentPaneInset recordContentPaneInset(Style style) {
+        if (contentPaneInsets == null) {
+            contentPaneInsets = new ArrayList<ContentPaneInset>();
+        }
+        for (int iter = contentPaneInsets.size() - 1; iter >= 0; iter--) {
+            if (contentPaneInsets.get(iter).style == style) { //NOPMD CompareObjectsWithEquals
+                contentPaneInsets.remove(iter);
+            }
+        }
+        while (contentPaneInsets.size() >= CONTENT_PANE_STYLES) {
+            // A component presents four styles at most, so an older entry than that belongs to a
+            // style that has since been replaced and is no longer attached to the content pane
+            contentPaneInsets.remove(0);
+        }
+        ContentPaneInset inset = new ContentPaneInset(style);
+        contentPaneInsets.add(inset);
+        return inset;
     }
 
     /// Gets the position where the Sheet is to be displayed.
@@ -1471,15 +1518,16 @@ public class Sheet extends Container {
 
     }
 
-    /// The padding of the content pane as it was before the corner radius of a hand written
-    /// `RoundRectBorder` replaced it, kept alongside the style that was padded and the padding the
-    /// inset wrote there. Restoring writes the old padding back only into a style that still holds
-    /// exactly what the inset left, so a theme refresh that swaps the style, or a developer padding
-    /// the content pane between two shows, drops the snapshot rather than overwriting their work.
+    /// The padding of one style of the content pane as it was before the corner radius of a hand
+    /// written `RoundRectBorder` replaced it, kept alongside that style and the padding the inset
+    /// wrote into it. Restoring writes the old padding back only while the style still holds
+    /// exactly what the inset left, so padding changed since is not overwritten.
     ///
-    /// The inset is applied through the component selector, which pads the current style of the
-    /// content pane rather than all of its styles, so only that one style is ever recorded. The
-    /// selected, pressed and disabled styles are not part of the inset and have nothing to restore.
+    /// The inset is applied through the component selector, which pads the style the content pane
+    /// presents at the time rather than all of its styles. Which style that is follows the state of
+    /// the pane, so an inset applied while it was enabled has to be taken off the unselected style
+    /// even if the pane is disabled by the time the sheet is restyled. Hence the style is held
+    /// here, and the sheet keeps one of these per style it insetted.
     private static class ContentPaneInset {
         private final Style style;
         private final float[] padding;
@@ -1494,27 +1542,26 @@ public class Sheet extends Container {
         }
 
         /// Records what the inset left in the style, which is what `#isIntact` looks for later.
-        void recordApplied(Style inset) {
-            appliedPadding = paddingOf(inset);
-            appliedUnits = unitsOf(inset);
+        void recordApplied() {
+            appliedPadding = paddingOf(style);
+            appliedUnits = unitsOf(style);
         }
 
-        /// True when the given style is the one that was inset and still holds that inset.
-        boolean isIntact(Style current) {
-            return current == style //NOPMD CompareObjectsWithEquals
-                    && appliedPadding != null
-                    && same(paddingOf(current), appliedPadding)
-                    && same(unitsOf(current), appliedUnits);
+        /// True when the style still holds the inset that was applied to it.
+        boolean isIntact() {
+            return appliedPadding != null
+                    && same(paddingOf(style), appliedPadding)
+                    && same(unitsOf(style), appliedUnits);
         }
 
         /// Puts the padding back if the inset it replaced is still in place, otherwise leaves the
         /// style alone.
-        void restore(Style current) {
-            if (!isIntact(current)) {
+        void restore() {
+            if (!isIntact()) {
                 return;
             }
-            current.setPaddingUnit(units);
-            current.setPadding(padding[0], padding[1], padding[2], padding[3]);
+            style.setPaddingUnit(units);
+            style.setPadding(padding[0], padding[1], padding[2], padding[3]);
         }
 
         private static float[] paddingOf(Style s) {

--- a/CodenameOne/src/com/codename1/ui/Sheet.java
+++ b/CodenameOne/src/com/codename1/ui/Sheet.java
@@ -990,6 +990,13 @@ public class Sheet extends Container {
     /// and disabled ones on a pane that never had them, which registers elevation and surface
     /// state. So an entry for a style that has been replaced is simply carried until the next
     /// restore, where putting padding back into a detached style costs nothing.
+    ///
+    /// One entry is added per style the content pane presents while a hand written border is in
+    /// effect, so the count is bounded by how often something replaces those styles, a theme
+    /// refresh in practice, between one show of this sheet and the show that takes the inset off.
+    /// Holding the styles weakly instead would let the list shrink on its own, but the portable
+    /// weak reference of the platform is allowed to report that it holds nothing, and treating that
+    /// as a style that went away would silently skip a restore that is still owed.
     private ContentPaneInset recordContentPaneInset(Style style) {
         if (contentPaneInsets == null) {
             contentPaneInsets = new ArrayList<ContentPaneInset>();

--- a/CodenameOne/src/com/codename1/ui/Sheet.java
+++ b/CodenameOne/src/com/codename1/ui/Sheet.java
@@ -807,7 +807,7 @@ public class Sheet extends Container {
         if (border instanceof RoundRectBorder && !((RoundRectBorder) border).isCssBoxModel()) {
             // The inset pads the current style of the content pane, which is not always the same
             // style: it follows the state of the pane, so a sheet shown while the pane is disabled
-            // pads the disabled style. Each style that gets insetted is recorded separately
+            // pads the disabled style. Each style that gets inset is recorded separately
             Style contentStyle = contentPane.getStyle();
             ContentPaneInset inset = contentPaneInsetFor(contentStyle);
             if (inset == null || !inset.isIntact()) {
@@ -966,7 +966,7 @@ public class Sheet extends Container {
     }
 
     /// The inset recorded for the given style of the content pane, null when that style was never
-    /// insetted.
+    /// inset.
     private ContentPaneInset contentPaneInsetFor(Style style) {
         if (contentPaneInsets == null) {
             return null;
@@ -1527,7 +1527,7 @@ public class Sheet extends Container {
     /// presents at the time rather than all of its styles. Which style that is follows the state of
     /// the pane, so an inset applied while it was enabled has to be taken off the unselected style
     /// even if the pane is disabled by the time the sheet is restyled. Hence the style is held
-    /// here, and the sheet keeps one of these per style it insetted.
+    /// here, and the sheet keeps one of these per style it inset.
     private static class ContentPaneInset {
         private final Style style;
         private final float[] padding;

--- a/CodenameOne/src/com/codename1/ui/Sheet.java
+++ b/CodenameOne/src/com/codename1/ui/Sheet.java
@@ -960,8 +960,8 @@ public class Sheet extends Container {
         if (contentPaneInsets == null) {
             return;
         }
-        for (int iter = 0; iter < contentPaneInsets.size(); iter++) {
-            contentPaneInsets.get(iter).restore();
+        for (ContentPaneInset inset : contentPaneInsets) {
+            inset.restore();
         }
         contentPaneInsets = null;
     }
@@ -972,8 +972,7 @@ public class Sheet extends Container {
         if (contentPaneInsets == null) {
             return null;
         }
-        for (int iter = 0; iter < contentPaneInsets.size(); iter++) {
-            ContentPaneInset inset = contentPaneInsets.get(iter);
+        for (ContentPaneInset inset : contentPaneInsets) {
             if (inset.style == style) { //NOPMD CompareObjectsWithEquals
                 return inset;
             }
@@ -1548,8 +1547,8 @@ public class Sheet extends Container {
 
         ContentPaneInset(Style style) {
             this.style = style;
-            for (int iter = 0; iter < SIDES.length; iter++) {
-                remember(SIDES[iter]);
+            for (int side : SIDES) {
+                remember(side);
             }
         }
 
@@ -1566,9 +1565,9 @@ public class Sheet extends Container {
             if (appliedPadding == null) {
                 return;
             }
-            for (int iter = 0; iter < SIDES.length; iter++) {
-                if (!isIntact(SIDES[iter])) {
-                    remember(SIDES[iter]);
+            for (int side : SIDES) {
+                if (!isIntact(side)) {
+                    remember(side);
                 }
             }
         }
@@ -1577,8 +1576,7 @@ public class Sheet extends Container {
         void recordApplied() {
             appliedPadding = new float[SIDES.length];
             appliedUnits = new byte[SIDES.length];
-            for (int iter = 0; iter < SIDES.length; iter++) {
-                int side = SIDES[iter];
+            for (int side : SIDES) {
                 appliedPadding[side] = style.getPaddingFloatValue(false, side);
                 appliedUnits[side] = unitOf(style, side);
             }
@@ -1593,8 +1591,8 @@ public class Sheet extends Container {
 
         /// True when any side still holds its inset, meaning there is something left to restore.
         boolean hasIntactSide() {
-            for (int iter = 0; iter < SIDES.length; iter++) {
-                if (isIntact(SIDES[iter])) {
+            for (int side : SIDES) {
+                if (isIntact(side)) {
                     return true;
                 }
             }
@@ -1604,8 +1602,7 @@ public class Sheet extends Container {
         /// Puts back the padding of every side that still holds its inset, leaving the sides that
         /// were changed since as they are.
         void restore() {
-            for (int iter = 0; iter < SIDES.length; iter++) {
-                int side = SIDES[iter];
+            for (int side : SIDES) {
                 if (isIntact(side)) {
                     setPaddingUnit(style, side, units[side]);
                     style.setPadding(side, padding[side]);

--- a/CodenameOne/src/com/codename1/ui/Sheet.java
+++ b/CodenameOne/src/com/codename1/ui/Sheet.java
@@ -795,7 +795,14 @@ public class Sheet extends Container {
         if (border instanceof RoundRectBorder) {
             RoundRectBorder b = (RoundRectBorder) border;
 
-            $(contentPane).setPaddingMillimeters(b.getCornerRadius());
+            // A hand written RoundRectBorder reserves twice the radius of its own, so insetting
+            // the content pane by the radius keeps the content clear of the rounded corners. A
+            // border that came out of a stylesheet reserves nothing and the padding of the sheet
+            // is whatever the CSS asked for, so an inset here is padding the author never wrote,
+            // and on an empty content pane it becomes a gap under the title, see issue 5488.
+            if (!b.isCssBoxModel()) {
+                $(contentPane).setPaddingMillimeters(b.getCornerRadius());
+            }
         }
 
         // Deal with iPhoneX notch.

--- a/CodenameOne/src/com/codename1/ui/Sheet.java
+++ b/CodenameOne/src/com/codename1/ui/Sheet.java
@@ -351,6 +351,13 @@ public class Sheet extends Container {
     /// Original padding values to prevent accumulation when showing the sheet multiple times.
     /// These are set the first time the sheet is shown and used as the base for safe area calculations.
     private int[] originalPadding = null;
+    /// Padding of the content pane as it was before a hand written `RoundRectBorder` inset it by its
+    /// corner radius, in top, bottom, left, right order and in the units of `#contentPaneInsetUnits`.
+    /// Null while no inset is applied, so restyling the sheet with a border that asks for no inset
+    /// puts the padding back instead of leaving the inset of the previous border behind.
+    private float[] contentPaneInset = null;
+    /// Padding units of the content pane as they were before the inset, null for pixels.
+    private byte[] contentPaneInsetUnits = null;
     private Form form;
     private final Rectangle sheetBounds = new Rectangle();
     private boolean trackSheetBounds;
@@ -792,17 +799,18 @@ public class Sheet extends Container {
         titleParentStyle.setMarginLeft(titleMargin);
         titleParentStyle.setMarginRight(titleMargin);
         Border border = s.getBorder();
-        if (border instanceof RoundRectBorder) {
-            RoundRectBorder b = (RoundRectBorder) border;
-
-            // A hand written RoundRectBorder reserves twice the radius of its own, so insetting
-            // the content pane by the radius keeps the content clear of the rounded corners. A
-            // border that came out of a stylesheet reserves nothing and the padding of the sheet
-            // is whatever the CSS asked for, so an inset here is padding the author never wrote,
-            // and on an empty content pane it becomes a gap under the title, see issue 5488.
-            if (!b.isCssBoxModel()) {
-                $(contentPane).setPaddingMillimeters(b.getCornerRadius());
-            }
+        // A hand written RoundRectBorder reserves twice the radius of its own, so insetting the
+        // content pane by the radius keeps the content clear of the rounded corners. A border that
+        // came out of a stylesheet reserves nothing and the padding of the sheet is whatever the
+        // CSS asked for, so an inset here is padding the author never wrote, and on an empty
+        // content pane it becomes a gap under the title, see issue 5488.
+        if (border instanceof RoundRectBorder && !((RoundRectBorder) border).isCssBoxModel()) {
+            rememberContentPanePadding();
+            $(contentPane).setPaddingMillimeters(((RoundRectBorder) border).getCornerRadius());
+        } else {
+            // Restyling the sheet with a border that wants no inset has to take the inset of the
+            // previous border back off, otherwise the gap survives the restyle
+            restoreContentPanePadding();
         }
 
         // Deal with iPhoneX notch.
@@ -929,6 +937,37 @@ public class Sheet extends Container {
             this.setY(getHiddenY(cnt));
             cnt.animateLayout(duration);
         }
+    }
+
+    /// Stores the padding of the content pane as it is before the corner radius of a hand written
+    /// border insets it. Only the first inset is recorded, so showing the sheet again does not
+    /// record the inset as if it were the padding of the developer.
+    private void rememberContentPanePadding() {
+        if (contentPaneInset != null) {
+            return;
+        }
+        Style cps = contentPane.getStyle();
+        contentPaneInset = new float[]{
+                cps.getPaddingFloatValue(false, Component.TOP),
+                cps.getPaddingFloatValue(false, Component.BOTTOM),
+                cps.getPaddingFloatValue(false, Component.LEFT),
+                cps.getPaddingFloatValue(false, Component.RIGHT)
+        };
+        byte[] units = cps.getPaddingUnit();
+        contentPaneInsetUnits = units == null ? null : new byte[]{units[0], units[1], units[2], units[3]};
+    }
+
+    /// Puts back the padding `#rememberContentPanePadding` stored, doing nothing when no inset was
+    /// ever applied so a content pane the developer padded is left alone.
+    private void restoreContentPanePadding() {
+        if (contentPaneInset == null) {
+            return;
+        }
+        Style cps = contentPane.getAllStyles();
+        cps.setPaddingUnit(contentPaneInsetUnits);
+        cps.setPadding(contentPaneInset[0], contentPaneInset[1], contentPaneInset[2], contentPaneInset[3]);
+        contentPaneInset = null;
+        contentPaneInsetUnits = null;
     }
 
     /// Gets the position where the Sheet is to be displayed.

--- a/CodenameOne/src/com/codename1/ui/Sheet.java
+++ b/CodenameOne/src/com/codename1/ui/Sheet.java
@@ -942,6 +942,11 @@ public class Sheet extends Container {
     /// Stores the padding of the content pane as it is before the corner radius of a hand written
     /// border insets it. Only the first inset is recorded, so showing the sheet again does not
     /// record the inset as if it were the padding of the developer.
+    ///
+    /// The inset is written by the component selector, which pads the current style of the content
+    /// pane rather than all of its styles, so this reads that same style and
+    /// `#restoreContentPanePadding` writes back to it. The selected, pressed and disabled styles
+    /// are never insetted and so have nothing to restore.
     private void rememberContentPanePadding() {
         if (contentPaneInset != null) {
             return;
@@ -963,7 +968,7 @@ public class Sheet extends Container {
         if (contentPaneInset == null) {
             return;
         }
-        Style cps = contentPane.getAllStyles();
+        Style cps = contentPane.getStyle();
         cps.setPaddingUnit(contentPaneInsetUnits);
         cps.setPadding(contentPaneInset[0], contentPaneInset[1], contentPaneInset[2], contentPaneInset[3]);
         contentPaneInset = null;

--- a/maven/core-unittests/src/test/java/com/codename1/ui/SheetCssBorderRadiusTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/SheetCssBorderRadiusTest.java
@@ -27,9 +27,9 @@ import com.codename1.junit.UITestBase;
 import com.codename1.ui.layouts.BorderLayout;
 import com.codename1.ui.layouts.BoxLayout;
 import com.codename1.ui.plaf.RoundRectBorder;
+import com.codename1.ui.plaf.Style;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /// How a `border-radius` coming out of a stylesheet may pad a `Sheet`.
 ///
@@ -97,6 +97,52 @@ class SheetCssBorderRadiusTest extends UITestBase {
                 "a hand written radius keeps insetting the content pane");
         assertEquals(radius, sheet.getContentPane().getStyle().getPaddingLeftNoRTL(),
                 "a hand written radius keeps insetting the content pane");
+    }
+
+    @FormTest
+    void restylingToACssBorderTakesTheLegacyInsetBackOff() {
+        // The inset of a hand written border is written into the style of the content pane, so a
+        // sheet restyled with a CSS sized border has to have it removed rather than merely not
+        // reapplied, otherwise the gap outlives the restyle.
+        Sheet sheet = showSheet(RoundRectBorder.create().cornerRadius(4f));
+        assertEquals(Display.getInstance().convertToPixels(4f),
+                sheet.getContentPane().getStyle().getPaddingTop(),
+                "the hand written border insets the content pane on the first show");
+
+        sheet.getAllStyles().setBorder(cssBorder());
+        show(sheet);
+
+        assertEquals(0, sheet.getContentPane().getStyle().getPaddingTop(),
+                "the inset of the previous border may not survive the restyle");
+        assertEquals(0, sheet.getContentPane().getStyle().getPaddingLeftNoRTL(),
+                "the inset of the previous border may not survive the restyle");
+    }
+
+    @FormTest
+    void restylingRestoresThePaddingTheDeveloperSet() {
+        // Restoring must not zero the content pane, it puts back whatever was there before the
+        // border inset it, in the units it was written in.
+        Sheet sheet = new Sheet(null, "Title");
+        sheet.getContentPane().getAllStyles().setPaddingUnit(Style.UNIT_TYPE_DIPS);
+        sheet.getContentPane().getAllStyles().setPadding(1f, 1f, 2f, 2f);
+        sheet.getAllStyles().setBorder(RoundRectBorder.create().cornerRadius(4f));
+        zeroBox(sheet);
+        sheet.getContentPane().add(new Label("Test label 1"));
+        show(sheet);
+        assertEquals(Display.getInstance().convertToPixels(4f),
+                sheet.getContentPane().getStyle().getPaddingTop(),
+                "the hand written border insets the content pane on the first show");
+
+        sheet.getAllStyles().setBorder(cssBorder());
+        show(sheet);
+
+        Style contentStyle = sheet.getContentPane().getStyle();
+        assertEquals(Display.getInstance().convertToPixels(1f), contentStyle.getPaddingTop(),
+                "the padding of the developer comes back, in millimetres");
+        assertEquals(Display.getInstance().convertToPixels(2f), contentStyle.getPaddingLeftNoRTL(),
+                "the padding of the developer comes back, in millimetres");
+        assertEquals(Style.UNIT_TYPE_DIPS, contentStyle.getPaddingUnit()[Component.TOP],
+                "the padding unit of the developer comes back too");
     }
 
     private RoundRectBorder cssBorder() {

--- a/maven/core-unittests/src/test/java/com/codename1/ui/SheetCssBorderRadiusTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/SheetCssBorderRadiusTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.ui;
+
+import com.codename1.junit.FormTest;
+import com.codename1.junit.UITestBase;
+import com.codename1.ui.layouts.BorderLayout;
+import com.codename1.ui.layouts.BoxLayout;
+import com.codename1.ui.plaf.RoundRectBorder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/// How a `border-radius` coming out of a stylesheet may pad a `Sheet`.
+///
+/// A rule such as
+///
+/// ```css
+/// cntSheet { border-radius: 4mm 4mm 0mm 0mm; padding: 0mm; margin: 0mm; border: none; }
+/// ```
+///
+/// compiles to a `RoundRectBorder` (a `CSSBorder` before the JS port native themes work),
+/// and `Sheet.show` used to inset the content pane by the corner radius for every
+/// `RoundRectBorder` it saw. With `padding: 0mm` in the stylesheet that inset is padding
+/// the author never wrote and it renders as a band of empty space under the title, which is
+/// [issue 5488](https://github.com/codenameone/CodenameOne/issues/5488). The inset stays for
+/// hand written borders, which reserve twice the radius of their own.
+class SheetCssBorderRadiusTest extends UITestBase {
+
+    @FormTest
+    void cssSizedBorderDoesNotPadTheContentPane() {
+        Sheet sheet = showSheet(cssBorder());
+
+        Container contentPane = sheet.getContentPane();
+        assertEquals(0, contentPane.getStyle().getPaddingTop(),
+                "a stylesheet radius may not add padding above the content");
+        assertEquals(0, contentPane.getStyle().getPaddingBottom(),
+                "a stylesheet radius may not add padding below the content");
+        assertEquals(0, contentPane.getStyle().getPaddingLeftNoRTL(),
+                "a stylesheet radius may not indent the content");
+        assertEquals(0, contentPane.getStyle().getPaddingRightNoRTL(),
+                "a stylesheet radius may not indent the content");
+    }
+
+    @FormTest
+    void cssSizedBorderLeavesNoGapUnderTheTitle() {
+        // The reported app lays the sheet itself out in a Y box and adds to it directly, so the
+        // empty content pane sits between the title bar and the content: any padding it picks up
+        // is visible as a gap.
+        Sheet sheet = new Sheet(null, "Title");
+        sheet.getAllStyles().setBorder(cssBorder());
+        zeroBox(sheet);
+        sheet.setLayout(BoxLayout.y());
+        Label first = new Label("Test label 1");
+        sheet.add(first);
+        sheet.add(new Label("Test label 2"));
+        show(sheet);
+
+        Container contentPane = sheet.getContentPane();
+        assertEquals(0, contentPane.getPreferredH(),
+                "the empty content pane may not reserve height for the corner radius");
+        assertEquals(0, contentPane.getHeight(),
+                "the empty content pane may not take up height under the title");
+        int gap = first.getY() - (contentPane.getY() + contentPane.getHeight());
+        assertEquals(first.getStyle().getMarginTop(), gap,
+                "the first label must follow the title bar with nothing but its own margin above it");
+    }
+
+    @FormTest
+    void handWrittenBorderStillInsetsTheContentPane() {
+        // Legacy sizing: the border reserves twice the radius, so the content pane is inset by the
+        // radius to keep content clear of the rounded corners. That behavior is unchanged.
+        Sheet sheet = showSheet(RoundRectBorder.create().cornerRadius(4f));
+
+        int radius = Display.getInstance().convertToPixels(4f);
+        assertEquals(radius, sheet.getContentPane().getStyle().getPaddingTop(),
+                "a hand written radius keeps insetting the content pane");
+        assertEquals(radius, sheet.getContentPane().getStyle().getPaddingLeftNoRTL(),
+                "a hand written radius keeps insetting the content pane");
+    }
+
+    private RoundRectBorder cssBorder() {
+        // What the CSS compiler emits for border-radius: 4mm 4mm 0mm 0mm
+        return RoundRectBorder.create()
+                .cornerRadius(4f)
+                .topLeftMode(true)
+                .topRightMode(true)
+                .bottomLeftMode(false)
+                .bottomRightMode(false)
+                .cssBoxModel(true);
+    }
+
+    private Sheet showSheet(RoundRectBorder border) {
+        Sheet sheet = new Sheet(null, "Title");
+        sheet.getAllStyles().setBorder(border);
+        zeroBox(sheet);
+        sheet.getContentPane().add(new Label("Test label 1"));
+        sheet.getContentPane().add(new Label("Test label 2"));
+        show(sheet);
+        return sheet;
+    }
+
+    private void zeroBox(Sheet sheet) {
+        // padding: 0mm; margin: 0mm from the reported stylesheet
+        sheet.getAllStyles().setPadding(0, 0, 0, 0);
+        sheet.getAllStyles().setMargin(0, 0, 0, 0);
+    }
+
+    private void show(Sheet sheet) {
+        implementation.setBuiltinSoundsEnabled(false);
+        Form form = Display.getInstance().getCurrent();
+        form.setLayout(new BorderLayout());
+        sheet.show(0);
+        form.getAnimationManager().flush();
+        flushSerialCalls();
+        form.revalidate();
+    }
+}

--- a/maven/core-unittests/src/test/java/com/codename1/ui/SheetCssBorderRadiusTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/SheetCssBorderRadiusTest.java
@@ -145,6 +145,28 @@ class SheetCssBorderRadiusTest extends UITestBase {
                 "the padding unit of the developer comes back too");
     }
 
+    @FormTest
+    void restoringLeavesTheOtherStylesOfTheContentPaneAlone() {
+        // The inset pads the current style of the content pane, not all of its styles, so restoring
+        // may not write the padding of the current style over the selected, pressed and disabled
+        // styles the inset never touched.
+        Sheet sheet = new Sheet(null, "Title");
+        sheet.getContentPane().getSelectedStyle().setPadding(7, 7, 7, 7);
+        sheet.getContentPane().getPressedStyle().setPadding(9, 9, 9, 9);
+        sheet.getAllStyles().setBorder(RoundRectBorder.create().cornerRadius(4f));
+        zeroBox(sheet);
+        sheet.getContentPane().add(new Label("Test label 1"));
+        show(sheet);
+
+        sheet.getAllStyles().setBorder(cssBorder());
+        show(sheet);
+
+        assertEquals(7, sheet.getContentPane().getSelectedStyle().getPaddingTop(),
+                "the selected style of the content pane is not part of the inset");
+        assertEquals(9, sheet.getContentPane().getPressedStyle().getPaddingTop(),
+                "the pressed style of the content pane is not part of the inset");
+    }
+
     private RoundRectBorder cssBorder() {
         // What the CSS compiler emits for border-radius: 4mm 4mm 0mm 0mm
         return RoundRectBorder.create()

--- a/maven/core-unittests/src/test/java/com/codename1/ui/SheetCssBorderRadiusTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/SheetCssBorderRadiusTest.java
@@ -219,6 +219,30 @@ class SheetCssBorderRadiusTest extends UITestBase {
                 "the inset comes off the style it went into, not the style presented now");
     }
 
+    @FormTest
+    void everyStyleThatWasInsetIsRestoredHoweverManyThereAre() {
+        // Insets pile up one per style, and none of them may be evicted to make room: a style being
+        // the oldest recorded does not say it is gone, so evicting it would strand its inset.
+        Sheet sheet = showSheet(RoundRectBorder.create().cornerRadius(4f));
+        Style first = sheet.getContentPane().getStyle();
+        assertEquals(Display.getInstance().convertToPixels(4f), first.getPaddingTop(),
+                "the first style is inset by the hand written border");
+
+        for (int iter = 0; iter < 4; iter++) {
+            Style fresh = new Style(first);
+            fresh.setPaddingUnit(Style.UNIT_TYPE_PIXELS);
+            fresh.setPadding(0, 0, 0, 0);
+            sheet.getContentPane().setUnselectedStyle(fresh);
+            show(sheet);
+        }
+
+        sheet.getAllStyles().setBorder(cssBorder());
+        show(sheet);
+
+        assertEquals(0, first.getPaddingTop(),
+                "the style inset first is restored however many were recorded after it");
+    }
+
     private RoundRectBorder cssBorder() {
         // What the CSS compiler emits for border-radius: 4mm 4mm 0mm 0mm
         return RoundRectBorder.create()

--- a/maven/core-unittests/src/test/java/com/codename1/ui/SheetCssBorderRadiusTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/SheetCssBorderRadiusTest.java
@@ -243,6 +243,29 @@ class SheetCssBorderRadiusTest extends UITestBase {
                 "the style inset first is restored however many were recorded after it");
     }
 
+    @FormTest
+    void changingOneSideAfterTheInsetLeavesTheOtherThreeRestorable() {
+        // Each side stands on its own: padding one side after the inset says what that side should
+        // be, and says nothing about the three the inset is still sitting on.
+        Sheet sheet = showSheet(RoundRectBorder.create().cornerRadius(4f));
+        Style contentStyle = sheet.getContentPane().getStyle();
+
+        contentStyle.setPaddingUnitTop(Style.UNIT_TYPE_PIXELS);
+        contentStyle.setPadding(Component.TOP, 5f);
+
+        sheet.getAllStyles().setBorder(cssBorder());
+        show(sheet);
+
+        assertEquals(5, contentStyle.getPaddingTop(),
+                "the side padded after the inset keeps what it was given");
+        assertEquals(0, contentStyle.getPaddingBottom(),
+                "the sides still holding the inset are restored");
+        assertEquals(0, contentStyle.getPaddingLeftNoRTL(),
+                "the sides still holding the inset are restored");
+        assertEquals(0, contentStyle.getPaddingRightNoRTL(),
+                "the sides still holding the inset are restored");
+    }
+
     private RoundRectBorder cssBorder() {
         // What the CSS compiler emits for border-radius: 4mm 4mm 0mm 0mm
         return RoundRectBorder.create()

--- a/maven/core-unittests/src/test/java/com/codename1/ui/SheetCssBorderRadiusTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/SheetCssBorderRadiusTest.java
@@ -138,9 +138,9 @@ class SheetCssBorderRadiusTest extends UITestBase {
 
         Style contentStyle = sheet.getContentPane().getStyle();
         assertEquals(Display.getInstance().convertToPixels(1f), contentStyle.getPaddingTop(),
-                "the padding of the developer comes back, in millimetres");
+                "the padding of the developer comes back, in the unit it was written in");
         assertEquals(Display.getInstance().convertToPixels(2f), contentStyle.getPaddingLeftNoRTL(),
-                "the padding of the developer comes back, in millimetres");
+                "the padding of the developer comes back, in the unit it was written in");
         assertEquals(Style.UNIT_TYPE_DIPS, contentStyle.getPaddingUnit()[Component.TOP],
                 "the padding unit of the developer comes back too");
     }
@@ -165,6 +165,41 @@ class SheetCssBorderRadiusTest extends UITestBase {
                 "the selected style of the content pane is not part of the inset");
         assertEquals(9, sheet.getContentPane().getPressedStyle().getPaddingTop(),
                 "the pressed style of the content pane is not part of the inset");
+    }
+
+    @FormTest
+    void aThemeRefreshBetweenShowsDropsTheSnapshot() {
+        // Replacing the style of the content pane, which is what a theme refresh does, takes the
+        // inset with it. The snapshot then describes a style nobody is using any more and writing
+        // it into the fresh style would undo the theme.
+        Sheet sheet = showSheet(RoundRectBorder.create().cornerRadius(4f));
+
+        Style fresh = new Style(sheet.getContentPane().getStyle());
+        fresh.setPadding(3, 3, 3, 3);
+        fresh.setPaddingUnit(Style.UNIT_TYPE_PIXELS);
+        sheet.getContentPane().setUnselectedStyle(fresh);
+
+        sheet.getAllStyles().setBorder(cssBorder());
+        show(sheet);
+
+        assertEquals(3, sheet.getContentPane().getStyle().getPaddingTop(),
+                "the padding of the new style survives, the stale snapshot is dropped");
+    }
+
+    @FormTest
+    void paddingChangedBetweenShowsIsNotOverwritten() {
+        // The developer padding the content pane after the inset went on is saying what they want
+        // it to be. Restoring may not put the pre-inset padding back over that.
+        Sheet sheet = showSheet(RoundRectBorder.create().cornerRadius(4f));
+
+        sheet.getContentPane().getStyle().setPaddingUnit(Style.UNIT_TYPE_PIXELS);
+        sheet.getContentPane().getStyle().setPadding(5, 5, 5, 5);
+
+        sheet.getAllStyles().setBorder(cssBorder());
+        show(sheet);
+
+        assertEquals(5, sheet.getContentPane().getStyle().getPaddingTop(),
+                "padding set after the inset wins over the snapshot");
     }
 
     private RoundRectBorder cssBorder() {

--- a/maven/core-unittests/src/test/java/com/codename1/ui/SheetCssBorderRadiusTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/SheetCssBorderRadiusTest.java
@@ -202,6 +202,23 @@ class SheetCssBorderRadiusTest extends UITestBase {
                 "padding set after the inset wins over the snapshot");
     }
 
+    @FormTest
+    void disablingTheContentPaneBetweenShowsStillTakesTheInsetOff() {
+        // The style a component presents follows its state, so the pane being disabled by the time
+        // the sheet is restyled must not strand the inset in the unselected style it went into.
+        Sheet sheet = showSheet(RoundRectBorder.create().cornerRadius(4f));
+        assertEquals(Display.getInstance().convertToPixels(4f),
+                sheet.getContentPane().getUnselectedStyle().getPaddingTop(),
+                "the inset goes into the unselected style while the pane is enabled");
+
+        sheet.getContentPane().setEnabled(false);
+        sheet.getAllStyles().setBorder(cssBorder());
+        show(sheet);
+
+        assertEquals(0, sheet.getContentPane().getUnselectedStyle().getPaddingTop(),
+                "the inset comes off the style it went into, not the style presented now");
+    }
+
     private RoundRectBorder cssBorder() {
         // What the CSS compiler emits for border-radius: 4mm 4mm 0mm 0mm
         return RoundRectBorder.create()


### PR DESCRIPTION
Fixes #5488.

A stylesheet rule such as

```css
cntSheet { border-radius: 4mm 4mm 0mm 0mm; padding: 0mm; margin: 0mm; border: none; background: blue; }
```

renders a band of empty space under the sheet title in 7.0.262 that was not there in 7.0.233.

### Cause

The same border class switch behind #5454. PR #5054 made a simple `border-radius` compile to `RoundRectBorder` rather than `CSSBorder`, and `Sheet.show` has always inset the content pane by the corner radius for every `RoundRectBorder` it sees:

```java
$(contentPane).setPaddingMillimeters(b.getCornerRadius());
```

That inset exists because a hand written `RoundRectBorder` reserves twice its radius, so content would otherwise be drawn under the rounded corners. A border out of a stylesheet reserves nothing and the sheet is padded by whatever the CSS asked for, which here is nothing, so the inset is 4mm of padding on all four sides the author never wrote. The reported app lays the sheet out in a Y box and adds to it directly, so the empty content pane sits between the title bar and the labels, and those 8mm are the reported gap.

#5469 already stopped the radius from inflating the box, but the `cssBoxModel` flag it added never reached this padding line.

### Fix

Skip the inset for a CSS sized border, keep it for a hand written one. The default themes are unaffected: neither native theme defines a `Sheet` UIID, so the branch only runs for a sheet a developer styled, and a designer authored border is not flagged.

### Tests

New `SheetCssBorderRadiusTest`:

- `cssSizedBorderDoesNotPadTheContentPane` — the content pane picks up no padding on any side. Fails on master with 4px per side.
- `cssSizedBorderLeavesNoGapUnderTheTitle` — reproduces the reported layout, the empty content pane takes no height. Fails on master with 8px.
- `handWrittenBorderStillInsetsTheContentPane` — a legacy border is still inset by its radius, passes either way.

Full `core-unittests` suite: 4280 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
