### PR TITLE
Update Hashnode publish sheet recovery

### DIFF
--- a/scripts/website/syndicate_browser_posts.py
+++ b/scripts/website/syndicate_browser_posts.py
@@ -156,7 +156,9 @@ def _completed_hashnode_result(
     canonical_set: bool,
 ) -> dict[str, Any]:
     """Build persisted Hashnode state only after a public publish succeeds."""
-    if published_url is None:
+    if published_url is None or re.search(
+        r"^https?://(?:www\.)?hashnode\.com/(?:draft|edit)/", published_url
+    ):
         raise AdapterError(
             "Hashnode retained the article as an unpublished draft; "
             f"retry required: {draft_url}"
@@ -639,6 +641,9 @@ class HashnodeAdapter:
     # the dashboard is the only entry point that creates a fresh draft
     # bound to the user's primary publication.
     DASHBOARD_URL = "https://hashnode.com/"
+    PUBLICATION_URL = os.environ.get(
+        "HASHNODE_PUBLICATION_URL", "https://debugagent.com"
+    ).rstrip("/")
 
     TITLE_SELECTOR = "textarea[placeholder='Article Title...']"
     BODY_SELECTOR = "div[contenteditable='true']"
@@ -652,15 +657,20 @@ class HashnodeAdapter:
     COVER_UPLOAD_IMAGE_BUTTON_SELECTOR = "button:has-text('Upload Image')"
     SUBHEADING_BUTTON_SELECTOR = "button:has(span:text-is('Subheading'))"
     SUBHEADING_TEXTAREA_SELECTOR = "textarea[placeholder='Add a subheading']"
-    DISCOVERY_TAB_SELECTOR = "button[role='tab']:has-text('Discovery')"
-    TAGS_INPUT_SELECTOR = "input#editor-tags"
-    CANONICAL_TOGGLE_SELECTOR = "label:has-text('Add a canonical URL')"
-    CANONICAL_INPUT_SELECTOR = "input[placeholder='https://example.com/original-article']"
+    DIALOG_SELECTOR = "[role='dialog'][data-state='open']"
+    DISCOVERY_TAB_SELECTOR = f"{DIALOG_SELECTOR} button[role='tab']:has-text('Discovery')"
+    TAGS_INPUT_SELECTOR = f"{DIALOG_SELECTOR} input#editor-tags"
+    CANONICAL_TOGGLE_SELECTOR = f"{DIALOG_SELECTOR} button#republish-canonical"
+    CANONICAL_INPUT_SELECTOR = (
+        f"{DIALOG_SELECTOR} input[placeholder='https://example.com/original-article']"
+    )
     CLOSE_DIALOG_SELECTOR = "button:has-text('Close')"
     # The in-dialog Publish button (distinct from the top-bar Publish
     # which just opens the dialog) lives inside the open Radix dialog
     # alongside "Submit for Review" and "Close".
-    DIALOG_PUBLISH_SELECTOR = "[role='dialog'][data-state='open'] button:text-is('Publish')"
+    DIALOG_PUBLISH_SELECTOR = (
+        f"{DIALOG_SELECTOR} [data-slot='sheet-footer'] button:text-is('Publish')"
+    )
 
     # The five tags every Codename One syndicated post carries on
     # Hashnode. All five exist as canonical Hashnode tags so a
@@ -783,9 +793,21 @@ class HashnodeAdapter:
         published_url: str | None = None
         try:
             self._open_publish_dialog_discovery(page)
+            expected_public_url = self._public_url_from_discovery(page)
             tags_set = self._set_tags(page, mod)
             canonical_set = self._set_canonical_url(page, ctx.post.canonical_url, mod)
-            published_url = self._publish_from_dialog(page, draft_url)
+            if tags_set and canonical_set:
+                published_url = self._publish_from_dialog(
+                    page,
+                    draft_url,
+                    expected_public_url,
+                    ctx.post.canonical_url,
+                )
+            else:
+                print(
+                    "  [hashnode] refusing to publish until tags and canonical URL are verified",
+                    file=sys.stderr,
+                )
         except Exception as err:  # noqa: BLE001 — surface as non-fatal
             print(f"  [hashnode] publish-dialog flow failed (non-fatal): {err}",
                   file=sys.stderr)
@@ -892,6 +914,18 @@ class HashnodeAdapter:
         page.locator(self.DISCOVERY_TAB_SELECTOR).first.click(timeout=15000)
         page.wait_for_timeout(2000)
 
+    def _public_url_from_discovery(self, page) -> str:
+        """Read Hashnode's saved article slug before publishing."""
+        slug_section = page.locator(
+            f"{self.DIALOG_SELECTOR} label[for='editor-slug']"
+        ).first.locator("xpath=../..").inner_text()
+        match = re.search(r"(?:^|\s)/([a-z0-9][a-z0-9-]*)(?:\s|$)", slug_section)
+        if not match:
+            raise AdapterError(
+                f"Could not read Hashnode article slug from {slug_section!r}"
+            )
+        return f"{self.PUBLICATION_URL}/{match.group(1)}"
+
     def _set_tags(self, page, mod: str) -> bool:
         try:
             tags_input = page.locator(self.TAGS_INPUT_SELECTOR).first
@@ -901,13 +935,15 @@ class HashnodeAdapter:
             # JS is ignored — Hashnode listens for native pointer
             # events — so we use Playwright's real click and loop on
             # the live count.
-            pill_row = tags_input.locator("xpath=ancestor::div[contains(@class,'space-y-3')][1]")
+            dialog = page.locator(self.DIALOG_SELECTOR).first
+            selected_pills = dialog.locator("button").filter(
+                has_text=re.compile(r"^#[a-z0-9][a-z0-9-]*$")
+            )
             for _ in range(20):  # hard cap so we never loop forever
-                pills = pill_row.locator("button:has-text('#')")
-                count = pills.count()
+                count = selected_pills.count()
                 if count == 0:
                     break
-                pills.first.click()
+                selected_pills.first.click()
                 page.wait_for_timeout(400)
             # Add the canonical tag set. Typing alone + Enter triggers
             # Hashnode's autocomplete and frequently commits a
@@ -918,49 +954,34 @@ class HashnodeAdapter:
             #   2. Click the exact-match dropdown suggestion if one is
             #      present (its first line is "#<tag>" followed by a
             #      post-count line).
-            #   3. If no exact-match suggestion is available, press
-            #      Escape to dismiss the autocomplete dropdown, then
-            #      Enter to commit the literal typed value. Escape
-            #      before Enter prevents Enter from picking the
-            #      currently-highlighted fuzzy suggestion.
+            #   3. If no exact-match suggestion is available, press Enter
+            #      without pressing Escape. Hashnode's 2026-08 editor puts
+            #      these fields inside a Radix side sheet where Escape closes
+            #      the entire publish dialog.
             #
             # After each iteration verify the target pill landed; if
             # not, retry once more.
             for tag in self.TAGS:
-                pills_before = self._pill_count(pill_row)
+                if self._tag_is_selected(dialog, tag):
+                    continue
                 for attempt in range(2):
-                    tags_input.click()
-                    page.keyboard.press(f"{mod}+A")
-                    page.keyboard.press("Delete")
-                    page.keyboard.type(tag, delay=15)
+                    # Re-query and fill on every attempt. Selecting a tag
+                    # re-renders the tags control and detaches the old input.
+                    tags_input = page.locator(self.TAGS_INPUT_SELECTOR).first
+                    tags_input.fill(tag, timeout=10000)
                     page.wait_for_timeout(1200)
                     if not self._click_exact_tag_suggestion(page, tag):
-                        page.keyboard.press("Escape")
-                        page.wait_for_timeout(200)
-                        # Escape moves focus off the input on some
-                        # builds; re-focus, restore the typed value,
-                        # and commit with Enter so Hashnode treats
-                        # this as a "create new tag" rather than
-                        # selecting an autocomplete option.
-                        tags_input.click()
-                        if tags_input.input_value() != tag:
-                            page.keyboard.press(f"{mod}+A")
-                            page.keyboard.press("Delete")
-                            page.keyboard.type(tag, delay=15)
-                            page.wait_for_timeout(300)
-                        page.keyboard.press("Escape")
-                        page.wait_for_timeout(200)
-                        tags_input.click()
-                        page.keyboard.press("Enter")
+                        page.locator(self.TAGS_INPUT_SELECTOR).first.press("Enter")
                     page.wait_for_timeout(1200)
-                    if self._pill_count(pill_row) > pills_before:
+                    if self._tag_is_selected(dialog, tag):
                         break
                     print(f"  [hashnode] tag '{tag}' did not land (attempt {attempt + 1}); retrying",
                           file=sys.stderr)
                 else:
-                    print(f"  [hashnode] tag '{tag}' could not be added after retry; skipping",
+                    print(f"  [hashnode] tag '{tag}' could not be added after retry",
                           file=sys.stderr)
-            return True
+                    return False
+            return all(self._tag_is_selected(dialog, tag) for tag in self.TAGS)
         except Exception as err:  # noqa: BLE001
             print(f"  [hashnode] tag set failed (non-fatal): {err}",
                   file=sys.stderr)
@@ -969,6 +990,14 @@ class HashnodeAdapter:
     @staticmethod
     def _pill_count(pill_row) -> int:
         return pill_row.locator("button:has-text('#')").count()
+
+    @staticmethod
+    def _tag_is_selected(dialog, tag: str) -> bool:
+        return bool(dialog.locator("button").evaluate_all(
+            "(buttons, wanted) => buttons.some(button => "
+            "(button.innerText || '').trim() === wanted)",
+            f"#{tag}",
+        ))
 
     @staticmethod
     def _click_exact_tag_suggestion(page, tag: str) -> bool:
@@ -1004,7 +1033,13 @@ class HashnodeAdapter:
         page.mouse.click(clicked["x"], clicked["y"])
         return True
 
-    def _publish_from_dialog(self, page, draft_url: str) -> str | None:
+    def _publish_from_dialog(
+        self,
+        page,
+        draft_url: str,
+        expected_public_url: str,
+        canonical_url: str,
+    ) -> str | None:
         """Click the in-dialog Publish button and wait for the redirect
         to the live article URL. Returns the published URL on success
         or None on failure (the caller falls back to a Close-as-draft
@@ -1040,16 +1075,44 @@ class HashnodeAdapter:
         published_url = page.url
         if "/draft/" in published_url or published_url == draft_url:
             return None
+        # Hashnode's 2026-08 editor redirects successful publishes to an
+        # authenticated /edit/<post-id> route instead of the public article.
+        # Verify the expected publication-domain URL before recording it.
+        if re.search(
+            r"^https?://(?:www\.)?hashnode\.com/edit/", published_url
+        ):
+            return (
+                expected_public_url
+                if self._wait_for_public_article(expected_public_url, canonical_url)
+                else None
+            )
         return published_url
+
+    @staticmethod
+    def _wait_for_public_article(public_url: str, canonical_url: str) -> bool:
+        deadline = time.time() + 45
+        request = urllib.request.Request(public_url, headers={"User-Agent": _UA_STR})
+        while time.time() < deadline:
+            try:
+                with urllib.request.urlopen(request, timeout=15) as response:
+                    body = response.read().decode("utf-8", errors="replace")
+                if response.status == 200 and canonical_url in body:
+                    return True
+            except Exception:  # noqa: BLE001 -- public propagation is retried
+                pass
+            time.sleep(3)
+        return False
 
     def _set_canonical_url(self, page, canonical_url: str, mod: str) -> bool:
         try:
-            # "Add a canonical URL" is a Radix switch label that
-            # reveals the input below it. Only click if the input is
-            # not already visible (clicking a second time would toggle
-            # it back off).
+            # "Add a canonical URL" is now a Radix checkbox button inside
+            # the Discovery sheet. Only click when unchecked; clicking a
+            # second time would toggle canonical attribution back off.
             if page.locator(self.CANONICAL_INPUT_SELECTOR).count() == 0:
-                page.locator(self.CANONICAL_TOGGLE_SELECTOR).first.click(timeout=8000)
+                toggle = page.locator(self.CANONICAL_TOGGLE_SELECTOR).first
+                toggle.wait_for(state="visible", timeout=8000)
+                if toggle.get_attribute("aria-checked") != "true":
+                    toggle.click()
                 page.wait_for_timeout(1500)
             canonical_input = page.locator(self.CANONICAL_INPUT_SELECTOR).first
             # Locator.fill() programmatically replaces the value, but
@@ -1058,14 +1121,10 @@ class HashnodeAdapter:
             # earlier syndication) is already in the field. Select-all
             # + type generates real key events so React picks up the
             # change.
-            canonical_input.click()
-            page.keyboard.press(f"{mod}+A")
-            page.keyboard.press("Delete")
-            page.wait_for_timeout(300)
-            page.keyboard.type(canonical_url, delay=5)
+            canonical_input.fill(canonical_url)
             canonical_input.press("Tab")  # blur to flush onBlur handlers
             page.wait_for_timeout(2000)
-            return True
+            return canonical_input.input_value() == canonical_url
         except Exception as err:  # noqa: BLE001
             print(f"  [hashnode] canonical URL set failed (non-fatal): {err}",
                   file=sys.stderr)

--- a/scripts/website/test_syndicate_browser_posts.py
+++ b/scripts/website/test_syndicate_browser_posts.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import inspect
 import unittest
 
 from syndicate_blog_posts import State
 from syndicate_browser_posts import (
     AdapterError,
+    HashnodeAdapter,
     _completed_hashnode_result,
     _retryable_failed_draft,
 )
@@ -37,6 +39,17 @@ class HashnodeCompletionTest(unittest.TestCase):
         self.assertTrue(result["published"])
         self.assertTrue(result["canonical_set"])
 
+    def test_hashnode_edit_redirect_is_not_a_public_result(self) -> None:
+        with self.assertRaisesRegex(AdapterError, "unpublished draft"):
+            _completed_hashnode_result(
+                published_url="https://hashnode.com/edit/post-id",
+                draft_url="https://hashnode.com/draft/example",
+                cover_set=True,
+                subheading_set=True,
+                tags_set=True,
+                canonical_set=True,
+            )
+
     def test_explicit_recovery_accepts_only_failed_drafts(self) -> None:
         failed = State(
             raw={
@@ -66,6 +79,19 @@ class HashnodeCompletionTest(unittest.TestCase):
         )
         self.assertTrue(_retryable_failed_draft(failed, "example", "hashnode"))
         self.assertFalse(_retryable_failed_draft(complete, "example", "hashnode"))
+
+    def test_hashnode_publish_sheet_selectors_match_current_controls(self) -> None:
+        self.assertIn("button#republish-canonical", HashnodeAdapter.CANONICAL_TOGGLE_SELECTOR)
+        self.assertIn("sheet-footer", HashnodeAdapter.DIALOG_PUBLISH_SELECTOR)
+
+    def test_tag_entry_cannot_close_publish_sheet(self) -> None:
+        source = inspect.getsource(HashnodeAdapter._set_tags)
+        self.assertNotIn('press("Escape")', source)
+        self.assertIn("tags_input.fill(tag", source)
+
+    def test_publish_requires_tags_and_canonical(self) -> None:
+        source = inspect.getsource(HashnodeAdapter.submit_draft)
+        self.assertIn("if tags_set and canonical_set", source)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- update Hashnode automation for the current Radix publish-settings sheet
- keep tag autocomplete from closing the sheet and verify the exact five tags
- require canonical attribution before publishing
- verify the public publication-domain article when Hashnode redirects to an authenticated edit URL

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 scripts/website/test_syndicate_browser_posts.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 scripts/website/test_syndication_health.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 scripts/website/test_syndicate_blog_posts.py`
- live scoped recovery published `compact-strings-parparvm`; public sitemap, canonical URL, and all five tags verified
