### PR TITLE
ci: stop the port-status sweep from judging in-flight producer runs

### DIFF
--- a/scripts/hellocodenameone/conformance/backfill_port_status.sh
+++ b/scripts/hellocodenameone/conformance/backfill_port_status.sh
@@ -172,14 +172,25 @@ while IFS= read -r workflow; do
   # and a five-run cap then hides a perfectly good report just behind them. The
   # loop below stops as soon as every port the workflow owns is covered, so the
   # wider net costs nothing when the newest run is complete.
+  #
+  # A run that is still going is not a candidate at all. This sweep is scheduled
+  # while the long producers are mid-flight -- the Windows suite takes half an
+  # hour, the iOS one two -- and a running job has uploaded no artifact yet, so
+  # treating it as the newest candidate reported it as a producer that "uploaded
+  # no port-status artifact" and failed the nightly every single night. The
+  # conclusion test alone does not exclude it: `gh run list` types conclusion as
+  # a string, so an in-flight run comes back as "" rather than null and sails
+  # through `.conclusion != null`. Gate on status instead, which is what
+  # actually distinguishes finished from running.
   horizon="$(date -u -d "${sweep_stale_days} days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
     || date -u -v-"${sweep_stale_days}"d +%Y-%m-%dT%H:%M:%SZ)"
   # gh's --jq takes one expression and forwards no jq CLI options, so --arg has
   # to go to a separate jq invocation rather than being smuggled in after --jq.
   candidates="$(gh run list --workflow "${workflow}" --branch master --limit 100 \
-    --json databaseId,event,conclusion,updatedAt \
+    --json databaseId,event,status,conclusion,updatedAt \
     | jq -r --arg horizon "${horizon}" '[.[] | select((.event == "push" or .event == "schedule" or .event == "workflow_dispatch") and
-          (.conclusion != null and .conclusion != "cancelled" and .conclusion != "skipped") and
+          (.status == "completed") and
+          (.conclusion != null and .conclusion != "" and .conclusion != "cancelled" and .conclusion != "skipped") and
           (.updatedAt >= $horizon))]
           | sort_by(.updatedAt) | reverse | .[] | "\(.databaseId):\(.event)"')"
   if [ -z "${candidates}" ]; then


### PR DESCRIPTION
The nightly `Nightly platform and browser evidence` job `publish-latest-port-reports` has failed every night since 2026-08-08:

```
Ports whose newest report was unusable (an older one is still being served):
  parparvm-tests-windows.yml: newest run 31860469605 uploaded no port-status artifact
  scripts-ios.yml: newest run 31766923426 uploaded no port-status artifact
  scripts-mac-native.yml: newest run 31767081081 uploaded no port-status artifact
```

Every one of those runs succeeded and uploaded its report. They just had not got there yet. Last night: the sweep read run `31860469605` at 03:20:19; that run started 02:55 and uploaded `port-status-windows-arm64` at **03:26:28**. The nightly cron lands squarely inside the long producers -- ParparVM Windows takes ~30 minutes, scripts-ios ~2 hours -- so the collision recurs nightly.

## Cause

`backfill_port_status.sh` intends to consider only terminal runs, but the test does not exclude a running one:

```jq
(.conclusion != null and .conclusion != "cancelled" and .conclusion != "skipped")
```

`gh run list` types `conclusion` as a **string**, so an in-flight run comes back as `""`, not `null`, and passes. Being newest it then took the strict newest-run role, had no artifact to download, and was recorded as a producer emitting nothing. The merge behind it published a good report, so the public table stayed correct -- only the job went red.

## Fix

Gate on `status == "completed"`, which is what actually separates finished from running, and treat an empty conclusion as non-terminal too. `timed_out` and `startup_failure` runs remain candidates, so a producer that genuinely dies before normalization is still caught by the same check.

## Verification

Ran the amended filter against live data. With in-flight runs excluded, every producer's newest completed master run carries its artifacts: scripts-ios (ios-gl, ios-metal, tvos, watchos), parparvm-tests-windows (windows-arm64), scripts-mac-native, scripts-android, scripts-javascript, linux-build-run, windows-cross-build-run. The sweep should go green on the next nightly.

Unrelated to the syndication watchdog failure (#5550), which is a genuine alert about undrained Medium/DZone queue entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)