### PR TITLE
Fail CI on any SpotBugs finding, fix the iOS keySet iterator

### DIFF
--- a/.github/scripts/generate-quality-report.py
+++ b/.github/scripts/generate-quality-report.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import html
 import os
 import shutil
+import sys
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from pathlib import Path
@@ -334,7 +335,17 @@ def _parse_spotbugs_report(report_path: Path) -> AnalysisReport:
     return AnalysisReport(totals=severities, findings=findings)
 
 
-def parse_spotbugs() -> Tuple[Dict[str, AnalysisReport], bool, Optional[str]]:
+def parse_spotbugs() -> Tuple[
+    Dict[str, AnalysisReport], bool, Optional[str], Dict[str, str]
+]:
+    """Parse every SpotBugs report found under the target directories.
+
+    Returns the per-project reports, whether any report file existed at all, a
+    summary error for the markdown, and the per-project parse errors. The
+    per-project errors are reported separately because a report that parsed and
+    a report that failed to parse can occur in the same run, and the gate has
+    to fail on the latter instead of silently checking only the former.
+    """
     report_paths: Dict[str, Path] = {}
     for target_dir in TARGET_DIRS:
         for candidate in ("spotbugsXml.xml", "spotbugs.xml"):
@@ -343,18 +354,22 @@ def parse_spotbugs() -> Tuple[Dict[str, AnalysisReport], bool, Optional[str]]:
                 report_paths[_spotbugs_project_label(target_dir)] = path
                 break
     if not report_paths:
-        return {}, False, None
+        return {}, False, None, {}
     reports: Dict[str, AnalysisReport] = {}
-    errors: List[str] = []
+    errors: Dict[str, str] = {}
     for label, report_path in report_paths.items():
         try:
             reports[label] = _parse_spotbugs_report(report_path)
         except ET.ParseError as error:
-            errors.append(f"unable to parse {report_path.name}: {error}")
+            errors[label] = f"unable to parse {report_path.name}: {error}"
     if reports:
-        return reports, True, None
-    error_message = errors[0] if errors else "unable to parse SpotBugs report"
-    return {}, True, error_message
+        return reports, True, None, errors
+    error_message = (
+        next(iter(errors.values()))
+        if errors
+        else "unable to parse SpotBugs report"
+    )
+    return {}, True, error_message, errors
 
 
 def _required_spotbugs_projects() -> List[str]:
@@ -362,7 +377,10 @@ def _required_spotbugs_projects() -> List[str]:
     return [item.strip() for item in env_value.split(os.pathsep) if item.strip()]
 
 
-def _enforce_spotbugs_gate(reports: Dict[str, AnalysisReport]) -> None:
+def _enforce_spotbugs_gate(
+    reports: Dict[str, AnalysisReport],
+    parse_errors: Dict[str, str],
+) -> None:
     """Fail the build on any SpotBugs finding in any analysed project.
 
     This gate deliberately has no allow-list of patterns. An allow-list only
@@ -372,6 +390,15 @@ def _enforce_spotbugs_gate(reports: Dict[str, AnalysisReport]) -> None:
     spotbugs-exclude.xml instead, scoped to the class or method they apply to
     and with a comment explaining why - that keeps the report itself at zero.
     """
+    if parse_errors:
+        print("\n❌ Build failed because a SpotBugs report could not be parsed:")
+        for label in sorted(parse_errors):
+            print(f"  - {label}: {parse_errors[label]}")
+        print(
+            "  An unparseable report cannot be checked for findings, so it "
+            "fails rather than counting as clean."
+        )
+        sys.exit(1)
     required = _required_spotbugs_projects()
     missing = [label for label in required if label not in reports]
     if missing:
@@ -383,7 +410,7 @@ def _enforce_spotbugs_gate(reports: Dict[str, AnalysisReport]) -> None:
             "  A missing report means the analysis never ran; that would let "
             "findings through unnoticed."
         )
-        exit(1)
+        sys.exit(1)
     violations: List[Tuple[str, Finding]] = []
     for label in sorted(reports):
         for finding in reports[label].findings:
@@ -399,7 +426,7 @@ def _enforce_spotbugs_gate(reports: Dict[str, AnalysisReport]) -> None:
         "<Match> for it to that project's spotbugs-exclude.xml with a comment "
         "explaining why."
     )
-    exit(1)
+    sys.exit(1)
 
 
 def parse_pmd() -> Optional[AnalysisReport]:
@@ -754,7 +781,7 @@ def build_report(
 
     tests = parse_surefire()
     coverage, class_entries = parse_jacoco()
-    spotbugs_reports, spotbugs_generated, spotbugs_error = parse_spotbugs()
+    spotbugs_reports, spotbugs_generated, spotbugs_error, _ = parse_spotbugs()
     pmd = parse_pmd()
     checkstyle = parse_checkstyle()
     benchmark_report = parse_benchmark()
@@ -860,8 +887,8 @@ def main() -> None:
         return
 
     # Enforce quality gates
-    spotbugs_reports, _, _ = parse_spotbugs()
-    _enforce_spotbugs_gate(spotbugs_reports)
+    spotbugs_reports, _, _, spotbugs_parse_errors = parse_spotbugs()
+    _enforce_spotbugs_gate(spotbugs_reports, spotbugs_parse_errors)
 
     pmd = parse_pmd()
     if pmd:
@@ -921,7 +948,7 @@ def main() -> None:
             print("\n❌ Build failed due to forbidden PMD violations:")
             for v in violations:
                 print(f"  - {v.rule}: {v.location} - {v.message}")
-            exit(1)
+            sys.exit(1)
 
     checkstyle = parse_checkstyle()
     if checkstyle:
@@ -931,7 +958,7 @@ def main() -> None:
             for v in violations:
                 rule = v.rule or "unknown"
                 print(f"  - {rule}: {v.location} - {v.message}")
-            exit(1)
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/generate-quality-report.py
+++ b/.github/scripts/generate-quality-report.py
@@ -357,6 +357,51 @@ def parse_spotbugs() -> Tuple[Dict[str, AnalysisReport], bool, Optional[str]]:
     return {}, True, error_message
 
 
+def _required_spotbugs_projects() -> List[str]:
+    env_value = os.environ.get("QUALITY_REPORT_REQUIRED_SPOTBUGS") or ""
+    return [item.strip() for item in env_value.split(os.pathsep) if item.strip()]
+
+
+def _enforce_spotbugs_gate(reports: Dict[str, AnalysisReport]) -> None:
+    """Fail the build on any SpotBugs finding in any analysed project.
+
+    This gate deliberately has no allow-list of patterns. An allow-list only
+    ever catches the patterns somebody already thought to add, so the first
+    time SpotBugs reports a brand new pattern the build stays green and the
+    finding lands on master. Intentional exceptions belong in the project's
+    spotbugs-exclude.xml instead, scoped to the class or method they apply to
+    and with a comment explaining why - that keeps the report itself at zero.
+    """
+    required = _required_spotbugs_projects()
+    missing = [label for label in required if label not in reports]
+    if missing:
+        print(
+            "\n❌ Build failed because SpotBugs produced no report for: "
+            + ", ".join(sorted(missing))
+        )
+        print(
+            "  A missing report means the analysis never ran; that would let "
+            "findings through unnoticed."
+        )
+        exit(1)
+    violations: List[Tuple[str, Finding]] = []
+    for label in sorted(reports):
+        for finding in reports[label].findings:
+            violations.append((label, finding))
+    if not violations:
+        return
+    print(f"\n❌ Build failed due to {len(violations)} SpotBugs finding(s):")
+    for label, finding in violations:
+        rule = finding.rule or "unknown"
+        print(f"  - {rule}: {label} {finding.location} - {finding.message}")
+    print(
+        "\nFix the finding, or - if it is intentional - add a narrowly scoped "
+        "<Match> for it to that project's spotbugs-exclude.xml with a comment "
+        "explaining why."
+    )
+    exit(1)
+
+
 def parse_pmd() -> Optional[AnalysisReport]:
     report_path: Optional[Path] = None
     for target_dir in TARGET_DIRS:
@@ -809,174 +854,14 @@ def main() -> None:
     if not generate_html_only:
         REPORT_PATH.write_text(report + "\n", encoding="utf-8")
 
+    if generate_html_only:
+        # The HTML pass runs before the report and the PR comment are produced;
+        # gating here would hide the very findings we want the comment to show.
+        return
+
     # Enforce quality gates
     spotbugs_reports, _, _ = parse_spotbugs()
-    if spotbugs_reports:
-        cross_project_rules = {
-            "DE_MIGHT_IGNORE",
-            "BC_IMPOSSIBLE_CAST",
-            "DM_DEFAULT_ENCODING"
-        }
-        cross_project_violations: List[Tuple[str, Finding]] = []
-        for label, report in spotbugs_reports.items():
-            for finding in report.findings:
-                if finding.rule in cross_project_rules:
-                    cross_project_violations.append((label, finding))
-        if cross_project_violations:
-            print(
-                "\n❌ Build failed due to forbidden SpotBugs violations across projects:"
-            )
-            for label, finding in cross_project_violations:
-                location = finding.location
-                print(
-                    f"  - {finding.rule}: {label} {location} - {finding.message}"
-                )
-            exit(1)
-    spotbugs = spotbugs_reports.get("core-unittests")
-    if spotbugs:
-        forbidden_rules = {
-            "DE_MIGHT_IGNORE",
-            "NP_ALWAYS_NULL",
-            "NP_NULL_PARAM_DEREF",
-            "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
-            "RCN_REDUNDANT_NULLCHECK_OF_NULL_VALUE",
-            "UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR",
-            "SF_SWITCH_NO_DEFAULT",
-            "DM_DEFAULT_ENCODING",
-            "EQ_CHECK_FOR_OPERAND_NOT_COMPATIBLE_WITH_THIS",
-            "IA_AMBIGUOUS_INVOCATION_OF_INHERITED_OR_OUTER_METHOD",
-            "LI_LAZY_INIT_STATIC",
-            "RpC_REPEATED_CONDITIONAL_TEST",
-            "NS_NON_SHORT_CIRCUIT",
-            "ES_COMPARING_PARAMETER_STRING_WITH_EQ",
-            "FE_FLOATING_POINT_EQUALITY",
-            "FE_TEST_IF_EQUAL_TO_NOT_A_NUMBER",
-            "ICAST_IDIV_CAST_TO_DOUBLE",
-            "ICAST_QUESTIONABLE_UNSIGNED_RIGHT_SHIFT",
-            "SA_FIELD_SELF_ASSIGNMENT",
-            "UC_USELESS_CONDITION",
-            "UC_USELESS_OBJECT",
-            "UCF_USELESS_CONTROL_FLOW",
-            "EC_UNRELATED_TYPES",
-            "EQ_ALWAYS_FALSE",
-            "SBSC_USE_STRINGBUFFER_CONCATENATION",
-            "SIC_INNER_SHOULD_BE_STATIC",
-            "EQ_DOESNT_OVERRIDE_EQUALS",
-            "CO_COMPARETO_INCORRECT_FLOATING",
-            "DL_SYNCHRONIZATION_ON_SHARED_CONSTANT",
-            "SSD_DO_NOT_USE_INSTANCE_LOCK_ON_SHARED_STATIC_DATA",
-            "DLS_DEAD_LOCAL_STORE",
-            "DLS_DEAD_LOCAL_STORE_OF_NULL",
-            "DM_NUMBER_CTOR",
-            "DMI_INVOKING_TOSTRING_ON_ARRAY",
-            "EC_NULL_ARG",
-            "EC_UNRELATED_TYPES_USING_POINTER_EQUALITY",
-            "EQ_GETCLASS_AND_CLASS_CONSTANT",
-            "EQ_UNUSUAL",
-            "ES_COMPARING_STRINGS_WITH_EQ",
-            "FI_EMPTY",
-            "ST_WRITE_TO_STATIC_FROM_INSTANCE_METHOD",
-            "DM_GC",
-            "CN_IMPLEMENTS_CLONE_BUT_NOT_CLONEABLE",
-            "BC_UNCONFIRMED_CAST",
-            "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE",
-            "CN_IDIOM_NO_SUPER_CALL",
-            "DM_BOOLEAN_CTOR",
-            "DM_FP_NUMBER_CTOR",
-            "DM_EXIT",
-            "DC_DOUBLECHECK",
-            "DB_DUPLICATE_SWITCH_CLAUSES",
-            "EI_EXPOSE_REP", 
-            "EI_EXPOSE_REP2",
-            "EI_EXPOSE_STATIC_REP2",
-            "EQ_COMPARETO_USE_OBJECT_EQUALS",
-            "MS_EXPOSE_REP",
-            "NM_CONFUSING",
-            "NM_FIELD_NAMING_CONVENTION",
-            "NM_METHOD_NAMING_CONVENTION",
-            "NN_NAKED_NOTIFY",
-            "NO_NOTIFY_NOT_NOTIFYALL",
-            "NP_LOAD_OF_KNOWN_NULL_VALUE",
-            "NP_BOOLEAN_RETURN_NULL",
-            "RC_REF_COMPARISON_BAD_PRACTICE_BOOLEAN",
-            "OS_OPEN_STREAM",
-            "OS_OPEN_STREAM_EXCEPTION_PATH",
-            "OBL_UNSATISFIED_OBLIGATION_EXCEPTION_EDGE",
-            "RV_RETURN_VALUE_IGNORED_BAD_PRACTICE",
-            "REFLC_REFLECTION_MAY_INCREASE_ACCESSIBILITY_OF_CLASS",
-            "REC_CATCH_EXCEPTION",
-            "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
-            "RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT",
-            "INT_VACUOUS_COMPARISON",
-            "DM_STRING_TOSTRING",
-            "HE_HASHCODE_USE_OBJECT_EQUALS",
-            "IM_BAD_CHECK_FOR_ODD",
-            "IM_AVERAGE_COMPUTATION_COULD_OVERFLOW",
-            "INT_VACUOUS_BIT_OPERATION",
-            "ICAST_INT_2_LONG_AS_INSTANT",
-            "ICAST_INT_CAST_TO_FLOAT_PASSED_TO_ROUND",
-            "IT_NO_SUCH_ELEMENT",
-            "FL_FLOATS_AS_LOOP_COUNTERS",
-            "UI_INHERITANCE_UNSAFE_GETRESOURCE",
-            "IS2_INCONSISTENT_SYNC",
-            "RR_NOT_CHECKED",
-            "URF_UNREAD_FIELD",
-            "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD",
-            "UR_UNINIT_READ",
-            "UUF_UNUSED_FIELD",
-            "UWF_NULL_FIELD",
-            "UW_UNCOND_WAIT",
-            "LI_LAZY_INIT_UPDATE_STATIC",
-            "SIC_INNER_SHOULD_BE_STATIC_ANON",
-            "SS_SHOULD_BE_STATIC",
-            "UPM_UNCALLED_PRIVATE_METHOD",
-            "RV_RETURN_VALUE_IGNORED_INFERRED",
-            "RV_CHECK_FOR_POSITIVE_INDEXOF",
-            "SF_SWITCH_FALLTHROUGH",
-            "SIC_INNER_SHOULD_BE_STATIC_NEEDS_THIS",
-            "SA_FIELD_DOUBLE_ASSIGNMENT",
-            "SA_FIELD_SELF_COMPARISON",
-            "SR_NOT_CHECKED",
-            "SWL_SLEEP_WITH_LOCK_HELD",
-            "UC_USELESS_CONDITION_TYPE",
-            "BX_UNBOXING_IMMEDIATELY_REBOXED"
-        }
-
-        def _is_exempt(f: Finding) -> bool:
-            loc = f.path or f.location or ""
-            if f.rule == "SA_FIELD_SELF_ASSIGNMENT" and "InfBlocks.java" in loc:
-                return True
-            if f.rule == "SF_SWITCH_FALLTHROUGH" and "InfBlocks.java" in loc:
-                return True
-            if f.rule == "SF_SWITCH_FALLTHROUGH" and "InfCodes.java" in loc:
-                return True
-            if f.rule == "SF_SWITCH_FALLTHROUGH" and "Inflate.java" in loc:
-                return True
-            if f.rule == "URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD" and "TarEntry.java" in loc:
-                return True
-            if f.rule == "URF_UNREAD_FIELD" and "GridBagLayoutInfo" in loc:
-                return True
-            if f.rule == "NN_NAKED_NOTIFY" and "Display.java" in loc:
-                return True
-            if f.rule == "ICAST_QUESTIONABLE_UNSIGNED_RIGHT_SHIFT" and "Deflate.java" in loc:
-                return True
-            return False
-
-
-        # Apply the same forbidden_rules to every SpotBugs report (android,
-        # ios, codenameone-maven-plugin, ...) -- not just core-unittests --
-        # so a quality regression in a port is caught in CI just as quickly
-        # as one in core.
-        all_violations: List[Tuple[str, Finding]] = []
-        for label, report in spotbugs_reports.items():
-            for f in report.findings:
-                if f.rule in forbidden_rules and not _is_exempt(f):
-                    all_violations.append((label, f))
-        if all_violations:
-            print("\n❌ Build failed due to forbidden SpotBugs violations:")
-            for label, v in all_violations:
-                print(f"  - {v.rule}: {label} {v.location} - {v.message}")
-            exit(1)
+    _enforce_spotbugs_gate(spotbugs_reports)
 
     pmd = parse_pmd()
     if pmd:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -476,6 +476,10 @@ jobs:
         if: ${{ always() && matrix.java-version == 8 }}
         env:
           QUALITY_REPORT_TARGET_DIRS: maven/core-unittests/target:maven/android/target:maven/ios/target:vm/ByteCodeTranslator/target:maven/codenameone-maven-plugin/target
+          # Every project listed here must produce a SpotBugs report and that
+          # report must be empty. A missing report fails the gate too, so a
+          # SpotBugs run that silently stops running is not mistaken for clean.
+          QUALITY_REPORT_REQUIRED_SPOTBUGS: core-unittests:android:ios:ByteCodeTranslator:codenameone-maven-plugin
           QUALITY_REPORT_SERVER_URL: ${{ github.server_url }}
           QUALITY_REPORT_REPOSITORY: ${{ github.repository }}
           QUALITY_REPORT_REF: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -495,7 +499,7 @@ jobs:
           name: quality-report
           path: quality-report.md
       - name: Publish quality report comment
-        if: ${{ github.event_name == 'pull_request' && matrix.java-version == 8 }}
+        if: ${{ always() && github.event_name == 'pull_request' && matrix.java-version == 8 && hashFiles('quality-report.md') != '' }}
         uses: actions/github-script@v9
         with:
           script: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,35 @@ To use locally-built version, edit the generated `pom.xml`:
 - **Main JAVA_HOME (for building the framework)**: Must be JDK 8
 - **Runtime JDK for simulator / desktop run**: JDK 11 through 25 is supported. The Codename One Maven plugin checks this on entry to `cn1:run` and `cn1:debug` and aborts with a friendly error when an older JDK is in use. The build-time goals (`generate-desktop-app-wrapper`, `prepare-simulator-classpath`, the `executable-jar` profile) are not gated -- they still work on JDK 8 because they only generate icons / classpath metadata.
 
+### Static Analysis Gates
+
+PR CI (`.github/workflows/pr.yml`, Java 8 leg) runs SpotBugs over
+`core-unittests`, `android`, `ios`, `ByteCodeTranslator` and
+`codenameone-maven-plugin`, then enforces the result in
+`.github/scripts/generate-quality-report.py`.
+
+- **SpotBugs is a zero-findings gate.** *Any* finding of *any* pattern in *any*
+  of those projects fails the build, and a project that produces no SpotBugs
+  report at all fails it too (see `QUALITY_REPORT_REQUIRED_SPOTBUGS`). There is
+  no per-pattern allow-list, so a pattern nobody anticipated still fails.
+- **Record intentional exceptions in the project's `spotbugs-exclude.xml`**
+  (`maven/core-unittests/`, `Ports/Android/`, `Ports/iOSPort/`,
+  `vm/ByteCodeTranslator/`, `maven/codenameone-maven-plugin/`), scoped to the
+  class or method it applies to and with a comment explaining why. Keep the
+  generated report at zero rather than tolerating known noise.
+- PMD and Checkstyle still gate on their own lists in the same script.
+
+To reproduce the SpotBugs gate locally:
+
+```bash
+source tools/env.sh   # JDK 8
+cd maven && mvn -B -DskipTests=true -Pcompile-android \
+  -pl android,ios,codenameone-maven-plugin -am verify
+mvn -B -DskipTests=true -f ../vm/ByteCodeTranslator/pom.xml verify
+```
+
+Findings land in each module's `target/spotbugsXml.xml`.
+
 ### Working with Native Code
 
 Platform-specific native code locations:

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSVisionImpl.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSVisionImpl.java
@@ -312,10 +312,11 @@ public final class IOSVisionImpl extends VisionImpl {
             return out;
         }
         Map source = (Map) value;
-        for (Object key : source.keySet()) {
-            Object point = source.get(key);
+        for (Object entryObject : source.entrySet()) {
+            Map.Entry entry = (Map.Entry) entryObject;
+            Object point = entry.getValue();
             if (point instanceof Map) {
-                out.put(String.valueOf(key), new VisionPoint(
+                out.put(String.valueOf(entry.getKey()), new VisionPoint(
                         number((Map) point, "x"),
                         number((Map) point, "y")));
             }


### PR DESCRIPTION
## The finding

`IOSVisionImpl.parseLandmarks` iterated the landmark map via `keySet()` and did a `get()` per key (`WMI_WRONG_MAP_ITERATOR`). It now walks `entrySet()`.

## Why it reached master with green CI

The PR quality report already printed the finding with a red mark:

```
❌ ios: 1 findings (Normal: 1)
```

but the gate in `.github/scripts/generate-quality-report.py` only failed on an explicit allow-list of ~100 SpotBugs patterns, and `WMI_WRONG_MAP_ITERATOR` was not one of them. An allow-list can only catch patterns somebody already thought to add, so every new pattern gets one free pass onto master.

## The gate change

SpotBugs is now a **zero-findings** gate:

- any finding, any pattern, any analysed project (`core-unittests`, `android`, `ios`, `ByteCodeTranslator`, `codenameone-maven-plugin`) fails the build;
- a project that produces **no** SpotBugs report fails it too (`QUALITY_REPORT_REQUIRED_SPOTBUGS`), so an analysis that silently stops running is not mistaken for clean;
- intentional exceptions go in the project's `spotbugs-exclude.xml`, scoped to the class or method with a comment - already how the ports record theirs;
- the ~100-entry allow-list and its file-specific exemptions are removed; those exemptions were already covered by `core-unittests/spotbugs-exclude.xml`.

Enforcement is skipped in the HTML-only pass and the PR comment now publishes even when the gate fails, so the failure arrives together with the report that explains it.

PMD and Checkstyle gating is unchanged.

## Verification

- Ran the CI SpotBugs commands locally on JDK 8: `core-unittests`, `android`, `ios`, `ByteCodeTranslator` and `codenameone-maven-plugin` each report **zero** findings, so the stricter gate starts from a clean baseline.
- Fed the script a synthetic report containing exactly this `WMI_WRONG_MAP_ITERATOR` finding: exits 1 with the pattern, project, file:line and message.
- Missing-report case exits 1; the real clean reports exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)