### PR TITLE
Remove the noisy "Cookie tried to set to another path" log

### DIFF
--- a/CodenameOne/src/com/codename1/io/ConnectionRequest.java
+++ b/CodenameOne/src/com/codename1/io/ConnectionRequest.java
@@ -1697,7 +1697,6 @@ public class ConnectionRequest implements IOProgressListener {
             }
 
             if (Util.getImplementation().getURLPath(url).indexOf(path) != 0) { //if (!hc.getHost().endsWith(domain)) {
-                Log.p("Warning: Cookie tried to set to another path");
                 c.setPath(path);
             }
         }


### PR DESCRIPTION
Reported in [discussion #5528](https://github.com/codenameone/CodenameOne/discussions/5528) — this line floods device logs, several entries per request, continuously.

`ConnectionRequest.parseCookieHeader` logged a warning whenever a `Set-Cookie` `Path` attribute was not a prefix of the request path, and then honored that path anyway:

```java
if (Util.getImplementation().getURLPath(url).indexOf(path) != 0) {
    Log.p("Warning: Cookie tried to set to another path");
    c.setPath(path);
}
```

Two reasons to drop it:

- **It warns about nothing actionable.** The domain check directly above it (`ConnectionRequest.java:1681`) *rewrites* the cookie's domain, so its log tells you a cookie was altered. The path branch changes nothing about the outcome — it flags the code doing the correct thing.
- **It fires on valid cookies.** RFC 6265 places no requirement on `Path` relative to the request URI; browsers accept any path. And `CodenameOneImplementation.getURLPath` returns the *host* when the URL has no path, so `https://example.com` yields `"example.com"` and a plain `Path=/` cookie warns on every single response. The check is also `indexOf` rather than a prefix test, so `/v1` inside `/api/v1/x` matches at index 4 and warns too.

Only the log line is removed. Cookie parsing behavior is unchanged: when the condition is false the cookie keeps `Cookie`'s default `"/"` path exactly as before.

Tightening the check itself (making `setPath` unconditional, per RFC) would narrow cookie scope for existing apps, so that is deliberately left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)