### PR TITLE
Blog: document the missing crash-protection build hint

### DIFF
--- a/docs/website/content/blog/seamless-crash-protection.md
+++ b/docs/website/content/blog/seamless-crash-protection.md
@@ -10,6 +10,8 @@ feed_html: '<img src="https://www.codenameone.com/blog/seamless-crash-protection
 
 ![Seamless Crash Protection That Symbolicates Native Crashes](/blog/seamless-crash-protection.jpg)
 
+_Editor note (2026-07-31): the original "Turning it on" section listed only the two runtime calls and omitted the `codename1.arg.crashProtection.enabled=true` build hint. The hint is required: without it the build server never uploads the build's symbols, and crash reports from that build are dropped on arrival. The section below has been corrected._
+
 [Friday's release post](/blog/native-linux-apple-watch-game-builder-crash-protection/) introduced the new crash-protection system. This post is the detailed version: why it exists, what it does on the device, and how to turn it on.
 
 The motivation is portability. Every port we add widens the set of platforms an app can break on, and testing across all of them by hand does not scale. The old crash-protection tool emailed you a stack trace; that worked, but it did not symbolicate native crashes, and a busy app could bury you in mail. The new `com.codename1.crash` package replaces it with something seamless, and the seam it removes is the work you used to do yourself.
@@ -86,7 +88,17 @@ CrashProtection.setScrubber(new MyScrubber());
 
 ## Turning it on
 
-Crash protection is opt-in and off by default, and the choice is yours to make: it is persisted in `Preferences`. Install the handler during startup and enable uploads:
+Crash protection is opt-in and off by default, and turning it on takes two steps: one build hint and two lines of code.
+
+Start with the build hint. Add this to your `codenameone_settings.properties`:
+
+```
+codename1.arg.crashProtection.enabled=true
+```
+
+The `codename1.arg.` prefix ships the property to the build server as a build hint, and it is what tells a successful release build to upload its symbol artifacts, `mapping.txt` on Android or the dSYM on iOS, alongside the normal binary. Those symbols are also what the server matches an incoming report against, so a build that never uploaded them has its reports dropped on arrival. If you set the two calls below but skip this line, nothing will ever reach your repository.
+
+Then install the handler during startup and enable uploads. That choice is yours to make, and it is persisted in `Preferences`:
 
 ```java
 CrashProtection.install();
@@ -94,6 +106,8 @@ CrashProtection.setEnabled(true);
 ```
 
 `install()` registers the crash handler and, on the next launch, drains any reports that were stored but not yet uploaded. In the simulator uploads are skipped, so you can call both methods unconditionally without sending test crashes to the cloud. `setEnabled(false)` stops uploads later without uninstalling.
+
+One consequence of tying reports to symbols is worth planning around: symbol bundles are retained for three weeks on Pro and six on Enterprise, so crash protection covers the window right after a release, when a regression is most likely to surface. It is not a permanent watch on a build you shipped months ago. Ship a fresh build and its own symbols start the window again.
 
 A few details worth knowing. The endpoint is fixed to the Codename One cloud, so there is nothing to configure there. On Android the new handler runs alongside the legacy `Log.bindCrashProtection` path, guarded so a bug in one cannot suppress the other, which means you can adopt the new system without losing the old behavior while you migrate.
 

--- a/docs/website/content/blog/seamless-crash-protection.md
+++ b/docs/website/content/blog/seamless-crash-protection.md
@@ -24,7 +24,7 @@ Put plainly: once a product ships on several platforms and starts to grow, this 
 
 **It files GitHub issues, not emails.** Crashes land where you already track work, deduplicated, instead of arriving as a stream of messages.
 
-**It symbolicates native crashes on every platform we support.** Native faults on iOS, macOS, Windows (Win32) and Linux come back as symbolicated stacks, and obfuscated Android exceptions are deobfuscated back to your original class and method names. The cloud build keeps the symbols and applies them server-side, so every platform we ship is covered.
+**It symbolicates native crashes on every platform we support.** Native faults on iOS, watchOS, tvOS, macOS, Windows (Win32) and Linux come back as symbolicated stacks, and obfuscated Android exceptions are deobfuscated back to your original class and method names. The cloud build keeps the symbols and applies them server-side, so every platform we ship is covered.
 
 ## Storage-first delivery on the device
 
@@ -48,7 +48,7 @@ sequenceDiagram
     Cloud->>GitHub: open or update an issue (dedup by eventId)
 {{< /mermaid >}}
 
-Symbolication is the half that needs the cloud. After a successful release build, the executor ships the build's symbol artifacts, `mapping.txt` for Android or the dSYM for iOS, to the server, which keeps them and applies them when a matching crash arrives. On iOS the existing signal handlers already convert native signals into JVM exceptions that flow through the same error handler, so a native crash and a Java exception travel the same path.
+Symbolication is the half that needs the cloud. After a successful release build, the executor ships the build's symbol artifacts to the server, which keeps them and applies them when a matching crash arrives. On Android that is the ProGuard/R8 `mapping.txt`. An Apple build sends one archive holding every slice it produced, because a single Xcode archive can emit several independently symbolicated binaries: the phone app, an embedded watch app, an Apple TV app, and the Mac Catalyst slice. Each carries its own debug symbols, and the server picks the one matching the device a crash came from, so a watch crash resolves against the watch binary rather than the phone's. On iOS the existing signal handlers already convert native signals into JVM exceptions that flow through the same error handler, so a native crash and a Java exception travel the same path.
 
 ## A real native crash, made readable
 


### PR DESCRIPTION
Corrects the crash-protection deep-dive post, which documented the runtime setup but omitted the build hint it depends on.

## What was wrong

The "Turning it on" section listed only:

```java
CrashProtection.install();
CrashProtection.setEnabled(true);
```

It never mentioned `codename1.arg.crashProtection.enabled=true`. Without that hint the build server does not upload the build's symbols, BuildCloud's ingest gate drops every report from that build on arrival, and the device deletes its buffered copy on the `204`. A developer who follows the post exactly gets silence, with nothing anywhere to indicate why.

Reported by a customer who wired crash protection up in early July, shipped on the 3rd, and never saw an issue filed. The developer guide's setup checklist already had the hint; only the blog post was missing it.

## Changes

1. **Editor note** under the hero image, following the `_Editor note:_ ...` convention already used in `cocoapods.md`. The post was published and people have set their apps up from it, so a silent rewrite would leave them with no signal that anything changed.
2. **"Turning it on" now leads with the build hint**, framed as "one build hint and two lines of code", and says explicitly that the two calls alone deliver nothing.
3. **A short paragraph on the symbol retention window**, so the post sets the right expectation: crash protection covers the weeks after a release, when a regression is most likely to surface, not a permanent watch on a build shipped months ago. This is the next question the same customer would have asked.
4. **watchOS and tvOS added to the platform list**, which previously omitted them while claiming "every platform we support". That gap is the one a customer notices first — a watch crash arriving unsymbolicated after reading that sentence looks like a bug in the service rather than a limit of it.
5. **The symbolication paragraph rewritten** for the multi-slice archive: an Apple build ships every slice it produced, and the server picks the one matching the crashing device, so a watch crash resolves against the watch binary rather than the phone's. Worth stating plainly, because "which binary answered" is exactly what a developer cannot see from a GitHub issue.

## Sequencing

The post describes behaviour implemented by two other PRs, neither live yet:

- **[BuildDaemon#167](https://github.com/codenameone/BuildDaemon/pull/167)** — wires the builders that never called the symbol uploader, and packs every Apple slice into one archive.
- **[BuildCloud#123](https://github.com/codenameone/BuildCloud/pull/123)** — makes the server select the slice matching the device a crash came from.

**This must not publish before both deploy**, or the post documents behaviour the service does not yet have.

Note also that the fix is forward-only: builds already on the stores carry no symbols and never will, so affected developers need the hint plus a rebuild and redeploy before any crash reaches them.

## Checks

`scripts/website/blog_prose_gate.py` passes — no net-new prose findings. The LanguageTool leg was not run locally (the 259 MB download stalls in this environment); CI will cover it. Diff is ASCII-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

