### PR TITLE
Fix the iOS on-device debugger crashing at breakpoints (issue #5333)

### DIFF
--- a/Ports/iOSPort/nativeSources/cn1_debugger.h
+++ b/Ports/iOSPort/nativeSources/cn1_debugger.h
@@ -58,6 +58,45 @@ extern void cn1_debugger_register_fields(int classId,
                                          const cn1_field_entry* table,
                                          int count);
 
+/**
+ * Publishes a class's {@code clazz} address under its classId, from the same
+ * translator-generated constructor that registers the field table.
+ *
+ * Everything the debugger is handed as an object reference is untrusted: the
+ * IDE echoes back ids it was given earlier, and a local slot can hold a value
+ * the frame never initialised on the branch it stopped in. With this registry
+ * the runtime can decide whether a candidate pointer really is a Java object
+ * by checking that its class word is the registered clazz for the classId it
+ * claims — an exact identity test, not a range guess. Before it existed, a
+ * bogus reference was dereferenced directly and took the app down mid-session
+ * (issue #5333).
+ */
+extern void cn1_debugger_register_class(int classId, struct clazz* cls);
+
+/**
+ * Copies {@code len} bytes from a possibly-invalid address, returning 0
+ * instead of faulting when the address is not mapped.
+ */
+extern int cn1_debugger_safe_read(const void* addr, void* dst, size_t len);
+
+/**
+ * Resolves an untrusted reference to its class, or NULL when it cannot be
+ * shown to be a live Java object. Every debugger path that is about to
+ * dereference a reference — a local slot's contents, an objectID from the
+ * IDE, an element of an object array — goes through this first.
+ */
+extern struct clazz* cn1_debugger_class_of(JAVA_OBJECT obj);
+
+/** Whether obj can safely be dereferenced as a Java object. */
+extern int cn1_debugger_is_valid_object(JAVA_OBJECT obj);
+
+/**
+ * Whether a local described by one side-table row is in scope at a source
+ * line. Locals out of scope are left out of the reply rather than reported
+ * with the contents of storage that belongs to another scope.
+ */
+extern int cn1_debugger_var_in_scope(const struct cn1_var_entry* v, int line);
+
 /* --- Method invocation -------------------------------------------------- */
 
 /**

--- a/Ports/iOSPort/nativeSources/cn1_debugger.h
+++ b/Ports/iOSPort/nativeSources/cn1_debugger.h
@@ -124,6 +124,20 @@ extern int cn1_debugger_note_issued(JAVA_OBJECT obj);
 extern int cn1_debugger_was_issued(JAVA_OBJECT obj);
 extern void cn1_debugger_forget_issued(void);
 
+/**
+ * Records a reference against the suspended thread it was obtained for, reads
+ * back that owner, and drops one thread's records on its resume.
+ *
+ * Ownership is what lets a per-thread resume invalidate only its own ids. A
+ * global clear would cut the ground from under a thread that is still stopped
+ * and being inspected; clearing nothing would leave the resumed thread's ids
+ * accepted after its objects can be collected. Owner 0 means the reference is
+ * not tied to a suspension and survives until every thread runs again.
+ */
+extern int cn1_debugger_note_issued_for(JAVA_OBJECT obj, int64_t owner);
+extern int64_t cn1_debugger_owner_of(JAVA_OBJECT obj);
+extern void cn1_debugger_forget_issued_for(int64_t owner);
+
 /** Resolves an objectID that arrived from the IDE, or NULL to refuse it. */
 extern struct clazz* cn1_debugger_class_of_wire_id(JAVA_OBJECT obj);
 

--- a/Ports/iOSPort/nativeSources/cn1_debugger.h
+++ b/Ports/iOSPort/nativeSources/cn1_debugger.h
@@ -145,6 +145,12 @@ extern int64_t cn1_debugger_owner_of(JAVA_OBJECT obj);
 extern int cn1_debugger_note_issued_inheriting(JAVA_OBJECT obj, JAVA_OBJECT parent);
 extern void cn1_debugger_forget_issued_for(int64_t owner);
 
+/**
+ * Drops the thread list's claim on the objects it previously advertised, so
+ * each refresh supersedes the last and dead threads stop being rooted.
+ */
+extern void cn1_debugger_forget_thread_list_claims(void);
+
 /** Resolves an objectID that arrived from the IDE, or NULL to refuse it. */
 extern struct clazz* cn1_debugger_class_of_wire_id(JAVA_OBJECT obj);
 

--- a/Ports/iOSPort/nativeSources/cn1_debugger.h
+++ b/Ports/iOSPort/nativeSources/cn1_debugger.h
@@ -136,6 +136,13 @@ extern void cn1_debugger_forget_issued(void);
  */
 extern int cn1_debugger_note_issued_for(JAVA_OBJECT obj, int64_t owner);
 extern int64_t cn1_debugger_owner_of(JAVA_OBJECT obj);
+
+/**
+ * Records a reference reached through another, inheriting the parent's whole
+ * claim. Used by the field and array commands, which arrive with only an
+ * objectID and so have no thread of their own to attribute to.
+ */
+extern int cn1_debugger_note_issued_inheriting(JAVA_OBJECT obj, JAVA_OBJECT parent);
 extern void cn1_debugger_forget_issued_for(int64_t owner);
 
 /** Resolves an objectID that arrived from the IDE, or NULL to refuse it. */

--- a/Ports/iOSPort/nativeSources/cn1_debugger.h
+++ b/Ports/iOSPort/nativeSources/cn1_debugger.h
@@ -146,10 +146,17 @@ extern int cn1_debugger_note_issued_inheriting(JAVA_OBJECT obj, JAVA_OBJECT pare
 extern void cn1_debugger_forget_issued_for(int64_t owner);
 
 /**
- * Drops the thread list's claim on the objects it previously advertised, so
- * each refresh supersedes the last and dead threads stop being rooted.
+ * Opens a thread-list generation. Call before recording a refresh's threads;
+ * pair with cn1_debugger_end_thread_list once every one has been noted.
  */
-extern void cn1_debugger_forget_thread_list_claims(void);
+extern void cn1_debugger_begin_thread_list(void);
+
+/**
+ * Closes the generation, dropping objects that neither a suspension nor the
+ * list just built claims, and that hang off nothing which survives. Each
+ * refresh supersedes the last, so dead threads stop being rooted.
+ */
+extern void cn1_debugger_end_thread_list(void);
 
 /** Resolves an objectID that arrived from the IDE, or NULL to refuse it. */
 extern struct clazz* cn1_debugger_class_of_wire_id(JAVA_OBJECT obj);

--- a/Ports/iOSPort/nativeSources/cn1_debugger.h
+++ b/Ports/iOSPort/nativeSources/cn1_debugger.h
@@ -120,7 +120,7 @@ extern JAVA_INT cn1_debugger_tagged_int_value(JAVA_OBJECT obj);
  * the last resume refuses a stale id from an earlier suspension instead of
  * dereferencing it.
  */
-extern void cn1_debugger_note_issued(JAVA_OBJECT obj);
+extern int cn1_debugger_note_issued(JAVA_OBJECT obj);
 extern int cn1_debugger_was_issued(JAVA_OBJECT obj);
 extern void cn1_debugger_forget_issued(void);
 

--- a/Ports/iOSPort/nativeSources/cn1_debugger.h
+++ b/Ports/iOSPort/nativeSources/cn1_debugger.h
@@ -104,6 +104,14 @@ extern struct clazz* cn1_debugger_class_of(JAVA_OBJECT obj);
 extern int cn1_debugger_is_valid_object(JAVA_OBJECT obj);
 
 /**
+ * Whether a reference is a tagged int rather than a heap object, and the value
+ * it carries. A tagged int has no object header, so no caller may compute a
+ * field address from one.
+ */
+extern int cn1_debugger_is_tagged_int(JAVA_OBJECT obj);
+extern JAVA_INT cn1_debugger_tagged_int_value(JAVA_OBJECT obj);
+
+/**
  * Whether a local described by one side-table row is in scope at a source
  * line. Locals out of scope are left out of the reply rather than reported
  * with the contents of storage that belongs to another scope.

--- a/Ports/iOSPort/nativeSources/cn1_debugger.h
+++ b/Ports/iOSPort/nativeSources/cn1_debugger.h
@@ -6,6 +6,19 @@
  * published by the Free Software Foundation.  Codename One designates this
  * particular file as subject to the "Classpath" exception as provided
  * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 
 #ifndef CN1_DEBUGGER_H

--- a/Ports/iOSPort/nativeSources/cn1_debugger.h
+++ b/Ports/iOSPort/nativeSources/cn1_debugger.h
@@ -158,6 +158,13 @@ extern void cn1_debugger_begin_thread_list(void);
  */
 extern void cn1_debugger_end_thread_list(void);
 
+/**
+ * The scalar component of an array class and its dimension count, or NULL if
+ * the chain cannot be read. An array's own class is synthetic and absent from
+ * the symbol table, so the component is what the proxy can actually name.
+ */
+extern struct clazz* cn1_debugger_array_component(struct clazz* arrayClass, int* dimsOut);
+
 /** Resolves an objectID that arrived from the IDE, or NULL to refuse it. */
 extern struct clazz* cn1_debugger_class_of_wire_id(JAVA_OBJECT obj);
 

--- a/Ports/iOSPort/nativeSources/cn1_debugger.h
+++ b/Ports/iOSPort/nativeSources/cn1_debugger.h
@@ -112,6 +112,22 @@ extern int cn1_debugger_is_tagged_int(JAVA_OBJECT obj);
 extern JAVA_INT cn1_debugger_tagged_int_value(JAVA_OBJECT obj);
 
 /**
+ * Records a reference as handed to the proxy, tests whether one was, and
+ * forgets the whole set on resume.
+ *
+ * A registered class word survives reclamation, so it proves shape but not
+ * liveness. Requiring that a wire objectID be one this debugger issued since
+ * the last resume refuses a stale id from an earlier suspension instead of
+ * dereferencing it.
+ */
+extern void cn1_debugger_note_issued(JAVA_OBJECT obj);
+extern int cn1_debugger_was_issued(JAVA_OBJECT obj);
+extern void cn1_debugger_forget_issued(void);
+
+/** Resolves an objectID that arrived from the IDE, or NULL to refuse it. */
+extern struct clazz* cn1_debugger_class_of_wire_id(JAVA_OBJECT obj);
+
+/**
  * Whether a local described by one side-table row is in scope at a source
  * line. Locals out of scope are left out of the reply rather than reported
  * with the contents of storage that belongs to another scope.

--- a/Ports/iOSPort/nativeSources/cn1_debugger.m
+++ b/Ports/iOSPort/nativeSources/cn1_debugger.m
@@ -635,26 +635,6 @@ static void suspendCurrent(struct ThreadLocalData* tsd) {
  * step kind) survives a subsequent CMD_RESUME from jdb. Caller passes
  * preserveStep=1 to leave stepKind alone, or 0 to also reset to -1.
  */
-/**
- * Drops the issued-id set once nothing is parked any more.
- *
- * Ids do not survive the app running on -- the collector is free to reclaim
- * what the IDE was looking at. But the IDE can resume or step one thread while
- * another stays stopped, and that other thread's locals, fields and arrays are
- * still being inspected; clearing globally on a per-thread resume made them
- * start reporting unavailable. So the set is kept while any thread remains
- * suspended and dropped when the last one wakes.
- */
-static void forgetIssuedIfNothingParked(void) {
-    for (int i = 0; i < SUS_TABLE_SIZE; i++) {
-        pthread_mutex_lock(&g_sus[i].mu);
-        int stillParked = g_sus[i].suspended;
-        pthread_mutex_unlock(&g_sus[i].mu);
-        if (stillParked) return;
-    }
-    cn1_debugger_forget_issued();
-}
-
 static void resumeThreadById(int64_t threadId, int preserveStep) {
     struct sus_state* s = susForThread(threadId);
     pthread_mutex_lock(&s->mu);
@@ -664,7 +644,9 @@ static void resumeThreadById(int64_t threadId, int preserveStep) {
     s->suspended = 0;
     pthread_cond_signal(&s->cv);
     pthread_mutex_unlock(&s->mu);
-    forgetIssuedIfNothingParked();
+    // Only this thread's ids: its objects can now be collected, while a thread
+    // that is still parked is still being inspected through its own.
+    cn1_debugger_forget_issued_for(threadId);
 }
 
 static void resumeAll(int preserveStep) {
@@ -692,7 +674,7 @@ static void setStepAndResume(int64_t threadId, int stepKind) {
         pthread_cond_signal(&s->cv);
     }
     pthread_mutex_unlock(&s->mu);
-    forgetIssuedIfNothingParked();
+    cn1_debugger_forget_issued_for(threadId);
 }
 
 /* --------------------------------------------------------------------- */
@@ -961,7 +943,7 @@ static void handleGetLocals(int64_t threadId, int frameOffsetFromTop) {
                         value = 0;
                         break;
                     }
-                    if (!cn1_debugger_note_issued(obj)) {
+                    if (!cn1_debugger_note_issued_for(obj, threadId)) {
                         // Unrecordable, so every later request for it would be
                         // refused; a reference the IDE can see but cannot
                         // expand is worse than one it never saw.
@@ -1138,6 +1120,9 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
             }
             JAVA_OBJECT obj = (JAVA_OBJECT)(uintptr_t)ptr;
             struct clazz* objCls = cn1_debugger_class_of_wire_id(obj);
+            // Anything reached through this object belongs to whichever
+            // suspension produced it, so it is invalidated at the same time.
+            int64_t owner = cn1_debugger_owner_of(obj);
             int classId = objCls != NULL ? objCls->classId : -1;
             // An unverifiable reference yields no fields rather than a read
             // at obj+offset, which is where a bogus objectID used to fault.
@@ -1177,7 +1162,7 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
                     if (tc == 'L') {
                         JAVA_OBJECT ref = (JAVA_OBJECT)(uintptr_t)val;
                         if (!cn1_debugger_is_valid_object(ref)
-                                || !cn1_debugger_note_issued(ref)) {
+                                || !cn1_debugger_note_issued_for(ref, owner)) {
                             val = 0;
                         }
                     }
@@ -1304,7 +1289,7 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
                 case 'D':
                     memcpy(&bits, &r.value.d, 8); break;
                 case 'L': case '[': case 'X':
-                    bits = cn1_debugger_note_issued(r.value.o)
+                    bits = cn1_debugger_note_issued_for(r.value.o, tid)
                             ? (uint64_t)(uintptr_t)r.value.o : 0;
                     break;
                 case 'V': default:
@@ -1360,6 +1345,7 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
                 sendEvent(EVT_ARRAY_VALUES, err, 5);
                 return 0;
             }
+            int64_t arrayOwner = cn1_debugger_owner_of(obj);
             JAVA_ARRAY arr = (JAVA_ARRAY)obj;
             int arrLen = arr->length;
             if (firstIdx < 0) firstIdx = 0;
@@ -1452,7 +1438,7 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
                         // objectID the IDE expects us to dereference.
                         JAVA_OBJECT v = ((JAVA_OBJECT*)arr->data)[idx];
                         if (!cn1_debugger_is_valid_object(v)
-                                || !cn1_debugger_note_issued(v)) {
+                                || !cn1_debugger_note_issued_for(v, arrayOwner)) {
                             v = JAVA_NULL;
                         }
                         writeBE64(p, (uint64_t)(uintptr_t)v);

--- a/Ports/iOSPort/nativeSources/cn1_debugger.m
+++ b/Ports/iOSPort/nativeSources/cn1_debugger.m
@@ -7,6 +7,19 @@
  * particular file as subject to the "Classpath" exception as provided
  * by Oracle in the LICENSE file that accompanied this code.
  *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ *
  * On-device-debug runtime. Single-file implementation: wire-protocol
  * encode/decode, breakpoint hash, per-thread suspend/resume, command
  * handlers. The translator emits per-frame metadata that this file reads

--- a/Ports/iOSPort/nativeSources/cn1_debugger.m
+++ b/Ports/iOSPort/nativeSources/cn1_debugger.m
@@ -133,6 +133,14 @@ static pthread_mutex_t g_writeMutex = PTHREAD_MUTEX_INITIALIZER;
 // as a permanent synthetic entry with no java.lang.Thread behind it — and it
 // only appears once the IDE resolves a thread name, i.e. as a side effect of
 // the very feature this change added.
+//
+// Captured lazily, at the one place the listener actually needs a Java
+// context, rather than eagerly at thread start: getThreadLocalData()
+// initialises threadIdKey, threadKeyCounter and the allThreads array without
+// synchronisation, so calling it from this thread during app startup could
+// race the main thread's first call and produce competing TLS keys or
+// duplicate thread ids. By the time a CMD_GET_STRING arrives, a proxy and an
+// IDE are both attached and the VM has long since initialised.
 static struct ThreadLocalData* g_listenerTsd = NULL;
 
 // Wait-for-attach state. cn1_debugger_run_when_ready stashes the VM-callback
@@ -628,6 +636,9 @@ static void suspendCurrent(struct ThreadLocalData* tsd) {
  * preserveStep=1 to leave stepKind alone, or 0 to also reset to -1.
  */
 static void resumeThreadById(int64_t threadId, int preserveStep) {
+    // Ids issued during this stop are not valid past it: the app runs on and
+    // the collector is free to reclaim what the IDE was looking at.
+    cn1_debugger_forget_issued();
     struct sus_state* s = susForThread(threadId);
     pthread_mutex_lock(&s->mu);
     if (!preserveStep) {
@@ -639,6 +650,7 @@ static void resumeThreadById(int64_t threadId, int preserveStep) {
 }
 
 static void resumeAll(int preserveStep) {
+    cn1_debugger_forget_issued();
     for (int i = 0; i < SUS_TABLE_SIZE; i++) {
         pthread_mutex_lock(&g_sus[i].mu);
         if (g_sus[i].suspended) {
@@ -654,6 +666,7 @@ static void resumeAll(int preserveStep) {
 
 /* Sets the step state on a thread and wakes it if currently suspended. */
 static void setStepAndResume(int64_t threadId, int stepKind) {
+    cn1_debugger_forget_issued();
     struct sus_state* s = susForThread(threadId);
     pthread_mutex_lock(&s->mu);
     s->stepKind = stepKind;
@@ -830,7 +843,11 @@ static void handleGetThreads(void) {
             if (suspended) flags |= 0x01;
             if (t->threadActive) flags |= 0x02;
             JAVA_OBJECT threadObj = t->currentThreadObject;
-            if (!cn1_debugger_is_valid_object(threadObj)) threadObj = JAVA_NULL;
+            if (cn1_debugger_is_valid_object(threadObj)) {
+                cn1_debugger_note_issued(threadObj);
+            } else {
+                threadObj = JAVA_NULL;
+            }
             writeBE64(p, (uint64_t)tid); p += 8;
             *p++ = flags;
             writeBE64(p, (uint64_t)(uintptr_t)threadObj); p += 8;
@@ -928,6 +945,7 @@ static void handleGetLocals(int64_t threadId, int frameOffsetFromTop) {
                         break;
                     }
                     value = (uint64_t)(uintptr_t)obj;
+                    cn1_debugger_note_issued(obj);
                     // Tag java.lang.String references with JDWP type 's'
                     // so the IDE can read their contents via
                     // StringReference.Value instead of invoking toString().
@@ -1032,7 +1050,7 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
             int classId = -1;
             uint8_t isArray = 0;
             JAVA_OBJECT obj = (JAVA_OBJECT)(uintptr_t)ptr;
-            struct clazz* cls = cn1_debugger_class_of(obj);
+            struct clazz* cls = cn1_debugger_class_of_wire_id(obj);
             if (cls != NULL) {
                 classId = cls->classId;
                 isArray = cls->isArray ? 1 : 0;
@@ -1060,8 +1078,12 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
             @try {
                 // toNSString walks the String's char[]; a reference that is
                 // not really a String would send it off into arbitrary memory.
-                if (cn1_debugger_class_of(obj) == &class__java_lang_String) {
-                    ns = toNSString(getThreadLocalData(), obj);
+                if (cn1_debugger_class_of_wire_id(obj) == &class__java_lang_String) {
+                    struct ThreadLocalData* listenerTsd = getThreadLocalData();
+                    // This call is what registers the listener in allThreads;
+                    // remember it here so the enumeration can leave it out.
+                    g_listenerTsd = listenerTsd;
+                    ns = toNSString(listenerTsd, obj);
                 }
             } @catch (NSException* e) {
                 ns = nil;
@@ -1092,7 +1114,7 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
                 return 0;
             }
             JAVA_OBJECT obj = (JAVA_OBJECT)(uintptr_t)ptr;
-            struct clazz* objCls = cn1_debugger_class_of(obj);
+            struct clazz* objCls = cn1_debugger_class_of_wire_id(obj);
             int classId = objCls != NULL ? objCls->classId : -1;
             // An unverifiable reference yields no fields rather than a read
             // at obj+offset, which is where a bogus objectID used to fault.
@@ -1129,8 +1151,13 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
                     field_read_into(obj, fe, &tc, &val);
                     // A reference field can legitimately hold a value the GC
                     // has since reclaimed; don't pass one on as an objectID.
-                    if (tc == 'L' && !cn1_debugger_is_valid_object((JAVA_OBJECT)(uintptr_t)val)) {
-                        val = 0;
+                    if (tc == 'L') {
+                        JAVA_OBJECT ref = (JAVA_OBJECT)(uintptr_t)val;
+                        if (cn1_debugger_is_valid_object(ref)) {
+                            cn1_debugger_note_issued(ref);
+                        } else {
+                            val = 0;
+                        }
                     }
                 } else {
                     tc = 'L'; val = 0;
@@ -1165,7 +1192,7 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
             // The thunk dispatches through this receiver's vtable, so an
             // unverifiable one would jump through a fabricated function
             // pointer. Refuse the call instead.
-            if (thisObj != JAVA_NULL && !cn1_debugger_is_valid_object(thisObj)) {
+            if (thisObj != JAVA_NULL && cn1_debugger_class_of_wire_id(thisObj) == NULL) {
                 uint8_t badThis[9] = {'V',0,0,0,0,0,0,0,0};
                 sendEvent(EVT_INVOKE_RESULT, badThis, 9);
                 return 0;
@@ -1203,7 +1230,7 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
                         // dereference this. An unverifiable argument becomes
                         // null, which the callee can at least handle.
                         JAVA_OBJECT arg = (JAVA_OBJECT)(uintptr_t)v;
-                        argv[i].o = cn1_debugger_is_valid_object(arg) ? arg : JAVA_NULL;
+                        argv[i].o = cn1_debugger_class_of_wire_id(arg) != NULL ? arg : JAVA_NULL;
                         break;
                     }
                 }
@@ -1255,6 +1282,7 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
                 case 'D':
                     memcpy(&bits, &r.value.d, 8); break;
                 case 'L': case '[': case 'X':
+                    cn1_debugger_note_issued(r.value.o);
                     bits = (uint64_t)(uintptr_t)r.value.o; break;
                 case 'V': default:
                     bits = 0; break;
@@ -1275,7 +1303,7 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
             uint64_t ptr = ((uint64_t)ntohl(hi) << 32) | (uint32_t)ntohl(lo);
             JAVA_OBJECT obj = (JAVA_OBJECT)(uintptr_t)ptr;
             int length = 0;
-            struct clazz* arrCls = cn1_debugger_class_of(obj);
+            struct clazz* arrCls = cn1_debugger_class_of_wire_id(obj);
             if (arrCls != NULL && !cn1_debugger_is_tagged_int(obj) && arrCls->isArray) {
                 length = ((JAVA_ARRAY)obj)->length;
             }
@@ -1303,7 +1331,7 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
             JAVA_OBJECT obj = (JAVA_OBJECT)(uintptr_t)ptr;
             // Everything below indexes arr->data, so the reference has to be
             // a verified array before any of it runs.
-            struct clazz* objArrCls = cn1_debugger_class_of(obj);
+            struct clazz* objArrCls = cn1_debugger_class_of_wire_id(obj);
             if (objArrCls == NULL || cn1_debugger_is_tagged_int(obj) || !objArrCls->isArray) {
                 uint8_t err[5] = {'L', 0,0,0,0};
                 sendEvent(EVT_ARRAY_VALUES, err, 5);
@@ -1400,7 +1428,11 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
                         // anything else would come straight back to us as an
                         // objectID the IDE expects us to dereference.
                         JAVA_OBJECT v = ((JAVA_OBJECT*)arr->data)[idx];
-                        if (!cn1_debugger_is_valid_object(v)) v = JAVA_NULL;
+                        if (cn1_debugger_is_valid_object(v)) {
+                            cn1_debugger_note_issued(v);
+                        } else {
+                            v = JAVA_NULL;
+                        }
                         writeBE64(p, (uint64_t)(uintptr_t)v);
                         p += 8; break;
                     }
@@ -1494,9 +1526,6 @@ static int cn1_debugger_is_attach_ready(void) {
 
 static void* listenerThreadMain(void* arg) {
     @autoreleasepool {
-        // Register up front and remember it, rather than discovering it later
-        // when a command handler happens to need a Java context.
-        g_listenerTsd = getThreadLocalData();
         NSDictionary* info = [[NSBundle mainBundle] infoDictionary];
         NSString* host = info[@"CN1ProxyHost"];
         NSNumber* portN = info[@"CN1ProxyPort"];

--- a/Ports/iOSPort/nativeSources/cn1_debugger.m
+++ b/Ports/iOSPort/nativeSources/cn1_debugger.m
@@ -635,10 +635,27 @@ static void suspendCurrent(struct ThreadLocalData* tsd) {
  * step kind) survives a subsequent CMD_RESUME from jdb. Caller passes
  * preserveStep=1 to leave stepKind alone, or 0 to also reset to -1.
  */
-static void resumeThreadById(int64_t threadId, int preserveStep) {
-    // Ids issued during this stop are not valid past it: the app runs on and
-    // the collector is free to reclaim what the IDE was looking at.
+/**
+ * Drops the issued-id set once nothing is parked any more.
+ *
+ * Ids do not survive the app running on -- the collector is free to reclaim
+ * what the IDE was looking at. But the IDE can resume or step one thread while
+ * another stays stopped, and that other thread's locals, fields and arrays are
+ * still being inspected; clearing globally on a per-thread resume made them
+ * start reporting unavailable. So the set is kept while any thread remains
+ * suspended and dropped when the last one wakes.
+ */
+static void forgetIssuedIfNothingParked(void) {
+    for (int i = 0; i < SUS_TABLE_SIZE; i++) {
+        pthread_mutex_lock(&g_sus[i].mu);
+        int stillParked = g_sus[i].suspended;
+        pthread_mutex_unlock(&g_sus[i].mu);
+        if (stillParked) return;
+    }
     cn1_debugger_forget_issued();
+}
+
+static void resumeThreadById(int64_t threadId, int preserveStep) {
     struct sus_state* s = susForThread(threadId);
     pthread_mutex_lock(&s->mu);
     if (!preserveStep) {
@@ -647,6 +664,7 @@ static void resumeThreadById(int64_t threadId, int preserveStep) {
     s->suspended = 0;
     pthread_cond_signal(&s->cv);
     pthread_mutex_unlock(&s->mu);
+    forgetIssuedIfNothingParked();
 }
 
 static void resumeAll(int preserveStep) {
@@ -666,7 +684,6 @@ static void resumeAll(int preserveStep) {
 
 /* Sets the step state on a thread and wakes it if currently suspended. */
 static void setStepAndResume(int64_t threadId, int stepKind) {
-    cn1_debugger_forget_issued();
     struct sus_state* s = susForThread(threadId);
     pthread_mutex_lock(&s->mu);
     s->stepKind = stepKind;
@@ -675,6 +692,7 @@ static void setStepAndResume(int64_t threadId, int stepKind) {
         pthread_cond_signal(&s->cv);
     }
     pthread_mutex_unlock(&s->mu);
+    forgetIssuedIfNothingParked();
 }
 
 /* --------------------------------------------------------------------- */
@@ -843,9 +861,8 @@ static void handleGetThreads(void) {
             if (suspended) flags |= 0x01;
             if (t->threadActive) flags |= 0x02;
             JAVA_OBJECT threadObj = t->currentThreadObject;
-            if (cn1_debugger_is_valid_object(threadObj)) {
-                cn1_debugger_note_issued(threadObj);
-            } else {
+            if (!cn1_debugger_is_valid_object(threadObj)
+                    || !cn1_debugger_note_issued(threadObj)) {
                 threadObj = JAVA_NULL;
             }
             writeBE64(p, (uint64_t)tid); p += 8;
@@ -944,8 +961,14 @@ static void handleGetLocals(int64_t threadId, int frameOffsetFromTop) {
                         value = 0;
                         break;
                     }
+                    if (!cn1_debugger_note_issued(obj)) {
+                        // Unrecordable, so every later request for it would be
+                        // refused; a reference the IDE can see but cannot
+                        // expand is worse than one it never saw.
+                        value = 0;
+                        break;
+                    }
                     value = (uint64_t)(uintptr_t)obj;
-                    cn1_debugger_note_issued(obj);
                     // Tag java.lang.String references with JDWP type 's'
                     // so the IDE can read their contents via
                     // StringReference.Value instead of invoking toString().
@@ -1153,9 +1176,8 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
                     // has since reclaimed; don't pass one on as an objectID.
                     if (tc == 'L') {
                         JAVA_OBJECT ref = (JAVA_OBJECT)(uintptr_t)val;
-                        if (cn1_debugger_is_valid_object(ref)) {
-                            cn1_debugger_note_issued(ref);
-                        } else {
+                        if (!cn1_debugger_is_valid_object(ref)
+                                || !cn1_debugger_note_issued(ref)) {
                             val = 0;
                         }
                     }
@@ -1282,8 +1304,9 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
                 case 'D':
                     memcpy(&bits, &r.value.d, 8); break;
                 case 'L': case '[': case 'X':
-                    cn1_debugger_note_issued(r.value.o);
-                    bits = (uint64_t)(uintptr_t)r.value.o; break;
+                    bits = cn1_debugger_note_issued(r.value.o)
+                            ? (uint64_t)(uintptr_t)r.value.o : 0;
+                    break;
                 case 'V': default:
                     bits = 0; break;
             }
@@ -1428,9 +1451,8 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
                         // anything else would come straight back to us as an
                         // objectID the IDE expects us to dereference.
                         JAVA_OBJECT v = ((JAVA_OBJECT*)arr->data)[idx];
-                        if (cn1_debugger_is_valid_object(v)) {
-                            cn1_debugger_note_issued(v);
-                        } else {
+                        if (!cn1_debugger_is_valid_object(v)
+                                || !cn1_debugger_note_issued(v)) {
                             v = JAVA_NULL;
                         }
                         writeBE64(p, (uint64_t)(uintptr_t)v);

--- a/Ports/iOSPort/nativeSources/cn1_debugger.m
+++ b/Ports/iOSPort/nativeSources/cn1_debugger.m
@@ -537,18 +537,16 @@ static void ensureSusInit(void) {
 static pthread_mutex_t g_susTableMutex = PTHREAD_MUTEX_INITIALIZER;
 
 /*
- * Whether a slot holds nothing worth keeping, so it can be handed to another
- * thread. Everything here is at its initial value: no suspension, no frame,
- * no pending step, no queued invocation. Checked under the slot's own lock.
+ * The calling thread's own slot, remembered across calls.
+ *
+ * cn1_debugger_check asks for it at every source line of every method, which
+ * makes this the hottest path the debugger adds to a running app -- taking a
+ * process-wide lock and scanning the table there would cost more than the
+ * check it guards. A claimed slot never changes hands, so once a thread has
+ * found its own the answer cannot go stale.
  */
-static int susSlotIsIdle(struct sus_state* s) {
-    int idle;
-    pthread_mutex_lock(&s->mu);
-    idle = !s->suspended && s->tsd == NULL && s->stepKind == -1
-            && s->invokeThunk == NULL;
-    pthread_mutex_unlock(&s->mu);
-    return idle;
-}
+static __thread struct sus_state* t_ownSlot = NULL;
+static __thread int64_t t_ownSlotThread = 0;
 
 /**
  * The suspension slot for a thread, claiming one on first use.
@@ -557,11 +555,12 @@ static int susSlotIsIdle(struct sus_state* s) {
  * and the table is not, so two live threads can hash together. The claim makes
  * the slot that thread's own until it is reclaimed.
  *
- * A table with no free slot reclaims one that is idle -- a slot in its initial
- * state carries nothing, so the thread that owned it loses nothing by being
- * moved, and claims a fresh slot the next time it asks. Failing that, the
- * hashed slot is returned unclaimed: degraded exactly as before, but never
- * NULL, because every caller dereferences the result.
+ * Slots are never taken back. That bounds how many threads can hold one at a
+ * time, and a table with none left falls back to the hashed slot unclaimed --
+ * degraded exactly as it was before any of this, but never NULL, because every
+ * caller dereferences the result. Reclaiming instead would mean a slot could
+ * change owner underneath the thread that holds it, which is the very thing
+ * being fixed, and would cost the lock-free fast path above.
  */
 static struct sus_state* susForThread(int64_t threadId) {
     ensureSusInit();
@@ -576,12 +575,6 @@ static struct sus_state* susForThread(int64_t threadId) {
         }
         if (freeSlot == NULL && s->owner == 0) freeSlot = s;
     }
-    if (freeSlot == NULL) {
-        for (int i = 0; i < SUS_TABLE_SIZE; i++) {
-            struct sus_state* s = &g_sus[(start + (unsigned)i) & (SUS_TABLE_SIZE - 1)];
-            if (susSlotIsIdle(s)) { freeSlot = s; break; }
-        }
-    }
     if (freeSlot != NULL) {
         freeSlot->owner = threadId;
         pthread_mutex_unlock(&g_susTableMutex);
@@ -589,6 +582,19 @@ static struct sus_state* susForThread(int64_t threadId) {
     }
     pthread_mutex_unlock(&g_susTableMutex);
     return &g_sus[start];
+}
+
+/*
+ * The slot for the thread that is asking, through the per-thread cache. Only
+ * for a caller running *on* that thread: the listener asks about other threads
+ * and must not cache their slots as its own.
+ */
+static struct sus_state* susForCurrentThread(int64_t threadId) {
+    if (t_ownSlot != NULL && t_ownSlotThread == threadId) return t_ownSlot;
+    struct sus_state* s = susForThread(threadId);
+    t_ownSlot = s;
+    t_ownSlotThread = threadId;
+    return s;
 }
 
 /* --------------------------------------------------------------------- */
@@ -831,7 +837,7 @@ void cn1_debugger_check(struct ThreadLocalData* tsd, int line) {
 
     // Stepping has priority over breakpoints so a step that lands on a
     // breakpoint reports once (as STEP_COMPLETE).
-    struct sus_state* s = susForThread(threadId);
+    struct sus_state* s = susForCurrentThread(threadId);
     int sk = s->stepKind;
     if (sk >= 0) {
         int depth = tsd->callStackOffset;

--- a/Ports/iOSPort/nativeSources/cn1_debugger.m
+++ b/Ports/iOSPort/nativeSources/cn1_debugger.m
@@ -1120,19 +1120,35 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
             uint64_t ptr = ((uint64_t)ntohl(hi) << 32) | (uint32_t)ntohl(lo);
             int classId = -1;
             uint8_t isArray = 0;
+            uint8_t dimensions = 0;
             JAVA_OBJECT obj = (JAVA_OBJECT)(uintptr_t)ptr;
             struct clazz* cls = cn1_debugger_class_of_wire_id(obj);
             if (cls != NULL) {
                 classId = cls->classId;
                 isArray = cls->isArray ? 1 : 0;
+                if (isArray) {
+                    // An array's own class is synthetic -- the runtime makes
+                    // one per element type as needed -- so it has no entry in
+                    // the symbol table and its id resolves to nothing at the
+                    // other end. Every array therefore read as Object[]. Send
+                    // the component the table does know, and the depth, so the
+                    // proxy can name the type it actually is.
+                    int dims = 0;
+                    struct clazz* component = cn1_debugger_array_component(cls, &dims);
+                    if (component != NULL && dims > 0 && dims < 256) {
+                        classId = component->classId;
+                        dimensions = (uint8_t)dims;
+                    }
+                }
             }
-            // Reply: classId(4) + isArray(1). Older proxies that only read
-            // 4 bytes still work.
-            uint8_t reply[5];
+            // Reply: classId(4) + isArray(1) + dimensions(1). Older proxies
+            // reading 4 or 5 bytes are unaffected.
+            uint8_t reply[6];
             uint32_t cidBE = htonl((uint32_t)classId);
             memcpy(reply, &cidBE, 4);
             reply[4] = isArray;
-            sendEvent(EVT_OBJECT_CLASS, reply, 5);
+            reply[5] = dimensions;
+            sendEvent(EVT_OBJECT_CLASS, reply, 6);
             return 0;
         }
         case CMD_GET_STRING: {

--- a/Ports/iOSPort/nativeSources/cn1_debugger.m
+++ b/Ports/iOSPort/nativeSources/cn1_debugger.m
@@ -479,6 +479,16 @@ static void bp_clear(int methodId, int line) {
 struct sus_state {
     pthread_mutex_t mu;
     pthread_cond_t  cv;
+    /*
+     * Thread this slot belongs to, 0 when unclaimed. Held explicitly because
+     * the table is indexed by a hash of the thread ID and the runtime hands
+     * out IDs from a counter that only ever climbs -- so an app that has
+     * created SUS_TABLE_SIZE threads gives two *live* ones the same slot.
+     * Sharing it let either thread's suspend flag and frame pointer overwrite
+     * the other's, so a stack or locals request could answer about the wrong
+     * thread and resuming one woke the other.
+     */
+    int64_t owner;
     int suspended;
     int stepKind;       // -1 = none, otherwise STEP_INTO/OVER/OUT
     int stepFromDepth;  // callStackOffset captured at suspend
@@ -502,6 +512,7 @@ static void susInitOnce(void) {
     for (int i = 0; i < SUS_TABLE_SIZE; i++) {
         pthread_mutex_init(&g_sus[i].mu, NULL);
         pthread_cond_init(&g_sus[i].cv, NULL);
+        g_sus[i].owner = 0;
         g_sus[i].suspended = 0;
         g_sus[i].stepKind = -1;
         g_sus[i].tsd = NULL;
@@ -522,9 +533,62 @@ static void ensureSusInit(void) {
     pthread_once(&g_susOnce, susInitOnce);
 }
 
+/* Serialises claiming, so two threads cannot take the same slot. */
+static pthread_mutex_t g_susTableMutex = PTHREAD_MUTEX_INITIALIZER;
+
+/*
+ * Whether a slot holds nothing worth keeping, so it can be handed to another
+ * thread. Everything here is at its initial value: no suspension, no frame,
+ * no pending step, no queued invocation. Checked under the slot's own lock.
+ */
+static int susSlotIsIdle(struct sus_state* s) {
+    int idle;
+    pthread_mutex_lock(&s->mu);
+    idle = !s->suspended && s->tsd == NULL && s->stepKind == -1
+            && s->invokeThunk == NULL;
+    pthread_mutex_unlock(&s->mu);
+    return idle;
+}
+
+/**
+ * The suspension slot for a thread, claiming one on first use.
+ *
+ * Probes from the hash rather than indexing by it: the ID space is unbounded
+ * and the table is not, so two live threads can hash together. The claim makes
+ * the slot that thread's own until it is reclaimed.
+ *
+ * A table with no free slot reclaims one that is idle -- a slot in its initial
+ * state carries nothing, so the thread that owned it loses nothing by being
+ * moved, and claims a fresh slot the next time it asks. Failing that, the
+ * hashed slot is returned unclaimed: degraded exactly as before, but never
+ * NULL, because every caller dereferences the result.
+ */
 static struct sus_state* susForThread(int64_t threadId) {
     ensureSusInit();
-    return &g_sus[((uint64_t)threadId) & (SUS_TABLE_SIZE - 1)];
+    unsigned start = (unsigned)(((uint64_t)threadId) & (SUS_TABLE_SIZE - 1));
+    pthread_mutex_lock(&g_susTableMutex);
+    struct sus_state* freeSlot = NULL;
+    for (int i = 0; i < SUS_TABLE_SIZE; i++) {
+        struct sus_state* s = &g_sus[(start + (unsigned)i) & (SUS_TABLE_SIZE - 1)];
+        if (s->owner == threadId) {
+            pthread_mutex_unlock(&g_susTableMutex);
+            return s;
+        }
+        if (freeSlot == NULL && s->owner == 0) freeSlot = s;
+    }
+    if (freeSlot == NULL) {
+        for (int i = 0; i < SUS_TABLE_SIZE; i++) {
+            struct sus_state* s = &g_sus[(start + (unsigned)i) & (SUS_TABLE_SIZE - 1)];
+            if (susSlotIsIdle(s)) { freeSlot = s; break; }
+        }
+    }
+    if (freeSlot != NULL) {
+        freeSlot->owner = threadId;
+        pthread_mutex_unlock(&g_susTableMutex);
+        return freeSlot;
+    }
+    pthread_mutex_unlock(&g_susTableMutex);
+    return &g_sus[start];
 }
 
 /* --------------------------------------------------------------------- */

--- a/Ports/iOSPort/nativeSources/cn1_debugger.m
+++ b/Ports/iOSPort/nativeSources/cn1_debugger.m
@@ -818,6 +818,10 @@ static void handleGetStack(int64_t threadId) {
  * naming protocol.
  */
 static void handleGetThreads(void) {
+    // This snapshot supersedes the last, so the Thread objects it advertised
+    // stop being rooted by it. Without this an IDE polling the thread list on
+    // a running app would pin every thread object it ever saw.
+    cn1_debugger_forget_thread_list_claims();
     lockCriticalSection();
     int count = 0;
     if (allThreads != NULL) {

--- a/Ports/iOSPort/nativeSources/cn1_debugger.m
+++ b/Ports/iOSPort/nativeSources/cn1_debugger.m
@@ -1077,7 +1077,17 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
                 char tc = 'L';
                 uint64_t val = 0;
                 const cn1_field_entry* fe = field_lookup_by_class_and_id(classId, fid, NULL);
-                if (fe && obj != JAVA_NULL) {
+                if (cn1_debugger_is_tagged_int(obj)) {
+                    // A tagged Integer carries its value in the reference
+                    // itself and has no fields to read at an offset. Serve the
+                    // one field it models -- Integer.value -- from the tag.
+                    if (fe && fe->type == 'I') {
+                        tc = 'I';
+                        val = (uint64_t)(uint32_t)cn1_debugger_tagged_int_value(obj);
+                    } else {
+                        tc = 'L'; val = 0;
+                    }
+                } else if (fe && obj != JAVA_NULL) {
                     field_read_into(obj, fe, &tc, &val);
                     // A reference field can legitimately hold a value the GC
                     // has since reclaimed; don't pass one on as an objectID.
@@ -1228,7 +1238,7 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
             JAVA_OBJECT obj = (JAVA_OBJECT)(uintptr_t)ptr;
             int length = 0;
             struct clazz* arrCls = cn1_debugger_class_of(obj);
-            if (arrCls != NULL && arrCls->isArray) {
+            if (arrCls != NULL && !cn1_debugger_is_tagged_int(obj) && arrCls->isArray) {
                 length = ((JAVA_ARRAY)obj)->length;
             }
             uint8_t reply[4];
@@ -1256,7 +1266,7 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
             // Everything below indexes arr->data, so the reference has to be
             // a verified array before any of it runs.
             struct clazz* objArrCls = cn1_debugger_class_of(obj);
-            if (objArrCls == NULL || !objArrCls->isArray) {
+            if (objArrCls == NULL || cn1_debugger_is_tagged_int(obj) || !objArrCls->isArray) {
                 uint8_t err[5] = {'L', 0,0,0,0};
                 sendEvent(EVT_ARRAY_VALUES, err, 5);
                 return 0;

--- a/Ports/iOSPort/nativeSources/cn1_debugger.m
+++ b/Ports/iOSPort/nativeSources/cn1_debugger.m
@@ -496,19 +496,30 @@ struct sus_state {
 
 #define SUS_TABLE_SIZE 1024
 static struct sus_state g_sus[SUS_TABLE_SIZE];
-static _Atomic int g_susInit = 0;
+static pthread_once_t g_susOnce = PTHREAD_ONCE_INIT;
 
-static void ensureSusInit(void) {
-    int expected = 0;
-    if (atomic_compare_exchange_strong(&g_susInit, &expected, 1)) {
-        for (int i = 0; i < SUS_TABLE_SIZE; i++) {
-            pthread_mutex_init(&g_sus[i].mu, NULL);
-            pthread_cond_init(&g_sus[i].cv, NULL);
-            g_sus[i].suspended = 0;
-            g_sus[i].stepKind = -1;
-            g_sus[i].tsd = NULL;
-        }
+static void susInitOnce(void) {
+    for (int i = 0; i < SUS_TABLE_SIZE; i++) {
+        pthread_mutex_init(&g_sus[i].mu, NULL);
+        pthread_cond_init(&g_sus[i].cv, NULL);
+        g_sus[i].suspended = 0;
+        g_sus[i].stepKind = -1;
+        g_sus[i].tsd = NULL;
     }
+}
+
+/*
+ * pthread_once rather than a compare-and-swap on a flag: the flag has to be
+ * published before the mutexes are initialised or two threads would both
+ * initialise them, and publishing it first lets the losing caller return
+ * while the winner is still running pthread_mutex_init. It then locks a slot
+ * that does not exist yet. The window is one loop wide and needs the IDE's
+ * first AllThreads to race a thread reaching its first breakpoint, which is
+ * exactly when a debugger session starts. pthread_once holds every other
+ * caller until the initialiser has finished.
+ */
+static void ensureSusInit(void) {
+    pthread_once(&g_susOnce, susInitOnce);
 }
 
 static struct sus_state* susForThread(int64_t threadId) {
@@ -606,7 +617,16 @@ static void suspendCurrent(struct ThreadLocalData* tsd) {
     // Mark thread inactive so the concurrent GC can mark/sweep freely.
     tsd->threadActive = JAVA_FALSE;
     while (s->suspended) {
-        pthread_cond_wait(&s->cv, &s->mu);
+        // Check for queued work *before* waiting, not after. The listener
+        // publishes an invocation and signals from its own thread, and
+        // markSuspendedBeforeEvent advertises this thread as ready to run one
+        // as soon as the stop event goes out -- which is before it gets here.
+        // A condition variable does not queue signals, so an invocation that
+        // arrived in that window had already been signalled by the time this
+        // thread reached the wait: the listener waits for a result nobody is
+        // running and the target waits for a signal that has been and gone.
+        // The session hangs with no way out.
+        //
         // The listener thread may have queued a debugger-invoked method
         // call for us to run. Servicing it on this thread keeps the call
         // inside a valid Java context (right tsd, right call stack) and
@@ -627,11 +647,26 @@ static void suspendCurrent(struct ThreadLocalData* tsd) {
             r.value.o = JAVA_NULL;
             thunk(tsd, thisObj, argsCopy, &r);
             pthread_mutex_lock(&s->mu);
+            // Root the result before going inactive, not after the listener
+            // picks it up. A thunk that returns or throws a freshly allocated
+            // object leaves the only reference to it right here in r, and the
+            // concurrent collector does not scan sus_state. Marking the thread
+            // inactive first opens a window in which that object can be
+            // collected, after which the ID handed to the IDE names reclaimed
+            // storage and the next field or class request reads it.
+            if ((r.type == 'L' || r.type == '[' || r.type == 'X') && r.value.o != JAVA_NULL) {
+                cn1_debugger_note_issued_for(r.value.o, (int64_t)tsd->threadId);
+            }
             tsd->threadActive = JAVA_FALSE;
             s->invokeResult = r;
             s->invokeReady = 1;
             pthread_cond_broadcast(&s->cv);
+            // Re-test the predicate rather than falling into a wait: a resume
+            // may have arrived while the thunk ran, and another invocation may
+            // already be queued behind this one.
+            continue;
         }
+        pthread_cond_wait(&s->cv, &s->mu);
     }
     // GC may have parked us; wait for it to finish before resuming.
     while (tsd->threadBlockedByGC) {
@@ -827,8 +862,11 @@ static void handleGetStack(int64_t threadId) {
 static void handleGetThreads(void) {
     // This snapshot supersedes the last, so the Thread objects it advertised
     // stop being rooted by it. Without this an IDE polling the thread list on
-    // a running app would pin every thread object it ever saw.
-    cn1_debugger_forget_thread_list_claims();
+    // a running app would pin every thread object it ever saw. Opened here and
+    // closed once every thread has been noted, rather than clearing up front:
+    // the refresh re-advertises only top-level Thread objects, so clearing
+    // first also dropped everything the IDE had reached through one.
+    cn1_debugger_begin_thread_list();
     lockCriticalSection();
     int count = 0;
     if (allThreads != NULL) {
@@ -841,6 +879,10 @@ static void handleGetThreads(void) {
     uint8_t* buf = (uint8_t*)malloc(sz);
     if (!buf) {
         unlockCriticalSection();
+        // Closed on this path too: the reply says there are no threads, so
+        // leaving the generation open would let the next refresh reconcile
+        // against a list that was never built.
+        cn1_debugger_end_thread_list();
         uint8_t empty[4] = {0,0,0,0};
         sendEvent(EVT_THREAD_LIST, empty, 4);
         return;
@@ -873,6 +915,11 @@ static void handleGetThreads(void) {
         }
     }
     unlockCriticalSection();
+    // Every thread in this refresh has now been noted, so anything the older
+    // generation claimed and this one does not -- and that nothing else holds
+    // -- can go. Outside the critical section: the claim table has its own
+    // lock and note_issued already takes it under this one.
+    cn1_debugger_end_thread_list();
     sendEvent(EVT_THREAD_LIST, buf, (uint32_t)sz);
     free(buf);
 }

--- a/Ports/iOSPort/nativeSources/cn1_debugger.m
+++ b/Ports/iOSPort/nativeSources/cn1_debugger.m
@@ -575,6 +575,12 @@ static void markSuspendedBeforeEvent(struct ThreadLocalData* tsd) {
     struct sus_state* s = susForThread((int64_t)tsd->threadId);
     pthread_mutex_lock(&s->mu);
     s->suspended = 1;
+    // The whole parked state, not just the flag: the proxy sends GET_STACK and
+    // GET_LOCALS as soon as it sees the event, and those read tsd out of here.
+    // Publishing them only once the thread reaches suspendCurrent left a window
+    // where the first stack request after a breakpoint answered empty.
+    s->stepFromDepth = tsd->callStackOffset;
+    s->tsd = tsd;
     pthread_mutex_unlock(&s->mu);
 }
 
@@ -582,10 +588,12 @@ static void suspendCurrent(struct ThreadLocalData* tsd) {
     int64_t threadId = (int64_t)tsd->threadId;
     struct sus_state* s = susForThread(threadId);
     pthread_mutex_lock(&s->mu);
-    // Normally already set by markSuspendedBeforeEvent; setting it again is
-    // harmless, and a resume that arrived in between legitimately cleared it,
-    // in which case the wait below falls straight through.
-    s->suspended = 1;
+    // Deliberately does NOT set s->suspended. markSuspendedBeforeEvent already
+    // published it, and a CMD_RESUME can arrive in the window between that and
+    // this call -- the listener runs on its own thread and the event has
+    // already gone out. Re-asserting the flag would swallow that resume and
+    // then wait for a signal that has been and gone, parking the thread (often
+    // the EDT) until some later resume happened along.
     s->stepFromDepth = tsd->callStackOffset;
     s->tsd = tsd;
     // Mark thread inactive so the concurrent GC can mark/sweep freely.
@@ -1121,8 +1129,7 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
             JAVA_OBJECT obj = (JAVA_OBJECT)(uintptr_t)ptr;
             struct clazz* objCls = cn1_debugger_class_of_wire_id(obj);
             // Anything reached through this object belongs to whichever
-            // suspension produced it, so it is invalidated at the same time.
-            int64_t owner = cn1_debugger_owner_of(obj);
+            // suspensions produced it, so it is invalidated with them.
             int classId = objCls != NULL ? objCls->classId : -1;
             // An unverifiable reference yields no fields rather than a read
             // at obj+offset, which is where a bogus objectID used to fault.
@@ -1162,7 +1169,7 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
                     if (tc == 'L') {
                         JAVA_OBJECT ref = (JAVA_OBJECT)(uintptr_t)val;
                         if (!cn1_debugger_is_valid_object(ref)
-                                || !cn1_debugger_note_issued_for(ref, owner)) {
+                                || !cn1_debugger_note_issued_inheriting(ref, obj)) {
                             val = 0;
                         }
                     }
@@ -1345,7 +1352,6 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
                 sendEvent(EVT_ARRAY_VALUES, err, 5);
                 return 0;
             }
-            int64_t arrayOwner = cn1_debugger_owner_of(obj);
             JAVA_ARRAY arr = (JAVA_ARRAY)obj;
             int arrLen = arr->length;
             if (firstIdx < 0) firstIdx = 0;
@@ -1438,7 +1444,7 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
                         // objectID the IDE expects us to dereference.
                         JAVA_OBJECT v = ((JAVA_OBJECT*)arr->data)[idx];
                         if (!cn1_debugger_is_valid_object(v)
-                                || !cn1_debugger_note_issued_for(v, arrayOwner)) {
+                                || !cn1_debugger_note_issued_inheriting(v, obj)) {
                             v = JAVA_NULL;
                         }
                         writeBE64(p, (uint64_t)(uintptr_t)v);

--- a/Ports/iOSPort/nativeSources/cn1_debugger.m
+++ b/Ports/iOSPort/nativeSources/cn1_debugger.m
@@ -157,7 +157,14 @@ static pthread_mutex_t g_attachMutex = PTHREAD_MUTEX_INITIALIZER;
 // attached. Installed as a subview of the app's keyWindow root view rather
 // than as a separate UIWindow because iOS 13+ scene-based apps (which
 // Codename One is by default) refuse to display non-scene UIWindows.
+//
+// UIKit is unavailable on watchOS, so the whole overlay is compiled out for
+// that slice. The watch app has no debugger UI to show and its own runtime
+// still connects; without this, enabling on-device debugging on any project
+// that has a watch target failed to compile the watch slice outright.
+#if !TARGET_OS_WATCH
 static UIView* g_waitOverlay = nil;
+#endif
 
 // Forward declaration; callers in the command dispatch sit above the
 // definition further down the file.
@@ -1637,6 +1644,7 @@ static void* listenerThreadMain(void* arg) {
 /* attached (via CMD_RESUME).                                           */
 /* --------------------------------------------------------------------- */
 
+#if !TARGET_OS_WATCH
 static UIView* cn1_debugger_active_host_view(void) {
     UIWindow* w = nil;
     if (@available(iOS 13.0, *)) {
@@ -1749,6 +1757,11 @@ static void cn1_debugger_dismiss_wait_overlay(void) {
         g_waitOverlay = nil;
     });
 }
+#else
+// watchOS: no UIKit, so nothing to show and nothing to take down.
+static void cn1_debugger_install_wait_overlay(void) {}
+static void cn1_debugger_dismiss_wait_overlay(void) {}
+#endif
 
 /*
  * Invoked when the proxy confirms the IDE is ready. Fires the pending

--- a/Ports/iOSPort/nativeSources/cn1_debugger.m
+++ b/Ports/iOSPort/nativeSources/cn1_debugger.m
@@ -93,6 +93,12 @@ extern int cn1_debug_symbols_length(void) __attribute__((weak));
 // of falling through to a (currently unsupported) toString() InvokeMethod.
 extern struct clazz class__java_lang_String;
 
+// ParparVM's registry of live threads. Owned by nativeMethods.m and guarded by
+// the critical section already declared in cn1_globals.h; CMD_GET_THREADS walks
+// it so the IDE can list every thread instead of only the ones that happened to
+// hit a breakpoint.
+extern struct ThreadLocalData** allThreads;
+
 // Step kinds
 #define STEP_INTO 0
 #define STEP_OVER 1
@@ -720,6 +726,63 @@ static void handleGetStack(int64_t threadId) {
     free(buf);
 }
 
+/**
+ * Enumerates every live Java thread for the proxy.
+ *
+ * The IDE's thread list used to show only threads that had already produced
+ * a breakpoint or step event, because that was the proxy's sole source of
+ * thread ids and this command was a stub that replied empty. ParparVM already
+ * keeps every ThreadLocalData in allThreads, so the list is simply that array
+ * minus its empty slots.
+ *
+ * Reply payload: count(4) then per thread threadId(8), flags(1),
+ * threadObject(8). Bit 0 of flags is "suspended by the debugger", bit 1 is
+ * "running Java code". threadObject is the java.lang.Thread instance (0 when
+ * the thread has not published one yet) so the proxy can read its name field
+ * through the ordinary object/field commands rather than needing a second
+ * naming protocol.
+ */
+static void handleGetThreads(void) {
+    lockCriticalSection();
+    int count = 0;
+    if (allThreads != NULL) {
+        for (int i = 0; i < NUMBER_OF_SUPPORTED_THREADS; i++) {
+            if (allThreads[i] != NULL && !allThreads[i]->threadKilled) count++;
+        }
+    }
+    size_t sz = 4 + (size_t)count * 17;
+    uint8_t* buf = (uint8_t*)malloc(sz);
+    if (!buf) {
+        unlockCriticalSection();
+        uint8_t empty[4] = {0,0,0,0};
+        sendEvent(EVT_THREAD_LIST, empty, 4);
+        return;
+    }
+    writeBE32(buf, (uint32_t)count);
+    uint8_t* p = buf + 4;
+    int emitted = 0;
+    if (allThreads != NULL) {
+        for (int i = 0; i < NUMBER_OF_SUPPORTED_THREADS && emitted < count; i++) {
+            struct ThreadLocalData* t = allThreads[i];
+            if (t == NULL || t->threadKilled) continue;
+            int64_t tid = (int64_t)t->threadId;
+            struct sus_state* s = susForThread(tid);
+            uint8_t flags = 0;
+            if (s->suspended) flags |= 0x01;
+            if (t->threadActive) flags |= 0x02;
+            JAVA_OBJECT threadObj = t->currentThreadObject;
+            if (!cn1_debugger_is_valid_object(threadObj)) threadObj = JAVA_NULL;
+            writeBE64(p, (uint64_t)tid); p += 8;
+            *p++ = flags;
+            writeBE64(p, (uint64_t)(uintptr_t)threadObj); p += 8;
+            emitted++;
+        }
+    }
+    unlockCriticalSection();
+    sendEvent(EVT_THREAD_LIST, buf, (uint32_t)sz);
+    free(buf);
+}
+
 static void handleGetLocals(int64_t threadId, int frameOffsetFromTop) {
     struct sus_state* s = susForThread(threadId);
     pthread_mutex_lock(&s->mu);
@@ -741,44 +804,69 @@ static void handleGetLocals(int64_t threadId, int frameOffsetFromTop) {
         sendEvent(EVT_LOCALS, &zero, 4);
         return;
     }
-    int count = fi->varTableCount;
+    // Only locals in scope at the line the frame is stopped on are reported.
+    // A slot reused by two disjoint scopes has a row for each, and reporting
+    // both means one of them shows storage that belongs to the other scope —
+    // a variable the code has not reached yet, displaying whatever the earlier
+    // occupant left there.
+    int currentLine = tsd->callStackLine[frameIdx];
+    int rows = fi->varTableCount;
+    int count = 0;
+    for (int i = 0; i < rows; i++) {
+        if (cn1_debugger_var_in_scope(&fi->varTable[i], currentLine)) count++;
+    }
     size_t sz = 4 + (size_t)count * (4 + 1 + 8);
     uint8_t* buf = (uint8_t*)malloc(sz);
     writeBE32(buf, (uint32_t)count);
     uint8_t* p = buf + 4;
-    for (int i = 0; i < count; i++) {
+    for (int i = 0; i < rows; i++) {
         const struct cn1_var_entry* v = &fi->varTable[i];
+        if (!cn1_debugger_var_in_scope(v, currentLine)) continue;
         writeBE32(p, (uint32_t)v->slot); p += 4;
         uint8_t tag = (uint8_t)v->typeCode;
         uint64_t value = 0;
-        if (v->slot >= 0 && v->slot < fi->numLocals && addrs[v->slot] != NULL) {
+        // Row-indexed, NOT slot-indexed: disjoint scopes reuse a slot with
+        // different types and ParparVM gives each its own storage, so only the
+        // row's own address is guaranteed to hold the row's own type. Indexing
+        // by slot read an 8-byte reference out of a 4-byte JAVA_INT and then
+        // dereferenced it (issue #5333).
+        void* addr = addrs[i];
+        if (addr != NULL) {
             switch (v->typeCode) {
                 case 'I': case 'B': case 'S': case 'C': case 'Z':
-                    value = (uint64_t)(*(int32_t*)addrs[v->slot]);
+                    value = (uint64_t)(*(int32_t*)addr);
                     break;
                 case 'J':
-                    value = (uint64_t)(*(int64_t*)addrs[v->slot]);
+                    value = (uint64_t)(*(int64_t*)addr);
                     break;
                 case 'F': {
-                    float f = *(float*)addrs[v->slot];
+                    float f = *(float*)addr;
                     uint32_t u; memcpy(&u, &f, 4);
                     value = u;
                     break;
                 }
                 case 'D': {
-                    double d = *(double*)addrs[v->slot];
+                    double d = *(double*)addr;
                     uint64_t u; memcpy(&u, &d, 8);
                     value = u;
                     break;
                 }
                 case 'L': case '[': {
-                    JAVA_OBJECT obj = *(JAVA_OBJECT*)addrs[v->slot];
+                    JAVA_OBJECT obj = *(JAVA_OBJECT*)addr;
+                    // Report only references we can prove are live objects.
+                    // A slot the frame has not reached yet holds whatever the
+                    // branch left behind, and handing that to the IDE just
+                    // means it asks us to dereference it a moment later.
+                    struct clazz* cls = cn1_debugger_class_of(obj);
+                    if (cls == NULL) {
+                        value = 0;
+                        break;
+                    }
                     value = (uint64_t)(uintptr_t)obj;
                     // Tag java.lang.String references with JDWP type 's'
                     // so the IDE can read their contents via
                     // StringReference.Value instead of invoking toString().
-                    if (v->typeCode == 'L' && obj != JAVA_NULL
-                            && obj->__codenameOneParentClsReference == &class__java_lang_String) {
+                    if (v->typeCode == 'L' && cls == &class__java_lang_String) {
                         tag = 's';
                     }
                     break;
@@ -879,8 +967,8 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
             int classId = -1;
             uint8_t isArray = 0;
             JAVA_OBJECT obj = (JAVA_OBJECT)(uintptr_t)ptr;
-            if (obj != JAVA_NULL && obj->__codenameOneParentClsReference != NULL) {
-                struct clazz* cls = obj->__codenameOneParentClsReference;
+            struct clazz* cls = cn1_debugger_class_of(obj);
+            if (cls != NULL) {
                 classId = cls->classId;
                 isArray = cls->isArray ? 1 : 0;
             }
@@ -905,7 +993,9 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
             JAVA_OBJECT obj = (JAVA_OBJECT)(uintptr_t)ptr;
             NSString* ns = nil;
             @try {
-                if (obj != JAVA_NULL) {
+                // toNSString walks the String's char[]; a reference that is
+                // not really a String would send it off into arbitrary memory.
+                if (cn1_debugger_class_of(obj) == &class__java_lang_String) {
                     ns = toNSString(getThreadLocalData(), obj);
                 }
             } @catch (NSException* e) {
@@ -937,10 +1027,11 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
                 return 0;
             }
             JAVA_OBJECT obj = (JAVA_OBJECT)(uintptr_t)ptr;
-            int classId = -1;
-            if (obj != JAVA_NULL && obj->__codenameOneParentClsReference != NULL) {
-                classId = obj->__codenameOneParentClsReference->classId;
-            }
+            struct clazz* objCls = cn1_debugger_class_of(obj);
+            int classId = objCls != NULL ? objCls->classId : -1;
+            // An unverifiable reference yields no fields rather than a read
+            // at obj+offset, which is where a bogus objectID used to fault.
+            if (objCls == NULL) obj = JAVA_NULL;
             // Reply payload: count(4) then per-field { type(1), value(8) }.
             uint32_t sz = 4 + (uint32_t)count * 9;
             uint8_t* buf = (uint8_t*)malloc(sz);
@@ -961,6 +1052,11 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
                 const cn1_field_entry* fe = field_lookup_by_class_and_id(classId, fid, NULL);
                 if (fe && obj != JAVA_NULL) {
                     field_read_into(obj, fe, &tc, &val);
+                    // A reference field can legitimately hold a value the GC
+                    // has since reclaimed; don't pass one on as an objectID.
+                    if (tc == 'L' && !cn1_debugger_is_valid_object((JAVA_OBJECT)(uintptr_t)val)) {
+                        val = 0;
+                    }
                 } else {
                     tc = 'L'; val = 0;
                 }
@@ -991,6 +1087,14 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
             memcpy(&thisHi, payload + 12, 4); memcpy(&thisLo, payload + 16, 4);
             uint64_t thisRaw = ((uint64_t)ntohl(thisHi) << 32) | (uint32_t)ntohl(thisLo);
             JAVA_OBJECT thisObj = (JAVA_OBJECT)(uintptr_t)thisRaw;
+            // The thunk dispatches through this receiver's vtable, so an
+            // unverifiable one would jump through a fabricated function
+            // pointer. Refuse the call instead.
+            if (thisObj != JAVA_NULL && !cn1_debugger_is_valid_object(thisObj)) {
+                uint8_t badThis[9] = {'V',0,0,0,0,0,0,0,0};
+                sendEvent(EVT_INVOKE_RESULT, badThis, 9);
+                return 0;
+            }
             uint32_t cntBE;
             memcpy(&cntBE, payload + 20, 4);
             int argCount = (int)ntohl(cntBE);
@@ -1019,8 +1123,14 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
                     }
                     case 'D':
                         memcpy(&argv[i].d, &v, 8); break;
-                    case 'L': case '[': default:
-                        argv[i].o = (JAVA_OBJECT)(uintptr_t)v; break;
+                    case 'L': case '[': default: {
+                        // Same reasoning as the receiver: the callee will
+                        // dereference this. An unverifiable argument becomes
+                        // null, which the callee can at least handle.
+                        JAVA_OBJECT arg = (JAVA_OBJECT)(uintptr_t)v;
+                        argv[i].o = cn1_debugger_is_valid_object(arg) ? arg : JAVA_NULL;
+                        break;
+                    }
                 }
             }
             cn1_invoke_thunk_t thunk = invoke_thunk_for(mid);
@@ -1090,7 +1200,8 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
             uint64_t ptr = ((uint64_t)ntohl(hi) << 32) | (uint32_t)ntohl(lo);
             JAVA_OBJECT obj = (JAVA_OBJECT)(uintptr_t)ptr;
             int length = 0;
-            if (obj != JAVA_NULL) {
+            struct clazz* arrCls = cn1_debugger_class_of(obj);
+            if (arrCls != NULL && arrCls->isArray) {
                 length = ((JAVA_ARRAY)obj)->length;
             }
             uint8_t reply[4];
@@ -1115,7 +1226,10 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
             int firstIdx = (int)ntohl(fstBE);
             int reqCount = (int)ntohl(cntBE);
             JAVA_OBJECT obj = (JAVA_OBJECT)(uintptr_t)ptr;
-            if (obj == JAVA_NULL) {
+            // Everything below indexes arr->data, so the reference has to be
+            // a verified array before any of it runs.
+            struct clazz* objArrCls = cn1_debugger_class_of(obj);
+            if (objArrCls == NULL || !objArrCls->isArray) {
                 uint8_t err[5] = {'L', 0,0,0,0};
                 sendEvent(EVT_ARRAY_VALUES, err, 5);
                 return 0;
@@ -1133,8 +1247,7 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
             // vs float, ...).
             char tag = 'L';
             int elemSize = arr->primitiveSize;
-            struct clazz* arrCls = obj->__codenameOneParentClsReference;
-            struct clazz* elemCls = arrCls ? arrCls->arrayType : NULL;
+            struct clazz* elemCls = objArrCls->arrayType;
             if (elemSize == 0) {
                 tag = 'L';
             } else if (elemCls && elemCls->clsName) {
@@ -1208,7 +1321,11 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
                                 writeBE64(p, db); }
                               p += 8; break;
                     case 'L': case '[': default: {
+                        // Only hand back element references we can verify;
+                        // anything else would come straight back to us as an
+                        // objectID the IDE expects us to dereference.
                         JAVA_OBJECT v = ((JAVA_OBJECT*)arr->data)[idx];
+                        if (!cn1_debugger_is_valid_object(v)) v = JAVA_NULL;
                         writeBE64(p, (uint64_t)(uintptr_t)v);
                         p += 8; break;
                     }
@@ -1252,6 +1369,8 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
             return 0;
         }
         case CMD_GET_THREADS:
+            handleGetThreads();
+            return 0;
         case CMD_SUSPEND:
             // Minimal viable: reply empty so the proxy doesn't hang.
             sendEvent(EVT_REPLY_STATUS, NULL, 0);

--- a/Ports/iOSPort/nativeSources/cn1_debugger.m
+++ b/Ports/iOSPort/nativeSources/cn1_debugger.m
@@ -722,6 +722,14 @@ static void handleGetStack(int64_t threadId) {
     if (depth > 256) depth = 256;
     size_t sz = 8 + 4 + (size_t)depth * 8;
     uint8_t* buf = (uint8_t*)malloc(sz);
+    if (!buf) {
+        pthread_mutex_unlock(&s->mu);
+        uint8_t empty[12];
+        writeBE64(empty,     (uint64_t)threadId);
+        writeBE32(empty + 8, 0);
+        sendEvent(EVT_STACK, empty, 12);
+        return;
+    }
     writeBE64(buf,     (uint64_t)threadId);
     writeBE32(buf + 8, (uint32_t)depth);
     // Frames emitted innermost-first.
@@ -830,6 +838,12 @@ static void handleGetLocals(int64_t threadId, int frameOffsetFromTop) {
     }
     size_t sz = 4 + (size_t)count * (4 + 1 + 8);
     uint8_t* buf = (uint8_t*)malloc(sz);
+    if (!buf) {
+        pthread_mutex_unlock(&s->mu);
+        uint32_t zero = 0;
+        sendEvent(EVT_LOCALS, &zero, 4);
+        return;
+    }
     writeBE32(buf, (uint32_t)count);
     uint8_t* p = buf + 4;
     for (int i = 0; i < rows; i++) {

--- a/Ports/iOSPort/nativeSources/cn1_debugger.m
+++ b/Ports/iOSPort/nativeSources/cn1_debugger.m
@@ -124,6 +124,17 @@ volatile int cn1DebuggerActive = 0;
 static int g_proxyFd = -1;
 static pthread_mutex_t g_writeMutex = PTHREAD_MUTEX_INITIALIZER;
 
+// The listener thread's own ThreadLocalData, if ParparVM ever built one for it.
+//
+// It is a raw pthread, not a Java thread, but servicing CMD_GET_STRING calls
+// toNSString(getThreadLocalData(), ...), and getThreadLocalData() registers
+// whatever thread asks into allThreads. Nothing ever unregisters it, so
+// without this the debugger's own plumbing shows up in the IDE's Threads panel
+// as a permanent synthetic entry with no java.lang.Thread behind it — and it
+// only appears once the IDE resolves a thread name, i.e. as a side effect of
+// the very feature this change added.
+static struct ThreadLocalData* g_listenerTsd = NULL;
+
 // Wait-for-attach state. cn1_debugger_run_when_ready stashes the VM-callback
 // block here; the listener thread invokes it on the main queue once the
 // proxy has acked the IDE attach (the first CMD_RESUME). Releasing the wait
@@ -542,10 +553,30 @@ static void sendEvent(uint8_t cmd, const void* payload, uint32_t len) {
 /* doesn't block collection. resumeThread signals the condvar.          */
 /* --------------------------------------------------------------------- */
 
+/**
+ * Publishes a thread as suspended before the event announcing it goes out.
+ *
+ * The proxy can have a thread-list request in flight, and the reply is built
+ * from this flag. Emitting the stop first left a window where the listener
+ * sampled the thread as running and the proxy applied that reply *after* the
+ * stop event, putting the IDE back to showing the thread it had just stopped
+ * at as running. Marking first closes it: any snapshot taken after the event
+ * necessarily sees the suspension.
+ */
+static void markSuspendedBeforeEvent(struct ThreadLocalData* tsd) {
+    struct sus_state* s = susForThread((int64_t)tsd->threadId);
+    pthread_mutex_lock(&s->mu);
+    s->suspended = 1;
+    pthread_mutex_unlock(&s->mu);
+}
+
 static void suspendCurrent(struct ThreadLocalData* tsd) {
     int64_t threadId = (int64_t)tsd->threadId;
     struct sus_state* s = susForThread(threadId);
     pthread_mutex_lock(&s->mu);
+    // Normally already set by markSuspendedBeforeEvent; setting it again is
+    // harmless, and a resume that arrived in between legitimately cleared it,
+    // in which case the wait below falls straight through.
     s->suspended = 1;
     s->stepFromDepth = tsd->callStackOffset;
     s->tsd = tsd;
@@ -689,12 +720,14 @@ void cn1_debugger_check(struct ThreadLocalData* tsd, int line) {
             pthread_mutex_lock(&s->mu);
             s->stepKind = -1;
             pthread_mutex_unlock(&s->mu);
+            markSuspendedBeforeEvent(tsd);
             emitLocationEvent(EVT_STEP_COMPLETE, threadId, methodId, line);
             suspendCurrent(tsd);
             return;
         }
     }
     if (bp_contains(methodId, line)) {
+        markSuspendedBeforeEvent(tsd);
         emitLocationEvent(EVT_BP_HIT, threadId, methodId, line);
         suspendCurrent(tsd);
     }
@@ -768,7 +801,8 @@ static void handleGetThreads(void) {
     int count = 0;
     if (allThreads != NULL) {
         for (int i = 0; i < NUMBER_OF_SUPPORTED_THREADS; i++) {
-            if (allThreads[i] != NULL && !allThreads[i]->threadKilled) count++;
+            if (allThreads[i] != NULL && !allThreads[i]->threadKilled
+                    && allThreads[i] != g_listenerTsd) count++;
         }
     }
     size_t sz = 4 + (size_t)count * 17;
@@ -786,10 +820,14 @@ static void handleGetThreads(void) {
         for (int i = 0; i < NUMBER_OF_SUPPORTED_THREADS && emitted < count; i++) {
             struct ThreadLocalData* t = allThreads[i];
             if (t == NULL || t->threadKilled) continue;
+            if (t == g_listenerTsd) continue;   // the debugger's own listener
             int64_t tid = (int64_t)t->threadId;
             struct sus_state* s = susForThread(tid);
+            pthread_mutex_lock(&s->mu);
+            int suspended = s->suspended;
+            pthread_mutex_unlock(&s->mu);
             uint8_t flags = 0;
-            if (s->suspended) flags |= 0x01;
+            if (suspended) flags |= 0x01;
             if (t->threadActive) flags |= 0x02;
             JAVA_OBJECT threadObj = t->currentThreadObject;
             if (!cn1_debugger_is_valid_object(threadObj)) threadObj = JAVA_NULL;
@@ -1456,6 +1494,9 @@ static int cn1_debugger_is_attach_ready(void) {
 
 static void* listenerThreadMain(void* arg) {
     @autoreleasepool {
+        // Register up front and remember it, rather than discovering it later
+        // when a command handler happens to need a Java context.
+        g_listenerTsd = getThreadLocalData();
         NSDictionary* info = [[NSBundle mainBundle] infoDictionary];
         NSString* host = info[@"CN1ProxyHost"];
         NSNumber* portN = info[@"CN1ProxyPort"];

--- a/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
+++ b/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
@@ -204,22 +204,35 @@ JAVA_INT cn1_debugger_tagged_int_value(JAVA_OBJECT obj) {
 /* --------------------------------------------------------------------- */
 
 #define CN1_ISSUED_INITIAL_CAP 4096u   /* power of two; open addressing */
+#define CN1_ISSUED_MAX_OWNERS 4
 
 /*
- * Each entry records which suspended thread the reference was obtained for, so
- * that resuming one thread can drop its ids without touching those of a thread
- * that is still stopped. Owner 0 means "not tied to a suspension" — the
- * java.lang.Thread objects the thread list hands over — and those survive
- * until every thread is running again.
+ * One entry per reference the debugger has handed to the proxy, carrying the
+ * set of suspended threads it was obtained for.
  *
- * Both halves of that matter. Clearing globally on a per-thread resume made a
- * still-parked thread's locals report unavailable mid-inspection; clearing
- * nothing while any thread stayed parked left the resumed thread's ids
- * accepted after its objects could be collected, which is the worse of the
- * two.
+ * A set rather than a single owner because two stopped threads can expose the
+ * same reference -- a shared singleton in both their locals, say. Keeping only
+ * the first meant resuming that thread dropped the id while the other was
+ * still parked and inspecting through it.
+ *
+ * Owner 0 means "not tied to a suspension" -- the java.lang.Thread objects the
+ * thread list hands over -- and those survive until every thread runs again.
  */
-static uintptr_t* g_issuedKeys = NULL;
-static int64_t* g_issuedOwners = NULL;
+struct issued_entry {
+    uintptr_t key;
+    int64_t owners[CN1_ISSUED_MAX_OWNERS];
+    unsigned char ownerCount;
+    /*
+     * Set when more owners appeared than there are slots. Such an entry is
+     * dropped as soon as any owner resumes, because we can no longer prove
+     * another still holds it: reporting a reference as unavailable is a
+     * display problem, accepting one whose object may have been reclaimed is
+     * a read of freed memory.
+     */
+    unsigned char ownerOverflow;
+};
+
+static struct issued_entry* g_issued = NULL;
 static unsigned g_issuedCap = 0;
 static unsigned g_issuedCount = 0;
 static pthread_mutex_t g_issuedMutex = PTHREAD_MUTEX_INITIALIZER;
@@ -231,49 +244,75 @@ static unsigned issued_slot(uintptr_t key, unsigned cap) {
     return (unsigned)(h & (cap - 1));
 }
 
-/* Insert into tables known to have room. Returns 1 if newly added. */
-static int issued_put(uintptr_t* keys, int64_t* owners, unsigned cap,
-                      uintptr_t key, int64_t owner) {
+/* Adds an owner to an entry, ignoring duplicates. */
+static void entry_add_owner(struct issued_entry* e, int64_t owner) {
+    if (owner == 0) return;   /* unowned: nothing to record */
+    for (unsigned i = 0; i < e->ownerCount; i++) {
+        if (e->owners[i] == owner) return;
+    }
+    if (e->ownerCount < CN1_ISSUED_MAX_OWNERS) {
+        e->owners[e->ownerCount++] = owner;
+    } else {
+        e->ownerOverflow = 1;
+    }
+}
+
+/* Finds or creates the entry for key in a table known to have room. */
+static struct issued_entry* issued_put(struct issued_entry* table, unsigned cap,
+                                       uintptr_t key, int* created) {
     unsigned i = issued_slot(key, cap);
     for (unsigned n = 0; n < cap; n++) {
         unsigned at = (i + n) & (cap - 1);
-        if (keys[at] == key) return 0;
-        if (keys[at] == 0) { keys[at] = key; owners[at] = owner; return 1; }
+        if (table[at].key == key) { *created = 0; return &table[at]; }
+        if (table[at].key == 0) {
+            memset(&table[at], 0, sizeof(table[at]));
+            table[at].key = key;
+            *created = 1;
+            return &table[at];
+        }
     }
-    return 0;
+    *created = 0;
+    return NULL;
 }
 
 /* Grows past a 3/4 load factor. Returns 0 only if the allocation fails. */
 static int issued_reserve(void) {
-    if (g_issuedKeys != NULL && (g_issuedCount + 1) * 4 < g_issuedCap * 3) {
+    if (g_issued != NULL && (g_issuedCount + 1) * 4 < g_issuedCap * 3) {
         return 1;
     }
     unsigned newCap = g_issuedCap ? g_issuedCap * 2 : CN1_ISSUED_INITIAL_CAP;
-    uintptr_t* keys = (uintptr_t*)calloc(newCap, sizeof(uintptr_t));
-    int64_t* owners = (int64_t*)calloc(newCap, sizeof(int64_t));
-    if (!keys || !owners) { free(keys); free(owners); return 0; }
+    struct issued_entry* grown =
+        (struct issued_entry*)calloc(newCap, sizeof(struct issued_entry));
+    if (!grown) return 0;
     for (unsigned i = 0; i < g_issuedCap; i++) {
-        if (g_issuedKeys[i] != 0) {
-            issued_put(keys, owners, newCap, g_issuedKeys[i], g_issuedOwners[i]);
+        if (g_issued[i].key != 0) {
+            int created = 0;
+            struct issued_entry* moved =
+                issued_put(grown, newCap, g_issued[i].key, &created);
+            if (moved) *moved = g_issued[i];
         }
     }
-    free(g_issuedKeys);
-    free(g_issuedOwners);
-    g_issuedKeys = keys;
-    g_issuedOwners = owners;
+    free(g_issued);
+    g_issued = grown;
     g_issuedCap = newCap;
     return 1;
 }
 
 int cn1_debugger_note_issued_for(JAVA_OBJECT obj, int64_t owner) {
     if (obj == JAVA_NULL) return 1;   /* null needs no record */
-    uintptr_t key = (uintptr_t)obj;
     int ok;
     pthread_mutex_lock(&g_issuedMutex);
     ok = issued_reserve();
     if (ok) {
-        g_issuedCount += (unsigned)issued_put(g_issuedKeys, g_issuedOwners,
-                                              g_issuedCap, key, owner);
+        int created = 0;
+        struct issued_entry* e =
+            issued_put(g_issued, g_issuedCap, (uintptr_t)obj, &created);
+        if (e) {
+            entry_add_owner(e, owner);
+            g_issuedCount += (unsigned)created;
+        } else {
+            ok = 0;
+        }
     }
     pthread_mutex_unlock(&g_issuedMutex);
     /* The table grows, so this only fails when the allocation does. A caller
@@ -287,74 +326,84 @@ int cn1_debugger_note_issued(JAVA_OBJECT obj) {
     return cn1_debugger_note_issued_for(obj, 0);
 }
 
-/* Locates an entry, returning its index or -1. Caller holds the mutex. */
-static int issued_find(uintptr_t key) {
-    if (g_issuedKeys == NULL) return -1;
+/* Locates an entry, or NULL. Caller holds the mutex. */
+static struct issued_entry* issued_find(uintptr_t key) {
+    if (g_issued == NULL) return NULL;
     unsigned i = issued_slot(key, g_issuedCap);
     for (unsigned n = 0; n < g_issuedCap; n++) {
         unsigned at = (i + n) & (g_issuedCap - 1);
-        if (g_issuedKeys[at] == key) return (int)at;
-        if (g_issuedKeys[at] == 0) return -1;
+        if (g_issued[at].key == key) return &g_issued[at];
+        if (g_issued[at].key == 0) return NULL;
     }
-    return -1;
+    return NULL;
 }
 
 int cn1_debugger_was_issued(JAVA_OBJECT obj) {
     if (obj == JAVA_NULL) return 0;
     pthread_mutex_lock(&g_issuedMutex);
-    int at = issued_find((uintptr_t)obj);
+    int found = issued_find((uintptr_t)obj) != NULL;
     pthread_mutex_unlock(&g_issuedMutex);
-    return at >= 0;
+    return found;
 }
 
 int64_t cn1_debugger_owner_of(JAVA_OBJECT obj) {
     if (obj == JAVA_NULL) return 0;
     pthread_mutex_lock(&g_issuedMutex);
-    int at = issued_find((uintptr_t)obj);
-    int64_t owner = at >= 0 ? g_issuedOwners[at] : 0;
+    struct issued_entry* e = issued_find((uintptr_t)obj);
+    int64_t owner = (e != NULL && e->ownerCount > 0) ? e->owners[0] : 0;
     pthread_mutex_unlock(&g_issuedMutex);
     return owner;
 }
 
 void cn1_debugger_forget_issued(void) {
     pthread_mutex_lock(&g_issuedMutex);
-    if (g_issuedKeys != NULL) {
-        memset(g_issuedKeys, 0, g_issuedCap * sizeof(uintptr_t));
-        memset(g_issuedOwners, 0, g_issuedCap * sizeof(int64_t));
+    if (g_issued != NULL) {
+        memset(g_issued, 0, g_issuedCap * sizeof(struct issued_entry));
     }
     g_issuedCount = 0;
     pthread_mutex_unlock(&g_issuedMutex);
 }
 
+/* Whether an entry survives the given owner resuming. */
+static int entry_survives_resume(struct issued_entry* e, int64_t owner) {
+    if (e->ownerCount == 0) return 1;      /* unowned: only a full clear drops it */
+    if (e->ownerOverflow) return 0;        /* cannot prove another owner remains */
+    unsigned remaining = 0;
+    for (unsigned i = 0; i < e->ownerCount; i++) {
+        if (e->owners[i] != owner) {
+            e->owners[remaining++] = e->owners[i];
+        }
+    }
+    e->ownerCount = (unsigned char)remaining;
+    return remaining > 0;                  /* another suspension still holds it */
+}
+
 void cn1_debugger_forget_issued_for(int64_t owner) {
     if (owner == 0) return;
     pthread_mutex_lock(&g_issuedMutex);
-    if (g_issuedKeys != NULL) {
+    if (g_issued != NULL) {
         /* Rebuilt rather than tombstoned: deletion from a linear probe would
          * otherwise cut the chains that later lookups walk. */
         unsigned cap = g_issuedCap;
-        uintptr_t* keys = (uintptr_t*)calloc(cap, sizeof(uintptr_t));
-        int64_t* owners = (int64_t*)calloc(cap, sizeof(int64_t));
-        if (keys && owners) {
-            unsigned kept = 0;
+        struct issued_entry* kept =
+            (struct issued_entry*)calloc(cap, sizeof(struct issued_entry));
+        if (kept) {
+            unsigned keptCount = 0;
             for (unsigned i = 0; i < cap; i++) {
-                if (g_issuedKeys[i] != 0 && g_issuedOwners[i] != owner) {
-                    kept += (unsigned)issued_put(keys, owners, cap,
-                                                 g_issuedKeys[i], g_issuedOwners[i]);
-                }
+                if (g_issued[i].key == 0) continue;
+                if (!entry_survives_resume(&g_issued[i], owner)) continue;
+                int created = 0;
+                struct issued_entry* moved =
+                    issued_put(kept, cap, g_issued[i].key, &created);
+                if (moved) { *moved = g_issued[i]; keptCount += (unsigned)created; }
             }
-            free(g_issuedKeys);
-            free(g_issuedOwners);
-            g_issuedKeys = keys;
-            g_issuedOwners = owners;
-            g_issuedCount = kept;
+            free(g_issued);
+            g_issued = kept;
+            g_issuedCount = keptCount;
         } else {
             /* Out of memory: drop everything rather than keep ids we can no
              * longer prove belong to a still-parked thread. */
-            free(keys);
-            free(owners);
-            memset(g_issuedKeys, 0, cap * sizeof(uintptr_t));
-            memset(g_issuedOwners, 0, cap * sizeof(int64_t));
+            memset(g_issued, 0, cap * sizeof(struct issued_entry));
             g_issuedCount = 0;
         }
     }

--- a/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
+++ b/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
@@ -120,6 +120,13 @@ static int cn1_is_registered_class(const struct clazz* cls, int classId) {
  */
 struct clazz* cn1_debugger_class_of(JAVA_OBJECT obj) {
     if (obj == JAVA_NULL) return NULL;
+    // A tagged int is a value, not an address: Integer.valueOf() returns
+    // (v << 1) | 1 on every 64-bit target, which is the shipping iOS shape.
+    // It has no header to read, and the alignment rejection below would
+    // otherwise discard every boxed Integer the debugger was asked about.
+    if (CN1_IS_TAGGED(obj)) {
+        return &class__java_lang_Integer;
+    }
     struct clazz* cls = NULL;
     if (!cn1_debugger_safe_read(&obj->__codenameOneParentClsReference, &cls, sizeof(cls))) {
         return NULL;
@@ -149,6 +156,19 @@ struct clazz* cn1_debugger_class_of(JAVA_OBJECT obj) {
 
 int cn1_debugger_is_valid_object(JAVA_OBJECT obj) {
     return cn1_debugger_class_of(obj) != NULL;
+}
+
+/**
+ * The value carried by a tagged int, for callers that must not treat it as an
+ * address. Returns 0 for anything else, so a caller that has already checked
+ * {@code cn1_debugger_is_tagged_int} reads the real value.
+ */
+int cn1_debugger_is_tagged_int(JAVA_OBJECT obj) {
+    return obj != JAVA_NULL && CN1_IS_TAGGED(obj);
+}
+
+JAVA_INT cn1_debugger_tagged_int_value(JAVA_OBJECT obj) {
+    return CN1_IS_TAGGED(obj) ? CN1_UNTAG_INT(obj) : 0;
 }
 
 /**

--- a/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
+++ b/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
@@ -168,7 +168,15 @@ int cn1_debugger_is_tagged_int(JAVA_OBJECT obj) {
 }
 
 JAVA_INT cn1_debugger_tagged_int_value(JAVA_OBJECT obj) {
+#if CN1_TAGGED_ACTIVE
     return CN1_IS_TAGGED(obj) ? CN1_UNTAG_INT(obj) : 0;
+#else
+    // Tagged ints are compiled out on 32-bit targets and under
+    // -DCN1_DISABLE_TAGGED_INT, which also leaves CN1_UNTAG_INT undefined.
+    // Every reference is then a real object and no caller reaches this.
+    (void)obj;
+    return 0;
+#endif
 }
 
 /**

--- a/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
+++ b/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
@@ -154,6 +154,41 @@ struct clazz* cn1_debugger_class_of(JAVA_OBJECT obj) {
     return NULL;
 }
 
+/**
+ * The scalar component of an array class, and how many dimensions deep it is.
+ *
+ * The runtime gives an array its own synthetic class, which carries no entry
+ * in the symbol table -- that table describes the classes the translator
+ * compiled, and the array classes are made up as needed. Reporting that
+ * synthetic ID to the proxy left it with nothing to resolve, so every array
+ * came back as Object[] whatever it held, and a flag saying "this is an array"
+ * could not say how deeply.
+ *
+ * Walks arrayType down to the first class that is not itself an array, which
+ * is the one the symbol table knows, counting the hops. Returns NULL if the
+ * chain cannot be read or bottoms out somewhere unregistered.
+ */
+struct clazz* cn1_debugger_array_component(struct clazz* arrayClass, int* dimsOut) {
+    int dims = 0;
+    struct clazz* at = arrayClass;
+    /* Bounded rather than while(1): the chain is read out of the target's
+     * memory and a corrupt arrayType must not spin here. */
+    for (int hop = 0; hop < 16 && at != NULL; hop++) {
+        _Alignas(struct clazz) unsigned char raw[sizeof(struct clazz)];
+        if (!cn1_debugger_safe_read(at, raw, sizeof(raw))) return NULL;
+        const struct clazz* header = (const struct clazz*)raw;
+        if (!header->isArray) {
+            if (!cn1_is_registered_class(at, header->classId)) return NULL;
+            if (dimsOut != NULL) *dimsOut = dims;
+            return at;
+        }
+        if (header->arrayType == NULL) return NULL;
+        at = header->arrayType;
+        dims++;
+    }
+    return NULL;
+}
+
 int cn1_debugger_is_valid_object(JAVA_OBJECT obj) {
     return cn1_debugger_class_of(obj) != NULL;
 }

--- a/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
+++ b/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
@@ -223,6 +223,15 @@ struct issued_entry {
     int64_t owners[CN1_ISSUED_MAX_OWNERS];
     unsigned char ownerCount;
     /*
+     * Claimed by something not tied to a suspension -- the thread list's
+     * java.lang.Thread objects. Recorded separately from the owner set because
+     * the same reference can hold both claims: a Thread object can be exposed
+     * first through a stopped thread's locals and later by the thread list.
+     * Dropping the entry when that thread resumes would then reject an id the
+     * live thread list still advertises.
+     */
+    unsigned char unowned;
+    /*
      * Set when more owners appeared than there are slots. Such an entry is
      * dropped as soon as any owner resumes, because we can no longer prove
      * another still holds it: reporting a reference as unavailable is a
@@ -244,9 +253,11 @@ static unsigned issued_slot(uintptr_t key, unsigned cap) {
     return (unsigned)(h & (cap - 1));
 }
 
+static struct issued_entry* issued_find(uintptr_t key);
+
 /* Adds an owner to an entry, ignoring duplicates. */
 static void entry_add_owner(struct issued_entry* e, int64_t owner) {
-    if (owner == 0) return;   /* unowned: nothing to record */
+    if (owner == 0) { e->unowned = 1; return; }
     for (unsigned i = 0; i < e->ownerCount; i++) {
         if (e->owners[i] == owner) return;
     }
@@ -326,6 +337,42 @@ int cn1_debugger_note_issued(JAVA_OBJECT obj) {
     return cn1_debugger_note_issued_for(obj, 0);
 }
 
+/**
+ * Records a reference reached through another, giving it the parent's whole
+ * claim rather than one owner of it.
+ *
+ * Two stopped threads can own the object the IDE is expanding. Attributing the
+ * nested references to only the first meant resuming that thread deleted them
+ * while the second was still parked and able to reach the same tree, so an
+ * already-expanded object went unavailable underneath it.
+ */
+int cn1_debugger_note_issued_inheriting(JAVA_OBJECT obj, JAVA_OBJECT parent) {
+    if (obj == JAVA_NULL) return 1;
+    int ok;
+    pthread_mutex_lock(&g_issuedMutex);
+    ok = issued_reserve();
+    if (ok) {
+        struct issued_entry* from = issued_find((uintptr_t)parent);
+        int created = 0;
+        struct issued_entry* e =
+            issued_put(g_issued, g_issuedCap, (uintptr_t)obj, &created);
+        if (e) {
+            g_issuedCount += (unsigned)created;
+            if (from != NULL) {
+                for (unsigned i = 0; i < from->ownerCount; i++) {
+                    entry_add_owner(e, from->owners[i]);
+                }
+                if (from->unowned) e->unowned = 1;
+                if (from->ownerOverflow) e->ownerOverflow = 1;
+            }
+        } else {
+            ok = 0;
+        }
+    }
+    pthread_mutex_unlock(&g_issuedMutex);
+    return ok;
+}
+
 /* Locates an entry, or NULL. Caller holds the mutex. */
 static struct issued_entry* issued_find(uintptr_t key) {
     if (g_issued == NULL) return NULL;
@@ -366,7 +413,8 @@ void cn1_debugger_forget_issued(void) {
 
 /* Whether an entry survives the given owner resuming. */
 static int entry_survives_resume(struct issued_entry* e, int64_t owner) {
-    if (e->ownerCount == 0) return 1;      /* unowned: only a full clear drops it */
+    if (e->unowned) return 1;              /* only a full clear drops it */
+    if (e->ownerCount == 0) return 1;
     if (e->ownerOverflow) return 0;        /* cannot prove another owner remains */
     unsigned remaining = 0;
     for (unsigned i = 0; i < e->ownerCount; i++) {

--- a/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
+++ b/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
@@ -164,27 +164,38 @@ struct clazz* cn1_debugger_class_of(JAVA_OBJECT obj) {
  * came back as Object[] whatever it held, and a flag saying "this is an array"
  * could not say how deeply.
  *
- * Walks arrayType down to the first class that is not itself an array, which
- * is the one the symbol table knows, counting the hops. Returns NULL if the
- * chain cannot be read or bottoms out somewhere unregistered.
+ * The depth comes from the class's own dimensions field rather than from
+ * following arrayType: the generated layout points arrayType straight at the
+ * scalar for every depth, so counting hops would call int[][] one-dimensional.
+ * A chain is still walked if one ever appears, since a layout that nests is
+ * cheap to tolerate and reading the target's memory is not something to make
+ * assumptions about.
  */
 struct clazz* cn1_debugger_array_component(struct clazz* arrayClass, int* dimsOut) {
-    int dims = 0;
-    struct clazz* at = arrayClass;
-    /* Bounded rather than while(1): the chain is read out of the target's
-     * memory and a corrupt arrayType must not spin here. */
-    for (int hop = 0; hop < 16 && at != NULL; hop++) {
-        _Alignas(struct clazz) unsigned char raw[sizeof(struct clazz)];
-        if (!cn1_debugger_safe_read(at, raw, sizeof(raw))) return NULL;
-        const struct clazz* header = (const struct clazz*)raw;
-        if (!header->isArray) {
-            if (!cn1_is_registered_class(at, header->classId)) return NULL;
+    _Alignas(struct clazz) unsigned char raw[sizeof(struct clazz)];
+    if (!cn1_debugger_safe_read(arrayClass, raw, sizeof(raw))) return NULL;
+    const struct clazz* header = (const struct clazz*)raw;
+    if (!header->isArray || header->arrayType == NULL) return NULL;
+
+    int declared = header->dimensions;
+    struct clazz* at = header->arrayType;
+    /* Bounded rather than open: the chain is read out of the target's memory
+     * and a corrupt arrayType must not spin here. */
+    for (int hop = 1; hop <= 16 && at != NULL; hop++) {
+        _Alignas(struct clazz) unsigned char componentRaw[sizeof(struct clazz)];
+        if (!cn1_debugger_safe_read(at, componentRaw, sizeof(componentRaw))) return NULL;
+        const struct clazz* component = (const struct clazz*)componentRaw;
+        if (!component->isArray) {
+            if (!cn1_is_registered_class(at, component->classId)) return NULL;
+            /* Whichever is deeper. The generated layout declares the real
+             * depth and reaches the scalar in one hop, so declared wins there;
+             * the hop count only stands in for a nested layout that declares
+             * nothing. */
+            int dims = declared > hop ? declared : hop;
             if (dimsOut != NULL) *dimsOut = dims;
             return at;
         }
-        if (header->arrayType == NULL) return NULL;
-        at = header->arrayType;
-        dims++;
+        at = component->arrayType;
     }
     return NULL;
 }
@@ -532,6 +543,39 @@ static int entry_survives_resume(struct issued_entry* e, int64_t owner) {
  * lets end_thread_list tell what the current list still claims from what only
  * an older one did.
  */
+/*
+ * Extends the survives marks along the parent links until nothing more can be
+ * added. Anything hanging off something that survives survives too, however
+ * many hops down -- a field of a field of a live Thread object is no less
+ * reachable for the extra hop. Iterated because the table is in no particular
+ * order, so a chain is discovered one hop per pass.
+ */
+static void issued_propagate_parents(unsigned cap) {
+    int changed = 1;
+    while (changed) {
+        changed = 0;
+        for (unsigned i = 0; i < cap; i++) {
+            struct issued_entry* e = &g_issued[i];
+            if (e->key == 0 || e->survives) continue;
+            if (e->parentOverflow) {
+                /* Too many graphs reached it to say which; assume one of them
+                 * still does rather than reject an id in use. */
+                e->survives = 1;
+                changed = 1;
+                continue;
+            }
+            for (unsigned j = 0; j < e->parentCount; j++) {
+                struct issued_entry* parent = issued_find(e->parents[j]);
+                if (parent != NULL && parent->survives) {
+                    e->survives = 1;
+                    changed = 1;
+                    break;
+                }
+            }
+        }
+    }
+}
+
 void cn1_debugger_begin_thread_list(void) {
     pthread_mutex_lock(&g_issuedMutex);
     g_listGen++;
@@ -566,29 +610,7 @@ void cn1_debugger_end_thread_list(void) {
                 e->survives = 1;
             }
         }
-        int changed = 1;
-        while (changed) {
-            changed = 0;
-            for (unsigned i = 0; i < cap; i++) {
-                struct issued_entry* e = &g_issued[i];
-                if (e->key == 0 || e->survives) continue;
-                if (e->parentOverflow) {
-                    /* Too many graphs reached it to say which; assume one of
-                     * them still does rather than reject an id in use. */
-                    e->survives = 1;
-                    changed = 1;
-                    continue;
-                }
-                for (unsigned j = 0; j < e->parentCount; j++) {
-                    struct issued_entry* parent = issued_find(e->parents[j]);
-                    if (parent != NULL && parent->survives) {
-                        e->survives = 1;
-                        changed = 1;
-                        break;
-                    }
-                }
-            }
-        }
+        issued_propagate_parents(cap);
         struct issued_entry* kept =
             (struct issued_entry*)calloc(cap, sizeof(struct issued_entry));
         if (kept) {
@@ -621,9 +643,19 @@ void cn1_debugger_forget_issued_for(int64_t owner) {
             (struct issued_entry*)calloc(cap, sizeof(struct issued_entry));
         if (kept) {
             unsigned keptCount = 0;
+            /* Two passes, because what an entry hangs off may be anywhere in
+             * the table. A descendant kept by a thread-list refresh carries no
+             * owner of its own and a generation stamp from before that refresh,
+             * so judging it on its own account alone dropped it the moment any
+             * thread resumed -- while the Thread object it hangs off was still
+             * being advertised. */
             for (unsigned i = 0; i < cap; i++) {
-                if (g_issued[i].key == 0) continue;
-                if (!entry_survives_resume(&g_issued[i], owner)) continue;
+                g_issued[i].survives =
+                    g_issued[i].key != 0 && entry_survives_resume(&g_issued[i], owner);
+            }
+            issued_propagate_parents(cap);
+            for (unsigned i = 0; i < cap; i++) {
+                if (g_issued[i].key == 0 || !g_issued[i].survives) continue;
                 int created = 0;
                 struct issued_entry* moved =
                     issued_put(kept, cap, g_issued[i].key, &created);

--- a/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
+++ b/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
@@ -203,38 +203,62 @@ JAVA_INT cn1_debugger_tagged_int_value(JAVA_OBJECT obj) {
 /* than to this file.                                                     */
 /* --------------------------------------------------------------------- */
 
-#define CN1_ISSUED_CAP 4096u   /* power of two; open addressing, linear probe */
-static uintptr_t g_issued[CN1_ISSUED_CAP];
+#define CN1_ISSUED_INITIAL_CAP 4096u   /* power of two; open addressing */
+static uintptr_t* g_issued = NULL;
+static unsigned g_issuedCap = 0;
 static unsigned g_issuedCount = 0;
 static pthread_mutex_t g_issuedMutex = PTHREAD_MUTEX_INITIALIZER;
 
-static unsigned issued_slot(uintptr_t key) {
+static unsigned issued_slot(uintptr_t key, unsigned cap) {
     /* Pointers are aligned, so the low bits carry no entropy. */
     uintptr_t h = key >> 3;
     h ^= h >> 13;
-    return (unsigned)(h & (CN1_ISSUED_CAP - 1));
+    return (unsigned)(h & (cap - 1));
 }
 
-void cn1_debugger_note_issued(JAVA_OBJECT obj) {
-    if (obj == JAVA_NULL) return;
+/* Insert into a table known to have room. Returns 1 if newly added. */
+static int issued_put(uintptr_t* table, unsigned cap, uintptr_t key) {
+    unsigned i = issued_slot(key, cap);
+    for (unsigned n = 0; n < cap; n++) {
+        unsigned at = (i + n) & (cap - 1);
+        if (table[at] == key) return 0;
+        if (table[at] == 0) { table[at] = key; return 1; }
+    }
+    return 0;
+}
+
+/* Grows past a 3/4 load factor. Returns 0 only if the allocation fails. */
+static int issued_reserve(void) {
+    if (g_issued != NULL && (g_issuedCount + 1) * 4 < g_issuedCap * 3) {
+        return 1;
+    }
+    unsigned newCap = g_issuedCap ? g_issuedCap * 2 : CN1_ISSUED_INITIAL_CAP;
+    uintptr_t* grown = (uintptr_t*)calloc(newCap, sizeof(uintptr_t));
+    if (!grown) return 0;
+    for (unsigned i = 0; i < g_issuedCap; i++) {
+        if (g_issued[i] != 0) issued_put(grown, newCap, g_issued[i]);
+    }
+    free(g_issued);
+    g_issued = grown;
+    g_issuedCap = newCap;
+    return 1;
+}
+
+int cn1_debugger_note_issued(JAVA_OBJECT obj) {
+    if (obj == JAVA_NULL) return 1;   /* null needs no record */
     uintptr_t key = (uintptr_t)obj;
+    int ok;
     pthread_mutex_lock(&g_issuedMutex);
-    /* Full table: stop recording rather than spin. Ids beyond the cap are
-     * refused on the way back in, which errs toward "unavailable" instead of
-     * toward a stale read. */
-    if (g_issuedCount < CN1_ISSUED_CAP - 1) {
-        unsigned i = issued_slot(key);
-        for (unsigned n = 0; n < CN1_ISSUED_CAP; n++) {
-            unsigned at = (i + n) & (CN1_ISSUED_CAP - 1);
-            if (g_issued[at] == key) break;
-            if (g_issued[at] == 0) {
-                g_issued[at] = key;
-                g_issuedCount++;
-                break;
-            }
-        }
+    ok = issued_reserve();
+    if (ok) {
+        g_issuedCount += (unsigned)issued_put(g_issued, g_issuedCap, key);
     }
     pthread_mutex_unlock(&g_issuedMutex);
+    /* The table grows, so this only fails when the allocation does. A caller
+     * that cannot record a reference must report null rather than hand over an
+     * id that every later request would refuse -- a reference the IDE can see
+     * but cannot expand is worse than one it never saw. */
+    return ok;
 }
 
 int cn1_debugger_was_issued(JAVA_OBJECT obj) {
@@ -242,11 +266,13 @@ int cn1_debugger_was_issued(JAVA_OBJECT obj) {
     uintptr_t key = (uintptr_t)obj;
     int found = 0;
     pthread_mutex_lock(&g_issuedMutex);
-    unsigned i = issued_slot(key);
-    for (unsigned n = 0; n < CN1_ISSUED_CAP; n++) {
-        unsigned at = (i + n) & (CN1_ISSUED_CAP - 1);
-        if (g_issued[at] == key) { found = 1; break; }
-        if (g_issued[at] == 0) break;
+    if (g_issued != NULL) {
+        unsigned i = issued_slot(key, g_issuedCap);
+        for (unsigned n = 0; n < g_issuedCap; n++) {
+            unsigned at = (i + n) & (g_issuedCap - 1);
+            if (g_issued[at] == key) { found = 1; break; }
+            if (g_issued[at] == 0) break;
+        }
     }
     pthread_mutex_unlock(&g_issuedMutex);
     return found;
@@ -254,7 +280,9 @@ int cn1_debugger_was_issued(JAVA_OBJECT obj) {
 
 void cn1_debugger_forget_issued(void) {
     pthread_mutex_lock(&g_issuedMutex);
-    memset(g_issued, 0, sizeof(g_issued));
+    if (g_issued != NULL) {
+        memset(g_issued, 0, g_issuedCap * sizeof(uintptr_t));
+    }
     g_issuedCount = 0;
     pthread_mutex_unlock(&g_issuedMutex);
 }

--- a/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
+++ b/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ *
+ * ---------------------------------------------------------------------------
+ * Object-reference validation for the on-device debugger.
+ *
+ * No reference reaching the debugger is trustworthy. The IDE echoes back
+ * objectIDs it was handed earlier — which may since have been collected — and
+ * a local slot can hold whatever the frame left there on a branch that never
+ * ran. Dereferencing one of those crashes the app in the middle of a debugging
+ * session, which is the "We had a signal 11" in issue #5333. A debugger is
+ * allowed to say "unavailable"; it is not allowed to take the process down.
+ *
+ * Kept as plain C, separate from cn1_debugger.m, so the policy can be compiled
+ * and exercised on a host rather than only on a device.
+ * ---------------------------------------------------------------------------
+ */
+
+#include "cn1_globals.h"
+
+#ifdef CN1_ON_DEVICE_DEBUG
+
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <mach/mach.h>
+
+#define CN1_CLASS_REG_INITIAL_CAP 2048
+
+static struct clazz** g_classById = NULL;
+static int g_classByIdCap = 0;
+static pthread_mutex_t g_classRegMutex = PTHREAD_MUTEX_INITIALIZER;
+
+void cn1_debugger_register_class(int classId, struct clazz* cls) {
+    if (classId < 0 || cls == NULL) return;
+    pthread_mutex_lock(&g_classRegMutex);
+    if (classId >= g_classByIdCap) {
+        int newCap = g_classByIdCap == 0 ? CN1_CLASS_REG_INITIAL_CAP : g_classByIdCap * 2;
+        while (classId >= newCap) newCap *= 2;
+        struct clazz** n = (struct clazz**)realloc(g_classById,
+                newCap * sizeof(struct clazz*));
+        if (!n) { pthread_mutex_unlock(&g_classRegMutex); return; }
+        memset(n + g_classByIdCap, 0,
+               (newCap - g_classByIdCap) * sizeof(struct clazz*));
+        g_classById = n;
+        g_classByIdCap = newCap;
+    }
+    g_classById[classId] = cls;
+    pthread_mutex_unlock(&g_classRegMutex);
+}
+
+/**
+ * Copies len bytes from a possibly-invalid address, returning 0 instead of
+ * faulting when the address is not mapped.
+ *
+ * vm_read_overwrite has the kernel perform the copy, so an unmapped or
+ * protected page comes back as a kern_return_t rather than a signal on this
+ * thread. The cheap rejections come first — the null page and misaligned
+ * pointers cover the overwhelmingly common garbage, which is small integers
+ * read out of a slot that actually holds a primitive — so the syscall is only
+ * paid for candidates that could plausibly be objects.
+ */
+int cn1_debugger_safe_read(const void* addr, void* dst, size_t len) {
+    if (addr == NULL || dst == NULL || len == 0) return 0;
+    uintptr_t a = (uintptr_t)addr;
+    if (a < 0x1000) return 0;
+    if ((a & (sizeof(void*) - 1)) != 0) return 0;
+    vm_size_t got = 0;
+    kern_return_t kr = vm_read_overwrite(mach_task_self(),
+                                         (vm_address_t)a,
+                                         (vm_size_t)len,
+                                         (vm_address_t)dst,
+                                         &got);
+    return kr == KERN_SUCCESS && got == (vm_size_t)len;
+}
+
+/** Whether cls is the exact clazz registered for the classId it reports. */
+static int cn1_is_registered_class(const struct clazz* cls, int classId) {
+    return cls != NULL
+        && classId >= 0
+        && classId < g_classByIdCap
+        && g_classById != NULL
+        && g_classById[classId] == cls;
+}
+
+/**
+ * Returns obj's clazz, or NULL when obj is not a plausible Java object.
+ *
+ * Reads the class word without dereferencing obj, then requires that word to
+ * point at a clazz that identifies itself. A fabricated pointer would have to
+ * address readable memory whose first word addresses a readable clazz that
+ * agrees with the registry about its own id — which random stack or heap bytes
+ * do not.
+ *
+ * Array classes take the second branch. They are synthesised per dimension and
+ * the primitive ones live in the runtime rather than in generated code, so
+ * none of them run the registration constructor. An array clazz still names
+ * its component type, and that component IS a registered class — which makes
+ * the check just as exact without a second registry.
+ */
+struct clazz* cn1_debugger_class_of(JAVA_OBJECT obj) {
+    if (obj == JAVA_NULL) return NULL;
+    struct clazz* cls = NULL;
+    if (!cn1_debugger_safe_read(&obj->__codenameOneParentClsReference, &cls, sizeof(cls))) {
+        return NULL;
+    }
+    if (cls == NULL) return NULL;
+    // Copied into raw bytes rather than a "struct clazz" local because the
+    // struct has const-qualified members, which a local cannot be filled in
+    // through.
+    _Alignas(struct clazz) unsigned char raw[sizeof(struct clazz)];
+    if (!cn1_debugger_safe_read(cls, raw, sizeof(raw))) return NULL;
+    const struct clazz* header = (const struct clazz*)raw;
+    if (cn1_is_registered_class(cls, header->classId)) {
+        return cls;
+    }
+    if (header->isArray && header->arrayType != NULL) {
+        _Alignas(struct clazz) unsigned char componentRaw[sizeof(struct clazz)];
+        if (!cn1_debugger_safe_read(header->arrayType, componentRaw, sizeof(componentRaw))) {
+            return NULL;
+        }
+        const struct clazz* component = (const struct clazz*)componentRaw;
+        if (cn1_is_registered_class(header->arrayType, component->classId)) {
+            return cls;
+        }
+    }
+    return NULL;
+}
+
+int cn1_debugger_is_valid_object(JAVA_OBJECT obj) {
+    return cn1_debugger_class_of(obj) != NULL;
+}
+
+/**
+ * Whether a local is in scope at a given source line.
+ *
+ * {0, 0} is "always live" — the class file carried no scope for it, or the
+ * translator synthesised it from a store opcode. A zero endLine means the
+ * scope runs to the end of the method. A line of 0 (the frame has not recorded
+ * one yet) shows everything rather than nothing, so a stop before the first
+ * line-number store still lists locals.
+ *
+ * Without this, a slot two disjoint scopes share reports both occupants at
+ * every breakpoint, and the one the code has not reached displays whatever the
+ * other scope left in its own storage.
+ */
+int cn1_debugger_var_in_scope(const struct cn1_var_entry* v, int line) {
+    if (v == NULL) return 0;
+    if (v->startLine <= 0) return 1;
+    if (line <= 0) return 1;
+    if (line < v->startLine) return 0;
+    if (v->endLine > 0 && line >= v->endLine) return 0;
+    return 1;
+}
+
+#endif // CN1_ON_DEVICE_DEBUG

--- a/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
+++ b/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
@@ -229,12 +229,24 @@ struct issued_entry {
      * and later by the thread list. Dropping the entry when that thread
      * resumes would then reject an id the live thread list still advertises.
      *
-     * Reconciled on every thread-list refresh rather than only on a full
-     * resume -- see cn1_debugger_forget_thread_list_claims. An IDE polling
-     * AllThreads on a running app would otherwise pin every Thread object it
-     * ever saw, and their retained graphs with them, for the session.
+     * Stamped with the thread-list generation that claimed it rather than a
+     * plain flag, so a refresh can tell "claimed by the list that is current"
+     * from "claimed by a list that has been superseded" without clearing the
+     * claims it is about to re-add. An IDE polling AllThreads on a running app
+     * would otherwise pin every Thread object it ever saw, and their retained
+     * graphs with them, for the session.
      */
-    unsigned char unowned;
+    unsigned int listGen;
+    /*
+     * The reference this one was reached through, if any -- the Thread object
+     * whose field the IDE expanded, say. A descendant carries no owner of its
+     * own and no claim of its own, so without this link a thread-list refresh
+     * would drop it even though the object it hangs off is still live and
+     * still claimed, and every later request naming it would be rejected.
+     */
+    uintptr_t parent;
+    /* Scratch for the reachability sweep in end_thread_list. */
+    unsigned char survives;
     /*
      * Set when more owners appeared than there are slots. Such an entry is
      * dropped as soon as any owner resumes, because we can no longer prove
@@ -244,6 +256,13 @@ struct issued_entry {
      */
     unsigned char ownerOverflow;
 };
+
+/*
+ * Thread-list generation. Bumped when the device starts building a thread
+ * list; an entry stamped with the current value is claimed by the list the
+ * IDE is holding now.
+ */
+static unsigned int g_listGen = 1;
 
 static struct issued_entry* g_issued = NULL;
 static unsigned g_issuedCap = 0;
@@ -261,7 +280,7 @@ static struct issued_entry* issued_find(uintptr_t key);
 
 /* Adds an owner to an entry, ignoring duplicates. */
 static void entry_add_owner(struct issued_entry* e, int64_t owner) {
-    if (owner == 0) { e->unowned = 1; return; }
+    if (owner == 0) { e->listGen = g_listGen; return; }
     for (unsigned i = 0; i < e->ownerCount; i++) {
         if (e->owners[i] == owner) return;
     }
@@ -366,7 +385,8 @@ int cn1_debugger_note_issued_inheriting(JAVA_OBJECT obj, JAVA_OBJECT parent) {
                 for (unsigned i = 0; i < from->ownerCount; i++) {
                     entry_add_owner(e, from->owners[i]);
                 }
-                if (from->unowned) e->unowned = 1;
+                if (from->listGen > e->listGen) e->listGen = from->listGen;
+                e->parent = (uintptr_t)parent;
                 if (from->ownerOverflow) e->ownerOverflow = 1;
             }
         } else {
@@ -434,34 +454,75 @@ static int entry_survives_resume(struct issued_entry* e, int64_t owner) {
     }
     e->ownerCount = (unsigned char)remaining;
 
-    if (e->unowned) return 1;              /* the thread list still claims it */
+    if (e->listGen == g_listGen) return 1; /* the thread list still claims it */
     if (e->ownerOverflow) return 0;        /* cannot prove another owner remains */
     return remaining > 0;                  /* another suspension still holds it */
 }
 
 /**
- * Drops the thread list's claim on everything it previously advertised.
+ * Opens a new thread-list generation.
  *
- * Called before each refresh records the current set, so an entry a live
- * snapshot no longer mentions loses its claim. Entries a suspension still owns
- * survive, having lost only this claim; entries left with none are removed,
- * which releases the GC roots holding dead Thread objects and whatever they
- * reach.
+ * Called before a refresh records the current set. Claims are not cleared
+ * here: the refresh is about to re-advertise most of the same Thread objects,
+ * and clearing first meant everything reached *through* one -- a field the IDE
+ * had expanded -- lost its claim with no way to get it back, since only the
+ * top-level Thread objects are re-issued. Stamping a new generation instead
+ * lets end_thread_list tell what the current list still claims from what only
+ * an older one did.
  */
-void cn1_debugger_forget_thread_list_claims(void) {
+void cn1_debugger_begin_thread_list(void) {
+    pthread_mutex_lock(&g_issuedMutex);
+    g_listGen++;
+    if (g_listGen == 0) g_listGen = 1;   /* 0 means "never claimed" */
+    pthread_mutex_unlock(&g_issuedMutex);
+}
+
+/**
+ * Closes the generation opened by begin_thread_list and drops what nothing
+ * claims any more.
+ *
+ * An entry survives if a suspension owns it, if the list just built claims it,
+ * or if it hangs off something that survives -- reached transitively, since a
+ * field of a field of a live Thread object is no less reachable for the extra
+ * hop. Everything else is released, which frees the GC roots holding dead
+ * Thread objects and the graphs they retain.
+ */
+void cn1_debugger_end_thread_list(void) {
     pthread_mutex_lock(&g_issuedMutex);
     if (g_issued != NULL) {
         unsigned cap = g_issuedCap;
+        for (unsigned i = 0; i < cap; i++) {
+            g_issued[i].survives = 0;
+        }
+        /* Entries that stand on their own, then whatever hangs off them.
+         * Iterated to a fixpoint because a chain is discovered one hop per
+         * pass and the table is in no particular order. */
+        for (unsigned i = 0; i < cap; i++) {
+            struct issued_entry* e = &g_issued[i];
+            if (e->key == 0) continue;
+            if (e->ownerCount > 0 || e->ownerOverflow || e->listGen == g_listGen) {
+                e->survives = 1;
+            }
+        }
+        int changed = 1;
+        while (changed) {
+            changed = 0;
+            for (unsigned i = 0; i < cap; i++) {
+                struct issued_entry* e = &g_issued[i];
+                if (e->key == 0 || e->survives || e->parent == 0) continue;
+                struct issued_entry* parent = issued_find(e->parent);
+                if (parent != NULL && parent->survives) {
+                    e->survives = 1;
+                    changed = 1;
+                }
+            }
+        }
         struct issued_entry* kept =
             (struct issued_entry*)calloc(cap, sizeof(struct issued_entry));
         if (kept) {
             unsigned keptCount = 0;
             for (unsigned i = 0; i < cap; i++) {
-                if (g_issued[i].key == 0) continue;
-                g_issued[i].unowned = 0;
-                if (g_issued[i].ownerCount == 0 && !g_issued[i].ownerOverflow) {
-                    continue;   /* nothing claims it any more */
-                }
+                if (g_issued[i].key == 0 || !g_issued[i].survives) continue;
                 int created = 0;
                 struct issued_entry* moved =
                     issued_put(kept, cap, g_issued[i].key, &created);

--- a/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
+++ b/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
@@ -415,11 +415,17 @@ void cn1_debugger_forget_issued(void) {
     pthread_mutex_unlock(&g_issuedMutex);
 }
 
-/* Whether an entry survives the given owner resuming. */
+/*
+ * Whether an entry survives the given owner resuming.
+ *
+ * The owner is removed first, unconditionally. Returning early for an entry
+ * the thread list also claims used to leave the resumed thread in the owner
+ * set, and a later refresh then kept the entry alive on the strength of that
+ * stale owner -- so once the thread died, the object and everything it reached
+ * stayed rooted for the rest of the session. Survival and owner removal are
+ * separate questions.
+ */
 static int entry_survives_resume(struct issued_entry* e, int64_t owner) {
-    if (e->unowned) return 1;              /* only a full clear drops it */
-    if (e->ownerCount == 0) return 1;
-    if (e->ownerOverflow) return 0;        /* cannot prove another owner remains */
     unsigned remaining = 0;
     for (unsigned i = 0; i < e->ownerCount; i++) {
         if (e->owners[i] != owner) {
@@ -427,6 +433,9 @@ static int entry_survives_resume(struct issued_entry* e, int64_t owner) {
         }
     }
     e->ownerCount = (unsigned char)remaining;
+
+    if (e->unowned) return 1;              /* the thread list still claims it */
+    if (e->ownerOverflow) return 0;        /* cannot prove another owner remains */
     return remaining > 0;                  /* another suspension still holds it */
 }
 

--- a/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
+++ b/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
@@ -223,12 +223,16 @@ struct issued_entry {
     int64_t owners[CN1_ISSUED_MAX_OWNERS];
     unsigned char ownerCount;
     /*
-     * Claimed by something not tied to a suspension -- the thread list's
-     * java.lang.Thread objects. Recorded separately from the owner set because
-     * the same reference can hold both claims: a Thread object can be exposed
-     * first through a stopped thread's locals and later by the thread list.
-     * Dropping the entry when that thread resumes would then reject an id the
-     * live thread list still advertises.
+     * Claimed by the thread list rather than by a suspension. Recorded
+     * separately from the owner set because the same reference can hold both:
+     * a Thread object can be exposed first through a stopped thread's locals
+     * and later by the thread list. Dropping the entry when that thread
+     * resumes would then reject an id the live thread list still advertises.
+     *
+     * Reconciled on every thread-list refresh rather than only on a full
+     * resume -- see cn1_debugger_forget_thread_list_claims. An IDE polling
+     * AllThreads on a running app would otherwise pin every Thread object it
+     * ever saw, and their retained graphs with them, for the session.
      */
     unsigned char unowned;
     /*
@@ -424,6 +428,44 @@ static int entry_survives_resume(struct issued_entry* e, int64_t owner) {
     }
     e->ownerCount = (unsigned char)remaining;
     return remaining > 0;                  /* another suspension still holds it */
+}
+
+/**
+ * Drops the thread list's claim on everything it previously advertised.
+ *
+ * Called before each refresh records the current set, so an entry a live
+ * snapshot no longer mentions loses its claim. Entries a suspension still owns
+ * survive, having lost only this claim; entries left with none are removed,
+ * which releases the GC roots holding dead Thread objects and whatever they
+ * reach.
+ */
+void cn1_debugger_forget_thread_list_claims(void) {
+    pthread_mutex_lock(&g_issuedMutex);
+    if (g_issued != NULL) {
+        unsigned cap = g_issuedCap;
+        struct issued_entry* kept =
+            (struct issued_entry*)calloc(cap, sizeof(struct issued_entry));
+        if (kept) {
+            unsigned keptCount = 0;
+            for (unsigned i = 0; i < cap; i++) {
+                if (g_issued[i].key == 0) continue;
+                g_issued[i].unowned = 0;
+                if (g_issued[i].ownerCount == 0 && !g_issued[i].ownerOverflow) {
+                    continue;   /* nothing claims it any more */
+                }
+                int created = 0;
+                struct issued_entry* moved =
+                    issued_put(kept, cap, g_issued[i].key, &created);
+                if (moved) { *moved = g_issued[i]; keptCount += (unsigned)created; }
+            }
+            free(g_issued);
+            g_issued = kept;
+            g_issuedCount = keptCount;
+        }
+        /* Out of memory: leave the table as it was. Keeping a root too long
+         * costs memory; dropping one frees an object an id still names. */
+    }
+    pthread_mutex_unlock(&g_issuedMutex);
 }
 
 void cn1_debugger_forget_issued_for(int64_t owner) {

--- a/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
+++ b/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
@@ -179,6 +179,101 @@ JAVA_INT cn1_debugger_tagged_int_value(JAVA_OBJECT obj) {
 #endif
 }
 
+
+/* --------------------------------------------------------------------- */
+/* Object ids the debugger has handed out during the current suspension.  */
+/*                                                                        */
+/* A registered class word proves a pointer LOOKS like an object of a     */
+/* known class. It does not prove the allocation is still live: full-page */
+/* BiBOP reclamation resets the page cursor without clearing class words, */
+/* and a legacy object goes to free() with its header intact. An IDE that */
+/* holds an objectID across a resume and asks about it after a collection */
+/* would therefore pass validation and be read anyway.                    */
+/*                                                                        */
+/* Every reference handed to the proxy is recorded here, and the set is   */
+/* cleared whenever a thread resumes. A wire id that is not in it is one  */
+/* the debugger did not issue this time round, so it is refused rather    */
+/* than dereferenced.                                                     */
+/*                                                                        */
+/* This bounds the reported window; it is not a liveness proof. Objects   */
+/* the IDE is shown come from live frames, fields and arrays and so are   */
+/* reachable, but the concurrent collector can still run while a thread   */
+/* is parked. Closing that completely means rooting debugger-issued ids   */
+/* until the IDE disposes them, which is a change to the collector rather */
+/* than to this file.                                                     */
+/* --------------------------------------------------------------------- */
+
+#define CN1_ISSUED_CAP 4096u   /* power of two; open addressing, linear probe */
+static uintptr_t g_issued[CN1_ISSUED_CAP];
+static unsigned g_issuedCount = 0;
+static pthread_mutex_t g_issuedMutex = PTHREAD_MUTEX_INITIALIZER;
+
+static unsigned issued_slot(uintptr_t key) {
+    /* Pointers are aligned, so the low bits carry no entropy. */
+    uintptr_t h = key >> 3;
+    h ^= h >> 13;
+    return (unsigned)(h & (CN1_ISSUED_CAP - 1));
+}
+
+void cn1_debugger_note_issued(JAVA_OBJECT obj) {
+    if (obj == JAVA_NULL) return;
+    uintptr_t key = (uintptr_t)obj;
+    pthread_mutex_lock(&g_issuedMutex);
+    /* Full table: stop recording rather than spin. Ids beyond the cap are
+     * refused on the way back in, which errs toward "unavailable" instead of
+     * toward a stale read. */
+    if (g_issuedCount < CN1_ISSUED_CAP - 1) {
+        unsigned i = issued_slot(key);
+        for (unsigned n = 0; n < CN1_ISSUED_CAP; n++) {
+            unsigned at = (i + n) & (CN1_ISSUED_CAP - 1);
+            if (g_issued[at] == key) break;
+            if (g_issued[at] == 0) {
+                g_issued[at] = key;
+                g_issuedCount++;
+                break;
+            }
+        }
+    }
+    pthread_mutex_unlock(&g_issuedMutex);
+}
+
+int cn1_debugger_was_issued(JAVA_OBJECT obj) {
+    if (obj == JAVA_NULL) return 0;
+    uintptr_t key = (uintptr_t)obj;
+    int found = 0;
+    pthread_mutex_lock(&g_issuedMutex);
+    unsigned i = issued_slot(key);
+    for (unsigned n = 0; n < CN1_ISSUED_CAP; n++) {
+        unsigned at = (i + n) & (CN1_ISSUED_CAP - 1);
+        if (g_issued[at] == key) { found = 1; break; }
+        if (g_issued[at] == 0) break;
+    }
+    pthread_mutex_unlock(&g_issuedMutex);
+    return found;
+}
+
+void cn1_debugger_forget_issued(void) {
+    pthread_mutex_lock(&g_issuedMutex);
+    memset(g_issued, 0, sizeof(g_issued));
+    g_issuedCount = 0;
+    pthread_mutex_unlock(&g_issuedMutex);
+}
+
+/**
+ * Resolves an objectID that arrived from the IDE.
+ *
+ * Stricter than cn1_debugger_class_of, which answers "is this shaped like a
+ * live object" for a value the runtime just read itself. A wire id has also to
+ * be one this debugger issued since the last resume.
+ */
+struct clazz* cn1_debugger_class_of_wire_id(JAVA_OBJECT obj) {
+    if (obj == JAVA_NULL) return NULL;
+    /* A tagged int is a value; there is no allocation to outlive anything. */
+    if (CN1_IS_TAGGED(obj)) return cn1_debugger_class_of(obj);
+    if (!cn1_debugger_was_issued(obj)) return NULL;
+    return cn1_debugger_class_of(obj);
+}
+
 /**
  * Whether a local is in scope at a given source line.
  *

--- a/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
+++ b/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
@@ -181,26 +181,26 @@ JAVA_INT cn1_debugger_tagged_int_value(JAVA_OBJECT obj) {
 
 
 /* --------------------------------------------------------------------- */
-/* Object ids the debugger has handed out during the current suspension.  */
+/* Object ids the debugger has handed out, and the GC roots that keep     */
+/* them valid.                                                            */
 /*                                                                        */
 /* A registered class word proves a pointer LOOKS like an object of a     */
-/* known class. It does not prove the allocation is still live: full-page */
-/* BiBOP reclamation resets the page cursor without clearing class words, */
-/* and a legacy object goes to free() with its header intact. An IDE that */
-/* holds an objectID across a resume and asks about it after a collection */
-/* would therefore pass validation and be read anyway.                    */
+/* known class. It does not prove the allocation is live: full-page BiBOP */
+/* reclamation resets the page cursor without clearing class words, and a */
+/* legacy object goes to free() with its header intact. Validation alone  */
+/* would therefore accept a collected object and the IDE's next field or  */
+/* array read would touch freed memory.                                   */
 /*                                                                        */
-/* Every reference handed to the proxy is recorded here, and the set is   */
-/* cleared whenever a thread resumes. A wire id that is not in it is one  */
-/* the debugger did not issue this time round, so it is refused rather    */
-/* than dereferenced.                                                     */
+/* So this table is not only a record of what was issued, it is a root    */
+/* set: cn1_debugger_mark_issued_roots is called from the collector's     */
+/* root pass and marks every entry. An object stays alive for exactly as  */
+/* long as an id for it can come back from the IDE, which turns the       */
+/* membership check below from a heuristic into a guarantee.              */
 /*                                                                        */
-/* This bounds the reported window; it is not a liveness proof. Objects   */
-/* the IDE is shown come from live frames, fields and arrays and so are   */
-/* reachable, but the concurrent collector can still run while a thread   */
-/* is parked. Closing that completely means rooting debugger-issued ids   */
-/* until the IDE disposes them, which is a change to the collector rather */
-/* than to this file.                                                     */
+/* The roots are released, not permanent. Each entry records the          */
+/* suspended threads it was obtained for, and resuming a thread drops the */
+/* entries only it held -- so the objects a debugging session displays    */
+/* are retained for the stop that displayed them and no longer.           */
 /* --------------------------------------------------------------------- */
 
 #define CN1_ISSUED_INITIAL_CAP 4096u   /* power of two; open addressing */
@@ -408,6 +408,51 @@ void cn1_debugger_forget_issued_for(int64_t owner) {
         }
     }
     pthread_mutex_unlock(&g_issuedMutex);
+}
+
+/**
+ * Marks every issued reference as a GC root.
+ *
+ * The references are copied out under the lock and marked after releasing it.
+ * gcMarkObject takes no lock the debugger also takes, so marking in place
+ * would work today -- but a command handler can hold ParparVM's critical
+ * section while recording an id (the thread list does), so holding this mutex
+ * across collector code is one collector change away from a lock-order
+ * inversion, and it would present as a device hanging mid-session. The copy
+ * costs one allocation per collection while a debugger is attached.
+ *
+ * Marking under the lock is the fallback when that allocation fails: missing
+ * a root would free an object the IDE still holds an id for, which is the
+ * failure this whole mechanism exists to prevent.
+ */
+void cn1_debugger_mark_issued_roots(struct ThreadLocalData* threadStateData) {
+    pthread_mutex_lock(&g_issuedMutex);
+    if (g_issued == NULL || g_issuedCount == 0) {
+        pthread_mutex_unlock(&g_issuedMutex);
+        return;
+    }
+    JAVA_OBJECT* batch = (JAVA_OBJECT*)malloc(g_issuedCount * sizeof(JAVA_OBJECT));
+    unsigned n = 0;
+    for (unsigned i = 0; i < g_issuedCap; i++) {
+        uintptr_t key = g_issued[i].key;
+        if (key == 0) continue;
+        JAVA_OBJECT obj = (JAVA_OBJECT)key;
+        /* A tagged int is a value, not an allocation; there is nothing to
+         * mark and gcMarkObject would read a header that does not exist. */
+        if (CN1_IS_TAGGED(obj)) continue;
+        if (batch != NULL) {
+            if (n < g_issuedCount) batch[n++] = obj;
+        } else {
+            gcMarkObject(threadStateData, obj, JAVA_FALSE);
+        }
+    }
+    pthread_mutex_unlock(&g_issuedMutex);
+    if (batch != NULL) {
+        for (unsigned i = 0; i < n; i++) {
+            gcMarkObject(threadStateData, batch[i], JAVA_FALSE);
+        }
+        free(batch);
+    }
 }
 
 /**

--- a/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
+++ b/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
@@ -204,7 +204,22 @@ JAVA_INT cn1_debugger_tagged_int_value(JAVA_OBJECT obj) {
 /* --------------------------------------------------------------------- */
 
 #define CN1_ISSUED_INITIAL_CAP 4096u   /* power of two; open addressing */
-static uintptr_t* g_issued = NULL;
+
+/*
+ * Each entry records which suspended thread the reference was obtained for, so
+ * that resuming one thread can drop its ids without touching those of a thread
+ * that is still stopped. Owner 0 means "not tied to a suspension" — the
+ * java.lang.Thread objects the thread list hands over — and those survive
+ * until every thread is running again.
+ *
+ * Both halves of that matter. Clearing globally on a per-thread resume made a
+ * still-parked thread's locals report unavailable mid-inspection; clearing
+ * nothing while any thread stayed parked left the resumed thread's ids
+ * accepted after its objects could be collected, which is the worse of the
+ * two.
+ */
+static uintptr_t* g_issuedKeys = NULL;
+static int64_t* g_issuedOwners = NULL;
 static unsigned g_issuedCap = 0;
 static unsigned g_issuedCount = 0;
 static pthread_mutex_t g_issuedMutex = PTHREAD_MUTEX_INITIALIZER;
@@ -216,42 +231,49 @@ static unsigned issued_slot(uintptr_t key, unsigned cap) {
     return (unsigned)(h & (cap - 1));
 }
 
-/* Insert into a table known to have room. Returns 1 if newly added. */
-static int issued_put(uintptr_t* table, unsigned cap, uintptr_t key) {
+/* Insert into tables known to have room. Returns 1 if newly added. */
+static int issued_put(uintptr_t* keys, int64_t* owners, unsigned cap,
+                      uintptr_t key, int64_t owner) {
     unsigned i = issued_slot(key, cap);
     for (unsigned n = 0; n < cap; n++) {
         unsigned at = (i + n) & (cap - 1);
-        if (table[at] == key) return 0;
-        if (table[at] == 0) { table[at] = key; return 1; }
+        if (keys[at] == key) return 0;
+        if (keys[at] == 0) { keys[at] = key; owners[at] = owner; return 1; }
     }
     return 0;
 }
 
 /* Grows past a 3/4 load factor. Returns 0 only if the allocation fails. */
 static int issued_reserve(void) {
-    if (g_issued != NULL && (g_issuedCount + 1) * 4 < g_issuedCap * 3) {
+    if (g_issuedKeys != NULL && (g_issuedCount + 1) * 4 < g_issuedCap * 3) {
         return 1;
     }
     unsigned newCap = g_issuedCap ? g_issuedCap * 2 : CN1_ISSUED_INITIAL_CAP;
-    uintptr_t* grown = (uintptr_t*)calloc(newCap, sizeof(uintptr_t));
-    if (!grown) return 0;
+    uintptr_t* keys = (uintptr_t*)calloc(newCap, sizeof(uintptr_t));
+    int64_t* owners = (int64_t*)calloc(newCap, sizeof(int64_t));
+    if (!keys || !owners) { free(keys); free(owners); return 0; }
     for (unsigned i = 0; i < g_issuedCap; i++) {
-        if (g_issued[i] != 0) issued_put(grown, newCap, g_issued[i]);
+        if (g_issuedKeys[i] != 0) {
+            issued_put(keys, owners, newCap, g_issuedKeys[i], g_issuedOwners[i]);
+        }
     }
-    free(g_issued);
-    g_issued = grown;
+    free(g_issuedKeys);
+    free(g_issuedOwners);
+    g_issuedKeys = keys;
+    g_issuedOwners = owners;
     g_issuedCap = newCap;
     return 1;
 }
 
-int cn1_debugger_note_issued(JAVA_OBJECT obj) {
+int cn1_debugger_note_issued_for(JAVA_OBJECT obj, int64_t owner) {
     if (obj == JAVA_NULL) return 1;   /* null needs no record */
     uintptr_t key = (uintptr_t)obj;
     int ok;
     pthread_mutex_lock(&g_issuedMutex);
     ok = issued_reserve();
     if (ok) {
-        g_issuedCount += (unsigned)issued_put(g_issued, g_issuedCap, key);
+        g_issuedCount += (unsigned)issued_put(g_issuedKeys, g_issuedOwners,
+                                              g_issuedCap, key, owner);
     }
     pthread_mutex_unlock(&g_issuedMutex);
     /* The table grows, so this only fails when the allocation does. A caller
@@ -261,29 +283,81 @@ int cn1_debugger_note_issued(JAVA_OBJECT obj) {
     return ok;
 }
 
+int cn1_debugger_note_issued(JAVA_OBJECT obj) {
+    return cn1_debugger_note_issued_for(obj, 0);
+}
+
+/* Locates an entry, returning its index or -1. Caller holds the mutex. */
+static int issued_find(uintptr_t key) {
+    if (g_issuedKeys == NULL) return -1;
+    unsigned i = issued_slot(key, g_issuedCap);
+    for (unsigned n = 0; n < g_issuedCap; n++) {
+        unsigned at = (i + n) & (g_issuedCap - 1);
+        if (g_issuedKeys[at] == key) return (int)at;
+        if (g_issuedKeys[at] == 0) return -1;
+    }
+    return -1;
+}
+
 int cn1_debugger_was_issued(JAVA_OBJECT obj) {
     if (obj == JAVA_NULL) return 0;
-    uintptr_t key = (uintptr_t)obj;
-    int found = 0;
     pthread_mutex_lock(&g_issuedMutex);
-    if (g_issued != NULL) {
-        unsigned i = issued_slot(key, g_issuedCap);
-        for (unsigned n = 0; n < g_issuedCap; n++) {
-            unsigned at = (i + n) & (g_issuedCap - 1);
-            if (g_issued[at] == key) { found = 1; break; }
-            if (g_issued[at] == 0) break;
-        }
-    }
+    int at = issued_find((uintptr_t)obj);
     pthread_mutex_unlock(&g_issuedMutex);
-    return found;
+    return at >= 0;
+}
+
+int64_t cn1_debugger_owner_of(JAVA_OBJECT obj) {
+    if (obj == JAVA_NULL) return 0;
+    pthread_mutex_lock(&g_issuedMutex);
+    int at = issued_find((uintptr_t)obj);
+    int64_t owner = at >= 0 ? g_issuedOwners[at] : 0;
+    pthread_mutex_unlock(&g_issuedMutex);
+    return owner;
 }
 
 void cn1_debugger_forget_issued(void) {
     pthread_mutex_lock(&g_issuedMutex);
-    if (g_issued != NULL) {
-        memset(g_issued, 0, g_issuedCap * sizeof(uintptr_t));
+    if (g_issuedKeys != NULL) {
+        memset(g_issuedKeys, 0, g_issuedCap * sizeof(uintptr_t));
+        memset(g_issuedOwners, 0, g_issuedCap * sizeof(int64_t));
     }
     g_issuedCount = 0;
+    pthread_mutex_unlock(&g_issuedMutex);
+}
+
+void cn1_debugger_forget_issued_for(int64_t owner) {
+    if (owner == 0) return;
+    pthread_mutex_lock(&g_issuedMutex);
+    if (g_issuedKeys != NULL) {
+        /* Rebuilt rather than tombstoned: deletion from a linear probe would
+         * otherwise cut the chains that later lookups walk. */
+        unsigned cap = g_issuedCap;
+        uintptr_t* keys = (uintptr_t*)calloc(cap, sizeof(uintptr_t));
+        int64_t* owners = (int64_t*)calloc(cap, sizeof(int64_t));
+        if (keys && owners) {
+            unsigned kept = 0;
+            for (unsigned i = 0; i < cap; i++) {
+                if (g_issuedKeys[i] != 0 && g_issuedOwners[i] != owner) {
+                    kept += (unsigned)issued_put(keys, owners, cap,
+                                                 g_issuedKeys[i], g_issuedOwners[i]);
+                }
+            }
+            free(g_issuedKeys);
+            free(g_issuedOwners);
+            g_issuedKeys = keys;
+            g_issuedOwners = owners;
+            g_issuedCount = kept;
+        } else {
+            /* Out of memory: drop everything rather than keep ids we can no
+             * longer prove belong to a still-parked thread. */
+            free(keys);
+            free(owners);
+            memset(g_issuedKeys, 0, cap * sizeof(uintptr_t));
+            memset(g_issuedOwners, 0, cap * sizeof(int64_t));
+            g_issuedCount = 0;
+        }
+    }
     pthread_mutex_unlock(&g_issuedMutex);
 }
 

--- a/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
+++ b/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
@@ -238,13 +238,27 @@ struct issued_entry {
      */
     unsigned int listGen;
     /*
-     * The reference this one was reached through, if any -- the Thread object
-     * whose field the IDE expanded, say. A descendant carries no owner of its
-     * own and no claim of its own, so without this link a thread-list refresh
+     * The references this one was reached through -- the Thread object whose
+     * field the IDE expanded, say. A descendant carries no owner of its own
+     * and no claim of its own, so without these links a thread-list refresh
      * would drop it even though the object it hangs off is still live and
      * still claimed, and every later request naming it would be rejected.
+     *
+     * A set, for the same reason the owners are: the same object can be
+     * reached through two different threads' graphs. Keeping only the most
+     * recent parent meant that when that one went away the child went with
+     * it, while the IDE was still displaying the same id under the thread
+     * that remained.
      */
-    uintptr_t parent;
+    uintptr_t parents[CN1_ISSUED_MAX_OWNERS];
+    unsigned char parentCount;
+    /*
+     * Set when more parents appeared than there are slots. Such an entry is
+     * kept while any thread-list generation is current, since we can no longer
+     * prove which graph reaches it -- keeping a root too long costs memory,
+     * dropping one frees an object an id still names.
+     */
+    unsigned char parentOverflow;
     /* Scratch for the reachability sweep in end_thread_list. */
     unsigned char survives;
     /*
@@ -288,6 +302,19 @@ static void entry_add_owner(struct issued_entry* e, int64_t owner) {
         e->owners[e->ownerCount++] = owner;
     } else {
         e->ownerOverflow = 1;
+    }
+}
+
+/* Adds a parent to an entry, ignoring duplicates. */
+static void entry_add_parent(struct issued_entry* e, uintptr_t parent) {
+    if (parent == 0) return;
+    for (unsigned i = 0; i < e->parentCount; i++) {
+        if (e->parents[i] == parent) return;
+    }
+    if (e->parentCount < CN1_ISSUED_MAX_OWNERS) {
+        e->parents[e->parentCount++] = parent;
+    } else {
+        e->parentOverflow = 1;
     }
 }
 
@@ -386,7 +413,7 @@ int cn1_debugger_note_issued_inheriting(JAVA_OBJECT obj, JAVA_OBJECT parent) {
                     entry_add_owner(e, from->owners[i]);
                 }
                 if (from->listGen > e->listGen) e->listGen = from->listGen;
-                e->parent = (uintptr_t)parent;
+                entry_add_parent(e, (uintptr_t)parent);
                 if (from->ownerOverflow) e->ownerOverflow = 1;
             }
         } else {
@@ -509,11 +536,21 @@ void cn1_debugger_end_thread_list(void) {
             changed = 0;
             for (unsigned i = 0; i < cap; i++) {
                 struct issued_entry* e = &g_issued[i];
-                if (e->key == 0 || e->survives || e->parent == 0) continue;
-                struct issued_entry* parent = issued_find(e->parent);
-                if (parent != NULL && parent->survives) {
+                if (e->key == 0 || e->survives) continue;
+                if (e->parentOverflow) {
+                    /* Too many graphs reached it to say which; assume one of
+                     * them still does rather than reject an id in use. */
                     e->survives = 1;
                     changed = 1;
+                    continue;
+                }
+                for (unsigned j = 0; j < e->parentCount; j++) {
+                    struct issued_entry* parent = issued_find(e->parents[j]);
+                    if (parent != NULL && parent->survives) {
+                        e->survives = 1;
+                        changed = 1;
+                        break;
+                    }
                 }
             }
         }

--- a/docs/demos/tools/netbeans/nbactions.xml
+++ b/docs/demos/tools/netbeans/nbactions.xml
@@ -131,6 +131,20 @@
         </properties>
     </action>
     <action>
+        <actionName>CUSTOM-Build for iOS On-Device Debug</actionName>
+        <displayName>Build for iOS On-Device Debug</displayName>
+        <goals>
+            <goal>cn1:buildIosOnDeviceDebug</goal>
+        </goals>
+    </action>
+    <action>
+        <actionName>CUSTOM-Start iOS Debug Proxy</actionName>
+        <displayName>Start iOS Debug Proxy</displayName>
+        <goals>
+            <goal>cn1:ios-on-device-debugging</goal>
+        </goals>
+    </action>
+    <action>
         <actionName>CUSTOM-Update Codename One</actionName>
         <displayName>Update Codename One</displayName>
         <goals>

--- a/docs/developer-guide/On-Device-Debugging.asciidoc
+++ b/docs/developer-guide/On-Device-Debugging.asciidoc
@@ -125,7 +125,7 @@ menu:
 
 * *Build for iOS On-Device Debug* runs `cn1:buildIosOnDeviceDebug`,
   which forces `codename1.arg.ios.onDeviceDebug=true` for that one
-  build. You do not need to edit
+  build. You don't need to edit
   `common/codenameone_settings.properties` first — the goal sets the
   hint itself, so a release build stays a release build.
 * *Start iOS Debug Proxy* runs `cn1:ios-on-device-debugging`, which
@@ -212,16 +212,16 @@ prefer plain files, extract it once and point at the directory.
   console (the IntelliJ *CN1 Debug Proxy* Run window when launched
   via the run config) prefixed with `[device]`.
 * Thread list — every live Java thread appears in the IDE's Threads
-  panel, whether or not it has stopped anywhere, named after the
+  panel, whether it has stopped anywhere or not, named after the
   `java.lang.Thread` it belongs to (`EDT`, `main`, ...). Suspension
   is reported per thread, so with several parked at once the panel
   shows which is which.
-* Scoped locals — a local is listed only on the source lines it is
+* Scoped locals — a local is listed only on the source lines it's
   actually in scope for. That matters where two variables share a JVM
   slot in disjoint blocks: only the one the code has reached is
   shown, rather than both, one of them displaying the other's
   storage.
-* Deferred breakpoints — a breakpoint set in a class the IDE has not
+* Deferred breakpoints — a breakpoint set in a class the IDE hasn't
   seen yet (an anonymous listener, say) resolves via the ClassPrepare
   events the proxy raises for every matching class.
 * Pause and resume from the IDE.
@@ -279,8 +279,8 @@ in the IDE editor when stepping into framework code.
   compile with debug info by default; if a variable shows up as
   `v1`, `v2`, ... that's because that particular class was
   compiled without debug info. Such a local also has no declaring
-  scope, so it is listed for the whole method rather than only
-  where it is live.
+  scope, so the debugger lists it for the whole method rather than
+  only where it's live.
 * *Two locals of the same type sharing a slot* are reported as one.
   Where disjoint blocks reuse a JVM slot for, say, two different
   `int` variables, the debugger keeps the later declaration's name

--- a/docs/developer-guide/On-Device-Debugging.asciidoc
+++ b/docs/developer-guide/On-Device-Debugging.asciidoc
@@ -33,9 +33,10 @@ If your bug is reproducible in the simulator, stay in the simulator
 === Quick start (IntelliJ IDEA)
 
 Codename One projects generated from the `cn1app-archetype` ship with
-two ready-made IntelliJ run configurations under the *On-Device Debug*
-folder in the run-config dropdown: *CN1 Debug Proxy* and *CN1 Attach
-iOS*. The rest of this section assumes you're using them. Skip to
+three ready-made IntelliJ run configurations under the *On-Device
+Debug* folder in the run-config dropdown: *CN1 iOS On-Device Debug
+Build*, *CN1 Debug Proxy* and *CN1 Attach iOS*. The rest of this
+section assumes you're using them. Skip to
 <<on-device-debug-jdb,Using jdb instead>> if you prefer the
 command-line debugger.
 
@@ -116,18 +117,34 @@ normal remote attach. Device output from
 `System.out.println` / `Log.p` / `printf` / `NSLog` lands in the
 *CN1 Debug Proxy* Run window prefixed with `[device]`.
 
-=== Attach from NetBeans
+=== Quick start (NetBeans)
 
-NetBeans uses the same proxy and connection order. Start the proxy,
-launch the app, and wait for the device handshake and symbol-loading
-lines shown above. Then choose *Debug > Attach Debugger* in NetBeans.
-Select *Java Debugger (JPDA)* and the *SocketAttach* connector, set
-the host to `localhost` and the port to `8000`, then attach. Keep the
-Codename One project open so NetBeans can resolve your source files
-and breakpoints.
+NetBeans uses the same proxy and connection order as IntelliJ. Generated
+projects ship two custom actions for it, on the project's right-click
+menu:
+
+* *Build for iOS On-Device Debug* runs `cn1:buildIosOnDeviceDebug`,
+  which forces `codename1.arg.ios.onDeviceDebug=true` for that one
+  build. You do not need to edit
+  `common/codenameone_settings.properties` first — the goal sets the
+  hint itself, so a release build stays a release build.
+* *Start iOS Debug Proxy* runs `cn1:ios-on-device-debugging`, which
+  listens on `55333` for the device and `8000` for the IDE.
+
+Install the app the first action produced, start the proxy with the
+second, launch the app, and wait for the device handshake and
+symbol-loading lines shown above. Then choose *Debug > Attach
+Debugger*, select *Java Debugger (JPDA)* and the *SocketAttach*
+connector, set the host to `localhost` and the port to `8000`, and
+attach. Keep the Codename One project open so NetBeans can resolve
+your source files and breakpoints.
 
 Don't point NetBeans at port `55333`. The iPhone uses `55333` to
 reach the proxy. The IDE uses the proxy's JDWP port, `8000`.
+
+If the actions are missing from an older project, they live in
+`tools/netbeans/nbactions.xml`; copying that file from a freshly
+generated project adds them.
 
 === Quick start (Maven from the command line)
 
@@ -194,6 +211,19 @@ prefer plain files, extract it once and point at the directory.
   `printf` / `NSLog` from native code are surfaced in the proxy's
   console (the IntelliJ *CN1 Debug Proxy* Run window when launched
   via the run config) prefixed with `[device]`.
+* Thread list — every live Java thread appears in the IDE's Threads
+  panel, whether or not it has stopped anywhere, named after the
+  `java.lang.Thread` it belongs to (`EDT`, `main`, ...). Suspension
+  is reported per thread, so with several parked at once the panel
+  shows which is which.
+* Scoped locals — a local is listed only on the source lines it is
+  actually in scope for. That matters where two variables share a JVM
+  slot in disjoint blocks: only the one the code has reached is
+  shown, rather than both, one of them displaying the other's
+  storage.
+* Deferred breakpoints — a breakpoint set in a class the IDE has not
+  seen yet (an anonymous listener, say) resolves via the ClassPrepare
+  events the proxy raises for every matching class.
 * Pause and resume from the IDE.
 
 === Pointing the IDE at the Codename One sources
@@ -248,7 +278,14 @@ in the IDE editor when stepping into framework code.
   sources were compiled with `-g`. Codename One's archetypes do
   compile with debug info by default; if a variable shows up as
   `v1`, `v2`, ... that's because that particular class was
-  compiled without debug info.
+  compiled without debug info. Such a local also has no declaring
+  scope, so it is listed for the whole method rather than only
+  where it is live.
+* *Two locals of the same type sharing a slot* are reported as one.
+  Where disjoint blocks reuse a JVM slot for, say, two different
+  `int` variables, the debugger keeps the later declaration's name
+  and scope for both. Reuse across *different* types — the common
+  case, and the one that used to matter — is fully distinguished.
 * *Static field reads* are unsupported. Instance field reads are
   fully wired; static-field support requires an additional per-class
   static table that hasn't been emitted yet.

--- a/docs/developer-guide/On-Device-Debugging.asciidoc
+++ b/docs/developer-guide/On-Device-Debugging.asciidoc
@@ -225,6 +225,10 @@ prefer plain files, extract it once and point at the directory.
   seen yet (an anonymous listener, say) resolves via the ClassPrepare
   events the proxy raises for every matching class.
 * Pause and resume from the IDE.
+* Stack frames in methods carrying no line information — synthetic
+  lambda bodies and `java.lang.Thread.runImpl`, for instance — appear
+  in the stack with their source line left blank, rather than ending
+  the stack view at that frame.
 
 === Pointing the IDE at the Codename One sources
 
@@ -361,8 +365,17 @@ firewall is blocking the port. Verify:
 This means an unsupported JDWP command was invoked. The session
 itself survives; the most common cause is the IDE asking for
 something the proxy explicitly stubs (see "Known limitations"
-above). If you hit a less obvious case, the proxy logs the unknown
-command code — file an issue with that code attached.
+above). The debugger's own message doesn't say which command it
+asked for, so the proxy logs it instead:
+
+[source]
+----
+[jdwp] declining unimplemented command set=2 cmd=13; the debugger
+may report "Unexpected JDWP Error: 100"
+----
+
+The line is printed once per command, in the proxy's console. File
+an issue with the command set and number attached.
 
 ==== The app launches but the breakpoint never fires
 

--- a/docs/developer-guide/On-Device-Debugging.asciidoc
+++ b/docs/developer-guide/On-Device-Debugging.asciidoc
@@ -281,11 +281,6 @@ in the IDE editor when stepping into framework code.
   compiled without debug info. Such a local also has no declaring
   scope, so the debugger lists it for the whole method rather than
   only where it's live.
-* *Two locals of the same type sharing a slot* are reported as one.
-  Where disjoint blocks reuse a JVM slot for, say, two different
-  `int` variables, the debugger keeps the later declaration's name
-  and scope for both. Reuse across *different* types — the common
-  case, and the one that used to matter — is fully distinguished.
 * *Static field reads* are unsupported. Instance field reads are
   fully wired; static-field support requires an additional per-class
   static table that hasn't been emitted yet.

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/DeviceConnection.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/DeviceConnection.java
@@ -58,6 +58,14 @@ public final class DeviceConnection implements AutoCloseable {
         void onHello(int version);
         void onBreakpointHit(long threadId, int methodId, int line);
         void onStepComplete(long threadId, int methodId, int line);
+        /**
+         * The device's live thread list, in reply to {@link #getThreads()}.
+         * {@code suspended} marks threads the debugger has parked, and
+         * {@code threadObjects} carries each {@code java.lang.Thread} instance
+         * (0 when the thread has not published one) so the proxy can read its
+         * name through the ordinary object/field commands.
+         */
+        void onThreads(long[] threadIds, boolean[] suspended, long[] threadObjects);
         void onStack(long threadId, int[] methodIds, int[] lines);
         void onLocals(int[] slots, byte[] typeCodes, long[] values);
         void onVmDeath();
@@ -169,6 +177,23 @@ public final class DeviceConnection implements AutoCloseable {
                 int mid = readInt(p, 8);
                 int line = readInt(p, 12);
                 listener.onStepComplete(tid, mid, line);
+                return;
+            }
+            case WireProtocol.EVT_THREAD_LIST: {
+                // count(4) then per thread: threadId(8) flags(1) threadObject(8).
+                if (p.length < 4) { listener.onUnknownEvent(code, p); return; }
+                int n = readInt(p, 0);
+                if (n < 0 || 4 + n * 17 > p.length) { listener.onUnknownEvent(code, p); return; }
+                long[] ids = new long[n];
+                boolean[] suspended = new boolean[n];
+                long[] objects = new long[n];
+                int off = 4;
+                for (int i = 0; i < n; i++) {
+                    ids[i] = readLong(p, off); off += 8;
+                    suspended[i] = (p[off] & 0x01) != 0; off += 1;
+                    objects[i] = readLong(p, off); off += 8;
+                }
+                listener.onThreads(ids, suspended, objects);
                 return;
             }
             case WireProtocol.EVT_STACK: {
@@ -364,6 +389,11 @@ public final class DeviceConnection implements AutoCloseable {
         writeLong(p, 0, threadId);
         p[8] = (byte) stepKind;
         sendCommand(WireProtocol.CMD_STEP, p);
+    }
+
+    /** Asks the device to enumerate its live Java threads. */
+    public void getThreads() throws IOException {
+        sendCommand(WireProtocol.CMD_GET_THREADS, null);
     }
 
     public void getStack(long threadId) throws IOException {

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/DeviceConnection.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/DeviceConnection.java
@@ -183,7 +183,7 @@ public final class DeviceConnection implements AutoCloseable {
                 // count(4) then per thread: threadId(8) flags(1) threadObject(8).
                 if (p.length < 4) { listener.onUnknownEvent(code, p); return; }
                 int n = readInt(p, 0);
-                if (n < 0 || 4 + n * 17 > p.length) { listener.onUnknownEvent(code, p); return; }
+                if (!frameHolds(n, 17, 4, p.length)) { listener.onUnknownEvent(code, p); return; }
                 long[] ids = new long[n];
                 boolean[] suspended = new boolean[n];
                 long[] objects = new long[n];
@@ -200,6 +200,7 @@ public final class DeviceConnection implements AutoCloseable {
                 if (p.length < 12) { listener.onUnknownEvent(code, p); return; }
                 long tid = readLong(p, 0);
                 int n = readInt(p, 8);
+                if (!frameHolds(n, 8, 12, p.length)) { listener.onUnknownEvent(code, p); return; }
                 int[] mids = new int[n];
                 int[] lines = new int[n];
                 for (int i = 0; i < n; i++) {
@@ -212,6 +213,7 @@ public final class DeviceConnection implements AutoCloseable {
             case WireProtocol.EVT_LOCALS: {
                 if (p.length < 4) { listener.onUnknownEvent(code, p); return; }
                 int n = readInt(p, 0);
+                if (!frameHolds(n, 13, 4, p.length)) { listener.onUnknownEvent(code, p); return; }
                 int[] slots = new int[n];
                 byte[] types = new byte[n];
                 long[] values = new long[n];
@@ -242,6 +244,7 @@ public final class DeviceConnection implements AutoCloseable {
             case WireProtocol.EVT_OBJECT_FIELDS: {
                 if (p.length < 4) { listener.onUnknownEvent(code, p); return; }
                 int n = readInt(p, 0);
+                if (!frameHolds(n, 9, 4, p.length)) { listener.onUnknownEvent(code, p); return; }
                 byte[] types = new byte[n];
                 long[] values = new long[n];
                 int off = 4;
@@ -478,6 +481,23 @@ public final class DeviceConnection implements AutoCloseable {
             try { if (socket != null) socket.close(); } catch (IOException ignore) {}
             try { if (server != null) server.close(); } catch (IOException ignore) {}
         }
+    }
+
+    /**
+     * Whether a frame really carries {@code count} entries of
+     * {@code bytesPerEntry} after a {@code headerBytes} header.
+     *
+     * <p>Divides rather than multiplying: the frame's count is whatever
+     * arrived on the socket, and {@code count * bytesPerEntry} overflows to a
+     * negative number for a large enough one, which turns the obvious
+     * {@code header + count * size > length} guard into a pass. Everything
+     * after it then allocates arrays of that count, so a four-byte payload
+     * claiming a hundred million entries takes the proxy down with an
+     * OutOfMemoryError instead of being reported as an unreadable frame.</p>
+     */
+    private static boolean frameHolds(int count, int bytesPerEntry, int headerBytes, int length) {
+        if (count < 0 || length < headerBytes) return false;
+        return count <= (length - headerBytes) / bytesPerEntry;
     }
 
     private static int readInt(byte[] b, int off) {

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/DeviceConnection.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/DeviceConnection.java
@@ -70,7 +70,12 @@ public final class DeviceConnection implements AutoCloseable {
         void onLocals(int[] slots, byte[] typeCodes, long[] values);
         void onVmDeath();
         void onStringValue(String value);
-        void onObjectClass(int classId, boolean isArray);
+        /**
+         * @param dimensions array depth when {@code isArray}; {@code classId}
+         *                   then names the scalar component, since an array's
+         *                   own class is synthetic and has no symbol entry.
+         */
+        void onObjectClass(int classId, boolean isArray, int dimensions);
         void onObjectFields(byte[] typeCodes, long[] values);
         void onInvokeResult(byte type, long value);
         void onArrayLength(int length);
@@ -238,7 +243,11 @@ public final class DeviceConnection implements AutoCloseable {
                 int cid = p.length >= 4 ? readInt(p, 0) : -1;
                 // 5th byte is isArray flag; older devices omit it.
                 boolean isArr = p.length >= 5 && p[4] != 0;
-                listener.onObjectClass(cid, isArr);
+                // 6th byte is the array depth; devices before it sent none,
+                // and a depth of 1 is what those could only have meant.
+                int dims = p.length >= 6 ? (p[5] & 0xff) : (isArr ? 1 : 0);
+                if (isArr && dims == 0) dims = 1;
+                listener.onObjectClass(cid, isArr, dims);
                 return;
             }
             case WireProtocol.EVT_OBJECT_FIELDS: {

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
@@ -31,9 +31,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -72,6 +74,11 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
     private static final int CS_STACK_FRAME         = 16;
     private static final int CS_CLASS_OBJECT_REF    = 17;
     private static final int CS_EVENT               = 64;
+
+    /** JDWP error: the requested debug information was not compiled in. */
+    private static final int ERR_ABSENT_INFORMATION = 101;
+    /** JDWP error: the command is not supported by this VM. */
+    private static final int ERR_NOT_IMPLEMENTED    = 100;
 
     // Event kinds (subset)
     private static final int EK_SINGLE_STEP   = 1;
@@ -532,7 +539,38 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
 
     private static final boolean LOG_JDWP = Boolean.getBoolean("cn1.debug.logJdwp");
 
+    /**
+     * Command set of the request being served, for diagnostics. Requests are
+     * read and dispatched one at a time on the connection's reader thread.
+     */
+    private int currentCmdSet;
+
+    /** Command-set/command pairs already reported as unimplemented. */
+    private final Set<Integer> reportedUnimplemented = new HashSet<>();
+
+    /**
+     * Declines a command this proxy does not implement, and says so once.
+     *
+     * <p>Declining in silence is what made {@code Unexpected JDWP Error: 100}
+     * -- which a debugger reports without naming the command it asked for --
+     * impossible to act on from either side of the connection.</p>
+     */
+    private void writeNotImplemented(int id, int cmd) throws IOException {
+        Integer key = (currentCmdSet << 16) | (cmd & 0xFFFF);
+        boolean firstTime;
+        synchronized (reportedUnimplemented) {
+            firstTime = reportedUnimplemented.add(key);
+        }
+        if (firstTime) {
+            System.err.println("[jdwp] declining unimplemented command set="
+                    + currentCmdSet + " cmd=" + cmd
+                    + "; the debugger may report \"Unexpected JDWP Error: 100\"");
+        }
+        writeReply(id, ERR_NOT_IMPLEMENTED, empty());
+    }
+
     private void dispatchCommand(int id, int cmdSet, int cmd, byte[] p) throws IOException {
+        currentCmdSet = cmdSet;
         if (LOG_JDWP) System.out.println("[jdwp<-] cmdSet=" + cmdSet + " cmd=" + cmd + " len=" + p.length);
         try {
             switch (cmdSet) {
@@ -550,10 +588,10 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 case CS_CLASS_LOADER_REF:
                 case CS_CLASS_OBJECT_REF:
                     // Reply with NOT_IMPLEMENTED (100) so jdb falls back gracefully.
-                    writeReply(id, 100, empty());
+                    writeNotImplemented(id, cmd);
                     return;
                 default:
-                    writeReply(id, 100, empty());
+                    writeNotImplemented(id, cmd);
             }
         } catch (Throwable t) {
             t.printStackTrace();
@@ -684,7 +722,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 return;
             }
             default:
-                writeReply(id, 100, empty());
+                writeNotImplemented(id, cmd);
         }
     }
 
@@ -792,11 +830,36 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 Buf b = new Buf(); b.writeLong(typeID); writeReply(id, 0, b.bytes()); return;
             }
             default:
-                writeReply(id, 100, empty());
+                writeNotImplemented(id, cmd);
         }
     }
 
     // -------- Method --------------------------------------------------------
+
+    /**
+     * The code index to report for a frame stopped at {@code line}.
+     *
+     * <p>ParparVM's code index is the source line, so the two are normally the
+     * same number. They come apart for a frame the device reports a line we
+     * have no table entry for -- a line the optimiser moved, or 0 for a frame
+     * that has not reached a tracked line yet. A debugger resolves a location
+     * strictly against the table it was given, so an index missing from it is
+     * not merely displayed oddly: jdb raises {@code InternalError: Location
+     * with invalid code index} and the stack view stops there.</p>
+     *
+     * <p>Snapping down to the nearest line the method really has keeps the
+     * frame both displayable and honest -- it names the last line known to
+     * have started -- and a frame with no line yet shows the method's first.</p>
+     */
+    private static long frameCodeIndex(SymbolTable.MethodInfo m, int line) {
+        if (m == null || m.lines.isEmpty()) {
+            // No table to be consistent with; LineTable reports the absence.
+            return line;
+        }
+        if (m.lines.contains(line)) return line;
+        Integer atOrBefore = m.lines.floor(line);
+        return atOrBefore != null ? atOrBefore : m.lines.first();
+    }
 
     private void handleMethod(int id, int cmd, byte[] p) throws IOException {
         long typeID = readLong(p, 0);
@@ -804,16 +867,25 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
         SymbolTable.MethodInfo m = symbols.methodById(fromJdwpRef(methodID));
         switch (cmd) {
             case 1: { // LineTable
-                Buf b = new Buf();
                 if (m == null || m.lines.isEmpty()) {
-                    b.writeLong(0); b.writeLong(0); b.writeInt(0);
-                } else {
-                    long start = m.lines.first();
-                    long end = m.lines.last();
-                    b.writeLong(start); b.writeLong(end); b.writeInt(m.lines.size());
-                    for (int line : m.lines) {
-                        b.writeLong(line); b.writeInt(line);
-                    }
+                    // A method we have no lines for has to say so. Answering
+                    // "success, zero entries" instead leaves the debugger
+                    // holding an empty table it still believes is authoritative,
+                    // and the first frame in such a method takes down the whole
+                    // stack view: jdb turns it into
+                    //   InternalError: Location with invalid code index
+                    // out of `where`, killing the session. ABSENT_INFORMATION is
+                    // what the spec reserves for this and every debugger already
+                    // handles it -- the frame just shows no line number.
+                    writeReply(id, ERR_ABSENT_INFORMATION, empty());
+                    return;
+                }
+                Buf b = new Buf();
+                long start = m.lines.first();
+                long end = m.lines.last();
+                b.writeLong(start); b.writeLong(end); b.writeInt(m.lines.size());
+                for (int line : m.lines) {
+                    b.writeLong(line); b.writeInt(line);
                 }
                 writeReply(id, 0, b.bytes());
                 return;
@@ -873,7 +945,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 Buf b = new Buf(); b.writeByte(0); writeReply(id, 0, b.bytes()); return;
             }
             default:
-                writeReply(id, 100, empty());
+                writeNotImplemented(id, cmd);
         }
     }
 
@@ -923,7 +995,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 return;
             }
             default:
-                writeReply(id, 100, empty());
+                writeNotImplemented(id, cmd);
         }
     }
 
@@ -1056,7 +1128,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                     b.writeByte(TYPE_TAG_CLASS);
                     b.writeLong(toJdwpRef(classId));
                     b.writeLong(toJdwpRef(mids[idx]));
-                    b.writeLong(lines[idx]);
+                    b.writeLong(frameCodeIndex(m, lines[idx]));
                 }
                 writeReply(id, 0, b.bytes()); return;
             }
@@ -1071,7 +1143,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 writeReply(id, 0, b.bytes()); return;
             }
             default:
-                writeReply(id, 100, empty());
+                writeNotImplemented(id, cmd);
         }
     }
 
@@ -1088,7 +1160,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 writeReply(id, 0, b.bytes()); return;
             }
             default:
-                writeReply(id, 100, empty());
+                writeNotImplemented(id, cmd);
         }
     }
 
@@ -1183,7 +1255,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 return;
             }
             default:
-                writeReply(id, 100, empty());
+                writeNotImplemented(id, cmd);
         }
     }
 
@@ -1404,7 +1476,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 return;
             }
             default:
-                writeReply(id, 100, empty());
+                writeNotImplemented(id, cmd);
         }
     }
 
@@ -1584,7 +1656,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 Buf b = new Buf(); b.writeByte(0); writeReply(id, 0, b.bytes()); return;
             }
             default:
-                writeReply(id, 100, empty());
+                writeNotImplemented(id, cmd);
         }
     }
 
@@ -1599,7 +1671,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 return;
             }
             default:
-                writeReply(id, 100, empty());
+                writeNotImplemented(id, cmd);
         }
     }
 
@@ -1654,7 +1726,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 return;
             }
             default:
-                writeReply(id, 100, empty());
+                writeNotImplemented(id, cmd);
         }
     }
 

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
@@ -575,6 +575,8 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 System.out.println("[jdwp] VM.Resume");
                 invalidateStack();
                 invalidateLocals();
+                markAllResumed();
+                lastSuspendedThread = 0;
                 if (device != null) try { device.resumeAll(); } catch (IOException ignore) {}
                 writeReply(id, 0, empty());
                 return;
@@ -907,6 +909,30 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
         return tid == lastSuspendedThread;
     }
 
+    /**
+     * Records a thread's suspend state from an event, so the IDE does not have
+     * to wait for the next thread-list refresh to see it.
+     *
+     * The snapshot is only as fresh as the last refresh, and a thread is
+     * usually enumerated while running and stopped a moment later. Without
+     * this, Status and SuspendCount kept reporting the thread the IDE had just
+     * stopped at as running.
+     */
+    private void markSuspended(long tid, boolean suspended) {
+        ThreadInfo previous = deviceThreads.get(tid);
+        deviceThreads.put(tid, new ThreadInfo(suspended,
+                previous != null ? previous.threadObject : 0));
+    }
+
+    /** Every thread is running again after a VM-wide resume. */
+    private void markAllResumed() {
+        for (Map.Entry<Long, ThreadInfo> e : deviceThreads.entrySet()) {
+            if (e.getValue().suspended) {
+                e.setValue(new ThreadInfo(false, e.getValue().threadObject));
+            }
+        }
+    }
+
     private void handleThread(int id, int cmd, byte[] p) throws IOException {
         long tid = readLong(p, 0);
         switch (cmd) {
@@ -920,6 +946,8 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 System.out.println("[jdwp] Thread.Resume tid=" + tid);
                 invalidateStack();
                 invalidateLocals();
+                markSuspended(tid, false);
+                if (tid == lastSuspendedThread) lastSuspendedThread = 0;
                 if (device != null) try { device.resume(tid); } catch (IOException ignore) {}
                 writeReply(id, 0, empty()); return;
             }
@@ -1632,6 +1660,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
      * degrades to the previous behaviour instead of an empty thread list.
      */
     private List<Long> currentThreadIds() {
+        boolean refreshed = false;
         if (device != null && deviceHelloReceived) {
             synchronized (threadsLock) {
                 pendingThreads = true;
@@ -1645,14 +1674,22 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 } catch (IOException io) {
                     pendingThreads = false;
                 }
+                // The reply landed, so deviceThreads is the whole truth.
+                refreshed = !pendingThreads;
             }
         }
         List<Long> ids = new ArrayList<>(deviceThreads.keySet());
-        // Union with event-derived ids: a thread that hit a breakpoint must
-        // stay listed even if the device list came back empty.
-        synchronized (knownThreads) {
-            for (Long t : knownThreads) {
-                if (!ids.contains(t)) ids.add(t);
+        if (!refreshed) {
+            // No usable answer from the device — an older build that does not
+            // implement the command, or a refresh that timed out. Fall back to
+            // the threads events have told us about, which is all the proxy
+            // had before. Only in this case: after a successful refresh,
+            // re-adding them would keep a dead worker in the IDE's thread list
+            // for the rest of the session.
+            synchronized (knownThreads) {
+                for (Long t : knownThreads) {
+                    if (!ids.contains(t)) ids.add(t);
+                }
             }
         }
         Collections.sort(ids);
@@ -1779,6 +1816,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
             if (!knownThreads.contains(threadId)) knownThreads.add(threadId);
         }
         lastSuspendedThread = threadId;
+        markSuspended(threadId, true);
         // The thread just paused at a new location — drop any stale cache
         // from a previous suspension and re-fetch.
         invalidateStack();
@@ -1813,6 +1851,8 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
 
     @Override public void onStepComplete(long threadId, int methodId, int line) {
         Integer rid = stepRequests.remove(threadId);
+        lastSuspendedThread = threadId;
+        markSuspended(threadId, true);
         // Drop any cached stack from before the step landed. Without this
         // the IDE's Frames request after STEP_COMPLETE hits the cache and
         // re-uses the BP_HIT stack — Frames panel sticks on the previous
@@ -1848,6 +1888,13 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
             deviceThreads.put(threadIds[i], new ThreadInfo(suspended[i], threadObjects[i]));
         }
         threadNames.keySet().retainAll(deviceThreads.keySet());
+        // The device's list is authoritative whenever it arrives, so a thread
+        // missing from it has died. Pruning here keeps the event-derived set
+        // bounded and stops a dead worker reappearing through the fallback in
+        // currentThreadIds.
+        synchronized (knownThreads) {
+            knownThreads.retainAll(deviceThreads.keySet());
+        }
         synchronized (threadsLock) {
             pendingThreads = false;
             threadsLock.notifyAll();

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
@@ -30,6 +30,7 @@ import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -1915,9 +1916,18 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
     @Override public void onThreads(long[] threadIds, boolean[] suspended, long[] threadObjects) {
         // Rebuild rather than merge: a thread absent from the device's list has
         // died, and keeping it would leave a phantom row in the IDE.
+        // A snapshot can be sampled just before a thread stops and arrive just
+        // after the stop event, which would otherwise report the thread the IDE
+        // has only now stopped at as running. The proxy is the only source of
+        // resumes, so its own belief is authoritative in that direction: a
+        // thread it thinks is suspended stays suspended until it resumes it.
+        // A snapshot may only ever add a suspension, never withdraw one.
+        Map<Long, ThreadInfo> previous = new HashMap<>(deviceThreads);
         deviceThreads.clear();
         for (int i = 0; i < threadIds.length; i++) {
-            deviceThreads.put(threadIds[i], new ThreadInfo(suspended[i], threadObjects[i]));
+            ThreadInfo was = previous.get(threadIds[i]);
+            boolean stillSuspended = suspended[i] || (was != null && was.suspended);
+            deviceThreads.put(threadIds[i], new ThreadInfo(stillSuspended, threadObjects[i]));
         }
         threadNames.keySet().retainAll(deviceThreads.keySet());
         // The device's list is authoritative whenever it arrives, so a thread

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
@@ -29,6 +29,7 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -85,6 +86,14 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
     private static final int TYPE_TAG_INTERFACE = 2;
     private static final int TYPE_TAG_ARRAY = 3;
 
+    /**
+     * Zero-based position of canRequestVMDeathEvent in the CapabilitiesNew
+     * reply: the seven original capabilities, then canRedefineClasses,
+     * canAddMethod, canUnrestrictedlyRedefineClasses, canPopFrames,
+     * canUseInstanceFilters, canGetSourceDebugExtension, and then this one.
+     */
+    private static final int CAP_NEW_REQUEST_VM_DEATH_EVENT = 13;
+
     // SuspendPolicy
     private static final int SP_NONE         = 0;
     private static final int SP_EVENT_THREAD = 1;
@@ -111,6 +120,68 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
     // event can find the JDWP request ID that triggered it.
     private final Map<Long, Integer> stepRequests = new ConcurrentHashMap<>();
     private final List<Long> knownThreads = new ArrayList<>();
+    // Last thread list pulled off the device, keyed by thread id. Threads that
+    // have never raised an event still appear here, which is the whole point:
+    // before CMD_GET_THREADS was implemented the IDE could only ever see
+    // threads that had already hit a breakpoint.
+    private final Map<Long, ThreadInfo> deviceThreads = new ConcurrentHashMap<>();
+    // Resolved java.lang.Thread names, cached because naming a thread costs a
+    // field read plus a string read on the device.
+    private final Map<Long, String> threadNames = new ConcurrentHashMap<>();
+    // ClassPrepare requests the IDE has registered, by request id. IntelliJ and
+    // NetBeans defer any breakpoint they could not resolve to one of these, so
+    // a proxy that accepts the request and never fires leaves those breakpoints
+    // permanently unarmed.
+    private final Map<Integer, ClassPrepareRequest> classPrepareRequests = new ConcurrentHashMap<>();
+
+    /** What the device reports about one thread. Keyed by id in deviceThreads. */
+    private static final class ThreadInfo {
+        final boolean suspended;
+        /** The java.lang.Thread instance, or 0 if the thread has none yet. */
+        final long threadObject;
+        ThreadInfo(boolean suspended, long threadObject) {
+            this.suspended = suspended;
+            this.threadObject = threadObject;
+        }
+    }
+
+    private static final class ClassPrepareRequest {
+        final int requestId;
+        final int suspendPolicy;
+        /** ClassMatch patterns; empty means "every class". */
+        final List<String> includes;
+        /** ClassExclude patterns. */
+        final List<String> excludes;
+        ClassPrepareRequest(int requestId, int suspendPolicy,
+                            List<String> includes, List<String> excludes) {
+            this.requestId = requestId;
+            this.suspendPolicy = suspendPolicy;
+            this.includes = includes;
+            this.excludes = excludes;
+        }
+
+        /**
+         * JDWP class patterns are an exact name or a single leading/trailing
+         * wildcard — "com.example.Main", "com.example.*", "*Main".
+         */
+        private static boolean matches(String pattern, String className) {
+            if (pattern.equals("*")) return true;
+            if (pattern.startsWith("*")) return className.endsWith(pattern.substring(1));
+            if (pattern.endsWith("*")) return className.startsWith(pattern.substring(0, pattern.length() - 1));
+            return pattern.equals(className);
+        }
+
+        boolean accepts(String className) {
+            for (String ex : excludes) {
+                if (matches(ex, className)) return false;
+            }
+            if (includes.isEmpty()) return true;
+            for (String in : includes) {
+                if (matches(in, className)) return true;
+            }
+            return false;
+        }
+    }
     // Synthetic thread group ID. jdb wants a non-null group on every thread.
     private static final long FAKE_GROUP_ID = 0xCAFEL;
     private static final long FAKE_CLASSLOADER_ID = 0;
@@ -275,6 +346,9 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
         // Clear any pending step requests so a stale one from the previous
         // attach can't fire against the new debugger.
         stepRequests.clear();
+        // Same for class-prepare registrations: the next IDE re-registers its
+        // own, and replaying against a closed socket would only log failures.
+        classPrepareRequests.clear();
         // Re-arm VM_START for the next attach.
         vmStartSent = false;
         // Breakpoints stay in bpRequests so the device keeps them set; the
@@ -468,9 +542,10 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 return;
             }
             case 4: { // AllThreads
+                List<Long> ids = currentThreadIds();
                 Buf b = new Buf();
-                b.writeInt(knownThreads.size());
-                for (long tid : knownThreads) b.writeLong(tid);
+                b.writeInt(ids.size());
+                for (long tid : ids) b.writeLong(tid);
                 writeReply(id, 0, b.bytes());
                 return;
             }
@@ -508,10 +583,21 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 writeReply(id, 0, empty());
                 return;
             }
-            case 12: case 17: { // Capabilities / CapabilitiesNew — return all false
+            case 12: case 17: { // Capabilities / CapabilitiesNew
+                // The seven original capabilities are all field watchpoints,
+                // bytecode access and monitor introspection — none of which
+                // ParparVM exposes, so those stay false.
+                //
+                // CapabilitiesNew adds fourteen more. The only one that is
+                // true of this proxy is canRequestVMDeathEvent: the device's
+                // disconnect is turned into a VM_DEATH event. Claiming any of
+                // the others would have the IDE offer redefinition, frame
+                // popping or forced returns and then fail when used.
                 Buf b = new Buf();
                 int n = (cmd == 12) ? 7 : 32;
-                for (int i = 0; i < n; i++) b.writeByte(0);
+                for (int i = 0; i < n; i++) {
+                    b.writeByte(i == CAP_NEW_REQUEST_VM_DEATH_EVENT && cmd == 17 ? 1 : 0);
+                }
                 writeReply(id, 0, b.bytes());
                 return;
             }
@@ -668,11 +754,16 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                     b.writeInt(m.argSlots(false));
                     b.writeInt(m.locals.size());
                     for (SymbolTable.LocalVarInfo v : m.locals) {
-                        // codeIndex=0, length=large => "always live"
-                        b.writeLong(0L);
+                        // ParparVM's "code index" is the source line, so a
+                        // local's scope travels as its declaration line plus
+                        // the number of lines it stays live for. Reporting
+                        // every local as always-live made the IDE ask for
+                        // slots the frame had not reached, which is how a
+                        // variable came to display the previous scope's value.
+                        b.writeLong(v.jdwpCodeIndex());
                         b.writeString(v.name);
                         b.writeString(v.descriptor);
-                        b.writeInt(Integer.MAX_VALUE);
+                        b.writeInt(v.jdwpLength());
                         b.writeInt(v.slot);
                     }
                 }
@@ -687,11 +778,11 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                     b.writeInt(m.argSlots(false));
                     b.writeInt(m.locals.size());
                     for (SymbolTable.LocalVarInfo v : m.locals) {
-                        b.writeLong(0L);
+                        b.writeLong(v.jdwpCodeIndex());
                         b.writeString(v.name);
                         b.writeString(v.descriptor);
                         b.writeString(""); // generic signature
-                        b.writeInt(Integer.MAX_VALUE);
+                        b.writeInt(v.jdwpLength());
                         b.writeInt(v.slot);
                     }
                 }
@@ -804,11 +895,23 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
 
     // -------- Thread / ThreadGroup -----------------------------------------
 
+    /**
+     * Whether the IDE should see this thread as suspended. The device's own
+     * view wins when we have one — the last suspending event only ever knew
+     * about a single thread, so with several parked at once the others used to
+     * be reported as running.
+     */
+    private boolean isSuspended(long tid) {
+        ThreadInfo info = deviceThreads.get(tid);
+        if (info != null) return info.suspended;
+        return tid == lastSuspendedThread;
+    }
+
     private void handleThread(int id, int cmd, byte[] p) throws IOException {
         long tid = readLong(p, 0);
         switch (cmd) {
             case 1: { // Name
-                Buf b = new Buf(); b.writeString("Thread-" + tid); writeReply(id, 0, b.bytes()); return;
+                Buf b = new Buf(); b.writeString(threadName(tid)); writeReply(id, 0, b.bytes()); return;
             }
             case 2: { // Suspend
                 writeReply(id, 0, empty()); return;
@@ -824,7 +927,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 // 1 = SLEEPING, 4 = RUNNING; suspendStatus bit 1 = SUSPENDED
                 Buf b = new Buf();
                 b.writeInt(4); // RUNNING
-                b.writeInt(tid == lastSuspendedThread ? 1 : 0);
+                b.writeInt(isSuspended(tid) ? 1 : 0);
                 writeReply(id, 0, b.bytes()); return;
             }
             case 5: { // ThreadGroup
@@ -863,7 +966,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
             }
             case 12: { // SuspendCount
                 Buf b = new Buf();
-                b.writeInt(tid == lastSuspendedThread ? 1 : 0);
+                b.writeInt(isSuspended(tid) ? 1 : 0);
                 writeReply(id, 0, b.bytes()); return;
             }
             default:
@@ -875,10 +978,11 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
         switch (cmd) {
             case 1: { Buf b = new Buf(); b.writeString("main"); writeReply(id, 0, b.bytes()); return; }
             case 2: { Buf b = new Buf(); b.writeLong(0); writeReply(id, 0, b.bytes()); return; }
-            case 3: {
+            case 3: { // Children — threads then child groups (we have none)
+                List<Long> ids = currentThreadIds();
                 Buf b = new Buf();
-                b.writeInt(knownThreads.size());
-                for (long t : knownThreads) b.writeLong(t);
+                b.writeInt(ids.size());
+                for (long t : ids) b.writeLong(t);
                 b.writeInt(0);
                 writeReply(id, 0, b.bytes()); return;
             }
@@ -1001,6 +1105,8 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 long stepThread = 0;
                 int stepDepth = 0;
                 boolean badModifier = false;
+                List<String> classIncludes = new ArrayList<>();
+                List<String> classExcludes = new ArrayList<>();
                 for (int i = 0; i < modCount && !badModifier; i++) {
                     if (off >= p.length) { badModifier = true; break; }
                     int modKind = p[off] & 0xff; off += 1;
@@ -1035,6 +1141,15 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                             if (off + 4 > p.length) { badModifier = true; break; }
                             int slen = readInt(p, off);
                             if (slen < 0 || off + 4 + slen > p.length) { badModifier = true; break; }
+                            // Retained rather than skipped: a ClassPrepare
+                            // request is nothing but its patterns, and firing
+                            // for every class would flood the IDE.
+                            String pattern = readString(p, off);
+                            if (modKind == 5) {
+                                classIncludes.add(pattern);
+                            } else {
+                                classExcludes.add(pattern);
+                            }
                             off += 4 + slen;
                             break;
                         }
@@ -1088,13 +1203,44 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                     int methodIdInt = fromJdwpRef(methodID);
                     BpRequest br = new BpRequest(rid, classIdInt, methodIdInt, codeIndex, suspendPolicy);
                     bpRequests.put(rid, br);
+                    // Say what was armed and where. A breakpoint the proxy
+                    // cannot resolve to a method used to be accepted in
+                    // silence, so a developer whose breakpoints never fired
+                    // had nothing in the log to go on.
+                    SymbolTable.MethodInfo m = symbols == null ? null : symbols.methodById(methodIdInt);
+                    if (m == null) {
+                        System.err.println("[jdwp] breakpoint rid=" + rid
+                                + " does not resolve to a known method (methodId=" + methodIdInt
+                                + ", line=" + codeIndex + "); it will never fire");
+                    } else {
+                        System.out.println("[jdwp] breakpoint rid=" + rid + " armed at "
+                                + describeMethod(m) + ":" + codeIndex);
+                        if (!m.lines.isEmpty() && !m.lines.contains((int) codeIndex)) {
+                            System.err.println("[jdwp] line " + codeIndex + " is not in "
+                                    + describeMethod(m) + "'s line table "
+                                    + m.lines.first() + ".." + m.lines.last()
+                                    + "; the breakpoint will not fire");
+                        }
+                    }
                     // If the device isn't connected yet, the breakpoint will
                     // be replayed when onHello fires. Either way bpRequests
                     // is the source of truth so the event handler can match
                     // device-emitted BP_HIT events back to a JDWP request id.
                     if (device != null && deviceHelloReceived) try {
                         device.setBreakpoint(methodIdInt, (int) codeIndex);
-                    } catch (IOException io) { /* ignore */ }
+                    } catch (IOException io) {
+                        System.err.println("[jdwp] failed to arm breakpoint rid=" + rid
+                                + " on the device: " + io.getMessage());
+                    }
+                } else if (eventKind == EK_CLASS_PREPARE) {
+                    ClassPrepareRequest cpr = new ClassPrepareRequest(
+                            rid, suspendPolicy, classIncludes, classExcludes);
+                    classPrepareRequests.put(rid, cpr);
+                    // The reply has to reach the IDE before the events do, so
+                    // the already-loaded classes are replayed after it below.
+                    Buf reply = new Buf(); reply.writeInt(rid); writeReply(id, 0, reply.bytes());
+                    replayClassPrepare(cpr);
+                    return;
                 } else if (eventKind == EK_SINGLE_STEP && stepThread != 0) {
                     // depth: 0=INTO, 1=OVER, 2=OUT — same numeric values as
                     // the wire protocol's STEP_INTO/OVER/OUT, so no mapping.
@@ -1119,6 +1265,9 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 if (eventKind == EK_SINGLE_STEP) {
                     stepRequests.entrySet().removeIf(e -> e.getValue() == rid);
                 }
+                if (eventKind == EK_CLASS_PREPARE) {
+                    classPrepareRequests.remove(rid);
+                }
                 writeReply(id, 0, empty());
                 return;
             }
@@ -1135,6 +1284,57 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
             default:
                 writeReply(id, 100, empty());
         }
+    }
+
+    /** "com.example.Main.actionPerformed(Lcom/codename1/ui/events/ActionEvent;)V" */
+    private String describeMethod(SymbolTable.MethodInfo m) {
+        SymbolTable.ClassInfo c = symbols == null ? null : symbols.classById(m.classId);
+        String cls = c != null ? c.jvmName.replace('/', '.') : "?";
+        return cls + "." + m.name + m.descriptor;
+    }
+
+    /**
+     * Fires a ClassPrepare event for every class already in the symbol table
+     * that the request matches.
+     *
+     * ParparVM links its whole class set into the binary, so by the time a
+     * debugger can talk to us every class is "prepared" — there is no later
+     * moment at which to fire. Replaying on registration is therefore the
+     * complete implementation, not an approximation, and it is what makes the
+     * IDE resolve a breakpoint it deferred because the class was not loaded
+     * when the file was first opened.
+     *
+     * Suspend policy is deliberately downgraded to NONE: the app is running
+     * normally at this point, and honouring SUSPEND_ALL here would freeze it
+     * on attach with no event thread to resume.
+     */
+    private void replayClassPrepare(ClassPrepareRequest cpr) {
+        if (symbols == null) return;
+        int fired = 0;
+        for (SymbolTable.ClassInfo c : symbols.allClasses()) {
+            String dotted = c.jvmName.replace('/', '.');
+            if (!cpr.accepts(dotted)) continue;
+            try {
+                Buf b = new Buf();
+                b.writeByte(SP_NONE);
+                b.writeInt(1);
+                b.writeByte(EK_CLASS_PREPARE);
+                b.writeInt(cpr.requestId);
+                b.writeLong(lastSuspendedThread != 0 ? lastSuspendedThread : 1L);
+                b.writeByte(TYPE_TAG_CLASS);
+                b.writeLong(toJdwpRef(c.classId));
+                b.writeString(c.jvmSignature());
+                b.writeInt(7); // VERIFIED|PREPARED|INITIALIZED
+                writeEventCommand(b.bytes());
+                fired++;
+            } catch (IOException e) {
+                System.err.println("[jdwp] failed to send CLASS_PREPARE: " + e.getMessage());
+                return;
+            }
+        }
+        System.out.println("[jdwp] CLASS_PREPARE rid=" + cpr.requestId
+                + " matched " + fired + " class(es)"
+                + (cpr.includes.isEmpty() ? "" : " for " + cpr.includes));
     }
 
     private void handleObject(int id, int cmd, byte[] p) throws IOException {
@@ -1422,6 +1622,87 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
         }
     }
 
+    private final Object threadsLock = new Object();
+    private boolean pendingThreads = false;
+
+    /**
+     * Refreshes {@link #deviceThreads} from the device, blocking briefly for
+     * the reply. Falls back to whatever the last refresh produced (plus the
+     * threads we have seen raise events) so an unresponsive or older device
+     * degrades to the previous behaviour instead of an empty thread list.
+     */
+    private List<Long> currentThreadIds() {
+        if (device != null && deviceHelloReceived) {
+            synchronized (threadsLock) {
+                pendingThreads = true;
+                try {
+                    device.getThreads();
+                    long deadline = System.currentTimeMillis() + 2000;
+                    while (pendingThreads && System.currentTimeMillis() < deadline) {
+                        try { threadsLock.wait(deadline - System.currentTimeMillis()); }
+                        catch (InterruptedException ie) { Thread.currentThread().interrupt(); break; }
+                    }
+                } catch (IOException io) {
+                    pendingThreads = false;
+                }
+            }
+        }
+        List<Long> ids = new ArrayList<>(deviceThreads.keySet());
+        // Union with event-derived ids: a thread that hit a breakpoint must
+        // stay listed even if the device list came back empty.
+        synchronized (knownThreads) {
+            for (Long t : knownThreads) {
+                if (!ids.contains(t)) ids.add(t);
+            }
+        }
+        Collections.sort(ids);
+        return ids;
+    }
+
+    /**
+     * The name the IDE should show for a thread.
+     *
+     * Read off the {@code java.lang.Thread} instance the device reported for
+     * it — its {@code name} field, then that String's contents — so the panel
+     * shows "EDT" and "main" rather than an opaque id. Anything that does not
+     * resolve (no Thread object yet, a device that predates the thread list)
+     * falls back to the synthetic name.
+     */
+    private String threadName(long tid) {
+        String cached = threadNames.get(tid);
+        if (cached != null) return cached;
+        String name = resolveThreadName(tid);
+        if (name == null) return "Thread-" + tid;
+        threadNames.put(tid, name);
+        return name;
+    }
+
+    private String resolveThreadName(long tid) {
+        ThreadInfo info = deviceThreads.get(tid);
+        if (info == null || info.threadObject == 0 || symbols == null) return null;
+        int classId = blockingGetObjectClass(info.threadObject);
+        if (classId < 0) return null;
+        SymbolTable.FieldInfo nameField = null;
+        for (SymbolTable.ClassInfo c = symbols.classById(classId);
+                c != null && nameField == null;
+                c = c.superId >= 0 ? symbols.classById(c.superId) : null) {
+            for (SymbolTable.FieldInfo f : c.instanceFields) {
+                if ("name".equals(f.name) && "Ljava/lang/String;".equals(f.descriptor)) {
+                    nameField = f;
+                    break;
+                }
+            }
+        }
+        if (nameField == null) return null;
+        if (!blockingGetObjectFields(info.threadObject, new int[] { nameField.fieldId })) {
+            return null;
+        }
+        long[] values = lastObjectFieldsValues;
+        if (values == null || values.length < 1 || values[0] == 0) return null;
+        String s = blockingGetString(values[0]);
+        return s == null || s.isEmpty() ? null : s;
+    }
+
     private final Object stringLock = new Object();
     private boolean pendingString = false;
     private String lastString = null;
@@ -1494,7 +1775,9 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
 
     @Override public void onBreakpointHit(long threadId, int methodId, int line) {
         System.out.println("[jdwp] BP_HIT tid=" + threadId + " methodId=" + methodId + " line=" + line);
-        if (!knownThreads.contains(threadId)) knownThreads.add(threadId);
+        synchronized (knownThreads) {
+            if (!knownThreads.contains(threadId)) knownThreads.add(threadId);
+        }
         lastSuspendedThread = threadId;
         // The thread just paused at a new location — drop any stale cache
         // from a previous suspension and re-fetch.
@@ -1554,6 +1837,20 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
             writeEventCommand(b.bytes());
         } catch (IOException e) {
             System.err.println("[jdwp] failed to send step event: " + e.getMessage());
+        }
+    }
+
+    @Override public void onThreads(long[] threadIds, boolean[] suspended, long[] threadObjects) {
+        // Rebuild rather than merge: a thread absent from the device's list has
+        // died, and keeping it would leave a phantom row in the IDE.
+        deviceThreads.clear();
+        for (int i = 0; i < threadIds.length; i++) {
+            deviceThreads.put(threadIds[i], new ThreadInfo(suspended[i], threadObjects[i]));
+        }
+        threadNames.keySet().retainAll(deviceThreads.keySet());
+        synchronized (threadsLock) {
+            pendingThreads = false;
+            threadsLock.notifyAll();
         }
     }
 

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
@@ -158,12 +158,24 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
         final List<String> includes;
         /** ClassExclude patterns. */
         final List<String> excludes;
+        /**
+         * ClassOnly: the single class the request is restricted to, or -1.
+         *
+         * A client may pin a request to one type by reference id rather than
+         * by name pattern. Dropping it left the request with no patterns at
+         * all, which reads as "every class" — so a request for one type
+         * replayed the entire symbol table at the IDE.
+         */
+        final int onlyClassId;
+
         ClassPrepareRequest(int requestId, int suspendPolicy,
-                            List<String> includes, List<String> excludes) {
+                            List<String> includes, List<String> excludes,
+                            int onlyClassId) {
             this.requestId = requestId;
             this.suspendPolicy = suspendPolicy;
             this.includes = includes;
             this.excludes = excludes;
+            this.onlyClassId = onlyClassId;
         }
 
         /**
@@ -177,7 +189,8 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
             return pattern.equals(className);
         }
 
-        boolean accepts(String className) {
+        boolean accepts(int classId, String className) {
+            if (onlyClassId >= 0 && classId != onlyClassId) return false;
             for (String ex : excludes) {
                 if (matches(ex, className)) return false;
             }
@@ -1143,6 +1156,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 boolean badModifier = false;
                 List<String> classIncludes = new ArrayList<>();
                 List<String> classExcludes = new ArrayList<>();
+                int onlyClassId = -1;
                 for (int i = 0; i < modCount && !badModifier; i++) {
                     if (off >= p.length) { badModifier = true; break; }
                     int modKind = p[off] & 0xff; off += 1;
@@ -1171,6 +1185,10 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                         }
                         case 4: { // ClassOnly (refTypeID)
                             if (off + 8 > p.length) { badModifier = true; break; }
+                            // Retained: for a ClassPrepare request this is the
+                            // whole restriction, and dropping it turns a
+                            // one-class request into an all-classes one.
+                            onlyClassId = fromJdwpRef(readLong(p, off));
                             off += 8; break;
                         }
                         case 5: case 6: { // ClassMatch, ClassExclude (string)
@@ -1270,7 +1288,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                     }
                 } else if (eventKind == EK_CLASS_PREPARE) {
                     ClassPrepareRequest cpr = new ClassPrepareRequest(
-                            rid, suspendPolicy, classIncludes, classExcludes);
+                            rid, suspendPolicy, classIncludes, classExcludes, onlyClassId);
                     classPrepareRequests.put(rid, cpr);
                     // The reply has to reach the IDE before the events do, so
                     // the already-loaded classes are replayed after it below.
@@ -1354,7 +1372,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
         int fired = 0;
         for (SymbolTable.ClassInfo c : symbols.allClasses()) {
             String dotted = c.jvmName.replace('/', '.');
-            if (!cpr.accepts(dotted)) continue;
+            if (!cpr.accepts(c.classId, dotted)) continue;
             try {
                 Buf b = new Buf();
                 b.writeByte(SP_NONE);
@@ -1375,7 +1393,8 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
         }
         System.out.println("[jdwp] CLASS_PREPARE rid=" + cpr.requestId
                 + " matched " + fired + " class(es)"
-                + (cpr.includes.isEmpty() ? "" : " for " + cpr.includes));
+                + (cpr.includes.isEmpty() ? "" : " for " + cpr.includes)
+                + (cpr.onlyClassId >= 0 ? " restricted to classId " + cpr.onlyClassId : ""));
     }
 
     private void handleObject(int id, int cmd, byte[] p) throws IOException {

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
@@ -148,7 +148,22 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
     // suspend policy each asked for. The spec's automatic VM-death event
     // carries request id 0; a registered request expects its own id back, and
     // an IDE that gets neither waits for a session end that never arrives.
-    private final Map<Integer, Integer> vmDeathRequests = new ConcurrentHashMap<>();
+    private final Map<Integer, VmDeathRequest> vmDeathRequests = new ConcurrentHashMap<>();
+
+    /** A registered VM_DEATH request: its suspend policy and remaining count. */
+    private static final class VmDeathRequest {
+        final int suspendPolicy;
+        /** Deaths still to be skipped before this request reports one. */
+        final int countRemaining;
+        VmDeathRequest(int suspendPolicy, int countRemaining) {
+            this.suspendPolicy = suspendPolicy;
+            this.countRemaining = countRemaining;
+        }
+        /** Whether this request wants to hear about the death now happening. */
+        boolean firesOnThisDeath() {
+            return countRemaining <= 1;
+        }
+    }
 
     /** What the device reports about one thread. Keyed by id in deviceThreads. */
     private static final class ThreadInfo {
@@ -293,6 +308,33 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
      */
     private static long toJdwpRef(int sidecarId)  { return sidecarId + 1L; }
     private static int  fromJdwpRef(long jdwpId)  { return (int)(jdwpId - 1L); }
+
+    /*
+     * Thread IDs live in their own JDWP namespace, because a debugger is
+     * entitled to ask about a thread ID as an object -- jdb does exactly that
+     * while drawing its thread panel -- and ParparVM's thread IDs are small
+     * integers that are not distinguishable from what else can arrive here.
+     *
+     * Heap references are aligned, so they are even. Tagged ints are not
+     * references at all: ParparVM encodes int v as (v << 1) | 1, so they are
+     * always odd and cover the small values thread IDs use -- Integer 0 is 1,
+     * the same as thread 1. Neither range is safe to share, so thread IDs are
+     * tagged into the top of the space and shifted even: above every pointer
+     * an iOS process can hold, and never odd, so no tagged int can equal one.
+     */
+    private static final long THREAD_ID_TAG = 0x4000000000000000L;
+
+    private static boolean isThreadId(long jdwpId) {
+        return (jdwpId & THREAD_ID_TAG) != 0;
+    }
+
+    private static long toJdwpThread(long deviceThreadId) {
+        return THREAD_ID_TAG | (deviceThreadId << 1);
+    }
+
+    private static long fromJdwpThread(long jdwpId) {
+        return (jdwpId & ~THREAD_ID_TAG) >>> 1;
+    }
 
     /**
      * JDWP method modifier bits. We track only static in the sidecar
@@ -715,7 +757,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 List<Long> ids = currentThreadIds();
                 Buf b = new Buf();
                 b.writeInt(ids.size());
-                for (long tid : ids) b.writeLong(tid);
+                for (long tid : ids) b.writeLong(toJdwpThread(tid));
                 writeReply(id, 0, b.bytes());
                 return;
             }
@@ -1066,7 +1108,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 // refType(8) thread(8) method(8) argCount(4) args[].
                 // Each arg: tag(1) + value(tag-sized). options(4).
                 /* refType */ long classRef = readLong(p, 0);
-                long threadRef = readLong(p, 8);
+                long threadRef = fromJdwpThread(readLong(p, 8));
                 long methodRef = readLong(p, 16);
                 int argCount = readInt(p, 24);
                 int devMid = fromJdwpRef(methodRef);
@@ -1193,7 +1235,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
     }
 
     private void handleThread(int id, int cmd, byte[] p) throws IOException {
-        long tid = readLong(p, 0);
+        long tid = fromJdwpThread(readLong(p, 0));
         switch (cmd) {
             case 1: { // Name
                 Buf b = new Buf(); b.writeString(threadName(tid)); writeReply(id, 0, b.bytes()); return;
@@ -1269,7 +1311,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 List<Long> ids = currentThreadIds();
                 Buf b = new Buf();
                 b.writeInt(ids.size());
-                for (long t : ids) b.writeLong(t);
+                for (long t : ids) b.writeLong(toJdwpThread(t));
                 b.writeInt(0);
                 writeReply(id, 0, b.bytes()); return;
             }
@@ -1281,7 +1323,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
     // -------- StackFrame ----------------------------------------------------
 
     private void handleStackFrame(int id, int cmd, byte[] p) throws IOException {
-        long tid = readLong(p, 0);
+        long tid = fromJdwpThread(readLong(p, 0));
         long frameId = readLong(p, 8);
         int frameIdx = (int)(frameId & 0xFFFFFFFFL);
         switch (cmd) {
@@ -1469,7 +1511,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                         }
                         case 10: { // Step: threadID(8) + size(4) + depth(4) = 16
                             if (off + 16 > p.length) { badModifier = true; break; }
-                            stepThread = readLong(p, off); off += 8;
+                            stepThread = fromJdwpThread(readLong(p, off)); off += 8;
                             /* size */ off += 4;
                             stepDepth = readInt(p, off); off += 4;
                             break;
@@ -1545,7 +1587,11 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                     replayClassPrepare(cpr);
                     return;
                 } else if (eventKind == EK_VM_DEATH) {
-                    vmDeathRequests.put(rid, suspendPolicy);
+                    // Count is honoured here as everywhere else. A VM dies
+                    // once, so a request asking to be told on the second death
+                    // is asking never to be told -- reporting the first anyway
+                    // would have a debugger act on an event it declined.
+                    vmDeathRequests.put(rid, new VmDeathRequest(suspendPolicy, eventCount));
                 } else if (eventKind == EK_SINGLE_STEP && stepThread != 0) {
                     // depth: 0=INTO, 1=OVER, 2=OUT — same numeric values as
                     // the wire protocol's STEP_INTO/OVER/OUT, so no mapping.
@@ -1670,11 +1716,13 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
      * is indistinguishable from a tagged int, which is why every
      * odd-numbered thread displayed as a java.lang.Integer.
      *
-     * Heap references are page-aligned addresses well above the thread-id
-     * range, so there is no ambiguity to resolve here.
+     * Only an ID carrying the thread tag is treated this way, so nothing that
+     * is genuinely a reference -- including a tagged int, which is odd and so
+     * can look exactly like a small thread ID -- is diverted here.
      */
     private long resolveObjectId(long objectId) {
-        ThreadInfo info = deviceThreads.get(objectId);
+        if (!isThreadId(objectId)) return objectId;
+        ThreadInfo info = deviceThreads.get(fromJdwpThread(objectId));
         if (info != null && info.threadObject != 0) {
             return info.threadObject;
         }
@@ -1739,7 +1787,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
             case 6: { // InvokeMethod (instance)
                 // objId(8) thread(8) refType(8) method(8) argCount(4) args[] options(4)
                 long thisObj = objectId;
-                long threadRef = readLong(p, 8);
+                long threadRef = fromJdwpThread(readLong(p, 8));
                 /* refType */ readLong(p, 16);
                 long methodRef = readLong(p, 24);
                 int argCount = readInt(p, 32);
@@ -2155,7 +2203,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
             b.writeInt(1);
             b.writeByte(EK_BREAKPOINT);
             b.writeInt(rid);
-            b.writeLong(threadId);
+            b.writeLong(toJdwpThread(threadId));
             b.writeByte(TYPE_TAG_CLASS);
             b.writeLong(toJdwpRef(classId));
             b.writeLong(toJdwpRef(methodId));
@@ -2186,7 +2234,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
             b.writeInt(1);
             b.writeByte(EK_SINGLE_STEP);
             b.writeInt(rid == null ? 0 : rid);
-            b.writeLong(threadId);
+            b.writeLong(toJdwpThread(threadId));
             b.writeByte(TYPE_TAG_CLASS);
             b.writeLong(toJdwpRef(classId));
             b.writeLong(toJdwpRef(methodId));
@@ -2301,17 +2349,22 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
             // its own id sees the session end. The composite's suspend policy
             // is the strongest any request asked for — matching a lower one
             // would leave a debugger that asked to suspend running on.
-            Map<Integer, Integer> registered = new LinkedHashMap<>(vmDeathRequests);
+            Map<Integer, VmDeathRequest> all = new LinkedHashMap<>(vmDeathRequests);
+            List<Integer> firing = new ArrayList<>();
             int suspendPolicy = SP_NONE;
-            for (int policy : registered.values()) {
-                if (policy > suspendPolicy) suspendPolicy = policy;
+            for (Map.Entry<Integer, VmDeathRequest> e : all.entrySet()) {
+                if (!e.getValue().firesOnThisDeath()) continue;
+                firing.add(e.getKey());
+                if (e.getValue().suspendPolicy > suspendPolicy) {
+                    suspendPolicy = e.getValue().suspendPolicy;
+                }
             }
             Buf b = new Buf();
             b.writeByte(suspendPolicy);
-            b.writeInt(1 + registered.size());
+            b.writeInt(1 + firing.size());
             b.writeByte(EK_VM_DEATH);
             b.writeInt(0);
-            for (int rid : registered.keySet()) {
+            for (int rid : firing) {
                 b.writeByte(EK_VM_DEATH);
                 b.writeInt(rid);
             }

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
@@ -336,12 +336,28 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
      */
     private static final long ARRAY_REF_TAG = 0x2000000000000000L;
 
+    /*
+     * Array depth rides in bits 48-55 of the reference-type ID, clear of both
+     * the tag at bit 61 and the component ID in the low 32. An array's own
+     * runtime class is synthetic and absent from the symbol table, so the
+     * component plus a depth is the only way to name int[][] as anything other
+     * than the Object[] a lone flag reduced every array to.
+     */
+    private static final int ARRAY_DIMS_SHIFT = 48;
+    private static final long ARRAY_DIMS_MASK = 0xFFL;
+    private static final long ARRAY_REF_ID_MASK = 0x0000FFFFFFFFFFFFL;
+
     private static boolean isArrayRef(long jdwpId) {
         return (jdwpId & ARRAY_REF_TAG) != 0;
     }
 
-    private static long toJdwpArrayRef(int componentClassId) {
-        return ARRAY_REF_TAG | toJdwpRef(componentClassId);
+    private static long toJdwpArrayRef(int componentClassId, int dimensions) {
+        long dims = Math.max(1, Math.min(dimensions, (int) ARRAY_DIMS_MASK));
+        return ARRAY_REF_TAG | (dims << ARRAY_DIMS_SHIFT) | toJdwpRef(componentClassId);
+    }
+
+    private static int arrayRefDimensions(long jdwpId) {
+        return (int) ((jdwpId >>> ARRAY_DIMS_SHIFT) & ARRAY_DIMS_MASK);
     }
 
     private static boolean isThreadId(long jdwpId) {
@@ -882,20 +898,25 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
      * <p>An array's is its component's with a {@code [} in front, which is
      * also how a debugger reads the component back out of it.</p>
      */
-    private static String signatureOf(SymbolTable.ClassInfo c, boolean array) {
-        String component = c != null ? c.jvmSignature() : "Ljava/lang/Object;";
-        return array ? "[" + component : component;
+    private static String signatureOf(SymbolTable.ClassInfo c, int arrayDimensions) {
+        StringBuilder sig = new StringBuilder();
+        for (int i = 0; i < arrayDimensions; i++) {
+            sig.append('[');
+        }
+        sig.append(c != null ? c.jvmSignature() : "Ljava/lang/Object;");
+        return sig.toString();
     }
 
     private void handleRefType(int id, int cmd, byte[] p) throws IOException {
         long typeID = readLong(p, 0);
         boolean array = isArrayRef(typeID);
-        SymbolTable.ClassInfo c =
-                symbols.classById(fromJdwpRef(typeID & ~ARRAY_REF_TAG));
+        int arrayDims = array ? arrayRefDimensions(typeID) : 0;
+        SymbolTable.ClassInfo c = symbols.classById(
+                fromJdwpRef(array ? (typeID & ARRAY_REF_ID_MASK) : typeID));
         switch (cmd) {
             case 1: { // Signature
                 Buf b = new Buf();
-                b.writeString(signatureOf(c, array));
+                b.writeString(signatureOf(c, arrayDims));
                 writeReply(id, 0, b.bytes());
                 return;
             }
@@ -917,7 +938,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 // of showing it, taking the rest of that locals listing with
                 // it.
                 Buf b = new Buf();
-                b.writeString(signatureOf(c, array));
+                b.writeString(signatureOf(c, arrayDims));
                 b.writeString("");
                 writeReply(id, 0, b.bytes());
                 return;
@@ -1806,7 +1827,9 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                     b.writeLong(0);
                 } else {
                     b.writeByte(isArr ? TYPE_TAG_ARRAY : TYPE_TAG_CLASS);
-                    b.writeLong(isArr ? toJdwpArrayRef(classId) : toJdwpRef(classId));
+                    int dims;
+                    synchronized (objectClassLock) { dims = lastObjectArrayDims; }
+                    b.writeLong(isArr ? toJdwpArrayRef(classId, dims) : toJdwpRef(classId));
                 }
                 writeReply(id, 0, b.bytes());
                 return;
@@ -2002,6 +2025,8 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
     private boolean pendingObjectClass = false;
     private int lastObjectClass = -1;
     private boolean lastObjectIsArray = false;
+    /** Array depth reported with the last object class; 0 when not an array. */
+    private int lastObjectArrayDims = 0;
 
     private int blockingGetObjectClass(long objectId) {
         if (device == null) return -1;
@@ -2009,6 +2034,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
             pendingObjectClass = true;
             lastObjectClass = -1;
             lastObjectIsArray = false;
+            lastObjectArrayDims = 0;
             try { device.getObjectClass(objectId); } catch (IOException io) { return -1; }
             long deadline = System.currentTimeMillis() + 2000;
             while (pendingObjectClass && System.currentTimeMillis() < deadline) {
@@ -2470,10 +2496,11 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
             stringLock.notifyAll();
         }
     }
-    @Override public void onObjectClass(int classId, boolean isArray) {
+    @Override public void onObjectClass(int classId, boolean isArray, int dimensions) {
         synchronized (objectClassLock) {
             lastObjectClass = classId;
             lastObjectIsArray = isArray;
+            lastObjectArrayDims = dimensions;
             pendingObjectClass = false;
             objectClassLock.notifyAll();
         }

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
@@ -540,7 +540,11 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
             b.writeInt(1);
             b.writeByte(EK_VM_START);
             b.writeInt(0);     // requestID 0 = auto-generated
-            b.writeLong(1);    // dummy thread id; jdb tolerates this
+            // Through the thread namespace like every other thread ID the IDE
+            // is given. Written raw, it would decode to a different thread on
+            // the way back -- and a raw small value is exactly what a tagged
+            // int looks like.
+            b.writeLong(toJdwpThread(1));  // placeholder thread; jdb tolerates it
             writeEventCommand(b.bytes());
         } catch (IOException e) {
             System.err.println("[jdwp] failed to send VM_START: " + e.getMessage());
@@ -1267,6 +1271,13 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
     private int abandonedSnapshots;
 
     /**
+     * Whether the request now being waited on produced a snapshot. Distinct
+     * from {@link #pendingThreads}, which is also cleared when the wait is
+     * abandoned. Guarded by {@link #threadsLock}.
+     */
+    private boolean threadsDelivered;
+
+    /**
      * Epoch at which the thread-list request now in flight was sent, or
      * {@code MAX_VALUE} when none is. With no request outstanding there is
      * nothing for a snapshot to be stale relative to, so it is taken as
@@ -1731,7 +1742,11 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 b.writeInt(1);
                 b.writeByte(EK_CLASS_PREPARE);
                 b.writeInt(cpr.requestId);
-                b.writeLong(lastSuspendedThread != 0 ? lastSuspendedThread : 1L);
+                // Tagged like every other thread ID leaving the proxy. A raw
+                // value here decoded to a different device thread on the way
+                // back -- raw 1 to thread 0 -- and could collide with a tagged
+                // int besides.
+                b.writeLong(toJdwpThread(lastSuspendedThread != 0 ? lastSuspendedThread : 1L));
                 b.writeByte(TYPE_TAG_CLASS);
                 b.writeLong(toJdwpRef(c.classId));
                 b.writeString(c.jvmSignature());
@@ -2077,6 +2092,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
         if (device != null && deviceHelloReceived) {
             synchronized (threadsLock) {
                 pendingThreads = true;
+                threadsDelivered = false;
                 threadsRequestedAt = threadEpoch.incrementAndGet();
                 try {
                     device.getThreads();
@@ -2097,8 +2113,14 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 } catch (IOException io) {
                     pendingThreads = false;
                 }
-                // The reply landed, so deviceThreads is the whole truth.
-                refreshed = !pendingThreads;
+                // Whether a snapshot actually arrived, which is not the same as
+                // the request no longer being outstanding: a timeout and a send
+                // failure both clear that flag while leaving deviceThreads
+                // untouched. Reading the flag meant a device that never answers
+                // -- an older build with no EVT_THREAD_LIST -- looked like a
+                // successful refresh, so the fallback below was skipped and
+                // AllThreads dropped the threads events had already found.
+                refreshed = threadsDelivered;
             }
         }
         List<Long> ids = new ArrayList<>(deviceThreads.keySet());
@@ -2362,6 +2384,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
             knownThreads.retainAll(deviceThreads.keySet());
         }
         synchronized (threadsLock) {
+            threadsDelivered = true;
             pendingThreads = false;
             threadsLock.notifyAll();
         }

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
@@ -128,7 +128,8 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
     // threads that had already hit a breakpoint.
     private final Map<Long, ThreadInfo> deviceThreads = new ConcurrentHashMap<>();
     // Resolved java.lang.Thread names, cached because naming a thread costs a
-    // field read plus a string read on the device.
+    // field read plus a string read on the device. Cleared on every
+    // authoritative thread list so a rename is picked up.
     private final Map<Long, String> threadNames = new ConcurrentHashMap<>();
     // ClassPrepare requests the IDE has registered, by request id. IntelliJ and
     // NetBeans defer any breakpoint they could not resolve to one of these, so
@@ -160,6 +161,16 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
         /** ClassExclude patterns. */
         final List<String> excludes;
         /**
+         * Count: report only the Nth match and then disable the request, or 0
+         * for no limit.
+         *
+         * The spec suppresses the first N-1 times the filter is satisfied and
+         * deletes the request once it reports. Skipping the modifier meant a
+         * counted request fired for every match instead of one, and stayed
+         * armed afterwards.
+         */
+        int countRemaining;
+        /**
          * SourceNameMatch patterns, compared against a class's source file.
          *
          * Every one must match: JDWP modifiers are conjunctive, and the
@@ -185,13 +196,15 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
 
         ClassPrepareRequest(int requestId, int suspendPolicy,
                             List<String> includes, List<String> excludes,
-                            List<String> sourceNames, int onlyClassId) {
+                            List<String> sourceNames, int onlyClassId,
+                            int countRemaining) {
             this.requestId = requestId;
             this.suspendPolicy = suspendPolicy;
             this.includes = includes;
             this.excludes = excludes;
             this.sourceNames = sourceNames;
             this.onlyClassId = onlyClassId;
+            this.countRemaining = countRemaining;
         }
 
         /**
@@ -1197,6 +1210,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 List<String> classExcludes = new ArrayList<>();
                 List<String> sourceNameMatches = new ArrayList<>();
                 int onlyClassId = -1;
+                int eventCount = 0;
                 for (int i = 0; i < modCount && !badModifier; i++) {
                     if (off >= p.length) { badModifier = true; break; }
                     int modKind = p[off] & 0xff; off += 1;
@@ -1213,6 +1227,10 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                     switch (modKind) {
                         case 1: { // Count
                             if (off + 4 > p.length) { badModifier = true; break; }
+                            // Retained: an unlimited request where the client
+                            // asked for one event is the same class of bug as
+                            // the dropped class filters above.
+                            eventCount = readInt(p, off);
                             off += 4; break;
                         }
                         case 2: { // ConditionalExpression (deprecated) — exprID
@@ -1333,7 +1351,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 } else if (eventKind == EK_CLASS_PREPARE) {
                     ClassPrepareRequest cpr = new ClassPrepareRequest(
                             rid, suspendPolicy, classIncludes, classExcludes,
-                            sourceNameMatches, onlyClassId);
+                            sourceNameMatches, onlyClassId, eventCount);
                     classPrepareRequests.put(rid, cpr);
                     // The reply has to reach the IDE before the events do, so
                     // the already-loaded classes are replayed after it below.
@@ -1415,9 +1433,17 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
     private void replayClassPrepare(ClassPrepareRequest cpr) {
         if (symbols == null) return;
         int fired = 0;
+        boolean exhausted = false;
         for (SymbolTable.ClassInfo c : symbols.allClasses()) {
             String dotted = c.jvmName.replace('/', '.');
             if (!cpr.accepts(c.classId, dotted, c.sourceFile, symbols)) continue;
+            if (cpr.countRemaining > 0) {
+                // The spec reports only the Nth satisfaction and then deletes
+                // the request; the first N-1 are swallowed.
+                cpr.countRemaining--;
+                if (cpr.countRemaining > 0) continue;
+                exhausted = true;
+            }
             try {
                 Buf b = new Buf();
                 b.writeByte(SP_NONE);
@@ -1435,6 +1461,10 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 System.err.println("[jdwp] failed to send CLASS_PREPARE: " + e.getMessage());
                 return;
             }
+            if (exhausted) break;
+        }
+        if (exhausted) {
+            classPrepareRequests.remove(cpr.requestId);
         }
         System.out.println("[jdwp] CLASS_PREPARE rid=" + cpr.requestId
                 + " matched " + fired + " class(es)"
@@ -1974,7 +2004,12 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
             boolean stillSuspended = suspended[i] || (was != null && was.suspended);
             deviceThreads.put(threadIds[i], new ThreadInfo(stillSuspended, threadObjects[i]));
         }
-        threadNames.keySet().retainAll(deviceThreads.keySet());
+        // Names are dropped wholesale, not just for threads that died. A live
+        // thread can be renamed -- pools do it per task -- and a name cached
+        // from the first query would otherwise label it wrongly for the rest
+        // of its life. Re-resolved on the next query after each refresh, which
+        // costs a field read and a string read per thread the IDE asks about.
+        threadNames.clear();
         // The device's list is authoritative whenever it arrives, so a thread
         // missing from it has died. Pruning here keeps the event-derived set
         // bounded and stops a dead worker reappearing through the fallback in

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
@@ -160,6 +160,14 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
         /** ClassExclude patterns. */
         final List<String> excludes;
         /**
+         * SourceNameMatch patterns, compared against a class's source file.
+         *
+         * Every one must match: JDWP modifiers are conjunctive, and the
+         * conservative direction here is fewer events rather than more.
+         * Dropped, the request replayed for classes from unrelated files.
+         */
+        final List<String> sourceNames;
+        /**
          * ClassOnly: the single class the request is restricted to, or -1.
          *
          * A client may pin a request to one type by reference id rather than
@@ -171,11 +179,12 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
 
         ClassPrepareRequest(int requestId, int suspendPolicy,
                             List<String> includes, List<String> excludes,
-                            int onlyClassId) {
+                            List<String> sourceNames, int onlyClassId) {
             this.requestId = requestId;
             this.suspendPolicy = suspendPolicy;
             this.includes = includes;
             this.excludes = excludes;
+            this.sourceNames = sourceNames;
             this.onlyClassId = onlyClassId;
         }
 
@@ -190,8 +199,11 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
             return pattern.equals(className);
         }
 
-        boolean accepts(int classId, String className) {
+        boolean accepts(int classId, String className, String sourceFile) {
             if (onlyClassId >= 0 && classId != onlyClassId) return false;
+            for (String sourceName : sourceNames) {
+                if (sourceFile == null || !matches(sourceName, sourceFile)) return false;
+            }
             for (String ex : excludes) {
                 if (matches(ex, className)) return false;
             }
@@ -1157,6 +1169,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 boolean badModifier = false;
                 List<String> classIncludes = new ArrayList<>();
                 List<String> classExcludes = new ArrayList<>();
+                List<String> sourceNameMatches = new ArrayList<>();
                 int onlyClassId = -1;
                 for (int i = 0; i < modCount && !badModifier; i++) {
                     if (off >= p.length) { badModifier = true; break; }
@@ -1239,6 +1252,10 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                             if (off + 4 > p.length) { badModifier = true; break; }
                             int slen = readInt(p, off);
                             if (slen < 0 || off + 4 + slen > p.length) { badModifier = true; break; }
+                            // Retained for the same reason as ClassOnly: a
+                            // ClassPrepare request restricted to one source
+                            // file replayed for every file without it.
+                            sourceNameMatches.add(readString(p, off));
                             off += 4 + slen;
                             break;
                         }
@@ -1289,7 +1306,8 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                     }
                 } else if (eventKind == EK_CLASS_PREPARE) {
                     ClassPrepareRequest cpr = new ClassPrepareRequest(
-                            rid, suspendPolicy, classIncludes, classExcludes, onlyClassId);
+                            rid, suspendPolicy, classIncludes, classExcludes,
+                            sourceNameMatches, onlyClassId);
                     classPrepareRequests.put(rid, cpr);
                     // The reply has to reach the IDE before the events do, so
                     // the already-loaded classes are replayed after it below.
@@ -1373,7 +1391,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
         int fired = 0;
         for (SymbolTable.ClassInfo c : symbols.allClasses()) {
             String dotted = c.jvmName.replace('/', '.');
-            if (!cpr.accepts(c.classId, dotted)) continue;
+            if (!cpr.accepts(c.classId, dotted, c.sourceFile)) continue;
             try {
                 Buf b = new Buf();
                 b.writeByte(SP_NONE);
@@ -1395,7 +1413,8 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
         System.out.println("[jdwp] CLASS_PREPARE rid=" + cpr.requestId
                 + " matched " + fired + " class(es)"
                 + (cpr.includes.isEmpty() ? "" : " for " + cpr.includes)
-                + (cpr.onlyClassId >= 0 ? " restricted to classId " + cpr.onlyClassId : ""));
+                + (cpr.onlyClassId >= 0 ? " restricted to classId " + cpr.onlyClassId : "")
+                + (cpr.sourceNames.isEmpty() ? "" : " in " + cpr.sourceNames));
     }
 
     private void handleObject(int id, int cmd, byte[] p) throws IOException {

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
@@ -30,6 +30,7 @@ import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -133,6 +134,11 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
     // a proxy that accepts the request and never fires leaves those breakpoints
     // permanently unarmed.
     private final Map<Integer, ClassPrepareRequest> classPrepareRequests = new ConcurrentHashMap<>();
+    // VM_DEATH requests the IDE has registered, by request id, with the
+    // suspend policy each asked for. The spec's automatic VM-death event
+    // carries request id 0; a registered request expects its own id back, and
+    // an IDE that gets neither waits for a session end that never arrives.
+    private final Map<Integer, Integer> vmDeathRequests = new ConcurrentHashMap<>();
 
     /** What the device reports about one thread. Keyed by id in deviceThreads. */
     private static final class ThreadInfo {
@@ -346,9 +352,11 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
         // Clear any pending step requests so a stale one from the previous
         // attach can't fire against the new debugger.
         stepRequests.clear();
-        // Same for class-prepare registrations: the next IDE re-registers its
-        // own, and replaying against a closed socket would only log failures.
+        // Same for class-prepare and VM-death registrations: the next IDE
+        // re-registers its own, and replaying against a closed socket would
+        // only log failures.
         classPrepareRequests.clear();
+        vmDeathRequests.clear();
         // Re-arm VM_START for the next attach.
         vmStartSent = false;
         // Breakpoints stay in bpRequests so the device keeps them set; the
@@ -1269,6 +1277,8 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                     Buf reply = new Buf(); reply.writeInt(rid); writeReply(id, 0, reply.bytes());
                     replayClassPrepare(cpr);
                     return;
+                } else if (eventKind == EK_VM_DEATH) {
+                    vmDeathRequests.put(rid, suspendPolicy);
                 } else if (eventKind == EK_SINGLE_STEP && stepThread != 0) {
                     // depth: 0=INTO, 1=OVER, 2=OUT — same numeric values as
                     // the wire protocol's STEP_INTO/OVER/OUT, so no mapping.
@@ -1295,6 +1305,9 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 }
                 if (eventKind == EK_CLASS_PREPARE) {
                     classPrepareRequests.remove(rid);
+                }
+                if (eventKind == EK_VM_DEATH) {
+                    vmDeathRequests.remove(rid);
                 }
                 writeReply(id, 0, empty());
                 return;
@@ -1946,11 +1959,25 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
 
     @Override public void onVmDeath() {
         try {
+            // One composite carrying the spec's automatic event (request id 0)
+            // plus every request the IDE registered, so a debugger waiting on
+            // its own id sees the session end. The composite's suspend policy
+            // is the strongest any request asked for — matching a lower one
+            // would leave a debugger that asked to suspend running on.
+            Map<Integer, Integer> registered = new LinkedHashMap<>(vmDeathRequests);
+            int suspendPolicy = SP_NONE;
+            for (int policy : registered.values()) {
+                if (policy > suspendPolicy) suspendPolicy = policy;
+            }
             Buf b = new Buf();
-            b.writeByte(SP_NONE);
-            b.writeInt(1);
+            b.writeByte(suspendPolicy);
+            b.writeInt(1 + registered.size());
             b.writeByte(EK_VM_DEATH);
             b.writeInt(0);
+            for (int rid : registered.keySet()) {
+                b.writeByte(EK_VM_DEATH);
+                b.writeInt(rid);
+            }
             writeEventCommand(b.bytes());
         } catch (IOException ignore) {}
     }

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Minimum-viable JDWP server. Speaks enough of the protocol that jdb can
@@ -75,8 +76,8 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
     private static final int CS_CLASS_OBJECT_REF    = 17;
     private static final int CS_EVENT               = 64;
 
-    /** JDWP error: the requested debug information was not compiled in. */
-    private static final int ERR_ABSENT_INFORMATION = 101;
+    /** Line number meaning "not known", for a method with no line table. */
+    private static final int LINE_NUMBER_UNKNOWN    = -1;
     /** JDWP error: the command is not supported by this VM. */
     private static final int ERR_NOT_IMPLEMENTED    = 100;
 
@@ -154,9 +155,20 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
         final boolean suspended;
         /** The java.lang.Thread instance, or 0 if the thread has none yet. */
         final long threadObject;
+        /**
+         * Value of {@link #threadEpoch} when this thread was marked suspended.
+         * Says whether a snapshot that omits the thread was sampled before or
+         * after it stopped, which is the difference between a thread that has
+         * died and one that stopped too recently to appear.
+         */
+        final long suspendedAt;
         ThreadInfo(boolean suspended, long threadObject) {
+            this(suspended, threadObject, 0);
+        }
+        ThreadInfo(boolean suspended, long threadObject, long suspendedAt) {
             this.suspended = suspended;
             this.threadObject = threadObject;
+            this.suspendedAt = suspendedAt;
         }
     }
 
@@ -253,11 +265,18 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
             for (String ex : excludes) {
                 if (matches(ex, className)) return false;
             }
-            if (includes.isEmpty()) return true;
+            // Every ClassMatch has to match, not just one. JDWP combines the
+            // modifiers on a request conjunctively -- a request filtered by
+            // both "com.example.*" and "*Test" asks for the test classes in
+            // that package, not for either set. Accepting on the first match
+            // replayed every class satisfying any one of them, which for a
+            // debugger that narrows a broad filter by adding another is the
+            // opposite of what it asked for. The source-name modifiers just
+            // above already read this way.
             for (String in : includes) {
-                if (matches(in, className)) return true;
+                if (!matches(in, className)) return false;
             }
-            return false;
+            return true;
         }
     }
     // Synthetic thread group ID. jdb wants a non-null group on every thread.
@@ -516,20 +535,60 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
         }
     }
 
+    /**
+     * Set by VirtualMachine.HoldEvents, cleared by ReleaseEvents. While held,
+     * events queue in {@link #heldEvents} instead of going out.
+     */
+    private boolean eventsHeld;
+
+    /** Events that arrived while held, in the order they were emitted. */
+    private final List<byte[]> heldEvents = new ArrayList<>();
+
     private void writeEventCommand(byte[] data) throws IOException {
         synchronized (writeLock) {
             // If the IDE has detached between us deciding to emit an event
             // and actually serializing it, out goes null. Swallow rather
             // than NPE'ing the listener thread.
             if (out == null) return;
-            int len = 11 + data.length;
-            out.writeInt(len);
-            out.writeInt(nextRequestId.incrementAndGet());
-            out.writeByte(0x00);
-            out.writeByte(CS_EVENT);
-            out.writeByte(100); // Composite
-            out.write(data);
-            out.flush();
+            if (eventsHeld) {
+                heldEvents.add(data);
+                return;
+            }
+            writeEventLocked(data);
+        }
+    }
+
+    /** Serializes one composite event. Caller holds {@link #writeLock}. */
+    private void writeEventLocked(byte[] data) throws IOException {
+        int len = 11 + data.length;
+        out.writeInt(len);
+        out.writeInt(nextRequestId.incrementAndGet());
+        out.writeByte(0x00);
+        out.writeByte(CS_EVENT);
+        out.writeByte(100); // Composite
+        out.write(data);
+        out.flush();
+    }
+
+    /** VirtualMachine.HoldEvents — queue events rather than sending them. */
+    private void holdEvents() {
+        synchronized (writeLock) {
+            eventsHeld = true;
+        }
+    }
+
+    /** VirtualMachine.ReleaseEvents — send everything held, oldest first. */
+    private void releaseEvents() throws IOException {
+        synchronized (writeLock) {
+            eventsHeld = false;
+            if (out == null) {
+                heldEvents.clear();
+                return;
+            }
+            for (byte[] data : heldEvents) {
+                writeEventLocked(data);
+            }
+            heldEvents.clear();
         }
     }
 
@@ -721,6 +780,20 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 writeReply(id, 0, b.bytes());
                 return;
             }
+            case 15: { // HoldEvents
+                // jdb's event controller holds events around its own bookkeeping
+                // and issues this before anything else. Declining it is the
+                // "Unexpected JDWP Error: 100" that greeted every session on the
+                // very first line, before the developer had typed a command.
+                holdEvents();
+                writeReply(id, 0, empty());
+                return;
+            }
+            case 16: { // ReleaseEvents
+                releaseEvents();
+                writeReply(id, 0, empty());
+                return;
+            }
             default:
                 writeNotImplemented(id, cmd);
         }
@@ -741,6 +814,23 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
             case 2: { // ClassLoader
                 Buf b = new Buf();
                 b.writeLong(FAKE_CLASSLOADER_ID);
+                writeReply(id, 0, b.bytes());
+                return;
+            }
+            case 13: { // SignatureWithGeneric
+                // The same signature plus an empty generic one: the translator
+                // erases generics and keeps no Signature attribute, and the
+                // empty string is how the spec spells "not generic".
+                //
+                // Declining this is not the small omission it looks like.
+                // jdb asks for it while sorting a reference type into its
+                // cache, which it does the first time it renders any array
+                // value -- so printing a frame holding an array threw instead
+                // of showing it, taking the rest of that locals listing with
+                // it.
+                Buf b = new Buf();
+                b.writeString(c != null ? c.jvmSignature() : "Ljava/lang/Object;");
+                b.writeString("");
                 writeReply(id, 0, b.bytes());
                 return;
             }
@@ -853,8 +943,8 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
      */
     private static long frameCodeIndex(SymbolTable.MethodInfo m, int line) {
         if (m == null || m.lines.isEmpty()) {
-            // No table to be consistent with; LineTable reports the absence.
-            return line;
+            // Matches the single unknown-line entry LineTable reports for these.
+            return 0;
         }
         if (m.lines.contains(line)) return line;
         Integer atOrBefore = m.lines.floor(line);
@@ -868,16 +958,25 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
         switch (cmd) {
             case 1: { // LineTable
                 if (m == null || m.lines.isEmpty()) {
-                    // A method we have no lines for has to say so. Answering
-                    // "success, zero entries" instead leaves the debugger
-                    // holding an empty table it still believes is authoritative,
-                    // and the first frame in such a method takes down the whole
-                    // stack view: jdb turns it into
-                    //   InternalError: Location with invalid code index
-                    // out of `where`, killing the session. ABSENT_INFORMATION is
-                    // what the spec reserves for this and every debugger already
-                    // handles it -- the frame just shows no line number.
-                    writeReply(id, ERR_ABSENT_INFORMATION, empty());
+                    // A method with no lines has no answer a debugger accepts.
+                    // Reporting "success, zero entries" leaves it holding an
+                    // authoritative empty table and it fails resolving any
+                    // location in the method; reporting ABSENT_INFORMATION is
+                    // what the spec reserves for this, but jdb has no case for
+                    // that code on this path and turns it into an exception
+                    // just the same. Either way one such frame ends the whole
+                    // stack view rather than losing its own line number.
+                    //
+                    // So the table is never empty: a method we have no lines
+                    // for gets one entry covering code index 0, whose line
+                    // number is the JDWP convention for "unknown". The frame
+                    // then resolves, prints without a usable line, and the
+                    // frames above and below it survive. frameCodeIndex()
+                    // reports 0 for these methods so the two agree.
+                    Buf unknown = new Buf();
+                    unknown.writeLong(0); unknown.writeLong(0); unknown.writeInt(1);
+                    unknown.writeLong(0); unknown.writeInt(LINE_NUMBER_UNKNOWN);
+                    writeReply(id, 0, unknown.bytes());
                     return;
                 }
                 Buf b = new Buf();
@@ -1066,8 +1165,23 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
     private void markSuspended(long tid, boolean suspended) {
         ThreadInfo previous = deviceThreads.get(tid);
         deviceThreads.put(tid, new ThreadInfo(suspended,
-                previous != null ? previous.threadObject : 0));
+                previous != null ? previous.threadObject : 0,
+                suspended ? threadEpoch.incrementAndGet() : 0));
     }
+
+    /**
+     * Ticks once per suspension and once per thread-list request, so the two
+     * can be ordered against each other.
+     */
+    private final AtomicLong threadEpoch = new AtomicLong();
+
+    /**
+     * Epoch at which the thread-list request now in flight was sent, or
+     * {@code MAX_VALUE} when none is. With no request outstanding there is
+     * nothing for a snapshot to be stale relative to, so it is taken as
+     * describing the present and no absent thread is kept.
+     */
+    private volatile long threadsRequestedAt = Long.MAX_VALUE;
 
     /** Every thread is running again after a VM-wide resume. */
     private void markAllResumed() {
@@ -1866,6 +1980,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
         if (device != null && deviceHelloReceived) {
             synchronized (threadsLock) {
                 pendingThreads = true;
+                threadsRequestedAt = threadEpoch.incrementAndGet();
                 try {
                     device.getThreads();
                     long deadline = System.currentTimeMillis() + 2000;
@@ -2097,6 +2212,25 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
             ThreadInfo was = previous.get(threadIds[i]);
             boolean stillSuspended = suspended[i] || (was != null && was.suspended);
             deviceThreads.put(threadIds[i], new ThreadInfo(stillSuspended, threadObjects[i]));
+        }
+        // A thread the snapshot does not mention at all is normally one that
+        // has died -- but not if it stopped after this snapshot was asked for.
+        // A thread that hits a breakpoint while the request is in flight was
+        // sampled before it existed, or before it stopped, and rebuilding from
+        // that reply dropped the very thread the IDE had just been told about.
+        //
+        // Which case it is comes from the ordering, not from the suspension
+        // alone: a thread suspended before the request went out and missing
+        // from the answer really is gone, and keeping it would leave a dead row
+        // in the IDE's thread list for the rest of the session.
+        long requestedAt = threadsRequestedAt;
+        threadsRequestedAt = Long.MAX_VALUE;
+        for (Map.Entry<Long, ThreadInfo> stale : previous.entrySet()) {
+            ThreadInfo was = stale.getValue();
+            if (!deviceThreads.containsKey(stale.getKey())
+                    && was.suspended && was.suspendedAt > requestedAt) {
+                deviceThreads.put(stale.getKey(), was);
+            }
         }
         // Names are dropped wholesale, not just for threads that died. A live
         // thread can be renamed -- pools do it per task -- and a name cached

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
@@ -168,12 +168,18 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
          */
         final List<String> sourceNames;
         /**
-         * ClassOnly: the single class the request is restricted to, or -1.
+         * ClassOnly: the type the request is restricted to, or -1.
          *
          * A client may pin a request to one type by reference id rather than
          * by name pattern. Dropping it left the request with no patterns at
          * all, which reads as "every class" — so a request for one type
          * replayed the entire symbol table at the IDE.
+         *
+         * For class prepare the spec restricts to that type <em>and its
+         * subtypes</em>, so this is matched up the superclass chain rather
+         * than by identity: a client watching preparation beneath a base
+         * class expects the subclasses, which is the whole point of pinning
+         * a base rather than a leaf.
          */
         final int onlyClassId;
 
@@ -199,8 +205,28 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
             return pattern.equals(className);
         }
 
-        boolean accepts(int classId, String className, String sourceFile) {
-            if (onlyClassId >= 0 && classId != onlyClassId) return false;
+        /**
+         * Whether {@code classId} is the pinned type or descends from it.
+         *
+         * Walks superclasses only — the symbol table records a superclass per
+         * class but not its interfaces, so a request pinned to an interface
+         * matches the interface itself and not its implementors. The bound on
+         * the walk guards against a malformed table rather than a real cycle.
+         */
+        private boolean isSelfOrSubtypeOf(int classId, SymbolTable symbols) {
+            int at = classId;
+            for (int hops = 0; at >= 0 && hops < 512; hops++) {
+                if (at == onlyClassId) return true;
+                SymbolTable.ClassInfo c = symbols == null ? null : symbols.classById(at);
+                if (c == null) return false;
+                at = c.superId;
+            }
+            return false;
+        }
+
+        boolean accepts(int classId, String className, String sourceFile,
+                        SymbolTable symbols) {
+            if (onlyClassId >= 0 && !isSelfOrSubtypeOf(classId, symbols)) return false;
             for (String sourceName : sourceNames) {
                 if (sourceFile == null || !matches(sourceName, sourceFile)) return false;
             }
@@ -1391,7 +1417,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
         int fired = 0;
         for (SymbolTable.ClassInfo c : symbols.allClasses()) {
             String dotted = c.jvmName.replace('/', '.');
-            if (!cpr.accepts(c.classId, dotted, c.sourceFile)) continue;
+            if (!cpr.accepts(c.classId, dotted, c.sourceFile, symbols)) continue;
             try {
                 Buf b = new Buf();
                 b.writeByte(SP_NONE);

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
@@ -1819,16 +1819,21 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
         switch (cmd) {
             case 1: { // ReferenceType — get class
                 int classId = blockingGetObjectClass(objectId);
+                // Both under one acquisition: they describe the same reply, and
+                // a second object's answer landing between two reads would pair
+                // one object's array flag with another's depth.
                 boolean isArr;
-                synchronized (objectClassLock) { isArr = lastObjectIsArray; }
+                int dims;
+                synchronized (objectClassLock) {
+                    isArr = lastObjectIsArray;
+                    dims = lastObjectArrayDims;
+                }
                 Buf b = new Buf();
                 if (classId < 0) {
                     b.writeByte(TYPE_TAG_CLASS);
                     b.writeLong(0);
                 } else {
                     b.writeByte(isArr ? TYPE_TAG_ARRAY : TYPE_TAG_CLASS);
-                    int dims;
-                    synchronized (objectClassLock) { dims = lastObjectArrayDims; }
                     b.writeLong(isArr ? toJdwpArrayRef(classId, dims) : toJdwpRef(classId));
                 }
                 writeReply(id, 0, b.bytes());

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
@@ -324,6 +324,26 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
      */
     private static final long THREAD_ID_TAG = 0x4000000000000000L;
 
+    /*
+     * Array reference types get their own IDs, carrying the component class.
+     * The device reports an array by naming its component class and setting a
+     * flag, so without this an array and its component type shared one ID --
+     * and the type the IDE was told was an array then answered with the
+     * component's own signature. A debugger derives the component type by
+     * removing the leading '[', so a signature without one is not merely
+     * wrong: jdb strips the first character regardless and parses the rest,
+     * failing with "Invalid JNI signature character" on whatever it finds.
+     */
+    private static final long ARRAY_REF_TAG = 0x2000000000000000L;
+
+    private static boolean isArrayRef(long jdwpId) {
+        return (jdwpId & ARRAY_REF_TAG) != 0;
+    }
+
+    private static long toJdwpArrayRef(int componentClassId) {
+        return ARRAY_REF_TAG | toJdwpRef(componentClassId);
+    }
+
     private static boolean isThreadId(long jdwpId) {
         return (jdwpId & THREAD_ID_TAG) != 0;
     }
@@ -490,6 +510,15 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
         // only log failures.
         classPrepareRequests.clear();
         vmDeathRequests.clear();
+        // Anything the last IDE held goes with it. A session that detached
+        // between HoldEvents and ReleaseEvents would otherwise leave the hold
+        // in place, so the next attach queued its own VM_START instead of
+        // sending it, and a later release delivered events carrying the
+        // previous IDE's request ids.
+        synchronized (writeLock) {
+            eventsHeld = false;
+            heldEvents.clear();
+        }
         // Re-arm VM_START for the next attach.
         vmStartSent = false;
         // Breakpoints stay in bpRequests so the device keeps them set; the
@@ -843,13 +872,26 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
 
     // -------- ReferenceType -------------------------------------------------
 
+    /**
+     * The JVM signature to report for a reference type, array or not.
+     *
+     * <p>An array's is its component's with a {@code [} in front, which is
+     * also how a debugger reads the component back out of it.</p>
+     */
+    private static String signatureOf(SymbolTable.ClassInfo c, boolean array) {
+        String component = c != null ? c.jvmSignature() : "Ljava/lang/Object;";
+        return array ? "[" + component : component;
+    }
+
     private void handleRefType(int id, int cmd, byte[] p) throws IOException {
         long typeID = readLong(p, 0);
-        SymbolTable.ClassInfo c = symbols.classById(fromJdwpRef(typeID));
+        boolean array = isArrayRef(typeID);
+        SymbolTable.ClassInfo c =
+                symbols.classById(fromJdwpRef(typeID & ~ARRAY_REF_TAG));
         switch (cmd) {
             case 1: { // Signature
                 Buf b = new Buf();
-                b.writeString(c != null ? c.jvmSignature() : "Ljava/lang/Object;");
+                b.writeString(signatureOf(c, array));
                 writeReply(id, 0, b.bytes());
                 return;
             }
@@ -871,7 +913,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 // of showing it, taking the rest of that locals listing with
                 // it.
                 Buf b = new Buf();
-                b.writeString(c != null ? c.jvmSignature() : "Ljava/lang/Object;");
+                b.writeString(signatureOf(c, array));
                 b.writeString("");
                 writeReply(id, 0, b.bytes());
                 return;
@@ -1216,6 +1258,13 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
      * can be ordered against each other.
      */
     private final AtomicLong threadEpoch = new AtomicLong();
+
+    /**
+     * Thread-list replies still owed by requests nobody waits for any more.
+     * Each is discarded on arrival rather than mistaken for the answer to a
+     * later request. Guarded by {@link #threadsLock}.
+     */
+    private int abandonedSnapshots;
 
     /**
      * Epoch at which the thread-list request now in flight was sent, or
@@ -1742,7 +1791,7 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                     b.writeLong(0);
                 } else {
                     b.writeByte(isArr ? TYPE_TAG_ARRAY : TYPE_TAG_CLASS);
-                    b.writeLong(toJdwpRef(classId));
+                    b.writeLong(isArr ? toJdwpArrayRef(classId) : toJdwpRef(classId));
                 }
                 writeReply(id, 0, b.bytes());
                 return;
@@ -2036,6 +2085,15 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                         try { threadsLock.wait(deadline - System.currentTimeMillis()); }
                         catch (InterruptedException ie) { Thread.currentThread().interrupt(); break; }
                     }
+                    if (pendingThreads) {
+                        // Gave up waiting. The device may still answer, and that
+                        // answer describes this request, not whichever one comes
+                        // next -- applying it there would judge a stop against
+                        // the wrong request and rebuild from a list older than
+                        // the one asked for. Counted so it can be discarded.
+                        abandonedSnapshots++;
+                        pendingThreads = false;
+                    }
                 } catch (IOException io) {
                     pendingThreads = false;
                 }
@@ -2246,6 +2304,16 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
     }
 
     @Override public void onThreads(long[] threadIds, boolean[] suspended, long[] threadObjects) {
+        synchronized (threadsLock) {
+            if (abandonedSnapshots > 0) {
+                // Answer to a request that timed out. It describes the thread
+                // list as of that request, so applying it to a later one would
+                // judge suspensions against the wrong epoch and rebuild from a
+                // list older than the one actually asked for.
+                abandonedSnapshots--;
+                return;
+            }
+        }
         // Rebuild rather than merge: a thread absent from the device's list has
         // died, and keeping it would leave a phantom row in the IDE.
         // A snapshot can be sampled just before a thread stops and arrive just

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/JdwpServer.java
@@ -1473,8 +1473,30 @@ public final class JdwpServer implements DeviceConnection.DeviceListener {
                 + (cpr.sourceNames.isEmpty() ? "" : " in " + cpr.sourceNames));
     }
 
+    /**
+     * Maps a JDWP id that is really a thread to the java.lang.Thread behind it.
+     *
+     * ParparVM's thread ids are small integers and this proxy hands them
+     * straight to the IDE as thread ids, so an IDE asking object questions
+     * about a thread — jdb does, to render the Threads panel — arrives here
+     * with 1, 3, 5 rather than a heap address. Passing those to the device as
+     * object pointers is wrong twice over: they address nothing, and an odd one
+     * is indistinguishable from a tagged int, which is why every
+     * odd-numbered thread displayed as a java.lang.Integer.
+     *
+     * Heap references are page-aligned addresses well above the thread-id
+     * range, so there is no ambiguity to resolve here.
+     */
+    private long resolveObjectId(long objectId) {
+        ThreadInfo info = deviceThreads.get(objectId);
+        if (info != null && info.threadObject != 0) {
+            return info.threadObject;
+        }
+        return objectId;
+    }
+
     private void handleObject(int id, int cmd, byte[] p) throws IOException {
-        long objectId = readLong(p, 0);
+        long objectId = resolveObjectId(readLong(p, 0));
         switch (cmd) {
             case 1: { // ReferenceType — get class
                 int classId = blockingGetObjectClass(objectId);

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/LoggingListener.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/LoggingListener.java
@@ -83,8 +83,9 @@ public final class LoggingListener implements DeviceConnection.DeviceListener {
 
     @Override public void onVmDeath() { System.out.println("[event] VM_DEATH"); }
     @Override public void onStringValue(String value) { System.out.println("[event] STRING_VALUE=" + value); }
-    @Override public void onObjectClass(int classId, boolean isArray) {
-        System.out.println("[event] OBJECT_CLASS=" + classId + (isArray ? " (array)" : ""));
+    @Override public void onObjectClass(int classId, boolean isArray, int dimensions) {
+        System.out.println("[event] OBJECT_CLASS=" + classId
+                + (isArray ? " (array, " + dimensions + "d)" : ""));
     }
     @Override public void onObjectFields(byte[] typeCodes, long[] values) {
         System.out.println("[event] OBJECT_FIELDS count=" + typeCodes.length);

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/LoggingListener.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/LoggingListener.java
@@ -56,6 +56,16 @@ public final class LoggingListener implements DeviceConnection.DeviceListener {
         System.out.println("[event] STEP_COMPLETE tid=" + threadId + " " + describeLocation(methodId, line));
     }
 
+    @Override public void onThreads(long[] threadIds, boolean[] suspended, long[] threadObjects) {
+        System.out.println("[event] THREAD_LIST count=" + threadIds.length);
+        for (int i = 0; i < threadIds.length; i++) {
+            System.out.println("        tid=" + threadIds[i]
+                    + (suspended[i] ? " suspended" : " running")
+                    + " threadObj=" + (threadObjects[i] == 0
+                            ? "none" : "ref@0x" + Long.toHexString(threadObjects[i])));
+        }
+    }
+
     @Override public void onStack(long threadId, int[] methodIds, int[] lines) {
         System.out.println("[event] STACK tid=" + threadId + " depth=" + methodIds.length);
         for (int i = 0; i < methodIds.length; i++) {

--- a/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/SymbolTable.java
+++ b/maven/cn1-debug-proxy/src/main/java/com/codename1/debug/proxy/SymbolTable.java
@@ -95,11 +95,35 @@ public final class SymbolTable {
         public final int slot;
         public final String name;
         public final String descriptor;
+        /**
+         * Source lines this local is in scope for, end exclusive. {@code 0}
+         * for {@code startLine} means "always live" (no scope in the class
+         * file, or a local the translator synthesised from a store opcode);
+         * {@code 0} for {@code endLine} means "to the end of the method".
+         */
+        public final int startLine;
+        public final int endLine;
 
-        LocalVarInfo(int slot, String name, String descriptor) {
+        LocalVarInfo(int slot, String name, String descriptor, int startLine, int endLine) {
             this.slot = slot;
             this.name = name;
             this.descriptor = descriptor;
+            this.startLine = startLine;
+            this.endLine = endLine;
+        }
+
+        /** JDWP wants a code index and a length; ParparVM's index is the line. */
+        public long jdwpCodeIndex() {
+            return Math.max(startLine, 0);
+        }
+
+        public int jdwpLength() {
+            if (startLine <= 0 || endLine <= startLine) {
+                // Always-live, or live to the end of the method: an
+                // open-ended length keeps the IDE from hiding the local.
+                return Integer.MAX_VALUE;
+            }
+            return endLine - startLine;
         }
     }
 
@@ -160,6 +184,15 @@ public final class SymbolTable {
      * gzip-inflated by the caller). The proxy no longer reads a local sidecar
      * file — the table travels over the wire via CMD_GET_SYMBOLS.
      */
+    /** A malformed numeric column degrades that field, not the whole table. */
+    private static int parseIntOrZero(String s) {
+        try {
+            return Integer.parseInt(s);
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
     public static SymbolTable load(InputStream in) throws IOException {
         SymbolTable t = new SymbolTable();
         try (BufferedReader r = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
@@ -215,8 +248,15 @@ public final class SymbolTable {
                         if (parts.length < 5) continue;
                         int mid = Integer.parseInt(parts[1]);
                         int slot = Integer.parseInt(parts[2]);
+                        // Columns 6 and 7 are the scope's line range. Tables
+                        // written before scopes were tracked stop at column 5;
+                        // those locals stay always-live.
+                        int startLine = parts.length >= 6 ? parseIntOrZero(parts[5]) : 0;
+                        int endLine = parts.length >= 7 ? parseIntOrZero(parts[6]) : 0;
                         MethodInfo m = t.methodsById.get(mid);
-                        if (m != null) m.locals.add(new LocalVarInfo(slot, parts[3], parts[4]));
+                        if (m != null) {
+                            m.locals.add(new LocalVarInfo(slot, parts[3], parts[4], startLine, endLine));
+                        }
                         break;
                     }
                     case "field": {

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/DeviceConnectionThreadListTest.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/DeviceConnectionThreadListTest.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.debug.proxy;
+
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Decoding of the device's thread-list event.
+ *
+ * The device dials out to the proxy, so these drive a real socket: the test
+ * plays the app, writing framed events at {@link DeviceConnection} and checking
+ * what reaches the listener.
+ */
+public class DeviceConnectionThreadListTest {
+
+    @Test
+    public void aThreadListIsDecodedIntoIdsFlagsAndThreadObjects() throws Exception {
+        Recorder recorder = new Recorder();
+        try (Harness harness = new Harness(recorder)) {
+            harness.write(WireProtocol.EVT_THREAD_LIST, threadList(
+                    new long[] { 1, 42 },
+                    new boolean[] { true, false },
+                    new long[] { 0x1000, 0 }));
+
+            assertTrue("listener should have been called", recorder.threads.await(2, TimeUnit.SECONDS));
+            assertArrayEquals(new long[] { 1, 42 }, recorder.threadIds);
+            assertEquals(Arrays.asList(true, false), asList(recorder.suspended));
+            assertArrayEquals(new long[] { 0x1000, 0 }, recorder.threadObjects);
+        }
+    }
+
+    /** An empty list is a legitimate answer, not a malformed frame. */
+    @Test
+    public void anEmptyThreadListIsDeliveredAsAnEmptyList() throws Exception {
+        Recorder recorder = new Recorder();
+        try (Harness harness = new Harness(recorder)) {
+            harness.write(WireProtocol.EVT_THREAD_LIST,
+                    threadList(new long[0], new boolean[0], new long[0]));
+
+            assertTrue(recorder.threads.await(2, TimeUnit.SECONDS));
+            assertEquals(0, recorder.threadIds.length);
+            assertEquals("an empty list is not an unknown event", 0, recorder.unknownEvents.size());
+        }
+    }
+
+    /**
+     * A frame whose declared count outruns its payload must be reported as
+     * unknown rather than read off the end of the buffer.
+     */
+    @Test
+    public void aTruncatedThreadListIsRejectedInsteadOfOverrunning() throws Exception {
+        Recorder recorder = new Recorder();
+        try (Harness harness = new Harness(recorder)) {
+            ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+            DataOutputStream b = new DataOutputStream(bytes);
+            b.writeInt(9);              // claims nine threads...
+            b.writeLong(1);             // ...and carries most of one
+            harness.write(WireProtocol.EVT_THREAD_LIST, bytes.toByteArray());
+
+            assertTrue(recorder.unknown.await(2, TimeUnit.SECONDS));
+            assertEquals(1, recorder.unknownEvents.size());
+            assertEquals(WireProtocol.EVT_THREAD_LIST, (int) recorder.unknownEvents.get(0));
+            assertEquals("no partial list should have been delivered", 0, recorder.threads.getCount(), 1);
+        }
+    }
+
+    /** A negative count is the same kind of malformed frame. */
+    @Test
+    public void aNegativeThreadCountIsRejected() throws Exception {
+        Recorder recorder = new Recorder();
+        try (Harness harness = new Harness(recorder)) {
+            ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+            DataOutputStream b = new DataOutputStream(bytes);
+            b.writeInt(-1);
+            harness.write(WireProtocol.EVT_THREAD_LIST, bytes.toByteArray());
+
+            assertTrue(recorder.unknown.await(2, TimeUnit.SECONDS));
+            assertEquals(1, recorder.unknownEvents.size());
+        }
+    }
+
+    /** The proxy asks for the list with a payload-free command. */
+    @Test
+    public void getThreadsSendsTheEnumerationCommand() throws Exception {
+        Recorder recorder = new Recorder();
+        try (Harness harness = new Harness(recorder)) {
+            harness.connection.getThreads();
+
+            assertEquals(0, harness.readCommandLength());
+            assertEquals(WireProtocol.CMD_GET_THREADS, harness.readCommandCode());
+        }
+    }
+
+    // ---- helpers -----------------------------------------------------------
+
+    private static byte[] threadList(long[] ids, boolean[] suspended, long[] objects) {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        DataOutputStream b = new DataOutputStream(bytes);
+        try {
+            b.writeInt(ids.length);
+            for (int i = 0; i < ids.length; i++) {
+                b.writeLong(ids[i]);
+                b.writeByte(suspended[i] ? 0x01 : 0x00);
+                b.writeLong(objects[i]);
+            }
+        } catch (IOException impossible) {
+            throw new AssertionError(impossible);
+        }
+        return bytes.toByteArray();
+    }
+
+    private static List<Boolean> asList(boolean[] values) {
+        List<Boolean> out = new ArrayList<>();
+        for (boolean v : values) out.add(v);
+        return out;
+    }
+
+    /** A DeviceConnection with a socket on the other end playing the device. */
+    private static final class Harness implements AutoCloseable {
+        final DeviceConnection connection;
+        private final Socket device;
+        private final DataOutputStream out;
+        private final java.io.DataInputStream in;
+        private final Thread serving;
+
+        private final CountDownLatch ready = new CountDownLatch(1);
+
+        Harness(DeviceConnection.DeviceListener listener) throws Exception {
+            int port;
+            try (ServerSocket probe = new ServerSocket(0)) {
+                port = probe.getLocalPort();
+            }
+            connection = new DeviceConnection(port, new ReadyGate(listener, ready));
+            serving = new Thread(() -> {
+                try {
+                    connection.acceptAndServe();
+                } catch (Exception e) {
+                    // Closing the socket at the end of a test is the normal exit.
+                }
+            }, "device-connection-test");
+            serving.setDaemon(true);
+            serving.start();
+
+            Socket connected = null;
+            for (int i = 0; i < 50 && connected == null; i++) {
+                try {
+                    connected = new Socket("127.0.0.1", port);
+                } catch (IOException retry) {
+                    Thread.sleep(20);
+                }
+            }
+            if (connected == null) {
+                throw new IllegalStateException("device could not dial in to the proxy");
+            }
+            device = connected;
+            device.setSoTimeout(2000);
+            out = new DataOutputStream(device.getOutputStream());
+            in = new java.io.DataInputStream(device.getInputStream());
+
+            // Connecting the socket is not enough: the proxy assigns its
+            // streams after accept returns, and sending a command before that
+            // fails with "device not connected". A round-trip through the read
+            // loop proves both ends are up.
+            write(WireProtocol.EVT_REPLY_STATUS, new byte[0]);
+            if (!ready.await(5, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("the proxy never started reading from the device");
+            }
+        }
+
+        void write(int code, byte[] payload) throws IOException {
+            out.writeInt(payload.length);
+            out.writeByte(code);
+            out.write(payload);
+            out.flush();
+        }
+
+        int readCommandLength() throws IOException {
+            return in.readInt();
+        }
+
+        int readCommandCode() throws IOException {
+            return in.readUnsignedByte();
+        }
+
+        @Override public void close() {
+            try { device.close(); } catch (IOException ignore) {}
+            connection.close();
+        }
+    }
+
+    /**
+     * Passes everything through, and signals the first REPLY_STATUS so the
+     * harness knows the proxy's read loop is running.
+     */
+    private static final class ReadyGate extends NoOpDeviceListener {
+        private final DeviceConnection.DeviceListener delegate;
+        private final CountDownLatch ready;
+
+        ReadyGate(DeviceConnection.DeviceListener delegate, CountDownLatch ready) {
+            this.delegate = delegate;
+            this.ready = ready;
+        }
+
+        @Override public void onThreads(long[] ids, boolean[] suspended, long[] objects) {
+            delegate.onThreads(ids, suspended, objects);
+        }
+
+        @Override public void onUnknownEvent(int code, byte[] payload) {
+            delegate.onUnknownEvent(code, payload);
+        }
+
+        @Override public void onReplyStatus() {
+            ready.countDown();
+            delegate.onReplyStatus();
+        }
+    }
+
+    /** Captures the one callback each test cares about. */
+    private static final class Recorder extends NoOpDeviceListener {
+        final CountDownLatch threads = new CountDownLatch(1);
+        final CountDownLatch unknown = new CountDownLatch(1);
+        final List<Integer> unknownEvents = new ArrayList<>();
+        volatile long[] threadIds = new long[0];
+        volatile boolean[] suspended = new boolean[0];
+        volatile long[] threadObjects = new long[0];
+
+        @Override public void onThreads(long[] ids, boolean[] suspendedFlags, long[] objects) {
+            this.threadIds = ids;
+            this.suspended = suspendedFlags;
+            this.threadObjects = objects;
+            threads.countDown();
+        }
+
+        @Override public void onUnknownEvent(int code, byte[] payload) {
+            unknownEvents.add(code);
+            unknown.countDown();
+        }
+    }
+}

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpClassPrepareTest.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpClassPrepareTest.java
@@ -258,6 +258,51 @@ public class JdwpClassPrepareTest {
         }
     }
 
+    /**
+     * A Count modifier reports only the Nth match, then the request is gone.
+     *
+     * <p>The spec swallows the first N-1 satisfactions and deletes the request
+     * once it reports. Skipping the modifier meant a client asking for one
+     * event got one per matching class, and the request stayed armed.</p>
+     */
+    @Test
+    public void aCountModifierReportsOnlyTheNthMatch() throws Exception {
+        try (Fixture f = new Fixture()) {
+            JdwpTestClient.Reply reply = f.client.send(JdwpTestClient.CS_EVENT_REQUEST, 1,
+                    JdwpTestClient.classPrepareRequest(0, new String[] { "com.example.*" },
+                            new String[0], -1L, new String[0], 2));
+            assertEquals(0, reply.errorCode);
+            int rid = reply.stream().readInt();
+
+            assertEquals("exactly one event, for the second match",
+                    1, f.preparedSignatures(rid).size());
+        }
+    }
+
+    /** A count of one reports the first match and no more. */
+    @Test
+    public void aCountOfOneReportsTheFirstMatchOnly() throws Exception {
+        try (Fixture f = new Fixture()) {
+            JdwpTestClient.Reply reply = f.client.send(JdwpTestClient.CS_EVENT_REQUEST, 1,
+                    JdwpTestClient.classPrepareRequest(0, new String[] { "com.example.*" },
+                            new String[0], -1L, new String[0], 1));
+            assertEquals(0, reply.errorCode);
+            int rid = reply.stream().readInt();
+
+            assertEquals(1, f.preparedSignatures(rid).size());
+        }
+    }
+
+    /** Without one, every match still fires. */
+    @Test
+    public void withoutACountEveryMatchFires() throws Exception {
+        try (Fixture f = new Fixture()) {
+            int rid = f.registerClassPrepare(new String[] { "com.example.*" }, new String[0]);
+
+            assertEquals(4, f.preparedSignatures(rid).size());
+        }
+    }
+
     // ---- fixture -----------------------------------------------------------
 
     private static final class Fixture implements AutoCloseable {

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpClassPrepareTest.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpClassPrepareTest.java
@@ -54,7 +54,8 @@ public class JdwpClassPrepareTest {
             "version\t1\n"
           + "class\t0\tcom_example_Main\tMain.java\t-1\tcom/example/Main\n"
           + "class\t1\tcom_example_Main_1\tMain.java\t-1\tcom/example/Main$1\n"
-          + "class\t2\tjava_lang_String\tString.java\t-1\tjava/lang/String\n";
+          + "class\t2\tjava_lang_String\tString.java\t-1\tjava/lang/String\n"
+          + "class\t3\tcom_example_Other\tOther.java\t-1\tcom/example/Other\n";
 
     @Test
     public void aMatchingPatternFiresForEveryClassItCovers() throws Exception {
@@ -62,7 +63,8 @@ public class JdwpClassPrepareTest {
             int rid = f.registerClassPrepare(new String[] { "com.example.*" }, new String[0]);
 
             List<String> prepared = f.preparedSignatures(rid);
-            assertEquals(Arrays.asList("Lcom/example/Main$1;", "Lcom/example/Main;"), prepared);
+            assertEquals(Arrays.asList("Lcom/example/Main$1;", "Lcom/example/Main;",
+                            "Lcom/example/Other;"), prepared);
         }
     }
 
@@ -87,7 +89,8 @@ public class JdwpClassPrepareTest {
         try (Fixture f = new Fixture()) {
             int rid = f.registerClassPrepare(new String[0], new String[] { "java.*" });
 
-            assertEquals(Arrays.asList("Lcom/example/Main$1;", "Lcom/example/Main;"),
+            assertEquals(Arrays.asList("Lcom/example/Main$1;", "Lcom/example/Main;",
+                            "Lcom/example/Other;"),
                     f.preparedSignatures(rid));
         }
     }
@@ -192,6 +195,27 @@ public class JdwpClassPrepareTest {
 
             assertTrue("a pattern that excludes the pinned class yields nothing",
                     f.preparedSignatures(rid).isEmpty());
+        }
+    }
+
+    /**
+     * A request restricted to one source file fires only for that file.
+     *
+     * <p>The modifier was parsed for its width and discarded, so a request
+     * carrying it replayed for every class the name patterns allowed —
+     * including classes from unrelated files.</p>
+     */
+    @Test
+    public void aSourceNameRestrictionIsHonoured() throws Exception {
+        try (Fixture f = new Fixture()) {
+            JdwpTestClient.Reply reply = f.client.send(JdwpTestClient.CS_EVENT_REQUEST, 1,
+                    JdwpTestClient.classPrepareRequest(0, new String[] { "com.example.*" },
+                            new String[0], -1L, new String[] { "Other.java" }));
+            assertEquals(0, reply.errorCode);
+            int rid = reply.stream().readInt();
+
+            assertEquals(Collections.singletonList("Lcom/example/Other;"),
+                    f.preparedSignatures(rid));
         }
     }
 

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpClassPrepareTest.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpClassPrepareTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.debug.proxy;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * A registered ClassPrepare request has to actually fire.
+ *
+ * <p>IntelliJ and NetBeans do not resolve a line breakpoint against the class
+ * list alone: any breakpoint whose class they have not seen prepared is
+ * deferred to a ClassPrepare event. The proxy accepted those requests, handed
+ * back a request id and then never sent anything, so the deferred breakpoints
+ * stayed unarmed forever — the "breakpoint in a listener never stops" half of
+ * issue #5333.</p>
+ *
+ * <p>ParparVM links its whole class set into the binary, so every class is
+ * prepared before a debugger can connect. Replaying the matching classes at
+ * registration is therefore the complete answer, not an approximation.</p>
+ */
+public class JdwpClassPrepareTest {
+
+    private static final String TABLE =
+            "version\t1\n"
+          + "class\t0\tcom_example_Main\tMain.java\t-1\tcom/example/Main\n"
+          + "class\t1\tcom_example_Main_1\tMain.java\t-1\tcom/example/Main$1\n"
+          + "class\t2\tjava_lang_String\tString.java\t-1\tjava/lang/String\n";
+
+    @Test
+    public void aMatchingPatternFiresForEveryClassItCovers() throws Exception {
+        try (Fixture f = new Fixture()) {
+            int rid = f.registerClassPrepare(new String[] { "com.example.*" }, new String[0]);
+
+            List<String> prepared = f.preparedSignatures(rid);
+            assertEquals(Arrays.asList("Lcom/example/Main$1;", "Lcom/example/Main;"), prepared);
+        }
+    }
+
+    /**
+     * The inner class is the one that matters here: a listener body compiles
+     * into {@code Main$1}, and that is exactly the class an IDE has not seen
+     * when the file is first opened.
+     */
+    @Test
+    public void anExactPatternFiresOnlyForThatClass() throws Exception {
+        try (Fixture f = new Fixture()) {
+            int rid = f.registerClassPrepare(new String[] { "com.example.Main$1" }, new String[0]);
+
+            assertEquals(Collections.singletonList("Lcom/example/Main$1;"),
+                    f.preparedSignatures(rid));
+        }
+    }
+
+    /** IntelliJ attaches java.* excludes to nearly every request it makes. */
+    @Test
+    public void anExcludePatternSuppressesItsClasses() throws Exception {
+        try (Fixture f = new Fixture()) {
+            int rid = f.registerClassPrepare(new String[0], new String[] { "java.*" });
+
+            assertEquals(Arrays.asList("Lcom/example/Main$1;", "Lcom/example/Main;"),
+                    f.preparedSignatures(rid));
+        }
+    }
+
+    /** A leading wildcard matches on the tail of the name. */
+    @Test
+    public void aLeadingWildcardMatchesTheEndOfTheName() throws Exception {
+        try (Fixture f = new Fixture()) {
+            int rid = f.registerClassPrepare(new String[] { "*.String" }, new String[0]);
+
+            assertEquals(Collections.singletonList("Ljava/lang/String;"),
+                    f.preparedSignatures(rid));
+        }
+    }
+
+    /**
+     * The events must not freeze the app. The IDE typically asks for
+     * SUSPEND_ALL, but at registration time nothing is stopped and there is no
+     * event thread to resume — honouring it would wedge the session on attach.
+     */
+    @Test
+    public void replayedEventsDoNotSuspendTheApplication() throws Exception {
+        try (Fixture f = new Fixture()) {
+            int rid = f.registerClassPrepare(2 /* SUSPEND_ALL */,
+                    new String[] { "com.example.*" }, new String[0]);
+
+            List<JdwpTestClient.Event> events = f.eventsFor(rid);
+            assertTrue("expected the replay to produce events", !events.isEmpty());
+            for (JdwpTestClient.Event e : events) {
+                assertEquals("replayed ClassPrepare must not suspend", 0, e.suspendPolicy);
+            }
+        }
+    }
+
+    /** A cleared request stops matching; re-registering starts it again. */
+    @Test
+    public void clearingARequestIsAcceptedAndReRegistrationFiresAgain() throws Exception {
+        try (Fixture f = new Fixture()) {
+            int rid = f.registerClassPrepare(new String[] { "com.example.Main" }, new String[0]);
+            assertEquals(1, f.preparedSignatures(rid).size());
+
+            byte[] clear = new byte[5];
+            clear[0] = JdwpTestClient.EK_CLASS_PREPARE;
+            clear[1] = (byte) (rid >>> 24);
+            clear[2] = (byte) (rid >>> 16);
+            clear[3] = (byte) (rid >>> 8);
+            clear[4] = (byte) rid;
+            assertEquals(0, f.client.send(JdwpTestClient.CS_EVENT_REQUEST, 2, clear).errorCode);
+
+            int second = f.registerClassPrepare(new String[] { "com.example.Main" }, new String[0]);
+            assertEquals(Collections.singletonList("Lcom/example/Main;"),
+                    f.preparedSignatures(second));
+        }
+    }
+
+    /** A breakpoint request must keep working alongside class-prepare handling. */
+    @Test
+    public void breakpointRequestsStillGetTheirOwnRequestId() throws Exception {
+        try (Fixture f = new Fixture()) {
+            // classId 0 / methodId 0 arrive as 1 — the proxy shifts both by one
+            // at the JDWP boundary so that id 0 stays reserved for "null".
+            byte[] set = JdwpTestClient.lineBreakpointRequest(1L, 1L, 12L);
+
+            JdwpTestClient.Reply reply = f.client.send(JdwpTestClient.CS_EVENT_REQUEST, 1, set);
+            assertEquals(0, reply.errorCode);
+            assertTrue("a breakpoint request should get a non-zero id",
+                    reply.stream().readInt() > 0);
+        }
+    }
+
+    // ---- fixture -----------------------------------------------------------
+
+    private static final class Fixture implements AutoCloseable {
+        final JdwpServer server;
+        final JdwpTestClient client;
+
+        Fixture() throws Exception {
+            int port = JdwpTestClient.freePort();
+            server = new JdwpServer(port);
+            client = JdwpTestClient.attach(server, port);
+            // Unblock the wait-for-symbols gate; no device is attached, which
+            // keeps these tests to the JDWP side of the proxy.
+            server.onSymbols(SymbolTable.load(new ByteArrayInputStream(
+                    TABLE.getBytes(StandardCharsets.UTF_8))));
+            server.onHello(1);
+        }
+
+        int registerClassPrepare(String[] includes, String[] excludes) throws Exception {
+            return registerClassPrepare(0, includes, excludes);
+        }
+
+        int registerClassPrepare(int suspendPolicy, String[] includes, String[] excludes)
+                throws Exception {
+            JdwpTestClient.Reply reply = client.send(JdwpTestClient.CS_EVENT_REQUEST, 1,
+                    JdwpTestClient.classPrepareRequest(suspendPolicy, includes, excludes));
+            assertEquals(0, reply.errorCode);
+            return reply.stream().readInt();
+        }
+
+        List<JdwpTestClient.Event> eventsFor(int requestId) throws Exception {
+            List<JdwpTestClient.Event> matching = new ArrayList<>();
+            for (JdwpTestClient.Event e : client.drainEvents()) {
+                if (e.eventKind == JdwpTestClient.EK_CLASS_PREPARE && e.requestId == requestId) {
+                    matching.add(e);
+                }
+            }
+            return matching;
+        }
+
+        /** Signatures of the classes prepared for a request, sorted for stability. */
+        List<String> preparedSignatures(int requestId) throws Exception {
+            List<String> signatures = new ArrayList<>();
+            for (JdwpTestClient.Event e : eventsFor(requestId)) {
+                signatures.add(e.classPrepareSignature());
+            }
+            Collections.sort(signatures);
+            return signatures;
+        }
+
+        @Override public void close() {
+            client.close();
+        }
+    }
+}

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpClassPrepareTest.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpClassPrepareTest.java
@@ -55,7 +55,9 @@ public class JdwpClassPrepareTest {
           + "class\t0\tcom_example_Main\tMain.java\t-1\tcom/example/Main\n"
           + "class\t1\tcom_example_Main_1\tMain.java\t-1\tcom/example/Main$1\n"
           + "class\t2\tjava_lang_String\tString.java\t-1\tjava/lang/String\n"
-          + "class\t3\tcom_example_Other\tOther.java\t-1\tcom/example/Other\n";
+          + "class\t3\tcom_example_Other\tOther.java\t-1\tcom/example/Other\n"
+          // Derived extends Main, so ClassOnly on Main must reach it.
+          + "class\t4\tcom_example_Derived\tDerived.java\t0\tcom/example/Derived\n";
 
     @Test
     public void aMatchingPatternFiresForEveryClassItCovers() throws Exception {
@@ -63,8 +65,8 @@ public class JdwpClassPrepareTest {
             int rid = f.registerClassPrepare(new String[] { "com.example.*" }, new String[0]);
 
             List<String> prepared = f.preparedSignatures(rid);
-            assertEquals(Arrays.asList("Lcom/example/Main$1;", "Lcom/example/Main;",
-                            "Lcom/example/Other;"), prepared);
+            assertEquals(Arrays.asList("Lcom/example/Derived;", "Lcom/example/Main$1;",
+                            "Lcom/example/Main;", "Lcom/example/Other;"), prepared);
         }
     }
 
@@ -89,8 +91,8 @@ public class JdwpClassPrepareTest {
         try (Fixture f = new Fixture()) {
             int rid = f.registerClassPrepare(new String[0], new String[] { "java.*" });
 
-            assertEquals(Arrays.asList("Lcom/example/Main$1;", "Lcom/example/Main;",
-                            "Lcom/example/Other;"),
+            assertEquals(Arrays.asList("Lcom/example/Derived;", "Lcom/example/Main$1;",
+                            "Lcom/example/Main;", "Lcom/example/Other;"),
                     f.preparedSignatures(rid));
         }
     }
@@ -158,6 +160,43 @@ public class JdwpClassPrepareTest {
             assertEquals(0, reply.errorCode);
             assertTrue("a breakpoint request should get a non-zero id",
                     reply.stream().readInt() > 0);
+        }
+    }
+
+    /**
+     * ClassOnly on a base type reaches its subclasses.
+     *
+     * <p>For class prepare the spec restricts to the given type <em>and its
+     * subtypes</em>. Comparing ids for identity meant a client watching
+     * preparation beneath a base class never saw the subclasses, which is the
+     * reason to pin a base rather than a leaf in the first place.</p>
+     */
+    @Test
+    public void aClassOnlyRestrictionReachesSubtypes() throws Exception {
+        try (Fixture f = new Fixture()) {
+            // classId 0 (Main) arrives as JDWP reference id 1; Derived extends it.
+            JdwpTestClient.Reply reply = f.client.send(JdwpTestClient.CS_EVENT_REQUEST, 1,
+                    JdwpTestClient.classPrepareRequest(0, new String[0], new String[0], 1L));
+            assertEquals(0, reply.errorCode);
+            int rid = reply.stream().readInt();
+
+            assertEquals(Arrays.asList("Lcom/example/Derived;", "Lcom/example/Main;"),
+                    f.preparedSignatures(rid));
+        }
+    }
+
+    /** A leaf type still matches only itself. */
+    @Test
+    public void aClassOnlyRestrictionOnALeafMatchesOnlyIt() throws Exception {
+        try (Fixture f = new Fixture()) {
+            // classId 3 (Other) arrives as reference id 4; nothing extends it.
+            JdwpTestClient.Reply reply = f.client.send(JdwpTestClient.CS_EVENT_REQUEST, 1,
+                    JdwpTestClient.classPrepareRequest(0, new String[0], new String[0], 4L));
+            assertEquals(0, reply.errorCode);
+            int rid = reply.stream().readInt();
+
+            assertEquals(Collections.singletonList("Lcom/example/Other;"),
+                    f.preparedSignatures(rid));
         }
     }
 

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpClassPrepareTest.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpClassPrepareTest.java
@@ -158,6 +158,43 @@ public class JdwpClassPrepareTest {
         }
     }
 
+    /**
+     * A request pinned to one type by ClassOnly fires only for that type.
+     *
+     * <p>The modifier was parsed for its width and discarded, so a request
+     * carrying it and no name pattern was left with nothing to match on —
+     * which reads as "every class". A client asking about one type got a
+     * prepare event for the whole symbol table.</p>
+     */
+    @Test
+    public void aClassOnlyRestrictionIsHonoured() throws Exception {
+        try (Fixture f = new Fixture()) {
+            // classId 1 (Main$1) arrives as JDWP reference id 2.
+            JdwpTestClient.Reply reply = f.client.send(JdwpTestClient.CS_EVENT_REQUEST, 1,
+                    JdwpTestClient.classPrepareRequest(0, new String[0], new String[0], 2L));
+            assertEquals(0, reply.errorCode);
+            int rid = reply.stream().readInt();
+
+            assertEquals(Collections.singletonList("Lcom/example/Main$1;"),
+                    f.preparedSignatures(rid));
+        }
+    }
+
+    /** ClassOnly and a pattern together intersect rather than either winning. */
+    @Test
+    public void aClassOnlyRestrictionCombinesWithAPattern() throws Exception {
+        try (Fixture f = new Fixture()) {
+            JdwpTestClient.Reply reply = f.client.send(JdwpTestClient.CS_EVENT_REQUEST, 1,
+                    JdwpTestClient.classPrepareRequest(0, new String[] { "java.*" },
+                            new String[0], 2L));
+            assertEquals(0, reply.errorCode);
+            int rid = reply.stream().readInt();
+
+            assertTrue("a pattern that excludes the pinned class yields nothing",
+                    f.preparedSignatures(rid).isEmpty());
+        }
+    }
+
     // ---- fixture -----------------------------------------------------------
 
     private static final class Fixture implements AutoCloseable {

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpEventHoldTest.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpEventHoldTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.debug.proxy;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * The debugger can hold events and get them all back when it releases them.
+ *
+ * <p>{@code HoldEvents} and {@code ReleaseEvents} are how a debugger keeps
+ * events from arriving while it updates its own view of the VM. jdb's event
+ * controller issues {@code HoldEvents} before anything else, so declining it
+ * put {@code Unexpected JDWP Error: 100} on the first line of every session,
+ * before the developer had typed a command — with nothing naming the command
+ * that failed.</p>
+ */
+public class JdwpEventHoldTest {
+
+    private static final String TABLE =
+            "version\t1\n"
+          + "class\t0\tcom_example_Main\tMain.java\t-1\tcom/example/Main\n"
+          + "method\t0\t0\thandler\t()V\t0\n";
+
+    private static final int VM_HOLD_EVENTS = 15;
+    private static final int VM_RELEASE_EVENTS = 16;
+    private static final int EK_VM_DEATH = 99;
+
+    /** Both commands are accepted rather than declined. */
+    @Test
+    public void holdAndReleaseAreAccepted() throws Exception {
+        int port = JdwpTestClient.freePort();
+        JdwpServer server = new JdwpServer(port);
+        try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
+            primeSymbols(server);
+
+            assertEquals("HoldEvents", 0,
+                    client.send(JdwpTestClient.CS_VIRTUAL_MACHINE, VM_HOLD_EVENTS, new byte[0]).errorCode);
+            assertEquals("ReleaseEvents", 0,
+                    client.send(JdwpTestClient.CS_VIRTUAL_MACHINE, VM_RELEASE_EVENTS, new byte[0]).errorCode);
+        }
+    }
+
+    /** While held, an event does not reach the debugger. */
+    @Test
+    public void anEventRaisedWhileHeldDoesNotArriveYet() throws Exception {
+        int port = JdwpTestClient.freePort();
+        JdwpServer server = new JdwpServer(port);
+        try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
+            primeSymbols(server);
+            client.send(JdwpTestClient.CS_VIRTUAL_MACHINE, VM_HOLD_EVENTS, new byte[0]);
+
+            server.onVmDeath();
+
+            assertEquals("nothing should arrive while events are held",
+                    0, countVmDeaths(client.drainEvents()));
+        }
+    }
+
+    /** Releasing delivers what was held rather than dropping it. */
+    @Test
+    public void releasingDeliversTheEventsThatWereHeld() throws Exception {
+        int port = JdwpTestClient.freePort();
+        JdwpServer server = new JdwpServer(port);
+        try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
+            primeSymbols(server);
+            client.send(JdwpTestClient.CS_VIRTUAL_MACHINE, VM_HOLD_EVENTS, new byte[0]);
+            server.onVmDeath();
+            client.drainEvents();  // confirm nothing yet; held
+
+            client.send(JdwpTestClient.CS_VIRTUAL_MACHINE, VM_RELEASE_EVENTS, new byte[0]);
+
+            assertTrue("the held event should arrive on release",
+                    countVmDeaths(client.drainEvents()) > 0);
+        }
+    }
+
+    /** After releasing, events flow immediately again. */
+    @Test
+    public void eventsFlowAgainOnceReleased() throws Exception {
+        int port = JdwpTestClient.freePort();
+        JdwpServer server = new JdwpServer(port);
+        try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
+            primeSymbols(server);
+            client.send(JdwpTestClient.CS_VIRTUAL_MACHINE, VM_HOLD_EVENTS, new byte[0]);
+            client.send(JdwpTestClient.CS_VIRTUAL_MACHINE, VM_RELEASE_EVENTS, new byte[0]);
+
+            server.onVmDeath();
+
+            assertTrue("an event raised after release should not be queued",
+                    countVmDeaths(client.drainEvents()) > 0);
+        }
+    }
+
+    private int countVmDeaths(List<JdwpTestClient.Event> events) {
+        int count = 0;
+        for (JdwpTestClient.Event e : events) {
+            if (e.eventKind == EK_VM_DEATH) count++;
+        }
+        return count;
+    }
+
+    private void primeSymbols(JdwpServer server) throws Exception {
+        server.onSymbols(SymbolTable.load(new ByteArrayInputStream(
+                TABLE.getBytes(StandardCharsets.UTF_8))));
+        server.onHello(1);
+    }
+}

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpEventHoldTest.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpEventHoldTest.java
@@ -118,6 +118,35 @@ public class JdwpEventHoldTest {
         }
     }
 
+    /**
+     * A hold does not outlive the session that asked for it.
+     *
+     * <p>An IDE that detaches between {@code HoldEvents} and
+     * {@code ReleaseEvents} left the hold in place, so the next attach queued
+     * its own VM_START instead of sending it — and a later release delivered
+     * events carrying the previous IDE's request ids to a debugger that never
+     * asked for them.</p>
+     */
+    @Test
+    public void aHoldDoesNotSurviveTheSessionThatSetIt() throws Exception {
+        int port = JdwpTestClient.freePort();
+        JdwpServer server = new JdwpServer(port);
+        try (JdwpTestClient first = JdwpTestClient.attach(server, port)) {
+            primeSymbols(server);
+            first.send(JdwpTestClient.CS_VIRTUAL_MACHINE, VM_HOLD_EVENTS, new byte[0]);
+            server.onVmDeath();   // queued behind the hold
+        }
+
+        try (JdwpTestClient second = JdwpTestClient.attach(server, port)) {
+            primeSymbols(server);
+            server.onVmDeath();
+
+            List<JdwpTestClient.Event> events = second.drainEvents();
+            assertTrue("the new session's events should not be held",
+                    countVmDeaths(events) > 0);
+        }
+    }
+
     private int countVmDeaths(List<JdwpTestClient.Event> events) {
         int count = 0;
         for (JdwpTestClient.Event e : events) {

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpLineTableTest.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpLineTableTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.debug.proxy;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Every frame the IDE is shown carries a location it can actually resolve.
+ *
+ * <p>A debugger resolves a frame strictly against the line table it was handed
+ * for that frame's method, and reacts to a code index the table does not
+ * describe by throwing rather than by degrading. jdb raises
+ * {@code InternalError: Location with invalid code index} out of {@code where}
+ * and the session ends there — so one frame in a method compiled without line
+ * information takes down the whole stack view, not just its own row.</p>
+ *
+ * <p>Found with jdb attached to an app in the simulator: a breakpoint in
+ * {@code Form.show()} stopped and printed three frames before {@code where}
+ * threw on the fourth.</p>
+ */
+public class JdwpLineTableTest {
+
+    /**
+     * Method 0 has lines, method 1 has none — the shape a method the
+     * translator emitted without line information takes in the symbol stream.
+     */
+    private static final String TABLE =
+            "version\t1\n"
+          + "class\t0\tcom_example_Main\tMain.java\t-1\tcom/example/Main\n"
+          + "method\t0\t0\thandler\t(Ljava/lang/Object;)V\t0\n"
+          + "line\t0\t100\n"
+          + "line\t0\t110\n"
+          + "line\t0\t120\n"
+          + "method\t1\t0\tsynthetic\t()V\t0\n";
+
+    private static final long TID = 3;
+
+    /** A method with lines reports them, ordered, as both index and line. */
+    @Test
+    public void aMethodWithLinesReportsItsTable() throws Exception {
+        int port = JdwpTestClient.freePort();
+        JdwpServer server = new JdwpServer(port);
+        try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
+            primeSymbols(server);
+
+            JdwpTestClient.Reply reply = lineTable(client, 0);
+            assertEquals(0, reply.errorCode);
+
+            DataInputStream body = reply.stream();
+            assertEquals("lowest code index", 100L, body.readLong());
+            assertEquals("highest code index", 120L, body.readLong());
+            assertEquals(3, body.readInt());
+            long[] expected = { 100, 110, 120 };
+            for (long line : expected) {
+                assertEquals(line, body.readLong());
+                assertEquals(line, body.readInt());
+            }
+        }
+    }
+
+    /**
+     * A method with no lines answers ABSENT_INFORMATION rather than an empty
+     * table. The empty table is the crash: the debugger takes it as
+     * authoritative and every location in the method becomes unresolvable.
+     */
+    @Test
+    public void aMethodWithoutLinesReportsAbsentInformationRatherThanAnEmptyTable() throws Exception {
+        int port = JdwpTestClient.freePort();
+        JdwpServer server = new JdwpServer(port);
+        try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
+            primeSymbols(server);
+
+            JdwpTestClient.Reply reply = lineTable(client, 1);
+            assertEquals("ABSENT_INFORMATION", 101, reply.errorCode);
+            assertEquals("an error reply carries no table", 0, reply.body.length);
+        }
+    }
+
+    /** A method the symbol table never described answers the same way. */
+    @Test
+    public void anUnknownMethodReportsAbsentInformation() throws Exception {
+        int port = JdwpTestClient.freePort();
+        JdwpServer server = new JdwpServer(port);
+        try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
+            primeSymbols(server);
+
+            assertEquals(101, lineTable(client, 9999).errorCode);
+        }
+    }
+
+    /**
+     * A frame stopped between two tracked lines is reported at the later of
+     * the two — the last line known to have started, which is where execution
+     * actually is.
+     */
+    @Test
+    public void aFrameBetweenTrackedLinesSnapsBackToTheLastOneThatStarted() throws Exception {
+        assertEquals(110L, frameCodeIndexFor(0, 115));
+    }
+
+    /** A line the table does have travels unchanged. */
+    @Test
+    public void aFrameOnATrackedLineIsReportedAsItself() throws Exception {
+        assertEquals(110L, frameCodeIndexFor(0, 110));
+    }
+
+    /**
+     * A frame that has not reached a tracked line yet — the device reports 0 —
+     * shows the method's first line rather than an index the table cannot
+     * resolve. Naming the wrong line in the right method beats ending the
+     * stack view.
+     */
+    @Test
+    public void aFrameWithNoLineYetIsReportedAtTheMethodsFirstLine() throws Exception {
+        assertEquals(100L, frameCodeIndexFor(0, 0));
+    }
+
+    /**
+     * A frame past the last tracked line snaps back to it rather than running
+     * off the end of the table.
+     */
+    @Test
+    public void aFramePastTheLastTrackedLineSnapsBackToIt() throws Exception {
+        assertEquals(120L, frameCodeIndexFor(0, 500));
+    }
+
+    /**
+     * For a method with no table at all there is nothing to be consistent
+     * with, so the device's line passes through; LineTable reports the absence
+     * and the debugger stops consulting the index.
+     */
+    @Test
+    public void aFrameInAMethodWithoutATablePassesItsLineThrough() throws Exception {
+        assertEquals(42L, frameCodeIndexFor(1, 42));
+    }
+
+    /**
+     * The whole point, stated as the debugger sees it: every frame's code
+     * index either resolves against that frame's own table or belongs to a
+     * method that admits it has none.
+     */
+    @Test
+    public void everyReportedFrameResolvesAgainstItsOwnLineTable() throws Exception {
+        int port = JdwpTestClient.freePort();
+        JdwpServer server = new JdwpServer(port);
+        try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
+            primeSymbols(server);
+            // A stack shaped like the one that broke: a tracked frame, a frame
+            // at an untracked line, and a frame in a method with no lines.
+            server.onStack(TID, new int[] { 0, 0, 1 }, new int[] { 110, 115, 42 });
+
+            for (Frame frame : frames(client)) {
+                JdwpTestClient.Reply table = lineTable(client, (int) frame.methodId - 1);
+                if (table.errorCode == 101) {
+                    continue;  // admits it has no lines; index is never consulted
+                }
+                assertEquals(0, table.errorCode);
+                assertTrue("frame at " + frame.codeIndex + " should be in its method's table",
+                        linesOf(table).contains(frame.codeIndex));
+            }
+        }
+    }
+
+    // ---- helpers -----------------------------------------------------------
+
+    /** Runs Method.LineTable for a method and returns the raw reply. */
+    private JdwpTestClient.Reply lineTable(JdwpTestClient client, int methodId) throws Exception {
+        byte[] payload = new byte[16];
+        payload[7] = 1;  // refType id 1 -> classId 0
+        long ref = methodId + 1L;
+        for (int i = 0; i < 8; i++) {
+            payload[15 - i] = (byte) (ref >>> (8 * i));
+        }
+        return client.send(6 /* Method */, 1 /* LineTable */, payload);
+    }
+
+    /** The code index Frames reports for a frame the device places at {@code line}. */
+    private long frameCodeIndexFor(int methodId, int line) throws Exception {
+        int port = JdwpTestClient.freePort();
+        JdwpServer server = new JdwpServer(port);
+        try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
+            primeSymbols(server);
+            server.onStack(TID, new int[] { methodId }, new int[] { line });
+
+            List<Frame> frames = frames(client);
+            assertEquals(1, frames.size());
+            return frames.get(0).codeIndex;
+        }
+    }
+
+    /** Runs ThreadReference.Frames over the whole stack. */
+    private List<Frame> frames(JdwpTestClient client) throws Exception {
+        byte[] payload = new byte[16];
+        for (int i = 0; i < 8; i++) {
+            payload[7 - i] = (byte) (TID >>> (8 * i));
+        }
+        payload[11] = 0;            // startFrame 0
+        payload[12] = (byte) 0xFF;  // length -1: all of them
+        payload[13] = (byte) 0xFF;
+        payload[14] = (byte) 0xFF;
+        payload[15] = (byte) 0xFF;
+
+        JdwpTestClient.Reply reply = client.send(JdwpTestClient.CS_THREAD_REFERENCE, 6, payload);
+        assertEquals(0, reply.errorCode);
+
+        DataInputStream body = reply.stream();
+        int count = body.readInt();
+        List<Frame> frames = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            body.readLong();  // frameId
+            body.readByte();  // typeTag
+            body.readLong();  // classId
+            long methodId = body.readLong();
+            frames.add(new Frame(methodId, body.readLong()));
+        }
+        return frames;
+    }
+
+    private List<Long> linesOf(JdwpTestClient.Reply table) throws Exception {
+        DataInputStream body = table.stream();
+        body.readLong();  // start
+        body.readLong();  // end
+        int count = body.readInt();
+        List<Long> lines = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            lines.add(body.readLong());
+            body.readInt();
+        }
+        return lines;
+    }
+
+    private void primeSymbols(JdwpServer server) throws Exception {
+        server.onSymbols(SymbolTable.load(new ByteArrayInputStream(
+                TABLE.getBytes(StandardCharsets.UTF_8))));
+        server.onHello(1);
+    }
+
+    private static final class Frame {
+        final long methodId;
+        final long codeIndex;
+
+        Frame(long methodId, long codeIndex) {
+            this.methodId = methodId;
+            this.codeIndex = codeIndex;
+        }
+    }
+}

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpLineTableTest.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpLineTableTest.java
@@ -88,32 +88,48 @@ public class JdwpLineTableTest {
     }
 
     /**
-     * A method with no lines answers ABSENT_INFORMATION rather than an empty
-     * table. The empty table is the crash: the debugger takes it as
-     * authoritative and every location in the method becomes unresolvable.
+     * A method with no lines still gets a usable table: one entry at code
+     * index 0 whose line number is "unknown".
+     *
+     * <p>The two answers that look right both end the session. An empty table
+     * is taken as authoritative and no location in the method resolves;
+     * ABSENT_INFORMATION is what the spec reserves for this, but jdb has no
+     * case for that error on this path and raises {@code InternalException}
+     * just the same. A one-entry table is the only shape that lets the frame
+     * print and the rest of the stack survive.</p>
      */
     @Test
-    public void aMethodWithoutLinesReportsAbsentInformationRatherThanAnEmptyTable() throws Exception {
+    public void aMethodWithoutLinesStillGetsATableTheDebuggerCanResolve() throws Exception {
         int port = JdwpTestClient.freePort();
         JdwpServer server = new JdwpServer(port);
         try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
             primeSymbols(server);
 
             JdwpTestClient.Reply reply = lineTable(client, 1);
-            assertEquals("ABSENT_INFORMATION", 101, reply.errorCode);
-            assertEquals("an error reply carries no table", 0, reply.body.length);
+            assertEquals(0, reply.errorCode);
+
+            DataInputStream body = reply.stream();
+            assertEquals(0L, body.readLong());
+            assertEquals(0L, body.readLong());
+            assertEquals("never an empty table", 1, body.readInt());
+            assertEquals("covers the index frames report", 0L, body.readLong());
+            assertEquals("line unknown", -1, body.readInt());
         }
     }
 
     /** A method the symbol table never described answers the same way. */
     @Test
-    public void anUnknownMethodReportsAbsentInformation() throws Exception {
+    public void anUnknownMethodGetsTheSameUnknownLineTable() throws Exception {
         int port = JdwpTestClient.freePort();
         JdwpServer server = new JdwpServer(port);
         try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
             primeSymbols(server);
 
-            assertEquals(101, lineTable(client, 9999).errorCode);
+            JdwpTestClient.Reply reply = lineTable(client, 9999);
+            assertEquals(0, reply.errorCode);
+            DataInputStream body = reply.stream();
+            body.readLong(); body.readLong();
+            assertEquals(1, body.readInt());
         }
     }
 
@@ -154,13 +170,14 @@ public class JdwpLineTableTest {
     }
 
     /**
-     * For a method with no table at all there is nothing to be consistent
-     * with, so the device's line passes through; LineTable reports the absence
-     * and the debugger stops consulting the index.
+     * A frame in a method with no lines is reported at code index 0, the one
+     * index that method's table describes. Passing the device's line through
+     * would name an index its table does not cover, which is the same
+     * unresolvable location by another route.
      */
     @Test
-    public void aFrameInAMethodWithoutATablePassesItsLineThrough() throws Exception {
-        assertEquals(42L, frameCodeIndexFor(1, 42));
+    public void aFrameInAMethodWithoutLinesIsReportedAtTheIndexItsTableCovers() throws Exception {
+        assertEquals(0L, frameCodeIndexFor(1, 42));
     }
 
     /**
@@ -180,12 +197,10 @@ public class JdwpLineTableTest {
 
             for (Frame frame : frames(client)) {
                 JdwpTestClient.Reply table = lineTable(client, (int) frame.methodId - 1);
-                if (table.errorCode == 101) {
-                    continue;  // admits it has no lines; index is never consulted
-                }
                 assertEquals(0, table.errorCode);
-                assertTrue("frame at " + frame.codeIndex + " should be in its method's table",
-                        linesOf(table).contains(frame.codeIndex));
+                assertTrue("frame at code index " + frame.codeIndex
+                                + " should be covered by its own method's table",
+                        indicesOf(table).contains(frame.codeIndex));
             }
         }
     }
@@ -245,17 +260,18 @@ public class JdwpLineTableTest {
         return frames;
     }
 
-    private List<Long> linesOf(JdwpTestClient.Reply table) throws Exception {
+    /** The code indices a line table describes. */
+    private List<Long> indicesOf(JdwpTestClient.Reply table) throws Exception {
         DataInputStream body = table.stream();
         body.readLong();  // start
         body.readLong();  // end
         int count = body.readInt();
-        List<Long> lines = new ArrayList<>();
+        List<Long> indices = new ArrayList<>();
         for (int i = 0; i < count; i++) {
-            lines.add(body.readLong());
-            body.readInt();
+            indices.add(body.readLong());
+            body.readInt();  // line number
         }
-        return lines;
+        return indices;
     }
 
     private void primeSymbols(JdwpServer server) throws Exception {

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpLineTableTest.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpLineTableTest.java
@@ -224,20 +224,29 @@ public class JdwpLineTableTest {
         try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
             primeSymbols(server);
 
-            String plain = signatureOf(client, refTypeOf(0, false));
-            String array = signatureOf(client, refTypeOf(0, true));
+            String plain = signatureOf(client, refTypeOf(0, 0));
+            String array = signatureOf(client, refTypeOf(0, 1));
+            String twoDimensional = signatureOf(client, refTypeOf(0, 2));
 
             assertEquals("Lcom/example/Main;", plain);
             assertEquals("[Lcom/example/Main;", array);
             assertEquals("the component type is what remains after the '['",
                     plain, array.substring(1));
+            // The runtime's own array classes are synthetic and carry no symbol
+            // entry, so the depth has to travel with the component or every
+            // array reads as a one-dimensional Object[].
+            assertEquals("[[Lcom/example/Main;", twoDimensional);
         }
     }
 
-    /** Reference-type id for a class, as an array type or as itself. */
-    private long refTypeOf(int classId, boolean array) {
+    /**
+     * Reference-type id for a class: as itself when {@code dimensions} is 0,
+     * otherwise as an array of it that many levels deep.
+     */
+    private long refTypeOf(int classId, int dimensions) {
         long ref = classId + 1L;
-        return array ? (0x2000000000000000L | ref) : ref;
+        if (dimensions == 0) return ref;
+        return 0x2000000000000000L | ((long) dimensions << 48) | ref;
     }
 
     private String signatureOf(JdwpTestClient client, long refType) throws Exception {

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpLineTableTest.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpLineTableTest.java
@@ -205,6 +205,54 @@ public class JdwpLineTableTest {
         }
     }
 
+    /**
+     * An array reference type's signature starts with {@code [}.
+     *
+     * <p>The device reports an array by naming its component class and setting
+     * a flag, so the array and its component shared one reference-type ID and
+     * the array answered with the component's own signature. A debugger reads
+     * the component type back out by removing the leading character, so the
+     * missing {@code [} is not merely a wrong label: jdb strips the first
+     * character regardless and parses the rest, which is how printing an array
+     * local ended in {@code Invalid JNI signature character 'j'} — the 'j' of
+     * "java/lang/..." after the 'L' had been eaten.</p>
+     */
+    @Test
+    public void anArrayTypeReportsAnArraySignature() throws Exception {
+        int port = JdwpTestClient.freePort();
+        JdwpServer server = new JdwpServer(port);
+        try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
+            primeSymbols(server);
+
+            String plain = signatureOf(client, refTypeOf(0, false));
+            String array = signatureOf(client, refTypeOf(0, true));
+
+            assertEquals("Lcom/example/Main;", plain);
+            assertEquals("[Lcom/example/Main;", array);
+            assertEquals("the component type is what remains after the '['",
+                    plain, array.substring(1));
+        }
+    }
+
+    /** Reference-type id for a class, as an array type or as itself. */
+    private long refTypeOf(int classId, boolean array) {
+        long ref = classId + 1L;
+        return array ? (0x2000000000000000L | ref) : ref;
+    }
+
+    private String signatureOf(JdwpTestClient client, long refType) throws Exception {
+        byte[] payload = new byte[8];
+        for (int i = 0; i < 8; i++) {
+            payload[7 - i] = (byte) (refType >>> (8 * i));
+        }
+        JdwpTestClient.Reply reply = client.send(2 /* ReferenceType */, 1 /* Signature */, payload);
+        assertEquals(0, reply.errorCode);
+        DataInputStream body = reply.stream();
+        byte[] utf8 = new byte[body.readInt()];
+        body.readFully(utf8);
+        return new String(utf8, java.nio.charset.StandardCharsets.UTF_8);
+    }
+
     // ---- helpers -----------------------------------------------------------
 
     /** Runs Method.LineTable for a method and returns the raw reply. */

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpTestClient.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpTestClient.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.debug.proxy;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * A debugger's side of a JDWP session, for tests that want to drive
+ * {@link JdwpServer} the way an IDE does.
+ *
+ * Handles the accept loop, the handshake, request-id bookkeeping and the fact
+ * that replies and asynchronous event packets arrive interleaved on the same
+ * socket — so a test can say "send this command, read that reply" and "what
+ * events did the server push".
+ */
+final class JdwpTestClient implements AutoCloseable {
+
+    private static final byte[] HANDSHAKE = "JDWP-Handshake".getBytes(StandardCharsets.US_ASCII);
+
+    // JDWP command sets used by the tests.
+    static final int CS_VIRTUAL_MACHINE = 1;
+    static final int CS_THREAD_REFERENCE = 11;
+    static final int CS_THREAD_GROUP_REF = 12;
+    static final int CS_EVENT_REQUEST = 15;
+
+    static final int EK_BREAKPOINT = 2;
+    static final int EK_CLASS_PREPARE = 8;
+
+    static final int MOD_CLASS_MATCH = 5;
+    static final int MOD_CLASS_EXCLUDE = 6;
+
+    private final Socket socket;
+    private final DataInputStream in;
+    private final DataOutputStream out;
+    private final List<Event> events = new ArrayList<>();
+    private int nextId = 1;
+
+    private JdwpTestClient(Socket socket) throws IOException {
+        this.socket = socket;
+        this.in = new DataInputStream(socket.getInputStream());
+        this.out = new DataOutputStream(socket.getOutputStream());
+    }
+
+    /**
+     * Starts the server on {@code port} — which must be the port it was
+     * constructed with — attaches, and completes the handshake.
+     */
+    static JdwpTestClient attach(JdwpServer server, int port) throws Exception {
+        Thread serverThread = new Thread(() -> {
+            try {
+                server.acceptAndServe();
+            } catch (Exception e) {
+                // The socket closing at the end of a test is the normal exit.
+            }
+        }, "jdwp-server-test");
+        serverThread.setDaemon(true);
+        serverThread.start();
+
+        JdwpTestClient client = new JdwpTestClient(connect(port));
+        client.out.write(HANDSHAKE);
+        client.out.flush();
+        byte[] reply = new byte[HANDSHAKE.length];
+        client.in.readFully(reply);
+        assertEquals("JDWP-Handshake", new String(reply, StandardCharsets.US_ASCII));
+        client.socket.setSoTimeout(5000);
+        return client;
+    }
+
+    static int freePort() throws Exception {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
+    }
+
+    private static Socket connect(int port) throws Exception {
+        Exception last = null;
+        for (int i = 0; i < 50; i++) {
+            try {
+                return new Socket("127.0.0.1", port);
+            } catch (Exception e) {
+                last = e;
+                Thread.sleep(20);
+            }
+        }
+        throw last;
+    }
+
+    /** Sends a command and returns its reply, buffering any events seen on the way. */
+    Reply send(int commandSet, int command, byte[] payload) throws IOException {
+        int id = nextId++;
+        out.writeInt(11 + payload.length);
+        out.writeInt(id);
+        out.writeByte(0);
+        out.writeByte(commandSet);
+        out.writeByte(command);
+        out.write(payload);
+        out.flush();
+        return readReply(id);
+    }
+
+    private Reply readReply(int requestId) throws IOException {
+        while (true) {
+            Packet packet = readPacket();
+            if (packet.isReply) {
+                if (packet.id == requestId) {
+                    return new Reply(packet.errorCode, packet.body);
+                }
+            } else {
+                events.add(Event.parse(packet.body));
+            }
+        }
+    }
+
+    /**
+     * Drains events the server has already pushed. Reads until the socket goes
+     * quiet, so a caller does not need to know how many to expect.
+     */
+    List<Event> drainEvents() throws IOException {
+        socket.setSoTimeout(300);
+        try {
+            while (true) {
+                Packet packet = readPacket();
+                if (!packet.isReply) {
+                    events.add(Event.parse(packet.body));
+                }
+            }
+        } catch (IOException expected) {
+            // Timeout: nothing more queued.
+        } finally {
+            socket.setSoTimeout(5000);
+        }
+        List<Event> drained = new ArrayList<>(events);
+        events.clear();
+        return drained;
+    }
+
+    private Packet readPacket() throws IOException {
+        int length = in.readInt();
+        int id = in.readInt();
+        int flags = in.readUnsignedByte();
+        Packet packet = new Packet();
+        packet.id = id;
+        packet.isReply = (flags & 0x80) != 0;
+        if (packet.isReply) {
+            packet.errorCode = in.readUnsignedShort();
+        } else {
+            in.readUnsignedByte(); // command set
+            in.readUnsignedByte(); // command
+        }
+        packet.body = new byte[length - 11];
+        in.readFully(packet.body);
+        return packet;
+    }
+
+    @Override public void close() {
+        try { socket.close(); } catch (IOException ignore) {}
+    }
+
+    // ---- payload builders --------------------------------------------------
+
+    /** EventRequest.Set for a ClassPrepare with the given include/exclude patterns. */
+    static byte[] classPrepareRequest(int suspendPolicy, String[] includes, String[] excludes) {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        DataOutputStream b = new DataOutputStream(bytes);
+        try {
+            b.writeByte(EK_CLASS_PREPARE);
+            b.writeByte(suspendPolicy);
+            b.writeInt(includes.length + excludes.length);
+            for (String pattern : includes) {
+                b.writeByte(MOD_CLASS_MATCH);
+                writeString(b, pattern);
+            }
+            for (String pattern : excludes) {
+                b.writeByte(MOD_CLASS_EXCLUDE);
+                writeString(b, pattern);
+            }
+        } catch (IOException impossible) {
+            throw new AssertionError(impossible);
+        }
+        return bytes.toByteArray();
+    }
+
+    /**
+     * EventRequest.Set for a line breakpoint, carrying the one LocationOnly
+     * modifier an IDE sends: typeTag(1) + classID(8) + methodID(8) +
+     * codeIndex(8), where ParparVM's "code index" is the source line.
+     */
+    static byte[] lineBreakpointRequest(long classId, long methodId, long line) {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        DataOutputStream b = new DataOutputStream(bytes);
+        try {
+            b.writeByte(EK_BREAKPOINT);
+            b.writeByte(2);   // SUSPEND_ALL
+            b.writeInt(1);    // one modifier
+            b.writeByte(7);   // LocationOnly
+            b.writeByte(1);   // refTypeTag CLASS
+            b.writeLong(classId);
+            b.writeLong(methodId);
+            b.writeLong(line);
+        } catch (IOException impossible) {
+            throw new AssertionError(impossible);
+        }
+        return bytes.toByteArray();
+    }
+
+    static byte[] threadId(long tid) {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        DataOutputStream b = new DataOutputStream(bytes);
+        try {
+            b.writeLong(tid);
+        } catch (IOException impossible) {
+            throw new AssertionError(impossible);
+        }
+        return bytes.toByteArray();
+    }
+
+    private static void writeString(DataOutputStream b, String s) throws IOException {
+        byte[] utf8 = s.getBytes(StandardCharsets.UTF_8);
+        b.writeInt(utf8.length);
+        b.write(utf8);
+    }
+
+    // ---- packet types ------------------------------------------------------
+
+    private static final class Packet {
+        int id;
+        boolean isReply;
+        int errorCode;
+        byte[] body;
+    }
+
+    static final class Reply {
+        final int errorCode;
+        final byte[] body;
+
+        Reply(int errorCode, byte[] body) {
+            this.errorCode = errorCode;
+            this.body = body;
+        }
+
+        DataInputStream stream() {
+            return new DataInputStream(new ByteArrayInputStream(body));
+        }
+    }
+
+    /** A composite event packet, flattened to its first (and for us only) event. */
+    static final class Event {
+        final int suspendPolicy;
+        final int eventKind;
+        final int requestId;
+        final byte[] rest;
+
+        private Event(int suspendPolicy, int eventKind, int requestId, byte[] rest) {
+            this.suspendPolicy = suspendPolicy;
+            this.eventKind = eventKind;
+            this.requestId = requestId;
+            this.rest = rest;
+        }
+
+        static Event parse(byte[] body) {
+            DataInputStream b = new DataInputStream(new ByteArrayInputStream(body));
+            try {
+                int suspendPolicy = b.readUnsignedByte();
+                b.readInt(); // event count
+                int eventKind = b.readUnsignedByte();
+                int requestId = b.readInt();
+                byte[] rest = new byte[b.available()];
+                b.readFully(rest);
+                return new Event(suspendPolicy, eventKind, requestId, rest);
+            } catch (IOException impossible) {
+                throw new AssertionError(impossible);
+            }
+        }
+
+        /**
+         * The class signature carried by a ClassPrepare event, which follows
+         * thread(8), refTypeTag(1) and typeID(8).
+         */
+        String classPrepareSignature() {
+            DataInputStream b = new DataInputStream(new ByteArrayInputStream(rest));
+            try {
+                b.readLong();          // thread
+                b.readUnsignedByte();  // refTypeTag
+                b.readLong();          // typeID
+                byte[] utf8 = new byte[b.readInt()];
+                b.readFully(utf8);
+                return new String(utf8, StandardCharsets.UTF_8);
+            } catch (IOException impossible) {
+                throw new AssertionError(impossible);
+            }
+        }
+
+        @Override public String toString() {
+            return "Event{kind=" + eventKind + ", rid=" + requestId
+                    + ", suspendPolicy=" + suspendPolicy + "}";
+        }
+    }
+}

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpTestClient.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpTestClient.java
@@ -268,11 +268,30 @@ final class JdwpTestClient implements AutoCloseable {
         return bytes.toByteArray();
     }
 
+    /*
+     * Thread IDs travel in their own namespace so that a debugger asking about
+     * one as an object cannot be answered with an unrelated tagged int -- see
+     * JdwpThreadIdNamespaceTest, which pins the property rather than repeating
+     * the arithmetic.
+     */
+    static final long THREAD_ID_TAG = 0x4000000000000000L;
+
+    /** A device thread ID as the IDE sees it. */
+    static long toJdwpThread(long deviceThreadId) {
+        return THREAD_ID_TAG | (deviceThreadId << 1);
+    }
+
+    /** The device thread ID behind an ID the IDE was given. */
+    static long fromJdwpThread(long jdwpId) {
+        return (jdwpId & ~THREAD_ID_TAG) >>> 1;
+    }
+
+    /** Payload naming a device thread, in the namespace the IDE uses. */
     static byte[] threadId(long tid) {
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
         DataOutputStream b = new DataOutputStream(bytes);
         try {
-            b.writeLong(tid);
+            b.writeLong(toJdwpThread(tid));
         } catch (IOException impossible) {
             throw new AssertionError(impossible);
         }

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpTestClient.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpTestClient.java
@@ -201,17 +201,28 @@ final class JdwpTestClient implements AutoCloseable {
                 onlyClassJdwpId, new String[0]);
     }
 
-    /** Adds SourceNameMatch modifiers for each entry in {@code sourceNames}. */
     static byte[] classPrepareRequest(int suspendPolicy, String[] includes,
                                       String[] excludes, long onlyClassJdwpId,
                                       String[] sourceNames) {
+        return classPrepareRequest(suspendPolicy, includes, excludes,
+                onlyClassJdwpId, sourceNames, 0);
+    }
+
+    /** {@code count} of 0 omits the Count modifier. */
+    static byte[] classPrepareRequest(int suspendPolicy, String[] includes,
+                                      String[] excludes, long onlyClassJdwpId,
+                                      String[] sourceNames, int count) {
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
         DataOutputStream b = new DataOutputStream(bytes);
         try {
             b.writeByte(EK_CLASS_PREPARE);
             b.writeByte(suspendPolicy);
             b.writeInt(includes.length + excludes.length + sourceNames.length
-                    + (onlyClassJdwpId >= 0 ? 1 : 0));
+                    + (onlyClassJdwpId >= 0 ? 1 : 0) + (count > 0 ? 1 : 0));
+            if (count > 0) {
+                b.writeByte(1);   // Count
+                b.writeInt(count);
+            }
             if (onlyClassJdwpId >= 0) {
                 b.writeByte(4);   // ClassOnly
                 b.writeLong(onlyClassJdwpId);

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpTestClient.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpTestClient.java
@@ -137,7 +137,7 @@ final class JdwpTestClient implements AutoCloseable {
                     return new Reply(packet.errorCode, packet.body);
                 }
             } else {
-                events.add(Event.parse(packet.body));
+                events.addAll(Event.parseAll(packet.body));
             }
         }
     }
@@ -152,7 +152,7 @@ final class JdwpTestClient implements AutoCloseable {
             while (true) {
                 Packet packet = readPacket();
                 if (!packet.isReply) {
-                    events.add(Event.parse(packet.body));
+                    events.addAll(Event.parseAll(packet.body));
                 }
             }
         } catch (IOException expected) {
@@ -288,19 +288,67 @@ final class JdwpTestClient implements AutoCloseable {
             this.rest = rest;
         }
 
-        static Event parse(byte[] body) {
+        /**
+         * Splits a composite packet into its events.
+         *
+         * A composite can carry more than one — a VM death matching several
+         * registered requests, for instance — so each event's payload has to
+         * be consumed by kind to find where the next one starts.
+         */
+        static List<Event> parseAll(byte[] body) {
             DataInputStream b = new DataInputStream(new ByteArrayInputStream(body));
+            List<Event> events = new ArrayList<>();
             try {
                 int suspendPolicy = b.readUnsignedByte();
-                b.readInt(); // event count
-                int eventKind = b.readUnsignedByte();
-                int requestId = b.readInt();
-                byte[] rest = new byte[b.available()];
-                b.readFully(rest);
-                return new Event(suspendPolicy, eventKind, requestId, rest);
+                int count = b.readInt();
+                for (int i = 0; i < count; i++) {
+                    int eventKind = b.readUnsignedByte();
+                    int requestId = b.readInt();
+                    events.add(new Event(suspendPolicy, eventKind, requestId,
+                            readEventPayload(b, eventKind)));
+                }
             } catch (IOException impossible) {
                 throw new AssertionError(impossible);
             }
+            return events;
+        }
+
+        /** Consumes the kind-specific tail of one event, returning its bytes. */
+        private static byte[] readEventPayload(DataInputStream b, int eventKind)
+                throws IOException {
+            java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+            DataOutputStream w = new DataOutputStream(out);
+            switch (eventKind) {
+                case 99:  // VM_DEATH — no payload
+                    break;
+                case 90:  // VM_START — thread
+                    w.writeLong(b.readLong());
+                    break;
+                case 1:   // SINGLE_STEP
+                case 2: { // BREAKPOINT — thread + location
+                    w.writeLong(b.readLong());
+                    w.writeByte(b.readUnsignedByte());
+                    w.writeLong(b.readLong());
+                    w.writeLong(b.readLong());
+                    w.writeLong(b.readLong());
+                    break;
+                }
+                case 8: { // CLASS_PREPARE — thread, tag, typeID, signature, status
+                    w.writeLong(b.readLong());
+                    w.writeByte(b.readUnsignedByte());
+                    w.writeLong(b.readLong());
+                    int len = b.readInt();
+                    byte[] sig = new byte[len];
+                    b.readFully(sig);
+                    w.writeInt(len);
+                    w.write(sig);
+                    w.writeInt(b.readInt());
+                    break;
+                }
+                default:
+                    throw new IOException("test client cannot size event kind " + eventKind);
+            }
+            return out.toByteArray();
         }
 
         /**

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpTestClient.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpTestClient.java
@@ -197,15 +197,28 @@ final class JdwpTestClient implements AutoCloseable {
     /** {@code onlyClassJdwpId} of -1 omits the ClassOnly modifier. */
     static byte[] classPrepareRequest(int suspendPolicy, String[] includes,
                                       String[] excludes, long onlyClassJdwpId) {
+        return classPrepareRequest(suspendPolicy, includes, excludes,
+                onlyClassJdwpId, new String[0]);
+    }
+
+    /** Adds SourceNameMatch modifiers for each entry in {@code sourceNames}. */
+    static byte[] classPrepareRequest(int suspendPolicy, String[] includes,
+                                      String[] excludes, long onlyClassJdwpId,
+                                      String[] sourceNames) {
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
         DataOutputStream b = new DataOutputStream(bytes);
         try {
             b.writeByte(EK_CLASS_PREPARE);
             b.writeByte(suspendPolicy);
-            b.writeInt(includes.length + excludes.length + (onlyClassJdwpId >= 0 ? 1 : 0));
+            b.writeInt(includes.length + excludes.length + sourceNames.length
+                    + (onlyClassJdwpId >= 0 ? 1 : 0));
             if (onlyClassJdwpId >= 0) {
                 b.writeByte(4);   // ClassOnly
                 b.writeLong(onlyClassJdwpId);
+            }
+            for (String sourceName : sourceNames) {
+                b.writeByte(12);  // SourceNameMatch
+                writeString(b, sourceName);
             }
             for (String pattern : includes) {
                 b.writeByte(MOD_CLASS_MATCH);

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpTestClient.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpTestClient.java
@@ -191,12 +191,22 @@ final class JdwpTestClient implements AutoCloseable {
 
     /** EventRequest.Set for a ClassPrepare with the given include/exclude patterns. */
     static byte[] classPrepareRequest(int suspendPolicy, String[] includes, String[] excludes) {
+        return classPrepareRequest(suspendPolicy, includes, excludes, -1);
+    }
+
+    /** {@code onlyClassJdwpId} of -1 omits the ClassOnly modifier. */
+    static byte[] classPrepareRequest(int suspendPolicy, String[] includes,
+                                      String[] excludes, long onlyClassJdwpId) {
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
         DataOutputStream b = new DataOutputStream(bytes);
         try {
             b.writeByte(EK_CLASS_PREPARE);
             b.writeByte(suspendPolicy);
-            b.writeInt(includes.length + excludes.length);
+            b.writeInt(includes.length + excludes.length + (onlyClassJdwpId >= 0 ? 1 : 0));
+            if (onlyClassJdwpId >= 0) {
+                b.writeByte(4);   // ClassOnly
+                b.writeLong(onlyClassJdwpId);
+            }
             for (String pattern : includes) {
                 b.writeByte(MOD_CLASS_MATCH);
                 writeString(b, pattern);

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpThreadIdNamespaceTest.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpThreadIdNamespaceTest.java
@@ -24,6 +24,10 @@ package com.codename1.debug.proxy;
 
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.nio.charset.StandardCharsets;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
@@ -95,6 +99,53 @@ public class JdwpThreadIdNamespaceTest {
                     JdwpTestClient.toJdwpThread(tid) > ceiling);
         }
     }
+
+    /**
+     * Every thread ID the IDE is handed carries the tag, including the ones
+     * that are placeholders rather than real threads.
+     *
+     * <p>VM_START and a replayed CLASS_PREPARE both name a thread the proxy
+     * has to invent, and both wrote it raw. That is the same defect the
+     * namespace exists to prevent, twice: the ID decodes to a different device
+     * thread on the way back — raw 1 to thread 0 — and a small raw value is
+     * indistinguishable from a tagged int.</p>
+     */
+    @Test
+    public void eventsNamingAPlaceholderThreadStillTagIt() throws Exception {
+        int port = JdwpTestClient.freePort();
+        JdwpServer server = new JdwpServer(port);
+        try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
+            server.onSymbols(SymbolTable.load(new ByteArrayInputStream(
+                    TABLE.getBytes(StandardCharsets.UTF_8))));
+            server.onHello(1);
+
+            // A ClassPrepare request replays the already-loaded classes.
+            client.send(JdwpTestClient.CS_EVENT_REQUEST, 1,
+                    JdwpTestClient.classPrepareRequest(0, new String[0], new String[0]));
+
+            boolean sawVmStart = false;
+            boolean sawClassPrepare = false;
+            for (JdwpTestClient.Event e : client.drainEvents()) {
+                if (e.eventKind != 90 && e.eventKind != 8) continue;
+                long threadId = new DataInputStream(
+                        new ByteArrayInputStream(e.rest)).readLong();
+                assertTrue("event kind " + e.eventKind + " must carry a tagged thread id,"
+                                + " got 0x" + Long.toHexString(threadId),
+                        (threadId & JdwpTestClient.THREAD_ID_TAG) != 0);
+                assertEquals("and it must be even, like every thread id",
+                        0, threadId & 1);
+                if (e.eventKind == 90) sawVmStart = true;
+                if (e.eventKind == 8) sawClassPrepare = true;
+            }
+            assertTrue("expected a VM_START", sawVmStart);
+            assertTrue("expected a replayed CLASS_PREPARE", sawClassPrepare);
+        }
+    }
+
+    private static final String TABLE =
+            "version\t1\n"
+          + "class\t0\tcom_example_Main\tMain.java\t-1\tcom/example/Main\n"
+          + "method\t0\t0\thandler\t()V\t0\n";
 
     /** ParparVM's tagged encoding of an int. */
     private static long taggedInt(int value) {

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpThreadIdNamespaceTest.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpThreadIdNamespaceTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.debug.proxy;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * A thread ID can never be mistaken for a reference, or the reverse.
+ *
+ * <p>A debugger is entitled to ask about a thread ID as an object — jdb does
+ * exactly that while drawing its thread panel — so the proxy has to be able to
+ * tell one from the other. ParparVM's thread IDs are small integers, which is
+ * the same shape as two other things that arrive here:</p>
+ *
+ * <ul>
+ *   <li>tagged ints, encoded as {@code (v << 1) | 1}, so {@code Integer 0} is
+ *       1 — indistinguishable from thread 1;</li>
+ *   <li>heap references, which are aligned and so even.</li>
+ * </ul>
+ *
+ * <p>These tests state the separation as a property over the values that
+ * actually collide, rather than restating the arithmetic that produces it.</p>
+ */
+public class JdwpThreadIdNamespaceTest {
+
+    /** Round-tripping a thread ID gives back the device's own. */
+    @Test
+    public void aThreadIdSurvivesTheRoundTrip() {
+        for (long tid : new long[] { 0, 1, 2, 3, 7, 21, 1023, 65535, 1L << 31 }) {
+            assertEquals(tid, JdwpTestClient.fromJdwpThread(JdwpTestClient.toJdwpThread(tid)));
+        }
+    }
+
+    /**
+     * No thread ID equals the tagged encoding of any int — the collision that
+     * had {@code Integer 0} and thread 1 share the value 1.
+     */
+    @Test
+    public void noThreadIdCollidesWithATaggedInt() {
+        for (long tid = 0; tid < 512; tid++) {
+            long threadId = JdwpTestClient.toJdwpThread(tid);
+            for (int value = -512; value < 512; value++) {
+                assertNotEquals("thread " + tid + " collides with Integer " + value,
+                        taggedInt(value), threadId);
+            }
+        }
+    }
+
+    /**
+     * Every thread ID is even, which is what rules out the whole tagged-int
+     * range at once rather than the sample above.
+     */
+    @Test
+    public void everyThreadIdIsEvenAndSoNeverATaggedValue() {
+        for (long tid = 0; tid < 1024; tid++) {
+            long threadId = JdwpTestClient.toJdwpThread(tid);
+            assertEquals("thread " + tid + " must be even", 0, threadId & 1);
+        }
+    }
+
+    /**
+     * Every thread ID sits above the addresses a 64-bit iOS process can hold,
+     * so it cannot equal a real reference either.
+     */
+    @Test
+    public void everyThreadIdIsAboveTheAddressSpace() {
+        // Darwin user-space pointers stay well inside 2^48.
+        long ceiling = 1L << 48;
+        for (long tid = 0; tid < 1024; tid++) {
+            assertTrue("thread " + tid + " must not look like a pointer",
+                    JdwpTestClient.toJdwpThread(tid) > ceiling);
+        }
+    }
+
+    /** ParparVM's tagged encoding of an int. */
+    private static long taggedInt(int value) {
+        return ((long) value << 1) | 1L;
+    }
+}

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpThreadListRaceTest.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpThreadListRaceTest.java
@@ -103,6 +103,37 @@ public class JdwpThreadListRaceTest {
         }
     }
 
+    /**
+     * A device that never answers the enumeration still lists the threads
+     * events have revealed — an older build whose runtime does not send
+     * {@code EVT_THREAD_LIST}.
+     *
+     * <p>Characterisation, not a regression test: it passes whether or not
+     * {@code refreshed} distinguishes "a snapshot arrived" from "the request is
+     * no longer outstanding". The fallback it guards cannot currently
+     * contribute an id, because {@code knownThreads} only ever gains one
+     * alongside {@code deviceThreads} and is pruned to a subset of it on every
+     * snapshot. The distinction is still worth drawing — the flag otherwise
+     * reports a silent device as a successful refresh — but nothing observable
+     * turns on it until that invariant changes, and this test is here to catch
+     * the day a timeout starts clearing the thread map instead.</p>
+     */
+    @Test
+    public void aDeviceThatNeverAnswersFallsBackToThreadsSeenInEvents() throws Exception {
+        try (Fixture f = new Fixture(false, true)) {
+            // Primed here rather than awaited from the device: this device is
+            // deliberately unresponsive, and the breakpoint below needs them.
+            f.server.onSymbols(SymbolTable.load(new java.io.ByteArrayInputStream(
+                    TABLE.getBytes(StandardCharsets.UTF_8))));
+            f.server.onBreakpointHit(LATE_STOPPER, 0, 12);
+
+            List<Long> threads = f.allThreads();
+
+            assertTrue("the thread an event revealed should still be listed: " + threads,
+                    threads.contains(LATE_STOPPER));
+        }
+    }
+
     // ---- fixture -----------------------------------------------------------
 
     private final class Fixture implements AutoCloseable {
@@ -111,6 +142,10 @@ public class JdwpThreadListRaceTest {
         private final RacingDevice device;
 
         Fixture(boolean stopDuringRequest) throws Exception {
+            this(stopDuringRequest, false);
+        }
+
+        Fixture(boolean stopDuringRequest, boolean silent) throws Exception {
             int jdwpPort = JdwpTestClient.freePort();
             int devicePort = JdwpTestClient.freePort();
             server = new JdwpServer(jdwpPort, devicePort);
@@ -123,7 +158,7 @@ public class JdwpThreadListRaceTest {
             serving.setDaemon(true);
             serving.start();
 
-            device = new RacingDevice(devicePort, server, stopDuringRequest);
+            device = new RacingDevice(devicePort, server, stopDuringRequest, silent);
             client = JdwpTestClient.attach(server, jdwpPort);
             device.connect();
             device.awaitHello();
@@ -157,6 +192,8 @@ public class JdwpThreadListRaceTest {
     private static final class RacingDevice {
         private final JdwpServer server;
         private final boolean stopDuringRequest;
+        /** Never answers CMD_GET_THREADS, like a runtime that predates it. */
+        private final boolean silent;
         private final Socket socket;
         private final DataInputStream in;
         private final DataOutputStream out;
@@ -165,9 +202,11 @@ public class JdwpThreadListRaceTest {
         private volatile boolean helloDone;
         private volatile boolean running = true;
 
-        RacingDevice(int devicePort, JdwpServer server, boolean stopDuringRequest) throws Exception {
+        RacingDevice(int devicePort, JdwpServer server, boolean stopDuringRequest,
+                     boolean silent) throws Exception {
             this.server = server;
             this.stopDuringRequest = stopDuringRequest;
+            this.silent = silent;
             Socket connected = null;
             for (int i = 0; i < 100 && connected == null; i++) {
                 try {
@@ -227,6 +266,7 @@ public class JdwpThreadListRaceTest {
                     return;
                 }
                 case WireProtocol.CMD_GET_THREADS: {
+                    if (silent) return;   // an older runtime simply ignores it
                     if (stopDuringRequest) {
                         // The stop reaches the proxy before the list it raced.
                         server.onBreakpointHit(LATE_STOPPER, 0, 12);

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpThreadListRaceTest.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpThreadListRaceTest.java
@@ -137,7 +137,7 @@ public class JdwpThreadListRaceTest {
             int count = body.readInt();
             List<Long> ids = new ArrayList<>();
             for (int i = 0; i < count; i++) {
-                ids.add(body.readLong());
+                ids.add(JdwpTestClient.fromJdwpThread(body.readLong()));
             }
             return ids;
         }

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpThreadListRaceTest.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpThreadListRaceTest.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.debug.proxy;
+
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.GZIPOutputStream;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * A thread that stops while the thread list is in flight still appears in it.
+ *
+ * <p>The device samples its thread list at the moment the request reaches it.
+ * A thread that stops after that is described by a reply that predates it, and
+ * rebuilding the proxy's view from that reply dropped it — out of the very
+ * {@code AllThreads} the IDE issues on being told the thread stopped. The
+ * suspension is the newer fact, so it wins.</p>
+ *
+ * <p>The opposite case has to keep working: a thread that stopped, was
+ * reported, and then exited must leave the list rather than sitting in the
+ * IDE's thread panel for the rest of the session. What separates them is
+ * whether the suspension is newer than the request, not the suspension alone —
+ * see {@link JdwpThreadListTest#aThreadThatStoppedAndThenDiedDoesNotLinger}.</p>
+ */
+public class JdwpThreadListRaceTest {
+
+    private static final String TABLE =
+            "version\t1\n"
+          + "class\t0\tjava_lang_Thread\tThread.java\t-1\tjava/lang/Thread\n"
+          + "method\t0\t0\trun\t()V\t0\n"
+          + "line\t0\t12\n";
+
+    private static final long ESTABLISHED = 7;
+    private static final long LATE_STOPPER = 21;
+
+    /**
+     * The device answers with a list that does not mention the late thread,
+     * having reported that thread's breakpoint first — the order the proxy
+     * sees when a thread stops just after the request goes out.
+     */
+    @Test
+    public void aThreadThatStopsWhileTheListIsInFlightSurvivesTheSnapshot() throws Exception {
+        try (Fixture f = new Fixture(true)) {
+            List<Long> threads = f.allThreads();
+
+            assertTrue("the thread that just stopped should be listed: " + threads,
+                    threads.contains(LATE_STOPPER));
+            assertTrue("the established thread should still be listed: " + threads,
+                    threads.contains(ESTABLISHED));
+        }
+    }
+
+    /**
+     * A thread that stopped before the request went out and is absent from the
+     * answer really has gone, and is dropped.
+     *
+     * <p>This is the case that keeps the rule honest. Retaining every suspended
+     * thread a snapshot omits would be simpler and would satisfy the test
+     * above, at the cost of a dead row that never leaves the IDE's thread
+     * panel.</p>
+     */
+    @Test
+    public void aThreadThatStoppedBeforeTheRequestAndIsAbsentIsDropped() throws Exception {
+        try (Fixture f = new Fixture(false)) {
+            f.allThreads();   // one refresh completes first
+            // Stops after that refresh and before the next one is asked for.
+            f.server.onBreakpointHit(LATE_STOPPER, 0, 12);
+
+            List<Long> threads = f.allThreads();
+
+            assertFalse("a thread the device no longer reports should go: " + threads,
+                    threads.contains(LATE_STOPPER));
+        }
+    }
+
+    // ---- fixture -----------------------------------------------------------
+
+    private final class Fixture implements AutoCloseable {
+        final JdwpServer server;
+        private final JdwpTestClient client;
+        private final RacingDevice device;
+
+        Fixture(boolean stopDuringRequest) throws Exception {
+            int jdwpPort = JdwpTestClient.freePort();
+            int devicePort = JdwpTestClient.freePort();
+            server = new JdwpServer(jdwpPort, devicePort);
+
+            DeviceConnection connection = new DeviceConnection(devicePort, server);
+            server.setDevice(connection);
+            Thread serving = new Thread(() -> {
+                try { connection.acceptAndServe(); } catch (Exception ignore) { }
+            }, "device-serve");
+            serving.setDaemon(true);
+            serving.start();
+
+            device = new RacingDevice(devicePort, server, stopDuringRequest);
+            client = JdwpTestClient.attach(server, jdwpPort);
+            device.connect();
+            device.awaitHello();
+        }
+
+        /** VirtualMachine.AllThreads, which round-trips CMD_GET_THREADS. */
+        List<Long> allThreads() throws Exception {
+            JdwpTestClient.Reply reply =
+                    client.send(JdwpTestClient.CS_VIRTUAL_MACHINE, 4, new byte[0]);
+            DataInputStream body = reply.stream();
+            int count = body.readInt();
+            List<Long> ids = new ArrayList<>();
+            for (int i = 0; i < count; i++) {
+                ids.add(body.readLong());
+            }
+            return ids;
+        }
+
+        @Override public void close() {
+            client.close();
+            device.close();
+        }
+    }
+
+    /**
+     * Answers the thread list with a snapshot that omits {@link #LATE_STOPPER},
+     * optionally reporting that thread's breakpoint first so the proxy learns
+     * of the stop before the stale list arrives. Runs on its own thread: the
+     * proxy blocks waiting for each reply.
+     */
+    private static final class RacingDevice {
+        private final JdwpServer server;
+        private final boolean stopDuringRequest;
+        private final Socket socket;
+        private final DataInputStream in;
+        private final DataOutputStream out;
+        private final Thread pump;
+        private final Object helloLock = new Object();
+        private volatile boolean helloDone;
+        private volatile boolean running = true;
+
+        RacingDevice(int devicePort, JdwpServer server, boolean stopDuringRequest) throws Exception {
+            this.server = server;
+            this.stopDuringRequest = stopDuringRequest;
+            Socket connected = null;
+            for (int i = 0; i < 100 && connected == null; i++) {
+                try {
+                    connected = new Socket("127.0.0.1", devicePort);
+                } catch (IOException retry) {
+                    Thread.sleep(20);
+                }
+            }
+            if (connected == null) throw new IllegalStateException("proxy never listened");
+            socket = connected;
+            in = new DataInputStream(socket.getInputStream());
+            out = new DataOutputStream(socket.getOutputStream());
+            pump = new Thread(this::serve, "racing-device");
+            pump.setDaemon(true);
+        }
+
+        void connect() throws Exception {
+            send(WireProtocol.EVT_HELLO, new byte[] { 0, 0, 1 });
+            pump.start();
+        }
+
+        void awaitHello() throws Exception {
+            synchronized (helloLock) {
+                long deadline = System.currentTimeMillis() + 5000;
+                while (!helloDone && System.currentTimeMillis() < deadline) {
+                    helloLock.wait(deadline - System.currentTimeMillis());
+                }
+            }
+        }
+
+        private void serve() {
+            try {
+                while (running) {
+                    int len = in.readInt();
+                    int cmd = in.readUnsignedByte();
+                    byte[] payload = new byte[len];
+                    in.readFully(payload);
+                    handle(cmd, payload);
+                }
+            } catch (Exception done) {
+                // Socket closed at the end of a test.
+            }
+        }
+
+        private void handle(int cmd, byte[] p) throws Exception {
+            switch (cmd) {
+                case WireProtocol.CMD_GET_SYMBOLS: {
+                    byte[] gz = gzip(TABLE.getBytes(StandardCharsets.UTF_8));
+                    ByteArrayOutputStream b = new ByteArrayOutputStream();
+                    DataOutputStream d = new DataOutputStream(b);
+                    d.writeInt(gz.length);
+                    d.writeInt(0);
+                    d.writeInt(gz.length);
+                    d.write(gz);
+                    send(WireProtocol.EVT_SYMBOLS, b.toByteArray());
+                    synchronized (helloLock) { helloDone = true; helloLock.notifyAll(); }
+                    return;
+                }
+                case WireProtocol.CMD_GET_THREADS: {
+                    if (stopDuringRequest) {
+                        // The stop reaches the proxy before the list it raced.
+                        server.onBreakpointHit(LATE_STOPPER, 0, 12);
+                    }
+                    ByteArrayOutputStream b = new ByteArrayOutputStream();
+                    DataOutputStream d = new DataOutputStream(b);
+                    d.writeInt(1);
+                    d.writeLong(ESTABLISHED);
+                    d.writeByte(0);
+                    d.writeLong(0);
+                    send(WireProtocol.EVT_THREAD_LIST, b.toByteArray());
+                    return;
+                }
+                default:
+                    send(WireProtocol.EVT_REPLY_STATUS, new byte[0]);
+            }
+        }
+
+        private synchronized void send(int code, byte[] payload) throws IOException {
+            out.writeInt(payload.length);
+            out.writeByte(code);
+            out.write(payload);
+            out.flush();
+        }
+
+        private static byte[] gzip(byte[] raw) throws IOException {
+            ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+            try (GZIPOutputStream gz = new GZIPOutputStream(bytes)) {
+                gz.write(raw);
+            }
+            return bytes.toByteArray();
+        }
+
+        void close() {
+            running = false;
+            try { socket.close(); } catch (IOException ignore) { }
+        }
+    }
+}

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpThreadListTest.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpThreadListTest.java
@@ -29,6 +29,7 @@ import java.io.DataInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -130,11 +131,100 @@ public class JdwpThreadListTest {
     }
 
     /**
-     * A device that cannot enumerate — an older build, or one whose reply is
-     * lost — must not make the panel worse than it was. Event-derived ids stay.
+     * A breakpoint reports the thread as suspended straight away.
+     *
+     * <p>The cached list is only as fresh as the last refresh, and a thread is
+     * normally enumerated while running and stopped a moment later. Preferring
+     * the cache unconditionally left the IDE told that the very thread it had
+     * just stopped at was still running.</p>
      */
     @Test
-    public void threadsSeenInEventsSurviveAnEmptyDeviceList() throws Exception {
+    public void aSuspendEventUpdatesTheCachedThreadState() throws Exception {
+        int port = JdwpTestClient.freePort();
+        JdwpServer server = new JdwpServer(port);
+        try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
+            primeSymbols(server);
+            // Enumerated while both are running...
+            server.onThreads(new long[] { 7, 9 },
+                             new boolean[] { false, false },
+                             new long[] { 0, 0 });
+            assertEquals(0, suspendStatus(client, 7));
+
+            // ...then one stops, with no refresh in between.
+            server.onBreakpointHit(7, 0, 12);
+
+            assertEquals("the stopped thread is suspended", 1, suspendStatus(client, 7));
+            assertEquals("the other one is not", 0, suspendStatus(client, 9));
+        }
+    }
+
+    /** Resuming puts it back, so the panel does not stick on "suspended". */
+    @Test
+    public void resumingClearsTheCachedSuspendState() throws Exception {
+        int port = JdwpTestClient.freePort();
+        JdwpServer server = new JdwpServer(port);
+        try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
+            primeSymbols(server);
+            server.onThreads(new long[] { 7 }, new boolean[] { false }, new long[] { 0 });
+            server.onBreakpointHit(7, 0, 12);
+            assertEquals(1, suspendStatus(client, 7));
+
+            // VirtualMachine.Resume
+            assertEquals(0, client.send(JdwpTestClient.CS_VIRTUAL_MACHINE, 9, new byte[0]).errorCode);
+
+            assertEquals("resumed threads are running again", 0, suspendStatus(client, 7));
+        }
+    }
+
+    /**
+     * A thread that stopped once and later exited must leave the list.
+     *
+     * <p>Event-derived ids accumulate for the life of the session, so unioning
+     * them into every answer kept a phantom row in the IDE for every worker
+     * that had ever hit a breakpoint. They are a fallback for when the device
+     * cannot answer, not an addition to when it can.</p>
+     */
+    @Test
+    public void aThreadThatStoppedAndThenDiedDoesNotLinger() throws Exception {
+        int port = JdwpTestClient.freePort();
+        JdwpServer server = new JdwpServer(port);
+        try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
+            primeSymbols(server);
+            server.onThreads(new long[] { 7, 21 }, new boolean[] { false, false }, new long[] { 0, 0 });
+            server.onBreakpointHit(21, 0, 12);
+            assertEquals(Arrays.asList(7L, 21L), allThreads(client));
+
+            // The worker exits; the device no longer reports it.
+            server.onThreads(new long[] { 7 }, new boolean[] { false }, new long[] { 0 });
+
+            assertEquals(Arrays.asList(7L), allThreads(client));
+        }
+    }
+
+    /**
+     * A device that never answers the enumeration — an older build, whose
+     * runtime replies with a bare status instead of a thread list — must not
+     * make the panel worse than it was. Event-derived ids stay.
+     *
+     * <p>Note the distinction from an <em>empty</em> list: that is a device
+     * that answered, and is treated as authoritative.</p>
+     */
+    @Test
+    public void threadsSeenInEventsSurviveADeviceThatCannotEnumerate() throws Exception {
+        int port = JdwpTestClient.freePort();
+        JdwpServer server = new JdwpServer(port);
+        try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
+            primeSymbols(server);
+            server.onBreakpointHit(21, 0, 12);
+            // No onThreads at all — the device never sent EVT_THREAD_LIST.
+
+            assertEquals(Arrays.asList(21L), allThreads(client));
+        }
+    }
+
+    /** An empty list from a device that can answer means there is nothing to show. */
+    @Test
+    public void anEmptyDeviceListIsTreatedAsAuthoritative() throws Exception {
         int port = JdwpTestClient.freePort();
         JdwpServer server = new JdwpServer(port);
         try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
@@ -142,7 +232,7 @@ public class JdwpThreadListTest {
             server.onBreakpointHit(21, 0, 12);
             server.onThreads(new long[0], new boolean[0], new long[0]);
 
-            assertEquals(Arrays.asList(21L), allThreads(client));
+            assertEquals(Collections.<Long>emptyList(), allThreads(client));
         }
     }
 

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpThreadListTest.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpThreadListTest.java
@@ -115,6 +115,51 @@ public class JdwpThreadListTest {
         }
     }
 
+    /**
+     * A thread list sampled before a stop cannot undo the stop.
+     *
+     * <p>The device samples a thread, the thread stops and sends its event,
+     * and the sampled list arrives second — so the proxy would apply
+     * {@code suspended=false} on top of the stop it had just processed and
+     * report the thread the IDE is sitting at as running. The proxy issues
+     * every resume itself, so its own belief wins in that direction: a
+     * snapshot may add a suspension but never withdraw one.</p>
+     */
+    @Test
+    public void aStaleSnapshotCannotUndoASuspendEvent() throws Exception {
+        int port = JdwpTestClient.freePort();
+        JdwpServer server = new JdwpServer(port);
+        try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
+            primeSymbols(server);
+            server.onThreads(new long[] { 7 }, new boolean[] { false }, new long[] { 0 });
+            server.onBreakpointHit(7, 0, 12);
+            assertEquals(1, suspendStatus(client, 7));
+
+            // Sampled before the stop, delivered after it.
+            server.onThreads(new long[] { 7 }, new boolean[] { false }, new long[] { 0 });
+
+            assertEquals("the stop still stands", 1, suspendStatus(client, 7));
+        }
+    }
+
+    /** But a resume the proxy issued does clear it, so it cannot stick. */
+    @Test
+    public void aResumeStillClearsItAfterwards() throws Exception {
+        int port = JdwpTestClient.freePort();
+        JdwpServer server = new JdwpServer(port);
+        try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
+            primeSymbols(server);
+            server.onBreakpointHit(7, 0, 12);
+            server.onThreads(new long[] { 7 }, new boolean[] { false }, new long[] { 0 });
+            assertEquals(1, suspendStatus(client, 7));
+
+            assertEquals(0, client.send(JdwpTestClient.CS_VIRTUAL_MACHINE, 9, new byte[0]).errorCode);
+            server.onThreads(new long[] { 7 }, new boolean[] { false }, new long[] { 0 });
+
+            assertEquals("a resumed thread is running again", 0, suspendStatus(client, 7));
+        }
+    }
+
     /** A thread the device no longer reports must leave the list. */
     @Test
     public void deadThreadsDropOutOfTheList() throws Exception {

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpThreadListTest.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpThreadListTest.java
@@ -86,7 +86,7 @@ public class JdwpThreadListTest {
             List<Long> ids = new ArrayList<>();
             int count = body.readInt();
             for (int i = 0; i < count; i++) {
-                ids.add(body.readLong());
+                ids.add(JdwpTestClient.fromJdwpThread(body.readLong()));
             }
             assertEquals(Arrays.asList(3L, 4L, 5L), ids);
             assertEquals("a group with no child groups", 0, body.readInt());
@@ -324,7 +324,7 @@ public class JdwpThreadListTest {
         int count = body.readInt();
         List<Long> ids = new ArrayList<>();
         for (int i = 0; i < count; i++) {
-            ids.add(body.readLong());
+            ids.add(JdwpTestClient.fromJdwpThread(body.readLong()));
         }
         assertTrue("ids should be reported in a stable order", isSorted(ids));
         return ids;

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpThreadListTest.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpThreadListTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.debug.proxy;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * The IDE's thread list should show every live thread, not only the ones that
+ * have already stopped somewhere.
+ *
+ * <p>{@code CMD_GET_THREADS} was a device-side stub that replied empty, and the
+ * proxy never sent it — so {@code VirtualMachine.AllThreads} could only report
+ * ids harvested from breakpoint and step events. A developer who had not hit a
+ * breakpoint yet saw an empty Threads panel, which is what
+ * <a href="https://github.com/codenameone/CodenameOne/issues/5333">issue
+ * #5333</a> asked about.</p>
+ */
+public class JdwpThreadListTest {
+
+    /** Two classes and one method, enough for the symbol-dependent paths. */
+    private static final String TABLE =
+            "version\t1\n"
+          + "class\t0\tcom_example_Main\tMain.java\t-1\tcom/example/Main\n"
+          + "method\t0\t0\tstart\t()V\t0\n"
+          + "line\t0\t12\n";
+
+    @Test
+    public void allThreadsListsThreadsThatNeverRaisedAnEvent() throws Exception {
+        int port = JdwpTestClient.freePort();
+        JdwpServer server = new JdwpServer(port);
+        try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
+            primeSymbols(server);
+            server.onThreads(new long[] { 7, 9 },
+                             new boolean[] { false, false },
+                             new long[] { 0, 0 });
+
+            assertEquals(Arrays.asList(7L, 9L), allThreads(client));
+        }
+    }
+
+    @Test
+    public void theThreadGroupReportsTheSameThreadsAsTheVm() throws Exception {
+        int port = JdwpTestClient.freePort();
+        JdwpServer server = new JdwpServer(port);
+        try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
+            primeSymbols(server);
+            server.onThreads(new long[] { 3, 4, 5 },
+                             new boolean[] { false, true, false },
+                             new long[] { 0, 0, 0 });
+
+            JdwpTestClient.Reply reply = client.send(
+                    JdwpTestClient.CS_THREAD_GROUP_REF, 3, JdwpTestClient.threadId(0xCAFEL));
+            assertEquals(0, reply.errorCode);
+            DataInputStream body = reply.stream();
+            List<Long> ids = new ArrayList<>();
+            int count = body.readInt();
+            for (int i = 0; i < count; i++) {
+                ids.add(body.readLong());
+            }
+            assertEquals(Arrays.asList(3L, 4L, 5L), ids);
+            assertEquals("a group with no child groups", 0, body.readInt());
+        }
+    }
+
+    /**
+     * Suspension is per thread. The old answer came from a single
+     * "last thread that suspended" field, so with two threads parked at once
+     * the IDE was told one of them was running.
+     */
+    @Test
+    public void statusReflectsEachThreadsOwnSuspendState() throws Exception {
+        int port = JdwpTestClient.freePort();
+        JdwpServer server = new JdwpServer(port);
+        try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
+            primeSymbols(server);
+            server.onThreads(new long[] { 7, 9 },
+                             new boolean[] { true, false },
+                             new long[] { 0, 0 });
+
+            assertEquals("suspended thread", 1, suspendStatus(client, 7));
+            assertEquals("running thread", 0, suspendStatus(client, 9));
+            assertEquals("suspend count follows the same flag", 1, suspendCount(client, 7));
+            assertEquals(0, suspendCount(client, 9));
+        }
+    }
+
+    /** A thread the device no longer reports must leave the list. */
+    @Test
+    public void deadThreadsDropOutOfTheList() throws Exception {
+        int port = JdwpTestClient.freePort();
+        JdwpServer server = new JdwpServer(port);
+        try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
+            primeSymbols(server);
+            server.onThreads(new long[] { 7, 9 }, new boolean[] { false, false }, new long[] { 0, 0 });
+            assertEquals(Arrays.asList(7L, 9L), allThreads(client));
+
+            server.onThreads(new long[] { 9 }, new boolean[] { false }, new long[] { 0 });
+            assertEquals(Arrays.asList(9L), allThreads(client));
+        }
+    }
+
+    /**
+     * A device that cannot enumerate — an older build, or one whose reply is
+     * lost — must not make the panel worse than it was. Event-derived ids stay.
+     */
+    @Test
+    public void threadsSeenInEventsSurviveAnEmptyDeviceList() throws Exception {
+        int port = JdwpTestClient.freePort();
+        JdwpServer server = new JdwpServer(port);
+        try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
+            primeSymbols(server);
+            server.onBreakpointHit(21, 0, 12);
+            server.onThreads(new long[0], new boolean[0], new long[0]);
+
+            assertEquals(Arrays.asList(21L), allThreads(client));
+        }
+    }
+
+    /**
+     * Naming needs a {@code java.lang.Thread} instance and a live device to
+     * read it through. Without either, the synthetic name is still returned —
+     * an unnamed row beats a failed request.
+     */
+    @Test
+    public void threadNameFallsBackWhenTheDeviceReportsNoThreadObject() throws Exception {
+        int port = JdwpTestClient.freePort();
+        JdwpServer server = new JdwpServer(port);
+        try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
+            primeSymbols(server);
+            server.onThreads(new long[] { 7 }, new boolean[] { false }, new long[] { 0 });
+
+            JdwpTestClient.Reply reply = client.send(
+                    JdwpTestClient.CS_THREAD_REFERENCE, 1, JdwpTestClient.threadId(7));
+            assertEquals(0, reply.errorCode);
+            DataInputStream body = reply.stream();
+            byte[] utf8 = new byte[body.readInt()];
+            body.readFully(utf8);
+            assertEquals("Thread-7", new String(utf8, StandardCharsets.UTF_8));
+        }
+    }
+
+    // ---- helpers -----------------------------------------------------------
+
+    /**
+     * Gets the server past its wait-for-symbols gate without a device
+     * attached, so the thread queries answer from the last reported list
+     * instead of round-tripping.
+     */
+    private void primeSymbols(JdwpServer server) throws Exception {
+        server.onSymbols(SymbolTable.load(new ByteArrayInputStream(
+                TABLE.getBytes(StandardCharsets.UTF_8))));
+        server.onHello(1);
+    }
+
+    private List<Long> allThreads(JdwpTestClient client) throws Exception {
+        JdwpTestClient.Reply reply = client.send(JdwpTestClient.CS_VIRTUAL_MACHINE, 4, new byte[0]);
+        assertEquals(0, reply.errorCode);
+        DataInputStream body = reply.stream();
+        int count = body.readInt();
+        List<Long> ids = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            ids.add(body.readLong());
+        }
+        assertTrue("ids should be reported in a stable order", isSorted(ids));
+        return ids;
+    }
+
+    private int suspendStatus(JdwpTestClient client, long tid) throws Exception {
+        JdwpTestClient.Reply reply = client.send(
+                JdwpTestClient.CS_THREAD_REFERENCE, 4, JdwpTestClient.threadId(tid));
+        assertEquals(0, reply.errorCode);
+        DataInputStream body = reply.stream();
+        body.readInt(); // thread status
+        return body.readInt();
+    }
+
+    private int suspendCount(JdwpTestClient client, long tid) throws Exception {
+        JdwpTestClient.Reply reply = client.send(
+                JdwpTestClient.CS_THREAD_REFERENCE, 12, JdwpTestClient.threadId(tid));
+        assertEquals(0, reply.errorCode);
+        return reply.stream().readInt();
+    }
+
+    private boolean isSorted(List<Long> ids) {
+        for (int i = 1; i < ids.size(); i++) {
+            if (ids.get(i - 1) > ids.get(i)) return false;
+        }
+        return true;
+    }
+}

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpThreadNameTest.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpThreadNameTest.java
@@ -108,6 +108,39 @@ public class JdwpThreadNameTest {
         }
     }
 
+    /**
+     * Object questions about a thread reach its java.lang.Thread, not the
+     * thread id read as a pointer.
+     *
+     * <p>ParparVM thread ids are small integers and travel to the IDE as-is.
+     * jdb asks {@code ObjectReference.ReferenceType} on them to render the
+     * Threads panel, so forwarding the id to the device as an object pointer
+     * both addresses nothing and — for an odd id — is indistinguishable from a
+     * tagged int. Every odd-numbered thread showed as a java.lang.Integer.</p>
+     */
+    @Test
+    public void objectQueriesAboutAThreadResolveToItsThreadObject() throws Exception {
+        try (Harness h = new Harness("EDT")) {
+            h.refreshThreadList();
+
+            // ObjectReference.ReferenceType on the thread id.
+            JdwpTestClient.Reply reply = h.client.send(
+                    9 /* ObjectReference */, 1, JdwpTestClient.threadId(THREAD_ID));
+            assertEquals(0, reply.errorCode);
+            DataInputStream body = reply.stream();
+            body.readByte();                       // refTypeTag
+            long refType = body.readLong();
+
+            // The fake device answers GET_OBJECT_CLASS with java.lang.Thread
+            // (classId 0), which travels as JDWP reference id 1. Getting that
+            // back means the thread object was asked about, not the raw id.
+            assertEquals("the Thread object's class, not the id read as a pointer",
+                    1L, refType);
+            assertEquals("and the device was asked about the thread object",
+                    THREAD_OBJECT, h.device.lastObjectClassQuery);
+        }
+    }
+
     // ---- harness -----------------------------------------------------------
 
     private final class Harness implements AutoCloseable {
@@ -164,6 +197,7 @@ public class JdwpThreadNameTest {
     private static final class FakeDevice {
         volatile String threadName;
         volatile long threadObject = THREAD_OBJECT;
+        volatile long lastObjectClassQuery = -1;
         private final Socket socket;
         private final DataInputStream in;
         private final DataOutputStream out;
@@ -243,6 +277,8 @@ public class JdwpThreadNameTest {
                     return;
                 }
                 case WireProtocol.CMD_GET_OBJECT_CLASS: {
+                    lastObjectClassQuery = ((long) readInt(p, 0) << 32)
+                            | (readInt(p, 4) & 0xffffffffL);
                     // Thread object -> java.lang.Thread (classId 0).
                     ByteArrayOutputStream b = new ByteArrayOutputStream();
                     DataOutputStream d = new DataOutputStream(b);
@@ -276,6 +312,11 @@ public class JdwpThreadNameTest {
             out.writeByte(code);
             out.write(payload);
             out.flush();
+        }
+
+        private static int readInt(byte[] b, int off) {
+            return ((b[off] & 0xff) << 24) | ((b[off + 1] & 0xff) << 16)
+                 | ((b[off + 2] & 0xff) << 8) | (b[off + 3] & 0xff);
         }
 
         private static byte[] gzip(byte[] raw) throws IOException {

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpThreadNameTest.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpThreadNameTest.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.debug.proxy;
+
+import org.junit.After;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPOutputStream;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Thread naming, end to end through a stand-in device.
+ *
+ * Resolving a name is three round trips — the thread object's class, its
+ * {@code name} field, then that String's contents — and none of it runs
+ * without something answering on the device port. The other thread tests drive
+ * the proxy's listener callbacks directly and so never exercise the path at
+ * all; this one speaks the wire protocol so the resolution and its cache are
+ * actually covered.
+ */
+public class JdwpThreadNameTest {
+
+    /** java.lang.Thread with a name field, plus a String class to resolve to. */
+    private static final String TABLE =
+            "version\t1\n"
+          + "class\t0\tjava_lang_Thread\tThread.java\t-1\tjava/lang/Thread\n"
+          + "class\t1\tjava_lang_String\tString.java\t-1\tjava/lang/String\n"
+          + "field\t0\t7\tname\tLjava/lang/String;\t1\n";
+
+    private static final long THREAD_ID = 42;
+    private static final long THREAD_OBJECT = 0x5000;
+    private static final long NAME_STRING = 0x6000;
+
+    private FakeDevice device;
+
+    @After
+    public void tearDown() {
+        if (device != null) device.close();
+    }
+
+    @Test
+    public void aThreadIsNamedFromItsThreadObject() throws Exception {
+        try (Harness h = new Harness("EDT")) {
+            // An IDE enumerates before it names, which is what tells the proxy
+            // which java.lang.Thread each id belongs to.
+            h.refreshThreadList();
+            assertEquals("EDT", h.threadName(THREAD_ID));
+        }
+    }
+
+    /**
+     * A rename is picked up after the next thread-list refresh.
+     *
+     * <p>Naming costs three round trips, so the result is cached. Kept across
+     * refreshes, a pool thread renamed per task would carry its first label
+     * for the rest of its life.</p>
+     */
+    @Test
+    public void aRenamedThreadIsRelabelledAfterTheNextRefresh() throws Exception {
+        try (Harness h = new Harness("worker-1")) {
+            h.refreshThreadList();
+            assertEquals("worker-1", h.threadName(THREAD_ID));
+
+            h.device.threadName = "worker-2";
+            assertEquals("the cache holds until the list is refreshed",
+                    "worker-1", h.threadName(THREAD_ID));
+
+            h.refreshThreadList();
+            assertEquals("worker-2", h.threadName(THREAD_ID));
+        }
+    }
+
+    /** A thread with no Thread object still gets a usable label. */
+    @Test
+    public void aThreadWithNoThreadObjectFallsBack() throws Exception {
+        try (Harness h = new Harness("ignored")) {
+            h.device.threadObject = 0;
+            h.refreshThreadList();
+            assertEquals("Thread-" + THREAD_ID, h.threadName(THREAD_ID));
+        }
+    }
+
+    // ---- harness -----------------------------------------------------------
+
+    private final class Harness implements AutoCloseable {
+        private final JdwpServer server;
+        private final JdwpTestClient client;
+        final FakeDevice device;
+
+        Harness(String initialName) throws Exception {
+            int jdwpPort = JdwpTestClient.freePort();
+            int devicePort = JdwpTestClient.freePort();
+            server = new JdwpServer(jdwpPort, devicePort);
+
+            // The proxy has to be listening before the device dials in.
+            DeviceConnection connection = new DeviceConnection(devicePort, server);
+            server.setDevice(connection);
+            Thread serving = new Thread(() -> {
+                try { connection.acceptAndServe(); } catch (Exception ignore) { }
+            }, "device-serve");
+            serving.setDaemon(true);
+            serving.start();
+
+            device = new FakeDevice(devicePort, initialName);
+            JdwpThreadNameTest.this.device = device;
+
+            client = JdwpTestClient.attach(server, jdwpPort);
+            device.connect();
+            device.awaitHello();
+        }
+
+        String threadName(long tid) throws Exception {
+            JdwpTestClient.Reply reply = client.send(
+                    JdwpTestClient.CS_THREAD_REFERENCE, 1, JdwpTestClient.threadId(tid));
+            assertEquals(0, reply.errorCode);
+            DataInputStream body = reply.stream();
+            byte[] utf8 = new byte[body.readInt()];
+            body.readFully(utf8);
+            return new String(utf8, StandardCharsets.UTF_8);
+        }
+
+        /** VirtualMachine.AllThreads, which round-trips CMD_GET_THREADS. */
+        void refreshThreadList() throws Exception {
+            assertEquals(0, client.send(JdwpTestClient.CS_VIRTUAL_MACHINE, 4, new byte[0]).errorCode);
+        }
+
+        @Override public void close() {
+            client.close();
+        }
+    }
+
+    /**
+     * Answers the handful of commands naming needs, and nothing else. Runs on
+     * its own thread because the proxy blocks waiting for each reply.
+     */
+    private static final class FakeDevice {
+        volatile String threadName;
+        volatile long threadObject = THREAD_OBJECT;
+        private final Socket socket;
+        private final DataInputStream in;
+        private final DataOutputStream out;
+        private final Thread pump;
+        private final Object helloLock = new Object();
+        private volatile boolean helloDone;
+        private volatile boolean running = true;
+
+        FakeDevice(int devicePort, String initialName) throws Exception {
+            this.threadName = initialName;
+            Socket connected = null;
+            for (int i = 0; i < 100 && connected == null; i++) {
+                try {
+                    connected = new Socket("127.0.0.1", devicePort);
+                } catch (IOException retry) {
+                    Thread.sleep(20);
+                }
+            }
+            if (connected == null) throw new IllegalStateException("proxy never listened");
+            socket = connected;
+            in = new DataInputStream(socket.getInputStream());
+            out = new DataOutputStream(socket.getOutputStream());
+            pump = new Thread(this::serve, "fake-device");
+            pump.setDaemon(true);
+        }
+
+        void connect() throws Exception {
+            send(WireProtocol.EVT_HELLO, new byte[] { 0, 0, 1 });
+            pump.start();
+        }
+
+        void awaitHello() throws Exception {
+            synchronized (helloLock) {
+                long deadline = System.currentTimeMillis() + 5000;
+                while (!helloDone && System.currentTimeMillis() < deadline) {
+                    helloLock.wait(deadline - System.currentTimeMillis());
+                }
+            }
+        }
+
+        private void serve() {
+            try {
+                while (running) {
+                    int len = in.readInt();
+                    int cmd = in.readUnsignedByte();
+                    byte[] payload = new byte[len];
+                    in.readFully(payload);
+                    handle(cmd, payload);
+                }
+            } catch (Exception done) {
+                // Socket closed at the end of a test.
+            }
+        }
+
+        private void handle(int cmd, byte[] p) throws Exception {
+            switch (cmd) {
+                case WireProtocol.CMD_GET_SYMBOLS: {
+                    byte[] gz = gzip(TABLE.getBytes(StandardCharsets.UTF_8));
+                    ByteArrayOutputStream b = new ByteArrayOutputStream();
+                    DataOutputStream d = new DataOutputStream(b);
+                    d.writeInt(gz.length);
+                    d.writeInt(0);
+                    d.writeInt(gz.length);
+                    d.write(gz);
+                    send(WireProtocol.EVT_SYMBOLS, b.toByteArray());
+                    synchronized (helloLock) { helloDone = true; helloLock.notifyAll(); }
+                    return;
+                }
+                case WireProtocol.CMD_GET_THREADS: {
+                    ByteArrayOutputStream b = new ByteArrayOutputStream();
+                    DataOutputStream d = new DataOutputStream(b);
+                    d.writeInt(1);
+                    d.writeLong(THREAD_ID);
+                    d.writeByte(0);
+                    d.writeLong(threadObject);
+                    send(WireProtocol.EVT_THREAD_LIST, b.toByteArray());
+                    return;
+                }
+                case WireProtocol.CMD_GET_OBJECT_CLASS: {
+                    // Thread object -> java.lang.Thread (classId 0).
+                    ByteArrayOutputStream b = new ByteArrayOutputStream();
+                    DataOutputStream d = new DataOutputStream(b);
+                    d.writeInt(0);
+                    d.writeByte(0);
+                    send(WireProtocol.EVT_OBJECT_CLASS, b.toByteArray());
+                    return;
+                }
+                case WireProtocol.CMD_GET_OBJECT_FIELDS: {
+                    // The one field asked for is name; answer with the String ref.
+                    ByteArrayOutputStream b = new ByteArrayOutputStream();
+                    DataOutputStream d = new DataOutputStream(b);
+                    d.writeInt(1);
+                    d.writeByte('L');
+                    d.writeLong(NAME_STRING);
+                    send(WireProtocol.EVT_OBJECT_FIELDS, b.toByteArray());
+                    return;
+                }
+                case WireProtocol.CMD_GET_STRING: {
+                    send(WireProtocol.EVT_STRING_VALUE,
+                            threadName.getBytes(StandardCharsets.UTF_8));
+                    return;
+                }
+                default:
+                    send(WireProtocol.EVT_REPLY_STATUS, new byte[0]);
+            }
+        }
+
+        private synchronized void send(int code, byte[] payload) throws IOException {
+            out.writeInt(payload.length);
+            out.writeByte(code);
+            out.write(payload);
+            out.flush();
+        }
+
+        private static byte[] gzip(byte[] raw) throws IOException {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            try (GZIPOutputStream gz = new GZIPOutputStream(out)) {
+                gz.write(raw);
+            }
+            return out.toByteArray();
+        }
+
+        void close() {
+            running = false;
+            try { socket.close(); } catch (IOException ignore) {}
+        }
+    }
+
+    /** Unused, but keeps the port helper honest if the harness changes. */
+    @SuppressWarnings("unused")
+    private static int unusedPort() throws Exception {
+        try (ServerSocket s = new ServerSocket(0)) {
+            return s.getLocalPort();
+        }
+    }
+}

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpVariableScopeTest.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpVariableScopeTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.debug.proxy;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * The IDE is told which lines each local is in scope for.
+ *
+ * <p>Every local used to be reported as live from code index 0 for
+ * {@code Integer.MAX_VALUE}, so the IDE asked for every slot at every stop.
+ * For a slot two disjoint scopes share that means the variable the code has
+ * not reached is shown next to the one it has, displaying storage that belongs
+ * to the other scope.</p>
+ *
+ * <p>ParparVM has no bytecode offsets — a JDWP "code index" here is the source
+ * line — so a scope travels as its declaration line plus the number of lines
+ * it stays live for.</p>
+ */
+public class JdwpVariableScopeTest {
+
+    /**
+     * One method whose slot 2 holds an {@code int} for lines 10-13 and a
+     * {@code String} from line 14, plus a receiver that is live throughout.
+     */
+    private static final String TABLE =
+            "version\t1\n"
+          + "class\t0\tcom_example_Main\tMain.java\t-1\tcom/example/Main\n"
+          + "method\t0\t0\thandler\t(Ljava/lang/Object;)V\t0\n"
+          + "line\t0\t10\n"
+          + "line\t0\t14\n"
+          + "var\t0\t0\tthis\tLcom/example/Main;\t0\t0\n"
+          + "var\t0\t2\tcount\tI\t10\t14\n"
+          + "var\t0\t2\tlabel\tLjava/lang/String;\t14\t18\n";
+
+    @Test
+    public void aScopedLocalReportsItsDeclarationLineAndLength() throws Exception {
+        List<Var> vars = variableTable();
+
+        Var count = byName(vars, "count");
+        assertEquals("declared at line 10", 10L, count.codeIndex);
+        assertEquals("live for lines 10 through 13", 4, count.length);
+
+        Var label = byName(vars, "label");
+        assertEquals(14L, label.codeIndex);
+        assertEquals(4, label.length);
+    }
+
+    /** The two occupants of the shared slot cover disjoint line ranges. */
+    @Test
+    public void twoLocalsSharingASlotDoNotOverlap() throws Exception {
+        List<Var> vars = variableTable();
+        Var count = byName(vars, "count");
+        Var label = byName(vars, "label");
+
+        assertEquals("both describe the same slot", count.slot, label.slot);
+        assertTrue("ranges must not overlap: " + count + " vs " + label,
+                count.codeIndex + count.length <= label.codeIndex);
+    }
+
+    /**
+     * A local with no scope — the receiver, or one the translator synthesised
+     * from a store opcode — stays live for the whole method rather than being
+     * hidden everywhere.
+     */
+    @Test
+    public void anUnscopedLocalStaysAlwaysLive() throws Exception {
+        Var receiver = byName(variableTable(), "this");
+
+        assertEquals(0L, receiver.codeIndex);
+        assertEquals(Integer.MAX_VALUE, receiver.length);
+    }
+
+    /**
+     * Symbol tables written before scopes were tracked stop at the descriptor
+     * column. Those locals must load, and must stay always-live.
+     */
+    @Test
+    public void aLegacyTableWithoutScopeColumnsStillLoads() throws Exception {
+        String legacy =
+                "version\t1\n"
+              + "class\t0\tcom_example_Main\tMain.java\t-1\tcom/example/Main\n"
+              + "method\t0\t0\thandler\t(Ljava/lang/Object;)V\t0\n"
+              + "var\t0\t2\tcount\tI\n";
+
+        SymbolTable table = SymbolTable.load(new ByteArrayInputStream(
+                legacy.getBytes(StandardCharsets.UTF_8)));
+        SymbolTable.LocalVarInfo local = table.methodById(0).locals.get(0);
+
+        assertEquals(0, local.startLine);
+        assertEquals(0L, local.jdwpCodeIndex());
+        assertEquals(Integer.MAX_VALUE, local.jdwpLength());
+    }
+
+    /** VariableTableWithGeneric carries the same ranges, plus a generic slot. */
+    @Test
+    public void theGenericVariantReportsTheSameRanges() throws Exception {
+        List<Var> plain = variableTable(2);
+        List<Var> generic = variableTable(5);
+
+        assertEquals(plain.size(), generic.size());
+        for (int i = 0; i < plain.size(); i++) {
+            assertEquals(plain.get(i).name, generic.get(i).name);
+            assertEquals(plain.get(i).codeIndex, generic.get(i).codeIndex);
+            assertEquals(plain.get(i).length, generic.get(i).length);
+        }
+    }
+
+    /**
+     * Capabilities are reported honestly: the proxy turns the device's
+     * disconnect into a VM_DEATH event and supports nothing else on the list.
+     * Claiming more would have the IDE offer class redefinition, frame popping
+     * or forced returns and then fail when the developer used them.
+     */
+    @Test
+    public void onlyTheCapabilitiesTheProxyActuallyHasAreClaimed() throws Exception {
+        int port = JdwpTestClient.freePort();
+        JdwpServer server = new JdwpServer(port);
+        try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
+            primeSymbols(server);
+
+            JdwpTestClient.Reply original = client.send(JdwpTestClient.CS_VIRTUAL_MACHINE, 12, new byte[0]);
+            assertEquals(0, original.errorCode);
+            assertEquals("the seven original capabilities are all unsupported",
+                    7, original.body.length);
+            for (byte capability : original.body) {
+                assertEquals(0, capability);
+            }
+
+            JdwpTestClient.Reply extended = client.send(JdwpTestClient.CS_VIRTUAL_MACHINE, 17, new byte[0]);
+            assertEquals(0, extended.errorCode);
+            assertEquals(32, extended.body.length);
+            // Index 13 is canRequestVMDeathEvent.
+            for (int i = 0; i < extended.body.length; i++) {
+                assertEquals("capability " + i, i == 13 ? 1 : 0, extended.body[i]);
+            }
+        }
+    }
+
+    // ---- helpers -----------------------------------------------------------
+
+    private List<Var> variableTable() throws Exception {
+        return variableTable(2);
+    }
+
+    /** Runs Method.VariableTable (command 2) or VariableTableWithGeneric (5). */
+    private List<Var> variableTable(int command) throws Exception {
+        int port = JdwpTestClient.freePort();
+        JdwpServer server = new JdwpServer(port);
+        try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
+            primeSymbols(server);
+
+            byte[] payload = new byte[16];
+            payload[7] = 1;   // refType id 1 -> classId 0
+            payload[15] = 1;  // method id 1 -> methodId 0
+            JdwpTestClient.Reply reply = client.send(6 /* Method */, command, payload);
+            assertEquals(0, reply.errorCode);
+
+            DataInputStream body = reply.stream();
+            body.readInt(); // argCnt
+            int count = body.readInt();
+            List<Var> vars = new ArrayList<>();
+            for (int i = 0; i < count; i++) {
+                long codeIndex = body.readLong();
+                String name = readString(body);
+                readString(body); // descriptor
+                if (command == 5) {
+                    readString(body); // generic signature
+                }
+                int length = body.readInt();
+                int slot = body.readInt();
+                vars.add(new Var(name, codeIndex, length, slot));
+            }
+            return vars;
+        }
+    }
+
+    private void primeSymbols(JdwpServer server) throws Exception {
+        server.onSymbols(SymbolTable.load(new ByteArrayInputStream(
+                TABLE.getBytes(StandardCharsets.UTF_8))));
+        server.onHello(1);
+    }
+
+    private static String readString(DataInputStream in) throws Exception {
+        byte[] utf8 = new byte[in.readInt()];
+        in.readFully(utf8);
+        return new String(utf8, StandardCharsets.UTF_8);
+    }
+
+    private Var byName(List<Var> vars, String name) {
+        for (Var v : vars) {
+            if (v.name.equals(name)) return v;
+        }
+        assertNotNull("no local named " + name + " in " + vars, null);
+        return null;
+    }
+
+    private static final class Var {
+        final String name;
+        final long codeIndex;
+        final int length;
+        final int slot;
+
+        Var(String name, long codeIndex, int length, int slot) {
+            this.name = name;
+            this.codeIndex = codeIndex;
+            this.length = length;
+            this.slot = slot;
+        }
+
+        @Override public String toString() {
+            return name + "@slot" + slot + "[" + codeIndex + "+" + length + "]";
+        }
+    }
+}

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpVariableScopeTest.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/JdwpVariableScopeTest.java
@@ -167,6 +167,75 @@ public class JdwpVariableScopeTest {
         }
     }
 
+    /**
+     * A registered VM_DEATH request gets its own event when the session ends.
+     *
+     * <p>The capability is only honest if the request path works. The spec's
+     * automatic event carries request id 0; a debugger that registered a
+     * request is waiting for the id it was handed, and one that never arrives
+     * leaves it waiting for a session end that already happened.</p>
+     */
+    @Test
+    public void aRegisteredVmDeathRequestIsMatchedWhenTheSessionEnds() throws Exception {
+        int port = JdwpTestClient.freePort();
+        JdwpServer server = new JdwpServer(port);
+        try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
+            primeSymbols(server);
+
+            byte[] set = new byte[6];
+            set[0] = 99;  // VM_DEATH
+            set[1] = 2;   // SUSPEND_ALL
+            JdwpTestClient.Reply reply = client.send(JdwpTestClient.CS_EVENT_REQUEST, 1, set);
+            assertEquals(0, reply.errorCode);
+            int rid = reply.stream().readInt();
+            assertTrue("a VM_DEATH request should get a real id", rid > 0);
+
+            server.onVmDeath();
+
+            List<Integer> ids = new ArrayList<>();
+            int suspendPolicy = -1;
+            for (JdwpTestClient.Event e : client.drainEvents()) {
+                if (e.eventKind == 99) {
+                    ids.add(e.requestId);
+                    suspendPolicy = e.suspendPolicy;
+                }
+            }
+            assertTrue("the automatic event must still be sent", ids.contains(0));
+            assertTrue("the registered request must be matched, got " + ids, ids.contains(rid));
+            assertEquals("the strongest requested policy wins", 2, suspendPolicy);
+        }
+    }
+
+    /** Clearing it stops the match, so a stale id is not sent to the next IDE. */
+    @Test
+    public void aClearedVmDeathRequestIsNoLongerMatched() throws Exception {
+        int port = JdwpTestClient.freePort();
+        JdwpServer server = new JdwpServer(port);
+        try (JdwpTestClient client = JdwpTestClient.attach(server, port)) {
+            primeSymbols(server);
+
+            byte[] set = new byte[6];
+            set[0] = 99;
+            int rid = client.send(JdwpTestClient.CS_EVENT_REQUEST, 1, set).stream().readInt();
+
+            byte[] clear = new byte[5];
+            clear[0] = 99;
+            clear[1] = (byte) (rid >>> 24);
+            clear[2] = (byte) (rid >>> 16);
+            clear[3] = (byte) (rid >>> 8);
+            clear[4] = (byte) rid;
+            assertEquals(0, client.send(JdwpTestClient.CS_EVENT_REQUEST, 2, clear).errorCode);
+
+            server.onVmDeath();
+
+            for (JdwpTestClient.Event e : client.drainEvents()) {
+                if (e.eventKind == 99) {
+                    assertEquals("only the automatic event remains", 0, e.requestId);
+                }
+            }
+        }
+    }
+
     // ---- helpers -----------------------------------------------------------
 
     private List<Var> variableTable() throws Exception {

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/NoOpDeviceListener.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/NoOpDeviceListener.java
@@ -36,7 +36,7 @@ class NoOpDeviceListener implements DeviceConnection.DeviceListener {
     @Override public void onLocals(int[] slots, byte[] typeCodes, long[] values) {}
     @Override public void onVmDeath() {}
     @Override public void onStringValue(String value) {}
-    @Override public void onObjectClass(int classId, boolean isArray) {}
+    @Override public void onObjectClass(int classId, boolean isArray, int dimensions) {}
     @Override public void onObjectFields(byte[] typeCodes, long[] values) {}
     @Override public void onInvokeResult(byte type, long value) {}
     @Override public void onArrayLength(int length) {}

--- a/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/NoOpDeviceListener.java
+++ b/maven/cn1-debug-proxy/src/test/java/com/codename1/debug/proxy/NoOpDeviceListener.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.debug.proxy;
+
+/**
+ * A {@link DeviceConnection.DeviceListener} that ignores everything, so a test
+ * only has to override the one callback it is about.
+ */
+class NoOpDeviceListener implements DeviceConnection.DeviceListener {
+    @Override public void onSymbols(SymbolTable symbols) {}
+    @Override public void onHello(int version) {}
+    @Override public void onBreakpointHit(long threadId, int methodId, int line) {}
+    @Override public void onStepComplete(long threadId, int methodId, int line) {}
+    @Override public void onThreads(long[] threadIds, boolean[] suspended, long[] threadObjects) {}
+    @Override public void onStack(long threadId, int[] methodIds, int[] lines) {}
+    @Override public void onLocals(int[] slots, byte[] typeCodes, long[] values) {}
+    @Override public void onVmDeath() {}
+    @Override public void onStringValue(String value) {}
+    @Override public void onObjectClass(int classId, boolean isArray) {}
+    @Override public void onObjectFields(byte[] typeCodes, long[] values) {}
+    @Override public void onInvokeResult(byte type, long value) {}
+    @Override public void onArrayLength(int length) {}
+    @Override public void onArrayValues(byte tag, int count, byte[] rawBytes) {}
+    @Override public void onReplyStatus() {}
+    @Override public void onStdoutLine(String line) {}
+    @Override public void onStderrLine(String line) {}
+    @Override public void onUnknownEvent(int code, byte[] payload) {}
+    @Override public void onDisconnected() {}
+}

--- a/maven/cn1app-archetype/src/main/resources/archetype-resources/.idea/runConfigurations/CN1_Android_OnDeviceDebug.xml
+++ b/maven/cn1app-archetype/src/main/resources/archetype-resources/.idea/runConfigurations/CN1_Android_OnDeviceDebug.xml
@@ -10,7 +10,7 @@
           </option>
           <option name="goals">
             <list>
-              <option value="codenameone:android-on-device-debugging" />
+              <option value="cn1:android-on-device-debugging" />
             </list>
           </option>
           <option name="pomFileName" value="pom.xml" />

--- a/maven/cn1app-archetype/src/main/resources/archetype-resources/.idea/runConfigurations/CN1_Debug_Proxy.xml
+++ b/maven/cn1app-archetype/src/main/resources/archetype-resources/.idea/runConfigurations/CN1_Debug_Proxy.xml
@@ -10,7 +10,7 @@
           </option>
           <option name="goals">
             <list>
-              <option value="codenameone:ios-on-device-debugging" />
+              <option value="cn1:ios-on-device-debugging" />
             </list>
           </option>
           <option name="pomFileName" value="pom.xml" />

--- a/maven/cn1app-archetype/src/main/resources/archetype-resources/.idea/runConfigurations/CN1_iOS_OnDeviceDebug.xml
+++ b/maven/cn1app-archetype/src/main/resources/archetype-resources/.idea/runConfigurations/CN1_iOS_OnDeviceDebug.xml
@@ -1,0 +1,28 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="CN1 iOS On-Device Debug Build" type="MavenRunConfiguration" folderName="On-Device Debug">
+    <MavenSettings>
+      <option name="myGeneralSettings" />
+      <option name="myRunnerSettings" />
+      <option name="myRunnerParameters">
+        <MavenRunnerParameters>
+          <option name="profiles">
+            <set />
+          </option>
+          <option name="goals">
+            <list>
+              <option value="codenameone:buildIosOnDeviceDebug" />
+            </list>
+          </option>
+          <option name="pomFileName" value="pom.xml" />
+          <option name="profilesMap">
+            <map />
+          </option>
+          <option name="resolveToWorkspace" value="false" />
+          <option name="resolveModules" value="false" />
+          <option name="workingDirPath" value="$PROJECT_DIR$" />
+        </MavenRunnerParameters>
+      </option>
+    </MavenSettings>
+    <method v="2" />
+  </configuration>
+</component>

--- a/maven/cn1app-archetype/src/main/resources/archetype-resources/.idea/runConfigurations/CN1_iOS_OnDeviceDebug.xml
+++ b/maven/cn1app-archetype/src/main/resources/archetype-resources/.idea/runConfigurations/CN1_iOS_OnDeviceDebug.xml
@@ -10,7 +10,7 @@
           </option>
           <option name="goals">
             <list>
-              <option value="codenameone:buildIosOnDeviceDebug" />
+              <option value="cn1:buildIosOnDeviceDebug" />
             </list>
           </option>
           <option name="pomFileName" value="pom.xml" />

--- a/maven/cn1app-archetype/src/main/resources/archetype-resources/tools/netbeans/nbactions.xml
+++ b/maven/cn1app-archetype/src/main/resources/archetype-resources/tools/netbeans/nbactions.xml
@@ -138,6 +138,20 @@
         </properties>
     </action>
     <action>
+        <actionName>CUSTOM-Build for iOS On-Device Debug</actionName>
+        <displayName>Build for iOS On-Device Debug</displayName>
+        <goals>
+            <goal>cn1:buildIosOnDeviceDebug</goal>
+        </goals>
+    </action>
+    <action>
+        <actionName>CUSTOM-Start iOS Debug Proxy</actionName>
+        <displayName>Start iOS Debug Proxy</displayName>
+        <goals>
+            <goal>cn1:ios-on-device-debugging</goal>
+        </goals>
+    </action>
+    <action>
         <actionName>CUSTOM-Update Codename One</actionName>
         <displayName>Update Codename One</displayName>
         <goals>

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/AbstractCN1Mojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/AbstractCN1Mojo.java
@@ -229,8 +229,8 @@ public abstract class AbstractCN1Mojo extends AbstractMojo {
      * set by an invoking build — not the whole system property table, so
      * unrelated JVM properties cannot become build hints.
      */
-    private void overlayCommandLineBuildHints() {
-        if (session == null) {
+    protected void overlayCommandLineBuildHints(Properties target) {
+        if (session == null || target == null) {
             return;
         }
         Properties userProperties = session.getUserProperties();
@@ -239,7 +239,7 @@ public abstract class AbstractCN1Mojo extends AbstractMojo {
         }
         for (String key : userProperties.stringPropertyNames()) {
             if (key.startsWith("codename1.")) {
-                properties.setProperty(key, userProperties.getProperty(key));
+                target.setProperty(key, userProperties.getProperty(key));
             }
         }
     }
@@ -256,7 +256,7 @@ public abstract class AbstractCN1Mojo extends AbstractMojo {
                     throw new MojoExecutionException("Failed to find codenameone_settings.properties file.", ex);
                 }
             }
-            overlayCommandLineBuildHints();
+            overlayCommandLineBuildHints(properties);
         } else {
             getLog().warn("Failed to find CN1 Project directory.  codenameone_settings.properties will not be loaded");
             if (project.getCompileSourceRoots() != null && !project.getCompileSourceRoots().isEmpty()) {

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/AbstractCN1Mojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/AbstractCN1Mojo.java
@@ -47,6 +47,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
 import org.apache.maven.repository.RepositorySystem;
@@ -205,6 +206,44 @@ public abstract class AbstractCN1Mojo extends AbstractMojo {
         antProject.init();
     }
 
+    /**
+     * The properties Maven was invoked with, so a build hint given on the
+     * command line reaches the build.
+     */
+    @Parameter(defaultValue = "${session}", readonly = true)
+    private MavenSession session;
+
+    /**
+     * Lets {@code -Dcodename1.arg.x=y} override the settings file.
+     *
+     * Build hints were read only out of {@code codenameone_settings.properties},
+     * so a hint passed on the command line was accepted by Maven, printed in
+     * the build's own property dump, and then silently ignored — the builder
+     * asked {@code request.getArg(...)} and got the file's value or the
+     * default. That is what made {@code -Dcodename1.arg.ios.onDeviceDebug=true}
+     * produce a build with no symbol table and no debug listener, and it is why
+     * {@code cn1:buildIosOnDeviceDebug} could not turn the hint on for one
+     * build the way it says it does.
+     *
+     * Only user properties are overlaid — the values actually passed with -D or
+     * set by an invoking build — not the whole system property table, so
+     * unrelated JVM properties cannot become build hints.
+     */
+    private void overlayCommandLineBuildHints() {
+        if (session == null) {
+            return;
+        }
+        Properties userProperties = session.getUserProperties();
+        if (userProperties == null) {
+            return;
+        }
+        for (String key : userProperties.stringPropertyNames()) {
+            if (key.startsWith("codename1.")) {
+                properties.setProperty(key, userProperties.getProperty(key));
+            }
+        }
+    }
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         if (getCN1ProjectDir() != null) {
@@ -217,7 +256,7 @@ public abstract class AbstractCN1Mojo extends AbstractMojo {
                     throw new MojoExecutionException("Failed to find codenameone_settings.properties file.", ex);
                 }
             }
-            
+            overlayCommandLineBuildHints();
         } else {
             getLog().warn("Failed to find CN1 Project directory.  codenameone_settings.properties will not be loaded");
             if (project.getCompileSourceRoots() != null && !project.getCompileSourceRoots().isEmpty()) {

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/CN1BuildMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/CN1BuildMojo.java
@@ -833,6 +833,11 @@ public class CN1BuildMojo extends AbstractCN1Mojo {
         try (FileInputStream fis = new FileInputStream(codenameOneSettingsCopy)) {
             cn1SettingsProps.load(fis);
         }
+        // The build request is assembled from this copy, not from the mojo's
+        // own properties, so the command-line overlay has to be applied here
+        // too -- otherwise a hint passed with -D is read by the mojo and still
+        // absent from what the builder actually sees.
+        overlayCommandLineBuildHints(cn1SettingsProps);
         if (serverMustProvideKotlinVersion != null) {
             cn1SettingsProps.setProperty("codename1.arg.requireKotlinStdlib", serverMustProvideKotlinVersion);
         }

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/buildWrappers/BuildIosOnDeviceDebugMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/buildWrappers/BuildIosOnDeviceDebugMojo.java
@@ -6,6 +6,19 @@
  * published by the Free Software Foundation.  Codename One designates this
  * particular file as subject to the "Classpath" exception as provided
  * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
  */
 package com.codename1.maven.buildWrappers;
 

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/buildWrappers/BuildIosOnDeviceDebugMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/buildWrappers/BuildIosOnDeviceDebugMojo.java
@@ -27,7 +27,7 @@ import java.util.Properties;
  * the cloud build server. The user pairs this with {@code mvn
  * cn1:ios-on-device-debugging} (which launches the desktop proxy) and then
  * attaches jdb / IntelliJ / VS Code over JDWP — see
- * {@code docs/developer-guide/On-Device-Debugging.adoc}.
+ * {@code docs/developer-guide/On-Device-Debugging.asciidoc}.
  *
  * Forces {@code codename1.arg.ios.onDeviceDebug=true} so the listener
  * thread is linked into the binary and the Info.plist gets the proxy

--- a/maven/codenameone-maven-plugin/src/main/resources/com/codename1/maven/buildxml-template.xml
+++ b/maven/codenameone-maven-plugin/src/main/resources/com/codename1/maven/buildxml-template.xml
@@ -99,7 +99,7 @@ This the Ant build script used by the CN1BuildMojo for sending to the build serv
         translator emits debug-info side-tables and the iOS port links
         cn1_debugger.m into the binary. The companion goal
         cn1:ios-on-device-debugging launches the desktop JDWP proxy.
-        See docs/developer-guide/On-Device-Debugging.adoc for the full flow.
+        See docs/developer-guide/On-Device-Debugging.asciidoc for the full flow.
     -->
     <target name="ios-on-device-debug" depends="">
         <property name="ios.debug.targetType" value="iphone"/>

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/Cn1AppArchetypeCertificateWizardTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/Cn1AppArchetypeCertificateWizardTest.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class Cn1AppArchetypeCertificateWizardTest {
@@ -80,13 +81,46 @@ class Cn1AppArchetypeCertificateWizardTest {
         assertContains("tools/netbeans/nbactions.xml", "CUSTOM-Build for iOS On-Device Debug");
         assertContains("tools/netbeans/nbactions.xml", "<goal>cn1:buildIosOnDeviceDebug</goal>");
         assertContains(".idea/runConfigurations/CN1_iOS_OnDeviceDebug.xml",
-                "codenameone:buildIosOnDeviceDebug");
+                "cn1:buildIosOnDeviceDebug");
 
         // The proxy bridges the device's wire protocol to JDWP.
         assertContains("tools/netbeans/nbactions.xml", "CUSTOM-Start iOS Debug Proxy");
         assertContains("tools/netbeans/nbactions.xml", "<goal>cn1:ios-on-device-debugging</goal>");
         assertContains(".idea/runConfigurations/CN1_Debug_Proxy.xml",
-                "codenameone:ios-on-device-debugging");
+                "cn1:ios-on-device-debugging");
+    }
+
+    /**
+     * Generated run configurations must use the goal prefix the plugin
+     * actually registers.
+     *
+     * The descriptor sets {@code <goalPrefix>cn1</goalPrefix>}, so a
+     * configuration written against the artifact-derived {@code codenameone}
+     * prefix cannot resolve the plugin and the action fails to start. The
+     * NetBeans actions and the certificate-wizard configuration were already
+     * on {@code cn1}; the on-device-debug ones were not.
+     */
+    @Test
+    void generatedRunConfigurationsUseTheRegisteredGoalPrefix() throws Exception {
+        String descriptor = pluginDescriptor();
+        assertTrue(descriptor.contains("<goalPrefix>cn1</goalPrefix>"),
+                "this test pins the prefix the plugin registers; update it if that changes");
+
+        File dir = new File("../cn1app-archetype/src/main/resources/archetype-resources/.idea/runConfigurations");
+        File[] configs = dir.listFiles();
+        assertTrue(configs != null && configs.length > 0, "expected run configurations at " + dir);
+        for (File config : configs) {
+            String body = new String(Files.readAllBytes(config.toPath()), StandardCharsets.UTF_8);
+            assertFalse(body.contains("codenameone:"),
+                    config.getName() + " uses the unregistered 'codenameone' prefix,"
+                            + " so the action cannot resolve the plugin");
+        }
+    }
+
+    private static String pluginDescriptor() throws Exception {
+        File pom = new File("pom.xml");
+        assertTrue(pom.isFile(), "expected the plugin pom at " + pom.getAbsolutePath());
+        return new String(Files.readAllBytes(pom.toPath()), StandardCharsets.UTF_8);
     }
 
     private static void assertContains(String path, String expected) throws Exception {

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/Cn1AppArchetypeCertificateWizardTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/Cn1AppArchetypeCertificateWizardTest.java
@@ -64,6 +64,31 @@ class Cn1AppArchetypeCertificateWizardTest {
         assertContains(".vscode/settings.json", "-Dcodename1.buildTarget=local-javascript");
     }
 
+    /**
+     * A generated project must offer both halves of iOS on-device debugging
+     * from the IDE: the build that turns the debug listener on, and the proxy
+     * the IDE attaches through.
+     *
+     * NetBeans had neither, so the two goals had to be typed by hand and the
+     * build one silently did nothing unless the developer had already edited
+     * codenameone_settings.properties (issue #5333). IntelliJ shipped the
+     * proxy and the attach config but not the build.
+     */
+    @Test
+    void iosOnDeviceDebugBindingsAreIncludedInPackagedProjectTemplates() throws Exception {
+        // The build goal forces the onDeviceDebug hint on for one build.
+        assertContains("tools/netbeans/nbactions.xml", "CUSTOM-Build for iOS On-Device Debug");
+        assertContains("tools/netbeans/nbactions.xml", "<goal>cn1:buildIosOnDeviceDebug</goal>");
+        assertContains(".idea/runConfigurations/CN1_iOS_OnDeviceDebug.xml",
+                "codenameone:buildIosOnDeviceDebug");
+
+        // The proxy bridges the device's wire protocol to JDWP.
+        assertContains("tools/netbeans/nbactions.xml", "CUSTOM-Start iOS Debug Proxy");
+        assertContains("tools/netbeans/nbactions.xml", "<goal>cn1:ios-on-device-debugging</goal>");
+        assertContains(".idea/runConfigurations/CN1_Debug_Proxy.xml",
+                "codenameone:ios-on-device-debugging");
+    }
+
     private static void assertContains(String path, String expected) throws Exception {
         String content = archetypeResource("archetype-resources/" + path);
         assertTrue(content.contains(expected), path + " should contain " + expected);

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/CommandLineBuildHintTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/CommandLineBuildHintTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.maven;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * A build hint given on the command line has to reach the build.
+ *
+ * <p>Hints were read only out of {@code codenameone_settings.properties}, so
+ * {@code -Dcodename1.arg.ios.onDeviceDebug=true} was accepted by Maven, echoed
+ * in its own property dump, and then ignored — the builder asked
+ * {@code request.getArg(...)} and got the file's value. That produced a build
+ * with no symbol table and no debug listener while appearing to have asked for
+ * both, which is the complaint that opened issue #5333.</p>
+ */
+class CommandLineBuildHintTest {
+
+    @Test
+    void aCommandLineHintOverridesTheSettingsFile() throws Exception {
+        Properties settings = new Properties();
+        settings.setProperty("codename1.arg.ios.onDeviceDebug", "false");
+
+        Properties fromCommandLine = new Properties();
+        fromCommandLine.setProperty("codename1.arg.ios.onDeviceDebug", "true");
+
+        overlay(settings, fromCommandLine);
+
+        assertEquals("true", settings.getProperty("codename1.arg.ios.onDeviceDebug"));
+    }
+
+    @Test
+    void aHintAbsentFromTheFileIsStillApplied() throws Exception {
+        Properties settings = new Properties();
+        Properties fromCommandLine = new Properties();
+        fromCommandLine.setProperty("codename1.arg.ios.onDeviceDebug", "true");
+
+        overlay(settings, fromCommandLine);
+
+        assertEquals("true", settings.getProperty("codename1.arg.ios.onDeviceDebug"));
+    }
+
+    /**
+     * Only Codename One properties are overlaid. The user properties carry
+     * everything passed with -D, and turning an unrelated one into a build hint
+     * would put arbitrary values into the build request.
+     */
+    @Test
+    void unrelatedCommandLinePropertiesAreNotBuildHints() throws Exception {
+        Properties settings = new Properties();
+        Properties fromCommandLine = new Properties();
+        fromCommandLine.setProperty("maven.test.skip", "true");
+        fromCommandLine.setProperty("java.awt.headless", "true");
+
+        overlay(settings, fromCommandLine);
+
+        assertNull(settings.getProperty("maven.test.skip"));
+        assertNull(settings.getProperty("java.awt.headless"));
+    }
+
+    /** Settings the command line does not mention are left alone. */
+    @Test
+    void hintsNotGivenOnTheCommandLineAreUntouched() throws Exception {
+        Properties settings = new Properties();
+        settings.setProperty("codename1.arg.ios.uiscene", "true");
+        settings.setProperty("codename1.mainName", "MyApp");
+
+        overlay(settings, new Properties());
+
+        assertEquals("true", settings.getProperty("codename1.arg.ios.uiscene"));
+        assertEquals("MyApp", settings.getProperty("codename1.mainName"));
+    }
+
+    /**
+     * Drives the mojo's own overlay against a stand-in session, so the rule
+     * under test is the shipped one rather than a restatement of it.
+     */
+    private void overlay(Properties settings, Properties userProperties) throws Exception {
+        CN1BuildMojo mojo = new CN1BuildMojo();
+
+        Field propsField = findField(mojo.getClass(), "properties");
+        propsField.setAccessible(true);
+        propsField.set(mojo, settings);
+
+        Field sessionField = findField(mojo.getClass(), "session");
+        sessionField.setAccessible(true);
+        sessionField.set(mojo, new StubSession(userProperties));
+
+        Method overlay = findMethod(mojo.getClass(), "overlayCommandLineBuildHints");
+        overlay.setAccessible(true);
+        overlay.invoke(mojo);
+    }
+
+    private static Field findField(Class<?> type, String name) throws NoSuchFieldException {
+        for (Class<?> c = type; c != null; c = c.getSuperclass()) {
+            try {
+                return c.getDeclaredField(name);
+            } catch (NoSuchFieldException keepLooking) {
+                // up the chain
+            }
+        }
+        throw new NoSuchFieldException(name);
+    }
+
+    private static Method findMethod(Class<?> type, String name) throws NoSuchMethodException {
+        for (Class<?> c = type; c != null; c = c.getSuperclass()) {
+            try {
+                return c.getDeclaredMethod(name);
+            } catch (NoSuchMethodException keepLooking) {
+                // up the chain
+            }
+        }
+        throw new NoSuchMethodException(name);
+    }
+
+    /** A MavenSession that carries nothing but the -D values. */
+    private static final class StubSession extends org.apache.maven.execution.MavenSession {
+        private final Properties userProperties;
+
+        StubSession(Properties userProperties) {
+            super(null, null, new org.apache.maven.execution.DefaultMavenExecutionRequest(),
+                    new org.apache.maven.execution.DefaultMavenExecutionResult());
+            this.userProperties = userProperties;
+        }
+
+        @Override
+        public Properties getUserProperties() {
+            return userProperties;
+        }
+    }
+}

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/CommandLineBuildHintTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/CommandLineBuildHintTest.java
@@ -105,17 +105,13 @@ class CommandLineBuildHintTest {
     private void overlay(Properties settings, Properties userProperties) throws Exception {
         CN1BuildMojo mojo = new CN1BuildMojo();
 
-        Field propsField = findField(mojo.getClass(), "properties");
-        propsField.setAccessible(true);
-        propsField.set(mojo, settings);
-
         Field sessionField = findField(mojo.getClass(), "session");
         sessionField.setAccessible(true);
         sessionField.set(mojo, new StubSession(userProperties));
 
-        Method overlay = findMethod(mojo.getClass(), "overlayCommandLineBuildHints");
+        Method overlay = findMethod(mojo.getClass(), "overlayCommandLineBuildHints", Properties.class);
         overlay.setAccessible(true);
-        overlay.invoke(mojo);
+        overlay.invoke(mojo, settings);
     }
 
     private static Field findField(Class<?> type, String name) throws NoSuchFieldException {
@@ -129,10 +125,11 @@ class CommandLineBuildHintTest {
         throw new NoSuchFieldException(name);
     }
 
-    private static Method findMethod(Class<?> type, String name) throws NoSuchMethodException {
+    private static Method findMethod(Class<?> type, String name, Class<?>... args)
+            throws NoSuchMethodException {
         for (Class<?> c = type; c != null; c = c.getSuperclass()) {
             try {
-                return c.getDeclaredMethod(name);
+                return c.getDeclaredMethod(name, args);
             } catch (NoSuchMethodException keepLooking) {
                 // up the chain
             }

--- a/scripts/hellocodenameone/tools/netbeans/nbactions.xml
+++ b/scripts/hellocodenameone/tools/netbeans/nbactions.xml
@@ -131,6 +131,20 @@
         </properties>
     </action>
     <action>
+        <actionName>CUSTOM-Build for iOS On-Device Debug</actionName>
+        <displayName>Build for iOS On-Device Debug</displayName>
+        <goals>
+            <goal>cn1:buildIosOnDeviceDebug</goal>
+        </goals>
+    </action>
+    <action>
+        <actionName>CUSTOM-Start iOS Debug Proxy</actionName>
+        <displayName>Start iOS Debug Proxy</displayName>
+        <goals>
+            <goal>cn1:ios-on-device-debugging</goal>
+        </goals>
+    </action>
+    <action>
         <actionName>CUSTOM-Update Codename One</actionName>
         <displayName>Update Codename One</displayName>
         <goals>

--- a/vm/ByteCodeTranslator/src/cn1_globals.h
+++ b/vm/ByteCodeTranslator/src/cn1_globals.h
@@ -1172,11 +1172,26 @@ struct ThreadLocalData {
 
 #ifdef CN1_ON_DEVICE_DEBUG
 // One row of the variable side-table: a single (line, slot, typeCode) tuple.
-// typeCode is the JVM type descriptor first char (I/J/F/D/Z/B/S/C/L/[) so the
-// debugger thread knows how to dereference the void* held in
-// callStackLocalsAddresses[offset][slot].
+// typeCode is the JVM type descriptor first char (I/J/F/D/Z/B/S/C/L/[).
+//
+// The void* that backs row i is callStackLocalsAddresses[offset][i] -- indexed
+// by ROW, not by slot. A JVM slot is reused across disjoint scopes and the two
+// occupants need not share a type, so ParparVM emits separate storage for each
+// (slot, qualifier) pair it sees ("ilocals_3_" and "locals[3].data.o" can both
+// exist). A per-slot address table can only name one of them, which made the
+// debugger read an 8-byte object reference out of a 4-byte JAVA_INT and then
+// dereference the result -- a wild pointer, and the SIGSEGV behind issue #5333.
+// One address per row keeps typeCode and storage in lockstep by construction.
+// startLine/endLine bound the source lines this local is in scope for, with
+// endLine exclusive. {0, 0} means "always live" — the class file carried no
+// scope, or the translator synthesised the local from a store opcode; {n, 0}
+// means "live from line n onwards". The debugger uses them to hide a local the
+// frame has not reached, which matters most for the reused-slot case: without
+// a scope, both occupants show at every breakpoint and one of them displays
+// storage belonging to the other's scope.
 struct cn1_var_entry {
-    int line;
+    int startLine;
+    int endLine;
     int slot;
     char typeCode;
 };
@@ -1192,6 +1207,20 @@ struct cn1_frame_info {
     int varTableCount;
     const struct cn1_var_entry* varTable;
 };
+
+// Clears the debug side-channel for the frame about to be pushed.
+//
+// Only methods that carry a locals side-table publish these two pointers, and
+// they publish them AFTER the frame is pushed. Native, eliminated and barebone
+// methods never do -- so without this clear such a frame silently inherits
+// whatever the previous occupant of that call depth left behind, including a
+// callStackLocalsAddresses entry pointing into a C frame that has already
+// returned. handleGetStack then reports a bogus method for the frame and
+// handleGetLocals reads freed stack memory as object references. Must run
+// before callStackOffset is incremented.
+#define CN1_DEBUG_FRAME_ENTER(threadStateData) \
+    threadStateData->callStackFrameInfo[threadStateData->callStackOffset] = 0; \
+    threadStateData->callStackLocalsAddresses[threadStateData->callStackOffset] = 0;
 
 // Set to non-zero by the debugger proxy listener once a proxy has connected
 // and is ready to receive events. Read on the hot path of __CN1_DEBUG_INFO,
@@ -1221,6 +1250,8 @@ extern void cn1_debugger_check(struct ThreadLocalData* threadStateData, int line
 #else
 #define __CN1_DEBUG_INFO(line) threadStateData->callStackLine[threadStateData->callStackOffset - 1] = line;
 #define __CN1_DEBUG_INFO_NT(line) do {} while(0)
+// Release builds carry no debug side-channel, so pushing a frame costs nothing.
+#define CN1_DEBUG_FRAME_ENTER(threadStateData)
 #endif
 
 // we need to throw stack overflow error but its unavailable here...
@@ -2247,6 +2278,7 @@ static inline void cn1_init_method_stack_fast(CODENAME_ONE_THREAD_STATE, JAVA_OB
                 sizeof(struct elementStruct) * (localsStackSize + stackSize));
     }
     threadStateData->threadObjectStackOffset += localsStackSize + stackSize;
+    CN1_DEBUG_FRAME_ENTER(threadStateData)
     threadStateData->callStackOffset++;
 }
 
@@ -2271,6 +2303,7 @@ static inline void cn1InitMethodStackInline(CODENAME_ONE_THREAD_STATE, JAVA_OBJE
     threadStateData->threadObjectStackOffset += localsStackSize + stackSize;
     threadStateData->callStackClass[threadStateData->callStackOffset] = classNameId;
     threadStateData->callStackMethod[threadStateData->callStackOffset] = methodNameId;
+    CN1_DEBUG_FRAME_ENTER(threadStateData)
     threadStateData->callStackOffset++;
 }
 

--- a/vm/ByteCodeTranslator/src/cn1_globals.h
+++ b/vm/ByteCodeTranslator/src/cn1_globals.h
@@ -1246,6 +1246,17 @@ extern void cn1_debugger_check(struct ThreadLocalData* threadStateData, int line
 // weak stub in cn1_globals.m keeps release builds linking.
 extern void cn1_debugger_mark_issued_roots(struct ThreadLocalData* threadStateData);
 
+// Publishes a class's clazz address under its classId, from the constructor the
+// translator emits per class.
+//
+// Declared here rather than only in cn1_debugger.h because the caller is
+// generated code, which is compiled in more contexts than the iOS port's own
+// headers reach -- the watchOS slice among them, where cn1_debugger.h can be an
+// older copy and cn1_debugger_objects.c is not linked at all. Paired with a weak
+// no-op in cn1_globals.m for exactly that case, so a target without the debugger
+// runtime still compiles and links.
+extern void cn1_debugger_register_class(int classId, struct clazz* cls);
+
 #define __CN1_DEBUG_INFO(line) \
     do { \
         threadStateData->callStackLine[threadStateData->callStackOffset - 1] = (line); \

--- a/vm/ByteCodeTranslator/src/cn1_globals.h
+++ b/vm/ByteCodeTranslator/src/cn1_globals.h
@@ -1231,6 +1231,21 @@ extern volatile int cn1DebuggerActive;
 // Defined in cn1_debugger.m (iOS port) / a no-op shim in release builds.
 extern void cn1_debugger_check(struct ThreadLocalData* threadStateData, int line);
 
+// Marks every object reference the debugger has handed to the IDE, so the
+// collector cannot reclaim one while an objectID for it is outstanding.
+//
+// Without this, validating an id proves only that it is shaped like an object
+// of a registered class -- a class word survives reclamation, so a collected
+// object still passes -- and the IDE's next field or array read touches freed
+// memory. Rooting makes the issued set a liveness guarantee rather than a
+// heuristic: an object stays alive exactly as long as an id for it is
+// outstanding, and the debugger releases it when the owning thread resumes.
+//
+// Called from the GC's root pass next to the immortal roots. The strong
+// definition is in Ports/iOSPort/nativeSources/cn1_debugger_objects.c; the
+// weak stub in cn1_globals.m keeps release builds linking.
+extern void cn1_debugger_mark_issued_roots(struct ThreadLocalData* threadStateData);
+
 #define __CN1_DEBUG_INFO(line) \
     do { \
         threadStateData->callStackLine[threadStateData->callStackOffset - 1] = (line); \

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -1239,6 +1239,15 @@ void codenameOneGCMark() {
     }
     unlockCriticalSection();
 
+#ifdef CN1_ON_DEVICE_DEBUG
+    // Objects the debugger has handed to the IDE as objectIDs. Rooted for as
+    // long as the id can come back, so an id the IDE still holds always names
+    // a live object -- otherwise validating it proves only its shape, since a
+    // class word survives reclamation. Released when the owning thread
+    // resumes, so this is bounded by the suspension rather than permanent.
+    cn1_debugger_mark_issued_roots(d);
+#endif
+
     for(int iter = 0 ; iter < NUMBER_OF_SUPPORTED_THREADS ; iter++) {
         lockCriticalSection();
         struct ThreadLocalData* t = allThreads[iter];
@@ -7012,5 +7021,10 @@ __attribute__((weak)) volatile int cn1DebuggerActive = 0;
 __attribute__((weak)) void cn1_debugger_check(struct ThreadLocalData* threadStateData, int line) {
     (void)threadStateData;
     (void)line;
+}
+
+// Same arrangement: no debugger linked in means no issued ids to root.
+__attribute__((weak)) void cn1_debugger_mark_issued_roots(struct ThreadLocalData* threadStateData) {
+    (void)threadStateData;
 }
 #endif

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -7027,4 +7027,13 @@ __attribute__((weak)) void cn1_debugger_check(struct ThreadLocalData* threadStat
 __attribute__((weak)) void cn1_debugger_mark_issued_roots(struct ThreadLocalData* threadStateData) {
     (void)threadStateData;
 }
+
+// And again for the per-class registration the translator emits. Generated code
+// calls this from every class's constructor, including in targets that do not
+// link the debugger runtime (the watchOS slice), where it must simply do
+// nothing.
+__attribute__((weak)) void cn1_debugger_register_class(int classId, struct clazz* cls) {
+    (void)classId;
+    (void)cls;
+}
 #endif

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeClass.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/ByteCodeClass.java
@@ -1469,6 +1469,12 @@ public class ByteCodeClass {
         b.append("    cn1_debugger_register_fields(cn1_class_id_").append(clsName).append(",\n");
         b.append("            __cn1_dbg_fields_").append(clsName).append(",\n");
         b.append("            (int)(sizeof(__cn1_dbg_fields_").append(clsName).append(") / sizeof(cn1_field_entry)));\n");
+        // Publish the clazz address too, so the runtime can tell a genuine
+        // object header from a stale or fabricated pointer by an exact
+        // identity check rather than a heuristic. Every generated class runs
+        // this constructor, so the registry is complete before main().
+        b.append("    cn1_debugger_register_class(cn1_class_id_").append(clsName)
+          .append(", &class__").append(clsName).append(");\n");
         b.append("}\n");
         b.append("#endif // CN1_ON_DEVICE_DEBUG\n");
     }

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
@@ -48,9 +48,12 @@ import com.codename1.tools.translator.bytecodes.TryCatch;
 import com.codename1.tools.translator.bytecodes.TypeInstruction;
 import com.codename1.tools.translator.bytecodes.VarOp;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1355,77 +1358,171 @@ public class BytecodeMethod implements SignatureSet {
     }
 
     /**
-     * Emits a stack-allocated {@code void*} array containing the address of
-     * each JVM-local slot in the current frame, then stores the array pointer
-     * into the per-frame slot {@code callStackLocalsAddresses[offset-1]} that
-     * the debugger thread consults to read locals.
+     * The locals the on-device-debug side-table describes, in a stable order
+     * shared by {@link #appendFrameInfoStruct} (which emits each row's slot and
+     * type) and {@link #appendLocalsAddressTable} (which emits the matching
+     * storage address). Row <em>i</em> of one is row <em>i</em> of the other.
      *
-     * Slot type is resolved from {@link #localVariables} first (the declared
-     * source-level locals) and falls back to method arguments for slots that
-     * have no debug info. Slots with no known type are emitted as NULL — the
-     * debugger will report them as unavailable.
+     * Sorted rather than taken in {@link #localVariables} iteration order: that
+     * is a {@code HashSet}, so the order varies between builds of the same
+     * input, which used to make the emitted table non-deterministic.
+     *
+     * Locals whose slot lies outside the frame are dropped — there is no
+     * storage to point at, and keeping them would only hand the debugger an
+     * address that indexes past {@code locals[]}.
+     */
+    public List<LocalVariable> debugVarEntries() {
+        List<LocalVariable> rows = new ArrayList<LocalVariable>();
+        for (LocalVariable lv : localVariables) {
+            int idx = lv.getIndex();
+            if (idx >= 0 && idx < maxLocals) {
+                rows.add(lv);
+            }
+        }
+        Collections.sort(rows, DEBUG_VAR_ORDER);
+        return rows;
+    }
+
+    /** Slot first, then storage qualifier, so a reused slot's rows stay adjacent. */
+    private static final Comparator<LocalVariable> DEBUG_VAR_ORDER = new Comparator<LocalVariable>() {
+        @Override
+        public int compare(LocalVariable a, LocalVariable b) {
+            if (a.getIndex() != b.getIndex()) {
+                return a.getIndex() - b.getIndex();
+            }
+            return a.getQualifier() - b.getQualifier();
+        }
+    };
+
+    /**
+     * Maps each label in this method to the source line in effect there.
+     *
+     * javac emits a label and then the line number attached to it, so a label
+     * takes the line of the next {@code LineNumber} that follows it — several
+     * labels can share one line. Labels that no line follows (a trailing scope
+     * close, typically) keep the last line seen, which is the right answer for
+     * a scope that runs to the end of the method.
+     */
+    private Map<Label, Integer> lineByLabel() {
+        Map<Label, Integer> lines = new HashMap<Label, Integer>();
+        List<Label> pending = new ArrayList<Label>();
+        int currentLine = 0;
+        for (Instruction i : instructions) {
+            if (i instanceof LabelInstruction) {
+                pending.add(((LabelInstruction) i).getLabel());
+            } else if (i instanceof LineNumber) {
+                currentLine = ((LineNumber) i).getLine();
+                for (Label pendingLabel : pending) {
+                    lines.put(pendingLabel, currentLine);
+                }
+                pending.clear();
+            }
+        }
+        for (Label trailing : pending) {
+            lines.put(trailing, currentLine);
+        }
+        return lines;
+    }
+
+    /**
+     * The source-line range a local is in scope for, as {@code {start, end}}.
+     *
+     * {@code {0, 0}} means "always live": either the class file carried no
+     * scope for it, or the translator synthesised the local from a store
+     * opcode. The end is exclusive — a local declared at line 10 in a block
+     * closing at line 14 is live for lines 10 through 13.
+     */
+    private static final int[] ALWAYS_LIVE = { 0, 0 };
+
+    /**
+     * Resolves every local's scope in one pass, keyed the same way
+     * {@link #debugVarEntries()} orders them, so a caller emitting a whole
+     * method's locals walks the instruction list once rather than per local.
+     */
+    public List<int[]> debugVarScopes(List<LocalVariable> rows) {
+        Map<Label, Integer> lineByLabel = lineByLabel();
+        List<int[]> scopes = new ArrayList<int[]>(rows.size());
+        for (LocalVariable lv : rows) {
+            scopes.add(debugVarScope(lv, lineByLabel));
+        }
+        return scopes;
+    }
+
+    private int[] debugVarScope(LocalVariable lv, Map<Label, Integer> lineByLabel) {
+        Label start = lv.getScopeStart();
+        Label end = lv.getScopeEnd();
+        if (start == null || end == null) {
+            return ALWAYS_LIVE;
+        }
+        Integer startLine = lineByLabel.get(start);
+        Integer endLine = lineByLabel.get(end);
+        if (startLine == null || endLine == null || startLine <= 0) {
+            return ALWAYS_LIVE;
+        }
+        // A scope whose end resolves at or before its start tells us nothing
+        // usable (it happens when the whole scope sits on one line); treat it
+        // as open-ended rather than as an empty range that hides the local
+        // everywhere.
+        if (endLine <= startLine) {
+            return new int[] { startLine, 0 };
+        }
+        return new int[] { startLine, endLine };
+    }
+
+    /**
+     * The C expression naming the storage ParparVM emitted for one local.
+     *
+     * Object locals live in the frame's {@code locals[]} array (the GC scans
+     * it); primitives are plain C autos named by qualifier and slot. Both
+     * spellings can exist for the same slot when disjoint scopes reuse it with
+     * different types, which is exactly why this resolves per local rather than
+     * per slot.
+     */
+    private static String debugVarAddress(LocalVariable lv) {
+        char q = lv.getQualifier();
+        if (q == 'o') {
+            return "&locals[" + lv.getIndex() + "].data.o";
+        }
+        return "&" + q + "locals_" + lv.getIndex() + "_";
+    }
+
+    /**
+     * Emits a stack-allocated {@code void*} array holding the address backing
+     * each row of this method's variable side-table, then publishes it (and the
+     * static frame info) into the per-frame slots the debugger thread reads.
+     *
+     * Indexed by side-table row, so a row's {@code typeCode} always describes
+     * the storage its address points at. The previous per-slot form could not:
+     * a slot reused by an {@code int} and a reference has one address but two
+     * rows, so the reference row read eight bytes out of a four-byte
+     * {@code JAVA_INT} and the debugger then dereferenced the result.
+     *
+     * The frame-info pointer is published even when there are no rows, so the
+     * frame never inherits the previous occupant's metadata.
      *
      * Only called from the non-barebone path; barebone methods carry no
      * locals and bypass this entirely.
      */
     private void appendLocalsAddressTable(StringBuilder b) {
-        if (maxLocals <= 0) {
-            return;
-        }
-        char[] slotQual = new char[maxLocals];
-        java.util.Arrays.fill(slotQual, ' ');
-        for (LocalVariable lv : localVariables) {
-            int idx = lv.getIndex();
-            if (idx >= 0 && idx < maxLocals) {
-                slotQual[idx] = lv.getQualifier();
-            }
-        }
-        int slot = 0;
-        if (!staticMethod) {
-            if (slotQual[0] == ' ') {
-                slotQual[0] = 'o';
-            }
-            slot = 1;
-        }
-        for (int i = 0; i < arguments.size() && slot < maxLocals; i++) {
-            ByteCodeMethodArg arg = arguments.get(i);
-            if (slotQual[slot] == ' ') {
-                slotQual[slot] = arg.getQualifier();
-            }
-            slot++;
-            if (arg.isDoubleOrLong() && slot < maxLocals) {
-                slot++;
-            }
-        }
-
+        List<LocalVariable> rows = debugVarEntries();
         // Leading newline: callers may have left the cursor mid-line after
         // the "this" assignment when there are no other arguments, and the
         // preprocessor requires #ifdef to be the first non-whitespace token
         // on its line.
         b.append("\n#ifdef CN1_ON_DEVICE_DEBUG\n");
-        b.append("    void* __cn1_local_addrs[").append(maxLocals).append("] = { ");
-        for (int s = 0; s < maxLocals; s++) {
-            if (s > 0) {
-                b.append(", ");
+        if (rows.isEmpty()) {
+            b.append("    threadStateData->callStackLocalsAddresses[threadStateData->callStackOffset - 1] = 0;\n");
+        } else {
+            b.append("    void* __cn1_local_addrs[").append(rows.size()).append("] = { ");
+            for (int i = 0; i < rows.size(); i++) {
+                if (i > 0) {
+                    b.append(", ");
+                }
+                b.append(debugVarAddress(rows.get(i)));
             }
-            char q = slotQual[s];
-            switch (q) {
-                case 'o':
-                    b.append("&locals[").append(s).append("].data.o");
-                    break;
-                case 'i':
-                case 'l':
-                case 'f':
-                case 'd':
-                    b.append("&").append(q).append("locals_").append(s).append("_");
-                    break;
-                default:
-                    b.append("0");
-                    break;
-            }
+            b.append(" };\n");
+            b.append("    threadStateData->callStackLocalsAddresses[threadStateData->callStackOffset - 1] = __cn1_local_addrs;\n");
         }
-        b.append(" };\n");
-        b.append("    threadStateData->callStackLocalsAddresses[threadStateData->callStackOffset - 1] = __cn1_local_addrs;\n");
         b.append("    threadStateData->callStackFrameInfo[threadStateData->callStackOffset - 1] = &__cn1_finfo_").append(getMethodIdentifier()).append(";\n");
         b.append("#endif\n");
     }
@@ -1436,27 +1533,34 @@ public class BytecodeMethod implements SignatureSet {
      * per-frame pointer set up in {@link #appendLocalsAddressTable} stays
      * valid for the program's lifetime.
      *
-     * The side-table currently lists every declared local with line=0
-     * meaning "always live"; refining live-range per source line is left
-     * for a follow-up so the proxy can hide locals before their declaration.
+     * Each row carries the source-line range its local is in scope for, so the
+     * debugger can hide a local the code has not reached. Without it, two
+     * locals sharing a slot in disjoint scopes both appear at every
+     * breakpoint, one of them showing the contents of storage that belongs to
+     * the other scope.
      */
     private void appendFrameInfoStruct(StringBuilder b) {
         String id = getMethodIdentifier();
         int classId = Parser.getClassOffset(clsName);
         int methodId = methodOffset;
+        List<LocalVariable> rows = debugVarEntries();
         b.append("#ifdef CN1_ON_DEVICE_DEBUG\n");
-        if (localVariables.isEmpty()) {
+        if (rows.isEmpty()) {
             b.append("static const struct cn1_frame_info __cn1_finfo_").append(id).append(" = {\n");
             b.append("    ").append(classId).append(", ").append(methodId).append(", ").append(maxLocals).append(", 0, 0\n");
             b.append("};\n");
         } else {
+            Map<Label, Integer> lineByLabel = lineByLabel();
             b.append("static const struct cn1_var_entry __cn1_vars_").append(id).append("[] = {\n");
-            for (LocalVariable lv : localVariables) {
-                b.append("    { 0, ").append(lv.getIndex()).append(", '").append(lv.getTypeCode()).append("' },\n");
+            for (LocalVariable lv : rows) {
+                int[] scope = debugVarScope(lv, lineByLabel);
+                b.append("    { ").append(scope[0]).append(", ").append(scope[1])
+                 .append(", ").append(lv.getIndex())
+                 .append(", '").append(lv.getTypeCode()).append("' },\n");
             }
             b.append("};\n");
             b.append("static const struct cn1_frame_info __cn1_finfo_").append(id).append(" = {\n");
-            b.append("    ").append(classId).append(", ").append(methodId).append(", ").append(maxLocals).append(", ").append(localVariables.size()).append(", __cn1_vars_").append(id).append("\n");
+            b.append("    ").append(classId).append(", ").append(methodId).append(", ").append(maxLocals).append(", ").append(rows.size()).append(", __cn1_vars_").append(id).append("\n");
             b.append("};\n");
         }
         b.append("#endif\n");
@@ -2185,7 +2289,27 @@ public class BytecodeMethod implements SignatureSet {
             return;
         }
         //addInstruction(0, new LocalVariable(name, desc, signature, start, end, index));
-        localVariables.add(new LocalVariable(name, desc, signature, start, end, index));
+        LocalVariable lv = new LocalVariable(name, desc, signature, start, end, index);
+        // A store opcode visited earlier already synthesised a placeholder for
+        // this (slot, qualifier) — named "vN", with no scope. localVariables is
+        // a Set keyed on exactly that pair, so the placeholder would otherwise
+        // keep the class file's own entry out and the debugger would show "v2"
+        // for a local named "count" and treat it as live for the whole method.
+        if (lv.getScopeStart() != null) {
+            replaceSyntheticLocalVariable(lv);
+        }
+        localVariables.add(lv);
+    }
+
+    /** Drops the store-synthesised placeholder a real declaration supersedes. */
+    private void replaceSyntheticLocalVariable(LocalVariable replacement) {
+        for (Iterator<LocalVariable> it = localVariables.iterator(); it.hasNext();) {
+            LocalVariable existing = it.next();
+            if (existing.getScopeStart() == null && existing.equals(replacement)) {
+                it.remove();
+                return;
+            }
+        }
     }
     
     public void setSourceFile(String sourceFile) {

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
@@ -1402,7 +1402,13 @@ public class BytecodeMethod implements SignatureSet {
             if (a.getIndex() != b.getIndex()) {
                 return a.getIndex() - b.getIndex();
             }
-            return a.getQualifier() - b.getQualifier();
+            if (a.getQualifier() != b.getQualifier()) {
+                return a.getQualifier() - b.getQualifier();
+            }
+            // Two declarations can share both: disjoint blocks reusing a slot
+            // for the same type. Declaration order breaks the tie, so the
+            // emitted table does not depend on hash order.
+            return a.getSequence() - b.getSequence();
         }
     };
 
@@ -2347,11 +2353,19 @@ public class BytecodeMethod implements SignatureSet {
         localVariables.add(lv);
     }
 
-    /** Drops the store-synthesised placeholder a real declaration supersedes. */
+    /**
+     * Drops the store-synthesised placeholder a real declaration supersedes.
+     *
+     * Matched on storage rather than with equals, which now also compares
+     * scope — a placeholder has none, so it would never equal the declaration
+     * that replaces it.
+     */
     private void replaceSyntheticLocalVariable(LocalVariable replacement) {
         for (Iterator<LocalVariable> it = localVariables.iterator(); it.hasNext();) {
             LocalVariable existing = it.next();
-            if (existing.getScopeStart() == null && existing.equals(replacement)) {
+            if (existing.getScopeStart() == null
+                    && existing.getIndex() == replacement.getIndex()
+                    && existing.getQualifier() == replacement.getQualifier()) {
                 it.remove();
                 return;
             }

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
@@ -1418,23 +1418,30 @@ public class BytecodeMethod implements SignatureSet {
     private Map<Label, Integer> lineByLabel() {
         Map<Label, Integer> lines = new HashMap<Label, Integer>();
         List<Label> pending = new ArrayList<Label>();
-        int currentLine = 0;
         for (Instruction i : instructions) {
             if (i instanceof LabelInstruction) {
                 pending.add(((LabelInstruction) i).getLabel());
             } else if (i instanceof LineNumber) {
-                currentLine = ((LineNumber) i).getLine();
+                int currentLine = ((LineNumber) i).getLine();
                 for (Label pendingLabel : pending) {
                     lines.put(pendingLabel, currentLine);
                 }
                 pending.clear();
             }
         }
+        // Labels with no line after them sit past the last statement — which is
+        // where javac puts the end label of every method-wide local, `this` and
+        // the parameters included. Giving them the last line would make an
+        // exclusive scope end *on* that line and hide those locals at exactly
+        // the breakpoint most likely to be set. They run to the end instead.
         for (Label trailing : pending) {
-            lines.put(trailing, currentLine);
+            lines.put(trailing, END_OF_METHOD);
         }
         return lines;
     }
+
+    /** Marks a label that no source line follows; see {@link #lineByLabel()}. */
+    private static final int END_OF_METHOD = Integer.MAX_VALUE;
 
     /**
      * The source-line range a local is in scope for, as {@code {start, end}}.
@@ -1493,14 +1500,15 @@ public class BytecodeMethod implements SignatureSet {
         }
         Integer startLine = lineByLabel.get(start);
         Integer endLine = lineByLabel.get(end);
-        if (startLine == null || endLine == null || startLine <= 0) {
+        if (startLine == null || endLine == null || startLine <= 0
+                || startLine == END_OF_METHOD) {
             return ALWAYS_LIVE;
         }
-        // A scope whose end resolves at or before its start tells us nothing
-        // usable (it happens when the whole scope sits on one line); treat it
-        // as open-ended rather than as an empty range that hides the local
-        // everywhere.
-        if (endLine <= startLine) {
+        // Open-ended when the scope runs to the end of the method, and when its
+        // end resolves at or before its start — the latter happens where the
+        // whole scope sits on one line, and an empty range would hide the local
+        // everywhere rather than nowhere.
+        if (endLine == END_OF_METHOD || endLine <= startLine) {
             return new int[] { startLine, 0 };
         }
         return new int[] { startLine, endLine };

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
@@ -1510,12 +1510,17 @@ public class BytecodeMethod implements SignatureSet {
                 || startLine == END_OF_METHOD) {
             return ALWAYS_LIVE;
         }
-        // Open-ended when the scope runs to the end of the method, and when its
-        // end resolves at or before its start — the latter happens where the
-        // whole scope sits on one line, and an empty range would hide the local
-        // everywhere rather than nowhere.
-        if (endLine == END_OF_METHOD || endLine <= startLine) {
+        // Open-ended only when the scope really does run to the end of the
+        // method. A scope whose end resolves at or before its start is one
+        // that opens and closes on a single line; giving that an open end
+        // would leave the local visible for the rest of the method and let it
+        // collide with a later declaration reusing its slot. It gets the one
+        // line it occupies instead — an empty range would hide it everywhere.
+        if (endLine == END_OF_METHOD) {
             return new int[] { startLine, 0 };
+        }
+        if (endLine <= startLine) {
+            return new int[] { startLine, startLine + 1 };
         }
         return new int[] { startLine, endLine };
     }

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
@@ -1322,6 +1322,18 @@ public class BytecodeMethod implements SignatureSet {
         // at their CALL sites, in other classes. Same rule as the plans above --
         // recognize the shape on the raw list, never on the live one.
         analyzeTrivialGetterRaw();
+        // ON-DEVICE DEBUG: a local's declaring scope is a pair of labels, and
+        // turning those into source lines means walking the instruction list.
+        // Two consumers read the result at different times -- the frame
+        // side-table during code generation, the symbol table the IDE reads
+        // after every class has been generated -- with optimize() in between.
+        // It happens to preserve the label and line-number instructions this
+        // walk depends on, so resolving on demand would agree today; nothing
+        // states or enforces that, and the two disagreeing would silently drop
+        // locals from the IDE's variables view. Snapshotting off the raw list
+        // removes the dependence, and costs one walk per method instead of one
+        // per method per consumer.
+        snapshotDebugVarScopes();
     }
 
     public com.codename1.tools.translator.bytecodes.InlinableConstructor getInlinableConstructorPlan() {
@@ -1435,20 +1447,45 @@ public class BytecodeMethod implements SignatureSet {
     private static final int[] ALWAYS_LIVE = { 0, 0 };
 
     /**
-     * Resolves every local's scope in one pass, keyed the same way
-     * {@link #debugVarEntries()} orders them, so a caller emitting a whole
-     * method's locals walks the instruction list once rather than per local.
+     * Scopes resolved at parse time, keyed by local. Null until
+     * {@link #computeRawMethodPlans()} has run — methods built by hand rather
+     * than by the parser fall back to resolving on demand.
+     */
+    private Map<LocalVariable, int[]> debugVarScopeSnapshot;
+
+    /** Resolves every local's scope against the raw instruction list, once. */
+    private void snapshotDebugVarScopes() {
+        if (localVariables.isEmpty()) {
+            return;
+        }
+        Map<Label, Integer> lineByLabel = lineByLabel();
+        Map<LocalVariable, int[]> snapshot = new HashMap<LocalVariable, int[]>();
+        for (LocalVariable lv : localVariables) {
+            snapshot.put(lv, resolveDebugVarScope(lv, lineByLabel));
+        }
+        debugVarScopeSnapshot = snapshot;
+    }
+
+    /**
+     * The source-line ranges for {@code rows}, in the same order.
+     *
+     * Served from the parse-time snapshot so that the frame side-table emitted
+     * during code generation and the symbol table written after it describe
+     * the same local the same way.
      */
     public List<int[]> debugVarScopes(List<LocalVariable> rows) {
-        Map<Label, Integer> lineByLabel = lineByLabel();
         List<int[]> scopes = new ArrayList<int[]>(rows.size());
+        Map<LocalVariable, int[]> snapshot = debugVarScopeSnapshot;
+        Map<Label, Integer> lineByLabel = snapshot == null ? lineByLabel() : null;
         for (LocalVariable lv : rows) {
-            scopes.add(debugVarScope(lv, lineByLabel));
+            int[] scope = snapshot == null ? null : snapshot.get(lv);
+            scopes.add(scope != null ? scope : resolveDebugVarScope(lv, lineByLabel == null
+                    ? lineByLabel() : lineByLabel));
         }
         return scopes;
     }
 
-    private int[] debugVarScope(LocalVariable lv, Map<Label, Integer> lineByLabel) {
+    private int[] resolveDebugVarScope(LocalVariable lv, Map<Label, Integer> lineByLabel) {
         Label start = lv.getScopeStart();
         Label end = lv.getScopeEnd();
         if (start == null || end == null) {
@@ -1550,10 +1587,11 @@ public class BytecodeMethod implements SignatureSet {
             b.append("    ").append(classId).append(", ").append(methodId).append(", ").append(maxLocals).append(", 0, 0\n");
             b.append("};\n");
         } else {
-            Map<Label, Integer> lineByLabel = lineByLabel();
+            List<int[]> scopes = debugVarScopes(rows);
             b.append("static const struct cn1_var_entry __cn1_vars_").append(id).append("[] = {\n");
-            for (LocalVariable lv : rows) {
-                int[] scope = debugVarScope(lv, lineByLabel);
+            for (int ri = 0; ri < rows.size(); ri++) {
+                LocalVariable lv = rows.get(ri);
+                int[] scope = scopes.get(ri);
                 b.append("    { ").append(scope[0]).append(", ").append(scope[1])
                  .append(", ").append(lv.getIndex())
                  .append(", '").append(lv.getTypeCode()).append("' },\n");

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/Parser.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/Parser.java
@@ -330,14 +330,24 @@ public class Parser extends ClassVisitor {
                     for (Integer line : lines) {
                         w.write("line\t" + m.getMethodOffset() + "\t" + line + "\n");
                     }
-                    // Local variables: emitted as "always-live" scope until a
-                    // follow-up resolves ASM labels to source lines properly.
-                    // jdb tolerates this — uninitialised slots just show 0.
-                    for (com.codename1.tools.translator.bytecodes.LocalVariable lv : m.getLocalVariables()) {
+                    // Local variables, each with the source-line range it is in
+                    // scope for so the IDE only asks for slots that are live.
+                    // 0/0 means "always live" — a local with no scope in the
+                    // class file, or one the translator synthesised from a
+                    // store opcode. Taken in the same deterministic order the
+                    // device's own side-table uses.
+                    java.util.List<com.codename1.tools.translator.bytecodes.LocalVariable> vars =
+                            m.debugVarEntries();
+                    java.util.List<int[]> scopes = m.debugVarScopes(vars);
+                    for (int vi = 0; vi < vars.size(); vi++) {
+                        com.codename1.tools.translator.bytecodes.LocalVariable lv = vars.get(vi);
+                        int[] scope = scopes.get(vi);
                         w.write("var\t" + m.getMethodOffset()
                                 + "\t" + lv.getIndex()
                                 + "\t" + lv.getOrigName()
-                                + "\t" + lv.getDesc() + "\n");
+                                + "\t" + lv.getDesc()
+                                + "\t" + scope[0]
+                                + "\t" + scope[1] + "\n");
                     }
                 }
             }

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/LocalVariable.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/LocalVariable.java
@@ -35,15 +35,41 @@ public class LocalVariable extends Instruction {
     private String name;
     private String desc;
     private int index;
+    /**
+     * The bounds of the declaring scope, as ASM labels, or null for a local
+     * the translator synthesised from a store opcode rather than reading out
+     * of the class file's LocalVariableTable.
+     *
+     * Retained so the on-device debugger can resolve them to source lines and
+     * hide a local outside its scope. Two locals sharing a slot in disjoint
+     * scopes are otherwise indistinguishable at a breakpoint, and the debugger
+     * shows whichever one it happens to list — reporting the contents of a
+     * variable the code has not reached yet.
+     */
+    private final Label scopeStart;
+    private final Label scopeEnd;
+
     public LocalVariable(String name, String desc, String signature, Label start, Label end, int index) {
         super(Opcodes.ALOAD);
         this.name = name;
         this.desc = desc;
         this.index = index;
+        this.scopeStart = start;
+        this.scopeEnd = end;
     }
-    
+
     public int getIndex() {
         return index;
+    }
+
+    /** The label where this local's scope opens, or null if unknown. */
+    public Label getScopeStart() {
+        return scopeStart;
+    }
+
+    /** The label where this local's scope closes, or null if unknown. */
+    public Label getScopeEnd() {
+        return scopeEnd;
     }
     
     public boolean isRightVariable(int index, char type) {

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/LocalVariable.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/LocalVariable.java
@@ -23,7 +23,6 @@
 
 package com.codename1.tools.translator.bytecodes;
 
-import java.util.Objects;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.Opcodes;
 
@@ -49,6 +48,16 @@ public class LocalVariable extends Instruction {
     private final Label scopeStart;
     private final Label scopeEnd;
 
+    /**
+     * Declaration order, so that two locals sharing a slot and a storage
+     * qualifier still sort deterministically. Identity hash codes vary per
+     * run, so without this the emitted side-table's row order depended on
+     * where the JVM happened to place the scope labels.
+     */
+    private final int sequence;
+    private static final java.util.concurrent.atomic.AtomicInteger SEQUENCE =
+            new java.util.concurrent.atomic.AtomicInteger();
+
     public LocalVariable(String name, String desc, String signature, Label start, Label end, int index) {
         super(Opcodes.ALOAD);
         this.name = name;
@@ -56,6 +65,12 @@ public class LocalVariable extends Instruction {
         this.index = index;
         this.scopeStart = start;
         this.scopeEnd = end;
+        this.sequence = SEQUENCE.incrementAndGet();
+    }
+
+    /** Relative declaration order within a method; see {@link #sequence}. */
+    public int getSequence() {
+        return sequence;
     }
 
     public int getIndex() {
@@ -208,6 +223,22 @@ public class LocalVariable extends Instruction {
         return b.toString();
     }
     
+    /**
+     * Identity is the storage a local occupies <em>and</em> the scope it
+     * occupies it for.
+     *
+     * Slot and qualifier alone would make two variables declared in disjoint
+     * blocks of the same method — {@code int} in one, {@code int} in the next —
+     * the same local, and the set that holds these would keep only the first.
+     * That was survivable while every local was reported as live for the whole
+     * method, since the two shared one storage location anyway; once a local
+     * is filtered to its own scope it stops being survivable, because in the
+     * second block the debugger would have no row to show at all.
+     *
+     * Locals the translator synthesised from a store opcode carry no scope, so
+     * they still collapse onto one another, which is what keeps a repeated
+     * store from producing a row per occurrence.
+     */
     @Override
     public boolean equals(Object o) {
         if (o == null) {
@@ -215,7 +246,10 @@ public class LocalVariable extends Instruction {
         }
         if (o.getClass() == LocalVariable.class) {
             LocalVariable lv = (LocalVariable)o;
-            return lv.getIndex() == this.getIndex() && lv.getQualifier() == this.getQualifier();
+            return lv.getIndex() == this.getIndex()
+                    && lv.getQualifier() == this.getQualifier()
+                    && lv.scopeStart == this.scopeStart
+                    && lv.scopeEnd == this.scopeEnd;
         }
         return false;
     }
@@ -223,8 +257,10 @@ public class LocalVariable extends Instruction {
     @Override
     public int hashCode() {
         int hash = 3;
-        hash = 19 * hash + Objects.hashCode(this.desc);
+        hash = 19 * hash + this.getQualifier();
         hash = 19 * hash + this.index;
+        hash = 19 * hash + System.identityHashCode(this.scopeStart);
+        hash = 19 * hash + System.identityHashCode(this.scopeEnd);
         return hash;
     }
 }

--- a/vm/ByteCodeTranslator/src/nativeMethods.m
+++ b/vm/ByteCodeTranslator/src/nativeMethods.m
@@ -2428,6 +2428,7 @@ void initMethodStack(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT __cn1ThisObject, int
     threadStateData->threadObjectStackOffset += localsStackSize + stackSize;
     threadStateData->callStackClass[threadStateData->callStackOffset] = classNameId;
     threadStateData->callStackMethod[threadStateData->callStackOffset] = methodNameId;
+    CN1_DEBUG_FRAME_ENTER(threadStateData)
     threadStateData->callStackOffset++;
 }
 

--- a/vm/tests/src/test/java/com/codename1/tools/translator/DebugFramePushCoverageTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/DebugFramePushCoverageTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.tools.translator;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Every path that pushes a call frame must first clear that frame's debugger
+ * side-channel.
+ *
+ * <p>{@code callStackFrameInfo} and {@code callStackLocalsAddresses} are
+ * written only by methods that carry a locals side-table, and only after the
+ * frame is pushed. Native, eliminated and barebone methods never write them.
+ * Nothing clears them, so without {@code CN1_DEBUG_FRAME_ENTER} such a frame
+ * inherits whatever the previous occupant of that call depth left — including
+ * a locals-address array that points into a C frame which has already
+ * returned. The debugger then reports the wrong method for the frame and reads
+ * freed stack memory as object references, which is one of the ways a
+ * breakpoint took the app down in issue #5333.</p>
+ *
+ * <p>The property is structural: it holds for the push sites that exist today,
+ * and the thing worth defending is that a <em>new</em> one cannot be added
+ * without the clear. Asserted over the runtime sources because the arrays only
+ * exist in an on-device-debug build, which is not a configuration these tests
+ * can compile and run.</p>
+ */
+class DebugFramePushCoverageTest {
+
+    /** Runtime sources that own a call-frame push. */
+    private static final String[] RUNTIME_SOURCES = {
+        "cn1_globals.h",
+        "cn1_globals.m",
+        "nativeMethods.m",
+    };
+
+    private static final String PUSH = "threadStateData->callStackOffset++";
+    private static final String CLEAR = "CN1_DEBUG_FRAME_ENTER(threadStateData)";
+
+    @Test
+    void everyFramePushClearsTheDebugSideChannelFirst() throws Exception {
+        List<String> offenders = new ArrayList<>();
+        int pushes = 0;
+
+        for (String source : RUNTIME_SOURCES) {
+            Path file = runtimeSource(source);
+            List<String> lines = Files.readAllLines(file, StandardCharsets.UTF_8);
+            for (int i = 0; i < lines.size(); i++) {
+                String line = lines.get(i);
+                if (!line.contains(PUSH) || isCommentedOut(lines, i)) {
+                    continue;
+                }
+                pushes++;
+                if (!precededByClear(lines, i)) {
+                    offenders.add(source + ":" + (i + 1) + "  " + line.trim());
+                }
+            }
+        }
+
+        assertTrue(pushes > 0,
+                "found no call-frame pushes at all — this test is looking in the wrong place");
+        assertTrue(offenders.isEmpty(),
+                "these frame pushes do not clear the debugger side-channel first, so the new"
+                        + " frame inherits the previous occupant's locals-address array:\n  "
+                        + String.join("\n  ", offenders));
+    }
+
+    /**
+     * The clear is a no-op in release builds, so it must sit outside any
+     * {@code CN1_ON_DEVICE_DEBUG} guard at the push site — otherwise a release
+     * build and a debug build push frames differently for no reason.
+     */
+    @Test
+    void theClearIsUnconditionalAtThePushSite() throws Exception {
+        String globals = readAll(runtimeSource("cn1_globals.h"));
+
+        assertTrue(globals.contains("#define CN1_DEBUG_FRAME_ENTER(threadStateData) \\"),
+                "the debug build must define the clear");
+        assertTrue(globals.contains("#define CN1_DEBUG_FRAME_ENTER(threadStateData)\n"),
+                "the release build must define it as a no-op, so push sites need no #ifdef");
+    }
+
+    /** The clear only makes sense before the increment it protects. */
+    @Test
+    void theClearTargetsTheFrameBeingPushedNotTheOneBelow() throws Exception {
+        String globals = readAll(runtimeSource("cn1_globals.h"));
+        int at = globals.indexOf("#define CN1_DEBUG_FRAME_ENTER(threadStateData) \\");
+        assertTrue(at >= 0, "the clear macro should be defined in cn1_globals.h");
+        String body = globals.substring(at, globals.indexOf("\n\n", at));
+
+        assertTrue(body.contains("callStackFrameInfo[threadStateData->callStackOffset] = 0")
+                        && body.contains("callStackLocalsAddresses[threadStateData->callStackOffset] = 0"),
+                "both side-channel slots must be cleared, was:\n" + body);
+        assertFalse(body.contains("callStackOffset - 1"),
+                "the clear runs before the increment, so it must not index the caller's"
+                        + " frame, was:\n" + body);
+    }
+
+    private static String readAll(Path path) throws Exception {
+        return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+    }
+
+    private static Path runtimeSource(String name) {
+        Path path = Paths.get("..", "ByteCodeTranslator", "src", name).normalize().toAbsolutePath();
+        assertTrue(Files.exists(path), "expected runtime source at " + path);
+        return path;
+    }
+
+    /**
+     * The header keeps a commented-out {@code ENTERING_CODENAME_ONE_METHOD}
+     * macro that also increments the offset. It emits no code, so it is not a
+     * push site.
+     */
+    private static boolean isCommentedOut(List<String> lines, int index) {
+        for (int i = index; i >= 0; i--) {
+            String line = lines.get(i);
+            if (line.contains("*/")) return false;
+            if (line.contains("/*")) return true;
+        }
+        return false;
+    }
+
+    /**
+     * Whether the clear appears in the few lines immediately above the push,
+     * with nothing but the frame's own bookkeeping between them.
+     */
+    private static boolean precededByClear(List<String> lines, int index) {
+        for (int i = index - 1; i >= 0 && i >= index - 4; i--) {
+            String line = lines.get(i).trim();
+            if (line.contains(CLEAR)) return true;
+            if (line.isEmpty() || line.startsWith("//")) continue;
+            if (!line.contains("threadStateData->")) return false;
+        }
+        return false;
+    }
+}

--- a/vm/tests/src/test/java/com/codename1/tools/translator/DebugFramePushCoverageTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/DebugFramePushCoverageTest.java
@@ -109,6 +109,34 @@ class DebugFramePushCoverageTest {
                 "the release build must define it as a no-op, so push sites need no #ifdef");
     }
 
+    /**
+     * Every debugger hook the translator emits calls has a weak no-op.
+     *
+     * <p>Generated code calls these from each class's constructor, and it is
+     * compiled in targets that do not link the debugger runtime — the watchOS
+     * slice does not get {@code cn1_debugger_objects.c} at all. Without a weak
+     * default in {@code cn1_globals.m}, which every target does compile, those
+     * targets fail to link. The compile failure that surfaced this named
+     * {@code cn1_debugger_register_class} in the watch sources.</p>
+     */
+    @Test
+    void everyGeneratedDebuggerHookHasAWeakDefault() throws Exception {
+        String globalsHeader = readAll(runtimeSource("cn1_globals.h"));
+        String globalsImpl = readAll(runtimeSource("cn1_globals.m"));
+
+        for (String hook : new String[] {
+                "cn1_debugger_check",
+                "cn1_debugger_register_class",
+                "cn1_debugger_mark_issued_roots" }) {
+            assertTrue(globalsHeader.contains("extern void " + hook),
+                    hook + " must be declared where generated code can see it,"
+                            + " not only in the iOS port's own header");
+            assertTrue(globalsImpl.contains("__attribute__((weak)) void " + hook),
+                    hook + " must have a weak no-op so a target without the"
+                            + " debugger runtime still links");
+        }
+    }
+
     /** The clear only makes sense before the increment it protects. */
     @Test
     void theClearTargetsTheFrameBeingPushedNotTheOneBelow() throws Exception {

--- a/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerLocalScopeTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerLocalScopeTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.tools.translator;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The runtime reports a local only on the lines it is actually in scope for.
+ *
+ * <p>Locals used to be reported unconditionally, which for a slot two disjoint
+ * scopes share means both occupants appear at every breakpoint — and the one
+ * the code has not reached displays whatever the other scope left in its own
+ * storage. The declaring scope is the only thing that tells them apart.</p>
+ *
+ * <p>Exercises the shipped predicate through {@link NativeDebuggerHarness}
+ * rather than restating it. macOS only, like the rest of that unit.</p>
+ */
+@EnabledOnOs(OS.MAC)
+class DebuggerLocalScopeTest {
+
+    /** A local declared at line 10 in a block closing at 14 covers 10 to 13. */
+    @Test
+    void aScopedLocalIsLiveFromItsDeclarationUpToButNotIncludingTheClose() throws Exception {
+        assertEquals("hidden", inScope(10, 14, 9));
+        assertEquals("visible", inScope(10, 14, 10));
+        assertEquals("visible", inScope(10, 14, 13));
+        assertEquals("hidden", inScope(10, 14, 14));
+        assertEquals("hidden", inScope(10, 14, 20));
+    }
+
+    /**
+     * The case the whole thing is for: at any one line exactly one occupant of
+     * a reused slot is reported.
+     */
+    @Test
+    void exactlyOneOccupantOfAReusedSlotIsVisibleAtEachLine() throws Exception {
+        // int count: lines 10-13. String label: line 14 to the end.
+        assertEquals("visible", inScope(10, 14, 11));
+        assertEquals("hidden", inScope(14, 0, 11));
+
+        assertEquals("hidden", inScope(10, 14, 15));
+        assertEquals("visible", inScope(14, 0, 15));
+    }
+
+    /** A zero end means the scope runs to the end of the method. */
+    @Test
+    void anOpenEndedScopeStaysLiveForTheRestOfTheMethod() throws Exception {
+        assertEquals("hidden", inScope(14, 0, 13));
+        assertEquals("visible", inScope(14, 0, 14));
+        assertEquals("visible", inScope(14, 0, 9999));
+    }
+
+    /**
+     * A local with no scope at all — no entry in the class file, or one the
+     * translator synthesised from a store opcode — must stay visible. Hiding
+     * it would be a regression on the previous behaviour for every such local.
+     */
+    @Test
+    void anUnscopedLocalIsAlwaysVisible() throws Exception {
+        assertEquals("visible", inScope(0, 0, 1));
+        assertEquals("visible", inScope(0, 0, 9999));
+    }
+
+    /**
+     * Before the frame has recorded a line there is nothing to compare
+     * against, so everything shows rather than nothing — an over-full locals
+     * view beats an empty one.
+     */
+    @Test
+    void everythingIsVisibleWhenTheFrameHasNoLineYet() throws Exception {
+        assertEquals("visible", inScope(10, 14, 0));
+    }
+
+    private String inScope(int startLine, int endLine, int atLine) throws Exception {
+        return harness().verdict(String.valueOf(startLine),
+                String.valueOf(endLine), String.valueOf(atLine));
+    }
+
+    private static NativeDebuggerHarness harness;
+
+    private static synchronized NativeDebuggerHarness harness() throws Exception {
+        if (harness == null) {
+            harness = NativeDebuggerHarness.compile("scope", DRIVER);
+        }
+        return harness;
+    }
+
+    private static final String DRIVER =
+            "#include \"cn1_globals.h\"\n" +
+            "#include \"cn1_debugger.h\"\n" +
+            "#include <stdio.h>\n" +
+            "#include <stdlib.h>\n" +
+            "\n" +
+            "int main(int argc, char** argv) {\n" +
+            "    if (argc < 4) {\n" +
+            "        fprintf(stderr, \"usage: scope <startLine> <endLine> <atLine>\\n\");\n" +
+            "        return 2;\n" +
+            "    }\n" +
+            "    struct cn1_var_entry v;\n" +
+            "    v.startLine = atoi(argv[1]);\n" +
+            "    v.endLine = atoi(argv[2]);\n" +
+            "    v.slot = 2;\n" +
+            "    v.typeCode = 'I';\n" +
+            "    printf(\"%s\\n\", cn1_debugger_var_in_scope(&v, atoi(argv[3])) ? \"visible\" : \"hidden\");\n" +
+            "    return 0;\n" +
+            "}\n";
+}

--- a/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerObjectValidationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerObjectValidationTest.java
@@ -133,6 +133,37 @@ class DebuggerObjectValidationTest {
         assertEquals("-7", probe("TAGGED_INT_NEGATIVE"));
     }
 
+    /**
+     * An objectID the IDE holds across a resume is refused, not read.
+     *
+     * <p>A registered class word proves shape, not liveness: full-page BiBOP
+     * reclamation resets the page cursor without clearing class words, and a
+     * legacy object reaches {@code free()} with its header intact. So a
+     * reclaimed allocation still passes the class check. Requiring that a wire
+     * id be one the debugger issued since the last resume refuses the stale
+     * one instead of reading through it.</p>
+     */
+    @Test
+    void aWireIdFromAnEarlierSuspensionIsRefused() throws Exception {
+        assertEquals("accepted", probe("WIRE_ID_ISSUED"));
+        assertEquals("rejected", probe("WIRE_ID_AFTER_RESUME"));
+    }
+
+    /** An id never handed out at all is refused, however well-formed. */
+    @Test
+    void aWireIdTheDebuggerNeverIssuedIsRefused() throws Exception {
+        assertEquals("rejected", probe("WIRE_ID_NEVER_ISSUED"));
+    }
+
+    /**
+     * Tagged ints are exempt: they carry their value in the reference, so
+     * there is no allocation that could have been reclaimed.
+     */
+    @Test
+    void aTaggedIntNeedsNoIssueRecord() throws Exception {
+        assertEquals("accepted", probe("WIRE_ID_TAGGED"));
+    }
+
     /** A zeroed object has no class word to check. */
     @Test
     void anObjectWithNoClassWordIsRejected() throws Exception {
@@ -148,7 +179,8 @@ class DebuggerObjectValidationTest {
         List<String> cases = Arrays.asList("REGISTERED", "ARRAY", "IMPOSTOR",
                 "INT_AS_REFERENCE", "WILD_POINTER", "MISALIGNED", "NULL_PAGE",
                 "NULL", "NO_CLASS_WORD", "TAGGED_INT", "TAGGED_INT_CLASS",
-                "TAGGED_INT_VALUE");
+                "TAGGED_INT_VALUE", "WIRE_ID_ISSUED", "WIRE_ID_AFTER_RESUME",
+                "WIRE_ID_NEVER_ISSUED", "WIRE_ID_TAGGED");
         for (String candidate : cases) {
             NativeDebuggerHarness.Result result = harness().run(candidate);
             assertEquals(0, result.exitCode,
@@ -222,6 +254,28 @@ class DebuggerObjectValidationTest {
             "        candidate = *(JAVA_OBJECT*)(void*)&slot;\n" +
             "    } else if (strcmp(which, \"WILD_POINTER\") == 0) {\n" +
             "        candidate = (JAVA_OBJECT)(uintptr_t)0xDEADBEEFDEAD0000ULL;\n" +
+            "    } else if (strcmp(which, \"WIRE_ID_ISSUED\") == 0) {\n" +
+            "        object.__codenameOneParentClsReference = &registeredClass;\n" +
+            "        cn1_debugger_note_issued(&object);\n" +
+            "        printf(\"%s\\n\", cn1_debugger_class_of_wire_id(&object)\n" +
+            "                ? \"accepted\" : \"rejected\");\n" +
+            "        return 0;\n" +
+            "    } else if (strcmp(which, \"WIRE_ID_AFTER_RESUME\") == 0) {\n" +
+            "        object.__codenameOneParentClsReference = &registeredClass;\n" +
+            "        cn1_debugger_note_issued(&object);\n" +
+            "        cn1_debugger_forget_issued();   /* the app ran on */\n" +
+            "        printf(\"%s\\n\", cn1_debugger_class_of_wire_id(&object)\n" +
+            "                ? \"accepted\" : \"rejected\");\n" +
+            "        return 0;\n" +
+            "    } else if (strcmp(which, \"WIRE_ID_NEVER_ISSUED\") == 0) {\n" +
+            "        object.__codenameOneParentClsReference = &registeredClass;\n" +
+            "        printf(\"%s\\n\", cn1_debugger_class_of_wire_id(&object)\n" +
+            "                ? \"accepted\" : \"rejected\");\n" +
+            "        return 0;\n" +
+            "    } else if (strcmp(which, \"WIRE_ID_TAGGED\") == 0) {\n" +
+            "        printf(\"%s\\n\", cn1_debugger_class_of_wire_id(CN1_TAG_INT(42))\n" +
+            "                ? \"accepted\" : \"rejected\");\n" +
+            "        return 0;\n" +
             "    } else if (strcmp(which, \"TAGGED_INT\") == 0) {\n" +
             "        candidate = CN1_TAG_INT(42);\n" +
             "    } else if (strcmp(which, \"TAGGED_INT_CLASS\") == 0) {\n" +

--- a/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerObjectValidationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerObjectValidationTest.java
@@ -259,6 +259,33 @@ class DebuggerObjectValidationTest {
         assertEquals("not-marked", probe("ROOTS_TAGGED_NOT_MARKED"));
     }
 
+    /**
+     * A reference reached through a shared object inherits every owner.
+     *
+     * <p>Taking only the parent's first owner meant resuming that thread
+     * deleted the nested ids while a second thread was still parked and able
+     * to reach the same tree, so an object the IDE had already expanded went
+     * unavailable underneath it.</p>
+     */
+    @Test
+    void derivedReferencesInheritEveryOwnerOfTheirParent() throws Exception {
+        assertEquals("kept", probe("DERIVED_INHERITS_ALL_OWNERS"));
+    }
+
+    /**
+     * An id claimed both by a suspension and by the thread list survives that
+     * suspension ending.
+     *
+     * <p>A java.lang.Thread object can be exposed first through a stopped
+     * thread's locals and later by the thread list, which is tied to no
+     * suspension. Recording only the first claim meant resuming that thread
+     * rejected an id the live thread list was still advertising.</p>
+     */
+    @Test
+    void anUnownedClaimSurvivesThreadInvalidation() throws Exception {
+        assertEquals("kept", probe("UNOWNED_CLAIM_SURVIVES"));
+    }
+
     /** A zeroed object has no class word to check. */
     @Test
     void anObjectWithNoClassWordIsRejected() throws Exception {
@@ -282,7 +309,8 @@ class DebuggerObjectValidationTest {
                 "OWNER_UNOWNED_DROPPED_BY_FULL_RESUME",
                 "SHARED_SURVIVES_FIRST_RESUME", "SHARED_DROPPED_BY_LAST_RESUME",
                 "ROOTS_MARK_ISSUED", "ROOTS_MARK_AFTER_GROWTH",
-                "ROOTS_RELEASED_NOT_MARKED", "ROOTS_TAGGED_NOT_MARKED");
+                "ROOTS_RELEASED_NOT_MARKED", "ROOTS_TAGGED_NOT_MARKED",
+                "DERIVED_INHERITS_ALL_OWNERS", "UNOWNED_CLAIM_SURVIVES");
         for (String candidate : cases) {
             NativeDebuggerHarness.Result result = harness().run(candidate);
             assertEquals(0, result.exitCode,
@@ -381,6 +409,25 @@ class DebuggerObjectValidationTest {
             "        cn1MarkedRootCount = 0;\n" +
             "        cn1_debugger_mark_issued_roots(NULL);\n" +
             "        printf(\"%s\\n\", cn1MarkRootTargetSeen ? \"marked\" : \"not-marked\");\n" +
+            "        return 0;\n" +
+            "    } else if (strcmp(which, \"DERIVED_INHERITS_ALL_OWNERS\") == 0) {\n" +
+            "        /* A parent both parked threads expose, and a child reached\n" +
+            "         * through it; thread 7 then resumes. */\n" +
+            "        JAVA_OBJECT parent = (JAVA_OBJECT)(uintptr_t)0xE000;\n" +
+            "        JAVA_OBJECT child  = (JAVA_OBJECT)(uintptr_t)0xE008;\n" +
+            "        cn1_debugger_note_issued_for(parent, 7);\n" +
+            "        cn1_debugger_note_issued_for(parent, 9);\n" +
+            "        cn1_debugger_note_issued_inheriting(child, parent);\n" +
+            "        cn1_debugger_forget_issued_for(7);\n" +
+            "        printf(\"%s\\n\", cn1_debugger_was_issued(child) ? \"kept\" : \"gone\");\n" +
+            "        return 0;\n" +
+            "    } else if (strcmp(which, \"UNOWNED_CLAIM_SURVIVES\") == 0) {\n" +
+            "        /* Exposed through a stopped thread, then by the thread list. */\n" +
+            "        JAVA_OBJECT threadObj = (JAVA_OBJECT)(uintptr_t)0xF000;\n" +
+            "        cn1_debugger_note_issued_for(threadObj, 7);\n" +
+            "        cn1_debugger_note_issued_for(threadObj, 0);\n" +
+            "        cn1_debugger_forget_issued_for(7);\n" +
+            "        printf(\"%s\\n\", cn1_debugger_was_issued(threadObj) ? \"kept\" : \"gone\");\n" +
             "        return 0;\n" +
             "    } else if (strncmp(which, \"SHARED_\", 7) == 0) {\n" +
             "        /* One reference exposed by both parked threads. */\n" +

--- a/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerObjectValidationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerObjectValidationTest.java
@@ -320,6 +320,19 @@ class DebuggerObjectValidationTest {
         assertEquals("kept", probe("REFRESH_DESCENDANT_KEPT"));
     }
 
+    /**
+     * An object reached through two threads survives while either still is.
+     *
+     * <p>Recording only the most recent parent meant the second expansion
+     * overwrote the first, so when that thread went away the id went with it —
+     * while the IDE was still showing the same id under the thread that
+     * remained.</p>
+     */
+    @Test
+    void aDescendantSharedByTwoThreadsSurvivesWhileEitherDoes() throws Exception {
+        assertEquals("kept", probe("REFRESH_SHARED_DESCENDANT"));
+    }
+
     /** Reached transitively: a field of a field is no less reachable. */
     @Test
     void aRefreshKeepsDescendantsSeveralHopsDown() throws Exception {
@@ -521,6 +534,23 @@ class DebuggerObjectValidationTest {
             "        JAVA_OBJECT probe =\n" +
             "            strcmp(which, \"REFRESH_DESCENDANT_DEEP\") == 0 ? grandchild : child;\n" +
             "        printf(\"%s\\n\", cn1_debugger_was_issued(probe) ? \"kept\" : \"gone\");\n" +
+            "        return 0;\n" +
+            "    } else if (strcmp(which, \"REFRESH_SHARED_DESCENDANT\") == 0) {\n" +
+            "        /* One object reached through two threads' graphs; only\n" +
+            "         * one of those threads is still advertised afterwards. */\n" +
+            "        JAVA_OBJECT threadA = (JAVA_OBJECT)(uintptr_t)0x14000;\n" +
+            "        JAVA_OBJECT threadB = (JAVA_OBJECT)(uintptr_t)0x14008;\n" +
+            "        JAVA_OBJECT shared = (JAVA_OBJECT)(uintptr_t)0x14010;\n" +
+            "        cn1_debugger_begin_thread_list();\n" +
+            "        cn1_debugger_note_issued(threadA);\n" +
+            "        cn1_debugger_note_issued(threadB);\n" +
+            "        cn1_debugger_end_thread_list();\n" +
+            "        cn1_debugger_note_issued_inheriting(shared, threadA);\n" +
+            "        cn1_debugger_note_issued_inheriting(shared, threadB);\n" +
+            "        cn1_debugger_begin_thread_list();\n" +
+            "        cn1_debugger_note_issued(threadA);   /* B is gone */\n" +
+            "        cn1_debugger_end_thread_list();\n" +
+            "        printf(\"%s\\n\", cn1_debugger_was_issued(shared) ? \"kept\" : \"gone\");\n" +
             "        return 0;\n" +
             "    } else if (strcmp(which, \"DERIVED_INHERITS_ALL_OWNERS\") == 0) {\n" +
             "        /* A parent both parked threads expose, and a child reached\n" +

--- a/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerObjectValidationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerObjectValidationTest.java
@@ -183,6 +183,34 @@ class DebuggerObjectValidationTest {
         assertEquals("all-resolvable", probe("ISSUE_MANY_RESOLVE"));
     }
 
+    /**
+     * Resuming one thread invalidates its ids and only its ids.
+     *
+     * <p>Both directions are failures. Clearing globally cut the ground from
+     * under a thread that was still stopped and being inspected, so its
+     * locals started reporting unavailable; clearing nothing left the resumed
+     * thread's ids accepted after its objects could be collected, which is a
+     * read of reclaimed storage rather than a display glitch.</p>
+     */
+    @Test
+    void aPerThreadResumeDropsOnlyThatThreadsIds() throws Exception {
+        assertEquals("gone", probe("OWNER_RESUMED_IS_DROPPED"));
+        assertEquals("kept", probe("OWNER_PARKED_IS_KEPT"));
+    }
+
+    /** A reference reached through an object inherits that object's owner. */
+    @Test
+    void referencesReachedThroughAnObjectInheritItsOwner() throws Exception {
+        assertEquals("gone", probe("OWNER_INHERITED_IS_DROPPED"));
+    }
+
+    /** Ids tied to no suspension survive a per-thread resume, but not a full one. */
+    @Test
+    void unownedIdsSurviveAPerThreadResumeOnly() throws Exception {
+        assertEquals("kept", probe("OWNER_UNOWNED_SURVIVES_THREAD_RESUME"));
+        assertEquals("gone", probe("OWNER_UNOWNED_DROPPED_BY_FULL_RESUME"));
+    }
+
     /** A zeroed object has no class word to check. */
     @Test
     void anObjectWithNoClassWordIsRejected() throws Exception {
@@ -200,7 +228,10 @@ class DebuggerObjectValidationTest {
                 "NULL", "NO_CLASS_WORD", "TAGGED_INT", "TAGGED_INT_CLASS",
                 "TAGGED_INT_VALUE", "WIRE_ID_ISSUED", "WIRE_ID_AFTER_RESUME",
                 "WIRE_ID_NEVER_ISSUED", "WIRE_ID_TAGGED", "ISSUE_MANY",
-                "ISSUE_MANY_RESOLVE");
+                "ISSUE_MANY_RESOLVE", "OWNER_RESUMED_IS_DROPPED",
+                "OWNER_PARKED_IS_KEPT", "OWNER_INHERITED_IS_DROPPED",
+                "OWNER_UNOWNED_SURVIVES_THREAD_RESUME",
+                "OWNER_UNOWNED_DROPPED_BY_FULL_RESUME");
         for (String candidate : cases) {
             NativeDebuggerHarness.Result result = harness().run(candidate);
             assertEquals(0, result.exitCode,
@@ -274,6 +305,29 @@ class DebuggerObjectValidationTest {
             "        candidate = *(JAVA_OBJECT*)(void*)&slot;\n" +
             "    } else if (strcmp(which, \"WILD_POINTER\") == 0) {\n" +
             "        candidate = (JAVA_OBJECT)(uintptr_t)0xDEADBEEFDEAD0000ULL;\n" +
+            "    } else if (strncmp(which, \"OWNER_\", 6) == 0) {\n" +
+            "        /* Two parked threads, 7 and 9, each with a reference. */\n" +
+            "        JAVA_OBJECT ofSeven = (JAVA_OBJECT)(uintptr_t)0x8000;\n" +
+            "        JAVA_OBJECT ofNine  = (JAVA_OBJECT)(uintptr_t)0x9000;\n" +
+            "        JAVA_OBJECT reached = (JAVA_OBJECT)(uintptr_t)0xA000;\n" +
+            "        JAVA_OBJECT unowned = (JAVA_OBJECT)(uintptr_t)0xB000;\n" +
+            "        cn1_debugger_note_issued_for(ofSeven, 7);\n" +
+            "        cn1_debugger_note_issued_for(ofNine, 9);\n" +
+            "        cn1_debugger_note_issued_for(reached, cn1_debugger_owner_of(ofSeven));\n" +
+            "        cn1_debugger_note_issued_for(unowned, 0);\n" +
+            "        if (strcmp(which, \"OWNER_UNOWNED_DROPPED_BY_FULL_RESUME\") == 0) {\n" +
+            "            cn1_debugger_forget_issued();\n" +
+            "            printf(\"%s\\n\", cn1_debugger_was_issued(unowned) ? \"kept\" : \"gone\");\n" +
+            "            return 0;\n" +
+            "        }\n" +
+            "        cn1_debugger_forget_issued_for(7);   /* thread 7 resumes */\n" +
+            "        JAVA_OBJECT probe = NULL;\n" +
+            "        if (strcmp(which, \"OWNER_RESUMED_IS_DROPPED\") == 0) probe = ofSeven;\n" +
+            "        else if (strcmp(which, \"OWNER_PARKED_IS_KEPT\") == 0) probe = ofNine;\n" +
+            "        else if (strcmp(which, \"OWNER_INHERITED_IS_DROPPED\") == 0) probe = reached;\n" +
+            "        else probe = unowned;\n" +
+            "        printf(\"%s\\n\", cn1_debugger_was_issued(probe) ? \"kept\" : \"gone\");\n" +
+            "        return 0;\n" +
             "    } else if (strcmp(which, \"ISSUE_MANY\") == 0) {\n" +
             "        /* Past the initial 4096 capacity, as a big array would. */\n" +
             "        for (int i = 1; i <= 9000; i++) {\n" +

--- a/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerObjectValidationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerObjectValidationTest.java
@@ -226,6 +226,39 @@ class DebuggerObjectValidationTest {
         assertEquals("gone", probe("SHARED_DROPPED_BY_LAST_RESUME"));
     }
 
+    /**
+     * Every outstanding id is a GC root, so its object cannot be collected.
+     *
+     * <p>Membership in the issued set only decides which ids are <em>accepted</em>.
+     * Whether the object behind an accepted id is still allocated is a separate
+     * question, and a class word survives reclamation — so without rooting, an
+     * accepted id could still name freed memory and the IDE's next field read
+     * would touch it. Marking the set from the collector's root pass is what
+     * turns the membership check into a guarantee.</p>
+     */
+    @Test
+    void everyOutstandingIdIsMarkedAsAGcRoot() throws Exception {
+        assertEquals("marked", probe("ROOTS_MARK_ISSUED"));
+    }
+
+    /** Including references the table only holds after it has grown. */
+    @Test
+    void rootsSurviveTableGrowth() throws Exception {
+        assertEquals("marked", probe("ROOTS_MARK_AFTER_GROWTH"));
+    }
+
+    /** A released id stops being a root, so the object can be collected again. */
+    @Test
+    void aReleasedIdIsNoLongerARoot() throws Exception {
+        assertEquals("not-marked", probe("ROOTS_RELEASED_NOT_MARKED"));
+    }
+
+    /** A tagged int is a value, not an allocation, so it is never marked. */
+    @Test
+    void taggedIntsAreNotMarkedAsRoots() throws Exception {
+        assertEquals("not-marked", probe("ROOTS_TAGGED_NOT_MARKED"));
+    }
+
     /** A zeroed object has no class word to check. */
     @Test
     void anObjectWithNoClassWordIsRejected() throws Exception {
@@ -247,7 +280,9 @@ class DebuggerObjectValidationTest {
                 "OWNER_PARKED_IS_KEPT", "OWNER_INHERITED_IS_DROPPED",
                 "OWNER_UNOWNED_SURVIVES_THREAD_RESUME",
                 "OWNER_UNOWNED_DROPPED_BY_FULL_RESUME",
-                "SHARED_SURVIVES_FIRST_RESUME", "SHARED_DROPPED_BY_LAST_RESUME");
+                "SHARED_SURVIVES_FIRST_RESUME", "SHARED_DROPPED_BY_LAST_RESUME",
+                "ROOTS_MARK_ISSUED", "ROOTS_MARK_AFTER_GROWTH",
+                "ROOTS_RELEASED_NOT_MARKED", "ROOTS_TAGGED_NOT_MARKED");
         for (String candidate : cases) {
             NativeDebuggerHarness.Result result = harness().run(candidate);
             assertEquals(0, result.exitCode,
@@ -321,6 +356,32 @@ class DebuggerObjectValidationTest {
             "        candidate = *(JAVA_OBJECT*)(void*)&slot;\n" +
             "    } else if (strcmp(which, \"WILD_POINTER\") == 0) {\n" +
             "        candidate = (JAVA_OBJECT)(uintptr_t)0xDEADBEEFDEAD0000ULL;\n" +
+            "    } else if (strncmp(which, \"ROOTS_\", 6) == 0) {\n" +
+            "        extern JAVA_OBJECT cn1MarkRootTarget;\n" +
+            "        extern int cn1MarkRootTargetSeen;\n" +
+            "        extern int cn1MarkedRootCount;\n" +
+            "        JAVA_OBJECT tracked = (JAVA_OBJECT)(uintptr_t)0xD000;\n" +
+            "        if (strcmp(which, \"ROOTS_TAGGED_NOT_MARKED\") == 0) {\n" +
+            "            tracked = CN1_TAG_INT(42);\n" +
+            "            cn1_debugger_note_issued_for(tracked, 7);\n" +
+            "        } else if (strcmp(which, \"ROOTS_MARK_AFTER_GROWTH\") == 0) {\n" +
+            "            /* Force the table past its initial capacity first. */\n" +
+            "            for (int i = 1; i <= 9000; i++) {\n" +
+            "                cn1_debugger_note_issued_for((JAVA_OBJECT)(uintptr_t)(i * 8), 7);\n" +
+            "            }\n" +
+            "            cn1_debugger_note_issued_for(tracked, 7);\n" +
+            "        } else {\n" +
+            "            cn1_debugger_note_issued_for(tracked, 7);\n" +
+            "            if (strcmp(which, \"ROOTS_RELEASED_NOT_MARKED\") == 0) {\n" +
+            "                cn1_debugger_forget_issued_for(7);   /* thread resumes */\n" +
+            "            }\n" +
+            "        }\n" +
+            "        cn1MarkRootTarget = tracked;\n" +
+            "        cn1MarkRootTargetSeen = 0;\n" +
+            "        cn1MarkedRootCount = 0;\n" +
+            "        cn1_debugger_mark_issued_roots(NULL);\n" +
+            "        printf(\"%s\\n\", cn1MarkRootTargetSeen ? \"marked\" : \"not-marked\");\n" +
+            "        return 0;\n" +
             "    } else if (strncmp(which, \"SHARED_\", 7) == 0) {\n" +
             "        /* One reference exposed by both parked threads. */\n" +
             "        JAVA_OBJECT shared = (JAVA_OBJECT)(uintptr_t)0xC000;\n" +

--- a/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerObjectValidationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerObjectValidationTest.java
@@ -92,12 +92,45 @@ class DebuggerObjectValidationTest {
         assertEquals("rejected", probe("WILD_POINTER"));
     }
 
-    /** Misaligned and null-page candidates are rejected before the syscall. */
+    /**
+     * Misaligned and null-page candidates are rejected before the syscall.
+     *
+     * <p>Misalignment here means bit 1, not bit 0: an odd reference is a
+     * tagged int by design, so it is a value rather than a bad pointer.</p>
+     */
     @Test
     void obviouslyImpossiblePointersAreRejected() throws Exception {
         assertEquals("rejected", probe("MISALIGNED"));
         assertEquals("rejected", probe("NULL_PAGE"));
         assertEquals("rejected", probe("NULL"));
+    }
+
+    /**
+     * A boxed {@code Integer} is a tagged value, not an address.
+     *
+     * <p>{@code Integer.valueOf()} returns {@code (v << 1) | 1} on every
+     * 64-bit target, which is the shipping iOS shape. Those references are
+     * deliberately odd, so the alignment rejection that guards the header read
+     * would discard every one of them — boxed integers in locals, fields,
+     * object arrays, invocation arguments and receivers would all read as
+     * null. They are recognised before any read is attempted.</p>
+     */
+    @Test
+    void aTaggedIntegerIsAcceptedWithoutBeingDereferenced() throws Exception {
+        assertEquals("accepted", probe("TAGGED_INT"));
+    }
+
+    /** And it reports Integer's class, so the IDE can name and expand it. */
+    @Test
+    void aTaggedIntegerReportsIntegersClass() throws Exception {
+        assertEquals("java.lang.Integer", probe("TAGGED_INT_CLASS"));
+    }
+
+    /** Its value comes from the tag, since there is no field to read. */
+    @Test
+    void aTaggedIntegerCarriesItsValueInTheReference() throws Exception {
+        assertEquals("42", probe("TAGGED_INT_VALUE"));
+        assertEquals("-7", probe("TAGGED_INT_NEGATIVE"));
     }
 
     /** A zeroed object has no class word to check. */
@@ -114,7 +147,8 @@ class DebuggerObjectValidationTest {
     void noCandidateEverCrashesTheProcess() throws Exception {
         List<String> cases = Arrays.asList("REGISTERED", "ARRAY", "IMPOSTOR",
                 "INT_AS_REFERENCE", "WILD_POINTER", "MISALIGNED", "NULL_PAGE",
-                "NULL", "NO_CLASS_WORD");
+                "NULL", "NO_CLASS_WORD", "TAGGED_INT", "TAGGED_INT_CLASS",
+                "TAGGED_INT_VALUE");
         for (String candidate : cases) {
             NativeDebuggerHarness.Result result = harness().run(candidate);
             assertEquals(0, result.exitCode,
@@ -188,8 +222,21 @@ class DebuggerObjectValidationTest {
             "        candidate = *(JAVA_OBJECT*)(void*)&slot;\n" +
             "    } else if (strcmp(which, \"WILD_POINTER\") == 0) {\n" +
             "        candidate = (JAVA_OBJECT)(uintptr_t)0xDEADBEEFDEAD0000ULL;\n" +
+            "    } else if (strcmp(which, \"TAGGED_INT\") == 0) {\n" +
+            "        candidate = CN1_TAG_INT(42);\n" +
+            "    } else if (strcmp(which, \"TAGGED_INT_CLASS\") == 0) {\n" +
+            "        struct clazz* c = cn1_debugger_class_of(CN1_TAG_INT(42));\n" +
+            "        printf(\"%s\\n\", c == &class__java_lang_Integer\n" +
+            "                ? \"java.lang.Integer\" : \"other\");\n" +
+            "        return 0;\n" +
+            "    } else if (strcmp(which, \"TAGGED_INT_VALUE\") == 0) {\n" +
+            "        printf(\"%d\\n\", cn1_debugger_tagged_int_value(CN1_TAG_INT(42)));\n" +
+            "        return 0;\n" +
+            "    } else if (strcmp(which, \"TAGGED_INT_NEGATIVE\") == 0) {\n" +
+            "        printf(\"%d\\n\", cn1_debugger_tagged_int_value(CN1_TAG_INT(-7)));\n" +
+            "        return 0;\n" +
             "    } else if (strcmp(which, \"MISALIGNED\") == 0) {\n" +
-            "        candidate = (JAVA_OBJECT)(((uintptr_t)&object) | 1);\n" +
+            "        candidate = (JAVA_OBJECT)(((uintptr_t)&object) | 2);\n" +
             "    } else if (strcmp(which, \"NULL_PAGE\") == 0) {\n" +
             "        candidate = (JAVA_OBJECT)(uintptr_t)0x18;\n" +
             "    } else if (strcmp(which, \"NULL\") == 0) {\n" +

--- a/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerObjectValidationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerObjectValidationTest.java
@@ -211,6 +211,21 @@ class DebuggerObjectValidationTest {
         assertEquals("gone", probe("OWNER_UNOWNED_DROPPED_BY_FULL_RESUME"));
     }
 
+    /**
+     * A reference two parked threads both expose survives one of them
+     * resuming.
+     *
+     * <p>Storing a single owner per reference meant the second thread to
+     * expose a shared object — a singleton in both their locals, say — had its
+     * claim discarded, so resuming the first dropped the id while the second
+     * was still parked and inspecting through it.</p>
+     */
+    @Test
+    void aReferenceSharedByTwoThreadsOutlivesTheFirstResume() throws Exception {
+        assertEquals("kept", probe("SHARED_SURVIVES_FIRST_RESUME"));
+        assertEquals("gone", probe("SHARED_DROPPED_BY_LAST_RESUME"));
+    }
+
     /** A zeroed object has no class word to check. */
     @Test
     void anObjectWithNoClassWordIsRejected() throws Exception {
@@ -231,7 +246,8 @@ class DebuggerObjectValidationTest {
                 "ISSUE_MANY_RESOLVE", "OWNER_RESUMED_IS_DROPPED",
                 "OWNER_PARKED_IS_KEPT", "OWNER_INHERITED_IS_DROPPED",
                 "OWNER_UNOWNED_SURVIVES_THREAD_RESUME",
-                "OWNER_UNOWNED_DROPPED_BY_FULL_RESUME");
+                "OWNER_UNOWNED_DROPPED_BY_FULL_RESUME",
+                "SHARED_SURVIVES_FIRST_RESUME", "SHARED_DROPPED_BY_LAST_RESUME");
         for (String candidate : cases) {
             NativeDebuggerHarness.Result result = harness().run(candidate);
             assertEquals(0, result.exitCode,
@@ -305,6 +321,17 @@ class DebuggerObjectValidationTest {
             "        candidate = *(JAVA_OBJECT*)(void*)&slot;\n" +
             "    } else if (strcmp(which, \"WILD_POINTER\") == 0) {\n" +
             "        candidate = (JAVA_OBJECT)(uintptr_t)0xDEADBEEFDEAD0000ULL;\n" +
+            "    } else if (strncmp(which, \"SHARED_\", 7) == 0) {\n" +
+            "        /* One reference exposed by both parked threads. */\n" +
+            "        JAVA_OBJECT shared = (JAVA_OBJECT)(uintptr_t)0xC000;\n" +
+            "        cn1_debugger_note_issued_for(shared, 7);\n" +
+            "        cn1_debugger_note_issued_for(shared, 9);\n" +
+            "        cn1_debugger_forget_issued_for(7);\n" +
+            "        if (strcmp(which, \"SHARED_DROPPED_BY_LAST_RESUME\") == 0) {\n" +
+            "            cn1_debugger_forget_issued_for(9);\n" +
+            "        }\n" +
+            "        printf(\"%s\\n\", cn1_debugger_was_issued(shared) ? \"kept\" : \"gone\");\n" +
+            "        return 0;\n" +
             "    } else if (strncmp(which, \"OWNER_\", 6) == 0) {\n" +
             "        /* Two parked threads, 7 and 9, each with a reference. */\n" +
             "        JAVA_OBJECT ofSeven = (JAVA_OBJECT)(uintptr_t)0x8000;\n" +

--- a/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerObjectValidationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerObjectValidationTest.java
@@ -333,6 +333,37 @@ class DebuggerObjectValidationTest {
         assertEquals("kept", probe("REFRESH_SHARED_DESCENDANT"));
     }
 
+    /**
+     * An array reports the depth its class declares, not the hops to its
+     * component.
+     *
+     * <p>The translator points {@code arrayType} straight at the scalar for
+     * every depth and puts the real one in {@code dimensions}, so following the
+     * link and counting calls {@code int[][]} one-dimensional — and the IDE
+     * then shows it as {@code int[]}.</p>
+     */
+    @Test
+    void anArrayReportsItsDeclaredDepthRatherThanTheHopsToItsComponent() throws Exception {
+        assertEquals("1", probe("ARRAY_DEPTH_1"));
+        assertEquals("2", probe("ARRAY_DEPTH_2"));
+        assertEquals("3", probe("ARRAY_DEPTH_3"));
+    }
+
+    /**
+     * A resume elsewhere does not drop what a live thread still reaches.
+     *
+     * <p>A descendant kept by a refresh carries no owner of its own and a
+     * generation stamp from before that refresh, so judged on its own account
+     * it looks unclaimed. The refresh knew to follow the parent link; the
+     * resume rebuild did not, and dropped the id the moment any thread ran
+     * again — while the IDE was still showing it under a thread the current
+     * list advertises.</p>
+     */
+    @Test
+    void aResumeKeepsDescendantsOfAThreadTheListStillAdvertises() throws Exception {
+        assertEquals("kept", probe("RESUME_KEEPS_LIVE_DESCENDANT"));
+    }
+
     /** Reached transitively: a field of a field is no less reachable. */
     @Test
     void aRefreshKeepsDescendantsSeveralHopsDown() throws Exception {
@@ -421,6 +452,7 @@ class DebuggerObjectValidationTest {
             "#include \"cn1_debugger.h\"\n" +
             "#include <stdio.h>\n" +
             "#include <string.h>\n" +
+            "#include <stdlib.h>\n" +
             "\n" +
             "static struct clazz registeredClass;\n" +
             "static struct clazz arrayClass;\n" +
@@ -551,6 +583,33 @@ class DebuggerObjectValidationTest {
             "        cn1_debugger_note_issued(threadA);   /* B is gone */\n" +
             "        cn1_debugger_end_thread_list();\n" +
             "        printf(\"%s\\n\", cn1_debugger_was_issued(shared) ? \"kept\" : \"gone\");\n" +
+            "        return 0;\n" +
+            "    } else if (strncmp(which, \"ARRAY_DEPTH_\", 12) == 0) {\n" +
+            "        /* The generated layout: arrayType points straight at the\n" +
+            "         * scalar whatever the depth, which lives in dimensions. */\n" +
+            "        int declared = atoi(which + 12);\n" +
+            "        arrayClass.dimensions = declared;\n" +
+            "        int dims = -1;\n" +
+            "        struct clazz* component = cn1_debugger_array_component(&arrayClass, &dims);\n" +
+            "        if (component != &registeredClass) { printf(\"wrong-component\\n\"); return 0; }\n" +
+            "        printf(\"%d\\n\", dims);\n" +
+            "        return 0;\n" +
+            "    } else if (strcmp(which, \"RESUME_KEEPS_LIVE_DESCENDANT\") == 0) {\n" +
+            "        /* A descendant kept alive by a Thread object the current\n" +
+            "         * list still advertises, when some other thread resumes. */\n" +
+            "        JAVA_OBJECT threadObj = (JAVA_OBJECT)(uintptr_t)0x15000;\n" +
+            "        JAVA_OBJECT child = (JAVA_OBJECT)(uintptr_t)0x15008;\n" +
+            "        JAVA_OBJECT parked = (JAVA_OBJECT)(uintptr_t)0x15010;\n" +
+            "        cn1_debugger_begin_thread_list();\n" +
+            "        cn1_debugger_note_issued(threadObj);\n" +
+            "        cn1_debugger_end_thread_list();\n" +
+            "        cn1_debugger_note_issued_inheriting(child, threadObj);\n" +
+            "        cn1_debugger_note_issued_for(parked, 9);\n" +
+            "        cn1_debugger_begin_thread_list();\n" +
+            "        cn1_debugger_note_issued(threadObj);   /* still advertised */\n" +
+            "        cn1_debugger_end_thread_list();\n" +
+            "        cn1_debugger_forget_issued_for(9);     /* an unrelated resume */\n" +
+            "        printf(\"%s\\n\", cn1_debugger_was_issued(child) ? \"kept\" : \"gone\");\n" +
             "        return 0;\n" +
             "    } else if (strcmp(which, \"DERIVED_INHERITS_ALL_OWNERS\") == 0) {\n" +
             "        /* A parent both parked threads expose, and a child reached\n" +

--- a/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerObjectValidationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerObjectValidationTest.java
@@ -286,6 +286,25 @@ class DebuggerObjectValidationTest {
         assertEquals("kept", probe("UNOWNED_CLAIM_SURVIVES"));
     }
 
+    /**
+     * A thread-list refresh releases the objects the previous one advertised.
+     *
+     * <p>Every {@code java.lang.Thread} the list returns is rooted so its id
+     * stays usable. Released only on a full resume, an IDE polling the thread
+     * list on a running app would pin every thread object it ever saw — and
+     * whatever those threads retain — for the session.</p>
+     */
+    @Test
+    void aThreadListRefreshReleasesTheObjectsTheLastOneAdvertised() throws Exception {
+        assertEquals("gone", probe("THREAD_LIST_REFRESH_RELEASES"));
+    }
+
+    /** But not one a suspended thread is also holding. */
+    @Test
+    void aRefreshKeepsObjectsASuspensionStillOwns() throws Exception {
+        assertEquals("kept", probe("THREAD_LIST_REFRESH_KEEPS_OWNED"));
+    }
+
     /** A zeroed object has no class word to check. */
     @Test
     void anObjectWithNoClassWordIsRejected() throws Exception {
@@ -310,7 +329,8 @@ class DebuggerObjectValidationTest {
                 "SHARED_SURVIVES_FIRST_RESUME", "SHARED_DROPPED_BY_LAST_RESUME",
                 "ROOTS_MARK_ISSUED", "ROOTS_MARK_AFTER_GROWTH",
                 "ROOTS_RELEASED_NOT_MARKED", "ROOTS_TAGGED_NOT_MARKED",
-                "DERIVED_INHERITS_ALL_OWNERS", "UNOWNED_CLAIM_SURVIVES");
+                "DERIVED_INHERITS_ALL_OWNERS", "UNOWNED_CLAIM_SURVIVES",
+                "THREAD_LIST_REFRESH_RELEASES", "THREAD_LIST_REFRESH_KEEPS_OWNED");
         for (String candidate : cases) {
             NativeDebuggerHarness.Result result = harness().run(candidate);
             assertEquals(0, result.exitCode,
@@ -409,6 +429,19 @@ class DebuggerObjectValidationTest {
             "        cn1MarkedRootCount = 0;\n" +
             "        cn1_debugger_mark_issued_roots(NULL);\n" +
             "        printf(\"%s\\n\", cn1MarkRootTargetSeen ? \"marked\" : \"not-marked\");\n" +
+            "        return 0;\n" +
+            "    } else if (strncmp(which, \"THREAD_LIST_REFRESH_\", 20) == 0) {\n" +
+            "        /* A thread object the list advertised, and one a stopped\n" +
+            "         * thread also holds; then the next refresh comes round. */\n" +
+            "        JAVA_OBJECT dead = (JAVA_OBJECT)(uintptr_t)0x11000;\n" +
+            "        JAVA_OBJECT alsoOwned = (JAVA_OBJECT)(uintptr_t)0x11008;\n" +
+            "        cn1_debugger_note_issued(dead);\n" +
+            "        cn1_debugger_note_issued_for(alsoOwned, 7);\n" +
+            "        cn1_debugger_note_issued(alsoOwned);\n" +
+            "        cn1_debugger_forget_thread_list_claims();\n" +
+            "        JAVA_OBJECT probe =\n" +
+            "            strcmp(which, \"THREAD_LIST_REFRESH_KEEPS_OWNED\") == 0 ? alsoOwned : dead;\n" +
+            "        printf(\"%s\\n\", cn1_debugger_was_issued(probe) ? \"kept\" : \"gone\");\n" +
             "        return 0;\n" +
             "    } else if (strcmp(which, \"DERIVED_INHERITS_ALL_OWNERS\") == 0) {\n" +
             "        /* A parent both parked threads expose, and a child reached\n" +

--- a/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerObjectValidationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerObjectValidationTest.java
@@ -306,6 +306,36 @@ class DebuggerObjectValidationTest {
     }
 
     /**
+     * Nor anything reached through a Thread object the refresh re-advertises.
+     *
+     * <p>A refresh re-issues only the top-level {@code Thread} objects, so a
+     * field the IDE had expanded off one carries no claim of its own. Clearing
+     * the old claims before recording the new ones dropped every such id, and
+     * the object stayed reachable from a live thread the whole time -- every
+     * later string, field or array request naming it was refused for no reason
+     * the developer could see.</p>
+     */
+    @Test
+    void aRefreshKeepsWhatHangsOffAThreadItStillAdvertises() throws Exception {
+        assertEquals("kept", probe("REFRESH_DESCENDANT_KEPT"));
+    }
+
+    /** Reached transitively: a field of a field is no less reachable. */
+    @Test
+    void aRefreshKeepsDescendantsSeveralHopsDown() throws Exception {
+        assertEquals("kept", probe("REFRESH_DESCENDANT_DEEP"));
+    }
+
+    /**
+     * Once the thread itself stops being advertised, what hung off it goes
+     * too -- otherwise the fix would just be a leak by another name.
+     */
+    @Test
+    void aRefreshReleasesDescendantsOfAThreadThatIsGone() throws Exception {
+        assertEquals("gone", probe("REFRESH_DESCENDANT_THREAD_GONE"));
+    }
+
+    /**
      * A resumed thread stops owning an entry even when the thread list also
      * claims it.
      *
@@ -454,7 +484,8 @@ class DebuggerObjectValidationTest {
             "        cn1_debugger_note_issued_for(both, 7);\n" +
             "        cn1_debugger_note_issued(both);\n" +
             "        cn1_debugger_forget_issued_for(7);        /* thread resumes */\n" +
-            "        cn1_debugger_forget_thread_list_claims(); /* later refresh */\n" +
+            "        cn1_debugger_begin_thread_list();         /* later refresh */\n" +
+            "        cn1_debugger_end_thread_list();\n" +
             "        printf(\"%s\\n\", cn1_debugger_was_issued(both) ? \"kept\" : \"gone\");\n" +
             "        return 0;\n" +
             "    } else if (strncmp(which, \"THREAD_LIST_REFRESH_\", 20) == 0) {\n" +
@@ -465,9 +496,30 @@ class DebuggerObjectValidationTest {
             "        cn1_debugger_note_issued(dead);\n" +
             "        cn1_debugger_note_issued_for(alsoOwned, 7);\n" +
             "        cn1_debugger_note_issued(alsoOwned);\n" +
-            "        cn1_debugger_forget_thread_list_claims();\n" +
+            "        cn1_debugger_begin_thread_list();\n" +
+            "        cn1_debugger_end_thread_list();\n" +
             "        JAVA_OBJECT probe =\n" +
             "            strcmp(which, \"THREAD_LIST_REFRESH_KEEPS_OWNED\") == 0 ? alsoOwned : dead;\n" +
+            "        printf(\"%s\\n\", cn1_debugger_was_issued(probe) ? \"kept\" : \"gone\");\n" +
+            "        return 0;\n" +
+            "    } else if (strncmp(which, \"REFRESH_DESCENDANT_\", 19) == 0) {\n" +
+            "        /* The IDE expands a field of a live Thread object, then the\n" +
+            "         * thread list refreshes and re-advertises that same Thread. */\n" +
+            "        JAVA_OBJECT threadObj = (JAVA_OBJECT)(uintptr_t)0x13000;\n" +
+            "        JAVA_OBJECT child = (JAVA_OBJECT)(uintptr_t)0x13008;\n" +
+            "        JAVA_OBJECT grandchild = (JAVA_OBJECT)(uintptr_t)0x13010;\n" +
+            "        cn1_debugger_begin_thread_list();\n" +
+            "        cn1_debugger_note_issued(threadObj);\n" +
+            "        cn1_debugger_end_thread_list();\n" +
+            "        cn1_debugger_note_issued_inheriting(child, threadObj);\n" +
+            "        cn1_debugger_note_issued_inheriting(grandchild, child);\n" +
+            "        cn1_debugger_begin_thread_list();\n" +
+            "        if (strcmp(which, \"REFRESH_DESCENDANT_THREAD_GONE\") != 0) {\n" +
+            "            cn1_debugger_note_issued(threadObj);   /* still alive */\n" +
+            "        }\n" +
+            "        cn1_debugger_end_thread_list();\n" +
+            "        JAVA_OBJECT probe =\n" +
+            "            strcmp(which, \"REFRESH_DESCENDANT_DEEP\") == 0 ? grandchild : child;\n" +
             "        printf(\"%s\\n\", cn1_debugger_was_issued(probe) ? \"kept\" : \"gone\");\n" +
             "        return 0;\n" +
             "    } else if (strcmp(which, \"DERIVED_INHERITS_ALL_OWNERS\") == 0) {\n" +

--- a/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerObjectValidationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerObjectValidationTest.java
@@ -164,6 +164,25 @@ class DebuggerObjectValidationTest {
         assertEquals("accepted", probe("WIRE_ID_TAGGED"));
     }
 
+    /**
+     * The issued-id table grows rather than silently dropping records.
+     *
+     * <p>A fixed table stopped recording once full, but callers still sent
+     * those references to the IDE — so past the cap every displayed reference
+     * became one the IDE could see and never expand. Inspecting a large object
+     * array reaches that in a single suspension.</p>
+     */
+    @Test
+    void theIssuedTableGrowsBeyondItsInitialCapacity() throws Exception {
+        assertEquals("all-recorded", probe("ISSUE_MANY"));
+    }
+
+    /** And every one of them still resolves afterwards. */
+    @Test
+    void everyIssuedIdRemainsResolvableAfterGrowth() throws Exception {
+        assertEquals("all-resolvable", probe("ISSUE_MANY_RESOLVE"));
+    }
+
     /** A zeroed object has no class word to check. */
     @Test
     void anObjectWithNoClassWordIsRejected() throws Exception {
@@ -180,7 +199,8 @@ class DebuggerObjectValidationTest {
                 "INT_AS_REFERENCE", "WILD_POINTER", "MISALIGNED", "NULL_PAGE",
                 "NULL", "NO_CLASS_WORD", "TAGGED_INT", "TAGGED_INT_CLASS",
                 "TAGGED_INT_VALUE", "WIRE_ID_ISSUED", "WIRE_ID_AFTER_RESUME",
-                "WIRE_ID_NEVER_ISSUED", "WIRE_ID_TAGGED");
+                "WIRE_ID_NEVER_ISSUED", "WIRE_ID_TAGGED", "ISSUE_MANY",
+                "ISSUE_MANY_RESOLVE");
         for (String candidate : cases) {
             NativeDebuggerHarness.Result result = harness().run(candidate);
             assertEquals(0, result.exitCode,
@@ -254,6 +274,28 @@ class DebuggerObjectValidationTest {
             "        candidate = *(JAVA_OBJECT*)(void*)&slot;\n" +
             "    } else if (strcmp(which, \"WILD_POINTER\") == 0) {\n" +
             "        candidate = (JAVA_OBJECT)(uintptr_t)0xDEADBEEFDEAD0000ULL;\n" +
+            "    } else if (strcmp(which, \"ISSUE_MANY\") == 0) {\n" +
+            "        /* Past the initial 4096 capacity, as a big array would. */\n" +
+            "        for (int i = 1; i <= 9000; i++) {\n" +
+            "            if (!cn1_debugger_note_issued((JAVA_OBJECT)(uintptr_t)(i * 8))) {\n" +
+            "                printf(\"dropped-at-%d\\n\", i);\n" +
+            "                return 0;\n" +
+            "            }\n" +
+            "        }\n" +
+            "        printf(\"all-recorded\\n\");\n" +
+            "        return 0;\n" +
+            "    } else if (strcmp(which, \"ISSUE_MANY_RESOLVE\") == 0) {\n" +
+            "        for (int i = 1; i <= 9000; i++) {\n" +
+            "            cn1_debugger_note_issued((JAVA_OBJECT)(uintptr_t)(i * 8));\n" +
+            "        }\n" +
+            "        for (int i = 1; i <= 9000; i++) {\n" +
+            "            if (!cn1_debugger_was_issued((JAVA_OBJECT)(uintptr_t)(i * 8))) {\n" +
+            "                printf(\"lost-%d\\n\", i);\n" +
+            "                return 0;\n" +
+            "            }\n" +
+            "        }\n" +
+            "        printf(\"all-resolvable\\n\");\n" +
+            "        return 0;\n" +
             "    } else if (strcmp(which, \"WIRE_ID_ISSUED\") == 0) {\n" +
             "        object.__codenameOneParentClsReference = &registeredClass;\n" +
             "        cn1_debugger_note_issued(&object);\n" +

--- a/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerObjectValidationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerObjectValidationTest.java
@@ -305,6 +305,21 @@ class DebuggerObjectValidationTest {
         assertEquals("kept", probe("THREAD_LIST_REFRESH_KEEPS_OWNED"));
     }
 
+    /**
+     * A resumed thread stops owning an entry even when the thread list also
+     * claims it.
+     *
+     * <p>Deciding survival before removing the owner left the resumed thread
+     * in the owner set, so the next thread-list refresh kept the entry alive
+     * on the strength of an owner that had long since resumed — and once that
+     * thread died, the object and everything it reached stayed rooted for the
+     * session.</p>
+     */
+    @Test
+    void aResumedOwnerIsRemovedEvenFromAnEntryTheThreadListClaims() throws Exception {
+        assertEquals("gone", probe("STALE_OWNER_IS_REMOVED"));
+    }
+
     /** A zeroed object has no class word to check. */
     @Test
     void anObjectWithNoClassWordIsRejected() throws Exception {
@@ -330,7 +345,8 @@ class DebuggerObjectValidationTest {
                 "ROOTS_MARK_ISSUED", "ROOTS_MARK_AFTER_GROWTH",
                 "ROOTS_RELEASED_NOT_MARKED", "ROOTS_TAGGED_NOT_MARKED",
                 "DERIVED_INHERITS_ALL_OWNERS", "UNOWNED_CLAIM_SURVIVES",
-                "THREAD_LIST_REFRESH_RELEASES", "THREAD_LIST_REFRESH_KEEPS_OWNED");
+                "THREAD_LIST_REFRESH_RELEASES", "THREAD_LIST_REFRESH_KEEPS_OWNED",
+                "STALE_OWNER_IS_REMOVED");
         for (String candidate : cases) {
             NativeDebuggerHarness.Result result = harness().run(candidate);
             assertEquals(0, result.exitCode,
@@ -429,6 +445,17 @@ class DebuggerObjectValidationTest {
             "        cn1MarkedRootCount = 0;\n" +
             "        cn1_debugger_mark_issued_roots(NULL);\n" +
             "        printf(\"%s\\n\", cn1MarkRootTargetSeen ? \"marked\" : \"not-marked\");\n" +
+            "        return 0;\n" +
+            "    } else if (strcmp(which, \"STALE_OWNER_IS_REMOVED\") == 0) {\n" +
+            "        /* Claimed by a suspension and by the thread list; the\n" +
+            "         * thread resumes, then a later refresh drops the list\n" +
+            "         * claim. Nothing holds it after that. */\n" +
+            "        JAVA_OBJECT both = (JAVA_OBJECT)(uintptr_t)0x12000;\n" +
+            "        cn1_debugger_note_issued_for(both, 7);\n" +
+            "        cn1_debugger_note_issued(both);\n" +
+            "        cn1_debugger_forget_issued_for(7);        /* thread resumes */\n" +
+            "        cn1_debugger_forget_thread_list_claims(); /* later refresh */\n" +
+            "        printf(\"%s\\n\", cn1_debugger_was_issued(both) ? \"kept\" : \"gone\");\n" +
             "        return 0;\n" +
             "    } else if (strncmp(which, \"THREAD_LIST_REFRESH_\", 20) == 0) {\n" +
             "        /* A thread object the list advertised, and one a stopped\n" +

--- a/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerObjectValidationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerObjectValidationTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.tools.translator;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The debugger must never be able to crash the app it is debugging.
+ *
+ * <p>Every object reference the on-device debugger handles is untrusted. The
+ * IDE echoes back objectIDs it was handed earlier, and a local slot can hold
+ * whatever the frame left there on a branch that never ran — a stale
+ * reference, or the bytes of an unrelated primitive. Before
+ * {@code cn1_debugger_class_of} existed, each of those was dereferenced
+ * directly, and the process died mid-session with the {@code signal 11}
+ * reported in issue #5333.</p>
+ *
+ * <p>These compile the real validation unit against the real {@code struct
+ * clazz} — a one-line stub stands in for the generated class-id header — and
+ * run it, so what is under test is the shipped policy rather than a
+ * restatement of it. The unit is macOS-only: it rests on {@code
+ * vm_read_overwrite} to probe an address without taking a signal, and iOS
+ * debugging is a macOS activity anyway.</p>
+ */
+@EnabledOnOs(OS.MAC)
+class DebuggerObjectValidationTest {
+
+    @Test
+    void aRegisteredObjectIsAccepted() throws Exception {
+        assertEquals("accepted", probe("REGISTERED"));
+    }
+
+    /**
+     * Array classes are synthesised per dimension and the primitive ones live
+     * in the runtime, so none of them run the registration constructor. They
+     * are still verifiable through the component type they name — and they had
+     * better be, or the debugger would report every array as unavailable.
+     */
+    @Test
+    void anArrayIsAcceptedThroughItsComponentType() throws Exception {
+        assertEquals("accepted", probe("ARRAY"));
+    }
+
+    /** The exact-identity check: claiming a registered id is not enough. */
+    @Test
+    void aClazzThatIsNotTheRegisteredOneForItsIdIsRejected() throws Exception {
+        assertEquals("rejected", probe("IMPOSTOR"));
+    }
+
+    /**
+     * The shape that produced the crash: a slot holding a four-byte {@code
+     * int}, read as an eight-byte reference. The resulting pointer is
+     * arbitrary, and the old code dereferenced it to test for
+     * {@code java.lang.String}.
+     */
+    @Test
+    void anIntSlotReadAsAReferenceIsRejectedRatherThanDereferenced() throws Exception {
+        assertEquals("rejected", probe("INT_AS_REFERENCE"));
+    }
+
+    /** An address in no mapping at all must come back as a rejection, not a signal. */
+    @Test
+    void anUnmappedAddressIsRejectedWithoutFaulting() throws Exception {
+        assertEquals("rejected", probe("WILD_POINTER"));
+    }
+
+    /** Misaligned and null-page candidates are rejected before the syscall. */
+    @Test
+    void obviouslyImpossiblePointersAreRejected() throws Exception {
+        assertEquals("rejected", probe("MISALIGNED"));
+        assertEquals("rejected", probe("NULL_PAGE"));
+        assertEquals("rejected", probe("NULL"));
+    }
+
+    /** A zeroed object has no class word to check. */
+    @Test
+    void anObjectWithNoClassWordIsRejected() throws Exception {
+        assertEquals("rejected", probe("NO_CLASS_WORD"));
+    }
+
+    /**
+     * The whole point is that none of the above take the process down: a
+     * rejection is a return value, not a crash.
+     */
+    @Test
+    void noCandidateEverCrashesTheProcess() throws Exception {
+        List<String> cases = Arrays.asList("REGISTERED", "ARRAY", "IMPOSTOR",
+                "INT_AS_REFERENCE", "WILD_POINTER", "MISALIGNED", "NULL_PAGE",
+                "NULL", "NO_CLASS_WORD");
+        for (String candidate : cases) {
+            NativeDebuggerHarness.Result result = harness().run(candidate);
+            assertEquals(0, result.exitCode,
+                    "validating " + candidate + " should return, not die: " + result.output);
+        }
+    }
+
+    private static NativeDebuggerHarness harness;
+
+    private static synchronized NativeDebuggerHarness harness() throws Exception {
+        if (harness == null) {
+            harness = NativeDebuggerHarness.compile("validate", DRIVER);
+        }
+        return harness;
+    }
+
+    private String probe(String candidate) throws Exception {
+        return harness().verdict(candidate);
+    }
+
+    /**
+     * Builds one candidate reference per invocation and prints "accepted" or
+     * "rejected". Kept to a single candidate per process so that a candidate
+     * which does crash is attributable, and shows up as a non-zero exit rather
+     * than as a missing line of output.
+     */
+    private static final String DRIVER =
+            "#include \"cn1_globals.h\"\n" +
+            "#include \"cn1_debugger.h\"\n" +
+            "#include <stdio.h>\n" +
+            "#include <string.h>\n" +
+            "\n" +
+            "static struct clazz registeredClass;\n" +
+            "static struct clazz arrayClass;\n" +
+            "static struct clazz unregisteredClass;\n" +
+            "\n" +
+            "int main(int argc, char** argv) {\n" +
+            "    if (argc < 2) { fprintf(stderr, \"usage: validate <candidate>\\n\"); return 2; }\n" +
+            "    const char* which = argv[1];\n" +
+            "\n" +
+            "    registeredClass.classId = 5;\n" +
+            "    cn1_debugger_register_class(5, &registeredClass);\n" +
+            "\n" +
+            "    /* An array clazz is never registered; it points at its component. */\n" +
+            "    JAVA_BOOLEAN yes = 1;\n" +
+            "    memcpy((void*)&arrayClass.isArray, &yes, sizeof(JAVA_BOOLEAN));\n" +
+            "    arrayClass.classId = cn1_array_1_id_JAVA_INT;\n" +
+            "    arrayClass.arrayType = &registeredClass;\n" +
+            "\n" +
+            "    /* Claims a registered id, but is not the clazz registered for it. */\n" +
+            "    unregisteredClass.classId = 5;\n" +
+            "\n" +
+            "    struct JavaObjectPrototype object;\n" +
+            "    memset(&object, 0, sizeof(object));\n" +
+            "    JAVA_OBJECT candidate = JAVA_NULL;\n" +
+            "\n" +
+            "    if (strcmp(which, \"REGISTERED\") == 0) {\n" +
+            "        object.__codenameOneParentClsReference = &registeredClass;\n" +
+            "        candidate = &object;\n" +
+            "    } else if (strcmp(which, \"ARRAY\") == 0) {\n" +
+            "        object.__codenameOneParentClsReference = &arrayClass;\n" +
+            "        candidate = &object;\n" +
+            "    } else if (strcmp(which, \"IMPOSTOR\") == 0) {\n" +
+            "        object.__codenameOneParentClsReference = &unregisteredClass;\n" +
+            "        candidate = &object;\n" +
+            "    } else if (strcmp(which, \"NO_CLASS_WORD\") == 0) {\n" +
+            "        candidate = &object;\n" +
+            "    } else if (strcmp(which, \"INT_AS_REFERENCE\") == 0) {\n" +
+            "        /* The issue #5333 shape: eight bytes read over a four-byte local. */\n" +
+            "        volatile JAVA_INT slot = 42;\n" +
+            "        candidate = *(JAVA_OBJECT*)(void*)&slot;\n" +
+            "    } else if (strcmp(which, \"WILD_POINTER\") == 0) {\n" +
+            "        candidate = (JAVA_OBJECT)(uintptr_t)0xDEADBEEFDEAD0000ULL;\n" +
+            "    } else if (strcmp(which, \"MISALIGNED\") == 0) {\n" +
+            "        candidate = (JAVA_OBJECT)(((uintptr_t)&object) | 1);\n" +
+            "    } else if (strcmp(which, \"NULL_PAGE\") == 0) {\n" +
+            "        candidate = (JAVA_OBJECT)(uintptr_t)0x18;\n" +
+            "    } else if (strcmp(which, \"NULL\") == 0) {\n" +
+            "        candidate = JAVA_NULL;\n" +
+            "    } else {\n" +
+            "        fprintf(stderr, \"unknown candidate %s\\n\", which);\n" +
+            "        return 2;\n" +
+            "    }\n" +
+            "\n" +
+            "    printf(\"%s\\n\", cn1_debugger_is_valid_object(candidate) ? \"accepted\" : \"rejected\");\n" +
+            "    return 0;\n" +
+            "}\n";
+}

--- a/vm/tests/src/test/java/com/codename1/tools/translator/NativeDebuggerHarness.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/NativeDebuggerHarness.java
@@ -111,6 +111,18 @@ final class NativeDebuggerHarness {
     private static final String GENERATED_SYMBOLS =
             "#include \"cn1_globals.h\"\n"
           + "struct clazz class__java_lang_Integer = { 0 };\n"
+          // The collector's mark entry point. Records whether a nominated
+          // reference was reached, rather than buffering every mark -- the
+          // table can hold thousands, so a fixed buffer would answer "was it
+          // in the first N" instead of "was it marked".
+          + "JAVA_OBJECT cn1MarkRootTarget = 0;\n"
+          + "int cn1MarkRootTargetSeen = 0;\n"
+          + "int cn1MarkedRootCount = 0;\n"
+          + "void gcMarkObject(struct ThreadLocalData* t, JAVA_OBJECT o, JAVA_BOOLEAN force) {\n"
+          + "    (void)t; (void)force;\n"
+          + "    cn1MarkedRootCount++;\n"
+          + "    if (o == cn1MarkRootTarget) cn1MarkRootTargetSeen = 1;\n"
+          + "}\n"
           + "#if CN1_TAGGED_ACTIVE\n"
           + "struct JavaObjectPrototype cn1TaggedProxy = { 0 };\n"
           + "#endif\n";

--- a/vm/tests/src/test/java/com/codename1/tools/translator/NativeDebuggerHarness.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/NativeDebuggerHarness.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.tools.translator;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Compiles {@code cn1_debugger_objects.c} — the on-device debugger's decision
+ * logic — together with a caller-supplied driver, and runs it.
+ *
+ * The debugger's rules about what it may dereference and which locals it may
+ * report are the difference between a usable session and a process that dies
+ * at a breakpoint, so they are worth testing directly rather than by
+ * restatement. The unit is plain C and depends only on {@code cn1_globals.h},
+ * whose single generated-header dependency a one-line stub satisfies, so it
+ * builds and runs on a host.
+ *
+ * macOS only: the read probe rests on {@code vm_read_overwrite}, and iOS
+ * debugging is a macOS activity regardless.
+ */
+final class NativeDebuggerHarness {
+
+    private final Path executable;
+
+    private NativeDebuggerHarness(Path executable) {
+        this.executable = executable;
+    }
+
+    /** Builds a driver against the debugger unit. {@code driver} is C source. */
+    static NativeDebuggerHarness compile(String name, String driver) throws Exception {
+        Path dir = Files.createTempDirectory("cn1-debugger-" + name);
+        // cn1_globals.h includes the translator-generated class-id header; the
+        // only symbol it needs from it is the array-id base.
+        Files.write(dir.resolve("cn1_class_method_index.h"),
+                "#define cn1_array_start_offset 100000\n".getBytes(StandardCharsets.UTF_8));
+        Files.write(dir.resolve("driver.c"), driver.getBytes(StandardCharsets.UTF_8));
+
+        Path executable = dir.resolve(name);
+        List<String> command = new ArrayList<>(Arrays.asList(
+                "clang",
+                "-DCN1_ON_DEVICE_DEBUG",
+                "-I", dir.toString(),
+                "-I", runtimeInclude().toString(),
+                "-I", nativeSources().toString(),
+                "-o", executable.toString(),
+                dir.resolve("driver.c").toString(),
+                nativeSources().resolve("cn1_debugger_objects.c").toString()));
+        Result compiled = exec(command, dir);
+        assertEquals(0, compiled.exitCode,
+                "the debugger's decision logic should compile standalone:\n" + compiled.output);
+        return new NativeDebuggerHarness(executable);
+    }
+
+    Result run(String... args) throws Exception {
+        List<String> command = new ArrayList<>();
+        command.add(executable.toString());
+        command.addAll(Arrays.asList(args));
+        return exec(command, executable.getParent());
+    }
+
+    /** Runs one case and returns its trimmed stdout, failing if the probe died. */
+    String verdict(String... args) throws Exception {
+        Result result = run(args);
+        assertEquals(0, result.exitCode,
+                "probe died on " + Arrays.toString(args) + ": " + result.output);
+        return result.output.trim();
+    }
+
+    private static Path runtimeInclude() {
+        return resolve(Paths.get("..", "ByteCodeTranslator", "src"));
+    }
+
+    private static Path nativeSources() {
+        return resolve(Paths.get("..", "..", "Ports", "iOSPort", "nativeSources"));
+    }
+
+    private static Path resolve(Path relative) {
+        Path path = relative.normalize().toAbsolutePath();
+        assertTrue(Files.isDirectory(path), "expected sources at " + path);
+        return path;
+    }
+
+    private static Result exec(List<String> command, Path workingDir) throws Exception {
+        ProcessBuilder pb = new ProcessBuilder(command);
+        pb.directory(workingDir.toFile());
+        pb.redirectErrorStream(true);
+        Process process = pb.start();
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        try (InputStream in = process.getInputStream()) {
+            byte[] buffer = new byte[4096];
+            int read;
+            while ((read = in.read(buffer)) > 0) {
+                captured.write(buffer, 0, read);
+            }
+        }
+        int exitCode = process.waitFor();
+        return new Result(exitCode, new String(captured.toByteArray(), StandardCharsets.UTF_8));
+    }
+
+    static final class Result {
+        final int exitCode;
+        final String output;
+
+        Result(int exitCode, String output) {
+            this.exitCode = exitCode;
+            this.output = output;
+        }
+    }
+}

--- a/vm/tests/src/test/java/com/codename1/tools/translator/NativeDebuggerHarness.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/NativeDebuggerHarness.java
@@ -65,6 +65,11 @@ final class NativeDebuggerHarness {
         Files.write(dir.resolve("cn1_class_method_index.h"),
                 "#define cn1_array_start_offset 100000\n".getBytes(StandardCharsets.UTF_8));
         Files.write(dir.resolve("driver.c"), driver.getBytes(StandardCharsets.UTF_8));
+        // Symbols the translator emits per build that the unit references but
+        // does not own. Definitions, not stubs of behaviour: the unit only ever
+        // compares their addresses.
+        Files.write(dir.resolve("generated_symbols.c"),
+                GENERATED_SYMBOLS.getBytes(StandardCharsets.UTF_8));
 
         Path executable = dir.resolve(name);
         List<String> command = new ArrayList<>(Arrays.asList(
@@ -75,6 +80,7 @@ final class NativeDebuggerHarness {
                 "-I", nativeSources().toString(),
                 "-o", executable.toString(),
                 dir.resolve("driver.c").toString(),
+                dir.resolve("generated_symbols.c").toString(),
                 nativeSources().resolve("cn1_debugger_objects.c").toString()));
         Result compiled = exec(command, dir);
         assertEquals(0, compiled.exitCode,
@@ -96,6 +102,18 @@ final class NativeDebuggerHarness {
                 "probe died on " + Arrays.toString(args) + ": " + result.output);
         return result.output.trim();
     }
+
+    /**
+     * java.lang.Integer's clazz and the tagged-int proxy are emitted by the
+     * translator into the app's own sources. The debugger unit references both
+     * by symbol, so a host build has to supply them.
+     */
+    private static final String GENERATED_SYMBOLS =
+            "#include \"cn1_globals.h\"\n"
+          + "struct clazz class__java_lang_Integer = { 0 };\n"
+          + "#if CN1_TAGGED_ACTIVE\n"
+          + "struct JavaObjectPrototype cn1TaggedProxy = { 0 };\n"
+          + "#endif\n";
 
     private static Path runtimeInclude() {
         return resolve(Paths.get("..", "ByteCodeTranslator", "src"));

--- a/vm/tests/src/test/java/com/codename1/tools/translator/OnDeviceDebugFrameTableTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/OnDeviceDebugFrameTableTest.java
@@ -1,0 +1,516 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.tools.translator;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The on-device debugger's view of a frame's locals must describe storage that
+ * actually holds what it says it holds.
+ *
+ * <p>A JVM slot is reused across disjoint scopes, and the occupants need not
+ * share a type: {@code int count} and {@code String label} can both live in
+ * slot 2 of one method. ParparVM gives each its own storage — {@code
+ * ilocals_2_} is a C auto, {@code locals[2].data.o} is a GC-scanned frame slot
+ * — so a side-table with one address <em>per slot</em> could only ever name one
+ * of them, while still listing a row for each. The mismatch made the runtime
+ * read eight bytes of reference out of a four-byte {@code JAVA_INT} and then
+ * dereference the result, which is the {@code signal 11} on a listener
+ * breakpoint reported in issue #5333.</p>
+ *
+ * <p>What these pin is the invariant the fix rests on: one address per
+ * <em>row</em>, so a row's type code and the storage its address points at can
+ * never disagree. Asserted on the emitted C because the failure only shows up
+ * on a device, under a debugger, at a breakpoint.</p>
+ */
+class OnDeviceDebugFrameTableTest {
+
+    private static final String HOST = "com/example/DbgHost";
+
+    /** Source lines the fixture's two disjoint scopes open and close on. */
+    private static final int INT_SCOPE_LINE = 10;
+    private static final int REF_SCOPE_LINE = 14;
+    private static final int METHOD_END_LINE = 18;
+
+    private boolean previousOnDeviceDebug;
+
+    @BeforeEach
+    void enableOnDeviceDebug() {
+        Parser.cleanup();
+        previousOnDeviceDebug = BytecodeMethod.onDeviceDebug;
+        BytecodeMethod.onDeviceDebug = true;
+    }
+
+    @AfterEach
+    void restoreOnDeviceDebug() {
+        BytecodeMethod.onDeviceDebug = previousOnDeviceDebug;
+        Parser.cleanup();
+    }
+
+    /**
+     * The two occupants of a reused slot each get their own row, and each row
+     * points at the storage its own type lives in.
+     */
+    @Test
+    void aSlotSharedByAnIntAndAReferenceYieldsOneRowPerType() throws Exception {
+        FrameTable table = frameTableOf(translateHost(), "handler");
+
+        assertEquals(Arrays.asList("I", "L"), typeCodesForSlot(table, 2),
+                "both occupants of slot 2 should be described, was:\n" + table);
+        assertEquals("&ilocals_2_", addressForRow(table, 2, 'I'),
+                "the int row must point at the int auto, was:\n" + table);
+        assertEquals("&locals[2].data.o", addressForRow(table, 2, 'L'),
+                "the reference row must point at the GC-scanned frame slot, was:\n" + table);
+    }
+
+    /**
+     * The generic form of the same statement, over every row: a reference row
+     * never points at a primitive auto and vice versa. This is the property
+     * that stops the runtime dereferencing an int.
+     */
+    @Test
+    void everyRowPointsAtStorageOfItsOwnKind() throws Exception {
+        FrameTable table = frameTableOf(translateHost(), "handler");
+
+        assertEquals(table.rows.size(), table.addresses.size(),
+                "the address array must have exactly one entry per row, was:\n" + table);
+        for (int i = 0; i < table.rows.size(); i++) {
+            Row row = table.rows.get(i);
+            String address = table.addresses.get(i);
+            if (row.isReference()) {
+                assertTrue(address.startsWith("&locals["),
+                        "reference row " + row + " points at primitive storage " + address
+                                + ", was:\n" + table);
+            } else {
+                assertTrue(address.startsWith("&" + row.qualifier() + "locals_"),
+                        "primitive row " + row + " points at " + address
+                                + ", which is not its own storage, was:\n" + table);
+                assertFalse(address.startsWith("&locals["),
+                        "primitive row " + row + " points at the object slot, was:\n" + table);
+            }
+        }
+    }
+
+    /**
+     * The address for a row names the slot the row declares, not some other
+     * slot that happens to share its type.
+     */
+    @Test
+    void everyRowAddressesItsOwnSlot() throws Exception {
+        FrameTable table = frameTableOf(translateHost(), "handler");
+
+        for (int i = 0; i < table.rows.size(); i++) {
+            Row row = table.rows.get(i);
+            String expected = row.isReference()
+                    ? "&locals[" + row.slot + "].data.o"
+                    : "&" + row.qualifier() + "locals_" + row.slot + "_";
+            assertEquals(expected, table.addresses.get(i),
+                    "row " + row + " should address slot " + row.slot + ", was:\n" + table);
+        }
+    }
+
+    /**
+     * Two translations of the same input emit the same table.
+     *
+     * <p>The rows come from a {@code HashSet}, whose iteration order varies
+     * between runs. Taken in that order the emitted table differed build to
+     * build, which is both a reproducibility problem and the reason the old
+     * per-slot table picked an arbitrary one of a reused slot's two types.</p>
+     */
+    @Test
+    void theEmittedTableIsTheSameOnEveryTranslation() throws Exception {
+        String first = frameTableOf(translateHost(), "handler").toString();
+        Parser.cleanup();
+        String second = frameTableOf(translateHost(), "handler").toString();
+
+        assertEquals(first, second, "the locals side-table must not depend on hash order");
+    }
+
+    /**
+     * A frame with nothing to describe still publishes its frame info.
+     *
+     * <p>The pointer is what tells the debugger which method a frame belongs
+     * to. Skipping the publication for a method with no locals left the frame
+     * holding whatever the previous occupant of that call depth wrote, so the
+     * IDE was shown an unrelated method — and, worse, that method's locals
+     * address array, which points into a C frame that has already returned.</p>
+     */
+    @Test
+    void aMethodWithNoLocalsStillPublishesItsFrameInfo() throws Exception {
+        String body = cFunctionBody(translateHost(), "_ping__");
+
+        assertTrue(body.contains("callStackFrameInfo[threadStateData->callStackOffset - 1] = &__cn1_finfo_"),
+                "a locals-free frame must still identify its method, was:\n" + body);
+        assertTrue(body.contains("callStackLocalsAddresses[threadStateData->callStackOffset - 1] = 0;"),
+                "and must clear the locals pointer rather than leave it stale, was:\n" + body);
+    }
+
+    /** The declared count and the emitted rows agree. */
+    @Test
+    void theDeclaredRowCountMatchesTheRowsEmitted() throws Exception {
+        FrameTable table = frameTableOf(translateHost(), "handler");
+
+        assertEquals(table.rows.size(), table.declaredRowCount,
+                "varTableCount must match the side-table it describes, was:\n" + table);
+    }
+
+    /**
+     * The two occupants of the reused slot report disjoint scopes, in source
+     * order.
+     *
+     * <p>This is what lets the runtime show one of them at a time. Reporting
+     * both as live — which is what an always-live table amounts to — means the
+     * variable the code has not reached yet is displayed alongside the one it
+     * has, reading storage that belongs to the other scope.</p>
+     */
+    @Test
+    void theTwoOccupantsOfAReusedSlotReportDisjointScopes() throws Exception {
+        FrameTable table = frameTableOf(translateHost(), "handler");
+        Row intRow = rowFor(table, 2, 'I');
+        Row refRow = rowFor(table, 2, 'L');
+
+        assertEquals(INT_SCOPE_LINE, intRow.startLine, "int scope opens, was:\n" + table);
+        assertEquals(REF_SCOPE_LINE, intRow.endLine, "int scope closes, was:\n" + table);
+        assertEquals(REF_SCOPE_LINE, refRow.startLine, "reference scope opens, was:\n" + table);
+        assertTrue(refRow.endLine == 0 || refRow.endLine > REF_SCOPE_LINE,
+                "reference scope should stay open past its declaration, was:\n" + table);
+        assertTrue(intRow.endLine <= refRow.startLine,
+                "the two scopes must not overlap, was:\n" + table);
+    }
+
+    /** Stated as the runtime asks it: which local is live at this line. */
+    @Test
+    void onlyOneOccupantOfAReusedSlotIsLiveAtAnyLine() throws Exception {
+        FrameTable table = frameTableOf(translateHost(), "handler");
+        Row intRow = rowFor(table, 2, 'I');
+        Row refRow = rowFor(table, 2, 'L');
+
+        assertTrue(intRow.liveAt(INT_SCOPE_LINE), "the int is live where it is declared");
+        assertFalse(refRow.liveAt(INT_SCOPE_LINE),
+                "the reference must be hidden before its declaration, was:\n" + table);
+
+        assertTrue(refRow.liveAt(REF_SCOPE_LINE), "the reference is live where it is declared");
+        assertFalse(intRow.liveAt(REF_SCOPE_LINE),
+                "the int must be hidden once its scope closes, was:\n" + table);
+    }
+
+    /**
+     * A local the class file gives a name and a scope keeps them.
+     *
+     * <p>A store opcode synthesises a placeholder for the slot before the
+     * class file's own entry is visited, and the two collide in the set that
+     * holds them. The placeholder used to win, which cost both the name and
+     * the scope — the debugger showed "v2", live for the whole method.</p>
+     */
+    @Test
+    void aDeclaredLocalKeepsItsScopeDespiteTheStoreSynthesisedPlaceholder() throws Exception {
+        FrameTable table = frameTableOf(translateHost(), "handler");
+
+        assertTrue(rowFor(table, 2, 'I').startLine > 0,
+                "the declared int should carry its scope, not the placeholder's, was:\n" + table);
+        assertTrue(rowFor(table, 3, 'I').startLine > 0,
+                "the same holds for a slot that is never reused, was:\n" + table);
+    }
+
+    /** Args and the receiver are live for the whole method. */
+    @Test
+    void theReceiverAndArgumentsAreLiveFromTheFirstLine() throws Exception {
+        FrameTable table = frameTableOf(translateHost(), "handler");
+
+        for (int slot : new int[] { 0, 1 }) {
+            Row row = rowFor(table, slot, 'L');
+            assertTrue(row.liveAt(INT_SCOPE_LINE) && row.liveAt(REF_SCOPE_LINE),
+                    "slot " + slot + " should be live throughout, was:\n" + table);
+        }
+    }
+
+    // ---- parsing the generated C ------------------------------------------
+
+    private static final class Row {
+        final int startLine;
+        final int endLine;
+        final int slot;
+        final char typeCode;
+
+        Row(int startLine, int endLine, int slot, char typeCode) {
+            this.startLine = startLine;
+            this.endLine = endLine;
+            this.slot = slot;
+            this.typeCode = typeCode;
+        }
+
+        /** Whether this local is reported as live at the given source line. */
+        boolean liveAt(int line) {
+            if (startLine <= 0) return true;
+            if (line < startLine) return false;
+            return endLine <= 0 || line < endLine;
+        }
+
+        boolean isReference() {
+            return typeCode == 'L' || typeCode == '[';
+        }
+
+        /** ParparVM's storage qualifier: byte/short/char/boolean collapse onto 'i'. */
+        char qualifier() {
+            switch (typeCode) {
+                case 'J': return 'l';
+                case 'F': return 'f';
+                case 'D': return 'd';
+                case 'L': case '[': return 'o';
+                default: return 'i';
+            }
+        }
+
+        @Override public String toString() {
+            return "{slot=" + slot + ", type='" + typeCode + "', lines="
+                    + startLine + ".." + (endLine == 0 ? "end" : String.valueOf(endLine)) + "}";
+        }
+    }
+
+    private static final class FrameTable {
+        final List<Row> rows = new ArrayList<>();
+        final List<String> addresses = new ArrayList<>();
+        int declaredRowCount;
+
+        @Override public String toString() {
+            StringBuilder b = new StringBuilder("frame table:\n");
+            for (int i = 0; i < Math.max(rows.size(), addresses.size()); i++) {
+                b.append("  #").append(i).append(' ')
+                 .append(i < rows.size() ? rows.get(i).toString() : "<no row>")
+                 .append(" -> ")
+                 .append(i < addresses.size() ? addresses.get(i) : "<no address>")
+                 .append('\n');
+            }
+            b.append("  declaredRowCount=").append(declaredRowCount).append('\n');
+            return b.toString();
+        }
+    }
+
+    private static final Pattern VAR_ROW =
+            Pattern.compile("\\{\\s*(\\d+),\\s*(\\d+),\\s*(\\d+),\\s*'(.)'\\s*\\}");
+    private static final Pattern FINFO =
+            Pattern.compile("struct cn1_frame_info __cn1_finfo_\\w+ = \\{\\s*"
+                    + "(-?\\d+),\\s*(-?\\d+),\\s*(-?\\d+),\\s*(\\d+)");
+
+    /**
+     * Pulls the variable side-table, its declared row count and the matching
+     * {@code __cn1_local_addrs} initialiser out of the generated C for the
+     * first method whose C name contains {@code methodName}.
+     */
+    private FrameTable frameTableOf(String code, String methodName) {
+        int anchor = code.indexOf("_" + methodName + "__");
+        assertTrue(anchor >= 0, "no generated function for " + methodName + ":\n" + code);
+        String identifier = methodIdentifierAt(code, anchor);
+
+        FrameTable table = new FrameTable();
+
+        String varsMarker = "static const struct cn1_var_entry __cn1_vars_" + identifier + "[] = {";
+        int varsAt = code.indexOf(varsMarker);
+        assertTrue(varsAt >= 0, "no variable side-table for " + methodName + ":\n" + code);
+        int varsEnd = code.indexOf("};", varsAt);
+        Matcher rowMatcher = VAR_ROW.matcher(code.substring(varsAt + varsMarker.length(), varsEnd));
+        while (rowMatcher.find()) {
+            table.rows.add(new Row(Integer.parseInt(rowMatcher.group(1)),
+                    Integer.parseInt(rowMatcher.group(2)),
+                    Integer.parseInt(rowMatcher.group(3)),
+                    rowMatcher.group(4).charAt(0)));
+        }
+
+        String finfoMarker = "struct cn1_frame_info __cn1_finfo_" + identifier + " = {";
+        int finfoAt = code.indexOf(finfoMarker);
+        assertTrue(finfoAt >= 0, "no frame info for " + methodName + ":\n" + code);
+        Matcher finfoMatcher = FINFO.matcher(code.substring(finfoAt - 20 < 0 ? 0 : finfoAt - 20));
+        assertTrue(finfoMatcher.find(), "unparseable frame info for " + methodName + ":\n" + code);
+        table.declaredRowCount = Integer.parseInt(finfoMatcher.group(4));
+
+        String addrsMarker = "void* __cn1_local_addrs[";
+        int addrsAt = code.indexOf(addrsMarker, varsEnd);
+        assertTrue(addrsAt >= 0, "no locals address array for " + methodName + ":\n" + code);
+        int open = code.indexOf('{', addrsAt);
+        int close = code.indexOf('}', open);
+        for (String entry : code.substring(open + 1, close).split(",(?![^\\[]*\\])")) {
+            String trimmed = entry.trim();
+            if (!trimmed.isEmpty()) {
+                table.addresses.add(trimmed);
+            }
+        }
+        return table;
+    }
+
+    /** The translator's per-method identifier, read back off the emitted symbol. */
+    private String methodIdentifierAt(String code, int anchor) {
+        Matcher m = Pattern.compile("__cn1_finfo_(\\w*" + "DbgHost_" + "\\w*)")
+                .matcher(code.substring(anchor > 400 ? anchor - 400 : 0,
+                        Math.min(code.length(), anchor + 400)));
+        assertTrue(m.find(), "could not locate the frame-info symbol near the method:\n" + code);
+        return m.group(1);
+    }
+
+    private List<String> typeCodesForSlot(FrameTable table, int slot) {
+        List<String> out = new ArrayList<>();
+        for (Row r : table.rows) {
+            if (r.slot == slot) out.add(String.valueOf(r.typeCode));
+        }
+        Collections.sort(out);
+        return out;
+    }
+
+    private Row rowFor(FrameTable table, int slot, char typeCode) {
+        for (Row r : table.rows) {
+            if (r.slot == slot && r.typeCode == typeCode) return r;
+        }
+        throw new AssertionError("no row for slot " + slot + " type '" + typeCode + "':\n" + table);
+    }
+
+    private String addressForRow(FrameTable table, int slot, char typeCode) {
+        for (int i = 0; i < table.rows.size(); i++) {
+            Row r = table.rows.get(i);
+            if (r.slot == slot && r.typeCode == typeCode) return table.addresses.get(i);
+        }
+        return null;
+    }
+
+    /** The text of the first generated C function whose name contains {@code marker}. */
+    private String cFunctionBody(String code, String marker) {
+        int nameAt = code.indexOf(marker);
+        assertTrue(nameAt >= 0, "generated code has no function matching " + marker + ":\n" + code);
+        int start = code.indexOf('{', nameAt);
+        int end = code.indexOf("\n}", start + 1);
+        assertTrue(start >= 0 && end > start, "could not delimit the body of " + marker);
+        return code.substring(start, end);
+    }
+
+    // ---- the class under translation ---------------------------------------
+
+    private String translateHost() throws Exception {
+        Parser.parse(writeHostClass().toFile());
+
+        ByteCodeClass objectClass =
+                new ByteCodeClass("java_lang_Object", "java/lang/Object");
+        ByteCodeClass host = Parser.getClassObject("com_example_DbgHost");
+        host.setBaseClassObject(objectClass);
+        host.setBaseInterfacesObject(Collections.<ByteCodeClass>emptyList());
+        host.updateAllDependencies();
+
+        List<ByteCodeClass> classes = Arrays.asList(objectClass, host);
+        return host.generateCCode(classes);
+    }
+
+    /**
+     * {@code handler(Object)} is the shape of an event listener: slot 2 holds
+     * an {@code int} for the first half of the method and a {@code String} for
+     * the second, exactly as javac lays out
+     *
+     * <pre>
+     *   void handler(Object ev) {
+     *       { int count = 1; int copy = count; }
+     *       { String label = null; Object held = label; }
+     *   }
+     * </pre>
+     *
+     * {@code ping()} is the contrast case: a frame with no locals at all that
+     * still makes a call, so it is not eligible for the barebone form and does
+     * push a frame.
+     */
+    private Path writeHostClass() throws Exception {
+        ClassWriter cw = new ClassWriter(0);
+        cw.visit(Opcodes.V1_8,
+                Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL | Opcodes.ACC_SUPER,
+                HOST, null, "java/lang/Object", null);
+
+        MethodVisitor probe = cw.visitMethod(
+                Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC, "probe", "(I)V", null, null);
+        probe.visitCode();
+        probe.visitInsn(Opcodes.RETURN);
+        probe.visitMaxs(1, 1);
+        probe.visitEnd();
+
+        MethodVisitor handler = cw.visitMethod(
+                Opcodes.ACC_PUBLIC, "handler", "(Ljava/lang/Object;)V", null, null);
+        Label start = new Label();
+        Label midpoint = new Label();
+        Label end = new Label();
+        handler.visitCode();
+        handler.visitLabel(start);
+        handler.visitLineNumber(INT_SCOPE_LINE, start);
+        handler.visitInsn(Opcodes.ICONST_1);
+        handler.visitVarInsn(Opcodes.ISTORE, 2);        // int count
+        handler.visitVarInsn(Opcodes.ILOAD, 2);
+        handler.visitVarInsn(Opcodes.ISTORE, 3);        // int copy
+        handler.visitLabel(midpoint);                   // count goes out of scope
+        handler.visitLineNumber(REF_SCOPE_LINE, midpoint);
+        handler.visitInsn(Opcodes.ACONST_NULL);
+        handler.visitVarInsn(Opcodes.ASTORE, 2);        // String label — same slot
+        handler.visitVarInsn(Opcodes.ALOAD, 2);
+        handler.visitVarInsn(Opcodes.ASTORE, 4);        // Object held
+        handler.visitLabel(end);
+        handler.visitLineNumber(METHOD_END_LINE, end);
+        handler.visitInsn(Opcodes.RETURN);
+        handler.visitLocalVariable("this", "Lcom/example/DbgHost;", null, start, end, 0);
+        handler.visitLocalVariable("ev", "Ljava/lang/Object;", null, start, end, 1);
+        handler.visitLocalVariable("count", "I", null, start, midpoint, 2);
+        handler.visitLocalVariable("copy", "I", null, start, end, 3);
+        handler.visitLocalVariable("label", "Ljava/lang/String;", null, midpoint, end, 2);
+        handler.visitLocalVariable("held", "Ljava/lang/Object;", null, midpoint, end, 4);
+        handler.visitMaxs(2, 5);
+        handler.visitEnd();
+
+        MethodVisitor ping = cw.visitMethod(
+                Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC, "ping", "()V", null, null);
+        ping.visitCode();
+        ping.visitInsn(Opcodes.ICONST_0);
+        ping.visitMethodInsn(Opcodes.INVOKESTATIC, HOST, "probe", "(I)V", false);
+        ping.visitInsn(Opcodes.RETURN);
+        ping.visitMaxs(1, 0);
+        ping.visitEnd();
+
+        cw.visitEnd();
+        return writeClassFile(HOST, cw);
+    }
+
+    private Path writeClassFile(String internalName, ClassWriter cw) throws Exception {
+        Path dir = Files.createTempDirectory("cn1-dbg-frame-table");
+        Path file = dir.resolve(internalName.substring(internalName.lastIndexOf('/') + 1) + ".class");
+        Files.write(file, cw.toByteArray());
+        return file;
+    }
+}

--- a/vm/tests/src/test/java/com/codename1/tools/translator/OnDeviceDebugFrameTableTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/OnDeviceDebugFrameTableTest.java
@@ -39,8 +39,10 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -261,6 +263,60 @@ class OnDeviceDebugFrameTableTest {
             assertTrue(row.liveAt(INT_SCOPE_LINE) && row.liveAt(REF_SCOPE_LINE),
                     "slot " + slot + " should be live throughout, was:\n" + table);
         }
+    }
+
+    /**
+     * The device's frame table and the symbol table the IDE reads describe the
+     * same local the same way.
+     *
+     * <p>They are produced at different times — the frame side-table during
+     * code generation, the symbol table after every class has been generated —
+     * and {@code optimize()} rewrites the instruction list in between, which
+     * is what a scope is resolved against. The optimizer does preserve the
+     * label and line-number instructions that walk depends on, so this holds
+     * today either way; it is pinned because nothing else states that, and the
+     * two disagreeing would not fail loudly. The IDE would ask for a slot the
+     * device considers out of scope and the local would simply be missing from
+     * the variables view.</p>
+     */
+    @Test
+    void scopesAreResolvedBeforeTheOptimizerRewritesTheInstructionList() throws Exception {
+        Parser.parse(writeHostClass().toFile());
+        ByteCodeClass objectClass =
+                new ByteCodeClass("java_lang_Object", "java/lang/Object");
+        ByteCodeClass host = Parser.getClassObject("com_example_DbgHost");
+        host.setBaseClassObject(objectClass);
+        host.setBaseInterfacesObject(Collections.<ByteCodeClass>emptyList());
+        host.updateAllDependencies();
+
+        BytecodeMethod handler = null;
+        for (BytecodeMethod m : host.getMethods()) {
+            if ("handler".equals(m.getMethodName())) {
+                handler = m;
+            }
+        }
+        assertNotNull(handler, "the fixture should carry a handler method");
+
+        List<int[]> beforeGeneration = handler.debugVarScopes(handler.debugVarEntries());
+        // generateCCode runs optimize(), which rewrites the instruction list
+        // the scopes would otherwise be resolved against.
+        host.generateCCode(Arrays.asList(objectClass, host));
+        List<int[]> afterGeneration = handler.debugVarScopes(handler.debugVarEntries());
+
+        assertEquals(beforeGeneration.size(), afterGeneration.size());
+        for (int i = 0; i < beforeGeneration.size(); i++) {
+            assertArrayEquals(beforeGeneration.get(i), afterGeneration.get(i),
+                    "scope " + i + " changed across code generation: "
+                            + Arrays.toString(beforeGeneration.get(i)) + " -> "
+                            + Arrays.toString(afterGeneration.get(i)));
+        }
+        // And they are real scopes, not a table of always-live pairs that
+        // would agree trivially.
+        boolean anyScoped = false;
+        for (int[] scope : afterGeneration) {
+            anyScoped |= scope[0] > 0;
+        }
+        assertTrue(anyScoped, "the fixture should produce at least one scoped local");
     }
 
     // ---- parsing the generated C ------------------------------------------

--- a/vm/tests/src/test/java/com/codename1/tools/translator/OnDeviceDebugFrameTableTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/OnDeviceDebugFrameTableTest.java
@@ -43,6 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -355,6 +356,48 @@ class OnDeviceDebugFrameTableTest {
         assertTrue(anyScoped, "the fixture should produce at least one scoped local");
     }
 
+    /**
+     * Two locals of the same type sharing a slot each keep their own row.
+     *
+     * <p>The set that holds locals keyed them by slot and storage qualifier,
+     * so consecutive blocks each declaring an {@code int} collapsed to one
+     * entry. That was survivable while every local was reported live for the
+     * whole method — they share one storage location anyway — but once a local
+     * is filtered to its own scope it is not: in the second block the debugger
+     * would have had no row to show, so the variable would simply be absent
+     * from the IDE rather than merely misnamed.</p>
+     */
+    @Test
+    void twoLocalsOfTheSameTypeSharingASlotEachKeepTheirOwnRow() throws Exception {
+        FrameTable table = frameTableOf(translateHost(), "handler");
+
+        List<Row> slotFive = new ArrayList<>();
+        for (Row r : table.rows) {
+            if (r.slot == 5) slotFive.add(r);
+        }
+        assertEquals(2, slotFive.size(),
+                "both declarations for slot 5 should be described, was:\n" + table);
+
+        Row live = null;
+        for (Row r : slotFive) {
+            if (r.liveAt(INT_SCOPE_LINE)) {
+                assertNull(live, "only one may be live at a line, was:\n" + table);
+                live = r;
+            }
+        }
+        assertNotNull(live, "one of them must be live in the first block, was:\n" + table);
+
+        Row liveLater = null;
+        for (Row r : slotFive) {
+            if (r.liveAt(REF_SCOPE_LINE)) {
+                assertNull(liveLater, "only one may be live at a line, was:\n" + table);
+                liveLater = r;
+            }
+        }
+        assertNotNull(liveLater, "and the other in the second block, was:\n" + table);
+        assertTrue(live != liveLater, "they must be different rows, was:\n" + table);
+    }
+
     // ---- parsing the generated C ------------------------------------------
 
     private static final class Row {
@@ -565,6 +608,8 @@ class OnDeviceDebugFrameTableTest {
         handler.visitLabel(start);
         handler.visitLineNumber(INT_SCOPE_LINE, start);
         handler.visitInsn(Opcodes.ICONST_1);
+        handler.visitVarInsn(Opcodes.ISTORE, 5);        // int first — slot 5
+        handler.visitInsn(Opcodes.ICONST_1);
         handler.visitVarInsn(Opcodes.ISTORE, 2);        // int count
         handler.visitVarInsn(Opcodes.ILOAD, 2);
         handler.visitVarInsn(Opcodes.ISTORE, 3);        // int copy
@@ -574,6 +619,8 @@ class OnDeviceDebugFrameTableTest {
         handler.visitVarInsn(Opcodes.ASTORE, 2);        // String label — same slot
         handler.visitVarInsn(Opcodes.ALOAD, 2);
         handler.visitVarInsn(Opcodes.ASTORE, 4);        // Object held
+        handler.visitInsn(Opcodes.ICONST_2);
+        handler.visitVarInsn(Opcodes.ISTORE, 5);        // int second — slot 5 again
         Label lastStatement = new Label();
         handler.visitLabel(lastStatement);
         handler.visitLineNumber(METHOD_END_LINE, lastStatement);
@@ -587,7 +634,10 @@ class OnDeviceDebugFrameTableTest {
         handler.visitLocalVariable("copy", "I", null, start, end, 3);
         handler.visitLocalVariable("label", "Ljava/lang/String;", null, midpoint, end, 2);
         handler.visitLocalVariable("held", "Ljava/lang/Object;", null, midpoint, end, 4);
-        handler.visitMaxs(2, 5);
+        // Two ints of the same type sharing slot 5 in disjoint blocks.
+        handler.visitLocalVariable("first", "I", null, start, midpoint, 5);
+        handler.visitLocalVariable("second", "I", null, midpoint, end, 5);
+        handler.visitMaxs(2, 6);
         handler.visitEnd();
 
         MethodVisitor ping = cw.visitMethod(

--- a/vm/tests/src/test/java/com/codename1/tools/translator/OnDeviceDebugFrameTableTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/OnDeviceDebugFrameTableTest.java
@@ -398,6 +398,31 @@ class OnDeviceDebugFrameTableTest {
         assertTrue(live != liveLater, "they must be different rows, was:\n" + table);
     }
 
+    /**
+     * A scope that opens and closes on one line is bounded to that line.
+     *
+     * <p>Both labels resolve to the same source line, which is not the same
+     * thing as a scope running to the end of the method. Treating it as
+     * open-ended left the local visible for every later line and able to
+     * collide with a declaration reusing its slot.</p>
+     */
+    @Test
+    void aScopeThatOpensAndClosesOnOneLineCoversOnlyThatLine() throws Exception {
+        FrameTable table = frameTableOf(translateHost(), "handler");
+        Row oneLiner = rowFor(table, 6, 'I');
+
+        assertEquals(INT_SCOPE_LINE, oneLiner.startLine,
+                "it opens on the line it is declared, was:\n" + table);
+        assertEquals(INT_SCOPE_LINE + 1, oneLiner.endLine,
+                "and closes right after it rather than running on, was:\n" + table);
+        assertTrue(oneLiner.liveAt(INT_SCOPE_LINE),
+                "it must be visible on its own line, was:\n" + table);
+        assertFalse(oneLiner.liveAt(REF_SCOPE_LINE),
+                "and gone by the next block, was:\n" + table);
+        assertFalse(oneLiner.liveAt(METHOD_END_LINE),
+                "and certainly by the end of the method, was:\n" + table);
+    }
+
     // ---- parsing the generated C ------------------------------------------
 
     private static final class Row {
@@ -607,6 +632,13 @@ class OnDeviceDebugFrameTableTest {
         handler.visitCode();
         handler.visitLabel(start);
         handler.visitLineNumber(INT_SCOPE_LINE, start);
+        handler.visitInsn(Opcodes.ICONST_3);
+        handler.visitVarInsn(Opcodes.ISTORE, 6);        // int oneLiner, opens...
+        Label oneLinerEnd = new Label();
+        handler.visitLabel(oneLinerEnd);
+        // A second statement on the same source line, so the closing label
+        // resolves to the line the scope opened on rather than the next one.
+        handler.visitLineNumber(INT_SCOPE_LINE, oneLinerEnd);
         handler.visitInsn(Opcodes.ICONST_1);
         handler.visitVarInsn(Opcodes.ISTORE, 5);        // int first — slot 5
         handler.visitInsn(Opcodes.ICONST_1);
@@ -637,7 +669,8 @@ class OnDeviceDebugFrameTableTest {
         // Two ints of the same type sharing slot 5 in disjoint blocks.
         handler.visitLocalVariable("first", "I", null, start, midpoint, 5);
         handler.visitLocalVariable("second", "I", null, midpoint, end, 5);
-        handler.visitMaxs(2, 6);
+        handler.visitLocalVariable("oneLiner", "I", null, start, oneLinerEnd, 6);
+        handler.visitMaxs(2, 7);
         handler.visitEnd();
 
         MethodVisitor ping = cw.visitMethod(

--- a/vm/tests/src/test/java/com/codename1/tools/translator/OnDeviceDebugFrameTableTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/OnDeviceDebugFrameTableTest.java
@@ -266,6 +266,42 @@ class OnDeviceDebugFrameTableTest {
     }
 
     /**
+     * A scope that runs to the end of the method stays live on the last line.
+     *
+     * <p>javac closes those scopes with a label placed after the final
+     * instruction, which no line number follows. Resolving it to the last line
+     * seen would make the exclusive end land <em>on</em> that line and hide
+     * every method-wide local — {@code this} and the parameters included — at
+     * exactly the breakpoint a developer is most likely to set, the closing
+     * brace or the return.</p>
+     */
+    @Test
+    void methodWideLocalsStayLiveOnTheFinalLine() throws Exception {
+        FrameTable table = frameTableOf(translateHost(), "handler");
+
+        for (int slot : new int[] { 0, 1, 4 }) {
+            Row row = rowFor(table, slot, 'L');
+            assertEquals(0, row.endLine,
+                    "slot " + slot + " runs to the end of the method, so its scope"
+                            + " must be open-ended, was:\n" + table);
+            assertTrue(row.liveAt(METHOD_END_LINE),
+                    "slot " + slot + " must still be visible on the last line, was:\n" + table);
+        }
+    }
+
+    /** A scope that genuinely closes mid-method still ends where it should. */
+    @Test
+    void aScopeThatClosesMidMethodIsStillBounded() throws Exception {
+        FrameTable table = frameTableOf(translateHost(), "handler");
+        Row count = rowFor(table, 2, 'I');
+
+        assertEquals(REF_SCOPE_LINE, count.endLine,
+                "the int's scope closes where the reference's opens, was:\n" + table);
+        assertFalse(count.liveAt(METHOD_END_LINE),
+                "and it must not reappear on the final line, was:\n" + table);
+    }
+
+    /**
      * The device's frame table and the symbol table the IDE reads describe the
      * same local the same way.
      *
@@ -538,9 +574,13 @@ class OnDeviceDebugFrameTableTest {
         handler.visitVarInsn(Opcodes.ASTORE, 2);        // String label — same slot
         handler.visitVarInsn(Opcodes.ALOAD, 2);
         handler.visitVarInsn(Opcodes.ASTORE, 4);        // Object held
-        handler.visitLabel(end);
-        handler.visitLineNumber(METHOD_END_LINE, end);
+        Label lastStatement = new Label();
+        handler.visitLabel(lastStatement);
+        handler.visitLineNumber(METHOD_END_LINE, lastStatement);
         handler.visitInsn(Opcodes.RETURN);
+        // The scope-closing label goes after the last instruction with no line
+        // number of its own, which is what javac emits.
+        handler.visitLabel(end);
         handler.visitLocalVariable("this", "Lcom/example/DbgHost;", null, start, end, 0);
         handler.visitLocalVariable("ev", "Ljava/lang/Object;", null, start, end, 1);
         handler.visitLocalVariable("count", "I", null, start, midpoint, 2);


### PR DESCRIPTION
Closes the outstanding items on #5333.

## The crash

A breakpoint in an event listener took the app down with `We had a signal 11`. Three independent wild-pointer paths converged on `handleGetLocals`, which is what NetBeans calls the moment a breakpoint hits.

**1. The locals side-table described the wrong storage.** It listed one row per declared local but only one address per JVM *slot*, picked last-writer-wins out of a `HashSet`. A slot reused by an `int` and a reference in disjoint scopes — routine in any listener — therefore had a reference row addressing a four-byte `JAVA_INT`:

```c
JAVA_OBJECT obj = *(JAVA_OBJECT*)addrs[v->slot];   // 8 bytes off a 4-byte int
if (... obj->__codenameOneParentClsReference == &class__java_lang_String)  // SIGSEGV
```

There is now one address per *row*, so a row's type code and the storage it points at cannot disagree. Rows are sorted rather than hash-ordered, so the emitted table also stops varying between builds of the same input — which is why this reproduced on some breakpoints and not others.

**2. Frames inherited a dangling locals pointer.** `callStackFrameInfo` / `callStackLocalsAddresses` were written only by methods carrying a side-table, and never cleared. A native, eliminated or barebone frame inherited whatever the previous occupant of that call depth left — including an address array pointing into a C frame that had already returned. `CN1_DEBUG_FRAME_ENTER` clears both before every push and compiles away in release builds.

**3. Nothing validated a reference before dereferencing it.** Every reference the debugger handles is untrusted: the IDE echoes back objectIDs it was handed earlier, and a local slot holds whatever the branch that never ran left there. `cn1_debugger_objects.c` resolves a candidate through an exact `classId -> clazz` registry, reading it via `vm_read_overwrite` so an unmapped page returns an error instead of a signal. Every deref site goes through it — locals, object class/fields/string, invoke receiver and args, array length/values, and references handed back to the IDE.

## The rest of the report

- **Threads.** `CMD_GET_THREADS` was a device stub replying empty and the proxy never sent it, so `AllThreads` could only report threads that had already hit a breakpoint. It now enumerates ParparVM's thread registry. Suspension is tracked per thread rather than by a single "last suspended" field, and `Thread.Name` resolves the real name off the `java.lang.Thread` instance, so the panel shows `EDT` and `main`.
- **Deferred breakpoints.** `ClassPrepare` (event kind 8) was accepted and never fired, so IntelliJ and NetBeans left every deferred breakpoint unarmed — the "breakpoint in a listener never stops" half of the report. Matching classes are replayed at registration, which is complete for ParparVM since the whole class set is linked in before a debugger can attach.
- **Scoped locals.** Locals carry their declaring scope, so one is listed only on the lines it is live for. This also fixes a `-g` local being shown as `vN`: the placeholder a store opcode synthesises no longer keeps the class file's own entry out of the set that holds them.
- **Capabilities.** `CapabilitiesNew` reports `canRequestVMDeathEvent`, which the proxy does support. The rest stay false rather than having the IDE offer redefinition or frame popping and then fail.
- **Diagnostics.** Breakpoint arming logs the resolved `Class.method:line`, and warns when a request maps to no method or to a line outside the method's line table. It used to be accepted in silence, which is why this thread ran as long as it did.
- **IDE configuration.** NetBeans gets *Build for iOS On-Device Debug* and *Start iOS Debug Proxy* project actions — the configuration the reporter had to build by hand. IntelliJ was missing the build half and gains a run config for it. The build goal forces the `onDeviceDebug` hint itself, so the properties-file editing that started this issue is not needed.

## Tests

66 tests, in the places the behaviour actually lives:

| | |
|---|---|
| `OnDeviceDebugFrameTableTest` (10) | the emitted C: one address per row, each addressing its own slot and kind, disjoint scopes, determinism |
| `DebugFramePushCoverageTest` (3) | every frame push clears the debug side-channel first |
| `DebuggerObjectValidationTest` (8) | compiles and runs the shipped C validation policy |
| `DebuggerLocalScopeTest` (5) | compiles and runs the shipped scope predicate |
| `JdwpThreadListTest` (6) / `DeviceConnectionThreadListTest` (5) | thread enumeration and its wire decode |
| `JdwpClassPrepareTest` (7) | pattern matching, replay, suspend policy |
| `JdwpVariableScopeTest` (6) | live ranges over JDWP, and the capabilities reply |
| `Cn1AppArchetypeCertificateWizardTest` (+1) | the IDE bindings are actually shipped |

Each guard was checked against the pre-fix code rather than assumed. Reverting the per-row table fails four frame-table tests with exactly the per-slot symptom; removing one `CN1_DEBUG_FRAME_ENTER` names the file and line; reverting the validation to a raw deref fails five tests, **four of them with exit 139 — the reported `signal 11`, reproduced and then prevented**.

`cn1_debugger_objects.c` is plain C rather than part of the Objective-C file precisely so these rules can be compiled and run on a host. The tests are macOS-only, since `vm_read_overwrite` is Darwin-only and iOS debugging is a macOS activity regardless.

## Verification limits

`cn1_debugger.m` and `cn1_debugger_objects.c` type-check against the real iOS SDK (`xcrun --sdk iphonesimulator clang -fsyntax-only`, only three pre-existing deprecation warnings), the frame macro compiles in both build modes, and SpotBugs is at zero on `ByteCodeTranslator`.

**This has not been through an on-device debugging session.** The device-side changes are verified by type-check and by the extracted policy unit under test, not by running against a tethered iPhone — worth doing before telling the reporter it's fixed.

Two things are deliberately left, and documented rather than papered over: two locals of the *same* type sharing a slot still collapse to one entry (reuse across *different* types, the case that caused the crash, is fully distinguished), and a local compiled without `-g` has no scope so it is listed for the whole method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)