### PR TITLE
Tapjacking / screen-overlay detection in DeviceIntegrity

### DIFF
--- a/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
+++ b/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
@@ -11405,30 +11405,54 @@ public abstract class CodenameOneImplementation {
         // application code while this lock is held, the deadlock ShieldSignals documents. It is
         // not a real gap either way: a listener can only be registered through Display, so
         // before init there is nobody to tell.
-        if (target == null || !target.hasListeners() || !Display.isInitialized()) {
+        if (target == null || !Display.isInitialized()) {
             return;
+        }
+        // The listeners are captured now rather than resolved when the runnable finally runs.
+        // Holding the dispatcher instead would mean the set is read at delivery, so a listener
+        // registered after this transition -- while an EDT backlog held the runnable -- would be
+        // told about a change that predates it, and whether it heard that would depend on
+        // whether some unrelated listener happened to exist at queue time, since an empty set
+        // queues nothing at all. A listener removed in the same window still receives this one
+        // event, which is the same trade ShieldSignals makes by snapshotting its own array here.
+        //
+        // Copied under the dispatcher's own monitor: getListenerCollection hands back the live
+        // list, and addListener/removeListener synchronize on the dispatcher.
+        ActionListener[] snapshot;
+        synchronized (target) {
+            java.util.Collection current = target.getListenerCollection();
+            if (current == null || current.isEmpty()) {
+                return;
+            }
+            Object[] raw = current.toArray();
+            snapshot = new ActionListener[raw.length];
+            for (int i = 0; i < raw.length; i++) {
+                snapshot[i] = (ActionListener) raw[i];
+            }
         }
         // Boolean source so a listener can read the state straight off the event without a
         // second call back into the API, which is what makes an ordered replay meaningful.
         Display.getInstance().callSerially(
-                new TapjackingDispatch(target, new ActionEvent(Boolean.valueOf(obscured))));
+                new TapjackingDispatch(snapshot, new ActionEvent(Boolean.valueOf(obscured))));
     }
 
     /// One queued tapjacking announcement. A named static class rather than an anonymous one
     /// because it captures nothing from the implementation instance -- the same shape, and for
     /// the same reason, as ShieldSignals' own dispatch.
     private static final class TapjackingDispatch implements Runnable {
-        private final com.codename1.ui.util.EventDispatcher target;
+        private final ActionListener[] targets;
         private final ActionEvent event;
 
-        TapjackingDispatch(com.codename1.ui.util.EventDispatcher target, ActionEvent event) {
-            this.target = target;
+        TapjackingDispatch(ActionListener[] targets, ActionEvent event) {
+            this.targets = targets;
             this.event = event;
         }
 
         @Override
         public void run() {
-            target.fireActionEvent(event);
+            for (ActionListener l : targets) {
+                l.actionPerformed(event);
+            }
         }
     }
 

--- a/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
+++ b/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
@@ -11398,11 +11398,17 @@ public abstract class CodenameOneImplementation {
     /// - `obscured`: true when the observed touch was obscured
     /// - `detail`: a short machine readable description of which flag fired, or null
     public void notifyScreenObscured(boolean obscured, String detail) {
-        if (obscured == screenObscured) {
-            return;
-        }
+        boolean changed = obscured != screenObscured;
         screenObscured = obscured;
         if (obscured) {
+            // Submitted on every obscured touch rather than only on the transition, because
+            // the bus and the listener want different things. ShieldSignals.add already
+            // de-duplicates: it refreshes the stored observation -- detail and timestamp --
+            // and stays silent when nothing changed. Gating this on the transition meant a
+            // partially obscured touch followed by a fully obscured one left the bus
+            // reporting "partiallyObscured" while BLOCK was dropping a fully obscured
+            // attack, and left "when did this device last look obscured" answering with the
+            // first sighting long after the fact.
             try {
                 com.codename1.security.shield.ShieldSignals.add(
                         com.codename1.security.shield.ShieldSignal.TAPJACK, 80, detail);
@@ -11410,6 +11416,11 @@ public abstract class CodenameOneImplementation {
                 // Reporting must never break input handling: this runs on the touch path.
                 Log.e(t);
             }
+        }
+        if (!changed) {
+            // The listener, unlike the bus, is a state-change notification. Firing it per
+            // touch would queue a runnable onto the EDT for every event of every gesture.
+            return;
         }
         if (tapjackingListeners != null && tapjackingListeners.hasListeners()) {
             // Boolean source so a listener can read the new state straight off the event without

--- a/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
+++ b/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
@@ -70,6 +70,7 @@ import com.codename1.payment.PurchaseCallback;
 import com.codename1.push.PushCallback;
 import com.codename1.security.Biometrics;
 import com.codename1.security.SecureStorage;
+import com.codename1.security.TapjackingPolicy;
 import com.codename1.ui.BrowserComponent;
 import com.codename1.ui.BrowserWindow;
 import com.codename1.ui.Button;
@@ -11333,6 +11334,99 @@ public abstract class CodenameOneImplementation {
     ///
     /// - `secure`: true to mark the window secure, false to clear the flag
     public void setSecureScreen(boolean secure) {
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Tapjacking / screen-overlay defense. The state lives here rather than in a port so every
+    // platform inherits the same reporting and dispatch semantics, and a port only has to supply
+    // the one thing it alone can know: whether a given touch arrived obscured.
+    // -----------------------------------------------------------------------------------------
+
+    private TapjackingPolicy tapjackingPolicy = TapjackingPolicy.OFF;
+    private boolean screenObscured;
+    private com.codename1.ui.util.EventDispatcher tapjackingListeners;
+
+    /// Sets the tapjacking policy. See
+    /// [com.codename1.security.DeviceIntegrity#setTapjackingProtection(TapjackingPolicy)]. Ports
+    /// that can also apply a platform level filter override this, call `super`, and apply it.
+    public void setTapjackingProtection(TapjackingPolicy policy) {
+        tapjackingPolicy = policy == null ? TapjackingPolicy.OFF : policy;
+    }
+
+    /// The tapjacking policy currently in force. Never null.
+    public TapjackingPolicy getTapjackingPolicy() {
+        return tapjackingPolicy;
+    }
+
+    /// True when the most recently observed touch arrived while another application's window was
+    /// drawn over this app. Always false where the platform cannot report it.
+    public boolean isScreenObscured() {
+        return screenObscured;
+    }
+
+    /// Registers a listener notified when the obscured state changes. See
+    /// [com.codename1.security.DeviceIntegrity#addTapjackingListener(ActionListener)].
+    public void addTapjackingListener(ActionListener l) {
+        if (l == null) {
+            return;
+        }
+        if (tapjackingListeners == null) {
+            tapjackingListeners = new com.codename1.ui.util.EventDispatcher();
+        }
+        tapjackingListeners.addListener(l);
+    }
+
+    /// Removes a listener added by [#addTapjackingListener(ActionListener)].
+    public void removeTapjackingListener(ActionListener l) {
+        if (l == null || tapjackingListeners == null) {
+            return;
+        }
+        tapjackingListeners.removeListener(l);
+    }
+
+    /// Called by a port when it observes a touch, to report whether that touch was obscured.
+    ///
+    /// Only a *change* is acted on. A port calls this for every touch it handles, so notifying
+    /// unconditionally would put a runnable on the EDT per touch and re-raise the same signal
+    /// forever; the interesting events are "an overlay appeared" and "it went away". The signal is
+    /// raised on the [com.codename1.security.shield.ShieldSignals] bus at severity 80, above
+    /// `ROOT` because an overlay over a live screen is an attack in progress rather than a standing
+    /// property of the device, and below `HOOK` because it has benign causes.
+    ///
+    /// #### Parameters
+    ///
+    /// - `obscured`: true when the observed touch was obscured
+    /// - `detail`: a short machine readable description of which flag fired, or null
+    public void notifyScreenObscured(boolean obscured, String detail) {
+        if (obscured == screenObscured) {
+            return;
+        }
+        screenObscured = obscured;
+        if (obscured) {
+            try {
+                com.codename1.security.shield.ShieldSignals.add(
+                        com.codename1.security.shield.ShieldSignal.TAPJACK, 80, detail);
+            } catch (Throwable t) {
+                // Reporting must never break input handling: this runs on the touch path.
+                Log.e(t);
+            }
+        }
+        if (tapjackingListeners != null && tapjackingListeners.hasListeners()) {
+            // Boolean source so a listener can read the new state straight off the event without
+            // a second call back into the API.
+            tapjackingListeners.fireActionEvent(new ActionEvent(Boolean.valueOf(obscured)));
+        }
+    }
+
+    /// Asks the OS to hide non-system windows drawn over this app while it is in the foreground.
+    /// See [com.codename1.security.DeviceIntegrity#setHideOverlayWindows(boolean)]. No-op where
+    /// unsupported.
+    public void setHideOverlayWindows(boolean hide) {
+    }
+
+    /// True where [#setHideOverlayWindows(boolean)] actually does something.
+    public boolean isHideOverlayWindowsSupported() {
+        return false;
     }
 
     /// Returns the build hints for the simulator, this will only work in the debug environment and it's

--- a/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
+++ b/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
@@ -11426,6 +11426,7 @@ public abstract class CodenameOneImplementation {
             this.event = event;
         }
 
+        @Override
         public void run() {
             target.fireActionEvent(event);
         }

--- a/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
+++ b/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
@@ -11342,6 +11342,16 @@ public abstract class CodenameOneImplementation {
     // the one thing it alone can know: whether a given touch arrived obscured.
     // -----------------------------------------------------------------------------------------
 
+    /// Guards the three fields below. They are written from the platform's input thread and read
+    /// and written from the EDT, and the pair (policy, state) has to move together: a report that
+    /// raced a switch-off would otherwise land after the state was cleared and leave
+    /// [#isScreenObscured()] stuck true, because nothing reports again once the policy is OFF.
+    ///
+    /// A lock rather than volatile fields, because the invariant spans two fields rather than
+    /// being about the visibility of either one. Dispatch never happens while it is held: see
+    /// [#notifyScreenObscured(boolean, String)].
+    private final Object tapjackingLock = new Object();
+
     private TapjackingPolicy tapjackingPolicy = TapjackingPolicy.OFF;
     private boolean screenObscured;
     private com.codename1.ui.util.EventDispatcher tapjackingListeners;
@@ -11350,26 +11360,37 @@ public abstract class CodenameOneImplementation {
     /// [com.codename1.security.DeviceIntegrity#setTapjackingProtection(TapjackingPolicy)]. Ports
     /// that can also apply a platform level filter override this, call `super`, and apply it.
     public void setTapjackingProtection(TapjackingPolicy policy) {
-        tapjackingPolicy = policy == null ? TapjackingPolicy.OFF : policy;
-        if (!tapjackingPolicy.isDetecting()) {
+        boolean retract;
+        synchronized (tapjackingLock) {
+            tapjackingPolicy = policy == null ? TapjackingPolicy.OFF : policy;
+            retract = !tapjackingPolicy.isDetecting();
+        }
+        if (retract) {
             // Switching off has to retract the state, because switching off is also what stops
             // anything from retracting it later: a port stops reporting under OFF -- the Android
             // one returns from tapjacked() before it reports -- so a screenObscured left true
             // here would have isScreenObscured() answering true for the rest of the process and
             // the listener would never receive its closing transition.
+            //
+            // Outside the lock: this dispatches to listeners, and holding a lock across
+            // application code invites the deadlock ShieldSignals documents at length.
             notifyScreenObscured(false, null);
         }
     }
 
     /// The tapjacking policy currently in force. Never null.
     public TapjackingPolicy getTapjackingPolicy() {
-        return tapjackingPolicy;
+        synchronized (tapjackingLock) {
+            return tapjackingPolicy;
+        }
     }
 
     /// True when the most recently observed touch arrived while another application's window was
     /// drawn over this app. Always false where the platform cannot report it.
     public boolean isScreenObscured() {
-        return screenObscured;
+        synchronized (tapjackingLock) {
+            return screenObscured;
+        }
     }
 
     /// Registers a listener notified when the obscured state changes. See
@@ -11378,18 +11399,29 @@ public abstract class CodenameOneImplementation {
         if (l == null) {
             return;
         }
-        if (tapjackingListeners == null) {
-            tapjackingListeners = new com.codename1.ui.util.EventDispatcher();
+        com.codename1.ui.util.EventDispatcher target;
+        synchronized (tapjackingLock) {
+            if (tapjackingListeners == null) {
+                tapjackingListeners = new com.codename1.ui.util.EventDispatcher();
+            }
+            target = tapjackingListeners;
         }
-        tapjackingListeners.addListener(l);
+        // EventDispatcher does its own locking; the lock above is only for the lazy creation,
+        // so that two threads registering at once cannot end up with two dispatchers and one
+        // of them holding a listener nothing ever fires.
+        target.addListener(l);
     }
 
     /// Removes a listener added by [#addTapjackingListener(ActionListener)].
     public void removeTapjackingListener(ActionListener l) {
-        if (l == null || tapjackingListeners == null) {
+        com.codename1.ui.util.EventDispatcher target;
+        synchronized (tapjackingLock) {
+            target = tapjackingListeners;
+        }
+        if (l == null || target == null) {
             return;
         }
-        tapjackingListeners.removeListener(l);
+        target.removeListener(l);
     }
 
     /// Called by a port when it observes a touch, to report whether that touch was obscured.
@@ -11406,8 +11438,22 @@ public abstract class CodenameOneImplementation {
     /// - `obscured`: true when the observed touch was obscured
     /// - `detail`: a short machine readable description of which flag fired, or null
     public void notifyScreenObscured(boolean obscured, String detail) {
-        boolean changed = obscured != screenObscured;
-        screenObscured = obscured;
+        boolean changed;
+        com.codename1.ui.util.EventDispatcher listeners;
+        synchronized (tapjackingLock) {
+            if (obscured && !tapjackingPolicy.isDetecting()) {
+                // A sighting that raced a switch-off. The port read the old policy, decided to
+                // report, and only got here after the EDT had already stored OFF and cleared the
+                // state. Letting it through would resurrect a state nothing clears afterwards --
+                // reporting has stopped -- and hand a listener an obscured callback for a
+                // protection the app had already turned off. Retractions are never dropped, only
+                // assertions, so the clearing path below still works.
+                return;
+            }
+            changed = obscured != screenObscured;
+            screenObscured = obscured;
+            listeners = tapjackingListeners;
+        }
         if (obscured) {
             // Submitted on every obscured touch rather than only on the transition, because
             // the bus and the listener want different things. ShieldSignals.add already
@@ -11430,10 +11476,11 @@ public abstract class CodenameOneImplementation {
             // touch would queue a runnable onto the EDT for every event of every gesture.
             return;
         }
-        if (tapjackingListeners != null && tapjackingListeners.hasListeners()) {
+        if (listeners != null && listeners.hasListeners()) {
             // Boolean source so a listener can read the new state straight off the event without
-            // a second call back into the API.
-            tapjackingListeners.fireActionEvent(new ActionEvent(Boolean.valueOf(obscured)));
+            // a second call back into the API -- which is also what makes dispatching outside the
+            // lock safe, since the event does not depend on the state still being current.
+            listeners.fireActionEvent(new ActionEvent(Boolean.valueOf(obscured)));
         }
     }
 

--- a/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
+++ b/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
@@ -11360,21 +11360,53 @@ public abstract class CodenameOneImplementation {
     /// [com.codename1.security.DeviceIntegrity#setTapjackingProtection(TapjackingPolicy)]. Ports
     /// that can also apply a platform level filter override this, call `super`, and apply it.
     public void setTapjackingProtection(TapjackingPolicy policy) {
-        boolean retract;
+        boolean retracted;
         synchronized (tapjackingLock) {
             tapjackingPolicy = policy == null ? TapjackingPolicy.OFF : policy;
-            retract = !tapjackingPolicy.isDetecting();
-        }
-        if (retract) {
             // Switching off has to retract the state, because switching off is also what stops
             // anything from retracting it later: a port stops reporting under OFF -- the Android
             // one returns from tapjacked() before it reports -- so a screenObscured left true
             // here would have isScreenObscured() answering true for the rest of the process and
             // the listener would never receive its closing transition.
             //
-            // Outside the lock: this dispatches to listeners, and holding a lock across
+            // Cleared here, inside the same critical section as the policy, rather than by a
+            // follow-up notifyScreenObscured(false) call. A retraction that mutated state after
+            // this lock was released could land after another thread had already re-enabled
+            // detection and reported a fresh sighting, wiping that newer observation and leaving
+            // BLOCK active over a state claiming the screen was clear. Policy and state move
+            // together or the pair is not an invariant at all.
+            retracted = !tapjackingPolicy.isDetecting() && screenObscured;
+            if (!tapjackingPolicy.isDetecting()) {
+                screenObscured = false;
+            }
+        }
+        if (retracted) {
+            // Dispatch only, no state mutation, and outside the lock: holding one across
             // application code invites the deadlock ShieldSignals documents at length.
-            notifyScreenObscured(false, null);
+            fireTapjackingState(false);
+        }
+    }
+
+    /// Announces a tapjacking state change to the listeners. Pure dispatch: the state has
+    /// already been written under [#tapjackingLock] by the caller.
+    ///
+    /// Drops itself when the value it would announce is no longer the one the API reports, the
+    /// same rule [com.codename1.security.shield.ShieldSignals] applies to its own bus -- a
+    /// superseded announcement is not worth making, because it was already wrong when it was
+    /// queued.
+    private void fireTapjackingState(boolean obscured) {
+        com.codename1.ui.util.EventDispatcher listeners;
+        synchronized (tapjackingLock) {
+            if (screenObscured != obscured) {
+                return;
+            }
+            listeners = tapjackingListeners;
+        }
+        if (listeners != null && listeners.hasListeners()) {
+            // Boolean source so a listener can read the new state straight off the event without
+            // a second call back into the API -- which is also what makes dispatching outside the
+            // lock safe, since the event does not depend on the state still being current.
+            listeners.fireActionEvent(new ActionEvent(Boolean.valueOf(obscured)));
         }
     }
 
@@ -11439,7 +11471,6 @@ public abstract class CodenameOneImplementation {
     /// - `detail`: a short machine readable description of which flag fired, or null
     public void notifyScreenObscured(boolean obscured, String detail) {
         boolean changed;
-        com.codename1.ui.util.EventDispatcher listeners;
         synchronized (tapjackingLock) {
             if (obscured && !tapjackingPolicy.isDetecting()) {
                 // A sighting that raced a switch-off. The port read the old policy, decided to
@@ -11452,7 +11483,6 @@ public abstract class CodenameOneImplementation {
             }
             changed = obscured != screenObscured;
             screenObscured = obscured;
-            listeners = tapjackingListeners;
         }
         if (obscured) {
             // Submitted on every obscured touch rather than only on the transition, because
@@ -11476,12 +11506,7 @@ public abstract class CodenameOneImplementation {
             // touch would queue a runnable onto the EDT for every event of every gesture.
             return;
         }
-        if (listeners != null && listeners.hasListeners()) {
-            // Boolean source so a listener can read the new state straight off the event without
-            // a second call back into the API -- which is also what makes dispatching outside the
-            // lock safe, since the event does not depend on the state still being current.
-            listeners.fireActionEvent(new ActionEvent(Boolean.valueOf(obscured)));
-        }
+        fireTapjackingState(obscured);
     }
 
     /// Asks the OS to hide non-system windows drawn over this app while it is in the foreground.

--- a/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
+++ b/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
@@ -11394,7 +11394,7 @@ public abstract class CodenameOneImplementation {
     /// same rule [com.codename1.security.shield.ShieldSignals] applies to its own bus -- a
     /// superseded announcement is not worth making, because it was already wrong when it was
     /// queued.
-    private void fireTapjackingState(boolean obscured) {
+    private void fireTapjackingState(final boolean obscured) {
         com.codename1.ui.util.EventDispatcher listeners;
         synchronized (tapjackingLock) {
             if (screenObscured != obscured) {
@@ -11402,11 +11402,35 @@ public abstract class CodenameOneImplementation {
             }
             listeners = tapjackingListeners;
         }
-        if (listeners != null && listeners.hasListeners()) {
-            // Boolean source so a listener can read the new state straight off the event without
-            // a second call back into the API -- which is also what makes dispatching outside the
-            // lock safe, since the event does not depend on the state still being current.
-            listeners.fireActionEvent(new ActionEvent(Boolean.valueOf(obscured)));
+        if (listeners == null || !listeners.hasListeners()) {
+            return;
+        }
+        final com.codename1.ui.util.EventDispatcher target = listeners;
+        Runnable dispatch = new Runnable() {
+            public void run() {
+                // Re-checked on arrival, not only before queuing. The check above cannot be
+                // enough: a report from the platform's input thread is delivered through
+                // callSerially, and in the gap the EDT can clear the state and announce that
+                // synchronously -- so the older value would arrive last and leave a listener
+                // holding the opposite of what the API reports. Dropping a superseded
+                // announcement is the same rule ShieldSignals applies to its own bus, for the
+                // same reason: it was already wrong when it was queued.
+                synchronized (tapjackingLock) {
+                    if (screenObscured != obscured) {
+                        return;
+                    }
+                }
+                // Boolean source so a listener can read the new state straight off the event
+                // without a second call back into the API.
+                target.fireActionEvent(new ActionEvent(Boolean.valueOf(obscured)));
+            }
+        };
+        // Queued rather than fired directly whenever we are off the EDT, so that the recheck
+        // above happens where the listener actually runs. On the EDT there is no gap to close.
+        if (Display.isInitialized() && !Display.getInstance().isEdt()) {
+            Display.getInstance().callSerially(dispatch);
+        } else {
+            dispatch.run();
         }
     }
 

--- a/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
+++ b/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
@@ -11351,6 +11351,14 @@ public abstract class CodenameOneImplementation {
     /// that can also apply a platform level filter override this, call `super`, and apply it.
     public void setTapjackingProtection(TapjackingPolicy policy) {
         tapjackingPolicy = policy == null ? TapjackingPolicy.OFF : policy;
+        if (!tapjackingPolicy.isDetecting()) {
+            // Switching off has to retract the state, because switching off is also what stops
+            // anything from retracting it later: a port stops reporting under OFF -- the Android
+            // one returns from tapjacked() before it reports -- so a screenObscured left true
+            // here would have isScreenObscured() answering true for the rest of the process and
+            // the listener would never receive its closing transition.
+            notifyScreenObscured(false, null);
+        }
     }
 
     /// The tapjacking policy currently in force. Never null.

--- a/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
+++ b/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
@@ -11360,7 +11360,6 @@ public abstract class CodenameOneImplementation {
     /// [com.codename1.security.DeviceIntegrity#setTapjackingProtection(TapjackingPolicy)]. Ports
     /// that can also apply a platform level filter override this, call `super`, and apply it.
     public void setTapjackingProtection(TapjackingPolicy policy) {
-        boolean retracted;
         synchronized (tapjackingLock) {
             tapjackingPolicy = policy == null ? TapjackingPolicy.OFF : policy;
             // Switching off has to retract the state, because switching off is also what stops
@@ -11375,62 +11374,60 @@ public abstract class CodenameOneImplementation {
             // detection and reported a fresh sighting, wiping that newer observation and leaving
             // BLOCK active over a state claiming the screen was clear. Policy and state move
             // together or the pair is not an invariant at all.
-            retracted = !tapjackingPolicy.isDetecting() && screenObscured;
-            if (!tapjackingPolicy.isDetecting()) {
+            if (!tapjackingPolicy.isDetecting() && screenObscured) {
                 screenObscured = false;
+                // Queued here, still holding the lock, so this retraction cannot be overtaken
+                // by an obscured report that changed the state before it.
+                queueTapjackingState(false);
             }
-        }
-        if (retracted) {
-            // Dispatch only, no state mutation, and outside the lock: holding one across
-            // application code invites the deadlock ShieldSignals documents at length.
-            fireTapjackingState(false);
         }
     }
 
-    /// Announces a tapjacking state change to the listeners. Pure dispatch: the state has
-    /// already been written under [#tapjackingLock] by the caller.
+    /// Queues a tapjacking state change for the listeners.
     ///
-    /// Drops itself when the value it would announce is no longer the one the API reports, the
-    /// same rule [com.codename1.security.shield.ShieldSignals] applies to its own bus -- a
-    /// superseded announcement is not worth making, because it was already wrong when it was
-    /// queued.
-    private void fireTapjackingState(final boolean obscured) {
-        com.codename1.ui.util.EventDispatcher listeners;
-        synchronized (tapjackingLock) {
-            if (screenObscured != obscured) {
-                return;
-            }
-            listeners = tapjackingListeners;
-        }
-        if (listeners == null || !listeners.hasListeners()) {
+    /// **Must be called while holding [#tapjackingLock].** That is the whole mechanism: queuing
+    /// inside the same critical section that wrote the state makes the delivery order identical
+    /// to the order the state actually changed in, on any number of threads. `callSerially`
+    /// appends to one FIFO whoever calls it, the EDT included, so nothing can overtake anything.
+    ///
+    /// Ordering is what this guarantees, deliberately, rather than currency. An earlier attempt
+    /// validated each announcement against the current state at delivery and dropped it if it no
+    /// longer matched. That silently swallowed real history: an overlay that appears and
+    /// withdraws before the EDT drains -- exactly what a malicious overlay does after a blocked
+    /// ACTION_DOWN -- would be coalesced into a single "clear" callback, and the app would never
+    /// learn that a gesture had been blocked, which is the one thing this listener exists to
+    /// tell it. Every transition is now delivered, in order, each carrying its own value; the
+    /// last one delivered is by construction the current state.
+    private void queueTapjackingState(boolean obscured) {
+        final com.codename1.ui.util.EventDispatcher target = tapjackingListeners;
+        // Display.isInitialized() implies codenameOneRunning, which is what makes callSerially
+        // queue rather than run the task inline -- and running it inline here would execute
+        // application code while this lock is held, the deadlock ShieldSignals documents. It is
+        // not a real gap either way: a listener can only be registered through Display, so
+        // before init there is nobody to tell.
+        if (target == null || !target.hasListeners() || !Display.isInitialized()) {
             return;
         }
-        final com.codename1.ui.util.EventDispatcher target = listeners;
-        Runnable dispatch = new Runnable() {
-            public void run() {
-                // Re-checked on arrival, not only before queuing. The check above cannot be
-                // enough: a report from the platform's input thread is delivered through
-                // callSerially, and in the gap the EDT can clear the state and announce that
-                // synchronously -- so the older value would arrive last and leave a listener
-                // holding the opposite of what the API reports. Dropping a superseded
-                // announcement is the same rule ShieldSignals applies to its own bus, for the
-                // same reason: it was already wrong when it was queued.
-                synchronized (tapjackingLock) {
-                    if (screenObscured != obscured) {
-                        return;
-                    }
-                }
-                // Boolean source so a listener can read the new state straight off the event
-                // without a second call back into the API.
-                target.fireActionEvent(new ActionEvent(Boolean.valueOf(obscured)));
-            }
-        };
-        // Queued rather than fired directly whenever we are off the EDT, so that the recheck
-        // above happens where the listener actually runs. On the EDT there is no gap to close.
-        if (Display.isInitialized() && !Display.getInstance().isEdt()) {
-            Display.getInstance().callSerially(dispatch);
-        } else {
-            dispatch.run();
+        // Boolean source so a listener can read the state straight off the event without a
+        // second call back into the API, which is what makes an ordered replay meaningful.
+        Display.getInstance().callSerially(
+                new TapjackingDispatch(target, new ActionEvent(Boolean.valueOf(obscured))));
+    }
+
+    /// One queued tapjacking announcement. A named static class rather than an anonymous one
+    /// because it captures nothing from the implementation instance -- the same shape, and for
+    /// the same reason, as ShieldSignals' own dispatch.
+    private static final class TapjackingDispatch implements Runnable {
+        private final com.codename1.ui.util.EventDispatcher target;
+        private final ActionEvent event;
+
+        TapjackingDispatch(com.codename1.ui.util.EventDispatcher target, ActionEvent event) {
+            this.target = target;
+            this.event = event;
+        }
+
+        public void run() {
+            target.fireActionEvent(event);
         }
     }
 
@@ -11507,6 +11504,13 @@ public abstract class CodenameOneImplementation {
             }
             changed = obscured != screenObscured;
             screenObscured = obscured;
+            if (changed) {
+                // Queued inside the lock so the delivery order matches the order the state
+                // changed in. The listener, unlike the signal bus below, is a state-change
+                // notification: announcing every touch would put a runnable on the EDT for
+                // every event of every gesture.
+                queueTapjackingState(obscured);
+            }
         }
         if (obscured) {
             // Submitted on every obscured touch rather than only on the transition, because
@@ -11525,12 +11529,6 @@ public abstract class CodenameOneImplementation {
                 Log.e(t);
             }
         }
-        if (!changed) {
-            // The listener, unlike the bus, is a state-change notification. Firing it per
-            // touch would queue a runnable onto the EDT for every event of every gesture.
-            return;
-        }
-        fireTapjackingState(obscured);
     }
 
     /// Asks the OS to hide non-system windows drawn over this app while it is in the foreground.

--- a/CodenameOne/src/com/codename1/security/DeviceIntegrity.java
+++ b/CodenameOne/src/com/codename1/security/DeviceIntegrity.java
@@ -23,9 +23,10 @@
 package com.codename1.security;
 
 import com.codename1.ui.Display;
+import com.codename1.ui.events.ActionListener;
 import com.codename1.util.AsyncResource;
 
-/// Device-integrity and runtime self-protection (RASP) entry point. Groups three families of
+/// Device-integrity and runtime self-protection (RASP) entry point. Groups four families of
 /// security primitives that an app -- a banking app in particular -- can use to react to a hostile
 /// runtime environment:
 ///
@@ -41,6 +42,11 @@ import com.codename1.util.AsyncResource;
 ///    [#hasUntrustedAccessibilityService(String...)] detect malware that abuses Android accessibility
 ///    services for overlays, remote control and on-screen text extraction, and [#setSecureScreen(boolean)]
 ///    blocks screenshots, screen recording and accessibility screen scraping on sensitive screens.
+/// 4. **Tapjacking / overlay defense** -- [#setTapjackingProtection(TapjackingPolicy)] detects, and
+///    optionally drops, touches that arrive while another app's window is drawn over yours, and
+///    [#setHideOverlayWindows(boolean)] asks Android 12+ to remove such windows outright. Where
+///    family 3 asks "is a hostile accessibility service installed", this one answers "is something
+///    covering the screen right now".
 ///
 /// #### Zero-code build hints
 ///
@@ -57,18 +63,26 @@ import com.codename1.util.AsyncResource;
 /// - `android.accessibilityGuard=true` (optionally `android.accessibilityGuard.allow=<csv packages>`
 ///   and `android.accessibilityGuard.mode=exit|warn`) -- checks the enabled accessibility services at
 ///   launch and exits (or logs) when an untrusted one is active.
+/// - `android.tapjackingGuard=true` (optionally `android.tapjackingGuard.mode=block|strict|report`
+///   and `android.tapjackingGuard.hideOverlays=true|false`) -- applies a tapjacking policy at
+///   startup and, by default, also asks Android 12+ to hide overlay windows, with no app code.
 ///
 /// #### Platform support
 ///
 /// - **Android** -- full support. Attestation via Play Integrity (requires the `android.playIntegrity`
 ///   build hint to bundle the SDK), RASP via the root/Frida/emulator checks, accessibility enumeration
-///   via the system settings, and secure screens via `FLAG_SECURE`.
+///   via the system settings, and secure screens via `FLAG_SECURE`. Tapjacking detection reads the
+///   obscured flags carried on each touch; [#setHideOverlayWindows(boolean)] needs Android 12+.
 /// - **iOS** -- attestation via App Attest (requires the `ios.appAttest` build hint), RASP via the
 ///   jailbreak detector. Accessibility-service enumeration and [#setSecureScreen(boolean)] are
-///   Android-only concepts and are no-ops on iOS.
+///   Android-only concepts and are no-ops on iOS. So is the tapjacking family: iOS gives no
+///   application a way to draw over another app, so there is nothing to detect and
+///   [#isScreenObscured()] is always false. (Screen recording and mirroring are a different threat,
+///   covered by the `ios.disableScreenshots` build hint.)
 /// - **JavaSE simulator / other ports** -- behave as a clean, unsupported device: attestation
 ///   completes with an error, [#isDeviceCompromised()] returns false and the accessibility list is
-///   empty. Application code never needs platform `if` statements.
+///   empty. Application code never needs platform `if` statements. The simulator can fake an
+///   overlay from `Simulate > App Shield > Screen Overlay (Tapjacking)`.
 public final class DeviceIntegrity {
 
     private DeviceIntegrity() {
@@ -232,5 +246,99 @@ public final class DeviceIntegrity {
     /// - `secure`: true to protect the screen, false to clear the protection
     public static void setSecureScreen(boolean secure) {
         Display.getInstance().setSecureScreen(secure);
+    }
+
+    /// Sets what the framework does about touches that arrive while another application's window is
+    /// drawn over this app -- a tapjacking attack.
+    ///
+    /// The default is [TapjackingPolicy#OFF]. [TapjackingPolicy#BLOCK] is the recommended setting
+    /// for a sensitive app: it drops any gesture that starts on a fully obscured window, and
+    /// reports it. Set this once during startup.
+    ///
+    /// ```java
+    /// DeviceIntegrity.setTapjackingProtection(TapjackingPolicy.BLOCK);
+    /// DeviceIntegrity.addTapjackingListener(e -> {
+    ///     if (DeviceIntegrity.isScreenObscured()) {
+    ///         Dialog.show("Security warning",
+    ///             "Another app is drawing over this screen. Close it before continuing.",
+    ///             "OK", null);
+    ///     }
+    /// });
+    /// ```
+    ///
+    /// #### Parameters
+    ///
+    /// - `policy`: the policy to apply; null is treated as [TapjackingPolicy#OFF]
+    public static void setTapjackingProtection(TapjackingPolicy policy) {
+        Display.getInstance().setTapjackingProtection(policy);
+    }
+
+    /// The tapjacking policy currently in force. Never null; [TapjackingPolicy#OFF] until set.
+    public static TapjackingPolicy getTapjackingPolicy() {
+        return Display.getInstance().getTapjackingPolicy();
+    }
+
+    /// True when the **most recently observed touch** arrived while another application's window was
+    /// drawn over this app.
+    ///
+    /// Read that literally. Android reports obscuring as a flag on a delivered touch event, so this
+    /// is not a live query of the window stack: if an overlay appears and the user never touches
+    /// the screen, nothing is observed and this stays false. It also only becomes live once a
+    /// policy other than [TapjackingPolicy#OFF] is set.
+    ///
+    /// That reactive limitation is the reason [#setHideOverlayWindows(boolean)] exists -- it
+    /// prevents the overlay instead of noticing it after the fact.
+    ///
+    /// #### Returns
+    ///
+    /// true if the last observed touch was obscured
+    public static boolean isScreenObscured() {
+        return Display.getInstance().isScreenObscured();
+    }
+
+    /// Registers a listener notified when the obscured state **changes** -- once when an overlay is
+    /// first observed, and again when a later touch arrives clean, so an app can raise and then
+    /// dismiss a warning. It does not fire per touch.
+    ///
+    /// This matters when the policy blocks: a blocked gesture is never delivered to your components,
+    /// so this listener is the only way the app learns the tap happened at all. Callbacks arrive on
+    /// the EDT, and the [com.codename1.ui.events.ActionEvent] source is a `Boolean` carrying the new
+    /// state.
+    ///
+    /// #### Parameters
+    ///
+    /// - `l`: the listener to add
+    public static void addTapjackingListener(ActionListener l) {
+        Display.getInstance().addTapjackingListener(l);
+    }
+
+    /// Removes a listener added by [#addTapjackingListener(ActionListener)].
+    public static void removeTapjackingListener(ActionListener l) {
+        Display.getInstance().removeTapjackingListener(l);
+    }
+
+    /// Asks the OS to hide non-system windows drawn over this app while it is in the foreground
+    /// (Android 12 / API 31 `Window.setHideOverlayWindows`).
+    ///
+    /// This is the strongest of the tapjacking defenses and the only one that also covers native
+    /// peer components such as `BrowserComponent` and native text fields, because it removes the
+    /// overlay rather than filtering the touches it enables. Pair it with [#setSecureScreen(boolean)]
+    /// when entering a sensitive screen and clear both on the way out.
+    ///
+    /// Requires Android 12 or newer -- check [#isHideOverlayWindowsSupported()]. On older Android
+    /// releases, and on every other platform, this is a no-op and the touch level policy set by
+    /// [#setTapjackingProtection(TapjackingPolicy)] is what protects the app.
+    ///
+    /// #### Parameters
+    ///
+    /// - `hide`: true to hide overlay windows, false to allow them again
+    public static void setHideOverlayWindows(boolean hide) {
+        Display.getInstance().setHideOverlayWindows(hide);
+    }
+
+    /// True when [#setHideOverlayWindows(boolean)] is actually enforced by this platform, i.e. on
+    /// Android 12 and newer. False elsewhere, where the call is silently ignored.
+    public static boolean isHideOverlayWindowsSupported() {
+        return Display.getInstance().isHideOverlayWindowsSupported();
     }
 }

--- a/CodenameOne/src/com/codename1/security/DeviceIntegrity.java
+++ b/CodenameOne/src/com/codename1/security/DeviceIntegrity.java
@@ -65,7 +65,10 @@ import com.codename1.util.AsyncResource;
 ///   launch and exits (or logs) when an untrusted one is active.
 /// - `android.tapjackingGuard=true` (optionally `android.tapjackingGuard.mode=block|strict|report`
 ///   and `android.tapjackingGuard.hideOverlays=true|false`) -- applies a tapjacking policy at
-///   startup and, by default, also asks Android 12+ to hide overlay windows, with no app code.
+///   startup and, by default, also asks Android 12+ to hide overlay windows (declaring the
+///   `HIDE_OVERLAY_WINDOWS` permission that needs), with no app code.
+/// - `android.hideOverlayWindows=true` -- declares that permission on its own, for apps that call
+///   [#setHideOverlayWindows(boolean)] directly without the launch-time guard.
 ///
 /// #### Platform support
 ///
@@ -325,9 +328,15 @@ public final class DeviceIntegrity {
     /// overlay rather than filtering the touches it enables. Pair it with [#setSecureScreen(boolean)]
     /// when entering a sensitive screen and clear both on the way out.
     ///
-    /// Requires Android 12 or newer -- check [#isHideOverlayWindowsSupported()]. On older Android
-    /// releases, and on every other platform, this is a no-op and the touch level policy set by
-    /// [#setTapjackingProtection(TapjackingPolicy)] is what protects the app.
+    /// Two things are required, and [#isHideOverlayWindowsSupported()] reports both rather than
+    /// claiming a protection you are not getting: Android 12 (API 31) or newer, and the
+    /// `android.permission.HIDE_OVERLAY_WINDOWS` manifest permission. Android throws without the
+    /// permission, so this call is skipped and logged instead. The `android.tapjackingGuard` build
+    /// hint declares it; apps that use only the runtime API should set `android.hideOverlayWindows`.
+    /// It is a normal install-time permission, so the user is never prompted.
+    ///
+    /// On older Android releases, and on every other platform, this is a no-op and the touch level
+    /// policy set by [#setTapjackingProtection(TapjackingPolicy)] is what protects the app.
     ///
     /// #### Parameters
     ///
@@ -336,8 +345,10 @@ public final class DeviceIntegrity {
         Display.getInstance().setHideOverlayWindows(hide);
     }
 
-    /// True when [#setHideOverlayWindows(boolean)] is actually enforced by this platform, i.e. on
-    /// Android 12 and newer. False elsewhere, where the call is silently ignored.
+    /// True when [#setHideOverlayWindows(boolean)] is actually enforced: Android 12 or newer **and**
+    /// the app holds `android.permission.HIDE_OVERLAY_WINDOWS`. False elsewhere, including on an
+    /// Android 12 device whose build never declared the permission -- the API level alone would be a
+    /// claim the app could not verify.
     public static boolean isHideOverlayWindowsSupported() {
         return Display.getInstance().isHideOverlayWindowsSupported();
     }

--- a/CodenameOne/src/com/codename1/security/DeviceIntegrity.java
+++ b/CodenameOne/src/com/codename1/security/DeviceIntegrity.java
@@ -261,7 +261,9 @@ public final class DeviceIntegrity {
     /// ```java
     /// DeviceIntegrity.setTapjackingProtection(TapjackingPolicy.BLOCK);
     /// DeviceIntegrity.addTapjackingListener(e -> {
-    ///     if (DeviceIntegrity.isScreenObscured()) {
+    ///     // The state comes off the event, not from isScreenObscured() -- see
+    ///     // addTapjackingListener for why re-reading the global state races here.
+    ///     if (Boolean.TRUE.equals(e.getSource())) {
     ///         Dialog.show("Security warning",
     ///             "Another app is drawing over this screen. Close it before continuing.",
     ///             "OK", null);
@@ -304,9 +306,14 @@ public final class DeviceIntegrity {
     /// dismiss a warning. It does not fire per touch.
     ///
     /// This matters when the policy blocks: a blocked gesture is never delivered to your components,
-    /// so this listener is the only way the app learns the tap happened at all. Callbacks arrive on
-    /// the EDT, and the [com.codename1.ui.events.ActionEvent] source is a `Boolean` carrying the new
-    /// state.
+    /// so this listener is the only way the app learns the tap happened at all.
+    ///
+    /// **Read the state from the event, not from [#isScreenObscured()].** The
+    /// [com.codename1.ui.events.ActionEvent] source is a `Boolean` carrying the state this callback
+    /// is announcing, and that is the value to branch on. Callbacks are delivered on the EDT while
+    /// the state is updated on the platform's input thread, so a busy EDT can let a later clean
+    /// touch land before this runs -- at which point the global query answers false and a warning
+    /// keyed on it would be skipped for the very event that raised it.
     ///
     /// #### Parameters
     ///

--- a/CodenameOne/src/com/codename1/security/TapjackingPolicy.java
+++ b/CodenameOne/src/com/codename1/security/TapjackingPolicy.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.security;
+
+/// What the framework should do about a touch that arrives while another application's window is
+/// drawn over this app. See [DeviceIntegrity#setTapjackingProtection(TapjackingPolicy)].
+///
+/// The distinction that matters here is between *fully* and *partially* obscured. Android reports
+/// them as two different flags, and they carry very different signal-to-noise:
+///
+/// - **Fully obscured** means another window sits directly over the point that was touched. That is
+///   the tapjacking attack itself, and it is rare enough in normal use that blocking on it is safe.
+/// - **Partially obscured** means some other window covers *part* of this app's window, anywhere.
+///   Benign system UI sets it routinely, so treating it as an attack will drop legitimate taps.
+///
+/// That is why [#BLOCK] stops at the first and [#STRICT] is a deliberate opt-in to the second.
+public enum TapjackingPolicy {
+
+    /// No detection and no reporting. This is the default: the check costs nothing but an app that
+    /// never asked for it should not start seeing signals, and blocking touches is not a behaviour
+    /// to switch on behind a developer's back.
+    OFF,
+
+    /// Observe and report, but never change event delivery. Touches are dispatched exactly as they
+    /// would be with [#OFF], while [DeviceIntegrity#isScreenObscured()], the tapjacking listeners
+    /// and the [com.codename1.security.shield.ShieldSignal#TAPJACK] signal all become live.
+    ///
+    /// Use this to measure how often obscuring actually happens in your user base before you commit
+    /// to dropping input.
+    REPORT,
+
+    /// Report, and drop any gesture that begins on a fully obscured window. **The recommended
+    /// setting for a sensitive app.**
+    ///
+    /// The whole gesture is dropped, not the individual event: swallowing a press while letting the
+    /// matching release through would leave the framework holding half a gesture.
+    BLOCK,
+
+    /// As [#BLOCK], and additionally drop gestures that arrive while the window is only *partially*
+    /// obscured.
+    ///
+    /// Understand the cost before choosing this. The partial flag is set by ordinary system UI, so
+    /// on some devices this will discard taps the user meant, and the app will read as unresponsive
+    /// with nothing in the logs to explain it. Reach for it only where a missed tap is clearly
+    /// preferable to a hijacked one.
+    STRICT;
+
+    /// Whether this policy wants the platform to look at the obscured flags at all. False only for
+    /// [#OFF], which is what lets a port skip the check entirely on the hot input path.
+    public boolean isDetecting() {
+        return this != OFF;
+    }
+
+    /// Whether a gesture carrying these obscured flags should be dropped rather than delivered.
+    ///
+    /// This is the whole blocking decision, kept here as pure logic so it is identical on every
+    /// port and can be tested without a device.
+    ///
+    /// #### Parameters
+    ///
+    /// - `obscured`: another window sits directly over the touched point
+    /// - `partiallyObscured`: another window covers some part of this app's window
+    ///
+    /// #### Returns
+    ///
+    /// true if the gesture must not be delivered to the application
+    public boolean blocks(boolean obscured, boolean partiallyObscured) {
+        if (this == BLOCK) {
+            return obscured;
+        }
+        if (this == STRICT) {
+            return obscured || partiallyObscured;
+        }
+        // OFF and REPORT never change delivery.
+        return false;
+    }
+}

--- a/CodenameOne/src/com/codename1/security/shield/ShieldSignal.java
+++ b/CodenameOne/src/com/codename1/security/shield/ShieldSignal.java
@@ -45,6 +45,11 @@ public final class ShieldSignal {
     public static final String REPACKAGED = "repackaged";
     /// An accessibility service that is not on the allow list is enabled.
     public static final String ACCESSIBILITY = "accessibility";
+    /// Another application's window was drawn over this app while it was being touched, which is
+    /// how a tapjacking attack presents itself. Unlike the signals above this describes a moment
+    /// rather than a property of the device: see
+    /// [com.codename1.security.DeviceIntegrity#isScreenObscured()].
+    public static final String TAPJACK = "tapjack";
 
     private final String id;
     private final int severity;

--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -331,6 +331,11 @@ public final class Display extends CN1Constants {
     private boolean lockOrientation;
     private boolean disableScreenshots;
 
+    /// Tapjacking settings supplied through setProperty before an implementation existed, applied
+    /// in init(). See the deferral in init() and the setProperty branches below.
+    private com.codename1.security.TapjackingPolicy pendingTapjackingPolicy;
+    private boolean pendingHideOverlayWindows;
+
     // huge false positive from PMD...
     @SuppressWarnings("PMD.SingularField")
     private Form eventForm;
@@ -373,6 +378,18 @@ public final class Display extends CN1Constants {
             if (INSTANCE.disableScreenshots) {
                 impl.setDisableScreenshots(true);
                 INSTANCE.disableScreenshots = false;
+            }
+
+            // Same deferral as disableScreenshots above: the android.tapjackingGuard build hint
+            // sets these properties from the activity stub, which can run before there is an impl
+            // to hand them to.
+            if (INSTANCE.pendingTapjackingPolicy != null) {
+                impl.setTapjackingProtection(INSTANCE.pendingTapjackingPolicy);
+                INSTANCE.pendingTapjackingPolicy = null;
+            }
+            if (INSTANCE.pendingHideOverlayWindows) {
+                impl.setHideOverlayWindows(true);
+                INSTANCE.pendingHideOverlayWindows = false;
             }
 
             // only enable but never disable the third softbutton
@@ -4009,6 +4026,22 @@ public final class Display extends CN1Constants {
             }
             impl.setDisableScreenshots("true".equalsIgnoreCase(value));
         }
+        if ("TapjackingProtection".equals(key)) {
+            com.codename1.security.TapjackingPolicy policy = parseTapjackingPolicy(value);
+            if (impl == null) {
+                pendingTapjackingPolicy = policy;
+                return;
+            }
+            impl.setTapjackingProtection(policy);
+        }
+        if ("HideOverlayWindows".equals(key)) {
+            boolean hide = "true".equalsIgnoreCase(value);
+            if (impl == null) {
+                pendingHideOverlayWindows = hide;
+                return;
+            }
+            impl.setHideOverlayWindows(hide);
+        }
         if ("Component.revalidateOnStyleChange".equals(key)) {
             Component.setRevalidateOnStyleChange("true".equalsIgnoreCase(value));
         }
@@ -4024,6 +4057,27 @@ public final class Display extends CN1Constants {
         } else {
             localProperties.put(key, value);
         }
+    }
+
+    /// Maps the `TapjackingProtection` property value onto the enum. The value reaches us from a
+    /// build hint, so an unrecognised one is a project configuration mistake rather than something
+    /// the app can handle: fall back to the safest useful reading, which is BLOCK, because the
+    /// property is only ever set when the developer asked for protection in the first place.
+    private static com.codename1.security.TapjackingPolicy parseTapjackingPolicy(String value) {
+        if (value == null) {
+            return com.codename1.security.TapjackingPolicy.OFF;
+        }
+        String v = value.trim();
+        if ("off".equalsIgnoreCase(v)) {
+            return com.codename1.security.TapjackingPolicy.OFF;
+        }
+        if ("report".equalsIgnoreCase(v)) {
+            return com.codename1.security.TapjackingPolicy.REPORT;
+        }
+        if ("strict".equalsIgnoreCase(v)) {
+            return com.codename1.security.TapjackingPolicy.STRICT;
+        }
+        return com.codename1.security.TapjackingPolicy.BLOCK;
     }
 
     /// Returns true if executing this URL should work, returns false if it will not
@@ -6922,6 +6976,43 @@ public final class Display extends CN1Constants {
     /// Marks the current screen secure (Android `FLAG_SECURE`), blocking screenshots/recording/scraping.
     public void setSecureScreen(boolean secure) {
         impl.setSecureScreen(secure);
+    }
+
+    /// Sets the tapjacking policy. See
+    /// `com.codename1.security.DeviceIntegrity#setTapjackingProtection(TapjackingPolicy)`.
+    public void setTapjackingProtection(com.codename1.security.TapjackingPolicy policy) {
+        impl.setTapjackingProtection(policy);
+    }
+
+    /// The tapjacking policy currently in force, never null.
+    public com.codename1.security.TapjackingPolicy getTapjackingPolicy() {
+        return impl.getTapjackingPolicy();
+    }
+
+    /// True when the most recently observed touch arrived over an obscured window. See
+    /// `com.codename1.security.DeviceIntegrity#isScreenObscured()`.
+    public boolean isScreenObscured() {
+        return impl.isScreenObscured();
+    }
+
+    /// Registers a listener notified when the obscured state changes.
+    public void addTapjackingListener(ActionListener l) {
+        impl.addTapjackingListener(l);
+    }
+
+    /// Removes a listener added by `addTapjackingListener()`.
+    public void removeTapjackingListener(ActionListener l) {
+        impl.removeTapjackingListener(l);
+    }
+
+    /// Asks the OS to hide overlay windows drawn over this app (Android 12+).
+    public void setHideOverlayWindows(boolean hide) {
+        impl.setHideOverlayWindows(hide);
+    }
+
+    /// True where `setHideOverlayWindows()` is actually enforced by the platform.
+    public boolean isHideOverlayWindowsSupported() {
+        return impl.isHideOverlayWindowsSupported();
     }
 
     /// Returns the build hints for the simulator, this will only work in the debug environment and it's

--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -2012,6 +2012,13 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
             }
             myView.getAndroidView().setVisibility(View.VISIBLE);
 
+            // A tapjacking policy set before the surface existed -- which is the normal case
+            // for the android.tapjackingGuard build hint -- stored the policy but had no view to
+            // put the filter flag on. Re-apply it now that there is one.
+            if (getTapjackingPolicy().isDetecting()) {
+                setTapjackingProtection(getTapjackingPolicy());
+            }
+
             if (Build.VERSION.SDK_INT >= 16) {
                 final View semanticHost = myView.getAndroidView();
                 accessibilityProvider = new AndroidAccessibilityProvider(semanticHost, this);
@@ -13855,6 +13862,67 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
                         act.getWindow().clearFlags(android.view.WindowManager.LayoutParams.FLAG_SECURE);
                     }
                 } catch(Throwable t) {
+                    com.codename1.io.Log.e(t);
+                }
+            }
+        });
+    }
+
+    @Override
+    public void setTapjackingProtection(com.codename1.security.TapjackingPolicy policy) {
+        super.setTapjackingProtection(policy);
+        final boolean filter = getTapjackingPolicy().blocks(true, false);
+        final Activity act = getActivity();
+        if (act == null || myView == null) {
+            return;
+        }
+        final View v = myView.getAndroidView();
+        if (v == null) {
+            return;
+        }
+        // Defense in depth only. AndroidAsyncView.dispatchTouchEvent bypasses the framework's
+        // onFilterTouchEventForSecurity, so this flag does not protect CN1 components -- that is
+        // CodenameOneView.tapjacked()'s job. It does cover the super.dispatchTouchEvent fallback
+        // path, which is how a native peer would otherwise still receive an obscured touch.
+        act.runOnUiThread(new Runnable() {
+            public void run() {
+                try {
+                    v.setFilterTouchesWhenObscured(filter);
+                } catch (Throwable t) {
+                    com.codename1.io.Log.e(t);
+                }
+            }
+        });
+    }
+
+    @Override
+    public boolean isHideOverlayWindowsSupported() {
+        return Build.VERSION.SDK_INT >= 31;
+    }
+
+    @Override
+    public void setHideOverlayWindows(final boolean hide) {
+        if (Build.VERSION.SDK_INT < 31) {
+            return;
+        }
+        final Activity act = getActivity();
+        if (act == null) {
+            return;
+        }
+        act.runOnUiThread(new Runnable() {
+            public void run() {
+                try {
+                    // Window.setHideOverlayWindows(boolean) is API 31 and absent from the
+                    // android.jar this port compiles against, so it is reached reflectively --
+                    // the same approach the port uses for the Play Integrity API.
+                    android.view.Window w = act.getWindow();
+                    if (w == null) {
+                        return;
+                    }
+                    java.lang.reflect.Method m = android.view.Window.class.getMethod(
+                            "setHideOverlayWindows", boolean.class);
+                    m.invoke(w, Boolean.valueOf(hide));
+                } catch (Throwable t) {
                     com.codename1.io.Log.e(t);
                 }
             }

--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -13897,12 +13897,40 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
 
     @Override
     public boolean isHideOverlayWindowsSupported() {
-        return Build.VERSION.SDK_INT >= 31;
+        // The permission half matters as much as the API level. Window.setHideOverlayWindows
+        // throws SecurityException without HIDE_OVERLAY_WINDOWS; reflection wraps it and the
+        // catch below only logs it, so reporting support on the API level alone would tell an
+        // app its native peers were protected when in fact nothing happened. It is a normal
+        // permission, granted at install once the manifest declares it, which the
+        // android.tapjackingGuard / android.hideOverlayWindows build hints arrange.
+        return Build.VERSION.SDK_INT >= 31 && hasHideOverlayWindowsPermission();
+    }
+
+    private boolean hasHideOverlayWindowsPermission() {
+        try {
+            Context ctx = getContext();
+            if (ctx == null) {
+                return false;
+            }
+            return ctx.checkSelfPermission("android.permission.HIDE_OVERLAY_WINDOWS")
+                    == android.content.pm.PackageManager.PERMISSION_GRANTED;
+        } catch (Throwable t) {
+            return false;
+        }
     }
 
     @Override
     public void setHideOverlayWindows(final boolean hide) {
         if (Build.VERSION.SDK_INT < 31) {
+            return;
+        }
+        if (!hasHideOverlayWindowsPermission()) {
+            // Said out loud rather than left to the swallowed SecurityException below: an app
+            // that calls this without the build hint would otherwise see no effect and no
+            // explanation for why its overlays were never hidden.
+            com.codename1.io.Log.p("Codename One: setHideOverlayWindows ignored, the app does "
+                    + "not hold android.permission.HIDE_OVERLAY_WINDOWS. Enable the "
+                    + "android.tapjackingGuard or android.hideOverlayWindows build hint.");
             return;
         }
         final Activity act = getActivity();

--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -2012,12 +2012,6 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
             }
             myView.getAndroidView().setVisibility(View.VISIBLE);
 
-            // A tapjacking policy set before the surface existed -- which is the normal case
-            // for the android.tapjackingGuard build hint -- stored the policy but had no view to
-            // put the filter flag on. Re-apply it now that there is one.
-            if (getTapjackingPolicy().isDetecting()) {
-                setTapjackingProtection(getTapjackingPolicy());
-            }
             if (hideOverlayWindowsRequested) {
                 setHideOverlayWindows(true);
             }
@@ -13865,33 +13859,6 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
                         act.getWindow().clearFlags(android.view.WindowManager.LayoutParams.FLAG_SECURE);
                     }
                 } catch(Throwable t) {
-                    com.codename1.io.Log.e(t);
-                }
-            }
-        });
-    }
-
-    @Override
-    public void setTapjackingProtection(com.codename1.security.TapjackingPolicy policy) {
-        super.setTapjackingProtection(policy);
-        final boolean filter = getTapjackingPolicy().blocks(true, false);
-        final Activity act = getActivity();
-        if (act == null || myView == null) {
-            return;
-        }
-        final View v = myView.getAndroidView();
-        if (v == null) {
-            return;
-        }
-        // Defense in depth only. AndroidAsyncView.dispatchTouchEvent bypasses the framework's
-        // onFilterTouchEventForSecurity, so this flag does not protect CN1 components -- that is
-        // CodenameOneView.tapjacked()'s job. It does cover the super.dispatchTouchEvent fallback
-        // path, which is how a native peer would otherwise still receive an obscured touch.
-        act.runOnUiThread(new Runnable() {
-            public void run() {
-                try {
-                    v.setFilterTouchesWhenObscured(filter);
-                } catch (Throwable t) {
                     com.codename1.io.Log.e(t);
                 }
             }

--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -2018,6 +2018,9 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
             if (getTapjackingPolicy().isDetecting()) {
                 setTapjackingProtection(getTapjackingPolicy());
             }
+            if (hideOverlayWindowsRequested) {
+                setHideOverlayWindows(true);
+            }
 
             if (Build.VERSION.SDK_INT >= 16) {
                 final View semanticHost = myView.getAndroidView();
@@ -13906,6 +13909,9 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
         return Build.VERSION.SDK_INT >= 31 && hasHideOverlayWindowsPermission();
     }
 
+    /** The last value passed to setHideOverlayWindows, replayed onto a recreated window. */
+    private boolean hideOverlayWindowsRequested;
+
     private boolean hasHideOverlayWindowsPermission() {
         try {
             Context ctx = getContext();
@@ -13921,6 +13927,12 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
 
     @Override
     public void setHideOverlayWindows(final boolean hide) {
+        // Recorded before the guards below because it is a request, not a result: the flag
+        // lives on the Window, and a configuration change destroys and recreates the activity
+        // without touching this implementation instance. initSurface() replays it onto the new
+        // window, otherwise an app that hid overlays on a sensitive screen would come back from
+        // a rotation with them allowed again and no way to notice.
+        hideOverlayWindowsRequested = hide;
         if (Build.VERSION.SDK_INT < 31) {
             return;
         }

--- a/Ports/Android/src/com/codename1/impl/android/CodenameOneView.java
+++ b/Ports/Android/src/com/codename1/impl/android/CodenameOneView.java
@@ -649,6 +649,13 @@ public class CodenameOneView {
     private boolean tapjackBlockedGesture = false;
 
     /**
+     * The hover counterpart of {@link #tapjackBlockedGesture}, tracked separately
+     * because hover enter/exit interleaves with touch rather than nesting inside
+     * it -- a stylus can hover while a finger is down.
+     */
+    private boolean tapjackBlockedHover = false;
+
+    /**
      * MotionEvent.FLAG_WINDOW_IS_PARTIALLY_OBSCURED. Added in API 21 but absent
      * from the android.jar this port compiles against, so the value is inlined --
      * the same approach the port already takes for FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS
@@ -833,7 +840,25 @@ public class CodenameOneView {
         if (this.implementation.getCurrentForm() == null) {
             return false;
         }
-        if (tapjacked(event)) {
+        // Hover is a paired sequence rather than a gesture: the enter puts a component into a
+        // hovered state that only the exit takes it out of. Filtering it the way touches are
+        // filtered would mean an overlay appearing mid-hover swallows the exit for an enter
+        // that was already delivered, leaving the component hovered permanently. So a sequence
+        // that STARTS obscured is withheld in full -- no enter was delivered, so no exit is
+        // owed -- while one that started clean always gets its release, whatever the flags say
+        // by then.
+        boolean hoverBlocked = tapjacked(event);
+        int hoverAction = event.getActionMasked();
+        if (hoverAction == MotionEvent.ACTION_HOVER_ENTER) {
+            tapjackBlockedHover = hoverBlocked;
+        }
+        if (tapjackBlockedHover) {
+            if (hoverAction == MotionEvent.ACTION_HOVER_EXIT) {
+                tapjackBlockedHover = false;
+            }
+            return true;
+        }
+        if (hoverBlocked && hoverAction != MotionEvent.ACTION_HOVER_EXIT) {
             return true;
         }
         final int x = (int) event.getX();

--- a/Ports/Android/src/com/codename1/impl/android/CodenameOneView.java
+++ b/Ports/Android/src/com/codename1/impl/android/CodenameOneView.java
@@ -31,6 +31,7 @@ import android.util.Log;
 import android.view.*;
 import android.view.inputmethod.EditorInfo;
 import android.os.Build;
+import com.codename1.security.TapjackingPolicy;
 import com.codename1.ui.Component;
 import com.codename1.ui.Display;
 import com.codename1.ui.Form;
@@ -630,7 +631,58 @@ public class CodenameOneView {
 
     private boolean cn1GrabbedPointer = false;
     //private boolean nativePeerGrabbedPointer = false;
-    
+
+    /**
+     * Android's own obscured-touch filtering, which
+     * {@code View.setFilterTouchesWhenObscured(true)} enables, runs inside
+     * {@code View.dispatchTouchEvent} via {@code onFilterTouchEventForSecurity}.
+     * {@link AndroidAsyncView#dispatchTouchEvent} -- the primary surface on every
+     * modern device -- calls straight into {@link #onTouchEvent} and only falls
+     * back to {@code super} when we decline the event, so that filtering never
+     * runs on the path CN1 components are actually reached through. The check has
+     * to be made explicitly here, or the flag would look enabled and do nothing.
+     *
+     * <p>Latched for the duration of a gesture rather than evaluated per event:
+     * dropping only the ACTION_DOWN would deliver a pointerReleased with no
+     * matching pointerPressed and leave the framework holding half a gesture.</p>
+     */
+    private boolean tapjackBlockedGesture = false;
+
+    /**
+     * MotionEvent.FLAG_WINDOW_IS_PARTIALLY_OBSCURED. Added in API 21 but absent
+     * from the android.jar this port compiles against, so the value is inlined --
+     * the same approach the port already takes for FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS
+     * in AndroidImplementation.
+     */
+    private static final int FLAG_WINDOW_IS_PARTIALLY_OBSCURED = 0x2;
+
+    /**
+     * Reports the obscured flags on an event and answers whether the touch it
+     * belongs to must be withheld from the application.
+     *
+     * @param event the event being handled
+     * @return true when the caller must not dispatch this event
+     */
+    private boolean tapjacked(MotionEvent event) {
+        TapjackingPolicy policy = this.implementation.getTapjackingPolicy();
+        if (policy == null || !policy.isDetecting()) {
+            return false;
+        }
+        boolean obscured;
+        boolean partial;
+        try {
+            int flags = event.getFlags();
+            obscured = (flags & MotionEvent.FLAG_WINDOW_IS_OBSCURED) != 0;
+            partial = (flags & FLAG_WINDOW_IS_PARTIALLY_OBSCURED) != 0;
+        } catch (Throwable t) {
+            // Detection must never break input handling.
+            return false;
+        }
+        this.implementation.notifyScreenObscured(obscured || partial,
+                obscured ? "obscured" : (partial ? "partiallyObscured" : null));
+        return policy.blocks(obscured, partial);
+    }
+
     public boolean onTouchEvent(MotionEvent event) {
 
         if (this.implementation.getCurrentForm() == null) {
@@ -712,6 +764,27 @@ public class CodenameOneView {
         }
         boolean consumeEvent = !isPeer || cn1GrabbedPointer;
 
+        // Tapjacking: a gesture that starts obscured is dropped in full.
+        //
+        // Returns true unconditionally rather than the consumeEvent computed above. That value
+        // is false when the touch landed on a native peer, and returning it would send the event
+        // back to AndroidAsyncView.dispatchTouchEvent, which then hands it to
+        // super.dispatchTouchEvent and straight on to the peer -- delivering to a
+        // BrowserComponent or a native text field precisely the touch we are withholding from
+        // everything else. Claiming the event is what actually drops it.
+        boolean blocked = tapjacked(event);
+        int tapjackAction = event.getAction();
+        if (tapjackAction == MotionEvent.ACTION_DOWN) {
+            tapjackBlockedGesture = blocked;
+        }
+        if (tapjackBlockedGesture) {
+            if (tapjackAction == MotionEvent.ACTION_UP || tapjackAction == MotionEvent.ACTION_CANCEL) {
+                tapjackBlockedGesture = false;
+                cn1GrabbedPointer = false;
+            }
+            return true;
+        }
+
         updatePointerMetadata(event, false);
 
         switch (event.getAction()) {
@@ -756,6 +829,9 @@ public class CodenameOneView {
         if (this.implementation.getCurrentForm() == null) {
             return false;
         }
+        if (tapjacked(event)) {
+            return true;
+        }
         final int x = (int) event.getX();
         final int y = (int) event.getY();
         updatePointerMetadata(event, true);
@@ -783,6 +859,9 @@ public class CodenameOneView {
     public boolean onGenericMotionEvent(MotionEvent event) {
         if (this.implementation.getCurrentForm() == null) {
             return false;
+        }
+        if (tapjacked(event)) {
+            return true;
         }
         if (event.getActionMasked() == MotionEvent.ACTION_SCROLL) {
             int x = (int) event.getX();

--- a/Ports/Android/src/com/codename1/impl/android/CodenameOneView.java
+++ b/Ports/Android/src/com/codename1/impl/android/CodenameOneView.java
@@ -645,6 +645,17 @@ public class CodenameOneView {
      * <p>Latched for the duration of a gesture rather than evaluated per event:
      * dropping only the ACTION_DOWN would deliver a pointerReleased with no
      * matching pointerPressed and leave the framework holding half a gesture.</p>
+     *
+     * <p>That latch is also why the port deliberately does <em>not</em> switch
+     * {@code setFilterTouchesWhenObscured} on for the native-peer fallback, which
+     * would otherwise look like free defense in depth. It filters per event, so an
+     * overlay appearing after a clean ACTION_DOWN on a peer would have the
+     * framework reject the ACTION_UP the peer was already owed, leaving a
+     * BrowserComponent or native text field stuck pressed with nothing to release
+     * it -- the same pairing failure the latch exists to avoid. A gesture that
+     * starts obscured never reaches {@code super.dispatchTouchEvent} at all,
+     * because this method claims it, so the peer is protected by the whole-gesture
+     * decision rather than by a per-event one.</p>
      */
     private boolean tapjackBlockedGesture = false;
 

--- a/Ports/Android/src/com/codename1/impl/android/CodenameOneView.java
+++ b/Ports/Android/src/com/codename1/impl/android/CodenameOneView.java
@@ -693,12 +693,37 @@ public class CodenameOneView {
              */
             return true;
         }
+        // Tapjacking has to be resolved before ANY side effect of the touch, not merely before
+        // the pointer dispatch below. The keyboard re-summon that follows is one such side
+        // effect: an obscured ACTION_UP reaching it would reopen the keyboard for a gesture the
+        // BLOCK/STRICT policy promised to withhold. Anything added to this method later belongs
+        // after this block for the same reason.
+        //
+        // Returns true rather than the consumeEvent computed further down. That value is false
+        // when the touch landed on a native peer, and returning it would send the event back to
+        // AndroidAsyncView.dispatchTouchEvent, which hands it to super.dispatchTouchEvent and
+        // straight on to the peer -- delivering to a BrowserComponent or a native text field
+        // precisely the touch we are withholding from everything else. Claiming the event is
+        // what actually drops it.
+        boolean tapjackBlocked = tapjacked(event);
+        int tapjackAction = event.getAction();
+        if (tapjackAction == MotionEvent.ACTION_DOWN) {
+            tapjackBlockedGesture = tapjackBlocked;
+        }
+        if (tapjackBlockedGesture) {
+            if (tapjackAction == MotionEvent.ACTION_UP || tapjackAction == MotionEvent.ACTION_CANCEL) {
+                tapjackBlockedGesture = false;
+                cn1GrabbedPointer = false;
+            }
+            return true;
+        }
+
         if (event.getAction() == MotionEvent.ACTION_UP) {
             // EditText re-summons a dismissed keyboard on every tap; give the pure
             // editors the same behavior while their input session is bound
             AndroidImplementation.showSoftInputForActiveClient();
         }
-        
+
         
 
         int[] x = null;
@@ -763,27 +788,6 @@ public class CodenameOneView {
             isPeer = !Sheet.isSheetVisibleAt(primaryX, primaryY);
         }
         boolean consumeEvent = !isPeer || cn1GrabbedPointer;
-
-        // Tapjacking: a gesture that starts obscured is dropped in full.
-        //
-        // Returns true unconditionally rather than the consumeEvent computed above. That value
-        // is false when the touch landed on a native peer, and returning it would send the event
-        // back to AndroidAsyncView.dispatchTouchEvent, which then hands it to
-        // super.dispatchTouchEvent and straight on to the peer -- delivering to a
-        // BrowserComponent or a native text field precisely the touch we are withholding from
-        // everything else. Claiming the event is what actually drops it.
-        boolean blocked = tapjacked(event);
-        int tapjackAction = event.getAction();
-        if (tapjackAction == MotionEvent.ACTION_DOWN) {
-            tapjackBlockedGesture = blocked;
-        }
-        if (tapjackBlockedGesture) {
-            if (tapjackAction == MotionEvent.ACTION_UP || tapjackAction == MotionEvent.ACTION_CANCEL) {
-                tapjackBlockedGesture = false;
-                cn1GrabbedPointer = false;
-            }
-            return true;
-        }
 
         updatePointerMetadata(event, false);
 

--- a/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
@@ -8744,7 +8744,14 @@ public class JavaSEPort extends CodenameOneImplementation {
                         // the tapjacking listeners and the ShieldSignal silent, so the
                         // switch would report a state it did not actually cause -- which
                         // is the failure this menu exists to avoid.
-                        notifyScreenObscured(v, v ? "simulated" : null);
+                        //
+                        // Only while the policy is detecting, though. OFF promises no
+                        // detection and no reporting, and the Android port keeps that
+                        // promise by returning from tapjacked() before it reports; a
+                        // simulator that raised the signal anyway would behave unlike the
+                        // device it is standing in for. setTapjackingProtection below
+                        // picks the flag up if detection is switched on afterwards.
+                        applySimulatedScreenOverlay();
                     }
                 }));
 
@@ -19534,6 +19541,25 @@ public class JavaSEPort extends CodenameOneImplementation {
         // As above: the desktop has no overlay windows to hide, so this is
         // recorded rather than acted on.
         JavaSEShield.hideOverlayWindows = hide;
+    }
+
+    @Override
+    public void setTapjackingProtection(com.codename1.security.TapjackingPolicy policy) {
+        super.setTapjackingProtection(policy);
+        // Switching detection on has to pick up an overlay the Simulate menu already has
+        // switched on, and switching it off has to retract it -- otherwise isScreenObscured()
+        // keeps answering true under a policy that promises no detection at all.
+        applySimulatedScreenOverlay();
+    }
+
+    /**
+     * Pushes the Simulate &gt; App Shield &gt; Screen Overlay toggle into the real
+     * reporting path, but only while a policy that actually detects is in force,
+     * so the simulator matches what the Android port would report.
+     */
+    private void applySimulatedScreenOverlay() {
+        boolean obscured = getTapjackingPolicy().isDetecting() && JavaSEShield.simScreenObscured;
+        notifyScreenObscured(obscured, obscured ? "simulated" : null);
     }
 
     @Override

--- a/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
@@ -8734,6 +8734,19 @@ public class JavaSEPort extends CodenameOneImplementation {
                         JavaSEShield.simUntrustedAccessibility = v;
                     }
                 }));
+        shieldMenu.add(shieldToggle(pref, "Screen Overlay (Tapjacking)",
+                "ShieldSim.tapjack", new ShieldToggleSink() {
+                    @Override
+                    public void set(boolean v) {
+                        JavaSEShield.simScreenObscured = v;
+                        // Drive the real state machine rather than overriding
+                        // isScreenObscured(). Setting a flag the getter reads would leave
+                        // the tapjacking listeners and the ShieldSignal silent, so the
+                        // switch would report a state it did not actually cause -- which
+                        // is the failure this menu exists to avoid.
+                        notifyScreenObscured(v, v ? "simulated" : null);
+                    }
+                }));
 
         shieldMenu.addSeparator();
 
@@ -19514,6 +19527,13 @@ public class JavaSEPort extends CodenameOneImplementation {
         // No OS-level equivalent on the desktop. Recorded so the menu can show
         // whether the app asked for it, which is what a developer is checking.
         JavaSEShield.secureScreen = secure;
+    }
+
+    @Override
+    public void setHideOverlayWindows(boolean hide) {
+        // As above: the desktop has no overlay windows to hide, so this is
+        // recorded rather than acted on.
+        JavaSEShield.hideOverlayWindows = hide;
     }
 
     @Override

--- a/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEShield.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEShield.java
@@ -76,6 +76,18 @@ public final class JavaSEShield {
     public static boolean simRepackaged;
     public static boolean simUntrustedAccessibility;
 
+    /**
+     * True when the simulated device reports that another app's window is drawn
+     * over this one, i.e. a tapjacking attempt.
+     *
+     * <p>Deliberately not part of {@link #simReasons()}. The compromise reasons
+     * describe a standing property of the device and feed
+     * {@code isDeviceCompromised()}; being obscured is a transient condition with
+     * benign causes, and folding it in would make a device look rooted because
+     * the notification shade was open.</p>
+     */
+    public static boolean simScreenObscured;
+
     // --- token ------------------------------------------------------------
 
     /** Simulated token lifetime. */
@@ -122,6 +134,9 @@ public final class JavaSEShield {
     /** True when the window is displaying a screen marked secure. */
     public static boolean secureScreen;
 
+    /** True when the app has asked the OS to hide overlay windows. */
+    public static boolean hideOverlayWindows;
+
     /** The compromise reasons the simulated device reports. */
     public static String[] simReasons() {
         List<String> out = new ArrayList<String>();
@@ -161,11 +176,13 @@ public final class JavaSEShield {
         simDebugger = false;
         simRepackaged = false;
         simUntrustedAccessibility = false;
+        simScreenObscured = false;
         tokenTtlSeconds = 300;
         serveExpiredToken = false;
         forcePinMismatch = false;
         failPinFetch = false;
         secureScreen = false;
+        hideOverlayWindows = false;
         onForcePinMismatchConsumed = null;
     }
 
@@ -185,6 +202,9 @@ public final class JavaSEShield {
           .append(forcePinMismatch ? "forcing mismatch" : "normal")
           .append(failPinFetch ? ", pin fetch failing" : "").append('\n');
         sb.append("Secure screen: ").append(secureScreen).append('\n');
+        sb.append("Screen overlay: ")
+          .append(simScreenObscured ? "obscured (tapjacking)" : "clear").append('\n');
+        sb.append("Hide overlay windows: ").append(hideOverlayWindows).append('\n');
         return sb.toString();
     }
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/SecurityJava017Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/SecurityJava017Snippet.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codenameone.developerguide.snippets.generated;
 
 import com.codename1.gpu.*;

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/SecurityJava017Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/SecurityJava017Snippet.java
@@ -1,0 +1,83 @@
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import java.util.*;
+
+
+class SecurityJava017Snippet {
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    void snippet() throws Exception {
+        // tag::security-java-017[]
+        // Switch on tapjacking protection once, during startup. BLOCK drops any gesture
+        // that begins while another app's window covers the touched point.
+        DeviceIntegrity.setTapjackingProtection(TapjackingPolicy.BLOCK);
+
+        // A blocked gesture never reaches your components, so this listener is how the
+        // app learns the tap happened. It fires when the state changes, not per touch.
+        DeviceIntegrity.addTapjackingListener(e -> {
+            if (DeviceIntegrity.isScreenObscured()) {
+                Dialog.show("Security warning",
+                        "Another app is drawing over this screen. Close it before continuing.",
+                        "OK", null);
+            }
+        });
+
+        // On a sensitive screen, remove the overlay instead of merely filtering its taps.
+        // This is Android 12+ only, and unlike the touch filter it also protects native
+        // peer components such as BrowserComponent.
+        if (DeviceIntegrity.isHideOverlayWindowsSupported()) {
+            DeviceIntegrity.setHideOverlayWindows(true);
+        }
+        DeviceIntegrity.setSecureScreen(true);
+        // end::security-java-017[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/SecurityJava017Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/SecurityJava017Snippet.java
@@ -85,8 +85,13 @@ class SecurityJava017Snippet {
 
         // A blocked gesture never reaches your components, so this listener is how the
         // app learns the tap happened. It fires when the state changes, not per touch.
+        //
+        // Read the state off the event, not from isScreenObscured(). The callback is
+        // delivered on the EDT while the state is updated on the platform's input thread,
+        // so a busy EDT can let a later clean touch land first -- and re-reading the
+        // global state would then skip the warning for the event that caused it.
         DeviceIntegrity.addTapjackingListener(e -> {
-            if (DeviceIntegrity.isScreenObscured()) {
+            if (Boolean.TRUE.equals(e.getSource())) {
                 Dialog.show("Security warning",
                         "Another app is drawing over this screen. Close it before continuing.",
                         "OK", null);

--- a/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
+++ b/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
@@ -225,10 +225,13 @@ If none of the services are defined to true then plus, auth, base, analytics, gc
 |Boolean true/false defaults to false. Switches on tapjacking / screen-overlay protection at launch, so touches that arrive while another app's window covers this one are detected and dropped. See the security chapter.
 
 |android.tapjackingGuard.mode
-|`block` (default), `strict`, `report` or `off`. `block` drops gestures that start on a fully obscured window, `report` only observes, `strict` also drops partially obscured touches (which benign system UI can trigger). Only relevant if `android.tapjackingGuard=true`.
+|`block` (default), `strict`, `report` or `off`. `block` drops gestures that start on a fully obscured window, `report` only observes, `strict` also drops touches where only part of the window is covered (which benign system UI can trigger). Only relevant if `android.tapjackingGuard=true`.
 
 |android.tapjackingGuard.hideOverlays
-|Boolean true/false defaults to true. Also asks Android 12+ to hide overlay windows drawn over the app, which is the only mitigation that covers native peer components. Only relevant if `android.tapjackingGuard=true`.
+|Boolean true/false defaults to true. Also asks Android 12+ to hide overlay windows drawn over the app, which is the only mitigation that covers native peer components, and declares the `HIDE_OVERLAY_WINDOWS` permission it requires. Only relevant if `android.tapjackingGuard=true`.
+
+|android.hideOverlayWindows
+|Boolean true/false defaults to false. Declares the `android.permission.HIDE_OVERLAY_WINDOWS` permission needed by `DeviceIntegrity.setHideOverlayWindows()` on Android 12+, for apps that call the runtime API without enabling `android.tapjackingGuard`. A normal install-time permission, so the user sees no prompt.
 
 |android.fridaDetection
 |Boolean true/false defaults to false. Indicates whether the app should check for the presence of the https://www.frida.re/[Frida] dynamic instrumentation toolkit on the device. If Frida is detected, the app will exit. This uses the [frida-blocker](https://github.com/shannah/frida-blocker) library to perform the frida detection.

--- a/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
+++ b/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
@@ -221,6 +221,15 @@ If none of the services are defined to true then plus, auth, base, analytics, gc
 |android.rootCheck
 |Boolean true/false defaults to false. Indicates whether the app should check for root access on the device. If root access is detected, the app will exit.
 
+|android.tapjackingGuard
+|Boolean true/false defaults to false. Switches on tapjacking / screen-overlay protection at launch, so touches that arrive while another app's window covers this one are detected and dropped. See the security chapter.
+
+|android.tapjackingGuard.mode
+|`block` (default), `strict`, `report` or `off`. `block` drops gestures that start on a fully obscured window, `report` only observes, `strict` also drops partially obscured touches (which benign system UI can trigger). Only relevant if `android.tapjackingGuard=true`.
+
+|android.tapjackingGuard.hideOverlays
+|Boolean true/false defaults to true. Also asks Android 12+ to hide overlay windows drawn over the app, which is the only mitigation that covers native peer components. Only relevant if `android.tapjackingGuard=true`.
+
 |android.fridaDetection
 |Boolean true/false defaults to false. Indicates whether the app should check for the presence of the https://www.frida.re/[Frida] dynamic instrumentation toolkit on the device. If Frida is detected, the app will exit. This uses the [frida-blocker](https://github.com/shannah/frida-blocker) library to perform the frida detection.
 

--- a/docs/developer-guide/App-Shield.asciidoc
+++ b/docs/developer-guide/App-Shield.asciidoc
@@ -354,6 +354,9 @@ None of this is testable against a real service on a developer's desktop, so the
 |Device signal toggles
 |Rooted / jailbroken, hooking framework, emulator, debugger, repackaged, untrusted accessibility service -- each raising the signal your code reacts to.
 
+|*Screen Overlay (Tapjacking)*
+|Fakes another app drawing over yours. It drives the real reporting path rather than setting a flag, so your tapjacking listener fires and the `tapjack` signal is raised exactly as it would be on a device. The desktop has no overlay windows, so this is the only way to reach that branch outside Android.
+
 |*Serve Expired Token*
 |The refresh path, without waiting out a real token's lifetime.
 

--- a/docs/developer-guide/languagetool-accept.txt
+++ b/docs/developer-guide/languagetool-accept.txt
@@ -642,6 +642,10 @@ BlueZ
 # -----------------------------------------------------------------------------
 unhardened
 unretraceable
+# Tapjacking (security.asciidoc). The standard industry name for the Android
+# overlay attack; "tapjack" is the signal id the API reports it under.
+[Tt]apjack(ing|ed|s)?
+[Uu]nobscured
 [Dd]eobfuscation
 [Mm]inif(y|ies|ied|ier|ication)
 [Uu]nminif(y|ies|ied|ier|ication)

--- a/docs/developer-guide/security.asciidoc
+++ b/docs/developer-guide/security.asciidoc
@@ -230,6 +230,35 @@ include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/g
 
 NOTE: Accessibility-service enumeration and `setSecureScreen()` are Android concepts; on iOS they're no-ops (iOS has no equivalent third-party accessibility-service threat model). Use `ios.disableScreenshots=true` to block screen capture on iOS as described in <<Disabling screenshots>>.
 
+==== Defending against tapjacking and screen overlays (Android)
+
+Tapjacking is the other half of the same attack. Instead of driving your app through an accessibility service, a malicious app draws its own window on top of yours -- a fake PIN pad, a fake confirmation button, or an invisible layer -- so the user believes they're tapping your UI while the tap is being framed, or harvested, by someone else. It's the classic way a banking transfer gets confirmed by a user who thought they were dismissing a notice.
+
+Android exposes this as flags on each touch event, and Codename One turns that into a policy you set once:
+
+* `android.tapjackingGuard=true` -- switches on protection at launch with no code. By default it blocks obscured touches and asks Android 12+ to hide overlay windows.
+* `android.tapjackingGuard.mode=block|strict|report` -- `block` (default) drops any gesture that starts while another window covers the touched point. `report` observes without changing behavior, which is the safe way to measure how often this happens in your user base first. `strict` also drops *partially* obscured touches; read the warning below before choosing it.
+* `android.tapjackingGuard.hideOverlays=true|false` -- whether to also call `setHideOverlayWindows()`. Defaults to `true`.
+
+The runtime API gives you the same control plus a notification:
+
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/SecurityJava017Snippet.java[tag=security-java-017,indent=0]
+----
+
+Two properties of this API are worth being precise about, because getting them wrong leads to a false sense of coverage.
+
+*Detection is touch-driven, not a live window query.* Android reports obscuring as a flag on a delivered `MotionEvent`, so `isScreenObscured()` means "the most recently observed touch arrived obscured". If an overlay appears and the user never touches the screen, nothing is observed. That's a platform limitation, not an implementation gap.
+
+*A blocked gesture is dropped in full.* Swallowing only the press and delivering the release would leave the framework holding half a gesture, so once a gesture starts obscured, everything through to the matching release is discarded. Your components see nothing at all -- which is exactly why the listener exists, and why an app that blocks should register one rather than rely on polling.
+
+`setHideOverlayWindows(true)` is the strongest of the three defenses and the only one that also covers native peer components such as `BrowserComponent` and native text fields, because it removes the offending window instead of filtering the touches it enables. It needs Android 12 (API 31); check `isHideOverlayWindowsSupported()`. Pair it with `setSecureScreen(true)` when you enter a sensitive screen and clear both on the way out.
+
+WARNING: `strict` mode blocks partially obscured touches, and ordinary system UI sets that flag routinely. On some devices this will discard taps the user intended and the app will simply feel broken, with nothing in the logs to explain it. Use it only where a missed tap is clearly preferable to a hijacked one, and test it on real hardware.
+
+NOTE: This family is Android-only. iOS gives no application a way to draw over another app, so there is nothing to detect: `isScreenObscured()` is always false and the policy has no effect. Screen recording and mirroring are a different threat, covered by `ios.disableScreenshots=true`. In the simulator, *Simulate > App Shield > Screen Overlay (Tapjacking)* fakes an overlay so you can exercise your listener on the desktop.
+
 === Strong Android certificates
 
 When Android launched RSA1024 with SHA1 was considered strong enough for the foreseeable future, this hasn't changed completely but the recommendation today is to use stronger ciphers for signing & encrypting as those can be compromised.

--- a/docs/developer-guide/security.asciidoc
+++ b/docs/developer-guide/security.asciidoc
@@ -237,7 +237,7 @@ Tapjacking is the other half of the same attack. Instead of driving your app thr
 Android exposes this as flags on each touch event, and Codename One turns that into a policy you set once:
 
 * `android.tapjackingGuard=true` -- switches on protection at launch with no code. By default it blocks obscured touches and asks Android 12+ to hide overlay windows.
-* `android.tapjackingGuard.mode=block|strict|report` -- `block` (default) drops any gesture that starts while another window covers the touched point. `report` observes without changing behavior, which is the safe way to measure how often this happens in your user base first. `strict` also drops *partially* obscured touches; read the warning below before choosing it.
+* `android.tapjackingGuard.mode=block|strict|report` -- `block` (default) drops any gesture that starts while another window covers the touched point. `report` observes without changing behavior, which is the safe way to measure how often this happens in your user base first. `strict` also drops touches where only part of the window is covered; read the warning below before choosing it.
 * `android.tapjackingGuard.hideOverlays=true|false` -- whether to also call `setHideOverlayWindows()`. Defaults to `true`.
 
 The runtime API gives you the same control plus a notification:
@@ -249,13 +249,18 @@ include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/g
 
 Two properties of this API are worth being precise about, because getting them wrong leads to a false sense of coverage.
 
-*Detection is touch-driven, not a live window query.* Android reports obscuring as a flag on a delivered `MotionEvent`, so `isScreenObscured()` means "the most recently observed touch arrived obscured". If an overlay appears and the user never touches the screen, nothing is observed. That's a platform limitation, not an implementation gap.
+*Detection is touch-driven, not a live window query.* Android reports obscuring as a flag on a delivered `MotionEvent`, so `isScreenObscured()` means "the most recently observed touch arrived obscured." If an overlay appears and the user never touches the screen, nothing is observed. That's a platform limitation, not an implementation gap.
 
 *A blocked gesture is dropped in full.* Swallowing only the press and delivering the release would leave the framework holding half a gesture, so once a gesture starts obscured, everything through to the matching release is discarded. Your components see nothing at all -- which is exactly why the listener exists, and why an app that blocks should register one rather than rely on polling.
 
-`setHideOverlayWindows(true)` is the strongest of the three defenses and the only one that also covers native peer components such as `BrowserComponent` and native text fields, because it removes the offending window instead of filtering the touches it enables. It needs Android 12 (API 31); check `isHideOverlayWindowsSupported()`. Pair it with `setSecureScreen(true)` when you enter a sensitive screen and clear both on the way out.
+`setHideOverlayWindows(true)` is the strongest of the three defenses and the only one that also covers native peer components such as `BrowserComponent` and native text fields, because it removes the offending window instead of filtering the touches it enables. Pair it with `setSecureScreen(true)` when you enter a sensitive screen and clear both on the way out.
 
-WARNING: `strict` mode blocks partially obscured touches, and ordinary system UI sets that flag routinely. On some devices this will discard taps the user intended and the app will simply feel broken, with nothing in the logs to explain it. Use it only where a missed tap is clearly preferable to a hijacked one, and test it on real hardware.
+It has two requirements, and `isHideOverlayWindowsSupported()` reports on both -- it returns `false` rather than claiming a protection you aren't getting:
+
+* Android 12 (API 31) or newer.
+* The `android.permission.HIDE_OVERLAY_WINDOWS` manifest permission. Without it the OS throws, so the call is skipped and logged instead. `android.tapjackingGuard=true` declares it for you; if you drive the runtime API without that hint, add `android.hideOverlayWindows=true`. It's a normal install-time permission -- no runtime prompt and no special-access screen for the user.
+
+WARNING: `strict` mode blocks touches where only part of the window is covered, and ordinary system UI causes that as a matter of course. On some devices this will discard taps the user intended and the app will simply feel broken, with nothing in the logs to explain it. Use it only where a missed tap is clearly preferable to a hijacked one, and test it on real hardware.
 
 NOTE: This family is Android-only. iOS gives no application a way to draw over another app, so there is nothing to detect: `isScreenObscured()` is always false and the policy has no effect. Screen recording and mirroring are a different threat, covered by `ios.disableScreenshots=true`. In the simulator, *Simulate > App Shield > Screen Overlay (Tapjacking)* fakes an overlay so you can exercise your listener on the desktop.
 

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
@@ -4238,6 +4238,22 @@ public class AndroidGradleBuilder extends Executor {
                     "    <uses-permission android:name=\"android.permission.POST_NOTIFICATIONS\" />\n");
         }
 
+        // Window.setHideOverlayWindows (Android 12+) throws SecurityException without this
+        // permission, so declaring it is what makes DeviceIntegrity.setHideOverlayWindows do
+        // anything at all. It is a normal (install-time) permission -- no runtime prompt, no
+        // special access screen -- so it is declared only for projects that asked for the
+        // overlay mitigation rather than added to every build.
+        //
+        // android.hideOverlayWindows exists for apps that drive the runtime API directly
+        // without the launch-time guard; android.tapjackingGuard implies it unless the project
+        // opted out with .hideOverlays=false.
+        if ("true".equalsIgnoreCase(request.getArg("android.hideOverlayWindows", "false"))
+                || (tapjackingGuard && request.getArg(
+                        "android.tapjackingGuard.hideOverlays", "true").equalsIgnoreCase("true"))) {
+            permissions += permissionAdd(request, "\"android.permission.HIDE_OVERLAY_WINDOWS\"",
+                    "    <uses-permission android:name=\"android.permission.HIDE_OVERLAY_WINDOWS\" />\n");
+        }
+
         if (capturePermission) {
             String andc = request.getArg("android.captureRecord", "enabled");
             if (request.getArg("and.captureRecord", andc).equals("enabled")) {

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
@@ -6835,6 +6835,16 @@ public class AndroidGradleBuilder extends Executor {
         // documentation promises launch-time protection -- worse than not offering it, because
         // the app ships believing it is guarded. The mirror is BuildDaemon#181 and the two are
         // meant to land together; keep them in step when either side changes.
+        //
+        // On ordering, since this looks late and is not: createOnCreateCode's output is the
+        // tail of the generated onCreate. The application's start() is emitted separately, by
+        // createStartInvocation, into the generated run() method that onResume reaches -- so
+        // Android has already returned from onCreate before any of it runs. Display is usually
+        // not initialized this early, which is fine and deliberate: Display.setProperty parks
+        // both values and Display.init() applies them, and that init happens in onResume ahead
+        // of the start call. The policy and the overlay request are therefore both in force
+        // before application code can show its first form. Moving these emissions later, into
+        // the start path, would be the change that actually opened a window.
         if (tapjackingGuard) {
             // Locale.ENGLISH, not the default locale: in a Turkish locale "STRICT".toLowerCase()
             // yields "strıct" (dotless i), which would silently miss the match below.

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
@@ -6828,6 +6828,13 @@ public class AndroidGradleBuilder extends Executor {
         // Unlike rootCheck/accessibilityGuard this is not a launch-time exit gate, it is a
         // standing runtime policy, so it is delivered as a Display property that
         // AndroidImplementation applies rather than as generated code in onCreate.
+        //
+        // This class builds locally. The cloud builder is a separate codebase
+        // (com.codename1.build.daemon.AndroidGradleBuilder in the BuildDaemon repo) and needs
+        // the identical block, or the hint is a silent no-op on cloud builds while the
+        // documentation promises launch-time protection -- worse than not offering it, because
+        // the app ships believing it is guarded. The mirror is BuildDaemon#181 and the two are
+        // meant to land together; keep them in step when either side changes.
         if (tapjackingGuard) {
             // Locale.ENGLISH, not the default locale: in a Turkish locale "STRICT".toLowerCase()
             // yields "strıct" (dotless i), which would silently miss the match below.

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
@@ -108,6 +108,8 @@ public class AndroidGradleBuilder extends Executor {
 
     private boolean accessibilityGuard = false;
 
+    private boolean tapjackingGuard = false;
+
     private boolean useGradle8 = true;
 
     // Flag to indicate whether we should strip kotlin from user classes
@@ -917,6 +919,7 @@ public class AndroidGradleBuilder extends Executor {
         fridaDetection = request.getArg("android.fridaDetection", "false").equals("true");
         playIntegrity = request.getArg("android.playIntegrity", "false").equals("true");
         accessibilityGuard = request.getArg("android.accessibilityGuard", "false").equals("true");
+        tapjackingGuard = request.getArg("android.tapjackingGuard", "false").equals("true");
         extendAppCompatActivity = request.getArg("android.extendAppCompatActivity", "false").equals("true");
         // When using gradle 8 we need to strip kotlin files from user classes otherwise we get duplicate class errors
         stripKotlinFromUserClasses = useGradle8;
@@ -6803,6 +6806,29 @@ public class AndroidGradleBuilder extends Executor {
 
         if (request.getArg("android.disableScreenshots", "false").equalsIgnoreCase("true")) {
             retVal += "Display.getInstance().setProperty(\"DisableScreenshots\", \"true\");\n";
+        }
+
+        // android.tapjackingGuard turns on overlay/tapjacking protection with no app code.
+        // Unlike rootCheck/accessibilityGuard this is not a launch-time exit gate, it is a
+        // standing runtime policy, so it is delivered as a Display property that
+        // AndroidImplementation applies rather than as generated code in onCreate.
+        if (tapjackingGuard) {
+            // Locale.ENGLISH, not the default locale: in a Turkish locale "STRICT".toLowerCase()
+            // yields "strıct" (dotless i), which would silently miss the match below.
+            String mode = request.getArg("android.tapjackingGuard.mode", "block")
+                    .trim().toLowerCase(java.util.Locale.ENGLISH);
+            if (!"block".equals(mode) && !"strict".equals(mode) && !"report".equals(mode)
+                    && !"off".equals(mode)) {
+                // A typo here would silently ship an unprotected app, so say so and use the
+                // documented default rather than passing the bad value through.
+                log("WARNING: unrecognized android.tapjackingGuard.mode '" + mode
+                        + "', using 'block'. Valid values are block, strict, report, off.");
+                mode = "block";
+            }
+            retVal += "Display.getInstance().setProperty(\"TapjackingProtection\", \"" + mode + "\");\n";
+            if (request.getArg("android.tapjackingGuard.hideOverlays", "true").equalsIgnoreCase("true")) {
+                retVal += "Display.getInstance().setProperty(\"HideOverlayWindows\", \"true\");\n";
+            }
         }
 
 

--- a/maven/core-unittests/src/test/java/com/codename1/security/TapjackingTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/security/TapjackingTest.java
@@ -390,6 +390,35 @@ class TapjackingTest extends UITestBase {
     }
 
     @Test
+    void aListenerRegisteredAfterATransitionDoesNotHearIt() {
+        // The listener set is captured when the transition is queued, not read when the EDT
+        // finally delivers it, so a listener that registers during an EDT backlog is not told
+        // about a change that predates it. Holding the dispatcher instead made that depend on
+        // whether an unrelated listener happened to exist at queue time, since an empty set
+        // queues nothing at all.
+        final List<Object> late = new ArrayList<Object>();
+        ActionListener lateListener = new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent evt) {
+                late.add(evt.getSource());
+            }
+        };
+
+        implementation.notifyScreenObscured(true, "obscured");
+        DeviceIntegrity.addTapjackingListener(lateListener);
+        flushSerialCalls();
+
+        try {
+            assertEquals(0, late.size(),
+                    "a listener must not receive a transition from before it registered");
+            // The listener that was registered when it happened still gets it.
+            assertTrue(observed.contains(Boolean.TRUE));
+        } finally {
+            DeviceIntegrity.removeTapjackingListener(lateListener);
+        }
+    }
+
+    @Test
     void aRemovedListenerStopsReceiving() {
         DeviceIntegrity.removeTapjackingListener(listener);
         implementation.notifyScreenObscured(true, "obscured");

--- a/maven/core-unittests/src/test/java/com/codename1/security/TapjackingTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/security/TapjackingTest.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.security;
+
+import com.codename1.junit.UITestBase;
+import com.codename1.security.shield.ShieldSignal;
+import com.codename1.security.shield.ShieldSignals;
+import com.codename1.ui.events.ActionEvent;
+import com.codename1.ui.events.ActionListener;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Coverage for the tapjacking / screen-overlay family of {@link DeviceIntegrity}.
+ *
+ * <p>Two things are being pinned down here. The first is the blocking truth table on
+ * {@link TapjackingPolicy}, which is pure logic precisely so that every port makes the
+ * same decision and it can be checked without a device. The second is the reporting
+ * contract: ports call {@code notifyScreenObscured} for every touch they handle, so the
+ * notification has to fire on a *change* of state rather than per event -- otherwise a
+ * user resting a finger on an obscured screen would queue a runnable per touch onto the
+ * EDT and re-raise the same signal forever.</p>
+ */
+class TapjackingTest extends UITestBase {
+
+    private final List<Object> observed = new ArrayList<Object>();
+    private ActionListener listener;
+
+    @BeforeEach
+    void armListener() {
+        ShieldSignals.clear();
+        DeviceIntegrity.setTapjackingProtection(TapjackingPolicy.OFF);
+        // The implementation is shared across test classes, so the obscured state has to be
+        // wound back explicitly; nothing else resets it.
+        implementation.notifyScreenObscured(false, null);
+        flushSerialCalls();
+        observed.clear();
+        listener = new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent evt) {
+                observed.add(evt.getSource());
+            }
+        };
+        DeviceIntegrity.addTapjackingListener(listener);
+    }
+
+    @AfterEach
+    void disarmListener() {
+        DeviceIntegrity.removeTapjackingListener(listener);
+        implementation.notifyScreenObscured(false, null);
+        DeviceIntegrity.setTapjackingProtection(TapjackingPolicy.OFF);
+        ShieldSignals.clear();
+    }
+
+    // --- policy plumbing --------------------------------------------------
+
+    @Test
+    void defaultsToOffAndAClearScreen() {
+        assertSame(TapjackingPolicy.OFF, DeviceIntegrity.getTapjackingPolicy());
+        assertFalse(DeviceIntegrity.isScreenObscured());
+    }
+
+    @Test
+    void policyRoundTrips() {
+        DeviceIntegrity.setTapjackingProtection(TapjackingPolicy.STRICT);
+        assertSame(TapjackingPolicy.STRICT, DeviceIntegrity.getTapjackingPolicy());
+    }
+
+    @Test
+    void aNullPolicyIsTreatedAsOffRatherThanStored() {
+        // Ports read the policy on the touch path and must never have to null check it.
+        DeviceIntegrity.setTapjackingProtection(TapjackingPolicy.BLOCK);
+        DeviceIntegrity.setTapjackingProtection(null);
+        assertSame(TapjackingPolicy.OFF, DeviceIntegrity.getTapjackingPolicy());
+    }
+
+    // --- the blocking truth table ----------------------------------------
+
+    @Test
+    void onlyOffSkipsDetection() {
+        assertFalse(TapjackingPolicy.OFF.isDetecting());
+        assertTrue(TapjackingPolicy.REPORT.isDetecting());
+        assertTrue(TapjackingPolicy.BLOCK.isDetecting());
+        assertTrue(TapjackingPolicy.STRICT.isDetecting());
+    }
+
+    @Test
+    void offAndReportNeverBlock() {
+        // REPORT exists to measure how often obscuring happens without changing behaviour,
+        // so it must stay indistinguishable from OFF at the delivery point.
+        for (TapjackingPolicy p : new TapjackingPolicy[] {
+                TapjackingPolicy.OFF, TapjackingPolicy.REPORT }) {
+            assertFalse(p.blocks(false, false));
+            assertFalse(p.blocks(true, false));
+            assertFalse(p.blocks(false, true));
+            assertFalse(p.blocks(true, true));
+        }
+    }
+
+    @Test
+    void blockStopsAtFullyObscured() {
+        // Partial obscuring is set by ordinary system UI. Blocking on it would discard taps
+        // the user meant, which is why it is STRICT's problem and not BLOCK's.
+        assertFalse(TapjackingPolicy.BLOCK.blocks(false, false));
+        assertTrue(TapjackingPolicy.BLOCK.blocks(true, false));
+        assertFalse(TapjackingPolicy.BLOCK.blocks(false, true));
+        assertTrue(TapjackingPolicy.BLOCK.blocks(true, true));
+    }
+
+    @Test
+    void strictAlsoBlocksPartiallyObscured() {
+        assertFalse(TapjackingPolicy.STRICT.blocks(false, false));
+        assertTrue(TapjackingPolicy.STRICT.blocks(true, false));
+        assertTrue(TapjackingPolicy.STRICT.blocks(false, true));
+        assertTrue(TapjackingPolicy.STRICT.blocks(true, true));
+    }
+
+    // --- reporting contract ----------------------------------------------
+
+    @Test
+    void anObscuredTouchFlipsTheStateNotifiesOnceAndRaisesTheSignal() {
+        implementation.notifyScreenObscured(true, "obscured");
+        flushSerialCalls();
+
+        assertTrue(DeviceIntegrity.isScreenObscured());
+        assertEquals(1, observed.size());
+        assertEquals(Boolean.TRUE, observed.get(0));
+
+        ShieldSignal raised = findTapjackSignal();
+        assertNotNull(raised, "an observed overlay has to reach the shield signal bus");
+        assertEquals(80, raised.getSeverity());
+        assertEquals("obscured", raised.getDetail());
+    }
+
+    @Test
+    void repeatedObscuredTouchesDoNotNotifyAgain() {
+        // A port calls this per touch. Re-notifying would put a runnable on the EDT for
+        // every one of them.
+        implementation.notifyScreenObscured(true, "obscured");
+        implementation.notifyScreenObscured(true, "obscured");
+        implementation.notifyScreenObscured(true, "obscured");
+        flushSerialCalls();
+
+        assertEquals(1, observed.size());
+        assertTrue(DeviceIntegrity.isScreenObscured());
+    }
+
+    @Test
+    void clearingTheOverlayNotifiesAgainSoAWarningCanBeDismissed() {
+        implementation.notifyScreenObscured(true, "obscured");
+        flushSerialCalls();
+        implementation.notifyScreenObscured(false, null);
+        flushSerialCalls();
+
+        assertFalse(DeviceIntegrity.isScreenObscured());
+        assertEquals(2, observed.size());
+        assertEquals(Boolean.TRUE, observed.get(0));
+        assertEquals(Boolean.FALSE, observed.get(1));
+    }
+
+    @Test
+    void aCleanTouchOnACleanScreenNotifiesNothing() {
+        implementation.notifyScreenObscured(false, null);
+        flushSerialCalls();
+        assertEquals(0, observed.size());
+        assertNull(findTapjackSignal());
+    }
+
+    @Test
+    void aRemovedListenerStopsReceiving() {
+        DeviceIntegrity.removeTapjackingListener(listener);
+        implementation.notifyScreenObscured(true, "obscured");
+        flushSerialCalls();
+
+        assertEquals(0, observed.size());
+        // The state and the signal are independent of the listener and must still update.
+        assertTrue(DeviceIntegrity.isScreenObscured());
+        assertNotNull(findTapjackSignal());
+    }
+
+    @Test
+    void hideOverlayWindowsIsUnsupportedAndHarmlessOnAPortThatLacksIt() {
+        // The contract every non-Android port relies on: calling it is always safe.
+        assertFalse(DeviceIntegrity.isHideOverlayWindowsSupported());
+        DeviceIntegrity.setHideOverlayWindows(true);
+        DeviceIntegrity.setHideOverlayWindows(false);
+    }
+
+    private ShieldSignal findTapjackSignal() {
+        for (ShieldSignal s : ShieldSignals.snapshot()) {
+            if (ShieldSignal.TAPJACK.equals(s.getId())) {
+                return s;
+            }
+        }
+        return null;
+    }
+}

--- a/maven/core-unittests/src/test/java/com/codename1/security/TapjackingTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/security/TapjackingTest.java
@@ -222,6 +222,25 @@ class TapjackingTest extends UITestBase {
     }
 
     @Test
+    void eachEventCarriesTheStateItAnnouncedNotTheLatestOne() {
+        // The documented pattern branches on the event source rather than on
+        // isScreenObscured(), because the state is written on the platform's input thread
+        // while callbacks are delivered on the EDT. Two changes queued before the EDT drains
+        // must therefore still arrive carrying their own values, not both carrying the last.
+        implementation.notifyScreenObscured(true, "obscured");
+        implementation.notifyScreenObscured(false, null);
+        flushSerialCalls();
+
+        assertEquals(2, observed.size());
+        assertEquals(Boolean.TRUE, observed.get(0),
+                "the first callback has to announce the state that raised it");
+        assertEquals(Boolean.FALSE, observed.get(1));
+        // The global query has already moved on -- which is the whole reason the event
+        // carries the value.
+        assertFalse(DeviceIntegrity.isScreenObscured());
+    }
+
+    @Test
     void aCleanTouchOnACleanScreenNotifiesNothing() {
         implementation.notifyScreenObscured(false, null);
         flushSerialCalls();

--- a/maven/core-unittests/src/test/java/com/codename1/security/TapjackingTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/security/TapjackingTest.java
@@ -163,6 +163,39 @@ class TapjackingTest extends UITestBase {
     }
 
     @Test
+    void escalatingFromPartialToFullyObscuredUpdatesTheSignal() {
+        // The two are separate observations under one id. Reporting only the transition left
+        // the bus saying "partiallyObscured" while a fully obscured attack was being blocked.
+        implementation.notifyScreenObscured(true, "partiallyObscured");
+        flushSerialCalls();
+        assertEquals("partiallyObscured", findTapjackSignal().getDetail());
+
+        implementation.notifyScreenObscured(true, "obscured");
+        flushSerialCalls();
+        assertEquals("obscured", findTapjackSignal().getDetail(),
+                "the bus has to hold the most recent observation, not the first one");
+
+        // Still one state change, so still one listener callback.
+        assertEquals(1, observed.size());
+    }
+
+    @Test
+    void repeatedSightingsRefreshTheSignalTimestamp() throws Exception {
+        // "When did this device last look obscured" is a question the answer gets used for,
+        // so an ongoing attack must not keep reporting the timestamp of the first sighting.
+        implementation.notifyScreenObscured(true, "obscured");
+        flushSerialCalls();
+        long first = findTapjackSignal().getTimestamp();
+
+        Thread.sleep(15L);
+        implementation.notifyScreenObscured(true, "obscured");
+        flushSerialCalls();
+
+        assertTrue(findTapjackSignal().getTimestamp() >= first,
+                "a repeat sighting must refresh the stored observation");
+    }
+
+    @Test
     void repeatedObscuredTouchesDoNotNotifyAgain() {
         // A port calls this per touch. Re-notifying would put a runnable on the EDT for
         // every one of them.

--- a/maven/core-unittests/src/test/java/com/codename1/security/TapjackingTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/security/TapjackingTest.java
@@ -230,6 +230,38 @@ class TapjackingTest extends UITestBase {
     }
 
     @Test
+    void switchingProtectionOffClearsTheObscuredState() {
+        // Switching off is also what stops anything from clearing it later: ports stop
+        // reporting under OFF, so a state left set here would answer true for the rest of
+        // the process.
+        DeviceIntegrity.setTapjackingProtection(TapjackingPolicy.BLOCK);
+        implementation.notifyScreenObscured(true, "obscured");
+        flushSerialCalls();
+        assertTrue(DeviceIntegrity.isScreenObscured());
+
+        DeviceIntegrity.setTapjackingProtection(TapjackingPolicy.OFF);
+        flushSerialCalls();
+
+        assertFalse(DeviceIntegrity.isScreenObscured());
+        assertEquals(2, observed.size(), "the listener is owed its closing transition");
+        assertEquals(Boolean.FALSE, observed.get(1));
+    }
+
+    @Test
+    void switchingBetweenDetectingPoliciesKeepsTheObscuredState() {
+        // Only OFF retracts. Tightening BLOCK to STRICT must not pretend the overlay went away.
+        DeviceIntegrity.setTapjackingProtection(TapjackingPolicy.BLOCK);
+        implementation.notifyScreenObscured(true, "obscured");
+        flushSerialCalls();
+
+        DeviceIntegrity.setTapjackingProtection(TapjackingPolicy.STRICT);
+        flushSerialCalls();
+
+        assertTrue(DeviceIntegrity.isScreenObscured());
+        assertEquals(1, observed.size());
+    }
+
+    @Test
     void aRemovedListenerStopsReceiving() {
         DeviceIntegrity.removeTapjackingListener(listener);
         implementation.notifyScreenObscured(true, "obscured");

--- a/maven/core-unittests/src/test/java/com/codename1/security/TapjackingTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/security/TapjackingTest.java
@@ -322,6 +322,27 @@ class TapjackingTest extends UITestBase {
     }
 
     @Test
+    void reEnablingDetectionAfterOffKeepsTheNewSighting() {
+        // The mirror of the switch-off race: one thread turns protection off while another
+        // re-enables it and reports. The retraction is applied inside the OFF transition rather
+        // than by a later call, so there is no delayed mutation left to wipe the newer sighting
+        // and leave BLOCK active over a state claiming the screen is clear.
+        DeviceIntegrity.setTapjackingProtection(TapjackingPolicy.BLOCK);
+        implementation.notifyScreenObscured(true, "obscured");
+        flushSerialCalls();
+
+        DeviceIntegrity.setTapjackingProtection(TapjackingPolicy.OFF);
+        DeviceIntegrity.setTapjackingProtection(TapjackingPolicy.BLOCK);
+        implementation.notifyScreenObscured(true, "obscured");
+        flushSerialCalls();
+
+        assertTrue(DeviceIntegrity.isScreenObscured(),
+                "the sighting reported after detection was re-enabled has to survive");
+        assertEquals(Boolean.TRUE, observed.get(observed.size() - 1),
+                "and the last thing a listener heard must not be a stale clearing event");
+    }
+
+    @Test
     void switchingBetweenDetectingPoliciesKeepsTheObscuredState() {
         // Only OFF retracts. Tightening BLOCK to STRICT must not pretend the overlay went away.
         DeviceIntegrity.setTapjackingProtection(TapjackingPolicy.BLOCK);

--- a/maven/core-unittests/src/test/java/com/codename1/security/TapjackingTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/security/TapjackingTest.java
@@ -241,12 +241,17 @@ class TapjackingTest extends UITestBase {
     }
 
     @Test
-    void eachEventCarriesTheStateItAnnouncedNotTheLatestOne() {
+    void eachDeliveredEventCarriesTheStateItAnnounced() {
         // The documented pattern branches on the event source rather than on
-        // isScreenObscured(), because the state is written on the platform's input thread
-        // while callbacks are delivered on the EDT. Two changes queued before the EDT drains
-        // must therefore still arrive carrying their own values, not both carrying the last.
+        // isScreenObscured(), because the state is written on the platform's input thread while
+        // callbacks are delivered on the EDT. Each transition that survives to delivery must
+        // therefore carry its own value rather than whatever the global happens to be by then.
+        //
+        // Drained between the two, because a transition superseded before it is delivered is
+        // deliberately dropped rather than announced late -- see
+        // aTransitionSupersededBeforeDeliveryIsDropped.
         implementation.notifyScreenObscured(true, "obscured");
+        flushSerialCalls();
         implementation.notifyScreenObscured(false, null);
         flushSerialCalls();
 
@@ -254,8 +259,6 @@ class TapjackingTest extends UITestBase {
         assertEquals(Boolean.TRUE, observed.get(0),
                 "the first callback has to announce the state that raised it");
         assertEquals(Boolean.FALSE, observed.get(1));
-        // The global query has already moved on -- which is the whole reason the event
-        // carries the value.
         assertFalse(DeviceIntegrity.isScreenObscured());
     }
 
@@ -319,6 +322,22 @@ class TapjackingTest extends UITestBase {
         DeviceIntegrity.setTapjackingProtection(TapjackingPolicy.OFF);
         flushSerialCalls();
         assertFalse(DeviceIntegrity.isScreenObscured());
+    }
+
+    @Test
+    void aTransitionSupersededBeforeDeliveryIsDropped() {
+        // Both calls come from off the EDT, as a port's input thread would, so the obscured
+        // announcement is queued rather than delivered inline. By the time it arrives the
+        // switch-off has already cleared the state, so delivering it would leave the listener
+        // holding true while the API reports false. It has to be dropped on arrival -- checking
+        // only before queuing cannot catch this.
+        implementation.notifyScreenObscured(true, "obscured");
+        DeviceIntegrity.setTapjackingProtection(TapjackingPolicy.OFF);
+        flushSerialCalls();
+
+        assertFalse(DeviceIntegrity.isScreenObscured());
+        assertFalse(observed.contains(Boolean.TRUE),
+                "the superseded obscured event must never reach the listener");
     }
 
     @Test

--- a/maven/core-unittests/src/test/java/com/codename1/security/TapjackingTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/security/TapjackingTest.java
@@ -59,10 +59,16 @@ class TapjackingTest extends UITestBase {
     @BeforeEach
     void armListener() {
         ShieldSignals.clear();
-        DeviceIntegrity.setTapjackingProtection(TapjackingPolicy.OFF);
         // The implementation is shared across test classes, so the obscured state has to be
-        // wound back explicitly; nothing else resets it.
+        // wound back explicitly; nothing else resets it. Switching to OFF is what retracts it.
+        DeviceIntegrity.setTapjackingProtection(TapjackingPolicy.OFF);
         implementation.notifyScreenObscured(false, null);
+        flushSerialCalls();
+        // Then arm a detecting policy as the baseline. A port only ever reports while it is
+        // detecting -- Android returns from tapjacked() before reporting under OFF -- and the
+        // core now refuses obscured reports arriving under OFF, so a test that reported from
+        // the default policy would be exercising a state no port can produce.
+        DeviceIntegrity.setTapjackingProtection(TapjackingPolicy.BLOCK);
         flushSerialCalls();
         observed.clear();
         listener = new ActionListener() {
@@ -85,9 +91,22 @@ class TapjackingTest extends UITestBase {
     // --- policy plumbing --------------------------------------------------
 
     @Test
-    void defaultsToOffAndAClearScreen() {
+    void offReportsNothingAndKeepsTheScreenClear() {
+        // Deliberately NOT asserted against a fresh TestCodenameOneImplementation: its
+        // constructor assigns the static singleton, so building one here would repoint
+        // UITestBase's `implementation` away from the instance Display holds and quietly
+        // desynchronize every later test in the class. That the untouched default is OFF is
+        // covered by aNullPolicyIsTreatedAsOffRatherThanStored.
+        DeviceIntegrity.setTapjackingProtection(TapjackingPolicy.OFF);
+        flushSerialCalls();
+        observed.clear();
+
+        implementation.notifyScreenObscured(true, "obscured");
+        flushSerialCalls();
+
         assertSame(TapjackingPolicy.OFF, DeviceIntegrity.getTapjackingPolicy());
         assertFalse(DeviceIntegrity.isScreenObscured());
+        assertEquals(0, observed.size());
     }
 
     @Test
@@ -264,6 +283,42 @@ class TapjackingTest extends UITestBase {
         assertFalse(DeviceIntegrity.isScreenObscured());
         assertEquals(2, observed.size(), "the listener is owed its closing transition");
         assertEquals(Boolean.FALSE, observed.get(1));
+    }
+
+    @Test
+    void aSightingThatRacedTheSwitchOffIsDropped() {
+        // The interleaving the ports can actually produce: Android's input thread reads the
+        // old BLOCK policy inside tapjacked() and decides to report, the EDT stores OFF and
+        // clears the state, and only then does the report land. Accepting it would set a
+        // state nothing clears afterwards -- reporting has stopped under OFF -- and hand a
+        // listener an obscured callback for protection the app had already switched off.
+        DeviceIntegrity.setTapjackingProtection(TapjackingPolicy.BLOCK);
+        DeviceIntegrity.setTapjackingProtection(TapjackingPolicy.OFF);
+        flushSerialCalls();
+        observed.clear();
+
+        implementation.notifyScreenObscured(true, "obscured");
+        flushSerialCalls();
+
+        assertFalse(DeviceIntegrity.isScreenObscured(),
+                "a report that lost the race must not resurrect the state");
+        assertEquals(0, observed.size());
+        assertNull(findTapjackSignal());
+    }
+
+    @Test
+    void aRetractionIsNeverDroppedEvenWhileOff() {
+        // Only assertions are refused while OFF. If the order had been the other way round --
+        // the sighting landing before the switch-off -- the clearing call is what rescues the
+        // state, so it must still be honoured under a non-detecting policy.
+        DeviceIntegrity.setTapjackingProtection(TapjackingPolicy.BLOCK);
+        implementation.notifyScreenObscured(true, "obscured");
+        flushSerialCalls();
+        assertTrue(DeviceIntegrity.isScreenObscured());
+
+        DeviceIntegrity.setTapjackingProtection(TapjackingPolicy.OFF);
+        flushSerialCalls();
+        assertFalse(DeviceIntegrity.isScreenObscured());
     }
 
     @Test

--- a/maven/core-unittests/src/test/java/com/codename1/security/TapjackingTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/security/TapjackingTest.java
@@ -241,17 +241,13 @@ class TapjackingTest extends UITestBase {
     }
 
     @Test
-    void eachDeliveredEventCarriesTheStateItAnnounced() {
+    void eachEventCarriesTheStateItAnnouncedNotTheLatestOne() {
         // The documented pattern branches on the event source rather than on
         // isScreenObscured(), because the state is written on the platform's input thread while
         // callbacks are delivered on the EDT. Each transition that survives to delivery must
         // therefore carry its own value rather than whatever the global happens to be by then.
         //
-        // Drained between the two, because a transition superseded before it is delivered is
-        // deliberately dropped rather than announced late -- see
-        // aTransitionSupersededBeforeDeliveryIsDropped.
         implementation.notifyScreenObscured(true, "obscured");
-        flushSerialCalls();
         implementation.notifyScreenObscured(false, null);
         flushSerialCalls();
 
@@ -325,19 +321,37 @@ class TapjackingTest extends UITestBase {
     }
 
     @Test
-    void aTransitionSupersededBeforeDeliveryIsDropped() {
-        // Both calls come from off the EDT, as a port's input thread would, so the obscured
-        // announcement is queued rather than delivered inline. By the time it arrives the
-        // switch-off has already cleared the state, so delivering it would leave the listener
-        // holding true while the API reports false. It has to be dropped on arrival -- checking
-        // only before queuing cannot catch this.
+    void queuedTransitionsArriveInOrderAndEndOnTheCurrentState() {
+        // Two transitions raised before the EDT drains, from off the EDT as a port's input
+        // thread would. Both are real history and both must arrive, in the order they happened,
+        // with the last one matching what the API now reports. Validating each against the
+        // current state at delivery instead would drop the first and lose the fact that
+        // anything was ever obscured.
         implementation.notifyScreenObscured(true, "obscured");
         DeviceIntegrity.setTapjackingProtection(TapjackingPolicy.OFF);
         flushSerialCalls();
 
         assertFalse(DeviceIntegrity.isScreenObscured());
-        assertFalse(observed.contains(Boolean.TRUE),
-                "the superseded obscured event must never reach the listener");
+        assertEquals(2, observed.size());
+        assertEquals(Boolean.TRUE, observed.get(0));
+        assertEquals(Boolean.FALSE, observed.get(1),
+                "the last event delivered has to agree with the state the API reports");
+    }
+
+    @Test
+    void anOverlayThatWithdrawsBeforeTheEdtDrainsIsStillReported() {
+        // The case that matters for the feature's whole purpose: a malicious overlay covers the
+        // ACTION_DOWN and withdraws before the EDT gets a turn. The gesture was blocked, and
+        // this listener is the only way the app can learn that, so coalescing the pair into a
+        // single "clear" callback would lose the security event entirely.
+        implementation.notifyScreenObscured(true, "obscured");
+        implementation.notifyScreenObscured(false, null);
+        flushSerialCalls();
+
+        assertFalse(DeviceIntegrity.isScreenObscured());
+        assertTrue(observed.contains(Boolean.TRUE),
+                "the app has to be told the screen was obscured, even briefly");
+        assertEquals(Boolean.FALSE, observed.get(observed.size() - 1));
     }
 
     @Test


### PR DESCRIPTION
## What

Adds tapjacking / screen-overlay defense as the **fourth family** in `com.codename1.security.DeviceIntegrity`, next to the accessibility-abuse defense whose docs already named overlay malware as the threat but shipped nothing against it.

Tapjacking is the attack where a malicious app draws its own window over yours -- a fake confirmation button, or an invisible layer -- so the user authorizes something they cannot see. It is the standard companion to accessibility-service abuse in banking-malware kits. Before this PR the repo had **no** support for it: `FLAG_WINDOW_IS_OBSCURED`, `setFilterTouchesWhenObscured` and `setHideOverlayWindows` appeared in no port.

## API

New `TapjackingPolicy` (`OFF` / `REPORT` / `BLOCK` / `STRICT`), which carries the blocking truth table as pure logic so every port decides identically and it is testable without a device. On `DeviceIntegrity`:

```java
DeviceIntegrity.setTapjackingProtection(TapjackingPolicy.BLOCK);
DeviceIntegrity.addTapjackingListener(e -> { /* warn the user */ });
if (DeviceIntegrity.isHideOverlayWindowsSupported()) {
    DeviceIntegrity.setHideOverlayWindows(true);   // Android 12+
}
```

Threaded through `Display` to `CodenameOneImplementation` in the existing style. Zero-code alternative: `android.tapjackingGuard=true` (+ `.mode=block|strict|report`, `.hideOverlays`).

## Three decisions worth reviewing

**1. Tapjacking is deliberately NOT a compromise reason.** Adding `"tapjack"` to `getCompromiseReasons()` would have been the one-line route -- it auto-flows to signals via `UnprotectedEngine.toSignal()`. But those reasons describe a *standing property of the device* and feed `isDeviceCompromised()`, whereas obscuring is transient with benign causes. Folding it in would report a rooted device whenever the notification shade was open. It gets its own state instead, and raises `ShieldSignal.TAPJACK` (severity 80) directly.

**2. Android's own filtering does not work here.** `AndroidAsyncView.dispatchTouchEvent` calls straight into `CodenameOneView.onTouchEvent` and only falls back to `super` when we decline, so `View.onFilterTouchEventForSecurity` -- what `setFilterTouchesWhenObscured` hooks -- never runs on the path CN1 components are reached through. The check is therefore explicit. `setFilterTouchesWhenObscured` is still set as defense-in-depth for the fallback path.

**3. Blocked gestures are latched and claimed.** Dropping only `ACTION_DOWN` would deliver a `pointerReleased` with no matching `pointerPressed`, so the block is latched through to `UP`/`CANCEL`. The handler returns `true` rather than the computed `consumeEvent` -- that value is `false` over a native peer, and returning it would send the obscured touch on to a `BrowserComponent` or native text field, i.e. exactly what is being withheld from everything else.

## Platform support

- **Android** -- full. Detection reads the obscured flags on each touch; `setHideOverlayWindows` needs API 31 and is reached reflectively (absent from the port's `android.jar`), as is `FLAG_WINDOW_IS_PARTIALLY_OBSCURED` (inlined `0x2`).
- **iOS / other ports** -- inherit the no-op default. No iOS app can draw over another, so there is nothing to detect; the docs say so rather than faking it. Screen recording is a separate threat already covered by `ios.disableScreenshots`.
- **Simulator** -- `Simulate > App Shield > Screen Overlay (Tapjacking)`, which drives the real reporting path rather than overriding the getter, so listeners and the signal actually fire.

## Honest limitations (stated in the docs)

- **Detection is touch-driven, not a live window query.** Android reports obscuring as a flag on a delivered `MotionEvent`, so if an overlay appears and the user never touches the screen, nothing is observed. That is why `setHideOverlayWindows` matters -- it is preventive rather than reactive.
- **`STRICT` carries real false-positive risk.** Benign system UI sets the partial-obscured flag, so `STRICT` can discard taps the user meant. It is opt-in and documented as such; `BLOCK` is the recommendation.

## Testing

13 new tests covering the truth table, the transition-only notification contract, listener lifecycle and the signal. Full local gate run (CI-faithful):

- Quality report gate: **EXIT=0** -- SpotBugs 0 across `core-unittests`/`android`/`ios`/`ByteCodeTranslator`/`codenameone-maven-plugin`, PMD 0, Checkstyle 0
- **4863 tests, 0 failed**; JavaSE port 224/224
- `check-cast-semantics.sh` exit 0; `check-since-tags.sh` clean; all sources ASCII

## Follow-up

The `android.tapjackingGuard` hint is implemented in this repo's `AndroidGradleBuilder`, covering local builds. **Cloud builds need the same hint mirrored into `com.codename1.build.daemon` in the BuildDaemon repo.** Until that lands the runtime API works everywhere but the build hint is a no-op on cloud builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
