### PR TITLE
Fix the attach race in HealthEdtDeliveryTest.aFacadeActionDeliversOnTheEdt

### DIFF
--- a/maven/core-unittests/src/test/java/com/codename1/health/HealthEdtDeliveryTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/health/HealthEdtDeliveryTest.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -330,14 +331,23 @@ class HealthEdtDeliveryTest extends UITestBase {
                 CN.callSerially(new Runnable() {
                     public void run() {
                         try {
-                            attached.await();
+                            // Bounded on purpose: a blocker that outlived its
+                            // release would park the EDT for the rest of the
+                            // suite, turning one failure into a hang.
+                            attached.await(10, TimeUnit.SECONDS);
                         } catch (InterruptedException ex) {
                             Thread.currentThread().interrupt();
                         }
                     }
                 });
-                Health.getInstance().openHealthSettings().onResult(landing);
-                attached.countDown();
+                try {
+                    Health.getInstance().openHealthSettings()
+                            .onResult(landing);
+                } finally {
+                    // In a finally so a throw above surfaces as itself rather
+                    // than as a suite-wide hang behind a still-parked EDT.
+                    attached.countDown();
+                }
             }
         }, true);
     }

--- a/maven/core-unittests/src/test/java/com/codename1/health/HealthEdtDeliveryTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/health/HealthEdtDeliveryTest.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -72,14 +73,20 @@ class HealthEdtDeliveryTest extends UITestBase {
      * Runs {@code op} off the EDT and waits for its delivery without blocking
      * the EDT.
      *
-     * <p>Worth spelling out, because the obvious harness fails in a way that
-     * looks like a product bug. These tests run on the EDT; the delivery being
-     * asserted is a {@code callSerially}; so waiting on a latch from the test
-     * thread stops the event loop and the runnable carrying the result can
-     * never run. {@code invokeAndBlock} is the CN1 answer -- it moves the
-     * waiting off the EDT and keeps the loop pumping. My first version of this
-     * file used a plain latch and reported the aggregate path as broken when
-     * it was not.</p>
+     * <p>Worth spelling out, because the harness reads as more than it is.
+     * JUnit runs these on {@code main}, not on the EDT, so
+     * {@code invokeAndBlock} takes its non-EDT branch and simply runs the
+     * operation inline; the real EDT pumps its own loop alongside, which is
+     * what carries the delivery. The call is kept because it states the
+     * precondition the assertion below checks -- the operation starts off the
+     * EDT -- and because it is what a caller would write.</p>
+     *
+     * <p>The consequence is that the EDT is free to deliver the moment a
+     * resource is completed, so every test here has to attach its listener
+     * before that can happen: an already-settled {@code AsyncResource} runs a
+     * late listener inline on the attaching thread, recording "not the EDT"
+     * for a delivery that did happen there. The store tests hold the backend;
+     * the facade test parks the EDT.</p>
      */
     private <T> void assertDeliveredOnEdt(final Landing<T> landing,
             final Runnable op) {
@@ -198,20 +205,6 @@ class HealthEdtDeliveryTest extends UITestBase {
     }
 
     /**
-     * The facade's own actions deliver on the EDT too.
-     *
-     * <p>These were missed when the store's results were moved onto
-     * {@code EdtResult}: {@code openHealthSettings} and
-     * {@code openProviderSetup} settle synchronously before the method
-     * returns, so a callback attached afterwards ran immediately on whatever
-     * thread called -- and a caller doing UI work in it, which is the whole
-     * point of "did the settings screen open?", raced rendering.</p>
-     *
-     * <p>The fallback facade is the one under test here because it is the one
-     * that settles inline; the port facades do the same thing through the
-     * same resource type.</p>
-     */
-    /**
      * Every public health resource is an EDT-delivering one.
      *
      * <p>Written as a source scan rather than as one test per operation
@@ -310,12 +303,41 @@ class HealthEdtDeliveryTest extends UITestBase {
         return "<unknown>";
     }
 
+    /**
+     * The facade's own actions deliver on the EDT too.
+     *
+     * <p>These were missed when the store's results were moved onto
+     * {@code EdtResult}: {@code openHealthSettings} and
+     * {@code openProviderSetup} settle synchronously before the method
+     * returns, so a callback attached afterwards ran immediately on whatever
+     * thread called -- and a caller doing UI work in it, which is the whole
+     * point of "did the settings screen open?", raced rendering.</p>
+     *
+     * <p>The fallback facade is the one under test here because it is the one
+     * that settles inline; the port facades do the same thing through the
+     * same resource type.</p>
+     */
     @Test
     void aFacadeActionDeliversOnTheEdt() {
         final Landing<Boolean> landing = new Landing<Boolean>();
+        final CountDownLatch attached = new CountDownLatch(1);
         assertDeliveredOnEdt(landing, new Runnable() {
             public void run() {
+                // The facade settles before it returns, so unlike the store
+                // tests there is nothing to hold back -- park the EDT instead.
+                // Serial calls run in order, so this blocker is ahead of the
+                // delivery in the queue and the listener wins the attach.
+                CN.callSerially(new Runnable() {
+                    public void run() {
+                        try {
+                            attached.await();
+                        } catch (InterruptedException ex) {
+                            Thread.currentThread().interrupt();
+                        }
+                    }
+                });
                 Health.getInstance().openHealthSettings().onResult(landing);
+                attached.countDown();
             }
         }, true);
     }


### PR DESCRIPTION
## The problem

`HealthEdtDeliveryTest.aFacadeActionDeliversOnTheEdt` fails **8/8 times** when run on its own, and flakes roughly **1 in 10** when the whole class runs:

```
AssertionFailedError: a result must arrive on the EDT on every backend ==> expected: <true> but was: <false>
  at HealthEdtDeliveryTest.assertDeliveredOnEdt(HealthEdtDeliveryTest.java:112)
  at HealthEdtDeliveryTest.aFacadeActionDeliversOnTheEdt(HealthEdtDeliveryTest.java:316)
```

`pr.yml` runs `core-unittests` on every PR, so this was an intermittent red build waiting to happen.

## Root cause

**The product code is correct** — `EdtResult` hops to the EDT in every failing run. The test loses a race it cannot win.

`Health.openHealthSettings()` completes its `EdtResult` *before it returns*:

```java
public AsyncResource<Boolean> openHealthSettings() {
    AsyncResource<Boolean> out = new EdtResult<Boolean>();
    out.complete(Boolean.FALSE);   // -> callSerially(Deliver)
    return out;
}
```

The test then attaches `.onResult(landing)` afterwards. By then the EDT has usually already run the queued `Deliver`, and `AsyncResource.ready` takes its already-settled branch (`AsyncResource.java:451`), invoking the listener **inline on the attaching thread**. The landing records `isEdt() == false` for a delivery that genuinely happened on the EDT.

Instrumenting the delivery proves it fires from the attach, not from the queued runnable:

```
at AsyncResource.ready(AsyncResource.java:470)   <-- runImmediately, already-done path
at AsyncResource.onResult(AsyncResource.java:634)
at HealthEdtDeliveryTest$1.run(...)
at com.codename1.ui.Display.invokeAndBlock(Display.java:1561)
```

This is the same race the class already documents on `anAggregateDeliversOnTheEdt`. The other six tests dodge it by holding the backend (`holdRead`/`holdWrite`/`holdAggregate`/`holdDelete`) until the listener is attached. The facade settles synchronously, so there is nothing to hold — which is why this one test was left exposed.

A second detail widens the window: JUnit runs these on `main`, not the EDT, so `CN.invokeAndBlock` takes its non-EDT branch (`Display.java:1561`, a plain `r.run()`). The real EDT spins idle alongside and grabs the queued delivery almost instantly. That is why isolation fails deterministically while a busier full-class run usually wins.

## The fix

Park the EDT behind a barrier queued *ahead* of the delivery, and release it once the listener is attached. Serial calls run FIFO, so the ordering is guaranteed rather than hoped for.

```java
CN.callSerially(new Runnable() {
    public void run() {
        try { attached.await(); } catch (InterruptedException ex) { Thread.currentThread().interrupt(); }
    }
});
Health.getInstance().openHealthSettings().onResult(landing);
attached.countDown();
```

Also in this change:

- **Corrected the `assertDeliveredOnEdt` docs.** They stated these tests run on the EDT and that `invokeAndBlock` keeps the loop pumping. Neither holds, and the gap between the comment and the behaviour is what made the race invisible. Replaced with what actually happens, plus the attach-before-settle rule every test here depends on.
- **Moved the facade test's javadoc back onto the facade test.** It had drifted upward and was sitting stacked above `everyPublicHealthResourceDeliversOnTheEdt`'s own javadoc, documenting a test ~100 lines away.

No production code is touched.

## Verification

| Run | Before | After |
|---|---|---|
| `-Dtest=HealthEdtDeliveryTest#aFacadeActionDeliversOnTheEdt` | 8/8 fail | **0/12 fail** |
| `-Dtest=HealthEdtDeliveryTest` (full class) | 1/10 fail | **0/30 fail** |

`mvn verify` on `core-unittests` is green: SpotBugs `BugInstance size is 0`, PMD, Checkstyle and Spotless all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)