### PR TITLE
Add recovery pages for missing and legacy URLs

### DIFF
--- a/docs/website/assets/css/extended/cn1-not-found.css
+++ b/docs/website/assets/css/extended/cn1-not-found.css
@@ -1,0 +1,161 @@
+.cn1-not-found-page {
+  width: 100vw;
+  margin-right: calc(50% - 50vw);
+  margin-left: calc(50% - 50vw);
+  padding: 84px max(24px, calc((100vw - var(--cn1-shell)) / 2)) 96px;
+  color: var(--cn1-text);
+  background:
+    radial-gradient(circle at 84% 8%, color-mix(in srgb, var(--cn1-accent) 15%, transparent), transparent 30%),
+    linear-gradient(180deg, color-mix(in srgb, var(--cn1-surface-soft) 58%, transparent), transparent 55%);
+}
+
+.cn1-not-found-hero {
+  max-width: 850px;
+}
+
+.cn1-not-found-code {
+  margin: 0 0 20px;
+  color: var(--cn1-accent);
+  font: 800 14px var(--cn1-mono);
+  letter-spacing: 0.18em;
+}
+
+.cn1-not-found-hero h1 {
+  margin: 0;
+  color: var(--cn1-text);
+  font-size: clamp(48px, 7vw, 82px);
+  line-height: 0.98;
+  letter-spacing: -0.05em;
+}
+
+.cn1-not-found-hero > p:not(.cn1-eyebrow, .cn1-not-found-code) {
+  max-width: 720px;
+  margin: 24px 0 30px;
+  color: var(--cn1-muted);
+  font-size: 18px;
+  line-height: 1.7;
+}
+
+.cn1-not-found-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+  max-width: var(--cn1-shell);
+  margin: 72px auto 0;
+}
+
+.cn1-not-found-card {
+  position: relative;
+  display: flex;
+  min-height: 210px;
+  padding: 26px 56px 26px 26px;
+  flex-direction: column;
+  border: 1px solid var(--cn1-border);
+  border-radius: var(--cn1-radius);
+  color: var(--cn1-text);
+  background: var(--cn1-surface);
+  box-shadow: var(--cn1-shadow-sm);
+  transition: border-color 160ms ease, transform 160ms ease;
+}
+
+.cn1-not-found-card:hover {
+  border-color: var(--cn1-accent);
+  transform: translateY(-2px);
+}
+
+.cn1-not-found-card__label {
+  margin-bottom: 28px;
+  color: var(--cn1-accent);
+  font: 700 11px var(--cn1-mono);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.cn1-not-found-card strong {
+  margin-bottom: 9px;
+  font-size: 21px;
+  letter-spacing: -0.025em;
+}
+
+.cn1-not-found-card > span:not(.cn1-not-found-card__label) {
+  color: var(--cn1-muted);
+  font-size: 13px;
+  line-height: 1.65;
+}
+
+.cn1-not-found-card svg {
+  position: absolute;
+  top: 26px;
+  right: 24px;
+  width: 20px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2;
+}
+
+.cn1-not-found-legacy {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 28px;
+  max-width: var(--cn1-shell);
+  margin: 24px auto 0;
+  padding: 28px;
+  border: 1px solid var(--cn1-border);
+  border-radius: var(--cn1-radius);
+  background: var(--cn1-surface-soft);
+}
+
+.cn1-not-found-legacy .cn1-eyebrow {
+  margin-bottom: 8px;
+}
+
+.cn1-not-found-legacy h2 {
+  margin: 0;
+  color: var(--cn1-text);
+  font-size: 20px;
+}
+
+.cn1-not-found-legacy > a {
+  flex: 0 0 auto;
+  color: var(--cn1-accent);
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.cn1-not-found-legacy > a span {
+  margin-left: 8px;
+}
+
+@media (max-width: 900px) {
+  .cn1-not-found-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 620px) {
+  .cn1-not-found-page {
+    padding: 52px 18px 70px;
+  }
+
+  .cn1-not-found-hero .cn1-action-row,
+  .cn1-not-found-hero .cn1-action {
+    width: 100%;
+  }
+
+  .cn1-not-found-grid {
+    grid-template-columns: 1fr;
+    margin-top: 52px;
+  }
+
+  .cn1-not-found-card {
+    min-height: 180px;
+  }
+
+  .cn1-not-found-legacy {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/docs/website/content/download.md
+++ b/docs/website/content/download.md
@@ -1,0 +1,12 @@
+---
+title: "Download Codename One"
+date: 2026-08-12
+slug: "download"
+url: "/download/"
+layout: "download"
+description: "Create a current Codename One Maven project or migrate an older plugin-based project."
+keywords:
+  - "codename one download"
+  - "codename one plugin"
+  - "codename one maven"
+---

--- a/docs/website/layouts/404.html
+++ b/docs/website/layouts/404.html
@@ -1,0 +1,61 @@
+{{- define "main" -}}
+<section class="cn1-not-found-page">
+  <header class="cn1-not-found-hero">
+    <p class="cn1-not-found-code">404</p>
+    <p class="cn1-eyebrow">Page not found</p>
+    <h1>That page isn't here.</h1>
+    <p>The address may be old or the page may have moved. Choose the part of Codename One you need, or search the site.</p>
+    <div class="cn1-action-row">
+      {{ partial "cn1-cta.html" (dict "label" "Search the site" "href" "/search/" "event" "404-search") }}
+      {{ partial "cn1-cta.html" (dict "label" "Go to the homepage" "href" "/" "variant" "secondary") }}
+    </div>
+  </header>
+
+  <nav class="cn1-not-found-grid" aria-label="Popular destinations">
+    <a class="cn1-not-found-card" href="/initializr/" data-cn1-conversion="404-initializr">
+      <span class="cn1-not-found-card__label">Start</span>
+      <strong>Create a project</strong>
+      <span>Generate a current Maven project with Initializr.</span>
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+    </a>
+    <a class="cn1-not-found-card" href="/getting-started/">
+      <span class="cn1-not-found-card__label">Set up</span>
+      <strong>Getting Started</strong>
+      <span>Install the prerequisites, run the simulator, and submit a build.</span>
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+    </a>
+    <a class="cn1-not-found-card" href="/developer-guide/">
+      <span class="cn1-not-found-card__label">Reference</span>
+      <strong>Developer Guide</strong>
+      <span>Find APIs, platform setup, build hints, and implementation details.</span>
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+    </a>
+    <a class="cn1-not-found-card" href="/demos/">
+      <span class="cn1-not-found-card__label">Explore</span>
+      <strong>Demos</strong>
+      <span>Browse working applications, screenshots, and source code.</span>
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+    </a>
+    <a class="cn1-not-found-card" href="/pricing/">
+      <span class="cn1-not-found-card__label">Plans</span>
+      <strong>Pricing</strong>
+      <span>Compare cloud-build limits, services, and support.</span>
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+    </a>
+    <a class="cn1-not-found-card" href="https://github.com/codenameone/CodenameOne/discussions" target="_blank" rel="noopener noreferrer">
+      <span class="cn1-not-found-card__label">Community</span>
+      <strong>GitHub Discussions</strong>
+      <span>Ask a question or find answers from other developers.</span>
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+    </a>
+  </nav>
+
+  <aside class="cn1-not-found-legacy">
+    <div>
+      <p class="cn1-eyebrow">Following an old download link?</p>
+      <h2>Use the current project or migration path.</h2>
+    </div>
+    <a href="/download/">Open download help <span aria-hidden="true">&rarr;</span></a>
+  </aside>
+</section>
+{{- end -}}

--- a/docs/website/layouts/_default/download.html
+++ b/docs/website/layouts/_default/download.html
@@ -1,0 +1,70 @@
+{{- define "main" -}}
+<div class="cn1-gs-page">
+  <section class="cn1-gs-hero">
+    <div>
+      <nav class="cn1-gs-breadcrumbs" aria-label="Breadcrumb"><a href="/">Home</a><span>/</span><span>Download</span></nav>
+      <p class="cn1-eyebrow">Current setup</p>
+      <h1>Looking for a Codename One download?</h1>
+      <p>Current Codename One projects use Maven, so there is no separate IDE plugin to install. Generate a project and open it in IntelliJ IDEA, NetBeans, Eclipse, VS Code, or another Maven-capable IDE.</p>
+      <div class="cn1-action-row">
+        {{ partial "cn1-cta.html" (dict "label" "Create a Java project" "href" "/initializr/" "event" "legacy-download-project") }}
+        {{ partial "cn1-cta.html" (dict "label" "Follow the setup guide" "href" "/getting-started/" "variant" "secondary") }}
+      </div>
+      <p class="cn1-gs-hero__note">If an older IDE plugin or archived link sent you here, use the migration path below.</p>
+    </div>
+    <aside class="cn1-gs-progress" aria-label="Choose a setup path">
+      <p>Choose your path</p>
+      <ol>
+        <li><a href="#new-project"><span>1</span>Start a new project</a></li>
+        <li><a href="#existing-project"><span>2</span>Migrate an older project</a></li>
+        <li><a href="#help"><span>3</span>Get setup help</a></li>
+      </ol>
+    </aside>
+  </section>
+
+  <section class="cn1-gs-prereqs">
+    <strong>What changed</strong>
+    <ul>
+      <li>New projects use one Maven structure across supported IDEs.</li>
+      <li>You no longer need the legacy NetBeans, IntelliJ IDEA, or Eclipse plugin to create a project.</li>
+      <li>Existing Ant-based Codename One projects can be migrated to Maven.</li>
+    </ul>
+  </section>
+
+  <div class="cn1-gs-steps">
+    <section class="cn1-gs-step" id="new-project">
+      <div class="cn1-gs-step__number">New project</div>
+      <div class="cn1-gs-step__body">
+        <p class="cn1-eyebrow">Generate</p>
+        <h2>Create a Maven project with Initializr.</h2>
+        <p>Choose Java, enter the project names, and download the generated project. Open its root directory in your IDE and run the included simulator target.</p>
+        <div class="cn1-action-row">
+          {{ partial "cn1-cta.html" (dict "label" "Open Initializr" "href" "/initializr/" "variant" "secondary" "event" "legacy-download-initializr") }}
+          {{ partial "cn1-cta.html" (dict "label" "Read Getting Started" "href" "/getting-started/" "variant" "text") }}
+        </div>
+      </div>
+    </section>
+
+    <section class="cn1-gs-step" id="existing-project">
+      <div class="cn1-gs-step__number">Existing project</div>
+      <div class="cn1-gs-step__body">
+        <p class="cn1-eyebrow">Keep your source</p>
+        <h2>Move an older Ant project to Maven.</h2>
+        <p>The migration tool generates the current Maven project structure from an existing Codename One application or library project. Review the migration steps before changing the original project.</p>
+        <div class="cn1-action-row">
+          {{ partial "cn1-cta.html" (dict "label" "Read the migration guide" "href" "/blog/migrating-your-project-to-maven/" "variant" "secondary" "event" "legacy-download-migration") }}
+        </div>
+      </div>
+    </section>
+  </div>
+
+  <section class="cn1-gs-help" id="help">
+    <div><p class="cn1-eyebrow">Need help?</p><h2>Use the current setup documentation.</h2></div>
+    <p>The Getting Started guide covers the supported JDK, Maven project generation, simulator, account, and first native build.</p>
+    <div class="cn1-action-row">
+      {{ partial "cn1-cta.html" (dict "label" "Open Getting Started" "href" "/getting-started/" "variant" "secondary") }}
+      {{ partial "cn1-cta.html" (dict "label" "Ask in GitHub Discussions" "href" "https://github.com/codenameone/CodenameOne/discussions" "variant" "text" "external" true) }}
+    </div>
+  </section>
+</div>
+{{- end -}}

--- a/docs/website/static/_redirects
+++ b/docs/website/static/_redirects
@@ -18,6 +18,8 @@
 /files/JavaSE.jar https://download.codenameone.com/files/JavaSE.jar 302
 
 # High-priority legacy URL redirects (Cloudflare)
+/download.html /download/ 301
+/download.html/ /download/ 301
 /videos.html /videos/ 301
 /videos.html/ /videos/ 301
 /video.html /videos/ 301

--- a/docs/website/static/_redirects
+++ b/docs/website/static/_redirects
@@ -18,8 +18,6 @@
 /files/JavaSE.jar https://download.codenameone.com/files/JavaSE.jar 302
 
 # High-priority legacy URL redirects (Cloudflare)
-/download.html /download/ 301
-/download.html/ /download/ 301
 /videos.html /videos/ 301
 /videos.html/ /videos/ 301
 /video.html /videos/ 301

--- a/docs/website/themes/PaperMod/layouts/partials/head.html
+++ b/docs/website/themes/PaperMod/layouts/partials/head.html
@@ -1,7 +1,7 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-{{- if hugo.IsProduction | or (eq site.Params.env "production") | and (ne .Params.robotsNoIndex true) }}
+{{- if and (or hugo.IsProduction (eq site.Params.env "production")) (ne .Params.robotsNoIndex true) (ne .RelPermalink "/404.html") }}
 <meta name="robots" content="index, follow">
 {{- else }}
 <meta name="robots" content="noindex, nofollow">


### PR DESCRIPTION
## What changed

- add a dedicated `/download/` compatibility page
- direct new users to Initializr and Getting Started
- direct legacy IDE plugin and Ant-project users to the Maven migration guide
- replace the bare 404 with search, homepage, project, setup, documentation, demos, pricing, community, and legacy-download routes
- mark the generated 404 page `noindex, nofollow` while leaving normal pages indexable

`docs/website/static/_redirects` is intentionally unchanged because that file has size and ordering constraints.

## Why

Old Codename One plugins and archived pages can still send visitors to retired URLs. The previous response was only `404`, which provided no route forward and did not distinguish a new project from an existing legacy project.

## Impact

Visitors arriving at `/download/` get a focused current-versus-legacy choice. Visitors reaching any other missing page get direct paths to the main areas of the site instead of a dead end.

## Validation

- `hugo --source docs/website --destination /tmp/cn1-download-recovery-public --environment production --cleanDestinationDir`
- browser render and semantic DOM inspection of `/download/` and `/404.html`
- verified the 404 has six destination cards with no horizontal overflow
- verified Search, Initializr, Getting Started, Developer Guide, Demos, Pricing, and `/download/` return HTTP 200 in the generated preview
- verified `404.html` is `noindex, nofollow` and the homepage remains `index, follow`
- verified zero net change to `docs/website/static/_redirects`
- `git diff --check`