### PR TITLE
Avoid duplicate INTERNET permission from ad cn1libs

### DIFF
--- a/maven/cn1-admob/common/codenameone_library_required.properties
+++ b/maven/cn1-admob/common/codenameone_library_required.properties
@@ -11,5 +11,4 @@
 codename1.arg.ios.pods=Google-Mobile-Ads-SDK
 # Android: Google Mobile Ads SDK + User Messaging Platform (UMP) for GDPR consent.
 codename1.arg.android.gradleDep=implementation 'com.google.android.gms:play-services-ads:24.0.0'\n    implementation 'com.google.android.ump:user-messaging-platform:3.1.0'
-# Android: ad serving requires network access.
-codename1.arg.android.xpermissions=<uses-permission android:name="android.permission.INTERNET" />
+# AndroidGradleBuilder supplies INTERNET for every Android build.

--- a/maven/cn1-applovin/common/codenameone_library_required.properties
+++ b/maven/cn1-applovin/common/codenameone_library_required.properties
@@ -11,5 +11,4 @@
 codename1.arg.ios.pods=AppLovinSDK
 # Android: AppLovin MAX SDK.
 codename1.arg.android.gradleDep=implementation 'com.applovin:applovin-sdk:13.0.1'
-# Android: ad serving requires network access.
-codename1.arg.android.xpermissions=<uses-permission android:name="android.permission.INTERNET" />
+# AndroidGradleBuilder supplies INTERNET for every Android build.

--- a/maven/cn1-unity-levelplay/common/codenameone_library_required.properties
+++ b/maven/cn1-unity-levelplay/common/codenameone_library_required.properties
@@ -10,5 +10,4 @@
 codename1.arg.ios.pods=IronSourceSDK
 # Android: Unity LevelPlay mediation SDK.
 codename1.arg.android.gradleDep=implementation 'com.unity3d.ads-mediation:mediation-sdk:8.4.0'
-# Android: ad serving requires network access.
-codename1.arg.android.xpermissions=<uses-permission android:name="android.permission.INTERNET" />
+# AndroidGradleBuilder supplies INTERNET for every Android build.


### PR DESCRIPTION
## Summary

- stop the AdMob, AppLovin, and Unity LevelPlay cn1libs from injecting `android.permission.INTERNET` through `android.xpermissions`
- keep their provider-specific Android and iOS dependency hints unchanged
- document that `AndroidGradleBuilder` supplies the base permission

## Root cause

`AndroidGradleBuilder` already adds `android.permission.INTERNET` to every Android manifest with `android:required="false"`. The three ad cn1libs also injected a second form without that attribute. Android manifest validation treated the two entries as duplicate `uses-permission` elements and failed the build.

## Validation

- `JAVA_HOME=/Users/shai/Library/Java/JavaVirtualMachines/azul-1.8.0_372/Contents/Home mvn -pl cn1-admob/common,cn1-applovin/common,cn1-unity-levelplay/common test -DskipTests=false`
- verified the copied `codenameone_library_required.properties` resources retain each SDK dependency hint and contain no `android.xpermissions` or `android.permission.INTERNET` entry
- `git diff --check`