### PR TITLE
Retry Maven Central flakes when building the release jars

### DIFF
--- a/.github/workflows/parparvm-tests.yml
+++ b/.github/workflows/parparvm-tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/parparvm-tests.yml'
+      - 'scripts/ci/retry.sh'
       - 'vm/**'
       - 'Ports/JavaScriptPort/**'
       - '!vm/**/README.md'
@@ -13,6 +14,7 @@ on:
     branches: [ master, main ]
     paths:
       - '.github/workflows/parparvm-tests.yml'
+      - 'scripts/ci/retry.sh'
       - 'vm/**'
       - 'Ports/JavaScriptPort/**'
       - '!vm/**/README.md'

--- a/.github/workflows/parparvm-tests.yml
+++ b/.github/workflows/parparvm-tests.yml
@@ -99,12 +99,11 @@ jobs:
 
       - name: Run ParparVM JVM tests
         working-directory: vm
-        # Maven Central intermittently serves 403 from the runner CDN edge and
-        # Maven treats it as a permanent resolution failure (killed this job at
-        # dependency download, before any test ran). Retry with a pause; a real
-        # build/test failure fails identically on every attempt.
+        # Maven Central intermittently serves 403/429 from the runner CDN edge
+        # and Maven treats it as a permanent resolution failure (killed this job
+        # at dependency download, before any test ran). See scripts/ci/retry.sh.
         run: |
-          retry() { local i; for i in 1 2 3; do "$@" && return 0; [ $i -lt 3 ] && { echo "attempt $i failed; retrying in 30s (possible transient Maven Central 403/5xx)"; sleep 30; }; done; return 1; }
+          retry() { bash ../scripts/ci/retry.sh "$@"; }
           retry mvn -B clean package -pl JavaAPI -am -DskipTests
           retry mvn -B test -pl tests -am -DexcludedGroups=benchmark
         env:
@@ -226,9 +225,12 @@ jobs:
           cache: 'maven'
 
       - name: Build release jars
+        # This job runs once per published release, so a transient Maven Central
+        # 403/429 here silently ships a release without its ParparVM jars (that
+        # is what happened to 7.0.264). Retry, as the vm-tests job already does.
         run: |
-          mvn -B -f vm/JavaAPI/pom.xml package
-          mvn -B -f vm/ByteCodeTranslator/pom.xml package
+          bash scripts/ci/retry.sh mvn -B -f vm/JavaAPI/pom.xml package
+          bash scripts/ci/retry.sh mvn -B -f vm/ByteCodeTranslator/pom.xml package
 
       - name: Verify release jars
         run: |

--- a/scripts/ci/retry.sh
+++ b/scripts/ci/retry.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Run a command, retrying on failure, for CI steps whose only realistic failure
+# mode is a transient artifact-repository hiccup. Maven Central intermittently
+# serves 403 or 429 ("Too Many Requests") from the runner CDN edge, and Maven
+# treats either as a permanent resolution failure -- the build dies at
+# dependency/plugin download, before anything is compiled. A real build or test
+# failure fails identically on every attempt, so retrying costs only time.
+#
+# Usage: bash scripts/ci/retry.sh mvn -B -f vm/JavaAPI/pom.xml package
+#
+# RETRY_ATTEMPTS (default 3) and RETRY_DELAY_SECONDS (default 30) override the
+# bounds; the command is always attempted at least once and the last attempt's
+# exit status is what this script returns.
+attempts="${RETRY_ATTEMPTS:-3}"
+delay="${RETRY_DELAY_SECONDS:-30}"
+
+if [ "$#" -eq 0 ]; then
+  echo "retry.sh: no command given" >&2
+  exit 2
+fi
+
+status=0
+for attempt in $(seq 1 "$attempts"); do
+  "$@" && exit 0
+  status=$?
+  if [ "$attempt" -lt "$attempts" ]; then
+    echo "retry.sh: attempt ${attempt}/${attempts} failed with status ${status};" \
+      "retrying in ${delay}s (possible transient Maven Central 403/429/5xx)" >&2
+    sleep "$delay"
+  fi
+done
+
+echo "retry.sh: command failed after ${attempts} attempts" >&2
+exit "$status"

--- a/scripts/ci/retry.sh
+++ b/scripts/ci/retry.sh
@@ -21,8 +21,21 @@ if [ "$#" -eq 0 ]; then
   exit 2
 fi
 
+# A malformed override must not silently degrade into "never ran the command,
+# reported success" -- these are set in workflow YAML, so a typo should be loud.
+# RETRY_ATTEMPTS must be >= 1: the command always runs at least once.
+case "$attempts" in
+  ''|*[!0-9]*|0) echo "retry.sh: RETRY_ATTEMPTS must be a positive integer, got '${attempts}'" >&2; exit 2 ;;
+esac
+case "$delay" in
+  ''|*[!0-9]*) echo "retry.sh: RETRY_DELAY_SECONDS must be a non-negative integer, got '${delay}'" >&2; exit 2 ;;
+esac
+
+# Counted with arithmetic rather than `seq`: BSD and GNU seq disagree on
+# degenerate ranges, and this loop body must run exactly `attempts` times.
 status=0
-for attempt in $(seq 1 "$attempts"); do
+attempt=1
+while [ "$attempt" -le "$attempts" ]; do
   "$@" && exit 0
   status=$?
   if [ "$attempt" -lt "$attempts" ]; then
@@ -30,6 +43,7 @@ for attempt in $(seq 1 "$attempts"); do
       "retrying in ${delay}s (possible transient Maven Central 403/429/5xx)" >&2
     sleep "$delay"
   fi
+  attempt=$((attempt + 1))
 done
 
 echo "retry.sh: command failed after ${attempts} attempts" >&2


### PR DESCRIPTION
## What happened

[Run 30594669157](https://github.com/codenameone/CodenameOne/actions/runs/30594669157) (release 7.0.264) failed the `release-jars` job 30s in:

```
[ERROR] Plugin org.apache.maven.plugins:maven-compiler-plugin:3.11.0 ... could not be resolved:
  status code: 429, reason phrase: Too Many Requests (429)
```

A transient Maven Central 429 from the runner CDN edge, at plugin resolution, before anything compiled. The job's last step attaches the ParparVM jars to the published release, so it never ran and **7.0.264 shipped without them** — every release since 7.0.261 has `ByteCodeTranslator-1.0-SNAPSHOT.jar` and `JavaAPI-1.0-SNAPSHOT.jar`, 7.0.264 had only the guide and javadocs. Anything fetching `releases/latest/download/...` for those jars got a 404.

The sibling `vm-tests` job on the same run passed — it already retries this exact flake (added for the 403 variant). `release-jars` called `mvn` bare.

This job only runs on release-published events, so it fails rarely, silently, and exactly when it matters.

## The change

Lift the inline retry out of `vm-tests` into `scripts/ci/retry.sh`, next to the existing `scripts/ci/apt-get-update.sh`, and use it from both jobs. Bounded at 3 attempts / 30s, overridable via `RETRY_ATTEMPTS` and `RETRY_DELAY_SECONDS`; the last attempt's exit status propagates. A real build failure fails identically on every attempt, so retrying only costs time on a genuinely broken build.

Verified locally: success passes through, a flaky command succeeds on attempt 2, a hard failure exits with the command's own status (7), a missing command exits 127, and no arguments exits 2.

## Already done separately

7.0.264's assets were restored by re-running the failed job — the release page now carries both jars again. This PR is only about it not recurring.

## Noted, not fixed here

- `softprops/action-gh-release@v1` in this job targets the deprecated Node 20 runtime (warning on the successful rerun). Same failure class — if it breaks, a release silently ships without jars — but a `v1`→`v2` bump is its own change.
- `HeavyLoadBenchmarkTest` logs `WARNING: Failed to compile HelloCodenameOne` on every run and continues: it compiles `scripts/hellocodenameone` with JDK 8, but that source is Java 17 (records, switch expressions, text blocks). The benchmark has never included the app payload it intends to. Pre-existing and unrelated to the release failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
