### PR TITLE
Fix ParparVM primitive array defaults

### DIFF
--- a/vm/ByteCodeTranslator/src/javascript/parparvm_runtime.js
+++ b/vm/ByteCodeTranslator/src/javascript/parparvm_runtime.js
@@ -1257,8 +1257,27 @@ const jvm = {
       throw new Error("Negative array size");
     }
     const array = new Array(size);
+    // Primitive leaf arrays use Java's zero defaults. Reference arrays and
+    // unallocated outer dimensions remain null.
+    let defaultValue = null;
+    if (dimensions === 1) {
+      switch (componentClass) {
+        case "JAVA_BOOLEAN":
+        case "JAVA_BYTE":
+        case "JAVA_CHAR":
+        case "JAVA_SHORT":
+        case "JAVA_INT":
+        case "JAVA_FLOAT":
+        case "JAVA_DOUBLE":
+          defaultValue = 0;
+          break;
+        case "JAVA_LONG":
+          defaultValue = _L0;
+          break;
+      }
+    }
     for (let i = 0; i < size; i++) {
-      array[i] = null;
+      array[i] = defaultValue;
     }
     array.__class = this.arrayClassName(componentClass, dimensions);
     array.__classDef = this.getArrayClass(componentClass, dimensions);

--- a/vm/tests/src/test/java/com/codename1/tools/translator/JavascriptRuntimeSemanticsTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/JavascriptRuntimeSemanticsTest.java
@@ -23,6 +23,7 @@
 
 package com.codename1.tools.translator;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 
 import java.io.ByteArrayOutputStream;
@@ -30,6 +31,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -330,13 +332,50 @@ class JavascriptRuntimeSemanticsTest {
 
     @ParameterizedTest
     @org.junit.jupiter.params.provider.MethodSource("com.codename1.tools.translator.BytecodeInstructionIntegrationTest#provideCompilerConfigs")
-    void preservesPrimitiveArrayLiteralAndCopySemanticsInWorkerRuntime(CompilerHelper.CompilerConfig config) throws Exception {
+    void preservesPrimitiveArrayDefaultsLiteralsAndCopySemanticsInWorkerRuntime(CompilerHelper.CompilerConfig config) throws Exception {
         WorkerRunResult result = translateAndRunFixture(config, "JsPrimitiveArraySemanticsApp.java", "JsPrimitiveArraySemanticsApp");
 
-        assertEquals(1023, result.result,
-                "Translated runtime should preserve primitive array literals and overlapping System.arraycopy semantics. raw="
+        assertEquals(32767, result.result,
+                "Translated runtime should preserve Java array defaults, primitive array literals, and overlapping System.arraycopy semantics. raw="
                         + result.rawMessage + " err=" + result.errorMessage);
         assertTrue(result.errorMessage == null || result.errorMessage.isEmpty(), "Worker should not emit an error message");
+    }
+
+    @Test
+    void newArrayUsesJavaDefaultsForPrimitiveReferenceAndNestedArrays() throws Exception {
+        Path runtime = Paths.get("..", "ByteCodeTranslator", "src", "javascript", "parparvm_runtime.js")
+                .toAbsolutePath().normalize();
+        assertTrue(Files.exists(runtime), "ParparVM JavaScript runtime should exist");
+
+        Path harness = Files.createTempFile("js-array-defaults", ".js");
+        String source = ""
+                + "const fs = require('fs');\n"
+                + "const vm = require('vm');\n"
+                + "global.self = global; global.window = global; global.global = global;\n"
+                + "global.postMessage = function() {};\n"
+                + "vm.runInThisContext(fs.readFileSync(" + quoteJs(runtime.toString()) + ", 'utf8'));\n"
+                + "const failures = [];\n"
+                + "const numeric = ['JAVA_BOOLEAN','JAVA_BYTE','JAVA_CHAR','JAVA_SHORT','JAVA_INT','JAVA_FLOAT','JAVA_DOUBLE'];\n"
+                + "for (const type of numeric) {\n"
+                + "  const array = jvm.newArray(2, type, 1);\n"
+                + "  if (array[0] !== 0 || array[1] !== 0) failures.push(type + '=' + String(array[0]));\n"
+                + "}\n"
+                + "const longs = jvm.newArray(2, 'JAVA_LONG', 1);\n"
+                + "if (!longs[0] || longs[0].__l !== 1 || longs[0].l !== 0 || longs[0].h !== 0) failures.push('JAVA_LONG');\n"
+                + "const references = jvm.newArray(2, 'java_lang_String', 1);\n"
+                + "if (references[0] !== null || references[1] !== null) failures.push('reference');\n"
+                + "const jagged = jvm.newArray(2, 'JAVA_INT[]', 1);\n"
+                + "if (jagged[0] !== null || jagged[1] !== null) failures.push('jagged');\n"
+                + "const multiOuter = jvm.newArray(2, 'JAVA_INT', 2);\n"
+                + "if (multiOuter[0] !== null || multiOuter[1] !== null) failures.push('multiOuter');\n"
+                + "if (failures.length) throw new Error('Wrong Java array defaults: ' + failures.join(','));\n";
+        Files.write(harness, source.getBytes(StandardCharsets.UTF_8));
+
+        Process process = new ProcessBuilder("node", harness.toString()).start();
+        String output = readAll(process.getInputStream());
+        String errors = readAll(process.getErrorStream());
+        assertEquals(0, process.waitFor(),
+                "ParparVM should initialize arrays with Java defaults. stdout: " + output + " stderr: " + errors);
     }
 
     @ParameterizedTest

--- a/vm/tests/src/test/resources/com/codename1/tools/translator/JsPrimitiveArraySemanticsApp.java
+++ b/vm/tests/src/test/resources/com/codename1/tools/translator/JsPrimitiveArraySemanticsApp.java
@@ -75,6 +75,43 @@ public class JsPrimitiveArraySemanticsApp {
             score |= 512;
         }
 
+        byte[] defaultByte = new byte[1];
+        int[] indexedByDefault = new int[] {73};
+        if (indexedByDefault[defaultByte[0]] == 73) {
+            score |= 1024;
+        }
+
+        boolean[] defaultBoolean = new boolean[1];
+        char[] defaultChar = new char[1];
+        short[] defaultShort = new short[1];
+        int[] defaultInt = new int[1];
+        if (!defaultBoolean[0] && defaultChar[0] == '\0'
+                && defaultShort[0] == 0 && defaultInt[0] == 0) {
+            score |= 2048;
+        }
+
+        long[] defaultLong = new long[1];
+        float[] defaultFloat = new float[1];
+        double[] defaultDouble = new double[1];
+        if (defaultLong[0] == 0L && defaultFloat[0] == 0f && defaultDouble[0] == 0d) {
+            score |= 4096;
+        }
+
+        Object[] defaultObject = new Object[1];
+        String[] defaultString = new String[1];
+        if (defaultObject[0] == null && defaultString[0] == null) {
+            score |= 8192;
+        }
+
+        int[][] allocatedPrimitiveMatrix = new int[1][1];
+        int[][] jaggedPrimitiveMatrix = new int[1][];
+        Object[][] jaggedReferenceMatrix = new Object[1][];
+        if (allocatedPrimitiveMatrix[0][0] == 0
+                && jaggedPrimitiveMatrix[0] == null
+                && jaggedReferenceMatrix[0] == null) {
+            score |= 16384;
+        }
+
         result = score;
         System.exit(score);
     }


### PR DESCRIPTION
## What changed

- Initialize primitive leaf arrays in the ParparVM JavaScript runtime with Java's required zero defaults.
- Keep reference arrays and unallocated outer array dimensions initialized to `null`.
- Add direct allocator coverage for every primitive type, reference arrays, and nested arrays.
- Extend the translated-worker fixture with an untouched `byte[]` value used as an array index, matching the failure mechanism that exposed the defect.

## Why

`jvm.newArray()` initialized every array slot to `null`. That violates Java semantics for primitive arrays. In the reported ZipMe path, an untouched byte value was later used as an array index; Java treats it as `0`, while JavaScript converted `null` into the property name `"null"`, corrupting the generated DEFLATE stream.

This fixes the allocator itself rather than patching ZipMe or the Skin Designer path.

## Checks

- `JavascriptRuntimeSemanticsTest#newArrayUsesJavaDefaultsForPrimitiveReferenceAndNestedArrays`
- `JavascriptRuntimeSemanticsTest#preservesPrimitiveArrayDefaultsLiteralsAndCopySemanticsInWorkerRuntime` (5 compiler configurations)
- Full `JavascriptRuntimeSemanticsTest`: 172 tests, 0 failures, 0 errors, 1 skipped
