### PR TITLE
Fix Hashnode public verification

### DIFF
--- a/scripts/website/syndicate_browser_posts.py
+++ b/scripts/website/syndicate_browser_posts.py
@@ -69,6 +69,7 @@ import os
 import re
 import sys
 import tempfile
+import time
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path

--- a/scripts/website/test_syndicate_browser_posts.py
+++ b/scripts/website/test_syndicate_browser_posts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import inspect
 import unittest
+from unittest.mock import MagicMock, patch
 
 from syndicate_blog_posts import State
 from syndicate_browser_posts import (
@@ -48,6 +49,25 @@ class HashnodeCompletionTest(unittest.TestCase):
                 subheading_set=True,
                 tags_set=True,
                 canonical_set=True,
+            )
+
+    def test_public_article_verification_accepts_matching_canonical(self) -> None:
+        response = MagicMock()
+        response.status = 200
+        response.read.return_value = (
+            b'<link rel="canonical" href="https://www.codenameone.com/blog/example/">'
+        )
+        response.__enter__.return_value = response
+
+        with patch(
+            "syndicate_browser_posts.urllib.request.urlopen",
+            return_value=response,
+        ):
+            self.assertTrue(
+                HashnodeAdapter._wait_for_public_article(
+                    "https://debugagent.com/example",
+                    "https://www.codenameone.com/blog/example/",
+                )
             )
 
     def test_explicit_recovery_accepts_only_failed_drafts(self) -> None:


### PR DESCRIPTION
## What changed

- import Python's `time` module for Hashnode public-article verification
- add focused coverage that executes the canonical verification path

## Why

Hashnode now redirects a successful publication to an authenticated `/edit/<id>` URL. The adapter verifies the derived public DebugAgent URL and canonical before persisting completion, but that verifier called `time.time()` and `time.sleep()` without importing `time`. The publish succeeded externally, then state recording crashed and later runs retried the article.

## Impact

Successful Hashnode publications can be verified and recorded again, preventing false health alerts and repeated unpublished recovery drafts.

## Validation

- `python3 scripts/website/test_syndicate_blog_posts.py` (5 tests)
- `python3 scripts/website/test_syndicate_browser_posts.py` (8 tests)
- `python3 scripts/website/test_syndication_health.py` (6 tests)
- `python3 scripts/website/test_queue_social_posts.py` (8 tests)
- `python3 -m py_compile scripts/website/syndicate_browser_posts.py scripts/website/test_syndicate_browser_posts.py`
