### PR TITLE
Move Google sign-in to GoogleSignIn 7, which has an arm64 simulator slice

### DIFF
--- a/Ports/iOSPort/nativeSources/CodenameOne_GLViewController.h
+++ b/Ports/iOSPort/nativeSources/CodenameOne_GLViewController.h
@@ -376,11 +376,12 @@ CLLocationManagerDelegate, AVAudioRecorderDelegate
 #ifdef INCLUDE_MOPUB
         ,MPAdViewDelegate
 #endif
+// GoogleSignIn 7 declares no GIDSignInDelegate -- the sign-in result goes to a
+// completion handler instead -- so only the legacy Google+ path adopts a
+// Google protocol here.
 #ifdef INCLUDE_GOOGLE_CONNECT
 #ifndef GOOGLE_SIGNIN
         ,GPPSignInDelegate
-#else
-        ,GIDSignInDelegate
 #endif
 #endif
 #ifdef INCLUDE_PHOTOLIBRARY_USAGE
@@ -424,10 +425,6 @@ CLLocationManagerDelegate, AVAudioRecorderDelegate
 @property (readonly, nonatomic, getter=isAnimating) BOOL animating;
 @property (nonatomic) NSInteger animationFrameInterval;
 @property (readwrite, assign) GLUIImage* currentMutableImage;
-#ifdef GOOGLE_SIGNIN
-- (void)signIn:(GIDSignIn *)signIn didSignInForUser:(GIDGoogleUser *)user withError:(NSError *)error;
-- (void)signIn:(GIDSignIn *)signIn didDisconnectWithUser:(GIDGoogleUser *)user withError:(NSError *)error;
-#endif
 
 -(EAGLView*)eaglView;
 -(void)startAnimation;

--- a/Ports/iOSPort/nativeSources/CodenameOne_GLViewController.m
+++ b/Ports/iOSPort/nativeSources/CodenameOne_GLViewController.m
@@ -3072,52 +3072,43 @@ static CodenameOne_GLViewController *sharedSingleton;
 #ifndef GOOGLE_SIGNIN
   GPPSignIn *signIn = [GPPSignIn sharedInstance];
   signIn.shouldFetchGooglePlusUser = YES;
-#else
-  GIDSignIn* signIn = [GIDSignIn sharedInstance];
-  signIn.shouldFetchBasicProfile = YES;
-#endif
-  
+
   //signIn.shouldFetchGoogleUserEmail = YES;  // Uncomment to get the user's email
 
   // You previously set kClientId in the "Initialize the Google+ client" step
   // signIn.clientID = googleClientId;
 
   // Uncomment one of these two statements for the scope you chose in the previous step
-#ifndef GOOGLE_SIGNIN
   signIn.scopes = @[ kGTLAuthScopePlusLogin ];  // "https://www.googleapis.com/auth/plus.login" scope
   //signIn.scopes = @[ @"profile" ];            // "profile" scope
-#else
-  signIn.scopes = @[ @"profile", @"email" ];
-#endif
 
   // Optional: declare signIn.actions, see "app activities"
   signIn.delegate = self;
+#else
+  // Nothing to prime for GoogleSignIn 7: none of the three properties this
+  // used to set still exist. The client id and the scopes are arguments to the
+  // sign-in call itself (see googleLogin in GoogleConnectImpl.m), which always
+  // requests the basic profile scopes, and the delegate is now a completion
+  // handler passed at the same call.
 #endif
-    
+#endif
+
 }
 
 #ifdef INCLUDE_GOOGLE_CONNECT
 #ifndef GOOGLE_SIGNIN
 extern void com_codename1_impl_ios_GoogleConnectImpl_finishedWithAuth(GTMOAuth2Authentication *auth, NSError * error);
-#else
-extern void com_codename1_impl_ios_GoogleConnectImpl_finishedWithAuth(GIDGoogleUser *user, NSError * error);
-extern void com_codename1_impl_ios_IOSNative_googleLogout__(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT me);
-#endif
-#ifndef GOOGLE_SIGNIN
+
 - (void)finishedWithAuth: (GTMOAuth2Authentication *)auth
                    error: (NSError *) error {
     com_codename1_impl_ios_GoogleConnectImpl_finishedWithAuth(auth, error);
 }
-#else
-- (void)signIn:(GIDSignIn *)signIn didSignInForUser:(GIDGoogleUser *)user withError:(NSError *)error {
-    // Perform any operations on signed in user here.
-    com_codename1_impl_ios_GoogleConnectImpl_finishedWithAuth(user, error);
-}
-- (void)signIn:(GIDSignIn *)signIn didDisconnectWithUser:(GIDGoogleUser *)user withError:(NSError *)error {
-    // Perform any operations when the user disconnects from app here.
-    com_codename1_impl_ios_IOSNative_googleLogout__(CN1_THREAD_GET_STATE_PASS_ARG fromNSString(CN1_THREAD_GET_STATE_PASS_ARG user.userID));
-}
 #endif
+// The GoogleSignIn path has no callbacks here any more: the two delegate
+// methods this file used to implement went away with GIDSignInDelegate, and
+// the result now arrives at the completion handler GoogleConnectImpl.m
+// installs, which is also where the Java-side fields are written. Nothing
+// forwards through the view controller.
 #endif
 
 bool lockDrawing;

--- a/Ports/iOSPort/nativeSources/GoogleConnectImpl.m
+++ b/Ports/iOSPort/nativeSources/GoogleConnectImpl.m
@@ -57,16 +57,18 @@ extern void releaseCN1(JAVA_OBJECT o);
 static JAVA_OBJECT googleLoginCallback = NULL;
 static NSString *accessToken;
 
+#ifdef GOOGLE_SIGNIN
+void com_codename1_impl_ios_GoogleConnectImpl_finishedWithAuth(GIDGoogleUser *user, NSError *error);
+#endif
+
 
 void com_codename1_impl_ios_IOSNative_googleLogin___java_lang_Object(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT me, JAVA_OBJECT instance) {
     if (googleLoginCallback == NULL) {
         googleLoginCallback = instance;
-#ifdef GOOGLE_SIGNIN
-        GIDSignIn* signIn = [GIDSignIn sharedInstance];
-#else
+#ifndef GOOGLE_SIGNIN
         GPPSignIn *signIn = [GPPSignIn sharedInstance];
 #endif
-        
+
         JAVA_OBJECT d = com_codename1_ui_Display_getInstance__(CN1_THREAD_GET_STATE_PASS_SINGLE_ARG);
         JAVA_OBJECT jClientID = virtual_com_codename1_ui_Display_getProperty___java_lang_String_java_lang_String_R_java_lang_String(CN1_THREAD_STATE_PASS_ARG d, fromNSString(CN1_THREAD_STATE_PASS_ARG @"ios.gplus.clientId"), JAVA_NULL);
         if (jClientID == JAVA_NULL) {
@@ -77,13 +79,15 @@ void com_codename1_impl_ios_IOSNative_googleLogin___java_lang_Object(CN1_THREAD_
             return;
         }
 #ifdef GOOGLE_SIGNIN
+        // GoogleSignIn never routed through the Google+ app, so the hint that
+        // demands it has always been inert on this path.
         NSString *requireGplusApp = @"false";
 #else
         NSString *requireGplusApp = toNSString(CN1_THREAD_STATE_PASS_ARG virtual_com_codename1_ui_Display_getProperty___java_lang_String_java_lang_String_R_java_lang_String(CN1_THREAD_STATE_PASS_ARG d, fromNSString(CN1_THREAD_STATE_PASS_ARG @"ios.gplus.requireGplusAppForLogin"), fromNSString(CN1_THREAD_STATE_PASS_ARG @"true"))
         );
 #endif
-        
-        
+
+
         if ([requireGplusApp isEqualToString:@"true"]) {
             BOOL isGooglePlusInstalled = [[UIApplication sharedApplication] canOpenURL: [NSURL
                                                                                          URLWithString:@"gplus://"]];
@@ -96,21 +100,39 @@ void com_codename1_impl_ios_IOSNative_googleLogin___java_lang_Object(CN1_THREAD_
             }
         }
         
-        signIn.clientID = toNSString(CN1_THREAD_STATE_PASS_ARG jClientID);
+        NSString *clientID = toNSString(CN1_THREAD_STATE_PASS_ARG jClientID);
         NSString *scope = toNSString(CN1_THREAD_STATE_PASS_ARG get_field_com_codename1_social_GoogleConnect_scope(googleLoginCallback));
-
+        NSArray *scopes = nil;
         if (scope != nil) {
-            signIn.scopes = [scope componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceCharacterSet]]; //@[scope];
+            scopes = [scope componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+        }
+
+#ifndef GOOGLE_SIGNIN
+        signIn.clientID = clientID;
+        if (scopes != nil) {
+            signIn.scopes = scopes;
         }
         dispatch_async(dispatch_get_main_queue(), ^{
-#ifdef GOOGLE_SIGNIN
-            [GIDSignIn sharedInstance].presentingViewController = [CodenameOne_GLViewController instance];
-            [[GIDSignIn sharedInstance] signIn];
-#else
             [signIn authenticate];
-#endif
         });
-    } 
+#else
+        // GoogleSignIn 7 takes the client id through a GIDConfiguration and the
+        // scopes as an argument, and hands the result to a completion handler
+        // rather than to a delegate. Note that additionalScopes is additive:
+        // the app's scope no longer replaces the profile and email scopes the
+        // way assigning signIn.scopes used to.
+        dispatch_async(dispatch_get_main_queue(), ^{
+            GIDSignIn *signIn = [GIDSignIn sharedInstance];
+            signIn.configuration = [[[GIDConfiguration alloc] initWithClientID:clientID] autorelease];
+            [signIn signInWithPresentingViewController:[CodenameOne_GLViewController instance]
+                                                  hint:nil
+                                      additionalScopes:scopes
+                                            completion:^(GIDSignInResult *result, NSError *error) {
+                com_codename1_impl_ios_GoogleConnectImpl_finishedWithAuth(result.user, error);
+            }];
+        });
+#endif
+    }
 }
 
 #ifndef GOOGLE_SIGNIN
@@ -140,16 +162,14 @@ void com_codename1_impl_ios_GoogleConnectImpl_finishedWithAuth(GTMOAuth2Authenti
 }
 #else
 void com_codename1_impl_ios_GoogleConnectImpl_finishedWithAuth(GIDGoogleUser *user, NSError *error) {
-    
-    if (user.authentication.accessToken != nil) {
-        [accessToken release];
-    }
-    accessToken = user.authentication.accessToken;
-    if (accessToken != nil) {
-        [accessToken retain];
-    }
-    
-    
+
+    // GoogleSignIn 7 replaced user.authentication.accessToken with a GIDToken.
+    // The previous token is released unconditionally: releasing it only when a
+    // replacement arrived leaked the old one on every failed sign-in.
+    [accessToken release];
+    accessToken = [user.accessToken.tokenString retain];
+
+
     if (googleLoginCallback != NULL) {
         if (error != nil) {
             set_field_com_codename1_social_GoogleImpl_loginMessage(fromNSString(CN1_THREAD_GET_STATE_PASS_ARG [error localizedDescription]), googleLoginCallback);
@@ -186,8 +206,16 @@ void com_codename1_impl_ios_IOSNative_googleLogout__(CN1_THREAD_STATE_MULTI_ARG 
 #ifndef GOOGLE_SIGNIN
     [[GPPSignIn sharedInstance] disconnect];
 #else
+    // -disconnect became -disconnectWithCompletion: in GoogleSignIn 7. The
+    // outcome now lands in the block below rather than in the view controller's
+    // signIn:didDisconnectWithUser: -- which used to call straight back into
+    // this function, so a delivered disconnect callback re-entered disconnect.
     dispatch_async(dispatch_get_main_queue(), ^{
-        [[GIDSignIn sharedInstance] disconnect];
+        [[GIDSignIn sharedInstance] disconnectWithCompletion:^(NSError *error) {
+            if (error != nil) {
+                CN1Log(@"Google disconnect failed: %@", [error localizedDescription]);
+            }
+        }];
     });
 #endif
     if (accessToken != nil) {

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
@@ -79,6 +79,17 @@ public class IPhoneBuilder extends Executor {
     private int podTimeout = 300000; // 5 minutes
     private int xcodeVersion;
     private static final String GOOGLE_SIGNIN_TUTORIAL_URL = "http://www.codenameone.com/...";
+
+    /**
+     * The CocoaPods requirement injected when an app enables Google sign-in.
+     * Held here rather than inline so the arm64-simulator floor it encodes is
+     * assertable -- see the comment at the injection site.
+     */
+    static final String GOOGLE_SIGNIN_POD = "GoogleSignIn ~>7.1";
+
+    /** Deployment target floor that {@link #GOOGLE_SIGNIN_POD} requires. */
+    static final String GOOGLE_SIGNIN_MIN_IOS = "12.0";
+
     private File resultDir;
     private boolean includePush;
     private File tmpFile;
@@ -922,8 +933,24 @@ public class IPhoneBuilder extends Executor {
         
                 
         if (useGoogleSignIn) {
-            iosPods += (((iosPods.length() > 0) ? ",":"") + "GoogleSignIn ~>5.0.0");
-            addMinDeploymentTarget("8.0");
+            // 5.0.x shipped a vendored fat framework whose only arm64 slice is
+            // built for the device (LC_VERSION_MIN_IPHONEOS); its simulator
+            // slices are i386 and x86_64. On an Apple Silicon Mac the linker
+            // therefore picked the device slice for an arm64 simulator build
+            // and refused it, so no app that enables Google sign-in could run
+            // in the simulator at all. 7.x is distributed as source, so
+            // CocoaPods compiles a slice for whichever platform is being built.
+            //
+            // 8.x and 9.x add an AppCheckCore dependency, which is Swift and
+            // depends in turn on two pods that define no module map. Adopting
+            // either would require use_modular_headers! in every generated
+            // Podfile, changing pod resolution for projects that have nothing
+            // to do with Google sign-in. 7.1 is the newest release that drops
+            // in without that.
+            iosPods += (((iosPods.length() > 0) ? ",":"") + GOOGLE_SIGNIN_POD);
+            // GoogleSignIn 7.1's own floor is iOS 10, but Xcode 26 accepts
+            // deployment targets no lower than 12.0.
+            addMinDeploymentTarget(GOOGLE_SIGNIN_MIN_IOS);
         }
         
         // Accumulator for AI/ML class hits. After the scan we apply

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/IPhoneBuilderDependencyConfigTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/IPhoneBuilderDependencyConfigTest.java
@@ -227,6 +227,41 @@ class IPhoneBuilderDependencyConfigTest {
         assertEquals("15.5", target);
     }
 
+    /**
+     * GoogleSignIn 5.x and 6.0 shipped a vendored fat framework whose only
+     * arm64 slice is built for the device, so an arm64 simulator build of any
+     * app that enabled Google sign-in failed to link -- "building for
+     * 'iOS-simulator', but linking in object file ... built for 'iOS'". The
+     * source-distributed 7.x line has no such slice to pick wrong. Dropping
+     * back below 7 breaks the simulator again on every Apple Silicon Mac,
+     * which is the whole of the current simulator install base.
+     */
+    @Test
+    void googleSignInPodStaysAboveTheArm64SimulatorFloor() {
+        String spec = IPhoneBuilder.GOOGLE_SIGNIN_POD;
+        assertTrue(spec.startsWith("GoogleSignIn "), spec);
+
+        String requirement = spec.substring("GoogleSignIn ".length()).trim();
+        assertTrue(requirement.startsWith("~>"),
+                "expected a pessimistic requirement, got " + requirement);
+
+        String version = requirement.substring(2).trim();
+        int major = Integer.parseInt(version.split("\\.")[0]);
+        assertTrue(major >= 7,
+                "GoogleSignIn " + version + " predates the source-distributed "
+                        + "releases and has no arm64 simulator slice");
+    }
+
+    @Test
+    void googleSignInDeploymentFloorIsAcceptedByCurrentXcode() {
+        // Xcode 26 rejects deployment targets below 12.0, and the pod's own
+        // podspec floor of 10.0 is therefore not usable as the project value.
+        String[] parts = IPhoneBuilder.GOOGLE_SIGNIN_MIN_IOS.split("\\.");
+        assertTrue(Integer.parseInt(parts[0]) >= 12,
+                "deployment floor " + IPhoneBuilder.GOOGLE_SIGNIN_MIN_IOS
+                        + " is below what current Xcode accepts");
+    }
+
     @Test
     void catalogPrivacyDefaultsReachGeneratedPlistMap() throws Exception {
         Method apply = IPhoneBuilder.class.getDeclaredMethod(


### PR DESCRIPTION
## What broke

`Test iOS packaging` has failed on master since 3a746af827 and on every PR that reaches the job. The device Release build passes; the Debug simulator build dies in `ld`:

```
ld: building for 'iOS-simulator', but linking in object file
    (Pods/GoogleSignIn/Frameworks/GoogleSignIn.framework/GoogleSignIn[arm64][2]
     (GIDAuthStateMigration...o)) built for 'iOS'
```

## Why it surfaced now, and why it is not a CI-config problem

3a746af827 (#5536) added `overlayCommandLineBuildHints()` to `AbstractCN1Mojo`, which made `-Dcodename1.arg.*` actually reach the builder. `ios-packaging.yml` has carried `-Dcodename1.arg.ios.gplus.clientId=...` all along and it had been silently ignored:

| run | pods installed |
|---|---|
| every green run through 2026-08-08 10:16 | `1 dependency ... 2 total pods` |
| first run after #5536 | `3 dependencies ... 7 total pods`, incl. GoogleSignIn |

So the hint started working and immediately exposed a real defect that had been sitting behind it. The right fix is the defect, not the hint.

## The defect

`IPhoneBuilder` pinned `GoogleSignIn ~>5.0.0`. That pod ships a vendored fat framework:

```
$ lipo -info Pods/GoogleSignIn/Frameworks/GoogleSignIn.framework/GoogleSignIn
Architectures in the fat file: ... are: armv7 i386 x86_64 arm64

$ otool -l -arch arm64 ...GoogleSignIn | grep -A2 LC_VERSION_MIN
      cmd LC_VERSION_MIN_IPHONEOS
  version 7.0
```

Both simulator slices are Intel and the only arm64 slice is a device slice. There is no arm64 simulator code in the binary, so the linker picks the device slice and refuses it. The pod predates Apple Silicon. **No Codename One app that enables Google sign-in has been able to run in the simulator on an Apple Silicon Mac** — which is the whole current install base.

## The fix

Move to `GoogleSignIn ~>7.1`, which is distributed as source (`source_files`, no `vendored_frameworks`), so CocoaPods compiles a slice for whichever platform is being built and the mismatch cannot arise.

**Why 7.1 and not 9.x.** 8.x and 9.x add an `AppCheckCore` dependency, which is Swift and depends in turn on `GoogleUtilities` and `RecaptchaInterop`, neither of which defines a module map. `pod install` refuses it:

> The Swift pod `AppCheckCore` depends upon `GoogleUtilities` and `RecaptchaInterop`, which do not define modules.

Adopting either would force `use_modular_headers!` into every generated Podfile and change pod resolution for projects with nothing to do with Google sign-in. 7.1 is the newest release that drops in without that.

## API migration

GoogleSignIn 6.0 replaced the delegate with completion handlers and 7.0 reshaped the token accessors, so the native sources had to move with the pod:

- **`GIDSignInDelegate` is gone.** `CodenameOne_GLViewController` no longer adopts it and its two callback methods are deleted. The result now arrives at a block installed by `GoogleConnectImpl`, which is where the Java-side fields were already written — nothing forwards through the view controller.
- **`initGoogleConnect` has nothing left to do** on this path: `clientID` and scopes are arguments to the sign-in call, and `shouldFetchBasicProfile` is gone because basic profile scopes are always requested.
- **`-disconnect` → `-disconnectWithCompletion:`.** Note the old `didDisconnectWithUser:` called straight back into `googleLogout`, so a delivered disconnect callback re-entered `disconnect`; the block has no path back.
- **`user.authentication.accessToken` → `user.accessToken.tokenString`.** While rewriting the assignment, the previous token is now released unconditionally — releasing it only when a replacement arrived dropped the last reference to the old one on every failed sign-in.

### One deliberate behaviour change

`additionalScopes` is additive — *"scopes to request in addition to the basic profile scopes"* (`GIDSignIn.h`) — where assigning `signIn.scopes` replaced them. An app setting a custom scope now keeps `profile` and `email` instead of losing them, which is what `initGoogleConnect` was trying to arrange before `googleLogin` overwrote it.

The deployment floor goes to **12.0** rather than the podspec's own 10.0, because Xcode 26 reports its supported range as 12.0 and up and warns below it.

## Verification

Checked against the real pod, not from memory. A minimal workspace with an ARC-off translation unit issuing exactly the calls this change makes:

| pod | `-sdk iphonesimulator` ARCHS=arm64 | `-sdk iphoneos` ARCHS=arm64 |
|---|---|---|
| `~>7.1` (7.1.0) | **BUILD SUCCEEDED** | **BUILD SUCCEEDED** |
| `~>5.0.0` (5.0.2) | reproduces the `built for 'iOS'` failure | n/a |

`GIDSignInDelegate` and `shouldFetchBasicProfile` were confirmed absent from the 7.1.0 headers and present in the 5.0.2 ones, rather than assumed.

Also green locally:
- `IPhoneBuilderDependencyConfigTest` — 19 tests, 0 failures (2 new)
- `mvn -pl codenameone-maven-plugin verify` — SpotBugs: **0 findings**

The port's own integration build is what CI exercises here, and `Test iOS packaging` on this PR is the real check.

## Regression guard

Two tests pin the floor: the pod major must stay `>= 7` (below that has no arm64 simulator slice) and the deployment floor must stay `>= 12` (below that current Xcode rejects). The spec moved into `IPhoneBuilder.GOOGLE_SIGNIN_POD` / `GOOGLE_SIGNIN_MIN_IOS` so it is assertable instead of buried inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)