### PR TITLE
Refuse an iOS build the profile cannot sign, before it is sent

### DIFF
--- a/CodenameOne/src/com/codename1/health/sensors/SensorSession.java
+++ b/CodenameOne/src/com/codename1/health/sensors/SensorSession.java
@@ -628,6 +628,18 @@ public class SensorSession {
                         + " the readings to a workout instead.");
             }
             if (retryable.isEmpty()) {
+                // Nothing here is going back, so nothing here is pending
+                // any more. A sample that had already failed once carries
+                // a tally entry, and a store whose type support has just
+                // gone away -- Health Connect reporting a provider it
+                // reported a moment ago, a permission revoked mid-ride --
+                // sends every sample down this path. Returning without
+                // clearing left those entries for the life of the
+                // session, so a provider that came and went repeatedly
+                // accumulated them.
+                synchronized (session.pendingWrites) {
+                    session.forgetWriteAttempts(batch);
+                }
                 session.fireError(asHealthException(error));
                 return;
             }

--- a/CodenameOne/src/com/codename1/health/sensors/SensorSession.java
+++ b/CodenameOne/src/com/codename1/health/sensors/SensorSession.java
@@ -466,20 +466,18 @@ public class SensorSession {
     /// the life of the session -- samples in the store, still strongly
     /// referenced here, accumulating for as long as a sensor streamed.
     ///
-    /// Linear against `keep` rather than a set: a batch is small, this
-    /// runs only on the failure path, and the identity comparison is the
-    /// point.
+    /// The kept set is an identity map for the same reason the tally is:
+    /// two readings of the same value at the same millisecond are
+    /// distinct samples, and equality would treat one as the other.
     private void forgetWriteAttemptsExcept(List<HealthSample> all,
             List<HealthSample> keep) {
+        Map<HealthSample, Boolean> kept =
+                new java.util.IdentityHashMap<HealthSample, Boolean>();
+        for (HealthSample sample : keep) {
+            kept.put(sample, Boolean.TRUE);
+        }
         for (HealthSample sample : all) {
-            boolean kept = false;
-            for (int i = 0; i < keep.size(); i++) {
-                if (keep.get(i) == sample) {
-                    kept = true;
-                    break;
-                }
-            }
-            if (!kept) {
+            if (!kept.containsKey(sample)) {
                 writeAttempts.remove(sample);
             }
         }

--- a/CodenameOne/src/com/codename1/health/sensors/SensorSession.java
+++ b/CodenameOne/src/com/codename1/health/sensors/SensorSession.java
@@ -422,9 +422,39 @@ public class SensorSession {
     /// stumble is transient, a run of them is not.
     private static final int MAX_WRITE_FAILURES = 3;
 
-    /// Consecutive failed flushes. Guarded by `pendingWrites`, the lock
-    /// the requeue decision is already taken under.
-    private int writeFailures;
+    /// How many times each still-pending sample has been in a failed
+    /// write. Guarded by `pendingWrites`, the lock the requeue decision
+    /// is already taken under.
+    ///
+    /// Per sample, not per session, because batches merge: a failed batch
+    /// goes back at the head of the buffer and the next flush claims it
+    /// together with whatever arrived meanwhile. A session-wide count
+    /// reached its limit on the old samples and discarded the new ones
+    /// along with them -- readings thrown away after a single attempt --
+    /// and two writes in flight at once did the same to each other.
+    ///
+    /// Identity, not equality: two readings of the same value at the same
+    /// millisecond are still two samples, each entitled to its own
+    /// attempts.
+    private final Map<HealthSample, Integer> writeAttempts =
+            new java.util.IdentityHashMap<HealthSample, Integer>();
+
+    /// Counts one failed attempt against `sample` and reports its total.
+    /// Call holding `pendingWrites`.
+    private int recordWriteFailure(HealthSample sample) {
+        Integer previous = writeAttempts.get(sample);
+        int attempts = (previous == null ? 0 : previous.intValue()) + 1;
+        writeAttempts.put(sample, Integer.valueOf(attempts));
+        return attempts;
+    }
+
+    /// Forgets samples that are no longer pending -- written, dropped, or
+    /// discarded by teardown. Call holding `pendingWrites`.
+    private void forgetWriteAttempts(List<HealthSample> samples) {
+        for (HealthSample sample : samples) {
+            writeAttempts.remove(sample);
+        }
+    }
 
     /// The timer's flush: claims the buffer only while the session runs.
     ///
@@ -528,11 +558,10 @@ public class SensorSession {
         @Override
         public void onReady(HealthWriteResult value, Throwable error) {
             if (error == null) {
-                // The run is broken, not merely paused: a store that
-                // accepted this batch has earned the full budget again
-                // for the next one.
+                // These are in the store and will never be sent again, so
+                // their tally goes with them.
                 synchronized (session.pendingWrites) {
-                    session.writeFailures = 0;
+                    session.forgetWriteAttempts(batch);
                 }
                 return;
             }
@@ -584,8 +613,13 @@ public class SensorSession {
             // endSession() flushes unconditionally and has more than one
             // caller, so a failed final write refilled the buffer and the
             // next teardown wrote it again.
+            // Split by what each sample has already been through, not by
+            // what the session has: the batch in hand can hold readings on
+            // their third attempt next to ones on their first.
+            List<HealthSample> keep =
+                    new ArrayList<HealthSample>(retryable.size());
+            List<HealthSample> exhausted = new ArrayList<HealthSample>();
             boolean requeued;
-            boolean giveUp;
             synchronized (session.pendingWrites) {
                 // The flag and the buffer under one lock, because
                 // teardown sets that flag and drains the buffer under it
@@ -595,35 +629,38 @@ public class SensorSession {
                 // ever claim again, since the re-arm below correctly
                 // declines to schedule anything for a dead session.
                 //
-                // The failure count lives under this lock too: it is read
-                // and written in the same breath as the requeue it
-                // governs, and the timer thread and the caller's thread
-                // both arrive here.
-                session.writeFailures++;
-                giveUp = session.writeFailures >= MAX_WRITE_FAILURES;
-                requeued = !session.flushingStopped && !giveUp;
-                if (requeued) {
-                    session.pendingWrites.addAll(0, retryable);
+                // The tally lives under this lock too: it is read and
+                // written in the same breath as the requeue it governs,
+                // and the timer thread and the caller's thread both
+                // arrive here.
+                for (HealthSample sample : retryable) {
+                    if (session.recordWriteFailure(sample)
+                            >= MAX_WRITE_FAILURES) {
+                        exhausted.add(sample);
+                    } else {
+                        keep.add(sample);
+                    }
                 }
-                if (giveUp) {
-                    // Counted from zero for whatever comes next. The
-                    // batch is gone, so the buffer is empty again and a
-                    // later sample re-arms the timer through the ordinary
-                    // path -- new readings still get their attempts; it
-                    // is only this batch that stops being resent.
-                    session.writeFailures = 0;
+                session.forgetWriteAttempts(exhausted);
+                requeued = !session.flushingStopped && !keep.isEmpty();
+                if (requeued) {
+                    session.pendingWrites.addAll(0, keep);
+                } else {
+                    // Nothing goes back, so nothing here is pending any
+                    // more and the tally must not go on holding it.
+                    session.forgetWriteAttempts(keep);
                 }
             }
-            if (giveUp) {
+            if (!exhausted.isEmpty()) {
                 com.codename1.io.Log.p("CN1 Health: the store refused "
-                        + MAX_WRITE_FAILURES + " attempts at the same batch"
-                        + " of sensor samples, so it is dropped rather than"
-                        + " retried for as long as the session runs. Later"
-                        + " readings are still written.");
+                        + exhausted.size() + " sensor sample(s) "
+                        + MAX_WRITE_FAILURES + " times, so they are dropped"
+                        + " rather than retried for as long as the session"
+                        + " runs. Later readings are still written.");
             }
             if (!requeued) {
-                // Either teardown won, or the batch has used up its
-                // attempts. Both end the same way: the samples are
+                // Either teardown won, or every sample in hand has used up
+                // its attempts. Both end the same way: the samples are
                 // reported rather than left in a buffer nobody will read
                 // -- this is the only notice the app gets that they were
                 // not stored -- and nothing is re-armed below, which is
@@ -927,6 +964,8 @@ public class SensorSession {
             // flag, so a short ride still keeps its final partial batch.
             synchronized (pendingWrites) {
                 flushingStopped = true;
+                // Nothing will be flushed again, so nothing needs a tally.
+                writeAttempts.clear();
             }
             cancelFlush();
         }

--- a/CodenameOne/src/com/codename1/health/sensors/SensorSession.java
+++ b/CodenameOne/src/com/codename1/health/sensors/SensorSession.java
@@ -456,6 +456,35 @@ public class SensorSession {
         }
     }
 
+    /// Forgets everything in `all` that is not in `keep`, by identity.
+    ///
+    /// A failed write leaves the buffer holding only what is going back;
+    /// everything else it carried is gone for good, whether it was
+    /// committed by a partial success, refused for its type, or out of
+    /// attempts. Removing only the ones this class explicitly dropped
+    /// left the committed prefix of every partial failure in the map for
+    /// the life of the session -- samples in the store, still strongly
+    /// referenced here, accumulating for as long as a sensor streamed.
+    ///
+    /// Linear against `keep` rather than a set: a batch is small, this
+    /// runs only on the failure path, and the identity comparison is the
+    /// point.
+    private void forgetWriteAttemptsExcept(List<HealthSample> all,
+            List<HealthSample> keep) {
+        for (HealthSample sample : all) {
+            boolean kept = false;
+            for (int i = 0; i < keep.size(); i++) {
+                if (keep.get(i) == sample) {
+                    kept = true;
+                    break;
+                }
+            }
+            if (!kept) {
+                writeAttempts.remove(sample);
+            }
+        }
+    }
+
     /// The timer's flush: claims the buffer only while the session runs.
     ///
     /// Checking the state at the top of the tick was not enough. The
@@ -641,14 +670,17 @@ public class SensorSession {
                         keep.add(sample);
                     }
                 }
-                session.forgetWriteAttempts(exhausted);
                 requeued = !session.flushingStopped && !keep.isEmpty();
                 if (requeued) {
                     session.pendingWrites.addAll(0, keep);
+                    // Everything else this write carried is gone for
+                    // good: committed by a partial success, refused for
+                    // its type, or out of attempts.
+                    session.forgetWriteAttemptsExcept(batch, keep);
                 } else {
-                    // Nothing goes back, so nothing here is pending any
-                    // more and the tally must not go on holding it.
-                    session.forgetWriteAttempts(keep);
+                    // Nothing goes back, so nothing this write carried is
+                    // pending any more and the tally must not hold it.
+                    session.forgetWriteAttempts(batch);
                 }
             }
             if (!exhausted.isEmpty()) {

--- a/CodenameOne/src/com/codename1/health/sensors/SensorSession.java
+++ b/CodenameOne/src/com/codename1/health/sensors/SensorSession.java
@@ -405,6 +405,27 @@ public class SensorSession {
     /// in the same breath as the session decides it has stopped.
     private boolean flushingStopped;
 
+    /// How many times in a row a batch may fail to be written before the
+    /// session stops resending it.
+    ///
+    /// A store that is busy or locked is worth retrying; one that keeps
+    /// refusing is not, and the answer does not change with time. Without
+    /// a bound the same batch went out every storeBatchMillis for as long
+    /// as the session streamed -- on a 10ms batch interval that is a
+    /// hundred writes and a hundred error callbacks per second, for ever,
+    /// on a device whose store had a revoked permission or no room left.
+    /// The unwritable-type case above is already dropped rather than
+    /// retried; this is the same failure one step along, where the type
+    /// is writable and the store still says no.
+    ///
+    /// Matched to the reconnect ladder's bound, for the same reason: a
+    /// stumble is transient, a run of them is not.
+    private static final int MAX_WRITE_FAILURES = 3;
+
+    /// Consecutive failed flushes. Guarded by `pendingWrites`, the lock
+    /// the requeue decision is already taken under.
+    private int writeFailures;
+
     /// The timer's flush: claims the buffer only while the session runs.
     ///
     /// Checking the state at the top of the tick was not enough. The
@@ -507,6 +528,12 @@ public class SensorSession {
         @Override
         public void onReady(HealthWriteResult value, Throwable error) {
             if (error == null) {
+                // The run is broken, not merely paused: a store that
+                // accepted this batch has earned the full budget again
+                // for the next one.
+                synchronized (session.pendingWrites) {
+                    session.writeFailures = 0;
+                }
                 return;
             }
             // Samples of a type the store will never accept are dropped
@@ -558,6 +585,7 @@ public class SensorSession {
             // caller, so a failed final write refilled the buffer and the
             // next teardown wrote it again.
             boolean requeued;
+            boolean giveUp;
             synchronized (session.pendingWrites) {
                 // The flag and the buffer under one lock, because
                 // teardown sets that flag and drains the buffer under it
@@ -566,15 +594,41 @@ public class SensorSession {
                 // its samples behind it -- into a buffer nothing will
                 // ever claim again, since the re-arm below correctly
                 // declines to schedule anything for a dead session.
-                requeued = !session.flushingStopped;
+                //
+                // The failure count lives under this lock too: it is read
+                // and written in the same breath as the requeue it
+                // governs, and the timer thread and the caller's thread
+                // both arrive here.
+                session.writeFailures++;
+                giveUp = session.writeFailures >= MAX_WRITE_FAILURES;
+                requeued = !session.flushingStopped && !giveUp;
                 if (requeued) {
                     session.pendingWrites.addAll(0, retryable);
                 }
+                if (giveUp) {
+                    // Counted from zero for whatever comes next. The
+                    // batch is gone, so the buffer is empty again and a
+                    // later sample re-arms the timer through the ordinary
+                    // path -- new readings still get their attempts; it
+                    // is only this batch that stops being resent.
+                    session.writeFailures = 0;
+                }
+            }
+            if (giveUp) {
+                com.codename1.io.Log.p("CN1 Health: the store refused "
+                        + MAX_WRITE_FAILURES + " attempts at the same batch"
+                        + " of sensor samples, so it is dropped rather than"
+                        + " retried for as long as the session runs. Later"
+                        + " readings are still written.");
             }
             if (!requeued) {
-                // Teardown won. The samples are reported rather than left
-                // in a buffer nobody will read: this is the only notice
-                // the app gets that they were not stored.
+                // Either teardown won, or the batch has used up its
+                // attempts. Both end the same way: the samples are
+                // reported rather than left in a buffer nobody will read
+                // -- this is the only notice the app gets that they were
+                // not stored -- and nothing is re-armed below, which is
+                // what stops a refusing store being asked again every
+                // storeBatchMillis for the life of the session.
                 session.fireError(asHealthException(error));
                 return;
             }

--- a/CodenameOne/src/com/codename1/health/sensors/SensorSession.java
+++ b/CodenameOne/src/com/codename1/health/sensors/SensorSession.java
@@ -422,6 +422,48 @@ public class SensorSession {
     /// stumble is transient, a run of them is not.
     private static final int MAX_WRITE_FAILURES = 3;
 
+    /// The longest a recoverable outage backs off to. A device that stays
+    /// locked costs a handful of wake-ups an hour rather than one per
+    /// batch interval, and the readings are still there when it opens.
+    private static final int MAX_RETRY_BACKOFF_MILLIS = 300000;
+
+    /// The delay the next retry of a recoverable failure will use.
+    /// Guarded by `pendingWrites`; zero means the run has not started.
+    private int retryDelayMillis;
+
+    /// Whether this failure is one that waiting will fix.
+    ///
+    /// The distinction matters because the attempt cap discards samples,
+    /// and these are the failures where discarding is wrong: iOS raises
+    /// DATABASE_INACCESSIBLE for as long as the device is locked -- which
+    /// is exactly when a background observer fires, and is documented as
+    /// retryable once it unlocks -- while RATE_LIMITED and TIMEOUT say in
+    /// as many words that the same write would work later. Counting
+    /// those, a device locked for three minutes at the default one-minute
+    /// batch interval lost its readings for good.
+    ///
+    /// A provider that is missing or needs updating is deliberately not
+    /// here: recovery needs the user to install something, which no
+    /// amount of retrying on a timer brings about, so those keep the cap.
+    private static boolean isRecoverable(Throwable error) {
+        if (!(error instanceof HealthException)) {
+            return false;
+        }
+        HealthError code = ((HealthException) error).getError();
+        return code == HealthError.DATABASE_INACCESSIBLE
+                || code == HealthError.RATE_LIMITED
+                || code == HealthError.TIMEOUT;
+    }
+
+    /// The next backoff step, doubling to the ceiling. Call holding
+    /// `pendingWrites`.
+    private int nextRetryDelay(int baseMillis) {
+        int base = Math.max(1, baseMillis);
+        retryDelayMillis = retryDelayMillis <= 0 ? base
+                : Math.min(retryDelayMillis * 2, MAX_RETRY_BACKOFF_MILLIS);
+        return retryDelayMillis;
+    }
+
     /// How many times each still-pending sample has been in a failed
     /// write. Guarded by `pendingWrites`, the lock the requeue decision
     /// is already taken under.
@@ -589,6 +631,9 @@ public class SensorSession {
                 // their tally goes with them.
                 synchronized (session.pendingWrites) {
                     session.forgetWriteAttempts(batch);
+                    // The store is answering again, so the next outage
+                    // starts its backoff from the top.
+                    session.retryDelayMillis = 0;
                 }
                 return;
             }
@@ -658,7 +703,9 @@ public class SensorSession {
             List<HealthSample> keep =
                     new ArrayList<HealthSample>(retryable.size());
             List<HealthSample> exhausted = new ArrayList<HealthSample>();
+            boolean recoverable = isRecoverable(error);
             boolean requeued;
+            int retryIn;
             synchronized (session.pendingWrites) {
                 // The flag and the buffer under one lock, because
                 // teardown sets that flag and drains the buffer under it
@@ -672,15 +719,26 @@ public class SensorSession {
                 // written in the same breath as the requeue it governs,
                 // and the timer thread and the caller's thread both
                 // arrive here.
-                for (HealthSample sample : retryable) {
-                    if (session.recordWriteFailure(sample)
-                            >= MAX_WRITE_FAILURES) {
-                        exhausted.add(sample);
-                    } else {
-                        keep.add(sample);
+                if (recoverable) {
+                    // Held, not counted. Waiting is the whole remedy, so
+                    // spending an attempt on each try would retire the
+                    // samples for the one reason they should be kept.
+                    keep.addAll(retryable);
+                } else {
+                    for (HealthSample sample : retryable) {
+                        if (session.recordWriteFailure(sample)
+                                >= MAX_WRITE_FAILURES) {
+                            exhausted.add(sample);
+                        } else {
+                            keep.add(sample);
+                        }
                     }
                 }
                 requeued = !session.flushingStopped && !keep.isEmpty();
+                retryIn = recoverable
+                        ? session.nextRetryDelay(
+                                session.options().getStoreBatchMillis())
+                        : session.options().getStoreBatchMillis();
                 if (requeued) {
                     session.pendingWrites.addAll(0, keep);
                     // Everything else this write carried is gone for
@@ -723,8 +781,7 @@ public class SensorSession {
             // stopped-only check and left exactly the session nobody
             // holds a handle to retrying on a timer.
             if (!session.isTerminal()) {
-                session.scheduleFlush(session.options()
-                        .getStoreBatchMillis());
+                session.scheduleFlush(retryIn);
             }
             session.fireError(asHealthException(error));
         }

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/CN1BuildMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/CN1BuildMojo.java
@@ -155,6 +155,10 @@ public class CN1BuildMojo extends AbstractCN1Mojo {
         // of silently succeeding with the cached artifact.
         applyHardeningPreflight();
 
+        // Signing problems that are visible in the .mobileprovision on disk should not cost a
+        // cloud build slot to discover. See applyIOSProvisioningPreflight.
+        applyIOSProvisioningPreflight();
+
         if (platform.contains("android")) {
             if (!BUILD_TARGET_ANDROID_PROJECT.equals(buildTarget)) {
                 File apkFile = androidApkFile();
@@ -323,6 +327,58 @@ public class CN1BuildMojo extends AbstractCN1Mojo {
         // is newer than the sources (getSourcesModificationTime does not account for build hints).
         overlayCommandLineBuildHints(settings);
         applyHardeningPreflight(settings);
+    }
+
+    /**
+     * Refuses an iOS device build whose provisioning profile makes signing impossible, before
+     * the build is packaged and sent.
+     *
+     * <p>These failures used to be discoverable only on a build server: an unreadable profile
+     * surfaced as an XML parser stack trace that never named the profile, and a profile of the
+     * wrong kind surfaced as an {@code exportArchive} error minutes into the build, after the
+     * whole app had already been compiled and archived. Both are decided by a file sitting in
+     * the project.
+     *
+     * <p>Only cloud iOS device builds are checked. A local Xcode-project generation signs
+     * later (or not at all), and the native-Mac targets ride the same platform with a different
+     * signing identity, so neither is this check's business.
+     */
+    private void applyIOSProvisioningPreflight() throws MojoFailureException {
+        if (platform == null || !platform.contains("ios") || buildTarget == null
+                || !buildTarget.startsWith("ios-device")) {
+            return;
+        }
+        Properties settings = new Properties();
+        File settingsFile = new File(getCN1ProjectDir(), "codenameone_settings.properties");
+        if (settingsFile.isFile()) {
+            try (FileInputStream fis = new FileInputStream(settingsFile)) {
+                settings.load(fis);
+            } catch (IOException ex) {
+                getLog().debug("Could not read codenameone_settings.properties for the iOS provisioning pre-flight", ex);
+                return;
+            }
+        } else {
+            return;
+        }
+        overlayCommandLineBuildHints(settings);
+
+        boolean release = buildTarget.contains("release");
+        List<IOSProvisioningPreflight.Problem> problems =
+                IOSProvisioningPreflight.check(settings, release, new Date());
+        String fatal = null;
+        for (IOSProvisioningPreflight.Problem problem : problems) {
+            if (problem.fatal) {
+                getLog().error(problem.message);
+                if (fatal == null) {
+                    fatal = problem.message;
+                }
+            } else {
+                getLog().warn(problem.message);
+            }
+        }
+        if (fatal != null) {
+            throw new MojoFailureException(fatal);
+        }
     }
 
     /**

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/CN1BuildMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/CN1BuildMojo.java
@@ -344,8 +344,7 @@ public class CN1BuildMojo extends AbstractCN1Mojo {
      * signing identity, so neither is this check's business.
      */
     private void applyIOSProvisioningPreflight() throws MojoFailureException {
-        if (platform == null || !platform.contains("ios") || buildTarget == null
-                || !buildTarget.startsWith("ios-device")) {
+        if (!isIOSDeviceBuild()) {
             return;
         }
         Properties settings = new Properties();
@@ -362,9 +361,32 @@ public class CN1BuildMojo extends AbstractCN1Mojo {
         }
         overlayCommandLineBuildHints(settings);
 
-        boolean release = buildTarget.contains("release");
-        List<IOSProvisioningPreflight.Problem> problems =
-                IOSProvisioningPreflight.check(settings, release, new Date());
+        // Only what the file itself decides. Whether the profile's KIND matches the export
+        // method cannot be judged yet: a CN1Lib can supply ios.*.distributionMethod through
+        // its appended/required properties, which createAntProject merges further down, so
+        // that comparison waits for applyIOSProvisioningPreflight(Properties) below.
+        report(IOSProvisioningPreflight.checkProfileFile(settings, buildTarget.contains("release"), new Date()));
+    }
+
+    private boolean isIOSDeviceBuild() {
+        return platform != null && platform.contains("ios")
+                && buildTarget != null && buildTarget.startsWith("ios-device");
+    }
+
+    /**
+     * The full pre-flight, run against the settings the build is actually submitted with --
+     * the project's own, plus the command-line overlay, plus every CN1Lib-contributed
+     * property. This is where a profile-kind/distribution-method mismatch is decided, since
+     * a library can still change the method after the early pass has run.
+     */
+    private void applyIOSProvisioningPreflight(Properties mergedSettings) throws MojoFailureException {
+        if (!isIOSDeviceBuild()) {
+            return;
+        }
+        report(IOSProvisioningPreflight.check(mergedSettings, buildTarget.contains("release"), new Date()));
+    }
+
+    private void report(List<IOSProvisioningPreflight.Problem> problems) throws MojoFailureException {
         String fatal = null;
         for (IOSProvisioningPreflight.Problem problem : problems) {
             if (problem.fatal) {
@@ -1424,6 +1446,11 @@ public class CN1BuildMojo extends AbstractCN1Mojo {
         // local-build refusal / force-off and produce a locally hardened artifact whose mapping is never
         // uploaded (so its crashes could never be retraced).
         applyHardeningPreflight(cn1SettingsProps);
+
+        // Same reason, for the same reason: a CN1Lib can supply ios.*.distributionMethod, so the
+        // profile's kind is compared against the export method only now that those properties
+        // have been merged -- an early refusal would reject a build the merge was about to fix.
+        applyIOSProvisioningPreflight(cn1SettingsProps);
 
 
         cn1SettingsProps.setProperty("codename1.arg.hyp.beamId", logPasskey);

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/CN1BuildMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/CN1BuildMojo.java
@@ -365,12 +365,12 @@ public class CN1BuildMojo extends AbstractCN1Mojo {
         // method cannot be judged yet: a CN1Lib can supply ios.*.distributionMethod through
         // its appended/required properties, which createAntProject merges further down, so
         // that comparison waits for applyIOSProvisioningPreflight(Properties) below.
-        report(IOSProvisioningPreflight.checkProfileFile(settings, buildTarget.contains("release"), new Date()));
+        report(IOSProvisioningPreflight.checkProfileFile(settings,
+                IOSProvisioningPreflight.isReleaseTarget(buildTarget), new Date()));
     }
 
     private boolean isIOSDeviceBuild() {
-        return platform != null && platform.contains("ios")
-                && buildTarget != null && buildTarget.startsWith("ios-device");
+        return IOSProvisioningPreflight.appliesTo(platform, buildTarget);
     }
 
     /**
@@ -383,7 +383,8 @@ public class CN1BuildMojo extends AbstractCN1Mojo {
         if (!isIOSDeviceBuild()) {
             return;
         }
-        report(IOSProvisioningPreflight.check(mergedSettings, buildTarget.contains("release"), new Date()));
+        report(IOSProvisioningPreflight.check(mergedSettings,
+                IOSProvisioningPreflight.isReleaseTarget(buildTarget), new Date()));
     }
 
     private void report(List<IOSProvisioningPreflight.Problem> problems) throws MojoFailureException {

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/IOSProvisioningPreflight.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/IOSProvisioningPreflight.java
@@ -199,13 +199,78 @@ final class IOSProvisioningPreflight {
     }
 
     /**
+     * Expands {@code ${name}} references the way the generated build file's
+     * {@code <property file="codenameone_settings.properties">} does: a profile path is
+     * routinely written as {@code ${user.home}/certs/dev.mobileprovision}, and Ant resolves
+     * that before handing the value to the build task. A name is looked up in the settings
+     * themselves first, then in the JVM's system properties, which is where {@code user.home}
+     * and friends live.
+     *
+     * <p>What cannot be resolved is left standing rather than guessed at, and the caller
+     * treats a value that still carries a placeholder as one it may not judge. Refusing a
+     * build over a path this code merely failed to expand would break configurations that
+     * work today -- the opposite of the point.
+     *
+     * @return the value with every resolvable reference expanded
+     */
+    static String resolvePlaceholders(String value, Properties settings) {
+        if (value == null) {
+            return null;
+        }
+        String current = value;
+        // Bounded: a self-referential property would otherwise spin here.
+        for (int pass = 0; pass < 10 && current.indexOf("${") >= 0; pass++) {
+            StringBuilder out = new StringBuilder();
+            boolean expandedAny = false;
+            int i = 0;
+            while (i < current.length()) {
+                int start = current.indexOf("${", i);
+                if (start < 0) {
+                    out.append(current.substring(i));
+                    break;
+                }
+                int end = current.indexOf('}', start);
+                if (end < 0) {
+                    out.append(current.substring(i));
+                    break;
+                }
+                out.append(current, i, start);
+                String name = current.substring(start + 2, end);
+                String replacement = settings == null ? null : settings.getProperty(name);
+                if (replacement == null) {
+                    replacement = System.getProperty(name);
+                }
+                if (replacement == null) {
+                    out.append(current, start, end + 1);
+                } else {
+                    out.append(replacement);
+                    expandedAny = true;
+                }
+                i = end + 1;
+            }
+            current = out.toString();
+            if (!expandedAny) {
+                break;
+            }
+        }
+        return current;
+    }
+
+    /**
      * @param checkMethodMismatch whether to also compare the profile's kind against the
      * distribution method these settings resolve to. Only true once the settings are the ones
      * the build will be submitted with, since a CN1Lib can still change the method.
      */
     private static void collectFileProblems(List<Problem> problems, Properties settings, boolean release,
             Date now, String path, String settingKey, boolean checkMethodMismatch) {
-        File file = new File(path.trim());
+        String resolved = resolvePlaceholders(path.trim(), settings);
+        if (resolved.indexOf("${") >= 0) {
+            // Ant resolves this when it binds the value to the build task; this check cannot,
+            // because it does not have that property context. A path it cannot resolve is a
+            // path it cannot judge -- and calling it missing would refuse a build that works.
+            return;
+        }
+        File file = new File(resolved);
         if (!file.exists() || !file.isFile()) {
             problems.add(new Problem("The provisioning profile for this build was not found at "
                     + file.getAbsolutePath() + " (" + settingKey + "). Point that setting at the "

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/IOSProvisioningPreflight.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/IOSProvisioningPreflight.java
@@ -27,8 +27,10 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -244,10 +246,7 @@ final class IOSProvisioningPreflight {
         if (plist == null) {
             return null;
         }
-        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        dbf.setValidating(false);
-        disableExternalDtdLoading(dbf);
-        DocumentBuilder db = dbf.newDocumentBuilder();
+        DocumentBuilder db = secureDocumentBuilder();
         Document doc = db.parse(new ByteArrayInputStream(plist));
 
         Profile profile = new Profile();
@@ -264,18 +263,36 @@ final class IOSProvisioningPreflight {
     }
 
     /**
-     * The plist DOCTYPE points at apple.com. Resolving it would make a local check depend on
-     * Apple's web server answering, so it is turned off where the parser supports it.
+     * A parser that treats the profile as what it is: untrusted input that nothing has
+     * verified. A {@code .mobileprovision} is signed, but neither this check nor the build
+     * server validates that signature, and a profile can arrive from anyone -- a client
+     * sending one for their app, a repository, a support ticket.
      *
-     * @return whether the parser honoured the request
+     * <p>The DOCTYPE itself has to stay legal, because every real plist declares one. What is
+     * refused is entity resolution: without this, an entity declared in a crafted profile's
+     * internal subset is resolved by the JDK parser, so a profile could read a local file or
+     * make a network request during someone's build -- and, used as the profile {@code Name},
+     * have the result printed back in an error message. Turning off external general and
+     * parameter entities, entity-reference expansion, XInclude and external DTD access closes
+     * that; secure processing additionally caps entity expansion, so a profile cannot hang a
+     * build with nested entities.
+     *
+     * <p>None of these is set "best effort": a parser that cannot be told to stop resolving
+     * entities has no business reading an untrusted profile, so the exception propagates and
+     * the profile is reported as unreadable rather than parsed unsafely.
      */
-    private static boolean disableExternalDtdLoading(DocumentBuilderFactory dbf) {
-        try {
-            dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-            return true;
-        } catch (Exception ex) {
-            return false;
-        }
+    private static DocumentBuilder secureDocumentBuilder() throws ParserConfigurationException {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setValidating(false);
+        dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        // the plist DOCTYPE also points at apple.com, so this keeps a local check from
+        // depending on Apple's web server answering
+        dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+        dbf.setXIncludeAware(false);
+        dbf.setExpandEntityReferences(false);
+        return dbf.newDocumentBuilder();
     }
 
     /**

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/IOSProvisioningPreflight.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/IOSProvisioningPreflight.java
@@ -43,6 +43,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Properties;
 import java.util.TimeZone;
 
@@ -515,7 +516,12 @@ final class IOSProvisioningPreflight {
      * looked valid and went on to spend a cloud build slot.
      */
     private static Date parseDate(String value) {
-        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        // Locale.US, not the machine's: the no-argument constructor takes the default
+        // locale's calendar, so under th_TH that is a BuddhistCalendar and Apple's 2099
+        // reads as Gregorian 1556 -- a perfectly good profile refused as expired on one
+        // developer's laptop and accepted on the next.
+        SimpleDateFormat format =
+                new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
         format.setTimeZone(TimeZone.getTimeZone("UTC"));
         format.setLenient(false);
         ParsePosition at = new ParsePosition(0);

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/IOSProvisioningPreflight.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/IOSProvisioningPreflight.java
@@ -108,7 +108,10 @@ final class IOSProvisioningPreflight {
         String method = release ? APP_STORE : DEVELOPMENT;
         method = arg(settings, "ios.distributionMethod", method);
         method = arg(settings, release ? "ios.release.distributionMethod" : "ios.debug.distributionMethod", method);
-        return method;
+        // The hint can be written as ${release.method} and passed with -D, exactly like the
+        // profile path. Comparing the literal placeholder against a profile's kind refused
+        // builds whose method Ant was about to resolve to the matching one.
+        return resolvePlaceholders(method, settings);
     }
 
     private static String arg(Properties settings, String hint, String defaultValue) {
@@ -237,9 +240,15 @@ final class IOSProvisioningPreflight {
                 }
                 out.append(current, i, start);
                 String name = current.substring(start + 2, end);
-                String replacement = settings == null ? null : settings.getProperty(name);
-                if (replacement == null) {
-                    replacement = System.getProperty(name);
+                // JVM properties first, which is Ant's own order. Ant seeds its project
+                // from the system properties before the generated build file's
+                // <property file="codenameone_settings.properties"> runs, and an Ant
+                // property cannot be set twice -- so -Dprofile.dir=/new beats a
+                // profile.dir=/old in the file. Reading the file first meant refusing
+                // /old/profile.mobileprovision as missing while the build used /new.
+                String replacement = System.getProperty(name);
+                if (replacement == null && settings != null) {
+                    replacement = settings.getProperty(name);
                 }
                 if (replacement == null) {
                     out.append(current, start, end + 1);
@@ -332,6 +341,10 @@ final class IOSProvisioningPreflight {
             return;
         }
         String method = effectiveDistributionMethod(settings, release);
+        if (method.indexOf("${") >= 0) {
+            // Same rule as the path: what this cannot resolve, it may not judge.
+            return;
+        }
         Problem mismatch = checkMethod(profile, method, describe, release);
         if (mismatch != null) {
             problems.add(mismatch);

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/IOSProvisioningPreflight.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/IOSProvisioningPreflight.java
@@ -455,14 +455,52 @@ final class IOSProvisioningPreflight {
      * <p>Keyed on what every Apple-issued profile carries and no ordinary plist does: the
      * profile's own UUID, when it expires, the entitlements it grants, and the certificates it
      * was issued to. Checked against real development, distribution and Xcode-team profiles.
-     * Deliberately a small set -- the more that is demanded here, the more likely this refuses
-     * a profile that is perfectly good.
+     *
+     * <p>Each is checked by shape, not merely by name. A corrupted file can keep the key and
+     * lose the value -- an empty UUID, Entitlements as a string, DeveloperCertificates as an
+     * empty array -- and presence alone accepted all of those. With a readable future expiry
+     * and no device list, deriveType then called it an App Store profile and a default release
+     * build sailed through.
+     *
+     * <p>Still deliberately a small set: the more that is demanded here, the more likely this
+     * refuses a profile that is perfectly good, which is the failure mode that matters most.
      */
     private static boolean isProvisioningPlist(Document doc) {
-        return valueForKey(doc, "UUID") != null
+        // ExpirationDate is required to be PRESENT here and is shape-checked downstream:
+        // a profile whose date is the wrong type or unreadable deserves the message that
+        // says so, rather than the generic "this is not a profile" this method produces.
+        return hasNonEmptyString(doc, "UUID")
                 && valueForKey(doc, "ExpirationDate") != null
-                && valueForKey(doc, "Entitlements") != null
-                && valueForKey(doc, "DeveloperCertificates") != null;
+                && hasValueTagged(doc, "Entitlements", "dict")
+                && hasDeveloperCertificates(doc);
+    }
+
+    /** A key whose value is a {@code <string>} with something in it. */
+    private static boolean hasNonEmptyString(Document doc, String key) {
+        Element value = valueForKey(doc, key);
+        return value != null && "string".equals(value.getTagName())
+                && value.getTextContent().trim().length() > 0;
+    }
+
+    /** A key whose value is of the expected plist type. */
+    private static boolean hasValueTagged(Document doc, String key, String tag) {
+        Element value = valueForKey(doc, key);
+        return value != null && tag.equals(value.getTagName());
+    }
+
+    /** An array holding at least one certificate with bytes in it. */
+    private static boolean hasDeveloperCertificates(Document doc) {
+        Element value = valueForKey(doc, "DeveloperCertificates");
+        if (value == null || !"array".equals(value.getTagName())) {
+            return false;
+        }
+        NodeList certificates = value.getElementsByTagName("data");
+        for (int i = 0; i < certificates.getLength(); i++) {
+            if (certificates.item(i).getTextContent().trim().length() > 0) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/IOSProvisioningPreflight.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/IOSProvisioningPreflight.java
@@ -38,7 +38,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
-import java.text.ParseException;
+import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -505,14 +505,25 @@ final class IOSProvisioningPreflight {
         return null;
     }
 
+    /**
+     * The profile's expiry, or null when the value is not exactly the timestamp Apple writes.
+     *
+     * <p>Strict on both counts, because the default is not. Lenient parsing rolls an
+     * impossible date over -- {@code 2099-02-30} becomes 2 March -- and
+     * {@code parse(String)} stops at the first character it cannot use, so a value with
+     * trailing garbage came back as a perfectly good date. Either way a corrupted profile
+     * looked valid and went on to spend a cloud build slot.
+     */
     private static Date parseDate(String value) {
         SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
         format.setTimeZone(TimeZone.getTimeZone("UTC"));
-        try {
-            return format.parse(value);
-        } catch (ParseException ex) {
+        format.setLenient(false);
+        ParsePosition at = new ParsePosition(0);
+        Date parsed = format.parse(value, at);
+        if (parsed == null || at.getIndex() != value.length()) {
             return null;
         }
+        return parsed;
     }
 
     /**

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/IOSProvisioningPreflight.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/IOSProvisioningPreflight.java
@@ -309,7 +309,18 @@ final class IOSProvisioningPreflight {
         }
 
         String describe = profile.name == null ? file.getName() : "\"" + profile.name + "\"";
-        if (profile.expirationDate != null && profile.expirationDate.before(now)) {
+        if (profile.expirationDate == null) {
+            // The key is there -- isProvisioningPlist insisted on that -- but its value is not
+            // a date this can read. Skipping the expiry check on that basis let a corrupted
+            // profile through on the strength of its type alone, which is the build slot this
+            // check exists to save. Every Apple-issued profile carries a readable expiry.
+            problems.add(new Problem("The provisioning profile " + describe + " at "
+                    + file.getAbsolutePath() + " has no readable expiry date, so it is not a"
+                    + " usable .mobileprovision file. Re-download it from the Apple Developer"
+                    + " portal, or re-generate it with the certificate wizard.", true));
+            return;
+        }
+        if (profile.expirationDate.before(now)) {
             problems.add(new Problem("The provisioning profile " + describe + " expired on "
                     + profile.expirationDate + ". Generate a new one in the Apple Developer portal "
                     + "and update " + settingKey + ".", true));
@@ -393,6 +404,8 @@ final class IOSProvisioningPreflight {
         if (name != null) {
             profile.name = name.getTextContent().trim();
         }
+        // Left null when the value is not a <date>, or is one this cannot read; the caller
+        // treats that as an unusable profile rather than as "no expiry to check".
         Element expires = valueForKey(doc, "ExpirationDate");
         if (expires != null && "date".equals(expires.getTagName())) {
             profile.expirationDate = parseDate(expires.getTextContent().trim());

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/IOSProvisioningPreflight.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/IOSProvisioningPreflight.java
@@ -380,6 +380,14 @@ final class IOSProvisioningPreflight {
         DocumentBuilder db = secureDocumentBuilder();
         Document doc = db.parse(new ByteArrayInputStream(plist));
 
+        if (!isProvisioningPlist(doc)) {
+            // An ordinary plist parses perfectly well. Info.plist has no device list, so
+            // deriveType would have called it an App Store profile, and a release build --
+            // whose default method is app-store -- would have sailed through this check and
+            // uploaded a file that cannot provision or sign anything.
+            return null;
+        }
+
         Profile profile = new Profile();
         Element name = valueForKey(doc, "Name");
         if (name != null) {
@@ -424,6 +432,23 @@ final class IOSProvisioningPreflight {
         dbf.setXIncludeAware(false);
         dbf.setExpandEntityReferences(false);
         return dbf.newDocumentBuilder();
+    }
+
+    /**
+     * Whether this plist is a provisioning profile rather than some other plist the setting
+     * happens to point at.
+     *
+     * <p>Keyed on what every Apple-issued profile carries and no ordinary plist does: the
+     * profile's own UUID, when it expires, the entitlements it grants, and the certificates it
+     * was issued to. Checked against real development, distribution and Xcode-team profiles.
+     * Deliberately a small set -- the more that is demanded here, the more likely this refuses
+     * a profile that is perfectly good.
+     */
+    private static boolean isProvisioningPlist(Document doc) {
+        return valueForKey(doc, "UUID") != null
+                && valueForKey(doc, "ExpirationDate") != null
+                && valueForKey(doc, "Entitlements") != null
+                && valueForKey(doc, "DeveloperCertificates") != null;
     }
 
     /**

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/IOSProvisioningPreflight.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/IOSProvisioningPreflight.java
@@ -118,6 +118,34 @@ final class IOSProvisioningPreflight {
         return value.trim();
     }
 
+    /**
+     * The build target {@code cn1:buildIosOnDeviceDebug} selects. Its buildxml target submits
+     * {@code codename1.ios.debug.provision} and is signed on the build server like any other
+     * debug device build, so a bad profile costs a cloud build slot there too.
+     */
+    static final String IOS_ON_DEVICE_DEBUG = "ios-on-device-debug";
+
+    /**
+     * Whether this build is one the pre-flight has any business judging: a cloud iOS build
+     * that the build server signs.
+     *
+     * <p>Excluded: {@code ios-source} (a local Xcode project, signed later or not at all), the
+     * simulator, and the native-Mac targets -- those ride {@code platform=ios} with a different
+     * signing identity, so the app's iOS profile settings do not describe them.
+     */
+    static boolean appliesTo(String platform, String buildTarget) {
+        return platform != null && platform.contains("ios") && buildTarget != null
+                && (buildTarget.startsWith("ios-device") || IOS_ON_DEVICE_DEBUG.equals(buildTarget));
+    }
+
+    /**
+     * Whether this target signs with the release (distribution) profile. Everything else --
+     * {@code ios-device} and {@code ios-on-device-debug} alike -- signs with the debug one.
+     */
+    static boolean isReleaseTarget(String buildTarget) {
+        return buildTarget != null && buildTarget.contains("release");
+    }
+
     /** The profile setting that applies to this build type. */
     static String provisioningProfileSettingKey(boolean release) {
         return release ? "codename1.ios.release.provision" : "codename1.ios.debug.provision";

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/IOSProvisioningPreflight.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/IOSProvisioningPreflight.java
@@ -1,0 +1,379 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.maven;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Properties;
+import java.util.TimeZone;
+
+/**
+ * Reads the {@code .mobileprovision} an iOS device build is about to sign with, and
+ * refuses the build locally when signing cannot possibly succeed.
+ *
+ * <p>Every case here used to be found only by a cloud build server: the profile is
+ * uploaded, an ~8GB toolchain runs for minutes, and the failure arrives as an Xcode
+ * export error or -- when the file could not be decoded at all -- as a bare XML parser
+ * stack trace with no mention of the profile. One real sequence: a build ran four
+ * minutes and died with {@code exportArchive Provisioning profile "..." is not an
+ * "iOS Ad Hoc" profile}, because the project asked for {@code ad-hoc} while the profile
+ * was an App Store one. Both facts were in the file, on disk, before the build was sent.
+ *
+ * <p>The payload of a {@code .mobileprovision} is a plain-text XML plist inside a CMS
+ * envelope, so it can be read here without {@code security}, Xcode, or a Mac.
+ *
+ * <p>The checks fail only where the outcome is certain -- a missing, empty, unreadable
+ * or expired profile, and the unambiguous type mismatches that {@code xcodebuild
+ * -exportArchive} rejects. Anything murkier (in-house/enterprise profiles, which Xcode
+ * accepts for more than one method) warns instead, because a false refusal here blocks
+ * a build that would have worked.
+ */
+final class IOSProvisioningPreflight {
+
+    /** {@code xcodebuild -exportArchive} distribution methods, as the daemon names them. */
+    static final String DEVELOPMENT = "development";
+    static final String AD_HOC = "ad-hoc";
+    static final String APP_STORE = "app-store";
+    static final String ENTERPRISE = "enterprise";
+
+    /** What a profile is, derived from the plist. */
+    static class Profile {
+        String name;
+        String type;
+        Date expirationDate;
+    }
+
+    /** A problem found before the build was sent: {@code message} is written for the user. */
+    static class Problem {
+        final String message;
+        final boolean fatal;
+
+        Problem(String message, boolean fatal) {
+            this.message = message;
+            this.fatal = fatal;
+        }
+    }
+
+    private IOSProvisioningPreflight() {
+    }
+
+    /**
+     * The distribution method this build will actually export with, resolved exactly as
+     * {@code IPhoneBuilder} resolves it on the build server: a per-build-type hint beats
+     * the shared hint, which beats the default (development for debug, app-store for
+     * release). Reading it any other way would refuse builds the server would have
+     * accepted.
+     */
+    static String effectiveDistributionMethod(Properties settings, boolean release) {
+        String method = release ? APP_STORE : DEVELOPMENT;
+        method = arg(settings, "ios.distributionMethod", method);
+        method = arg(settings, release ? "ios.release.distributionMethod" : "ios.debug.distributionMethod", method);
+        return method;
+    }
+
+    private static String arg(Properties settings, String hint, String defaultValue) {
+        String value = settings.getProperty("codename1.arg." + hint);
+        if (value == null || value.trim().isEmpty()) {
+            return defaultValue;
+        }
+        return value.trim();
+    }
+
+    /** The profile setting that applies to this build type. */
+    static String provisioningProfileSettingKey(boolean release) {
+        return release ? "codename1.ios.release.provision" : "codename1.ios.debug.provision";
+    }
+
+    /**
+     * @return the problems with the configured profile, in the order they should be
+     * reported; empty when there is nothing to say. A fatal problem means the build
+     * cannot succeed as configured.
+     */
+    static List<Problem> check(Properties settings, boolean release, Date now) {
+        List<Problem> problems = new ArrayList<Problem>();
+        String settingKey = provisioningProfileSettingKey(release);
+        String path = settings.getProperty(settingKey);
+        if (path == null || path.trim().isEmpty()) {
+            // Not fatal: a profile can still reach the server another way, and refusing here
+            // would invent a failure the build might not have.
+            problems.add(new Problem("No provisioning profile is configured for this build ("
+                    + settingKey + " is not set). An iOS device build has to be signed, so the "
+                    + "build server will reject it unless the profile is supplied another way.", false));
+            return problems;
+        }
+
+        File file = new File(path.trim());
+        if (!file.exists() || !file.isFile()) {
+            problems.add(new Problem("The provisioning profile for this build was not found at "
+                    + file.getAbsolutePath() + " (" + settingKey + "). Point that setting at the "
+                    + ".mobileprovision file, or re-generate it with the certificate wizard.", true));
+            return problems;
+        }
+
+        byte[] raw;
+        try {
+            raw = readFile(file);
+        } catch (IOException ex) {
+            problems.add(new Problem("The provisioning profile at " + file.getAbsolutePath()
+                    + " could not be read: " + ex.getMessage(), true));
+            return problems;
+        }
+
+        if (raw.length == 0) {
+            problems.add(new Problem("The provisioning profile at " + file.getAbsolutePath()
+                    + " is empty (0 bytes). Re-download it from the Apple Developer portal, or "
+                    + "re-generate it with the certificate wizard.", true));
+            return problems;
+        }
+
+        Profile profile;
+        try {
+            profile = parse(raw);
+        } catch (Exception ex) {
+            profile = null;
+        }
+        if (profile == null) {
+            problems.add(new Problem("The file at " + file.getAbsolutePath() + " (" + raw.length
+                    + " bytes) is not a valid .mobileprovision file -- it carries no readable "
+                    + "provisioning plist. Re-download it from the Apple Developer portal, or "
+                    + "re-generate it with the certificate wizard.", true));
+            return problems;
+        }
+
+        String describe = profile.name == null ? file.getName() : "\"" + profile.name + "\"";
+        if (profile.expirationDate != null && profile.expirationDate.before(now)) {
+            problems.add(new Problem("The provisioning profile " + describe + " expired on "
+                    + profile.expirationDate + ". Generate a new one in the Apple Developer portal "
+                    + "and update " + settingKey + ".", true));
+            return problems;
+        }
+
+        String method = effectiveDistributionMethod(settings, release);
+        Problem mismatch = checkMethod(profile, method, describe, release);
+        if (mismatch != null) {
+            problems.add(mismatch);
+        }
+        return problems;
+    }
+
+    /**
+     * The type mismatch {@code xcodebuild -exportArchive} would reject minutes into the
+     * cloud build. Enterprise profiles only warn: Xcode accepts an in-house profile for
+     * more than one method, so refusing one risks blocking a build that works.
+     */
+    private static Problem checkMethod(Profile profile, String method, String describe, boolean release) {
+        if (profile.type == null || method == null || method.equals(profile.type)) {
+            return null;
+        }
+        String hint = release ? "ios.release.distributionMethod" : "ios.debug.distributionMethod";
+        String message = "The provisioning profile " + describe + " is " + article(profile.type)
+                + " profile, but this build is configured to export with method \"" + method
+                + "\" (" + hint + "). Xcode will refuse to export with a mismatched profile."
+                + " Either set " + hint + "=" + profile.type + ", or use " + article(method)
+                + " provisioning profile.";
+        if (ENTERPRISE.equals(profile.type) || ENTERPRISE.equals(method)) {
+            return new Problem(message, false);
+        }
+        return new Problem(message, true);
+    }
+
+    private static String article(String type) {
+        if (AD_HOC.equals(type) || APP_STORE.equals(type) || ENTERPRISE.equals(type)) {
+            return "an " + describeType(type);
+        }
+        return "a " + describeType(type);
+    }
+
+    private static String describeType(String type) {
+        if (AD_HOC.equals(type)) {
+            return "Ad Hoc";
+        }
+        if (APP_STORE.equals(type)) {
+            return "App Store distribution";
+        }
+        if (ENTERPRISE.equals(type)) {
+            return "in-house (enterprise)";
+        }
+        return "Development";
+    }
+
+    /**
+     * Reads the plist payload of a {@code .mobileprovision}.
+     *
+     * @return what the profile is, or null when the bytes carry no provisioning plist.
+     */
+    static Profile parse(byte[] raw) throws Exception {
+        byte[] plist = extractEmbeddedPlist(raw);
+        if (plist == null) {
+            return null;
+        }
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setValidating(false);
+        disableExternalDtdLoading(dbf);
+        DocumentBuilder db = dbf.newDocumentBuilder();
+        Document doc = db.parse(new ByteArrayInputStream(plist));
+
+        Profile profile = new Profile();
+        Element name = valueForKey(doc, "Name");
+        if (name != null) {
+            profile.name = name.getTextContent().trim();
+        }
+        Element expires = valueForKey(doc, "ExpirationDate");
+        if (expires != null && "date".equals(expires.getTagName())) {
+            profile.expirationDate = parseDate(expires.getTextContent().trim());
+        }
+        profile.type = deriveType(doc);
+        return profile;
+    }
+
+    /**
+     * The plist DOCTYPE points at apple.com. Resolving it would make a local check depend on
+     * Apple's web server answering, so it is turned off where the parser supports it.
+     *
+     * @return whether the parser honoured the request
+     */
+    private static boolean disableExternalDtdLoading(DocumentBuilderFactory dbf) {
+        try {
+            dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            return true;
+        } catch (Exception ex) {
+            return false;
+        }
+    }
+
+    /**
+     * The four profile kinds, told apart the way Apple's own tooling does: an in-house
+     * profile provisions all devices, a profile that lists devices is Development when it
+     * allows the debugger to attach ({@code get-task-allow}) and Ad Hoc when it does not,
+     * and a profile that lists no devices at all is an App Store one.
+     */
+    private static String deriveType(Document doc) {
+        Element provisionsAllDevices = valueForKey(doc, "ProvisionsAllDevices");
+        if (provisionsAllDevices != null && "true".equals(provisionsAllDevices.getTagName())) {
+            return ENTERPRISE;
+        }
+        Element devices = valueForKey(doc, "ProvisionedDevices");
+        if (devices != null && "array".equals(devices.getTagName())) {
+            Element getTaskAllow = valueForKey(doc, "get-task-allow");
+            if (getTaskAllow != null && "true".equals(getTaskAllow.getTagName())) {
+                return DEVELOPMENT;
+            }
+            return AD_HOC;
+        }
+        return APP_STORE;
+    }
+
+    /** The element that follows the named {@code <key>} -- a plist's value for that key. */
+    private static Element valueForKey(Document doc, String key) {
+        NodeList keys = doc.getElementsByTagName("key");
+        for (int i = 0; i < keys.getLength(); i++) {
+            Element k = (Element) keys.item(i);
+            if (!key.equals(k.getTextContent().trim())) {
+                continue;
+            }
+            Node n = k.getNextSibling();
+            while (n != null && !(n instanceof Element)) {
+                n = n.getNextSibling();
+            }
+            if (n != null) {
+                return (Element) n;
+            }
+        }
+        return null;
+    }
+
+    private static Date parseDate(String value) {
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        format.setTimeZone(TimeZone.getTimeZone("UTC"));
+        try {
+            return format.parse(value);
+        } catch (ParseException ex) {
+            return null;
+        }
+    }
+
+    /**
+     * Lifts the {@code <?xml ... </plist>} payload out of the CMS envelope. The payload is
+     * not encrypted, which is what lets this run without {@code security} or a Mac.
+     */
+    static byte[] extractEmbeddedPlist(byte[] raw) {
+        if (raw == null) {
+            return null;
+        }
+        int start = indexOf(raw, "<?xml".getBytes(StandardCharsets.UTF_8), 0);
+        if (start < 0) {
+            return null;
+        }
+        byte[] end = "</plist>".getBytes(StandardCharsets.UTF_8);
+        int endPos = indexOf(raw, end, start);
+        if (endPos < 0) {
+            return null;
+        }
+        int len = endPos + end.length - start;
+        byte[] plist = new byte[len];
+        System.arraycopy(raw, start, plist, 0, len);
+        return plist;
+    }
+
+    private static int indexOf(byte[] haystack, byte[] needle, int from) {
+        outer:
+        for (int i = Math.max(0, from); i <= haystack.length - needle.length; i++) {
+            for (int j = 0; j < needle.length; j++) {
+                if (haystack[i + j] != needle[j]) {
+                    continue outer;
+                }
+            }
+            return i;
+        }
+        return -1;
+    }
+
+    private static byte[] readFile(File f) throws IOException {
+        try (InputStream is = new FileInputStream(f)) {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            byte[] buffer = new byte[8192];
+            int amount;
+            while ((amount = is.read(buffer)) > -1) {
+                baos.write(buffer, 0, amount);
+            }
+            return baos.toByteArray();
+        }
+    }
+}

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/IOSProvisioningPreflight.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/IOSProvisioningPreflight.java
@@ -124,9 +124,35 @@ final class IOSProvisioningPreflight {
     }
 
     /**
+     * The checks that depend only on the profile file itself, safe to run before a CN1Lib's
+     * properties have been merged in.
+     *
+     * <p>A library can supply {@code codename1.arg.ios.*.distributionMethod} through its
+     * appended/required properties, which the mojo merges later -- so deciding a type mismatch
+     * this early would refuse a build whose method the merge was about to make correct. That
+     * decision belongs to {@link #check}, run against the merged settings. What a file is,
+     * whether it exists, and whether it has expired cannot change in the merge, so those fail
+     * here, before the app is packaged.
+     *
+     * @return the problems with the file; empty when there is nothing to say, including when
+     * no profile is configured yet (the merge may still supply one).
+     */
+    static List<Problem> checkProfileFile(Properties settings, boolean release, Date now) {
+        List<Problem> problems = new ArrayList<Problem>();
+        String settingKey = provisioningProfileSettingKey(release);
+        String path = settings.getProperty(settingKey);
+        if (path == null || path.trim().isEmpty()) {
+            return problems;
+        }
+        collectFileProblems(problems, settings, release, now, path, settingKey, false);
+        return problems;
+    }
+
+    /**
      * @return the problems with the configured profile, in the order they should be
      * reported; empty when there is nothing to say. A fatal problem means the build
-     * cannot succeed as configured.
+     * cannot succeed as configured. Run this against the settings the build will actually
+     * be submitted with -- see {@link #checkProfileFile} for why.
      */
     static List<Problem> check(Properties settings, boolean release, Date now) {
         List<Problem> problems = new ArrayList<Problem>();
@@ -140,13 +166,23 @@ final class IOSProvisioningPreflight {
                     + "build server will reject it unless the profile is supplied another way.", false));
             return problems;
         }
+        collectFileProblems(problems, settings, release, now, path, settingKey, true);
+        return problems;
+    }
 
+    /**
+     * @param checkMethodMismatch whether to also compare the profile's kind against the
+     * distribution method these settings resolve to. Only true once the settings are the ones
+     * the build will be submitted with, since a CN1Lib can still change the method.
+     */
+    private static void collectFileProblems(List<Problem> problems, Properties settings, boolean release,
+            Date now, String path, String settingKey, boolean checkMethodMismatch) {
         File file = new File(path.trim());
         if (!file.exists() || !file.isFile()) {
             problems.add(new Problem("The provisioning profile for this build was not found at "
                     + file.getAbsolutePath() + " (" + settingKey + "). Point that setting at the "
                     + ".mobileprovision file, or re-generate it with the certificate wizard.", true));
-            return problems;
+            return;
         }
 
         byte[] raw;
@@ -155,14 +191,14 @@ final class IOSProvisioningPreflight {
         } catch (IOException ex) {
             problems.add(new Problem("The provisioning profile at " + file.getAbsolutePath()
                     + " could not be read: " + ex.getMessage(), true));
-            return problems;
+            return;
         }
 
         if (raw.length == 0) {
             problems.add(new Problem("The provisioning profile at " + file.getAbsolutePath()
                     + " is empty (0 bytes). Re-download it from the Apple Developer portal, or "
                     + "re-generate it with the certificate wizard.", true));
-            return problems;
+            return;
         }
 
         Profile profile;
@@ -176,7 +212,7 @@ final class IOSProvisioningPreflight {
                     + " bytes) is not a valid .mobileprovision file -- it carries no readable "
                     + "provisioning plist. Re-download it from the Apple Developer portal, or "
                     + "re-generate it with the certificate wizard.", true));
-            return problems;
+            return;
         }
 
         String describe = profile.name == null ? file.getName() : "\"" + profile.name + "\"";
@@ -184,15 +220,17 @@ final class IOSProvisioningPreflight {
             problems.add(new Problem("The provisioning profile " + describe + " expired on "
                     + profile.expirationDate + ". Generate a new one in the Apple Developer portal "
                     + "and update " + settingKey + ".", true));
-            return problems;
+            return;
         }
 
+        if (!checkMethodMismatch) {
+            return;
+        }
         String method = effectiveDistributionMethod(settings, release);
         Problem mismatch = checkMethod(profile, method, describe, release);
         if (mismatch != null) {
             problems.add(mismatch);
         }
-        return problems;
     }
 
     /**

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/IOSProvisioningPreflightTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/IOSProvisioningPreflightTest.java
@@ -249,6 +249,63 @@ public class IOSProvisioningPreflightTest {
         assertTrue(parsed.expirationDate.after(new Date()));
     }
 
+    // ---- a profile is untrusted input ----
+
+    /**
+     * Nothing here verifies the profile's CMS signature, and a profile can arrive from
+     * anyone. A crafted one must not be able to read a local file during someone's build --
+     * the DOCTYPE has to stay legal (every real plist declares one), but the entity in its
+     * internal subset must not be resolved. Disabling only {@code load-external-dtd} would
+     * leave this open.
+     */
+    @Test
+    public void doesNotResolveExternalEntitiesFromACraftedProfile() throws Exception {
+        File secret = File.createTempFile("preflight-secret", ".txt");
+        secret.deleteOnExit();
+        OutputStream out = new FileOutputStream(secret);
+        try {
+            out.write("TOP-SECRET-KEYCHAIN-CONTENTS".getBytes("UTF-8"));
+        } finally {
+            out.close();
+        }
+
+        String attack = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<!DOCTYPE plist [ <!ENTITY xxe SYSTEM \"file://" + secret.getAbsolutePath() + "\"> ]>\n"
+                + "<plist version=\"1.0\"><dict>\n"
+                + "<key>Name</key><string>&xxe;</string>\n"
+                + "<key>ExpirationDate</key><date>" + FUTURE + "</date>\n"
+                + "<key>Entitlements</key><dict><key>get-task-allow</key><false/></dict>\n"
+                + "</dict></plist>";
+
+        String name;
+        try {
+            IOSProvisioningPreflight.Profile parsed = IOSProvisioningPreflight.parse(attack.getBytes("UTF-8"));
+            name = parsed == null || parsed.name == null ? "" : parsed.name;
+        } catch (Exception refusedOutright) {
+            name = "";
+        }
+        assertFalse("the profile must not be able to read a local file, got: " + name,
+                name.contains("TOP-SECRET-KEYCHAIN-CONTENTS"));
+
+        // and the same profile, run through the full check, must not leak it into the message either
+        Properties p = settings(writeRaw(attack.getBytes("UTF-8")), true, "ad-hoc");
+        for (IOSProvisioningPreflight.Problem problem : check(p, true)) {
+            assertFalse("no message may carry the file's contents: " + problem.message,
+                    problem.message.contains("TOP-SECRET-KEYCHAIN-CONTENTS"));
+        }
+    }
+
+    /** A real profile still parses with the hardened parser -- the DOCTYPE stays legal. */
+    @Test
+    public void hardenedParserStillReadsARealProfile() throws Exception {
+        IOSProvisioningPreflight.Profile parsed =
+                IOSProvisioningPreflight.parse(development("Dev Profile").getBytes("UTF-8"));
+        assertNotNull(parsed);
+        assertEquals("Dev Profile", parsed.name);
+        assertEquals("development", parsed.type);
+        assertNotNull(parsed.expirationDate);
+    }
+
     @Test
     public void reportsNoPlistWhenThereIsNone() throws Exception {
         assertNull(IOSProvisioningPreflight.extractEmbeddedPlist(new byte[0]));

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/IOSProvisioningPreflightTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/IOSProvisioningPreflightTest.java
@@ -309,6 +309,57 @@ public class IOSProvisioningPreflightTest {
                 IOSProvisioningPreflight.resolvePlaceholders("/certs/dev.mobileprovision", new Properties()));
     }
 
+    /**
+     * The distribution hint can be a placeholder too: {@code -Drelease.method=ad-hoc} against
+     * {@code ...distributionMethod=${release.method}}. Comparing the literal placeholder to a
+     * profile's kind refused a build whose method Ant was about to resolve to the matching one.
+     */
+    @Test
+    public void expandsAPlaceholderInTheDistributionMethod() throws Exception {
+        System.setProperty("preflight.test.method", "ad-hoc");
+        try {
+            Properties p = settings(write(adHoc("AdHoc")), true, "${preflight.test.method}");
+            assertEquals("ad-hoc",
+                    IOSProvisioningPreflight.effectiveDistributionMethod(p, true));
+            assertTrue("a resolvable method that matches must not be refused",
+                    check(p, true).isEmpty());
+        } finally {
+            System.clearProperty("preflight.test.method");
+        }
+    }
+
+    /** A method it cannot resolve is a method it may not judge. */
+    @Test
+    public void anUnresolvableMethodIsNotJudged() throws Exception {
+        Properties p = settings(write(adHoc("AdHoc")), true, "${nobody.sets.this}");
+        assertTrue("an unresolvable method must not fail the build",
+                check(p, true).isEmpty());
+    }
+
+    /**
+     * Ant seeds its project from the JVM properties before the generated build file reads
+     * codenameone_settings.properties, and an Ant property cannot be set twice -- so
+     * {@code -Dprofile.dir=/new} beats a {@code profile.dir=/old} in the file. Reading the
+     * file first refused /old as missing while the build was using /new.
+     */
+    @Test
+    public void aCommandLinePropertyBeatsTheSettingsFile() throws Exception {
+        File profile = write(appStore("Store"));
+        System.setProperty("preflight.test.dir", profile.getParent());
+        try {
+            Properties p = new Properties();
+            // the stale value the settings file still carries
+            p.setProperty("preflight.test.dir", "/no/such/directory");
+            p.setProperty(IOSProvisioningPreflight.provisioningProfileSettingKey(true),
+                    "${preflight.test.dir}/" + profile.getName());
+            p.setProperty("codename1.arg.ios.release.distributionMethod", "app-store");
+            assertTrue("the -D value should win, as it does in Ant",
+                    check(p, true).isEmpty());
+        } finally {
+            System.clearProperty("preflight.test.dir");
+        }
+    }
+
     // ---- which builds this applies to ----
 
     /**

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/IOSProvisioningPreflightTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/IOSProvisioningPreflightTest.java
@@ -443,6 +443,30 @@ public class IOSProvisioningPreflightTest {
         assertEquals("Store", parsed.name);
     }
 
+    /**
+     * A profile whose expiry cannot be read is not usable, and must not pass on the strength
+     * of its type alone. The key being present was all {@code isProvisioningPlist} asked for,
+     * so without this a corrupted date silently skipped the expiry check entirely.
+     */
+    @Test
+    public void anUnreadableExpiryIsRefused() throws Exception {
+        String garbledDate = profile("Corrupted", "not-a-date",
+                "<key>Entitlements</key><dict><key>get-task-allow</key><false/></dict>\n");
+        assertFatal(check(settings(write(garbledDate), true, "app-store"), true),
+                "no readable expiry date");
+
+        // ...and so is one whose expiry is the wrong plist type altogether.
+        String wrongType = HEAD
+                + "<key>Name</key><string>Wrong Type</string>\n"
+                + "<key>UUID</key><string>0f7ac3c1-4d0e-4e8a-9d1f-8b6a2c5e7d90</string>\n"
+                + "<key>ExpirationDate</key><string>2099-01-01T00:00:00Z</string>\n"
+                + "<key>DeveloperCertificates</key><array><data>Zm9v</data></array>\n"
+                + "<key>Entitlements</key><dict><key>get-task-allow</key><false/></dict>\n"
+                + "</dict></plist>";
+        assertFatal(check(settings(write(wrongType), true, "app-store"), true),
+                "no readable expiry date");
+    }
+
     // ---- a profile is untrusted input ----
 
     /**

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/IOSProvisioningPreflightTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/IOSProvisioningPreflightTest.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.maven;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.Properties;
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * The pre-flight exists because of a real pair of cloud build failures minutes apart on
+ * one account: the first ran four minutes and died with {@code exportArchive Provisioning
+ * profile "HBZ_PROD_DISTRIBUTION" is not an "iOS Ad Hoc" profile}; the next two died with
+ * a bare {@code SAXParseException ... Premature end of file} that never named the profile,
+ * after the profile was swapped for an unreadable file. Both are decidable from the file
+ * on disk, before anything is uploaded.
+ */
+public class IOSProvisioningPreflightTest {
+
+    private static final String HEAD =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+            + "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" "
+            + "\"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n"
+            + "<plist version=\"1.0\"><dict>\n";
+
+    private static String profile(String name, String expiry, String body) {
+        return HEAD
+                + "<key>Name</key><string>" + name + "</string>\n"
+                + "<key>ExpirationDate</key><date>" + expiry + "</date>\n"
+                + body
+                + "</dict></plist>";
+    }
+
+    private static final String FUTURE = "2099-01-01T00:00:00Z";
+
+    private static String appStore(String name) {
+        return profile(name, FUTURE,
+                "<key>Entitlements</key><dict><key>get-task-allow</key><false/></dict>\n");
+    }
+
+    private static String adHoc(String name) {
+        return profile(name, FUTURE,
+                "<key>ProvisionedDevices</key><array><string>abc123</string></array>\n"
+                + "<key>Entitlements</key><dict><key>get-task-allow</key><false/></dict>\n");
+    }
+
+    private static String development(String name) {
+        return profile(name, FUTURE,
+                "<key>ProvisionedDevices</key><array><string>abc123</string></array>\n"
+                + "<key>Entitlements</key><dict><key>get-task-allow</key><true/></dict>\n");
+    }
+
+    private static String enterprise(String name) {
+        return profile(name, FUTURE,
+                "<key>ProvisionsAllDevices</key><true/>\n"
+                + "<key>Entitlements</key><dict><key>get-task-allow</key><false/></dict>\n");
+    }
+
+    /** Wraps a plist the way a real .mobileprovision does: plain text inside a CMS envelope. */
+    private File write(String plist) throws Exception {
+        byte[] payload = plist == null ? new byte[0] : plist.getBytes("UTF-8");
+        byte[] wrapped = new byte[payload.length + 24];
+        for (int i = 0; i < 16; i++) {
+            wrapped[i] = (byte) (0x80 + i);
+        }
+        System.arraycopy(payload, 0, wrapped, 16, payload.length);
+        return writeRaw(plist == null ? new byte[0] : wrapped);
+    }
+
+    private File writeRaw(byte[] contents) throws Exception {
+        File f = File.createTempFile("preflight", ".mobileprovision");
+        f.deleteOnExit();
+        OutputStream out = new FileOutputStream(f);
+        try {
+            out.write(contents);
+        } finally {
+            out.close();
+        }
+        return f;
+    }
+
+    private Properties settings(File profile, boolean release, String method) {
+        Properties p = new Properties();
+        if (profile != null) {
+            p.setProperty(IOSProvisioningPreflight.provisioningProfileSettingKey(release),
+                    profile.getAbsolutePath());
+        }
+        if (method != null) {
+            p.setProperty("codename1.arg.ios." + (release ? "release" : "debug") + ".distributionMethod", method);
+        }
+        return p;
+    }
+
+    private static List<IOSProvisioningPreflight.Problem> check(Properties p, boolean release) {
+        return IOSProvisioningPreflight.check(p, release, new Date());
+    }
+
+    private static void assertFatal(List<IOSProvisioningPreflight.Problem> problems, String... expectedFragments) {
+        assertFalse("expected a problem", problems.isEmpty());
+        IOSProvisioningPreflight.Problem first = problems.get(0);
+        assertTrue("expected a fatal problem, got: " + first.message, first.fatal);
+        for (String fragment : expectedFragments) {
+            assertTrue("expected the message to mention '" + fragment + "', got: " + first.message,
+                    first.message.contains(fragment));
+        }
+    }
+
+    // ---- the two failures that prompted this ----
+
+    /** The 17:30 failure: ad-hoc requested, App Store profile supplied. */
+    @Test
+    public void appStoreProfileCannotExportAsAdHoc() throws Exception {
+        Properties p = settings(write(appStore("HBZ_PROD_DISTRIBUTION")), true, "ad-hoc");
+        assertFatal(check(p, true), "HBZ_PROD_DISTRIBUTION", "App Store distribution",
+                "ad-hoc", "ios.release.distributionMethod=app-store");
+    }
+
+    /** The 17:37 and 17:42 failures: the swapped-in profile decoded to nothing. */
+    @Test
+    public void unreadableProfileIsNamedAsSuch() throws Exception {
+        File garbage = writeRaw("not a provisioning profile at all".getBytes("UTF-8"));
+        assertFatal(check(settings(garbage, true, null), true),
+                garbage.getAbsolutePath(), "not a valid .mobileprovision file");
+    }
+
+    @Test
+    public void emptyProfileIsNamedAsSuch() throws Exception {
+        File empty = writeRaw(new byte[0]);
+        assertFatal(check(settings(empty, true, null), true), "is empty (0 bytes)");
+    }
+
+    @Test
+    public void missingProfileIsNamedAsSuch() throws Exception {
+        Properties p = new Properties();
+        p.setProperty(IOSProvisioningPreflight.provisioningProfileSettingKey(true),
+                new File(System.getProperty("java.io.tmpdir"), "nope.mobileprovision").getAbsolutePath());
+        assertFatal(check(p, true), "was not found at", "nope.mobileprovision");
+    }
+
+    @Test
+    public void expiredProfileIsRefused() throws Exception {
+        Calendar past = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        past.add(Calendar.YEAR, -1);
+        String expiry = String.format("%tFT%<tTZ", past);
+        File f = write(profile("Old Profile", expiry,
+                "<key>Entitlements</key><dict><key>get-task-allow</key><false/></dict>\n"));
+        assertFatal(check(settings(f, true, null), true), "Old Profile", "expired on");
+    }
+
+    // ---- the combinations that must NOT be refused ----
+
+    @Test
+    public void matchingReleaseProfilePasses() throws Exception {
+        assertTrue(check(settings(write(appStore("Store")), true, "app-store"), true).isEmpty());
+        assertTrue(check(settings(write(adHoc("AdHoc")), true, "ad-hoc"), true).isEmpty());
+    }
+
+    @Test
+    public void matchingDebugProfilePasses() throws Exception {
+        assertTrue(check(settings(write(development("Dev")), false, null), false).isEmpty());
+    }
+
+    /** Release defaults to app-store, debug to development -- exactly as the server resolves it. */
+    @Test
+    public void defaultsMatchTheServer() {
+        Properties empty = new Properties();
+        assertEquals("app-store", IOSProvisioningPreflight.effectiveDistributionMethod(empty, true));
+        assertEquals("development", IOSProvisioningPreflight.effectiveDistributionMethod(empty, false));
+
+        Properties shared = new Properties();
+        shared.setProperty("codename1.arg.ios.distributionMethod", "enterprise");
+        assertEquals("enterprise", IOSProvisioningPreflight.effectiveDistributionMethod(shared, true));
+
+        // the build-type-qualified hint wins over the shared one
+        shared.setProperty("codename1.arg.ios.release.distributionMethod", "ad-hoc");
+        assertEquals("ad-hoc", IOSProvisioningPreflight.effectiveDistributionMethod(shared, true));
+        assertEquals("enterprise", IOSProvisioningPreflight.effectiveDistributionMethod(shared, false));
+    }
+
+    /**
+     * An in-house profile is the one case Xcode accepts for more than one method, so a
+     * mismatch there warns rather than blocking a build that would have worked.
+     */
+    @Test
+    public void enterpriseMismatchOnlyWarns() throws Exception {
+        List<IOSProvisioningPreflight.Problem> problems =
+                check(settings(write(enterprise("InHouse")), true, "app-store"), true);
+        assertEquals(1, problems.size());
+        assertFalse("an enterprise mismatch must not block the build", problems.get(0).fatal);
+    }
+
+    /** No profile configured is the server's call to make, not a local refusal. */
+    @Test
+    public void absentSettingWarnsButDoesNotBlock() {
+        List<IOSProvisioningPreflight.Problem> problems = check(new Properties(), true);
+        assertEquals(1, problems.size());
+        assertFalse(problems.get(0).fatal);
+    }
+
+    // ---- classification ----
+
+    @Test
+    public void classifiesEveryProfileKind() throws Exception {
+        assertEquals("app-store", IOSProvisioningPreflight.parse(appStore("a").getBytes("UTF-8")).type);
+        assertEquals("ad-hoc", IOSProvisioningPreflight.parse(adHoc("a").getBytes("UTF-8")).type);
+        assertEquals("development", IOSProvisioningPreflight.parse(development("a").getBytes("UTF-8")).type);
+        assertEquals("enterprise", IOSProvisioningPreflight.parse(enterprise("a").getBytes("UTF-8")).type);
+    }
+
+    @Test
+    public void readsTheProfileNameAndExpiry() throws Exception {
+        IOSProvisioningPreflight.Profile parsed =
+                IOSProvisioningPreflight.parse(appStore("My Profile").getBytes("UTF-8"));
+        assertNotNull(parsed);
+        assertEquals("My Profile", parsed.name);
+        assertNotNull(parsed.expirationDate);
+        assertTrue(parsed.expirationDate.after(new Date()));
+    }
+
+    @Test
+    public void reportsNoPlistWhenThereIsNone() throws Exception {
+        assertNull(IOSProvisioningPreflight.extractEmbeddedPlist(new byte[0]));
+        assertNull(IOSProvisioningPreflight.extractEmbeddedPlist("nothing".getBytes("UTF-8")));
+        // an opening tag with no close is a truncated file, not a profile
+        assertNull(IOSProvisioningPreflight.extractEmbeddedPlist("<?xml version=\"1.0\"?><plist>".getBytes("UTF-8")));
+    }
+}

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/IOSProvisioningPreflightTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/IOSProvisioningPreflightTest.java
@@ -30,6 +30,7 @@ import java.io.OutputStream;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Properties;
 import java.util.TimeZone;
 
@@ -500,6 +501,28 @@ public class IOSProvisioningPreflightTest {
         expected.clear();
         expected.set(2027, Calendar.MAY, 24, 1, 19, 39);
         assertEquals(expected.getTime(), parsed.expirationDate);
+    }
+
+    /**
+     * The verdict must not depend on the developer's locale.
+     *
+     * <p>{@code new SimpleDateFormat(pattern)} takes the default locale's calendar. Under
+     * {@code th_TH} that is a {@code BuddhistCalendar}, so Apple's {@code 2099} is read as
+     * Gregorian 1556 and a perfectly good profile is refused as expired -- on one laptop and
+     * not the next.
+     */
+    @Test
+    public void theVerdictDoesNotDependOnTheMachinesLocale() throws Exception {
+        Locale original = Locale.getDefault();
+        try {
+            Locale.setDefault(new Locale("th", "TH", "TH"));
+            Properties p = settings(write(appStore("Store")), true, "app-store");
+            assertTrue("a profile expiring in 2099 must not read as expired under a"
+                            + " non-Gregorian default calendar",
+                    check(p, true).isEmpty());
+        } finally {
+            Locale.setDefault(original);
+        }
     }
 
     // ---- a profile is untrusted input ----

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/IOSProvisioningPreflightTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/IOSProvisioningPreflightTest.java
@@ -55,10 +55,16 @@ public class IOSProvisioningPreflightTest {
             + "\"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n"
             + "<plist version=\"1.0\"><dict>\n";
 
+    /**
+     * The shape of a real profile: the fields every Apple-issued one carries, which is what
+     * tells a provisioning profile apart from any other plist the setting might point at.
+     */
     private static String profile(String name, String expiry, String body) {
         return HEAD
                 + "<key>Name</key><string>" + name + "</string>\n"
+                + "<key>UUID</key><string>0f7ac3c1-4d0e-4e8a-9d1f-8b6a2c5e7d90</string>\n"
                 + "<key>ExpirationDate</key><date>" + expiry + "</date>\n"
+                + "<key>DeveloperCertificates</key><array><data>Zm9v</data></array>\n"
                 + body
                 + "</dict></plist>";
     }
@@ -392,6 +398,49 @@ public class IOSProvisioningPreflightTest {
     public void mergedPassCatchesTheMismatch() throws Exception {
         Properties merged = settings(write(appStore("HBZ_PROD_DISTRIBUTION")), true, "ad-hoc");
         assertFatal(check(merged, true), "HBZ_PROD_DISTRIBUTION", "App Store distribution");
+    }
+
+    // ---- it has to actually be a profile ----
+
+    /**
+     * An ordinary plist parses perfectly well. {@code Info.plist} has no device list, so it
+     * would have been classified as an App Store profile -- and a release build, whose
+     * default method is app-store, would have passed this check and uploaded a file that
+     * cannot provision or sign anything.
+     */
+    @Test
+    public void anOrdinaryPlistIsNotAProfile() throws Exception {
+        String infoPlist = HEAD
+                + "<key>CFBundleName</key><string>MyApp</string>\n"
+                + "<key>CFBundleIdentifier</key><string>com.example.myapp</string>\n"
+                + "<key>CFBundleVersion</key><string>1.0</string>\n"
+                + "</dict></plist>";
+        assertNull("an Info.plist is not a provisioning profile",
+                IOSProvisioningPreflight.parse(infoPlist.getBytes("UTF-8")));
+
+        File f = writeRaw(infoPlist.getBytes("UTF-8"));
+        assertFatal(check(settings(f, true, null), true),
+                "not a valid .mobileprovision file");
+    }
+
+    /** A profile missing the fields every Apple-issued one carries is not one either. */
+    @Test
+    public void aPlistWithoutTheProfileFieldsIsNotAProfile() throws Exception {
+        String half = HEAD
+                + "<key>Name</key><string>Looks Like A Profile</string>\n"
+                + "<key>ExpirationDate</key><date>" + FUTURE + "</date>\n"
+                + "</dict></plist>";
+        assertNull("UUID, Entitlements and DeveloperCertificates are all required",
+                IOSProvisioningPreflight.parse(half.getBytes("UTF-8")));
+    }
+
+    /** ...and a real one still is. */
+    @Test
+    public void aRealProfileStillParses() throws Exception {
+        IOSProvisioningPreflight.Profile parsed =
+                IOSProvisioningPreflight.parse(appStore("Store").getBytes("UTF-8"));
+        assertNotNull(parsed);
+        assertEquals("Store", parsed.name);
     }
 
     // ---- a profile is untrusted input ----

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/IOSProvisioningPreflightTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/IOSProvisioningPreflightTest.java
@@ -467,6 +467,41 @@ public class IOSProvisioningPreflightTest {
                 "no readable expiry date");
     }
 
+    /**
+     * A date that is only nearly a date is not one.
+     *
+     * <p>{@code SimpleDateFormat} is lenient by default, so {@code 2099-02-30} rolls over to
+     * 2 March and looks like a valid future expiry; and {@code parse(String)} stops at the
+     * first character it cannot use, so trailing garbage is ignored. Both let a corrupted
+     * profile through the unreadable-expiry check.
+     */
+    @Test
+    public void aDateThatIsOnlyNearlyADateIsRefused() throws Exception {
+        String impossible = profile("Impossible Day", "2099-02-30T00:00:00Z",
+                "<key>Entitlements</key><dict><key>get-task-allow</key><false/></dict>\n");
+        assertFatal(check(settings(write(impossible), true, "app-store"), true),
+                "no readable expiry date");
+
+        String trailing = profile("Trailing Garbage", "2099-01-01T00:00:00Z and then some",
+                "<key>Entitlements</key><dict><key>get-task-allow</key><false/></dict>\n");
+        assertFatal(check(settings(write(trailing), true, "app-store"), true),
+                "no readable expiry date");
+    }
+
+    /** The timestamp Apple actually writes still reads, to the second. */
+    @Test
+    public void theRealTimestampFormatStillParses() throws Exception {
+        IOSProvisioningPreflight.Profile parsed = IOSProvisioningPreflight.parse(
+                profile("Real", "2027-05-24T01:19:39Z",
+                        "<key>Entitlements</key><dict><key>get-task-allow</key><true/></dict>\n")
+                        .getBytes("UTF-8"));
+        assertNotNull(parsed);
+        Calendar expected = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        expected.clear();
+        expected.set(2027, Calendar.MAY, 24, 1, 19, 39);
+        assertEquals(expected.getTime(), parsed.expirationDate);
+    }
+
     // ---- a profile is untrusted input ----
 
     /**

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/IOSProvisioningPreflightTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/IOSProvisioningPreflightTest.java
@@ -525,6 +525,69 @@ public class IOSProvisioningPreflightTest {
         }
     }
 
+    /**
+     * A corrupted file can keep the key names and lose the values. Presence alone accepted an
+     * empty UUID, Entitlements as a string, or an empty certificate array -- and with a
+     * readable future expiry and no device list, that reads as an App Store profile, so a
+     * default release build passed and uploaded something that cannot sign the app.
+     */
+    @Test
+    public void keysWithUnusableValuesAreNotAProfile() throws Exception {
+        assertNull("an empty UUID is not a UUID", IOSProvisioningPreflight.parse(
+                corrupted("<key>UUID</key><string></string>",
+                        "<key>DeveloperCertificates</key><array><data>Zm9v</data></array>",
+                        "<key>Entitlements</key><dict><key>get-task-allow</key><false/></dict>")
+                        .getBytes("UTF-8")));
+
+        assertNull("a UUID that is not a string is not a UUID", IOSProvisioningPreflight.parse(
+                corrupted("<key>UUID</key><array><string>x</string></array>",
+                        "<key>DeveloperCertificates</key><array><data>Zm9v</data></array>",
+                        "<key>Entitlements</key><dict><key>get-task-allow</key><false/></dict>")
+                        .getBytes("UTF-8")));
+
+        assertNull("entitlements are a dictionary", IOSProvisioningPreflight.parse(
+                corrupted("<key>UUID</key><string>u</string>",
+                        "<key>DeveloperCertificates</key><array><data>Zm9v</data></array>",
+                        "<key>Entitlements</key><string>none</string>")
+                        .getBytes("UTF-8")));
+
+        assertNull("an empty certificate array grants nothing", IOSProvisioningPreflight.parse(
+                corrupted("<key>UUID</key><string>u</string>",
+                        "<key>DeveloperCertificates</key><array></array>",
+                        "<key>Entitlements</key><dict><key>get-task-allow</key><false/></dict>")
+                        .getBytes("UTF-8")));
+
+        assertNull("a certificate array of empty data grants nothing",
+                IOSProvisioningPreflight.parse(
+                        corrupted("<key>UUID</key><string>u</string>",
+                                "<key>DeveloperCertificates</key><array><data> </data></array>",
+                                "<key>Entitlements</key><dict><key>get-task-allow</key><false/></dict>")
+                                .getBytes("UTF-8")));
+    }
+
+    /** A plist carrying the mandatory fields in their proper shapes still parses. */
+    @Test
+    public void properlyShapedFieldsStillParse() throws Exception {
+        IOSProvisioningPreflight.Profile parsed = IOSProvisioningPreflight.parse(
+                corrupted("<key>UUID</key><string>0f7ac3c1</string>",
+                        "<key>DeveloperCertificates</key><array><data>Zm9v</data></array>",
+                        "<key>Entitlements</key><dict><key>get-task-allow</key><false/></dict>")
+                        .getBytes("UTF-8"));
+        assertNotNull(parsed);
+        assertEquals("app-store", parsed.type);
+    }
+
+    /** A profile with the three mandatory fields spelled however the caller asks. */
+    private static String corrupted(String uuid, String certificates, String entitlements) {
+        return HEAD
+                + "<key>Name</key><string>Corrupted</string>\n"
+                + uuid + "\n"
+                + "<key>ExpirationDate</key><date>" + FUTURE + "</date>\n"
+                + certificates + "\n"
+                + entitlements + "\n"
+                + "</dict></plist>";
+    }
+
     // ---- a profile is untrusted input ----
 
     /**

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/IOSProvisioningPreflightTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/IOSProvisioningPreflightTest.java
@@ -249,6 +249,47 @@ public class IOSProvisioningPreflightTest {
         assertTrue(parsed.expirationDate.after(new Date()));
     }
 
+    // ---- which builds this applies to ----
+
+    /**
+     * {@code cn1:buildIosOnDeviceDebug} selects {@code ios-on-device-debug}, whose buildxml
+     * target submits {@code codename1.ios.debug.provision} to the build server exactly like
+     * {@code ios-device}. Missing it meant a bad profile still burned a cloud build slot on
+     * that flow.
+     */
+    @Test
+    public void appliesToEveryCloudIOSDeviceBuild() {
+        assertTrue(IOSProvisioningPreflight.appliesTo("ios", "ios-device"));
+        assertTrue(IOSProvisioningPreflight.appliesTo("ios", "ios-device-release"));
+        assertTrue(IOSProvisioningPreflight.appliesTo("ios", "ios-on-device-debug"));
+    }
+
+    /** ...and to nothing the build server does not sign with the app's iOS profile. */
+    @Test
+    public void doesNotApplyToLocalOrNonIOSBuilds() {
+        assertFalse("a local Xcode project is signed later, or not at all",
+                IOSProvisioningPreflight.appliesTo("ios", "ios-source"));
+        assertFalse("native Mac rides platform=ios with a different identity",
+                IOSProvisioningPreflight.appliesTo("ios", "mac-os-x-native"));
+        assertFalse(IOSProvisioningPreflight.appliesTo("javascript", "javascript"));
+        assertFalse(IOSProvisioningPreflight.appliesTo("android", "android-device"));
+        assertFalse(IOSProvisioningPreflight.appliesTo(null, "ios-device"));
+        assertFalse(IOSProvisioningPreflight.appliesTo("ios", null));
+    }
+
+    /** On-device debug signs with the DEBUG profile, like every non-release target. */
+    @Test
+    public void onlyTheReleaseTargetUsesTheReleaseProfile() {
+        assertTrue(IOSProvisioningPreflight.isReleaseTarget("ios-device-release"));
+        assertFalse(IOSProvisioningPreflight.isReleaseTarget("ios-device"));
+        assertFalse(IOSProvisioningPreflight.isReleaseTarget("ios-on-device-debug"));
+        assertFalse(IOSProvisioningPreflight.isReleaseTarget(null));
+
+        assertEquals("codename1.ios.debug.provision",
+                IOSProvisioningPreflight.provisioningProfileSettingKey(
+                        IOSProvisioningPreflight.isReleaseTarget("ios-on-device-debug")));
+    }
+
     // ---- the mismatch decision waits for the merged settings ----
 
     /**

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/IOSProvisioningPreflightTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/IOSProvisioningPreflightTest.java
@@ -249,6 +249,57 @@ public class IOSProvisioningPreflightTest {
         assertTrue(parsed.expirationDate.after(new Date()));
     }
 
+    // ---- the mismatch decision waits for the merged settings ----
+
+    /**
+     * A CN1Lib can supply {@code codename1.arg.ios.release.distributionMethod} through its
+     * appended/required properties, and the mojo merges those only later. Judging the profile
+     * kind before that merge would refuse an Ad Hoc profile against the release default of
+     * app-store -- a build the merge was about to make correct. So the early pass reads the
+     * file and stops short of the comparison.
+     */
+    @Test
+    public void earlyPassDoesNotJudgeTheMethodALibraryCouldStillSupply() throws Exception {
+        Properties beforeMerge = settings(write(adHoc("AdHoc")), true, null);
+        assertTrue("the early pass must not refuse on a method the merge can still change",
+                IOSProvisioningPreflight.checkProfileFile(beforeMerge, true, new Date()).isEmpty());
+
+        // the same settings, once the library's property has been merged in: still fine
+        Properties afterMerge = new Properties();
+        afterMerge.putAll(beforeMerge);
+        afterMerge.setProperty("codename1.arg.ios.release.distributionMethod", "ad-hoc");
+        assertTrue("a library-supplied method that matches must not be refused",
+                check(afterMerge, true).isEmpty());
+    }
+
+    /** The early pass still fails what the merge cannot fix. */
+    @Test
+    public void earlyPassStillCatchesAnUnusableFile() throws Exception {
+        File garbage = writeRaw("not a profile".getBytes("UTF-8"));
+        List<IOSProvisioningPreflight.Problem> problems =
+                IOSProvisioningPreflight.checkProfileFile(settings(garbage, true, null), true, new Date());
+        assertFalse(problems.isEmpty());
+        assertTrue(problems.get(0).fatal);
+
+        File missing = new File(System.getProperty("java.io.tmpdir"), "absent.mobileprovision");
+        Properties p = new Properties();
+        p.setProperty(IOSProvisioningPreflight.provisioningProfileSettingKey(true), missing.getAbsolutePath());
+        assertTrue(IOSProvisioningPreflight.checkProfileFile(p, true, new Date()).get(0).fatal);
+    }
+
+    /** No profile configured yet is not the early pass's business -- the merge may supply one. */
+    @Test
+    public void earlyPassIsSilentWhenNoProfileIsConfiguredYet() {
+        assertTrue(IOSProvisioningPreflight.checkProfileFile(new Properties(), true, new Date()).isEmpty());
+    }
+
+    /** The merged pass is the one that catches the real mismatch. */
+    @Test
+    public void mergedPassCatchesTheMismatch() throws Exception {
+        Properties merged = settings(write(appStore("HBZ_PROD_DISTRIBUTION")), true, "ad-hoc");
+        assertFatal(check(merged, true), "HBZ_PROD_DISTRIBUTION", "App Store distribution");
+    }
+
     // ---- a profile is untrusted input ----
 
     /**

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/IOSProvisioningPreflightTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/IOSProvisioningPreflightTest.java
@@ -249,6 +249,59 @@ public class IOSProvisioningPreflightTest {
         assertTrue(parsed.expirationDate.after(new Date()));
     }
 
+    // ---- Ant placeholders in the path ----
+
+    /**
+     * A profile path is routinely written as {@code ${user.home}/certs/dev.mobileprovision},
+     * and Ant expands it before the build task sees it. Handing the literal string to
+     * {@code new File} would report a perfectly good profile as missing and refuse a build
+     * that works today.
+     */
+    @Test
+    public void expandsAPlaceholderInTheProfilePath() throws Exception {
+        File profile = write(appStore("Store"));
+        Properties p = new Properties();
+        p.setProperty("certs.dir", profile.getParent());
+        p.setProperty(IOSProvisioningPreflight.provisioningProfileSettingKey(true),
+                "${certs.dir}/" + profile.getName());
+        p.setProperty("codename1.arg.ios.release.distributionMethod", "app-store");
+        assertTrue("an expandable path must be read, not reported missing",
+                check(p, true).isEmpty());
+    }
+
+    /** System properties are part of that context -- {@code user.home} lives there. */
+    @Test
+    public void expandsSystemPropertiesToo() {
+        assertEquals(System.getProperty("user.home") + "/certs/dev.mobileprovision",
+                IOSProvisioningPreflight.resolvePlaceholders(
+                        "${user.home}/certs/dev.mobileprovision", new Properties()));
+    }
+
+    /** A path this code cannot expand is a path it may not judge. */
+    @Test
+    public void aPathItCannotResolveIsNotRefused() {
+        Properties p = new Properties();
+        p.setProperty(IOSProvisioningPreflight.provisioningProfileSettingKey(true),
+                "${some.ant.property.only.ant.knows}/dev.mobileprovision");
+        assertTrue("an unresolvable placeholder must not fail the build",
+                check(p, true).isEmpty());
+        assertTrue(IOSProvisioningPreflight.checkProfileFile(p, true, new Date()).isEmpty());
+    }
+
+    /** A self-referential property must not spin. */
+    @Test
+    public void resolutionTerminates() {
+        Properties p = new Properties();
+        p.setProperty("a", "${a}");
+        assertEquals("${a}", IOSProvisioningPreflight.resolvePlaceholders("${a}", p));
+    }
+
+    @Test
+    public void leavesAnOrdinaryPathAlone() {
+        assertEquals("/certs/dev.mobileprovision",
+                IOSProvisioningPreflight.resolvePlaceholders("/certs/dev.mobileprovision", new Properties()));
+    }
+
     // ---- which builds this applies to ----
 
     /**

--- a/maven/core-unittests/src/test/java/com/codename1/health/sensors/BleSensorReconnectTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/health/sensors/BleSensorReconnectTest.java
@@ -644,6 +644,163 @@ class BleSensorReconnectTest extends UITestBase {
     }
 
     /**
+     * A partly successful write must not leave its committed samples
+     * behind in the attempt tally.
+     *
+     * <p>{@code uncommitted()} drops the committed prefix before the
+     * retry bookkeeping runs, and the tally was only cleared for samples
+     * this class explicitly dropped. So every partial failure left the
+     * records that DID reach the store sitting in the identity map,
+     * strongly referenced, for as long as the session streamed -- a map
+     * that only ever grew on a long ride with a flaky store.</p>
+     */
+    @Test
+    void aPartlyCommittedWriteDoesNotAccumulateAttempts() throws Exception {
+        FlakyPrefixStore store = new FlakyPrefixStore();
+        com.codename1.health.Health health =
+                new com.codename1.health.Health() {
+                    @Override
+                    public boolean isSupported() {
+                        return true;
+                    }
+
+                    @Override
+                    public com.codename1.health.HealthStore getStore() {
+                        return store;
+                    }
+                };
+        implementation.setHealth(health);
+        try {
+            FakePeripheral p = new FakePeripheral();
+            SensorSessionOptions options = new SensorSessionOptions()
+                    .setWriteToStore(true)
+                    .setStoreBatchMillis(10);
+            BleSensorSession session = new BleSensorSession("fake",
+                    HealthSensorProfile.HEART_RATE, options, p);
+            started.add(session);
+            AsyncResource<SensorSession> out =
+                    new AsyncResource<SensorSession>();
+            session.start(out);
+            flushSerialCalls();
+
+            // The low reading fails once and is committed on its next
+            // attempt, in the same write whose later chunk fails -- so it
+            // is a committed prefix of a failed write, and it already had
+            // a tally entry from the attempt before.
+            for (int round = 0; round < 4; round++) {
+                p.notifyHeartRate(70 + round * 10);
+                p.notifyHeartRate(72 + round * 10);
+                flushSerialCalls();
+                pump(200);
+            }
+
+            // The tally may hold what is still waiting to be written; it
+            // may not hold what already reached the store.
+            assertTrue(writeAttemptCount(session) <= pendingWriteCount(session),
+                    "the attempt tally kept "
+                            + writeAttemptCount(session) + " samples with only "
+                            + pendingWriteCount(session)
+                            + " still pending -- the committed ones leaked");
+        } finally {
+            implementation.setHealth(null);
+        }
+    }
+
+    private static int writeAttemptCount(SensorSession session)
+            throws Exception {
+        return sizeOfField(session, "writeAttempts");
+    }
+
+    private static int pendingWriteCount(SensorSession session)
+            throws Exception {
+        return sizeOfField(session, "pendingWrites");
+    }
+
+    /** Reads a private collection's size -- the tally has no getter. */
+    private static int sizeOfField(SensorSession session, String name)
+            throws Exception {
+        java.lang.reflect.Field f =
+                SensorSession.class.getDeclaredField(name);
+        f.setAccessible(true);
+        Object value = f.get(session);
+        if (value instanceof java.util.Map) {
+            java.util.Map<?, ?> m = (java.util.Map<?, ?>) value;
+            synchronized (value) {
+                return m.size();
+            }
+        }
+        java.util.Collection<?> c = (java.util.Collection<?>) value;
+        synchronized (value) {
+            return c.size();
+        }
+    }
+
+    /**
+     * Writes one record at a time. The even readings fail their first
+     * attempt and are committed on the next; the odd ones never succeed.
+     * So a retried batch commits a sample that already carries a failed
+     * attempt, and then fails -- which is the partial-commit case.
+     */
+    private static final class FlakyPrefixStore
+            extends com.codename1.health.HealthStore {
+
+        /// Offered counts per reading, touched from the flush thread.
+        private final java.util.Map<Integer, Integer> offers =
+                new java.util.HashMap<Integer, Integer>();
+
+        @Override
+        public boolean isSupported() {
+            return true;
+        }
+
+        @Override
+        public boolean isTypeSupported(
+                com.codename1.health.HealthDataType type) {
+            return true;
+        }
+
+        @Override
+        public boolean isWritable(
+                com.codename1.health.HealthDataType type) {
+            return true;
+        }
+
+        /** One record per chunk, so the batch splits sample by sample. */
+        @Override
+        public int getMaxWriteBatchSize() {
+            return 1;
+        }
+
+        @Override
+        protected void doWrite(
+                java.util.List<com.codename1.health.HealthSample> samples,
+                AsyncResource<com.codename1.health.HealthWriteResult> out) {
+            com.codename1.health.QuantitySample q =
+                    (com.codename1.health.QuantitySample) samples.get(0);
+            int bpm = (int) Math.round(q.getQuantity().getValue(
+                    com.codename1.health.HealthUnit.COUNT_PER_MINUTE));
+            int times;
+            synchronized (offers) {
+                Integer prev = offers.get(Integer.valueOf(bpm));
+                times = (prev == null ? 0 : prev.intValue()) + 1;
+                offers.put(Integer.valueOf(bpm), Integer.valueOf(times));
+            }
+            if (bpm % 2 != 0 || times < 2) {
+                out.error(new com.codename1.health.HealthException(
+                        com.codename1.health.HealthError
+                                .DATABASE_INACCESSIBLE,
+                        "scripted failure for " + bpm + " on attempt "
+                                + times));
+                return;
+            }
+            com.codename1.health.HealthWriteResult r =
+                    new com.codename1.health.HealthWriteResult();
+            r.addSampleId("committed-" + bpm);
+            out.complete(r);
+        }
+    }
+
+    /**
      * A session that has ended must not keep retrying its store writes.
      *
      * <p>The re-arm guard tested only for STOPPED, but the reconnect

--- a/maven/core-unittests/src/test/java/com/codename1/health/sensors/BleSensorReconnectTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/health/sensors/BleSensorReconnectTest.java
@@ -828,9 +828,12 @@ class BleSensorReconnectTest extends UITestBase {
                 offered++;
             }
             if (bpm % 2 != 0 || times < 2) {
+                // A permanent code on purpose: DATABASE_INACCESSIBLE is
+                // retryable, so it is held rather than counted, and this
+                // test is about what happens to samples that run out of
+                // attempts.
                 out.error(new com.codename1.health.HealthException(
-                        com.codename1.health.HealthError
-                                .DATABASE_INACCESSIBLE,
+                        com.codename1.health.HealthError.INVALID_DATA,
                         "scripted failure for " + bpm + " on attempt "
                                 + times));
                 return;
@@ -936,6 +939,155 @@ class BleSensorReconnectTest extends UITestBase {
         public boolean isWritable(
                 com.codename1.health.HealthDataType type) {
             return writable;
+        }
+    }
+
+    /**
+     * A locked device must not cost the wearer their readings.
+     *
+     * <p>iOS raises {@code DATABASE_INACCESSIBLE} for as long as the
+     * device is locked -- which is exactly when a background observer
+     * fires -- and the docs call it retryable once it unlocks. The
+     * attempt cap counted those failures like any other, so at the
+     * default one-minute batch interval a device locked for three minutes
+     * discarded its samples for good, even though the very next write
+     * would have succeeded.</p>
+     */
+    @Test
+    void aLockedDeviceKeepsItsReadings() throws Exception {
+        LockedStore store = new LockedStore();
+        com.codename1.health.Health health =
+                new com.codename1.health.Health() {
+                    @Override
+                    public boolean isSupported() {
+                        return true;
+                    }
+
+                    @Override
+                    public com.codename1.health.HealthStore getStore() {
+                        return store;
+                    }
+                };
+        implementation.setHealth(health);
+        try {
+            FakePeripheral p = new FakePeripheral();
+            SensorSessionOptions options = new SensorSessionOptions()
+                    .setWriteToStore(true)
+                    .setStoreBatchMillis(10);
+            BleSensorSession session = new BleSensorSession("fake",
+                    HealthSensorProfile.HEART_RATE, options, p);
+            started.add(session);
+            AsyncResource<SensorSession> out =
+                    new AsyncResource<SensorSession>();
+            session.start(out);
+            flushSerialCalls();
+
+            p.notifyHeartRate(72);
+            flushSerialCalls();
+
+            // Well past the three attempts that retire a permanent
+            // failure. The sample must still be there.
+            for (int i = 0; i < 40 && store.attempts() <= MAX_ATTEMPTS; i++) {
+                pump(100);
+            }
+            assertTrue(store.attempts() > MAX_ATTEMPTS,
+                    "the locked store should have been retried more than"
+                            + " the attempt cap, saw " + store.attempts());
+
+            // And when the device unlocks, the reading is written rather
+            // than long gone.
+            store.unlock();
+            for (int i = 0; i < 60 && !store.wrote(72); i++) {
+                pump(100);
+            }
+            assertTrue(store.wrote(72),
+                    "the reading should have been written once the store"
+                            + " came back");
+        } finally {
+            implementation.setHealth(null);
+        }
+    }
+
+    /** The cap SensorSession applies to permanent failures. */
+    private static final int MAX_ATTEMPTS = 3;
+
+    /**
+     * A store that is locked, as iOS is until first unlock: every write
+     * fails with the retryable DATABASE_INACCESSIBLE until it is opened.
+     */
+    private static final class LockedStore
+            extends com.codename1.health.HealthStore {
+
+        private final Object lock = new Object();
+        private boolean locked = true;
+        private int attempts;
+        private final java.util.List<Integer> written =
+                new ArrayList<Integer>();
+
+        void unlock() {
+            synchronized (lock) {
+                locked = false;
+            }
+        }
+
+        int attempts() {
+            synchronized (lock) {
+                return attempts;
+            }
+        }
+
+        boolean wrote(int bpm) {
+            synchronized (lock) {
+                return written.contains(Integer.valueOf(bpm));
+            }
+        }
+
+        @Override
+        public boolean isSupported() {
+            return true;
+        }
+
+        @Override
+        public boolean isTypeSupported(
+                com.codename1.health.HealthDataType type) {
+            return true;
+        }
+
+        /** True even while locked -- which is what iOS reports. */
+        @Override
+        public boolean isWritable(
+                com.codename1.health.HealthDataType type) {
+            return true;
+        }
+
+        @Override
+        protected void doWrite(
+                java.util.List<com.codename1.health.HealthSample> samples,
+                AsyncResource<com.codename1.health.HealthWriteResult> out) {
+            boolean shut;
+            synchronized (lock) {
+                attempts++;
+                shut = locked;
+                if (!shut) {
+                    for (com.codename1.health.HealthSample s : samples) {
+                        if (s instanceof com.codename1.health.QuantitySample) {
+                            written.add(Integer.valueOf((int) Math.round(
+                                    ((com.codename1.health.QuantitySample) s)
+                                            .getQuantity().getValue(
+                                            com.codename1.health.HealthUnit
+                                                    .COUNT_PER_MINUTE))));
+                        }
+                    }
+                }
+            }
+            if (shut) {
+                out.error(new com.codename1.health.HealthException(
+                        com.codename1.health.HealthError
+                                .DATABASE_INACCESSIBLE,
+                        "the device is locked"));
+                return;
+            }
+            out.complete(new com.codename1.health.HealthWriteResult());
         }
     }
 

--- a/maven/core-unittests/src/test/java/com/codename1/health/sensors/BleSensorReconnectTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/health/sensors/BleSensorReconnectTest.java
@@ -467,13 +467,18 @@ class BleSensorReconnectTest extends UITestBase {
         }
     }
 
-    /** Pumps the EDT for a while and reports the store's write count. */
+    /**
+     * Pumps the EDT for a while and reports the store's write count.
+     *
+     * <p>The slice is 100ms rather than 10ms because every flush is a blocking round trip to
+     * the EDT, and on the JDK 8 CI leg one costs on the order of a second where it costs
+     * milliseconds locally and on JDK 17/21. At 10ms slices this class issued ~500 of them and
+     * took 839s there against 9.5s locally -- which is what pushed the job past its 60-minute
+     * timeout. What the test needs is wall-clock time for the timers to fire and a drain
+     * afterwards, not a drain every 10ms.
+     */
     private int pumpFor(long millis, WriteCounter store) throws Exception {
-        long until = System.currentTimeMillis() + millis;
-        while (System.currentTimeMillis() < until) {
-            flushSerialCalls();
-            Thread.sleep(10);
-        }
+        pump(millis);
         return store.writeCount();
     }
 
@@ -728,12 +733,15 @@ class BleSensorReconnectTest extends UITestBase {
         flushSerialCalls();
     }
 
-    /** Pumps the EDT for a while so timers can fire. */
+    /**
+     * Pumps the EDT for a while so timers can fire -- see {@link #pumpFor} for why the slice
+     * is 100ms and not 10ms.
+     */
     private void pump(long millis) throws Exception {
         long until = System.currentTimeMillis() + millis;
         while (System.currentTimeMillis() < until) {
+            Thread.sleep(Math.min(100, Math.max(1, until - System.currentTimeMillis())));
             flushSerialCalls();
-            Thread.sleep(10);
         }
     }
 

--- a/maven/core-unittests/src/test/java/com/codename1/health/sensors/BleSensorReconnectTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/health/sensors/BleSensorReconnectTest.java
@@ -694,44 +694,66 @@ class BleSensorReconnectTest extends UITestBase {
                 pump(200);
             }
 
-            // The tally may hold what is still waiting to be written; it
-            // may not hold what already reached the store.
-            assertTrue(writeAttemptCount(session) <= pendingWriteCount(session),
-                    "the attempt tally kept "
-                            + writeAttemptCount(session) + " samples with only "
-                            + pendingWriteCount(session)
-                            + " still pending -- the committed ones leaked");
+            // Wait for the writes to stop before looking at the books.
+            // The retry timer claims a batch by emptying the buffer and
+            // only settles the tally when that write comes back, so a
+            // comparison taken mid-flight sees attempts without their
+            // pending samples and fails for a leak that is not there.
+            awaitQuietStore(store);
+
+            // One snapshot, under the monitor the production code takes,
+            // so a retry cannot move one number between the two reads.
+            int[] books = attemptsAndPending(session);
+            assertEquals(0, books[1],
+                    "every sample should have been committed or dropped by"
+                            + " now; " + books[1] + " are still pending");
+            assertEquals(0, books[0],
+                    "the attempt tally kept " + books[0] + " samples with"
+                            + " nothing pending -- the committed ones"
+                            + " leaked");
         } finally {
             implementation.setHealth(null);
         }
     }
 
-    private static int writeAttemptCount(SensorSession session)
-            throws Exception {
-        return sizeOfField(session, "writeAttempts");
-    }
-
-    private static int pendingWriteCount(SensorSession session)
-            throws Exception {
-        return sizeOfField(session, "pendingWrites");
-    }
-
-    /** Reads a private collection's size -- the tally has no getter. */
-    private static int sizeOfField(SensorSession session, String name)
-            throws Exception {
-        java.lang.reflect.Field f =
-                SensorSession.class.getDeclaredField(name);
-        f.setAccessible(true);
-        Object value = f.get(session);
-        if (value instanceof java.util.Map) {
-            java.util.Map<?, ?> m = (java.util.Map<?, ?>) value;
-            synchronized (value) {
-                return m.size();
+    /**
+     * Pumps until the store has been left alone for a while, so nothing
+     * is in flight when the books are read. Bounded, so a session that
+     * never settles fails the test rather than hanging it.
+     */
+    private void awaitQuietStore(FlakyPrefixStore store) throws Exception {
+        for (int i = 0; i < 40; i++) {
+            int before = store.offerCount();
+            pump(200);
+            if (store.offerCount() == before) {
+                return;
             }
         }
-        java.util.Collection<?> c = (java.util.Collection<?>) value;
-        synchronized (value) {
-            return c.size();
+        fail("the store was still being written to after 8s");
+    }
+
+    /**
+     * The tally size and the pending-buffer size, read together while
+     * holding the monitor the session takes for both -- so this cannot
+     * catch a retry halfway through moving samples from one to the other.
+     * Reflection because neither has a getter, and neither should.
+     *
+     * @return {tally size, pending size}
+     */
+    private static int[] attemptsAndPending(SensorSession session)
+            throws Exception {
+        java.lang.reflect.Field attemptsField =
+                SensorSession.class.getDeclaredField("writeAttempts");
+        attemptsField.setAccessible(true);
+        java.lang.reflect.Field pendingField =
+                SensorSession.class.getDeclaredField("pendingWrites");
+        pendingField.setAccessible(true);
+        java.util.Map<?, ?> attempts =
+                (java.util.Map<?, ?>) attemptsField.get(session);
+        java.util.Collection<?> pending =
+                (java.util.Collection<?>) pendingField.get(session);
+        synchronized (pending) {
+            return new int[] {attempts.size(), pending.size()};
         }
     }
 
@@ -747,6 +769,16 @@ class BleSensorReconnectTest extends UITestBase {
         /// Offered counts per reading, touched from the flush thread.
         private final java.util.Map<Integer, Integer> offers =
                 new java.util.HashMap<Integer, Integer>();
+
+        /// Total writes handed to this store, so the test can tell when
+        /// the session has stopped trying.
+        private int offered;
+
+        int offerCount() {
+            synchronized (offers) {
+                return offered;
+            }
+        }
 
         @Override
         public boolean isSupported() {
@@ -784,6 +816,7 @@ class BleSensorReconnectTest extends UITestBase {
                 Integer prev = offers.get(Integer.valueOf(bpm));
                 times = (prev == null ? 0 : prev.intValue()) + 1;
                 offers.put(Integer.valueOf(bpm), Integer.valueOf(times));
+                offered++;
             }
             if (bpm % 2 != 0 || times < 2) {
                 out.error(new com.codename1.health.HealthException(

--- a/maven/core-unittests/src/test/java/com/codename1/health/sensors/BleSensorReconnectTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/health/sensors/BleSensorReconnectTest.java
@@ -387,6 +387,87 @@ class BleSensorReconnectTest extends UITestBase {
     }
 
     /**
+     * A store that keeps refusing must not be asked forever.
+     *
+     * <p>A running session put the failed batch back and re-armed the
+     * timer on every failure, so the same samples went out every
+     * storeBatchMillis for as long as it streamed -- at the 10ms interval
+     * used here, a hundred writes and a hundred error callbacks a second,
+     * on a device whose store had a revoked permission or no room left.
+     * It also kept the EDT permanently non-idle, which is what made this
+     * class take 839s on one CI leg against 9.5s locally, and eventually
+     * blew a 60-minute job.</p>
+     *
+     * <p>The unwritable-type case was already dropped rather than
+     * retried; this is the same failure where the type is writable and
+     * the store still says no.</p>
+     */
+    @Test
+    void aRefusingStoreIsNotRetriedForever() throws Exception {
+        CountingStore store = new CountingStore();
+        com.codename1.health.Health health =
+                new com.codename1.health.Health() {
+                    @Override
+                    public boolean isSupported() {
+                        return true;
+                    }
+
+                    @Override
+                    public com.codename1.health.HealthStore getStore() {
+                        return store;
+                    }
+                };
+        implementation.setHealth(health);
+        try {
+            FakePeripheral p = new FakePeripheral();
+            SensorSessionOptions options = new SensorSessionOptions()
+                    .setWriteToStore(true)
+                    .setStoreBatchMillis(10);
+            BleSensorSession session = new BleSensorSession("fake",
+                    HealthSensorProfile.HEART_RATE, options, p);
+            started.add(session);
+            AsyncResource<SensorSession> out =
+                    new AsyncResource<SensorSession>();
+            session.start(out);
+            flushSerialCalls();
+            assertEquals(SensorSessionState.STREAMING, session.getState());
+
+            p.notifyHeartRate(72);
+            flushSerialCalls();
+
+            // The batch is attempted, and attempted again -- a store that
+            // is merely busy deserves that much.
+            int attempts = pumpFor(200, store);
+            assertTrue(attempts > 1,
+                    "a failed batch should be retried at least once, saw "
+                            + attempts);
+
+            // ...but the retries stop, while the session is still
+            // streaming. Without the bound this count climbs for as long
+            // as the test is willing to wait.
+            assertEquals(SensorSessionState.STREAMING, session.getState(),
+                    "giving up on the batch must not end the session");
+            int settled = pumpFor(300, store);
+            assertEquals(settled, pumpFor(300, store),
+                    "a refusing store must stop being retried; it was"
+                            + " asked again");
+            assertTrue(settled <= 6,
+                    "the ladder should be bounded, saw " + settled
+                            + " attempts");
+
+            // A later reading is still offered to the store: what is
+            // dropped is the batch, not the session.
+            int beforeNewSample = store.writeCount();
+            p.notifyHeartRate(73);
+            flushSerialCalls();
+            assertTrue(pumpFor(200, store) > beforeNewSample,
+                    "a new reading should still be attempted");
+        } finally {
+            implementation.setHealth(null);
+        }
+    }
+
+    /**
      * A session that has ended must not keep retrying its store writes.
      *
      * <p>The re-arm guard tested only for STOPPED, but the reconnect

--- a/maven/core-unittests/src/test/java/com/codename1/health/sensors/BleSensorReconnectTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/health/sensors/BleSensorReconnectTest.java
@@ -468,6 +468,182 @@ class BleSensorReconnectTest extends UITestBase {
     }
 
     /**
+     * A reading that arrives while the store is down keeps its own
+     * attempts.
+     *
+     * <p>A failed batch goes back at the head of the buffer, so the next
+     * flush claims it together with whatever arrived meanwhile. Counting
+     * failures per session rather than per sample meant the tally hit its
+     * limit on the oldest samples and threw the newest away with them --
+     * health data discarded after a single attempt, which is worse than
+     * the retry storm the bound was added to stop.</p>
+     *
+     * <p>Driven a write at a time rather than on a timer: the point is
+     * what happens to a reading that joins a batch already two attempts
+     * in, and only holding each write open makes that arrangement
+     * certain rather than lucky.</p>
+     */
+    @Test
+    void aNewReadingIsNotDiscardedWithAnOlderBatch() throws Exception {
+        DeferredRefusingStore store = new DeferredRefusingStore();
+        com.codename1.health.Health health =
+                new com.codename1.health.Health() {
+                    @Override
+                    public boolean isSupported() {
+                        return true;
+                    }
+
+                    @Override
+                    public com.codename1.health.HealthStore getStore() {
+                        return store;
+                    }
+                };
+        implementation.setHealth(health);
+        try {
+            FakePeripheral p = new FakePeripheral();
+            SensorSessionOptions options = new SensorSessionOptions()
+                    .setWriteToStore(true)
+                    .setStoreBatchMillis(10);
+            BleSensorSession session = new BleSensorSession("fake",
+                    HealthSensorProfile.HEART_RATE, options, p);
+            started.add(session);
+            AsyncResource<SensorSession> out =
+                    new AsyncResource<SensorSession>();
+            session.start(out);
+            flushSerialCalls();
+
+            // The first reading spends two of its three attempts.
+            p.notifyHeartRate(72);
+            flushSerialCalls();
+            assertTrue(awaitWrite(store).contains(72),
+                    "the first reading should have been offered");
+            store.failPending();
+            assertTrue(awaitWrite(store).contains(72),
+                    "a failed batch should be retried");
+            store.failPending();
+
+            // The second reading joins the batch the first is most of the
+            // way through.
+            p.notifyHeartRate(73);
+            flushSerialCalls();
+            java.util.List<Integer> merged = awaitWrite(store);
+            assertTrue(merged.contains(72) && merged.contains(73),
+                    "the new reading should be batched with the old one,"
+                            + " saw " + merged);
+            store.failPending();
+
+            // That failure was the first reading's third: it is dropped.
+            // The second has had one attempt and must still be offered.
+            java.util.List<Integer> afterDrop = awaitWrite(store);
+            assertTrue(afterDrop.contains(73),
+                    "the newer reading must keep its own attempts rather"
+                            + " than be discarded with the older one, saw "
+                            + afterDrop);
+            assertFalse(afterDrop.contains(72),
+                    "the older reading has used its attempts and should be"
+                            + " gone, saw " + afterDrop);
+        } finally {
+            store.failPending();
+            implementation.setHealth(null);
+        }
+    }
+
+    /**
+     * Pumps until the store is handed a batch, and reports what was in
+     * it. Bounded, so a batch that never arrives fails the test rather
+     * than hanging it.
+     */
+    private java.util.List<Integer> awaitWrite(DeferredRefusingStore store)
+            throws Exception {
+        for (int i = 0; i < 40; i++) {
+            java.util.List<Integer> batch = store.pendingBatch();
+            if (batch != null) {
+                return batch;
+            }
+            pump(50);
+        }
+        fail("the store was never handed a batch");
+        return null;
+    }
+
+    /**
+     * A store that refuses everything, one write at a time: it holds each
+     * write open until the test fails it, so the test decides exactly
+     * which samples are in flight together.
+     */
+    private static final class DeferredRefusingStore
+            extends com.codename1.health.HealthStore {
+
+        /// Both fields are written on whichever thread the flush runs on
+        /// and read by the test thread.
+        private final Object lock = new Object();
+        private AsyncResource<com.codename1.health.HealthWriteResult>
+                pending;
+        private java.util.List<Integer> pendingSamples;
+
+        /// The readings in the write currently open, or null if none is.
+        java.util.List<Integer> pendingBatch() {
+            synchronized (lock) {
+                return pendingSamples == null ? null
+                        : new java.util.ArrayList<Integer>(pendingSamples);
+            }
+        }
+
+        /// Refuses the open write, if there is one.
+        void failPending() {
+            AsyncResource<com.codename1.health.HealthWriteResult> out;
+            synchronized (lock) {
+                out = pending;
+                pending = null;
+                pendingSamples = null;
+            }
+            if (out != null) {
+                out.error(new com.codename1.health.HealthException(
+                        com.codename1.health.HealthError.UNKNOWN,
+                        "this store refuses everything"));
+            }
+        }
+
+        @Override
+        public boolean isSupported() {
+            return true;
+        }
+
+        @Override
+        public boolean isTypeSupported(
+                com.codename1.health.HealthDataType type) {
+            return true;
+        }
+
+        @Override
+        public boolean isWritable(
+                com.codename1.health.HealthDataType type) {
+            return true;
+        }
+
+        @Override
+        protected void doWrite(
+                java.util.List<com.codename1.health.HealthSample> samples,
+                AsyncResource<com.codename1.health.HealthWriteResult> out) {
+            java.util.List<Integer> bpms =
+                    new java.util.ArrayList<Integer>();
+            for (com.codename1.health.HealthSample sample : samples) {
+                if (sample instanceof com.codename1.health.QuantitySample) {
+                    double bpm = ((com.codename1.health.QuantitySample)
+                            sample).getQuantity().getValue(
+                            com.codename1.health.HealthUnit
+                                    .COUNT_PER_MINUTE);
+                    bpms.add(Integer.valueOf((int) Math.round(bpm)));
+                }
+            }
+            synchronized (lock) {
+                pending = out;
+                pendingSamples = bpms;
+            }
+        }
+    }
+
+    /**
      * A session that has ended must not keep retrying its store writes.
      *
      * <p>The re-arm guard tested only for STOPPED, but the reconnect

--- a/maven/core-unittests/src/test/java/com/codename1/health/sensors/BleSensorReconnectTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/health/sensors/BleSensorReconnectTest.java
@@ -571,8 +571,16 @@ class BleSensorReconnectTest extends UITestBase {
      * write open until the test fails it, so the test decides exactly
      * which samples are in flight together.
      */
-    private static final class DeferredRefusingStore
+    private static class DeferredRefusingStore
             extends com.codename1.health.HealthStore {
+
+        private int offers;
+
+        int offerCount() {
+            synchronized (lock) {
+                return offers;
+            }
+        }
 
         /// Both fields are written on whichever thread the flush runs on
         /// and read by the test thread.
@@ -639,6 +647,7 @@ class BleSensorReconnectTest extends UITestBase {
             synchronized (lock) {
                 pending = out;
                 pendingSamples = bpms;
+                offers++;
             }
         }
     }
@@ -830,6 +839,103 @@ class BleSensorReconnectTest extends UITestBase {
                     new com.codename1.health.HealthWriteResult();
             r.addSampleId("committed-" + bpm);
             out.complete(r);
+        }
+    }
+
+    /**
+     * A store that stops accepting the type must not leave the samples it
+     * already failed in the attempt tally.
+     *
+     * <p>When nothing in a batch is retryable any more the callback
+     * reports the error and returns early, and that return skipped the
+     * bookkeeping. A sample that had failed once already carried a tally
+     * entry, so it stayed referenced for the life of the session -- and a
+     * provider that comes and goes, which is exactly what Health Connect
+     * does when its SDK status changes or a permission is revoked
+     * mid-ride, accumulated one per round.</p>
+     */
+    @Test
+    void aStoreThatStopsAcceptingTheTypeDropsItsTally() throws Exception {
+        WithdrawingStore store = new WithdrawingStore();
+        com.codename1.health.Health health =
+                new com.codename1.health.Health() {
+                    @Override
+                    public boolean isSupported() {
+                        return true;
+                    }
+
+                    @Override
+                    public com.codename1.health.HealthStore getStore() {
+                        return store;
+                    }
+                };
+        implementation.setHealth(health);
+        try {
+            FakePeripheral p = new FakePeripheral();
+            SensorSessionOptions options = new SensorSessionOptions()
+                    .setWriteToStore(true)
+                    .setStoreBatchMillis(10);
+            BleSensorSession session = new BleSensorSession("fake",
+                    HealthSensorProfile.HEART_RATE, options, p);
+            started.add(session);
+            AsyncResource<SensorSession> out =
+                    new AsyncResource<SensorSession>();
+            session.start(out);
+            flushSerialCalls();
+
+            // One failure while the type is still writable, so the sample
+            // earns a tally entry. Driven a write at a time: on the timer
+            // the sample can burn all three attempts and be dropped before
+            // the type is withdrawn, and then there is nothing left to
+            // leak and the test passes whatever the code does.
+            p.notifyHeartRate(72);
+            flushSerialCalls();
+            assertTrue(awaitWrite(store).contains(72),
+                    "the sample should have been offered");
+            store.failPending();
+
+            // The retry claims it again. This write has to be in flight
+            // BEFORE the type is withdrawn: once it is not writable, the
+            // flush is refused before it ever reaches the store, and the
+            // callback that clears the tally never runs.
+            assertTrue(awaitWrite(store).contains(72),
+                    "the requeued sample should have been offered again");
+
+            // The store stops accepting the type while that write is out.
+            // Failing it now is what leaves the callback with nothing
+            // retryable -- the path that used to return without clearing
+            // anything.
+            store.withdrawType();
+            store.failPending();
+            pump(300);
+
+            int[] books = attemptsAndPending(session);
+            assertEquals(0, books[0],
+                    "the tally kept " + books[0] + " samples after the store"
+                            + " stopped accepting the type");
+        } finally {
+            implementation.setHealth(null);
+        }
+    }
+
+    /**
+     * A {@link DeferredRefusingStore} that can also stop accepting the
+     * type, so a test can put the session in the state where a failure
+     * leaves nothing retryable.
+     */
+    private static final class WithdrawingStore
+            extends DeferredRefusingStore {
+
+        private volatile boolean writable = true;
+
+        void withdrawType() {
+            writable = false;
+        }
+
+        @Override
+        public boolean isWritable(
+                com.codename1.health.HealthDataType type) {
+            return writable;
         }
     }
 

--- a/maven/core-unittests/src/test/java/com/codename1/ui/DisplayTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/DisplayTest.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.ui;
 
 import com.codename1.junit.FormTest;

--- a/maven/core-unittests/src/test/java/com/codename1/ui/DisplayTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/DisplayTest.java
@@ -78,10 +78,17 @@ public class DisplayTest extends UITestBase {
         // longer see. Only the deadline is new. The latch is what makes the EDT's write to it
         // visible here, and reports whether the runnable ever ran.
         final CountDownLatch done = new CountDownLatch(1);
+        final Throwable[] failure = new Throwable[1];
         display.callSeriallyAndWait(new Runnable() {
             public void run() {
                 try {
                     display.flushEdt();
+                } catch (Throwable t) {
+                    // Caught rather than allowed to escape. An exception leaving here never
+                    // reaches the test thread -- RunnableWrapper would not mark itself done,
+                    // so the wait below would burn its full timeout and then find a counted-down
+                    // latch and report success, losing the failure and charging 30s for it.
+                    failure[0] = t;
                 } finally {
                     done.countDown();
                 }
@@ -92,6 +99,22 @@ public class DisplayTest extends UITestBase {
                     + EDT_FLUSH_TIMEOUT_MS + "ms -- it is wedged, most likely on a lock held by"
                     + " a thread that is itself waiting for the EDT.\n" + dumpAllThreads());
         }
+        if (failure[0] != null) {
+            // Rethrown on the calling thread, so it fails the test that caused it rather than
+            // being logged on the EDT and surfacing as something confusing later in the suite.
+            rethrow(failure[0]);
+        }
+    }
+
+    /** Rethrows what the EDT threw, keeping its own stack as the cause. */
+    private static void rethrow(Throwable t) {
+        if (t instanceof RuntimeException) {
+            throw (RuntimeException) t;
+        }
+        if (t instanceof Error) {
+            throw (Error) t;
+        }
+        throw new IllegalStateException("The EDT flush failed: " + t, t);
     }
 
     /** Every live thread and where it is, for a wedge that has to be diagnosed from a CI log. */
@@ -111,6 +134,46 @@ public class DisplayTest extends UITestBase {
             sb.append('\n');
         }
         return sb.toString();
+    }
+
+    /**
+     * What the EDT throws must fail the test that caused it.
+     *
+     * <p>An {@code Error} -- which is what a JUnit assertion inside a
+     * queued runnable produces -- passes straight through
+     * {@code edtLoopImpl}, whose catch covers only
+     * {@code RuntimeException}. Letting it escape the runnable meant
+     * {@code RunnableWrapper} never marked itself done: the wait burned
+     * its full 30 seconds, then found the latch counted down and reported
+     * success. So an assertion that failed on the EDT cost half a minute
+     * and was recorded as a pass.</p>
+     */
+    @Test
+    void aFailureOnTheEdtReachesTheCallingThread() {
+        final AssertionError boom = new AssertionError("asserted on the EDT");
+        // Queued from inside another serial call, so it is still pending when the
+        // flush below starts and is processed by that flush rather than by the
+        // outer EDT loop -- which catches Throwable and only logs it.
+        Display.getInstance().callSerially(new Runnable() {
+            public void run() {
+                Display.getInstance().callSerially(new Runnable() {
+                    public void run() {
+                        throw boom;
+                    }
+                });
+            }
+        });
+
+        long started = System.currentTimeMillis();
+        try {
+            flushEdt();
+            fail("the error the EDT threw should have reached this thread");
+        } catch (AssertionError actual) {
+            assertSame(boom, actual,
+                    "the original error should arrive, not a substitute");
+        }
+        assertTrue(System.currentTimeMillis() - started < 5000,
+                "a failure should arrive at once, not after the wedge timeout");
     }
 
     @AfterEach

--- a/maven/core-unittests/src/test/java/com/codename1/ui/DisplayTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/DisplayTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -21,6 +23,26 @@ public class DisplayTest extends UITestBase {
         CN.getCurrentForm().getAnimationManager().flush();
     }
 
+    /**
+     * How long a queued runnable may take to reach the EDT before the suite calls it wedged.
+     * Generous next to any real flush (they finish in milliseconds) and short next to a CI job
+     * timeout, which is the point: a wedge should cost seconds, not the whole job.
+     */
+    private static final int EDT_FLUSH_TIMEOUT_MS = 30000;
+
+    /**
+     * Runs a flush on the EDT and waits for it -- with a deadline.
+     *
+     * <p>This used to call {@code callSeriallyAndWait}, which waits forever. Anything that
+     * wedges the EDT therefore wedged the whole suite: {@code BleSensorReconnectTest} printed
+     * its "Running" line, went silent, and the JDK 8 CI leg was cancelled 55 minutes later at
+     * the job timeout, with no test named as the culprit and no evidence of what it was
+     * waiting on. Every test in this suite reaches the EDT through here, so one deadlocked
+     * session anywhere costs an hour of CI and reports nothing.
+     *
+     * <p>A wedge is now a fast, named failure carrying the stack of every live thread --
+     * which is exactly the evidence needed to find the lock cycle behind it.
+     */
     public static void flushEdt() {
         final Display display = Display.getInstance();
         if (display.isEdt()) {
@@ -28,11 +50,45 @@ public class DisplayTest extends UITestBase {
             return;
         }
 
+        // Still callSeriallyAndWait, deliberately: its RunnableWrapper is what carries the
+        // invokeAndBlock nesting, and a plain callSerially plus a latch drops that -- which
+        // showed up at once as StorageImageAsyncTest timing out against a display it could no
+        // longer see. Only the deadline is new. The latch is what makes the EDT's write to it
+        // visible here, and reports whether the runnable ever ran.
+        final CountDownLatch done = new CountDownLatch(1);
         display.callSeriallyAndWait(new Runnable() {
             public void run() {
-                display.flushEdt();
+                try {
+                    display.flushEdt();
+                } finally {
+                    done.countDown();
+                }
             }
-        });
+        }, EDT_FLUSH_TIMEOUT_MS);
+        if (done.getCount() != 0) {
+            throw new IllegalStateException("The EDT did not run a queued runnable within "
+                    + EDT_FLUSH_TIMEOUT_MS + "ms -- it is wedged, most likely on a lock held by"
+                    + " a thread that is itself waiting for the EDT.\n" + dumpAllThreads());
+        }
+    }
+
+    /** Every live thread and where it is, for a wedge that has to be diagnosed from a CI log. */
+    private static String dumpAllThreads() {
+        StringBuilder sb = new StringBuilder("--- thread dump ---\n");
+        Map<Thread, StackTraceElement[]> traces = Thread.getAllStackTraces();
+        for (Map.Entry<Thread, StackTraceElement[]> e : traces.entrySet()) {
+            Thread t = e.getKey();
+            sb.append('"').append(t.getName()).append("\" ").append(t.getState());
+            if (t.isDaemon()) {
+                sb.append(" daemon");
+            }
+            sb.append('\n');
+            for (StackTraceElement frame : e.getValue()) {
+                sb.append("\tat ").append(frame).append('\n');
+            }
+            sb.append('\n');
+        }
+        return sb.toString();
     }
 
     @AfterEach


### PR DESCRIPTION
## Why

Two cloud builds on one account, seven minutes apart, failed for reasons that were both decidable from a file already sitting in the project:

1. The first ran **four minutes** — compile, archive, the whole app — then died at export:
   `error: exportArchive Provisioning profile "HBZ_PROD_DISTRIBUTION" is not an "iOS Ad Hoc" profile.`
   The project set `ios.release.distributionMethod=ad-hoc`; the profile was an App Store one.
2. The next two died 36s in with a bare `SAXParseException; lineNumber: 1; columnNumber: 1; Premature end of file` that never named the profile — the profile had been swapped for a file carrying no readable plist.

Both cost a cloud build slot to discover. Neither had to.

## What

A client-side pre-flight in `CN1BuildMojo`, next to the existing hardening pre-flight, that reads the `.mobileprovision` before the build is packaged. The payload of a `.mobileprovision` is a plain-text XML plist inside a CMS envelope, so its kind, name and expiry are readable **without Xcode, `security`, or a Mac** — which is what makes this a client-side check.

**Refused** (build stops locally, with a message naming the file and what to do):
- profile setting points at a file that does not exist
- the file is empty (0 bytes)
- the file carries no plist payload — "not a valid .mobileprovision file"
- the profile has expired, with the date
- the profile's kind is one `xcodebuild -exportArchive` will not export with, e.g. *"The provisioning profile "HBZ_PROD_DISTRIBUTION" is an App Store distribution profile, but this build is configured to export with method "ad-hoc" ... Either set `ios.release.distributionMethod=app-store`, or use an Ad Hoc provisioning profile."*

**Warns only** (never blocks):
- enterprise/in-house mismatches — Xcode accepts an in-house profile for more than one method, so a false refusal would block a build that works
- no profile configured at all — that is the server's call, and a profile can reach it another way

The distribution method is resolved exactly as `IPhoneBuilder` resolves it server-side (per-build-type hint beats the shared hint beats the default: development for debug, app-store for release). Reading it any other way would refuse builds the server would have accepted.

Scope is deliberately narrow: only cloud `ios-device*` targets. Local Xcode-project generation signs later or not at all, and the native-Mac targets ride the same platform with a different signing identity.

## Verification

- `mvn verify -pl codenameone-maven-plugin`: **499 tests pass**, SpotBugs **0 findings** (the zero-findings gate).
- 13 new tests covering both real failures, every profile kind, the server's method-resolution order, and each case that must *not* be refused.
- Classification checked against **real** profiles, not just the synthetic ones in the tests: development, distribution and Xcode team profiles all classify correctly.

## Related

Server-side, BuildDaemon `12a7ff1` makes failure 2 report why instead of emitting a bare SAX stack trace (it captures `security cms` exit code + stderr, and falls back to the embedded plist). That covers users on an older plugin; this PR stops the build before it is ever sent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)