### PR TITLE
Size the translator heap from the machine so large apps build unmodified

### DIFF
--- a/maven/codenameone-maven-plugin/spotbugs-exclude.xml
+++ b/maven/codenameone-maven-plugin/spotbugs-exclude.xml
@@ -206,6 +206,20 @@
         </Or>
     </Match>
 
+    <!--
+    TranslatorHeap reads the container memory limit so a build inside a cgroup
+    sizes the translator heap against that limit rather than the host's RAM.
+    The two paths it probes (/sys/fs/cgroup/memory.max for cgroup v2 and
+    /sys/fs/cgroup/memory/memory.limit_in_bytes for v1) are fixed locations in
+    the Linux kernel's pseudo-filesystem. There is nothing to make relative or
+    configurable, and both reads are guarded by isFile() so a non-Linux host
+    simply falls through to physical RAM.
+    -->
+    <Match>
+        <Class name="com.codename1.builders.TranslatorHeap" />
+        <Bug pattern="DMI_HARDCODED_ABSOLUTE_FILENAME" />
+    </Match>
+
     <!-- RichPropertiesReader wraps a properties file with helper lookups. -->
     <Match>
         <Class name="com.codename1.util.RichPropertiesReader" />

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/Executor.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/Executor.java
@@ -1955,7 +1955,7 @@ public abstract class Executor {
         final boolean[] running = new boolean[]{true};
 
         try {
-            new Thread() {
+            Thread reader = new Thread() {
                 public void run() {
                     try {
                         byte[] buffer = new byte[8192];
@@ -1971,7 +1971,8 @@ public abstract class Executor {
                         outputMessage.append("Exception on appending to log: " + ex);
                     }
                 }
-            }.start();
+            };
+            reader.start();
             if (timeout > -1) {
                 new Thread() {
                     public void run() {
@@ -1992,6 +1993,14 @@ public abstract class Executor {
                 }.start();
             }
             int val = p.waitFor();
+            // waitFor returns as soon as the process exits, but the reader thread
+            // may still be draining what is left in the pipe. Callers that inspect
+            // outputMessage after this returns (the translator's out-of-memory
+            // check, for one) would otherwise race the reader and read a partial
+            // tail -- and the tail is exactly where a JVM prints its
+            // OutOfMemoryError. Bounded so a wedged reader cannot hang the build;
+            // the process has already exited, so the stream reaches EOF promptly.
+            reader.join(30000);
             if (destroyed[0]) {
                 log("Process timed out");
                 return 1;

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/Executor.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/Executor.java
@@ -1993,6 +1993,12 @@ public abstract class Executor {
                 }.start();
             }
             int val = p.waitFor();
+            // Stop the timeout watcher FIRST. The process has already exited, so
+            // nothing it could do from here is useful -- and the join below can
+            // hold us here for a while, during which a watcher still counting
+            // would cross the deadline and flag a completed run as timed out.
+            running[0] = false;
+            boolean timedOut = destroyed[0];
             // waitFor returns as soon as the process exits, but the reader thread
             // may still be draining what is left in the pipe. Callers that inspect
             // outputMessage after this returns (the translator's out-of-memory
@@ -2001,11 +2007,10 @@ public abstract class Executor {
             // OutOfMemoryError. Bounded so a wedged reader cannot hang the build;
             // the process has already exited, so the stream reaches EOF promptly.
             reader.join(30000);
-            if (destroyed[0]) {
+            if (timedOut) {
                 log("Process timed out");
                 return 1;
             }
-            running[0] = false;
             log("Process return code is "+val);
             return val;
         } finally {

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
@@ -3520,16 +3520,18 @@ public class IPhoneBuilder extends Executor {
                         }
                     }
                 }
-                // Default heap; a -Xmx in CN1_TRANSLATOR_OPTS takes precedence.
-                // The dead-code cull builds an in-memory suffix automaton over
-                // all native symbols (NativeSymbolIndex, from #5236) to avoid the
-                // old O(N^2) substring scan that timed out on large apps -- that
-                // index trades time for memory, so the historical 384m cap now
-                // OOMs local iOS builds as the CN1 class count grows (issue
-                // #5344). The cloud builder already runs the same translator at
-                // 1024m; match it here so local and server builds behave alike.
+                // Heap sized from the machine (see TranslatorHeap), floored at the
+                // 1024m the cloud builder has always used; a -Xmx in
+                // CN1_TRANSLATOR_OPTS still takes precedence. The dead-code cull
+                // builds an in-memory suffix automaton over all native symbols
+                // (NativeSymbolIndex, from #5236) to avoid the old O(N^2) substring
+                // scan that timed out on large apps -- that index trades time for
+                // memory, so the historical 384m cap OOMed local iOS builds as the
+                // CN1 class count grew (issue #5344) and even 1024m is not enough
+                // for a large app (issue #5511).
+                int heapMB = TranslatorHeap.maxHeapMB(1024);
                 if (!heapOverridden) {
-                    parparCmd.add("-Xmx1024m");
+                    parparCmd.add("-Xmx" + heapMB + "m");
                 }
                 parparCmd.add("-jar");
                 parparCmd.add(parparVMCompilerJar);
@@ -3543,7 +3545,19 @@ public class IPhoneBuilder extends Executor {
                 parparCmd.add(buildVersion);
                 parparCmd.add(request.getArg("ios.project_type", "ios")); // ios, iphone, ipad
                 parparCmd.add(addLibs);
-                if (!exec(userDir, env, 420000, parparCmd.toArray(new String[0]))) {
+                int outputMark = message.length();
+                // 600s, matching the cloud builder running the identical translator
+                // over the identical input. Translation time grows with app size, so
+                // the lower local 420s cap meant a large app could translate fine on
+                // the build server yet be killed mid-run on the developer's own
+                // machine -- which is usually the slower of the two.
+                if (!exec(userDir, env, 600000, parparCmd.toArray(new String[0]))) {
+                    // Name the failure rather than leaving the build to report a
+                    // bare "translator failed" -- an out-of-memory death is
+                    // fixable by the developer, but only if we say so.
+                    if (!heapOverridden && TranslatorHeap.looksOutOfMemory(message.substring(outputMark))) {
+                        error(TranslatorHeap.outOfMemoryAdvice(heapMB, true), null);
+                    }
                     return false;
                 }
             } catch (Exception ex) {

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
@@ -3508,18 +3508,9 @@ public class IPhoneBuilder extends Executor {
                 // -Xmx) from the CN1_TRANSLATOR_OPTS environment variable. The
                 // forked JVM does not inherit the Maven process's -D properties,
                 // so this is the only way to reach the translator for tuning.
-                String translatorOpts = System.getenv("CN1_TRANSLATOR_OPTS");
-                boolean heapOverridden = false;
-                if (translatorOpts != null && !translatorOpts.trim().isEmpty()) {
-                    for (String opt : translatorOpts.trim().split("\\s+")) {
-                        if (!opt.isEmpty()) {
-                            parparCmd.add(opt);
-                            if (opt.startsWith("-Xmx")) {
-                                heapOverridden = true;
-                            }
-                        }
-                    }
-                }
+                java.util.List<String> translatorOpts = TranslatorHeap.extraJvmOptions();
+                parparCmd.addAll(translatorOpts);
+                boolean heapOverridden = TranslatorHeap.specifiesHeap(translatorOpts);
                 // Heap sized from the machine (see TranslatorHeap), floored at the
                 // 1024m the cloud builder has always used; a -Xmx in
                 // CN1_TRANSLATOR_OPTS still takes precedence. The dead-code cull

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/JavaScriptBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/JavaScriptBuilder.java
@@ -797,11 +797,14 @@ public class JavaScriptBuilder extends Executor {
         if (jsPortWebApp != null && jsPortWebApp.isDirectory() && !webAppOverridden) {
             extraOpts.add("-Dcodename1.javascriptport.webapp=" + jsPortWebApp.getAbsolutePath());
         }
-        // Default heap; a -Xmx in CN1_TRANSLATOR_OPTS takes precedence (apps
-        // that disable tree-shaking, e.g. the Playground, emit a much larger
-        // bundle and need a bigger heap to avoid OutOfMemoryError mid-emit).
+        // Heap sized from the machine (see TranslatorHeap); a -Xmx in
+        // CN1_TRANSLATOR_OPTS still takes precedence. The old fixed 512m was
+        // tuned against the sample apps and made a large app fail with
+        // OutOfMemoryError mid-emit unless the developer found and set
+        // CN1_TRANSLATOR_OPTS by hand (issue #5511).
+        int heapMB = TranslatorHeap.maxHeapMB(512);
         if (!heapOverridden) {
-            cmd.add("-Xmx512m");
+            cmd.add("-Xmx" + heapMB + "m");
         }
         cmd.addAll(extraOpts);
         cmd.add("-cp");
@@ -816,7 +819,17 @@ public class JavaScriptBuilder extends Executor {
         cmd.add(version == null ? "1.0" : version);
         cmd.add("ios");
         cmd.add("none");
-        return exec(tmpDir, env, -1, cmd.toArray(new String[0]));
+        int outputMark = message.length();
+        if (exec(tmpDir, env, -1, cmd.toArray(new String[0]))) {
+            return true;
+        }
+        // Name the failure rather than leaving the build to report a bare
+        // "translator failed" -- an out-of-memory death is fixable by the
+        // developer, but only if we say so.
+        if (!heapOverridden && TranslatorHeap.looksOutOfMemory(message.substring(outputMark))) {
+            error(TranslatorHeap.outOfMemoryAdvice(heapMB, true), null);
+        }
+        return false;
     }
 
     private File locateDistDir(File translatorOut, String translatorAppName) {

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/JavaScriptBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/JavaScriptBuilder.java
@@ -766,19 +766,8 @@ public class JavaScriptBuilder extends Executor {
         // CN1_TRANSLATOR_OPTS environment variable. The forked JVM does
         // not inherit the Maven process's -D properties, so this is the
         // only way to reach the translator for bisection / tuning.
-        String translatorOpts = System.getenv("CN1_TRANSLATOR_OPTS");
-        boolean heapOverridden = false;
-        java.util.List<String> extraOpts = new java.util.ArrayList<String>();
-        if (translatorOpts != null && !translatorOpts.trim().isEmpty()) {
-            for (String opt : translatorOpts.trim().split("\\s+")) {
-                if (!opt.isEmpty()) {
-                    extraOpts.add(opt);
-                    if (opt.startsWith("-Xmx")) {
-                        heapOverridden = true;
-                    }
-                }
-            }
-        }
+        java.util.List<String> extraOpts = TranslatorHeap.extraJvmOptions();
+        boolean heapOverridden = TranslatorHeap.specifiesHeap(extraOpts);
         // Hand the translator the JavaScript-port webapp (port.js, js/, style.css,
         // ...) so it bundles port.js -- the worker-side native bindings that make
         // Window.current() etc. resolve. Off-repo builds can't find it via the

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/LinuxNativeBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/LinuxNativeBuilder.java
@@ -288,14 +288,23 @@ public class LinuxNativeBuilder extends Executor {
 
         List<String> parparCmd = new ArrayList<String>();
         parparCmd.add("java");
+        // Extra translator JVM options from CN1_TRANSLATOR_OPTS, honoured on every
+        // target so the escape hatch does not work on some and silently do nothing
+        // on others.
+        List<String> translatorOpts = TranslatorHeap.extraJvmOptions();
+        parparCmd.addAll(translatorOpts);
         // Heap sized from the machine (see TranslatorHeap), floored at 2g: the
         // clean target's readNativeFiles loads both .m and .c (clean's
         // extension), so the in-memory native-source set is ~2x what the iOS
         // target loads, and the markDependencies/NativeSymbolIndex pass needs
         // headroom on top of that. Without the JavaAPI in classesDir the
         // translator never reaches that stage at scale; once JavaAPI is added
-        // the older 768m cap GC-thrashes.
-        parparCmd.add(TranslatorHeap.maxHeapArg(2048));
+        // the older 768m cap GC-thrashes. A -Xmx in CN1_TRANSLATOR_OPTS wins.
+        boolean heapOverridden = TranslatorHeap.specifiesHeap(translatorOpts);
+        int heapMB = TranslatorHeap.maxHeapMB(2048);
+        if (!heapOverridden) {
+            parparCmd.add("-Xmx" + heapMB + "m");
+        }
         parparCmd.add("-jar");
         parparCmd.add(parparVMCompilerJar.getAbsolutePath());
         parparCmd.add("clean");
@@ -311,7 +320,14 @@ public class LinuxNativeBuilder extends Executor {
         parparCmd.add("linux"); // project type
         parparCmd.add("none");  // additional native frameworks (none on Linux)
         try {
+            int outputMark = message.length();
             if (!exec(tmpFile, 600000, parparCmd.toArray(new String[0]))) {
+                // Name the failure rather than leaving the build to report a bare
+                // "translator failed" -- an out-of-memory death is fixable by the
+                // developer, but only if we say so.
+                if (!heapOverridden && TranslatorHeap.looksOutOfMemory(message.substring(outputMark))) {
+                    error(TranslatorHeap.outOfMemoryAdvice(heapMB, true), null);
+                }
                 return false;
             }
         } catch (Exception ex) {

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/LinuxNativeBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/LinuxNativeBuilder.java
@@ -288,13 +288,14 @@ public class LinuxNativeBuilder extends Executor {
 
         List<String> parparCmd = new ArrayList<String>();
         parparCmd.add("java");
-        // 2g: the clean target's readNativeFiles loads both .m and .c (clean's
+        // Heap sized from the machine (see TranslatorHeap), floored at 2g: the
+        // clean target's readNativeFiles loads both .m and .c (clean's
         // extension), so the in-memory native-source set is ~2x what the iOS
         // target loads, and the markDependencies/NativeSymbolIndex pass needs
         // headroom on top of that. Without the JavaAPI in classesDir the
         // translator never reaches that stage at scale; once JavaAPI is added
         // the older 768m cap GC-thrashes.
-        parparCmd.add("-Xmx2g");
+        parparCmd.add(TranslatorHeap.maxHeapArg(2048));
         parparCmd.add("-jar");
         parparCmd.add(parparVMCompilerJar.getAbsolutePath());
         parparCmd.add("clean");

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/TranslatorHeap.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/TranslatorHeap.java
@@ -198,18 +198,134 @@ final class TranslatorHeap {
         return physicalMemoryMB();
     }
 
+    /** Where the cgroup filesystem is mounted on Linux. */
+    private static final String CGROUP_ROOT = "/sys/fs/cgroup";
+
+    /** Lists the cgroup this process belongs to, one hierarchy per line. */
+    private static final String PROC_SELF_CGROUP = "/proc/self/cgroup";
+
+    private static long cgroupLimitMB() {
+        return cgroupLimitMB(new File(CGROUP_ROOT), readFileQuietly(new File(PROC_SELF_CGROUP)));
+    }
+
     /**
      * Reads the memory limit imposed on this process by its cgroup, in MB, or -1
      * when unlimited / unavailable. Handles cgroup v2 ({@code memory.max}, which
      * reads "max" when unlimited) and v1 ({@code memory.limit_in_bytes}, which
      * reports a sentinel near Long.MAX_VALUE when unlimited).
+     *
+     * <p>The limit is NOT necessarily at the mount root. When the process runs in
+     * its own cgroup namespace (the usual container case) the root files are the
+     * container's own limit, but under a systemd unit with {@code MemoryMax=}, or
+     * a container sharing the host cgroup namespace, the root shows the host's
+     * unlimited value and the real limit lives at the path named in
+     * {@code /proc/self/cgroup}. Reading only the root there would fall back to
+     * host RAM and size a heap the container cannot honour -- exactly the kernel
+     * OOM-kill this helper exists to avoid.
+     *
+     * <p>A limit set anywhere on the path applies, so the effective budget is the
+     * smallest limit found from the mount root down to this process's own cgroup.
+     *
+     * @param cgroupRoot      the cgroup filesystem mount point
+     * @param procSelfCgroup  contents of /proc/self/cgroup, or null when absent
+     * @return the limit in MB, or -1 when unlimited or not determinable
      */
-    private static long cgroupLimitMB() {
-        long v2 = readLimitFile(new File("/sys/fs/cgroup/memory.max"));
-        if (v2 > 0) {
-            return v2;
+    static long cgroupLimitMB(File cgroupRoot, String procSelfCgroup) {
+        // v2: one unified hierarchy, listed with an empty controller field.
+        long limit = walkForLimit(cgroupRoot, cgroupPath(procSelfCgroup, ""), "memory.max");
+        // v1: the memory controller is mounted in its own subdirectory.
+        limit = minPositive(limit, walkForLimit(new File(cgroupRoot, "memory"),
+                cgroupPath(procSelfCgroup, "memory"), "memory.limit_in_bytes"));
+        return limit;
+    }
+
+    /**
+     * Smallest limit found walking from a controller root down the given relative
+     * cgroup path. Descending (rather than starting at the leaf and walking up)
+     * means the traversal can never escape the controller root.
+     */
+    private static long walkForLimit(File controllerRoot, String relativePath, String limitFileName) {
+        if (controllerRoot == null || !controllerRoot.isDirectory()) {
+            return -1;
         }
-        return readLimitFile(new File("/sys/fs/cgroup/memory/memory.limit_in_bytes"));
+        long best = readLimitFile(new File(controllerRoot, limitFileName));
+        if (relativePath == null) {
+            return best;
+        }
+        File dir = controllerRoot;
+        for (String segment : relativePath.split("/")) {
+            if (segment.isEmpty()) {
+                continue;
+            }
+            dir = new File(dir, segment);
+            if (!dir.isDirectory()) {
+                break;
+            }
+            best = minPositive(best, readLimitFile(new File(dir, limitFileName)));
+        }
+        return best;
+    }
+
+    /**
+     * This process's cgroup path for a controller, from /proc/self/cgroup lines of
+     * the form {@code hierarchy-ID:controller-list:cgroup-path}.
+     *
+     * @param controller the v1 controller name, or "" for the v2 unified hierarchy
+     *                   (which is the line with an empty controller list)
+     * @return the path, or null when this hierarchy is not listed
+     */
+    static String cgroupPath(String procSelfCgroup, String controller) {
+        if (procSelfCgroup == null) {
+            return null;
+        }
+        for (String line : procSelfCgroup.split("\n")) {
+            String trimmed = line.trim();
+            // The path itself may contain ':', so split on the first two only.
+            int first = trimmed.indexOf(':');
+            if (first < 0) {
+                continue;
+            }
+            int second = trimmed.indexOf(':', first + 1);
+            if (second < 0) {
+                continue;
+            }
+            String controllers = trimmed.substring(first + 1, second);
+            String path = trimmed.substring(second + 1);
+            if (controller.isEmpty()) {
+                if (controllers.isEmpty()) {
+                    return path;
+                }
+            } else {
+                for (String c : controllers.split(",")) {
+                    if (controller.equals(c)) {
+                        return path;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    /** The smaller of two limits, ignoring non-positive (absent) ones. */
+    private static long minPositive(long a, long b) {
+        if (a <= 0) {
+            return b;
+        }
+        if (b <= 0) {
+            return a;
+        }
+        return Math.min(a, b);
+    }
+
+    private static String readFileQuietly(File f) {
+        try {
+            if (!f.isFile()) {
+                return null;
+            }
+            return new String(Files.readAllBytes(f.toPath()), StandardCharsets.UTF_8);
+        } catch (Exception ex) {
+            return null;
+        }
     }
 
     private static long readLimitFile(File f) {

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/TranslatorHeap.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/TranslatorHeap.java
@@ -27,6 +27,8 @@ import java.lang.management.ManagementFactory;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Picks the maximum heap for a forked ByteCodeTranslator JVM.
@@ -126,6 +128,49 @@ final class TranslatorHeap {
     static String maxHeapArg(int floorMB) {
         return "-Xmx" + maxHeapMB(floorMB) + "m";
     }
+
+    /**
+     * Extra JVM options for a forked translator, from {@code CN1_TRANSLATOR_OPTS}.
+     *
+     * <p>A forked JVM inherits none of this process's {@code -D} properties, so
+     * this variable is the only way to reach the translator with a diagnostic
+     * flag, a kill switch, or an explicit heap. Every builder that forks the
+     * translator must read it, or the escape hatch works on some targets and
+     * silently does nothing on others.
+     *
+     * @return the whitespace-separated tokens, never null
+     */
+    static List<String> extraJvmOptions() {
+        List<String> out = new ArrayList<String>();
+        String raw = System.getenv(OPTS_ENV);
+        if (raw != null && raw.trim().length() > 0) {
+            for (String opt : raw.trim().split("\\s+")) {
+                if (opt.length() > 0) {
+                    out.add(opt);
+                }
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Whether the caller-supplied options already set a maximum heap, in which
+     * case the auto-sized value must not be added on top of it.
+     */
+    static boolean specifiesHeap(List<String> options) {
+        if (options == null) {
+            return false;
+        }
+        for (String opt : options) {
+            if (opt.startsWith("-Xmx")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Raw JVM options passed through to the forked translator. */
+    static final String OPTS_ENV = "CN1_TRANSLATOR_OPTS";
 
     /**
      * Whether a failed translator run failed for lack of memory.

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/TranslatorHeap.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/TranslatorHeap.java
@@ -1,0 +1,289 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.builders;
+
+import java.io.File;
+import java.lang.management.ManagementFactory;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+/**
+ * Picks the maximum heap for a forked ByteCodeTranslator JVM.
+ *
+ * <p>The translator holds the whole parsed class model plus the emitted output in
+ * memory, so its peak scales with the size of the app being built. The heap used
+ * to be a hard-coded constant per target -- one tuned against the sample apps --
+ * which meant a genuinely large app died with OutOfMemoryError partway through
+ * translation and could only be built by setting {@code CN1_TRANSLATOR_OPTS} by
+ * hand (issue #5511). Sizing the ceiling from the machine instead lets those apps
+ * build unmodified.
+ *
+ * <p>Raising the ceiling is close to free for ordinary apps: {@code -Xmx} is a
+ * reservation, not a commitment, so a small app still runs at its natural
+ * footprint. The bound is deliberately conservative rather than "as much as the
+ * box has" -- half the detected budget, never more than {@link #CEILING_MB} --
+ * so a translator running inside a build container stays well clear of the
+ * container's own limit and a runaway build gets a clean Java OutOfMemoryError
+ * (which we can report) instead of a kernel OOM-kill (which we cannot).
+ */
+final class TranslatorHeap {
+    /**
+     * Absolute cap on the auto-sized heap, in MB. Large real-world apps have been
+     * observed needing ~1.6GB; this leaves headroom above that without ever
+     * approaching the memory ceiling of a build container.
+     */
+    static final int CEILING_MB = 4096;
+
+    /** Fraction of the detected memory budget the translator may claim. */
+    private static final double BUDGET_FRACTION = 0.5;
+
+    /**
+     * Per-box escape hatch: set to an explicit MB value to pin the heap. Honoured
+     * above the auto-sizing (but still below a {@code -Xmx} the caller passed in
+     * {@code CN1_TRANSLATOR_OPTS}, which wins over everything).
+     */
+    static final String HEAP_ENV = "CN1_TRANSLATOR_MAX_HEAP_MB";
+
+    private TranslatorHeap() {
+    }
+
+    /**
+     * Resolves the {@code -Xmx} value, in MB, for a forked translator.
+     *
+     * @param floorMB the target's historical hard-coded heap. The result is never
+     *                below this, so a machine (or container) too small to profit
+     *                from auto-sizing behaves exactly as it did before.
+     * @return the heap size in MB
+     */
+    static int maxHeapMB(int floorMB) {
+        return maxHeapMB(floorMB, System.getenv(HEAP_ENV), detectBudgetMB());
+    }
+
+    /**
+     * Testable core of {@link #maxHeapMB(int)}.
+     *
+     * @param floorMB   the target's historical hard-coded heap
+     * @param envValue  raw value of {@link #HEAP_ENV}, or null when unset
+     * @param budgetMB  detected memory budget in MB, or -1 when unknown
+     * @return the heap size in MB
+     */
+    static int maxHeapMB(int floorMB, String envValue, long budgetMB) {
+        if (floorMB < 1) {
+            floorMB = 1;
+        }
+        int override = parseMB(envValue);
+        if (override > 0) {
+            // An explicit override is a deliberate act by whoever configured the
+            // box, so it may go below the historical floor (a memory-starved box
+            // may need that) AND above CEILING_MB, which only bounds the value we
+            // pick automatically. Clamping it to the ceiling would make the knob
+            // useless anyway: the operator would just switch to
+            // CN1_TRANSLATOR_OPTS=-Xmx, which no ceiling applies to.
+            //
+            // What it may NOT do is exceed the memory the machine actually has --
+            // that is the setting that OOM-kills a build box rather than failing
+            // the one build, and it is the likely shape of a typo (an extra digit).
+            if (budgetMB > 0 && override > budgetMB) {
+                return (int) budgetMB;
+            }
+            return override;
+        }
+        if (budgetMB <= 0) {
+            return floorMB;
+        }
+        long heap = (long) (budgetMB * BUDGET_FRACTION);
+        if (heap > CEILING_MB) {
+            heap = CEILING_MB;
+        }
+        if (heap < floorMB) {
+            heap = floorMB;
+        }
+        return (int) heap;
+    }
+
+    /** The {@code -Xmx} argument for a forked translator, e.g. {@code -Xmx4096m}. */
+    static String maxHeapArg(int floorMB) {
+        return "-Xmx" + maxHeapMB(floorMB) + "m";
+    }
+
+    /**
+     * Whether a failed translator run failed for lack of memory.
+     *
+     * <p>A translator that dies this way otherwise just returns a non-zero exit
+     * code, and the build reports nothing more useful than "the translator
+     * failed" -- which is what sent the reporter of issue #5511 reading the build
+     * plugin's source to discover {@code CN1_TRANSLATOR_OPTS}. Recognising the
+     * failure lets us say what actually happened.
+     *
+     * @param processOutput the translator's captured stdout/stderr
+     * @return true when the output carries an out-of-memory signature
+     */
+    static boolean looksOutOfMemory(CharSequence processOutput) {
+        if (processOutput == null) {
+            return false;
+        }
+        String s = processOutput.toString();
+        return s.contains("java.lang.OutOfMemoryError")
+                || s.contains("GC overhead limit exceeded")
+                || s.contains("There is insufficient memory for the Java Runtime Environment");
+    }
+
+    /**
+     * The message to show when {@link #looksOutOfMemory} matches.
+     *
+     * @param heapMB                   the heap the translator was actually given, in MB
+     * @param canConfigureEnvironment  true for a build on the developer's own
+     *                                 machine, where they can raise the ceiling
+     *                                 themselves; false for a cloud build, where
+     *                                 the environment is not theirs to change and
+     *                                 pointing them at an env var would be useless
+     * @return an error message naming the heap in use and what can be done about it
+     */
+    static String outOfMemoryAdvice(int heapMB, boolean canConfigureEnvironment) {
+        String head = "The ByteCodeTranslator ran out of memory (it was given -Xmx" + heapMB + "m). "
+                + "This app needs a larger translation heap than the build machine's memory budget allows. ";
+        if (canConfigureEnvironment) {
+            return head + "Raise it by setting " + HEAP_ENV + " to a larger value in MB, or pass an "
+                    + "explicit heap via CN1_TRANSLATOR_OPTS (e.g. CN1_TRANSLATOR_OPTS=-Xmx6g), and "
+                    + "build again.";
+        }
+        return head + "Building locally lets you raise the ceiling via " + HEAP_ENV + "; otherwise "
+                + "reducing the amount of code in the app (dropping unused libraries) brings it back "
+                + "under the limit. Please report the app size on the issue tracker if neither applies.";
+    }
+
+    private static int parseMB(String value) {
+        if (value == null) {
+            return -1;
+        }
+        try {
+            return Integer.parseInt(value.trim());
+        } catch (NumberFormatException ex) {
+            return -1;
+        }
+    }
+
+    /**
+     * Memory this process is actually allowed to use, in MB, or -1 when it cannot
+     * be determined. A cgroup limit wins over physical RAM: inside a container the
+     * host's RAM is visible but irrelevant, and sizing against it is how a build
+     * ends up OOM-killed by the kernel.
+     */
+    static long detectBudgetMB() {
+        long cgroup = cgroupLimitMB();
+        if (cgroup > 0) {
+            return cgroup;
+        }
+        return physicalMemoryMB();
+    }
+
+    /**
+     * Reads the memory limit imposed on this process by its cgroup, in MB, or -1
+     * when unlimited / unavailable. Handles cgroup v2 ({@code memory.max}, which
+     * reads "max" when unlimited) and v1 ({@code memory.limit_in_bytes}, which
+     * reports a sentinel near Long.MAX_VALUE when unlimited).
+     */
+    private static long cgroupLimitMB() {
+        long v2 = readLimitFile(new File("/sys/fs/cgroup/memory.max"));
+        if (v2 > 0) {
+            return v2;
+        }
+        return readLimitFile(new File("/sys/fs/cgroup/memory/memory.limit_in_bytes"));
+    }
+
+    private static long readLimitFile(File f) {
+        try {
+            if (!f.isFile()) {
+                return -1;
+            }
+            String raw = new String(Files.readAllBytes(f.toPath()), StandardCharsets.UTF_8).trim();
+            if (raw.isEmpty() || "max".equals(raw)) {
+                return -1;
+            }
+            long bytes = Long.parseLong(raw);
+            // An "unlimited" v1 cgroup reports a huge sentinel (typically
+            // LONG_MAX rounded down to the page size). Anything at or above a
+            // petabyte is that sentinel, not a real limit.
+            if (bytes <= 0 || bytes >= (1024L * 1024L * 1024L * 1024L * 1024L)) {
+                return -1;
+            }
+            return bytes / (1024L * 1024L);
+        } catch (Exception ex) {
+            return -1;
+        }
+    }
+
+    /**
+     * Total physical RAM in MB, or -1 when unavailable.
+     *
+     * <p>Reflective on purpose. The accessor lives on
+     * {@code com.sun.management.OperatingSystemMXBean}, which is not guaranteed to
+     * exist on every JVM, and it was renamed from {@code getTotalPhysicalMemorySize}
+     * to {@code getTotalMemorySize} in Java 14 while this code still compiles at
+     * source level 8. Resolving the method against the public *interface* (rather
+     * than the non-public implementation class) means no setAccessible call and no
+     * illegal-access warning under JPMS.
+     */
+    private static long physicalMemoryMB() {
+        Object bean;
+        Class<?> sunOsBean;
+        try {
+            bean = ManagementFactory.getOperatingSystemMXBean();
+            sunOsBean = Class.forName("com.sun.management.OperatingSystemMXBean");
+        } catch (Exception ex) {
+            return -1;
+        } catch (LinkageError err) {
+            return -1;
+        }
+        if (bean == null || !sunOsBean.isInstance(bean)) {
+            return -1;
+        }
+        // Java 14+ name first, then the Java 8..13 spelling.
+        String[] candidates = {"getTotalMemorySize", "getTotalPhysicalMemorySize"};
+        for (String name : candidates) {
+            long bytes = invokeLongAccessor(sunOsBean, bean, name);
+            if (bytes > 0) {
+                return bytes / (1024L * 1024L);
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Invokes a no-arg accessor by name, returning -1 when it is absent on this
+     * JVM (the accessor was renamed in Java 14) or fails for any reason.
+     */
+    private static long invokeLongAccessor(Class<?> owner, Object target, String name) {
+        try {
+            Method m = owner.getMethod(name);
+            Object result = m.invoke(target);
+            if (result instanceof Number) {
+                return ((Number) result).longValue();
+            }
+            return -1;
+        } catch (Exception ex) {
+            return -1;
+        }
+    }
+}

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/WindowsNativeBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/WindowsNativeBuilder.java
@@ -271,14 +271,23 @@ public class WindowsNativeBuilder extends Executor {
 
         List<String> parparCmd = new ArrayList<String>();
         parparCmd.add("java");
+        // Extra translator JVM options from CN1_TRANSLATOR_OPTS, honoured on every
+        // target so the escape hatch does not work on some and silently do nothing
+        // on others.
+        List<String> translatorOpts = TranslatorHeap.extraJvmOptions();
+        parparCmd.addAll(translatorOpts);
         // Heap sized from the machine (see TranslatorHeap), floored at 2g: the
         // clean target's readNativeFiles loads both .m and .c (clean's
         // extension), so the in-memory native-source set is ~2x what the iOS
         // target loads, and the markDependencies/NativeSymbolIndex pass needs
         // headroom on top of that. Without the JavaAPI in classesDir the
         // translator never reaches that stage at scale; once JavaAPI is added
-        // the older 768m cap GC-thrashes.
-        parparCmd.add(TranslatorHeap.maxHeapArg(2048));
+        // the older 768m cap GC-thrashes. A -Xmx in CN1_TRANSLATOR_OPTS wins.
+        boolean heapOverridden = TranslatorHeap.specifiesHeap(translatorOpts);
+        int heapMB = TranslatorHeap.maxHeapMB(2048);
+        if (!heapOverridden) {
+            parparCmd.add("-Xmx" + heapMB + "m");
+        }
         parparCmd.add("-jar");
         parparCmd.add(parparVMCompilerJar.getAbsolutePath());
         // Output type: the portable "clean" C target. The "windows" app type
@@ -298,7 +307,14 @@ public class WindowsNativeBuilder extends Executor {
         parparCmd.add("windows"); // project type
         parparCmd.add("none");    // additional native frameworks (none on Windows)
         try {
+            int outputMark = message.length();
             if (!exec(tmpFile, 600000, parparCmd.toArray(new String[0]))) {
+                // Name the failure rather than leaving the build to report a bare
+                // "translator failed" -- an out-of-memory death is fixable by the
+                // developer, but only if we say so.
+                if (!heapOverridden && TranslatorHeap.looksOutOfMemory(message.substring(outputMark))) {
+                    error(TranslatorHeap.outOfMemoryAdvice(heapMB, true), null);
+                }
                 return false;
             }
         } catch (Exception ex) {

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/WindowsNativeBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/WindowsNativeBuilder.java
@@ -271,13 +271,14 @@ public class WindowsNativeBuilder extends Executor {
 
         List<String> parparCmd = new ArrayList<String>();
         parparCmd.add("java");
-        // 2g: the clean target's readNativeFiles loads both .m and .c (clean's
+        // Heap sized from the machine (see TranslatorHeap), floored at 2g: the
+        // clean target's readNativeFiles loads both .m and .c (clean's
         // extension), so the in-memory native-source set is ~2x what the iOS
         // target loads, and the markDependencies/NativeSymbolIndex pass needs
         // headroom on top of that. Without the JavaAPI in classesDir the
         // translator never reaches that stage at scale; once JavaAPI is added
         // the older 768m cap GC-thrashes.
-        parparCmd.add("-Xmx2g");
+        parparCmd.add(TranslatorHeap.maxHeapArg(2048));
         parparCmd.add("-jar");
         parparCmd.add(parparVMCompilerJar.getAbsolutePath());
         // Output type: the portable "clean" C target. The "windows" app type

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/ExecutorProcessTimeoutTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/ExecutorProcessTimeoutTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.builders;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers the interaction between the timeout watcher and the output reader in
+ * {@code Executor.executeProcess}: the translator's out-of-memory diagnostic
+ * needs the captured output to be complete when exec() returns, which means
+ * joining the reader -- and joining the reader must not leave the timeout
+ * watcher running past the deadline on a process that already finished.
+ */
+class ExecutorProcessTimeoutTest {
+
+    /** Executor is abstract; none of these hooks are exercised here. */
+    private static final class TestExecutor extends Executor {
+        @Override
+        protected String getDeviceIdCode() {
+            return "";
+        }
+
+        @Override
+        protected String generatePeerComponentCreationCode(String methodCallString) {
+            return "";
+        }
+
+        @Override
+        protected String convertPeerComponentToNative(String param) {
+            return "";
+        }
+
+        @Override
+        public boolean build(File sourceZip, BuildRequest request) {
+            return false;
+        }
+    }
+
+    @Test
+    void aProcessThatSucceedsIsNotReportedAsTimedOutWhileOutputIsStillDraining() throws Exception {
+        // The regression this guards: joining the reader thread after waitFor()
+        // left the timeout watcher counting, so a command that had already
+        // exited 0 could be reported as timed out if the deadline passed while
+        // the join was in progress -- surfacing as a random "translator failed"
+        // on the iOS and native steps, which are the ones that run with a timeout.
+        //
+        // Reproducing it needs the join to actually block, which means the pipe
+        // must outlive the process: the shell exits immediately while a
+        // backgrounded grandchild keeps the inherited stdout open. Without the
+        // fix the watcher fires at 1000ms during that wait and exec returns 1.
+        TestExecutor e = new TestExecutor();
+        ProcessBuilder pb = new ProcessBuilder("/bin/sh", "-c", "sleep 3 & echo started; exit 0");
+        int rc = e.executeProcess(pb, 1000);
+
+        assertEquals(0, rc, "a command that exited 0 must not be reported as timed out");
+    }
+
+    @Test
+    void outputIsCompleteWhenExecReturns() throws Exception {
+        // The out-of-memory check reads the captured output immediately after
+        // exec() returns, and a JVM prints OutOfMemoryError at the very end of
+        // the stream -- so a truncated tail is the failure that matters.
+        TestExecutor e = new TestExecutor();
+        StringBuilder sb = new StringBuilder();
+        ProcessBuilder pb = new ProcessBuilder("/bin/sh", "-c",
+                "for i in $(seq 1 500); do echo line-$i; done; echo java.lang.OutOfMemoryError: Java heap space");
+        int rc = executeCapturing(e, pb, sb);
+
+        assertEquals(0, rc);
+        assertTrue(TranslatorHeap.looksOutOfMemory(sb.toString()),
+                "the tail of the output must be present when exec returns");
+        assertTrue(sb.toString().contains("line-500"), "output must not be truncated");
+    }
+
+    /** executeProcess(pb, timeout) appends into the executor's own message buffer. */
+    private static int executeCapturing(TestExecutor e, ProcessBuilder pb, StringBuilder sink) throws Exception {
+        int mark = e.message.length();
+        int rc = e.executeProcess(pb, -1);
+        sink.append(e.message.substring(mark));
+        return rc;
+    }
+
+    @Test
+    void aProcessThatOverrunsItsDeadlineIsStillReportedAsTimedOut() throws Exception {
+        TestExecutor e = new TestExecutor();
+        ProcessBuilder pb = new ProcessBuilder("/bin/sh", "-c", "sleep 30");
+        int rc = e.executeProcess(pb, 1000);
+        assertEquals(1, rc, "a genuine timeout must still fail");
+    }
+}

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/ExecutorProcessTimeoutTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/ExecutorProcessTimeoutTest.java
@@ -35,6 +35,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * needs the captured output to be complete when exec() returns, which means
  * joining the reader -- and joining the reader must not leave the timeout
  * watcher running past the deadline on a process that already finished.
+ *
+ * <p>The child processes are JVMs running the helpers below rather than shell
+ * commands, so these run on Windows as well as Unix.
  */
 class ExecutorProcessTimeoutTest {
 
@@ -61,6 +64,54 @@ class ExecutorProcessTimeoutTest {
         }
     }
 
+    /** Sleeps, keeping whatever stdout it inherited open for that long. */
+    public static final class Sleeper {
+        public static void main(String[] args) throws Exception {
+            Thread.sleep(Long.parseLong(args[0]));
+        }
+    }
+
+    /**
+     * Starts a {@link Sleeper} that inherits this process's stdout, then exits
+     * immediately. The pipe therefore outlives this process, which is what makes
+     * the reader join in executeProcess actually block.
+     */
+    public static final class ExitsLeavingChildHoldingOutput {
+        public static void main(String[] args) throws Exception {
+            ProcessBuilder pb = javaProcess(Sleeper.class, args[0]);
+            pb.redirectOutput(ProcessBuilder.Redirect.INHERIT);
+            pb.redirectError(ProcessBuilder.Redirect.INHERIT);
+            pb.start();
+            System.out.println("started");
+            System.out.flush();
+        }
+    }
+
+    /** Prints many lines and then an out-of-memory signature as the very last line. */
+    public static final class PrintsThenFailsWithOom {
+        public static void main(String[] args) {
+            for (int i = 1; i <= 500; i++) {
+                System.out.println("line-" + i);
+            }
+            System.out.println("java.lang.OutOfMemoryError: Java heap space");
+            System.out.flush();
+        }
+    }
+
+    /** A JVM launch of the given helper class, portable across platforms. */
+    private static ProcessBuilder javaProcess(Class<?> main, String... args) {
+        String java = new File(new File(System.getProperty("java.home"), "bin"), "java").getAbsolutePath();
+        java.util.List<String> cmd = new java.util.ArrayList<String>();
+        cmd.add(java);
+        cmd.add("-cp");
+        cmd.add(System.getProperty("java.class.path"));
+        cmd.add(main.getName());
+        for (String a : args) {
+            cmd.add(a);
+        }
+        return new ProcessBuilder(cmd);
+    }
+
     @Test
     void aProcessThatSucceedsIsNotReportedAsTimedOutWhileOutputIsStillDraining() throws Exception {
         // The regression this guards: joining the reader thread after waitFor()
@@ -70,12 +121,10 @@ class ExecutorProcessTimeoutTest {
         // on the iOS and native steps, which are the ones that run with a timeout.
         //
         // Reproducing it needs the join to actually block, which means the pipe
-        // must outlive the process: the shell exits immediately while a
-        // backgrounded grandchild keeps the inherited stdout open. Without the
-        // fix the watcher fires at 1000ms during that wait and exec returns 1.
+        // must outlive the process. Without the fix the watcher fires at 1000ms
+        // during that wait and exec returns 1.
         TestExecutor e = new TestExecutor();
-        ProcessBuilder pb = new ProcessBuilder("/bin/sh", "-c", "sleep 3 & echo started; exit 0");
-        int rc = e.executeProcess(pb, 1000);
+        int rc = e.executeProcess(javaProcess(ExitsLeavingChildHoldingOutput.class, "4000"), 1000);
 
         assertEquals(0, rc, "a command that exited 0 must not be reported as timed out");
     }
@@ -86,30 +135,20 @@ class ExecutorProcessTimeoutTest {
         // exec() returns, and a JVM prints OutOfMemoryError at the very end of
         // the stream -- so a truncated tail is the failure that matters.
         TestExecutor e = new TestExecutor();
-        StringBuilder sb = new StringBuilder();
-        ProcessBuilder pb = new ProcessBuilder("/bin/sh", "-c",
-                "for i in $(seq 1 500); do echo line-$i; done; echo java.lang.OutOfMemoryError: Java heap space");
-        int rc = executeCapturing(e, pb, sb);
+        int mark = e.message.length();
+        int rc = e.executeProcess(javaProcess(PrintsThenFailsWithOom.class), -1);
+        String out = e.message.substring(mark);
 
         assertEquals(0, rc);
-        assertTrue(TranslatorHeap.looksOutOfMemory(sb.toString()),
+        assertTrue(TranslatorHeap.looksOutOfMemory(out),
                 "the tail of the output must be present when exec returns");
-        assertTrue(sb.toString().contains("line-500"), "output must not be truncated");
-    }
-
-    /** executeProcess(pb, timeout) appends into the executor's own message buffer. */
-    private static int executeCapturing(TestExecutor e, ProcessBuilder pb, StringBuilder sink) throws Exception {
-        int mark = e.message.length();
-        int rc = e.executeProcess(pb, -1);
-        sink.append(e.message.substring(mark));
-        return rc;
+        assertTrue(out.contains("line-500"), "output must not be truncated");
     }
 
     @Test
     void aProcessThatOverrunsItsDeadlineIsStillReportedAsTimedOut() throws Exception {
         TestExecutor e = new TestExecutor();
-        ProcessBuilder pb = new ProcessBuilder("/bin/sh", "-c", "sleep 30");
-        int rc = e.executeProcess(pb, 1000);
+        int rc = e.executeProcess(javaProcess(Sleeper.class, "30000"), 1000);
         assertEquals(1, rc, "a genuine timeout must still fail");
     }
 }

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/TranslatorHeapTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/TranslatorHeapTest.java
@@ -1,0 +1,122 @@
+package com.codename1.builders;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * The heap policy behind issue #5511: a hard-coded {@code -Xmx} made large apps
+ * untranslatable. These pin the properties the builders rely on -- most
+ * importantly that the change can never hand a target LESS heap than the
+ * constant it replaced.
+ */
+public class TranslatorHeapTest {
+
+    @Test
+    public void sizesFromHalfTheDetectedBudget() {
+        // 6GB budget -> 3GB, below the ceiling.
+        assertEquals(3072, TranslatorHeap.maxHeapMB(512, null, 6144));
+    }
+
+    @Test
+    public void neverExceedsTheCeiling() {
+        // A 64GB workstation must not hand the translator 32GB.
+        assertEquals(TranslatorHeap.CEILING_MB, TranslatorHeap.maxHeapMB(512, null, 65536));
+    }
+
+    @Test
+    public void neverGoesBelowTheTargetsHistoricalHeap() {
+        // A 1GB box would compute 512m for the iOS target, whose builder has
+        // always used 1024m. Auto-sizing must not be a downgrade.
+        assertEquals(1024, TranslatorHeap.maxHeapMB(1024, null, 1024));
+        // ... and the JS target keeps its own 512m floor on the same box.
+        assertEquals(512, TranslatorHeap.maxHeapMB(512, null, 1024));
+    }
+
+    @Test
+    public void fallsBackToTheHistoricalHeapWhenMemoryIsUndetectable() {
+        assertEquals(768, TranslatorHeap.maxHeapMB(768, null, -1));
+        assertEquals(768, TranslatorHeap.maxHeapMB(768, null, 0));
+    }
+
+    @Test
+    public void environmentOverrideWinsOverAutoSizing() {
+        // Auto-sizing would pick 4096 here (half of 8192, at the ceiling); the
+        // explicit setting takes precedence in both directions.
+        assertEquals(2500, TranslatorHeap.maxHeapMB(512, "2500", 8192));
+        // Whitespace is tolerated -- these get set by hand in a systemd unit.
+        assertEquals(2500, TranslatorHeap.maxHeapMB(512, "  2500 ", 8192));
+    }
+
+    @Test
+    public void environmentOverrideMayGoBelowTheFloorAndAboveTheCeiling() {
+        // Deliberately starving a small box is allowed...
+        assertEquals(256, TranslatorHeap.maxHeapMB(1024, "256", 8192));
+        // ...and so is going past the ceiling, which only bounds the automatic
+        // choice. A box with 32GB may legitimately want 6GB for a huge app.
+        assertEquals(6144, TranslatorHeap.maxHeapMB(512, "6144", 32768));
+    }
+
+    @Test
+    public void environmentOverrideCannotExceedTheMachinesMemory() {
+        // The shape of a typo (an extra digit) is also the setting that OOM-kills
+        // the build box instead of failing the one build.
+        assertEquals(8192, TranslatorHeap.maxHeapMB(512, "999999", 8192));
+        // With no detectable budget there is nothing to clamp against, so the
+        // operator's number stands.
+        assertEquals(6144, TranslatorHeap.maxHeapMB(512, "6144", -1));
+    }
+
+    @Test
+    public void malformedEnvironmentOverrideIsIgnored() {
+        assertEquals(3072, TranslatorHeap.maxHeapMB(512, "not-a-number", 6144));
+        assertEquals(3072, TranslatorHeap.maxHeapMB(512, "", 6144));
+        // A non-positive value is meaningless as a heap; fall through to auto-sizing.
+        assertEquals(3072, TranslatorHeap.maxHeapMB(512, "0", 6144));
+        assertEquals(3072, TranslatorHeap.maxHeapMB(512, "-1", 6144));
+    }
+
+    @Test
+    public void recognisesAnOutOfMemoryDeath() {
+        assertTrue(TranslatorHeap.looksOutOfMemory(
+                "Exception in thread \"main\" java.lang.OutOfMemoryError: Java heap space"));
+        assertTrue(TranslatorHeap.looksOutOfMemory(
+                "java.lang.OutOfMemoryError: GC overhead limit exceeded"));
+        assertTrue(TranslatorHeap.looksOutOfMemory(
+                "There is insufficient memory for the Java Runtime Environment to continue."));
+    }
+
+    @Test
+    public void doesNotMistakeAnOrdinaryFailureForOutOfMemory() {
+        assertFalse(TranslatorHeap.looksOutOfMemory(null));
+        assertFalse(TranslatorHeap.looksOutOfMemory(""));
+        assertFalse(TranslatorHeap.looksOutOfMemory(
+                "Exception in thread \"main\" java.lang.NullPointerException"));
+    }
+
+    @Test
+    public void adviceNamesTheHeapInUse() {
+        String local = TranslatorHeap.outOfMemoryAdvice(2048, true);
+        assertTrue(local.contains("-Xmx2048m"));
+        assertTrue(local.contains(TranslatorHeap.HEAP_ENV));
+        assertTrue(local.contains("CN1_TRANSLATOR_OPTS"));
+    }
+
+    @Test
+    public void cloudAdviceDoesNotTellTheDeveloperToSetAServerSideVariable() {
+        // On a cloud build the environment is not the developer's to change, so
+        // "export CN1_TRANSLATOR_OPTS" would be advice they cannot act on.
+        String cloud = TranslatorHeap.outOfMemoryAdvice(2048, false);
+        assertTrue(cloud.contains("-Xmx2048m"));
+        assertFalse(cloud.contains("CN1_TRANSLATOR_OPTS"));
+    }
+
+    @Test
+    public void detectsSomeMemoryBudgetOnThisMachine() {
+        // The whole policy degrades to the old constants if this returns -1, so
+        // make sure the detection actually works on a normal build machine.
+        assertTrue(TranslatorHeap.detectBudgetMB() > 0);
+    }
+}

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/TranslatorHeapTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/TranslatorHeapTest.java
@@ -238,6 +238,21 @@ public class TranslatorHeapTest {
         assertNull(TranslatorHeap.cgroupPath(null, ""));
     }
 
+    @Test
+    public void detectsAnExplicitHeapAmongTheExtraOptions() {
+        // Every builder that forks the translator uses this to decide whether to
+        // add the auto-sized heap on top of the caller's options. Getting it wrong
+        // means either two -Xmx flags or an ignored override.
+        assertTrue(TranslatorHeap.specifiesHeap(java.util.Arrays.asList("-Xmx6g")));
+        assertTrue(TranslatorHeap.specifiesHeap(
+                java.util.Arrays.asList("-Dparparvm.js.rta.off", "-Xmx6g")));
+        assertFalse(TranslatorHeap.specifiesHeap(java.util.Arrays.asList("-Dparparvm.js.rta.off")));
+        assertFalse(TranslatorHeap.specifiesHeap(java.util.Collections.<String>emptyList()));
+        assertFalse(TranslatorHeap.specifiesHeap(null));
+        // -Xms is not a maximum and must not suppress the auto-sized ceiling.
+        assertFalse(TranslatorHeap.specifiesHeap(java.util.Arrays.asList("-Xms512m")));
+    }
+
     private static File tempDir() throws Exception {
         File d = File.createTempFile("cn1-cgroup-test", "");
         assertTrue(d.delete());

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/TranslatorHeapTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/TranslatorHeapTest.java
@@ -24,8 +24,13 @@ package com.codename1.builders;
 
 import org.junit.Test;
 
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -136,9 +141,112 @@ public class TranslatorHeapTest {
     }
 
     @Test
-    public void detectsSomeMemoryBudgetOnThisMachine() {
-        // The whole policy degrades to the old constants if this returns -1, so
-        // make sure the detection actually works on a normal build machine.
-        assertTrue(TranslatorHeap.detectBudgetMB() > 0);
+    public void detectsAMemoryBudgetWhereverTheJvmExposesOne() {
+        // The whole policy degrades to the old constants if detection returns -1,
+        // so this guards against that regression going unnoticed. Asserting it
+        // unconditionally would make the test environment-dependent -- detection
+        // legitimately returns -1 on a JVM without the com.sun accessor -- so the
+        // assertion is tied to the exact condition that makes it obligatory.
+        boolean accessorAvailable;
+        try {
+            Class<?> sunOsBean = Class.forName("com.sun.management.OperatingSystemMXBean");
+            accessorAvailable = sunOsBean.isInstance(
+                    java.lang.management.ManagementFactory.getOperatingSystemMXBean());
+        } catch (Throwable ex) {
+            accessorAvailable = false;
+        }
+        if (accessorAvailable) {
+            assertTrue("physical memory is readable on this JVM, so detection must succeed",
+                    TranslatorHeap.detectBudgetMB() > 0);
+        }
+    }
+
+    @Test
+    public void readsTheCgroupLimitFromThisProcessesOwnCgroupNotTheMountRoot() throws Exception {
+        // A systemd unit with MemoryMax=, or a container sharing the host cgroup
+        // namespace: the mount root is unlimited and the real limit sits at the
+        // path named in /proc/self/cgroup. Reading only the root here would fall
+        // back to host RAM and pick a heap the cgroup cannot honour.
+        File root = tempDir();
+        write(new File(root, "memory.max"), "max");
+        File leaf = new File(root, "system.slice/cn1-daemon.service");
+        assertTrue(leaf.mkdirs());
+        write(new File(leaf, "memory.max"), String.valueOf(2048L * 1024 * 1024));
+
+        assertEquals(2048, TranslatorHeap.cgroupLimitMB(root, "0::/system.slice/cn1-daemon.service\n"));
+    }
+
+    @Test
+    public void takesTheTightestLimitOnThePath() throws Exception {
+        // A limit set anywhere on the path applies, so an ancestor's tighter
+        // limit is the one that will actually kill the build.
+        File root = tempDir();
+        write(new File(root, "memory.max"), "max");
+        File mid = new File(root, "system.slice");
+        assertTrue(mid.mkdirs());
+        write(new File(mid, "memory.max"), String.valueOf(1024L * 1024 * 1024));
+        File leaf = new File(mid, "cn1-daemon.service");
+        assertTrue(leaf.mkdirs());
+        write(new File(leaf, "memory.max"), String.valueOf(4096L * 1024 * 1024));
+
+        assertEquals(1024, TranslatorHeap.cgroupLimitMB(root, "0::/system.slice/cn1-daemon.service\n"));
+    }
+
+    @Test
+    public void fallsBackToTheMountRootWhenTheProcessCgroupIsUnknown() throws Exception {
+        // The container-with-its-own-namespace case: the root files ARE the
+        // container's limit and /proc/self/cgroup may be unreadable.
+        File root = tempDir();
+        write(new File(root, "memory.max"), String.valueOf(3072L * 1024 * 1024));
+        assertEquals(3072, TranslatorHeap.cgroupLimitMB(root, null));
+    }
+
+    @Test
+    public void readsACgroupV1Limit() throws Exception {
+        File root = tempDir();
+        File leaf = new File(root, "memory/docker/abc123");
+        assertTrue(leaf.mkdirs());
+        write(new File(leaf, "memory.limit_in_bytes"), String.valueOf(1536L * 1024 * 1024));
+
+        assertEquals(1536, TranslatorHeap.cgroupLimitMB(root,
+                "8:memory:/docker/abc123\n4:cpu,cpuacct:/docker/abc123\n"));
+    }
+
+    @Test
+    public void treatsAnUnlimitedCgroupAsNoLimit() throws Exception {
+        File root = tempDir();
+        write(new File(root, "memory.max"), "max");
+        File v1 = new File(root, "memory");
+        assertTrue(v1.mkdirs());
+        // The v1 "unlimited" sentinel, not a real 8-exabyte budget.
+        write(new File(v1, "memory.limit_in_bytes"), "9223372036854771712");
+
+        assertEquals(-1, TranslatorHeap.cgroupLimitMB(root, "0::/\n"));
+    }
+
+    @Test
+    public void parsesCgroupPathsIncludingOnesContainingColons() {
+        assertEquals("/system.slice/cn1.service",
+                TranslatorHeap.cgroupPath("0::/system.slice/cn1.service\n", ""));
+        assertEquals("/docker/abc",
+                TranslatorHeap.cgroupPath("8:memory:/docker/abc\n", "memory"));
+        // "memory" must not match "memory_hugetlb" or similar in a controller list.
+        assertNull(TranslatorHeap.cgroupPath("8:memoryfoo:/docker/abc\n", "memory"));
+        // systemd scope names legitimately contain ':'.
+        assertEquals("/user.slice/run-r:12.scope",
+                TranslatorHeap.cgroupPath("0::/user.slice/run-r:12.scope\n", ""));
+        assertNull(TranslatorHeap.cgroupPath(null, ""));
+    }
+
+    private static File tempDir() throws Exception {
+        File d = File.createTempFile("cn1-cgroup-test", "");
+        assertTrue(d.delete());
+        assertTrue(d.mkdirs());
+        d.deleteOnExit();
+        return d;
+    }
+
+    private static void write(File f, String contents) throws Exception {
+        Files.write(f.toPath(), contents.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/TranslatorHeapTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/TranslatorHeapTest.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.builders;
 
 import org.junit.Test;

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/JavascriptBundleWriter.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/JavascriptBundleWriter.java
@@ -227,8 +227,14 @@ final class JavascriptBundleWriter {
         // identifiers (avg ~45 chars, the largest single contributor to bundle
         // size) ship verbatim at every definition and call site.
         java.util.List<String> chunkStrings = new java.util.ArrayList<String>(chunks.size());
-        for (StringBuilder c : chunks) {
-            chunkStrings.add(c.toString());
+        for (int i = 0; i < chunks.size(); i++) {
+            // Drop each builder as it materialises. Holding the whole bundle
+            // simultaneously as StringBuilders and as Strings doubles the
+            // translator's peak for no benefit, and on a large app that
+            // doubling is the difference between finishing and dying with
+            // OutOfMemoryError (issue #5511).
+            chunkStrings.add(chunks.get(i).toString());
+            chunks.set(i, null);
         }
         minifyGeneratedIdentifiers(chunkStrings);
         aliasHotCn1Identifiers(chunkStrings);
@@ -249,6 +255,12 @@ final class JavascriptBundleWriter {
             String suffix = leadCount >= 10 ? String.format("_%02d", i + 1) : String.format("_%d", i + 1);
             Files.write(new File(outputDirectory, "translated_app" + suffix + ".js").toPath(),
                     minifyJs(hoistStringConstants(chunkStrings.get(i), aliasCounter)).getBytes(StandardCharsets.UTF_8));
+            // Once a chunk is on disk nothing reads it again, so release it
+            // rather than keeping the entire bundle resident until the last
+            // write. hoistStringConstants and minifyJs each materialise another
+            // copy of the chunk they are given, so this is where the emit phase
+            // is at its most memory-hungry.
+            chunkStrings.set(i, null);
         }
         Files.write(new File(outputDirectory, "translated_app.js").toPath(),
                 minifyJs(hoistStringConstants(chunkStrings.get(chunkStrings.size() - 1), aliasCounter)).getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
Fixes #5511.

## The problem

The reported `-Xmx512m` is not an isolated lowball. Every ByteCodeTranslator fork carried a hard-coded heap, tuned years ago against the sample apps:

| Target | Before |
|---|---|
| JavaScript | 512m |
| iOS | 1024m |
| Windows native | 2g |
| Linux native | 2g |

A large app exhausts that partway through translation and dies with `OutOfMemoryError`. The only way out was to discover `CN1_TRANSLATOR_OPTS` by reading this plugin's source, which is exactly what the reporter had to do.

The defaults were tighter than they looked. Bisecting the heap on the in-repo `hellocodenameone` JS build, the translator **OOMs at 384m and needs 448m** to finish. That is under 1.5x headroom on the sample app.

## The fix

`TranslatorHeap` derives the ceiling from the machine: **half the detected memory budget, capped at 4g**, floored at each target's historical constant so no target can end up with less heap than before. The budget reads the **cgroup limit** before falling back to physical RAM, so a build inside a container sizes against the container's limit rather than the host's. That is what keeps an over-large app failing as a Java `OutOfMemoryError` we can report, instead of a kernel OOM-kill we cannot.

Raising the ceiling is close to free for ordinary apps: `-Xmx` is a reservation, not a commitment.

`CN1_TRANSLATOR_MAX_HEAP_MB` pins the value per box. It may sit **above** the 4g cap (that cap bounds only the automatic choice; clamping the knob would achieve nothing since an operator would just switch to `CN1_TRANSLATOR_OPTS=-Xmx`, which no ceiling applies to). It may **not** exceed the memory the machine actually has -- that is the setting that OOM-kills a build box rather than failing one build, and it is the likely shape of a typo.

## Also in scope

- **A translator OOM now says so.** It previously returned `false` and the build reported nothing more useful than a failed step. The JS and iOS builders recognise the signature in the captured output and name the heap in use and how to raise it.
- **Local iOS translator timeout 420s -> 600s**, matching the cloud builder running the identical translator over identical input. Translation time grows with app size, so a large app could translate fine on the build server yet be killed on the developer's own machine, which is usually the slower of the two.
- **`JavascriptBundleWriter` peak reduction.** It held the whole bundle twice (as `StringBuilder`s and again as `String`s) at the chunk handoff, and kept every chunk resident until the last was written. Chunks are now freed as they materialise and as they reach disk.

## Measured

| Bundle shape | Before | After |
|---|---|---|
| Single chunk (hello-world) | 448m | 448m |
| Two chunks (`rta.off`) | 416m | **384m** |

The 32MB reduction is about one full UTF-16 copy of the emitted JS. It scales with bundle size, so it does nothing for a single-chunk app and progressively more for a large one -- the emit change is a modest structural win; the heap sizing is what actually unblocks the reported app.

**The emitted bundle is byte-identical**, verified on both the single-chunk and multi-chunk paths (the first check alone would not have covered the lead-chunk write loop the change touches).

## Verification

- Plugin: 435 tests green, SpotBugs **0 findings**
- ByteCodeTranslator: tests green, SpotBugs **0 findings**
- 13 unit tests pin the heap policy, including that no target can be handed less heap than its old constant

## Companion change

The cloud side needs the matching fix and is a separate PR against BuildDaemon: the daemon carried the same 512m for JS and, on iOS, **no `CN1_TRANSLATOR_OPTS` pass-through at all** -- so a cloud customer, who cannot set env vars on the build box, had no escape hatch whatsoever.

## Not addressed

Android remains a fixed cliff: `org.gradle.jvmargs=-Xmx2048m` and `dexOptions javaMaxHeapSize "3g"` are hard-coded with no build-hint override. That is a separate subsystem from the translator, but it is where a very large app hits the next wall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)