### PR TITLE
ParparVM: keep SP across a longjmp (fixes the musl ICE that breaks every PR)

### DIFF
--- a/vm/ByteCodeTranslator/src/cn1_globals.h
+++ b/vm/ByteCodeTranslator/src/cn1_globals.h
@@ -2262,61 +2262,108 @@ static inline void cn1InitMethodStackInline(CODENAME_ONE_THREAD_STATE, JAVA_OBJE
     threadStateData->callStackOffset++;
 }
 
+// How SP is declared, and why it is a parameter rather than a fixed token.
+//
+// ParparVM compiles a try/catch into a setjmp region, so the edges leaving it
+// are abnormal ones. SP is modified all through that region -- every push and
+// pop moves it -- and it is read again after a longjmp lands in the catch.
+// C99 7.13.2.1p3 makes the value of a non-volatile automatic that was modified
+// since the setjmp *indeterminate* after a longjmp, so the old unqualified
+// declaration was undefined behaviour in every method that catches anything.
+//
+// It stayed invisible until a toolchain took it up: gcc on musl refuses the
+// translation unit outright with `internal compiler error: SSA corruption` --
+// "Unable to coalesce ssa_names 57 and 58 which are marked as MUST COALESCE,
+// SP_57(ab) and SP_58(ab), during RTL pass: expand" -- because two versions of
+// SP live across an abnormal edge must occupy one register and cannot. Any Java
+// method with a short-circuit condition inside a try was enough to trigger it,
+// which means app code, not just the framework.
+//
+// `volatile` goes on the POINTER, not the pointee: `struct elementStruct* volatile SP`
+// keeps SP itself in memory so longjmp cannot clobber it, while stack slot
+// accesses through it stay ordinary. Writing `volatile struct elementStruct* SP`
+// would instead make every operand-stack read and write volatile, which is a
+// different -- and expensive -- statement.
+//
+// Only frames that actually emit setjmp pay for it; BytecodeMethod picks the
+// _VSP variant using the same test it already uses to decide whether locals are
+// volatile.
+#define CN1_DECLARE_SP(spQualifier, spPosition) \
+    struct elementStruct* spQualifier SP = &stack[spPosition];
+
 // we need to zero out the values with memset otherwise we will run into a problem
 // when invoking release on pre-existing object which might be garbage
-#define DEFINE_METHOD_STACK(stackSize, localsStackSize, spPosition, classNameId, methodNameId) \
+#define DEFINE_METHOD_STACK_IMPL(spQualifier, stackSize, localsStackSize, spPosition, classNameId, methodNameId) \
     const int cn1LocalsBeginInThread = threadStateData->threadObjectStackOffset; \
     struct elementStruct* locals = &threadStateData->threadObjectStack[cn1LocalsBeginInThread]; \
     struct elementStruct* stack = &threadStateData->threadObjectStack[threadStateData->threadObjectStackOffset + localsStackSize]; \
-    struct elementStruct* SP = &stack[spPosition]; \
+    CN1_DECLARE_SP(spQualifier, spPosition) \
     cn1InitMethodStackInline(threadStateData, (JAVA_OBJECT)1, stackSize, localsStackSize, classNameId, methodNameId); \
     const int currentCodenameOneCallStackOffset = threadStateData->callStackOffset;\
     int methodBlockOffset = threadStateData->tryBlockOffset;
 
-#define DEFINE_INSTANCE_METHOD_STACK(stackSize, localsStackSize, spPosition, classNameId, methodNameId) \
+#define DEFINE_METHOD_STACK(stackSize, localsStackSize, spPosition, classNameId, methodNameId) DEFINE_METHOD_STACK_IMPL(, stackSize, localsStackSize, spPosition, classNameId, methodNameId)
+#define DEFINE_METHOD_STACK_VSP(stackSize, localsStackSize, spPosition, classNameId, methodNameId) DEFINE_METHOD_STACK_IMPL(volatile, stackSize, localsStackSize, spPosition, classNameId, methodNameId)
+
+#define DEFINE_INSTANCE_METHOD_STACK_IMPL(spQualifier, stackSize, localsStackSize, spPosition, classNameId, methodNameId) \
     const int cn1LocalsBeginInThread = threadStateData->threadObjectStackOffset; \
     struct elementStruct* locals = &threadStateData->threadObjectStack[cn1LocalsBeginInThread]; \
     struct elementStruct* stack = &threadStateData->threadObjectStack[threadStateData->threadObjectStackOffset + localsStackSize]; \
-    struct elementStruct* SP = &stack[spPosition]; \
+    CN1_DECLARE_SP(spQualifier, spPosition) \
     cn1InitMethodStackInline(threadStateData, __cn1ThisObject, stackSize, localsStackSize, classNameId, methodNameId); \
     const int currentCodenameOneCallStackOffset = threadStateData->callStackOffset;\
     int methodBlockOffset = threadStateData->tryBlockOffset;
 
-#define DEFINE_METHOD_STACK_FAST_REF(stackSize, localsStackSize, spPosition) \
+#define DEFINE_INSTANCE_METHOD_STACK(stackSize, localsStackSize, spPosition, classNameId, methodNameId) DEFINE_INSTANCE_METHOD_STACK_IMPL(, stackSize, localsStackSize, spPosition, classNameId, methodNameId)
+#define DEFINE_INSTANCE_METHOD_STACK_VSP(stackSize, localsStackSize, spPosition, classNameId, methodNameId) DEFINE_INSTANCE_METHOD_STACK_IMPL(volatile, stackSize, localsStackSize, spPosition, classNameId, methodNameId)
+
+#define DEFINE_METHOD_STACK_FAST_REF_IMPL(spQualifier, stackSize, localsStackSize, spPosition) \
     const int cn1LocalsBeginInThread = threadStateData->threadObjectStackOffset; \
     struct elementStruct* locals = &threadStateData->threadObjectStack[cn1LocalsBeginInThread]; \
     struct elementStruct* stack = &threadStateData->threadObjectStack[threadStateData->threadObjectStackOffset + localsStackSize]; \
-    struct elementStruct* SP = &stack[spPosition]; \
+    CN1_DECLARE_SP(spQualifier, spPosition) \
     cn1_init_method_stack_fast(threadStateData, (JAVA_OBJECT)1, stackSize, localsStackSize, JAVA_TRUE); \
     const int currentCodenameOneCallStackOffset = threadStateData->callStackOffset;\
     int methodBlockOffset = threadStateData->tryBlockOffset;
 
-#define DEFINE_INSTANCE_METHOD_STACK_FAST_REF(stackSize, localsStackSize, spPosition) \
+#define DEFINE_METHOD_STACK_FAST_REF(stackSize, localsStackSize, spPosition) DEFINE_METHOD_STACK_FAST_REF_IMPL(, stackSize, localsStackSize, spPosition)
+#define DEFINE_METHOD_STACK_FAST_REF_VSP(stackSize, localsStackSize, spPosition) DEFINE_METHOD_STACK_FAST_REF_IMPL(volatile, stackSize, localsStackSize, spPosition)
+
+#define DEFINE_INSTANCE_METHOD_STACK_FAST_REF_IMPL(spQualifier, stackSize, localsStackSize, spPosition) \
     const int cn1LocalsBeginInThread = threadStateData->threadObjectStackOffset; \
     struct elementStruct* locals = &threadStateData->threadObjectStack[cn1LocalsBeginInThread]; \
     struct elementStruct* stack = &threadStateData->threadObjectStack[threadStateData->threadObjectStackOffset + localsStackSize]; \
-    struct elementStruct* SP = &stack[spPosition]; \
+    CN1_DECLARE_SP(spQualifier, spPosition) \
     cn1_init_method_stack_fast(threadStateData, __cn1ThisObject, stackSize, localsStackSize, JAVA_TRUE); \
     const int currentCodenameOneCallStackOffset = threadStateData->callStackOffset;\
     int methodBlockOffset = threadStateData->tryBlockOffset;
 
-#define DEFINE_METHOD_STACK_FAST_PRIMITIVE(stackSize, localsStackSize, spPosition) \
+#define DEFINE_INSTANCE_METHOD_STACK_FAST_REF(stackSize, localsStackSize, spPosition) DEFINE_INSTANCE_METHOD_STACK_FAST_REF_IMPL(, stackSize, localsStackSize, spPosition)
+#define DEFINE_INSTANCE_METHOD_STACK_FAST_REF_VSP(stackSize, localsStackSize, spPosition) DEFINE_INSTANCE_METHOD_STACK_FAST_REF_IMPL(volatile, stackSize, localsStackSize, spPosition)
+
+#define DEFINE_METHOD_STACK_FAST_PRIMITIVE_IMPL(spQualifier, stackSize, localsStackSize, spPosition) \
     const int cn1LocalsBeginInThread = threadStateData->threadObjectStackOffset; \
     struct elementStruct* locals = &threadStateData->threadObjectStack[cn1LocalsBeginInThread]; \
     struct elementStruct* stack = &threadStateData->threadObjectStack[threadStateData->threadObjectStackOffset + localsStackSize]; \
-    struct elementStruct* SP = &stack[spPosition]; \
+    CN1_DECLARE_SP(spQualifier, spPosition) \
     cn1_init_method_stack_fast(threadStateData, (JAVA_OBJECT)1, stackSize, localsStackSize, JAVA_FALSE); \
     const int currentCodenameOneCallStackOffset = threadStateData->callStackOffset;\
     int methodBlockOffset = threadStateData->tryBlockOffset;
 
-#define DEFINE_INSTANCE_METHOD_STACK_FAST_PRIMITIVE(stackSize, localsStackSize, spPosition) \
+#define DEFINE_METHOD_STACK_FAST_PRIMITIVE(stackSize, localsStackSize, spPosition) DEFINE_METHOD_STACK_FAST_PRIMITIVE_IMPL(, stackSize, localsStackSize, spPosition)
+#define DEFINE_METHOD_STACK_FAST_PRIMITIVE_VSP(stackSize, localsStackSize, spPosition) DEFINE_METHOD_STACK_FAST_PRIMITIVE_IMPL(volatile, stackSize, localsStackSize, spPosition)
+
+#define DEFINE_INSTANCE_METHOD_STACK_FAST_PRIMITIVE_IMPL(spQualifier, stackSize, localsStackSize, spPosition) \
     const int cn1LocalsBeginInThread = threadStateData->threadObjectStackOffset; \
     struct elementStruct* locals = &threadStateData->threadObjectStack[cn1LocalsBeginInThread]; \
     struct elementStruct* stack = &threadStateData->threadObjectStack[threadStateData->threadObjectStackOffset + localsStackSize]; \
-    struct elementStruct* SP = &stack[spPosition]; \
+    CN1_DECLARE_SP(spQualifier, spPosition) \
     cn1_init_method_stack_fast(threadStateData, __cn1ThisObject, stackSize, localsStackSize, JAVA_FALSE); \
     const int currentCodenameOneCallStackOffset = threadStateData->callStackOffset;\
     int methodBlockOffset = threadStateData->tryBlockOffset;
+
+#define DEFINE_INSTANCE_METHOD_STACK_FAST_PRIMITIVE(stackSize, localsStackSize, spPosition) DEFINE_INSTANCE_METHOD_STACK_FAST_PRIMITIVE_IMPL(, stackSize, localsStackSize, spPosition)
+#define DEFINE_INSTANCE_METHOD_STACK_FAST_PRIMITIVE_VSP(stackSize, localsStackSize, spPosition) DEFINE_INSTANCE_METHOD_STACK_FAST_PRIMITIVE_IMPL(volatile, stackSize, localsStackSize, spPosition)
 
 #define CN1_FAST_RETURN_RELEASE() \
     threadStateData->threadObjectStackOffset = cn1LocalsBeginInThread; \
@@ -2331,11 +2378,14 @@ static inline void cn1InitMethodStackInline(CODENAME_ONE_THREAD_STATE, JAVA_OBJE
 // no callStackOffset bump. The method body (PUSH/POP/SP ops, arithmetic, calls)
 // is emitted byte-for-byte unchanged; it just operates on this local SP. Frame
 // elimination is GC-trivial here -- it changes nothing the collector sees.
-#define DEFINE_METHOD_STACK_FRAMELESS(stackSize, localsStackSize, spPosition) \
+#define DEFINE_METHOD_STACK_FRAMELESS_IMPL(spQualifier, stackSize, localsStackSize, spPosition) \
     struct elementStruct cn1_frameless_frame[(localsStackSize) + (stackSize)]; \
     struct elementStruct* locals = &cn1_frameless_frame[0]; \
     struct elementStruct* stack = &cn1_frameless_frame[localsStackSize]; \
-    struct elementStruct* SP = &stack[spPosition];
+    CN1_DECLARE_SP(spQualifier, spPosition)
+
+#define DEFINE_METHOD_STACK_FRAMELESS(stackSize, localsStackSize, spPosition) DEFINE_METHOD_STACK_FRAMELESS_IMPL(, stackSize, localsStackSize, spPosition)
+#define DEFINE_METHOD_STACK_FRAMELESS_VSP(stackSize, localsStackSize, spPosition) DEFINE_METHOD_STACK_FRAMELESS_IMPL(volatile, stackSize, localsStackSize, spPosition)
 
 // Headroom (bytes) kept below the end of the native C stack: enough to detect the
 // overflow and still build + throw the StackOverflowError without overrunning.

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
@@ -1566,7 +1566,16 @@ public class BytecodeMethod implements SignatureSet {
             // for call-bearing methods with hot call-free loops and neutral for the
             // libm-style loops the heuristic originally protected.
             // -DCN1_FORCE_VOLATILE_LOCALS=true restores the always-volatile behavior.
-            boolean volatileLocals = FORCE_VOLATILE_LOCALS || onDeviceDebug || synchronizedMethod;
+            // Decided before the frame macro is emitted, because SP needs the
+            // same answer. A method that catches anything emits setjmp, and
+            // everything longjmp can leave stale has to be volatile: the
+            // locals below, and SP, which every push and pop moves inside the
+            // try region and which is read again in the catch. Keeping one
+            // decision for both is the point -- decided apart, only the locals
+            // got it, and SP stayed undefined behaviour that gcc on musl
+            // eventually refused to compile at all.
+            boolean volatileLocals = FORCE_VOLATILE_LOCALS || onDeviceDebug
+                    || synchronizedMethod;
             if (!volatileLocals) {
                 for (Instruction tcScan : instructions) {
                     if (tcScan instanceof TryCatch) {
@@ -1575,6 +1584,9 @@ public class BytecodeMethod implements SignatureSet {
                     }
                 }
             }
+            // Selects the _VSP variant of whichever frame macro is emitted
+            // below; empty for the ordinary ones so nothing else changes.
+            String spVariant = volatileLocals ? "_VSP" : "";
             Set<String> added = new HashSet<String>();
             for (LocalVariable lv : localVariables) {
                 String variableName = lv.getQualifier() + "locals_"+lv.getIndex()+"_";
@@ -1621,7 +1633,7 @@ public class BytecodeMethod implements SignatureSet {
                         b.append(".initialized) __STATIC_INITIALIZER_").append(framelessCls);
                         b.append("(threadStateData);\n");
                     }
-                    b.append("    DEFINE_METHOD_STACK_FRAMELESS(");
+                    b.append("    DEFINE_METHOD_STACK_FRAMELESS").append(spVariant).append("(");
                     b.append(maxStack);
                     b.append(", ");
                     b.append(maxLocals);
@@ -1635,12 +1647,12 @@ public class BytecodeMethod implements SignatureSet {
                     if(methodName.equals("__CLINIT__")) {
                         if (useFastMethodStack) {
                             if (usePrimitiveFastFrame) {
-                                b.append("    DEFINE_METHOD_STACK_FAST_PRIMITIVE(");
+                                b.append("    DEFINE_METHOD_STACK_FAST_PRIMITIVE").append(spVariant).append("(");
                             } else {
-                                b.append("    DEFINE_METHOD_STACK_FAST_REF(");
+                                b.append("    DEFINE_METHOD_STACK_FAST_REF").append(spVariant).append("(");
                             }
                         } else {
-                            b.append("    DEFINE_METHOD_STACK(");
+                            b.append("    DEFINE_METHOD_STACK").append(spVariant).append("(");
                         }
                     } else {
                         b.append("    if (!class__");
@@ -1649,23 +1661,23 @@ public class BytecodeMethod implements SignatureSet {
                         b.append(clsName.replace('/', '_').replace('$', '_'));
                         if (useFastMethodStack) {
                             if (usePrimitiveFastFrame) {
-                                b.append("(threadStateData);\n    DEFINE_METHOD_STACK_FAST_PRIMITIVE(");
+                                b.append("(threadStateData);\n    DEFINE_METHOD_STACK_FAST_PRIMITIVE").append(spVariant).append("(");
                             } else {
-                                b.append("(threadStateData);\n    DEFINE_METHOD_STACK_FAST_REF(");
+                                b.append("(threadStateData);\n    DEFINE_METHOD_STACK_FAST_REF").append(spVariant).append("(");
                             }
                         } else {
-                            b.append("(threadStateData);\n    DEFINE_METHOD_STACK(");
+                            b.append("(threadStateData);\n    DEFINE_METHOD_STACK").append(spVariant).append("(");
                         }
                     }
                 } else {
                     if (useFastMethodStack) {
                         if (usePrimitiveFastFrame) {
-                            b.append("    DEFINE_INSTANCE_METHOD_STACK_FAST_PRIMITIVE(");
+                            b.append("    DEFINE_INSTANCE_METHOD_STACK_FAST_PRIMITIVE").append(spVariant).append("(");
                         } else {
-                            b.append("    DEFINE_INSTANCE_METHOD_STACK_FAST_REF(");
+                            b.append("    DEFINE_INSTANCE_METHOD_STACK_FAST_REF").append(spVariant).append("(");
                         }
                     } else {
-                        b.append("    DEFINE_INSTANCE_METHOD_STACK(");
+                        b.append("    DEFINE_INSTANCE_METHOD_STACK").append(spVariant).append("(");
                     }
                 }
                 // The frameless branch above already emitted its complete macro
@@ -1685,7 +1697,8 @@ public class BytecodeMethod implements SignatureSet {
                     b.append(");\n");
                 }
             } else {
-                b.append("    struct elementStruct* SP = &threadStateData->threadObjectStack[threadStateData->threadObjectStackOffset];\n");
+                b.append("    struct elementStruct*").append(volatileLocals ? " volatile" : "")
+                        .append(" SP = &threadStateData->threadObjectStack[threadStateData->threadObjectStackOffset];\n");
             }
             int startOffset = 0;
             if(synchronizedMethod) {

--- a/vm/tests/src/test/java/com/codename1/tools/translator/SetjmpFrameVolatileTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/SetjmpFrameVolatileTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.tools.translator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A method that catches anything must declare its operand stack pointer
+ * {@code volatile}.
+ *
+ * <p>A try/catch is compiled into a {@code setjmp} region, so the edges leaving
+ * it are abnormal ones. {@code SP} is modified all through that region -- every
+ * push and pop moves it -- and it is read again after a {@code longjmp} lands in
+ * the catch. C99 7.13.2.1p3 makes the value of a non-volatile automatic that was
+ * modified since the {@code setjmp} <em>indeterminate</em> after a
+ * {@code longjmp}, so declaring it unqualified was undefined behaviour in every
+ * method that catches anything -- which is app code, not just framework code.</p>
+ *
+ * <p>It went unnoticed until a toolchain refused it. {@code gcc} on musl rejects
+ * the whole translation unit with {@code internal compiler error: SSA
+ * corruption} -- "Unable to coalesce ssa_names 57 and 58 which are marked as
+ * MUST COALESCE, SP_57(ab) and SP_58(ab), during RTL pass: expand" -- because
+ * two versions of {@code SP} live across an abnormal edge are required to share
+ * one register and cannot. A short-circuit condition inside a {@code try} was
+ * enough to trigger it, and the first report was a framework method that
+ * happened to have that shape.</p>
+ *
+ * <p>Asserted on the emitted C rather than by compiling, because the only
+ * toolchain that reproduces the crash is the one in the Alpine CI leg. What this
+ * pins is the property the fix rests on, in both directions: the qualifier
+ * appears exactly when a frame can be re-entered by a longjmp, and not
+ * otherwise, since making every frame pay for it was the thing the locals
+ * heuristic was carefully written to avoid.</p>
+ */
+class SetjmpFrameVolatileTest {
+
+    private static final String HOST = "com/example/SjHost";
+
+    @BeforeEach
+    void cleanParser() {
+        Parser.cleanup();
+    }
+
+    /**
+     * The frame of a method with a catch block declares a volatile SP; the frame
+     * of one without does not.
+     */
+    @Test
+    void onlySetjmpFramesDeclareAVolatileStackPointer() throws Exception {
+        String code = translateHost();
+
+        String guarded = cFunctionBody(code, "_catches___");
+        assertTrue(hasVolatileStackPointer(guarded),
+                "a method that catches must keep SP across the longjmp, was:\n"
+                        + guarded);
+
+        String plain = cFunctionBody(code, "_plain___");
+        assertFalse(hasVolatileStackPointer(plain),
+                "a method with no catch is unwound past, so its SP must stay"
+                        + " register-allocatable, was:\n" + plain);
+    }
+
+    /**
+     * The qualifier goes on the pointer, not on the pointee.
+     *
+     * <p>{@code volatile struct elementStruct* SP} would make every operand-stack
+     * read and write volatile -- a different and far more expensive statement
+     * than keeping the pointer itself in memory. The two spellings are one token
+     * apart and both compile, so nothing but a test distinguishes them.</p>
+     */
+    @Test
+    void theStackPointerIsVolatileNotTheStackItself() throws Exception {
+        String guarded = cFunctionBody(translateHost(), "_catches___");
+        assertFalse(guarded.contains("volatile struct elementStruct* SP")
+                        || guarded.contains("volatile struct elementStruct *SP"),
+                "the stack slots must not become volatile, only the pointer,"
+                        + " was:\n" + guarded);
+    }
+
+    /** Whether this frame declares SP as a volatile pointer, in any spelling. */
+    private boolean hasVolatileStackPointer(String body) {
+        String flat = body.replaceAll("\\s+", " ");
+        return flat.contains("elementStruct* volatile SP")
+                || flat.contains("elementStruct * volatile SP")
+                || flat.contains("_VSP(");
+    }
+
+    private String translateHost() throws Exception {
+        Parser.parse(writeHostClass().toFile());
+
+        ByteCodeClass objectClass =
+                new ByteCodeClass("java_lang_Object", "java/lang/Object");
+        ByteCodeClass host = Parser.getClassObject("com_example_SjHost");
+        host.setBaseClassObject(objectClass);
+        host.setBaseInterfacesObject(Collections.<ByteCodeClass>emptyList());
+        host.updateAllDependencies();
+
+        List<ByteCodeClass> classes = Arrays.asList(objectClass, host);
+        return host.generateCCode(classes);
+    }
+
+    /** The text of the first generated C function whose name contains {@code marker}. */
+    private String cFunctionBody(String code, String marker) {
+        int nameAt = code.indexOf(marker);
+        assertTrue(nameAt >= 0,
+                "generated code has no function matching " + marker + ":\n" + code);
+        int start = code.indexOf('{', nameAt);
+        int end = code.indexOf("\n}", start + 1);
+        assertTrue(start >= 0 && end > start,
+                "could not delimit the body of " + marker);
+        return code.substring(start, end);
+    }
+
+    /**
+     * Two static methods that differ only in whether they catch.
+     *
+     * <p>{@code catches(a, b)} is {@code try { return f(a) && f(b); } catch
+     * (Throwable t) { return false; }} -- the shape from the original report,
+     * where the short-circuit temporary is what ends up live across the region.
+     * {@code plain(a, b)} is the same condition with no handler.</p>
+     */
+    private Path writeHostClass() throws Exception {
+        ClassWriter cw = new ClassWriter(0);
+        cw.visit(Opcodes.V1_8,
+                Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL | Opcodes.ACC_SUPER,
+                HOST, null, "java/lang/Object", null);
+
+        MethodVisitor probe = cw.visitMethod(
+                Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC, "probe", "(I)Z",
+                null, null);
+        probe.visitCode();
+        probe.visitVarInsn(Opcodes.ILOAD, 0);
+        Label zero = new Label();
+        probe.visitJumpInsn(Opcodes.IFEQ, zero);
+        probe.visitInsn(Opcodes.ICONST_1);
+        probe.visitInsn(Opcodes.IRETURN);
+        probe.visitLabel(zero);
+        probe.visitInsn(Opcodes.ICONST_0);
+        probe.visitInsn(Opcodes.IRETURN);
+        probe.visitMaxs(2, 1);
+        probe.visitEnd();
+
+        emitShortCircuit(cw, "catches", true);
+        emitShortCircuit(cw, "plain", false);
+
+        cw.visitEnd();
+        return writeClassFile(HOST, cw);
+    }
+
+    /** {@code probe(a) && probe(b)}, optionally wrapped in a catch-all. */
+    private void emitShortCircuit(ClassWriter cw, String name,
+            boolean guarded) {
+        MethodVisitor m = cw.visitMethod(
+                Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC, name, "(II)Z",
+                null, null);
+        Label start = new Label();
+        Label end = new Label();
+        Label handler = new Label();
+        Label falseArm = new Label();
+        m.visitCode();
+        if (guarded) {
+            m.visitTryCatchBlock(start, end, handler, "java/lang/Throwable");
+        }
+        m.visitLabel(start);
+        m.visitVarInsn(Opcodes.ILOAD, 0);
+        m.visitMethodInsn(Opcodes.INVOKESTATIC, HOST, "probe", "(I)Z", false);
+        m.visitJumpInsn(Opcodes.IFEQ, falseArm);
+        m.visitVarInsn(Opcodes.ILOAD, 1);
+        m.visitMethodInsn(Opcodes.INVOKESTATIC, HOST, "probe", "(I)Z", false);
+        m.visitJumpInsn(Opcodes.IFEQ, falseArm);
+        m.visitInsn(Opcodes.ICONST_1);
+        m.visitInsn(Opcodes.IRETURN);
+        m.visitLabel(falseArm);
+        m.visitInsn(Opcodes.ICONST_0);
+        m.visitInsn(Opcodes.IRETURN);
+        m.visitLabel(end);
+        if (guarded) {
+            m.visitLabel(handler);
+            m.visitInsn(Opcodes.POP);
+            m.visitInsn(Opcodes.ICONST_0);
+            m.visitInsn(Opcodes.IRETURN);
+        }
+        m.visitMaxs(3, 3);
+        m.visitEnd();
+    }
+
+    private Path writeClassFile(String internalName, ClassWriter cw)
+            throws Exception {
+        Path outputDir = Files.createTempDirectory("parparvm-setjmp-volatile");
+        Path classFile = outputDir.resolve(internalName + ".class");
+        Files.createDirectories(classFile.getParent());
+        Files.write(classFile, cw.toByteArray());
+        return classFile;
+    }
+}


### PR DESCRIPTION
## What breaks

The Alpine (musl) CI leg fails on **every** open PR:

```
com_codename1_surfaces_SurfaceDiagnostics.c:574:14: internal compiler error: SSA corruption
Unable to coalesce ssa_names 57 and 58 which are marked as MUST COALESCE.
SP_57(ab) and SP_58(ab)
during RTL pass: expand
```

Confirmed on two unrelated branches (`first-class-health`, `fix/5482-low-memory-throttle`) at the identical file, line and message, so it is not branch-specific. `SurfaceDiagnostics` is simply the file that first acquired the triggering shape.

## Why it is not a SurfaceDiagnostics bug

`SP` is the generated **operand stack pointer**, and every frame macro declared it unqualified:

```c
struct elementStruct* SP = &stack[spPosition];
```

A `try`/`catch` is compiled into a `setjmp` region, so the edges leaving it are abnormal ones. `SP` is modified all through that region — every push and pop moves it — and it is read again after a `longjmp` lands in the catch. **C99 7.13.2.1p3** makes the value of a non-volatile automatic that was modified since the `setjmp` *indeterminate* after a `longjmp`. So this was undefined behaviour in every method that catches anything, on every target; musl's gcc is just the first toolchain to refuse it outright.

That matters because ParparVM compiles **application** code. A short-circuit condition inside a `try` is enough to trigger it:

```java
try {
    return f(a) && f(b);
} catch (Throwable t) {
    return false;
}
```

Any app with that shape cannot be built for musl. Patching the one framework method that happened to have it would have left every other occurrence — including code we do not write — to hit the same wall.

## The fix

`SP` is `volatile` in exactly the frames that emit `setjmp`, selected by the same test `BytecodeMethod` already used to decide whether *locals* are volatile. That decision is now made once and used for both — decided apart is precisely how `SP` came to be missed while the locals beside it were handled correctly.

Two details that are easy to get wrong and are pinned by tests:

- **The qualifier goes on the pointer, not the pointee.** `struct elementStruct* volatile SP` keeps `SP` in memory so `longjmp` cannot clobber it, while stack-slot accesses through it stay ordinary. `volatile struct elementStruct* SP` would make every operand-stack read and write volatile — a different and far more expensive statement. One token apart, both compile.
- **Frames with no catch keep an unqualified `SP`.** They are unwound *past* rather than re-entered, so they stay register-allocatable. Same reasoning and same performance argument as the existing locals heuristic.

## Verification, and its limit

`SetjmpFrameVolatileTest` asserts the emitted C in both directions: the qualifier appears for a method that catches, does not for one that does not, and lands on the pointer. Revert-checked — it fails against the old unqualified declaration.

It asserts on generated text rather than by compiling, deliberately: **the only toolchain that reproduces the ICE is the Alpine leg.** There is no local build that would have caught this and none that can prove it fixed, so this PR's own CI run is the test.

Local ParparVM suite: 413 tests, one pre-existing failure (`HeavyLoadBenchmarkTest`, which asserts `vm/JavaAPI/dist/JavaAPI.jar` exists before translating anything; that artifact is not built in this environment and the test has not changed since 2022). Everything that translates *and* natively compiles passes, including the 24-test clean-target suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)