### PR TITLE
Let TextRecognizer read non-Latin scripts

### DIFF
--- a/CodenameOne/src/com/codename1/ai/vision/TextScript.java
+++ b/CodenameOne/src/com/codename1/ai/vision/TextScript.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.ai.vision;
+
+/// Writing system selectors for {@link TextRecognizer}. The recognizers behind
+/// the portable API are script-specific rather than language-specific: one
+/// script covers every language written in it, and each script model also
+/// recognizes Latin characters embedded in the page.
+///
+/// Each selector call is also a build-time dependency marker, exactly like
+/// {@link VisionBackends}. The methods must remain distinct so a build packages
+/// only the script models the application actually asks for; a Japanese OCR
+/// application does not carry the Korean or Devanagari model.
+///
+/// ```java
+/// TextRecognizer recognizer = new TextRecognizer(
+///         new VisionOptions().textScript(TextScript.japanese()));
+/// recognizer.process(VisionImage.encoded(jpeg)).ready(result -> {
+///     Log.p(result.getText());
+/// });
+/// ```
+///
+/// A selector states the script, not the backend. Android maps each one to the
+/// matching ML Kit recognizer. Apple platforms map it to the Vision recognition
+/// languages for that script, and report the analysis as unsupported when the
+/// OS does not recognize that script -- selecting
+/// {@link VisionBackends#mlKitTextRecognition()} then supplies the script model
+/// through ML Kit instead.
+public final class TextScript {
+    private static final TextScript LATIN = new TextScript("latin");
+    private static final TextScript CHINESE = new TextScript("chinese");
+    private static final TextScript DEVANAGARI = new TextScript("devanagari");
+    private static final TextScript JAPANESE = new TextScript("japanese");
+    private static final TextScript KOREAN = new TextScript("korean");
+
+    private final String id;
+
+    private TextScript(String id) {
+        this.id = id;
+    }
+
+    /// Selects the Latin script, which is also the platform default. Referencing
+    /// it adds no model beyond the one every text recognizer already carries.
+    /// @return the Latin script selector
+    public static TextScript latin() {
+        return LATIN;
+    }
+
+    /// Selects the Chinese script, covering Simplified and Traditional Chinese.
+    /// @return the Chinese script selector
+    public static TextScript chinese() {
+        return CHINESE;
+    }
+
+    /// Selects the Devanagari script used by Hindi, Marathi, Nepali and Sanskrit.
+    /// @return the Devanagari script selector
+    public static TextScript devanagari() {
+        return DEVANAGARI;
+    }
+
+    /// Selects the Japanese script, covering kanji, hiragana and katakana.
+    /// @return the Japanese script selector
+    public static TextScript japanese() {
+        return JAPANESE;
+    }
+
+    /// Selects the Korean script, covering hangul and hanja.
+    /// @return the Korean script selector
+    public static TextScript korean() {
+        return KOREAN;
+    }
+
+    /// @return the stable identifier passed to the port, never {@code null}
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String toString() {
+        return id;
+    }
+}

--- a/CodenameOne/src/com/codename1/ai/vision/VisionOptions.java
+++ b/CodenameOne/src/com/codename1/ai/vision/VisionOptions.java
@@ -29,11 +29,23 @@ public final class VisionOptions {
     private VisionBackend backend = VisionBackends.auto();
     private float minimumConfidence;
     private int maximumResults;
+    private TextScript textScript;
 
     /// @param value selector, or {@code null} to restore automatic selection
     /// @return this options object
     public VisionOptions backend(VisionBackend value) {
         backend = value == null ? VisionBackends.auto() : value;
+        return this;
+    }
+
+    /// Selects the writing system {@link TextRecognizer} should read. Analyzers
+    /// other than the text recognizer ignore it.
+    ///
+    /// @param value script selector, or {@code null} for the platform default
+    ///        (Latin)
+    /// @return this options object
+    public VisionOptions textScript(TextScript value) {
+        textScript = value;
         return this;
     }
 
@@ -74,9 +86,16 @@ public final class VisionOptions {
         return maximumResults;
     }
 
+    /// @return the selected writing system, or {@code null} for the platform
+    ///         default
+    public TextScript getTextScript() {
+        return textScript;
+    }
+
     VisionOptions snapshot() {
         return new VisionOptions().backend(backend)
                 .minimumConfidence(minimumConfidence)
-                .maximumResults(maximumResults);
+                .maximumResults(maximumResults)
+                .textScript(textScript);
     }
 }

--- a/Ports/Android/src/com/codename1/impl/android/ai/AndroidTextRecognitionAdapter.java
+++ b/Ports/Android/src/com/codename1/impl/android/ai/AndroidTextRecognitionAdapter.java
@@ -30,14 +30,32 @@ import com.google.mlkit.vision.common.InputImage;
 import com.google.mlkit.vision.text.Text;
 import com.google.mlkit.vision.text.TextRecognition;
 import com.google.mlkit.vision.text.TextRecognizer;
+import com.google.mlkit.vision.text.TextRecognizerOptionsInterface;
 import com.google.mlkit.vision.text.latin.TextRecognizerOptions;
 
 import java.util.List;
 
-/** ML Kit text recognition; retained only for {@code TextRecognizer} users. */
-final class AndroidTextRecognitionAdapter extends AndroidVisionAdapter {
-    private final TextRecognizer client = TextRecognition.getClient(
-            TextRecognizerOptions.DEFAULT_OPTIONS);
+/**
+ * ML Kit text recognition; retained only for {@code TextRecognizer} users.
+ *
+ * <p>This class holds the Latin recognizer and the result mapping shared by
+ * every script. The other scripts live in their own subclasses because ML Kit
+ * ships one artifact per script model: keeping each {@code import} in a
+ * separate source file lets the builder delete the sources -- and therefore
+ * skip the Gradle dependencies -- for the models the application never asks
+ * for.</p>
+ */
+class AndroidTextRecognitionAdapter extends AndroidVisionAdapter {
+    private final TextRecognizer client;
+
+    AndroidTextRecognitionAdapter() {
+        this(TextRecognizerOptions.DEFAULT_OPTIONS);
+    }
+
+    AndroidTextRecognitionAdapter(TextRecognizerOptionsInterface options) {
+        client = TextRecognition.getClient(options);
+    }
+
     @Override
     @SuppressWarnings("unchecked")
     void analyze(InputImage input, final int imageWidth,

--- a/Ports/Android/src/com/codename1/impl/android/ai/AndroidTextRecognitionChineseAdapter.java
+++ b/Ports/Android/src/com/codename1/impl/android/ai/AndroidTextRecognitionChineseAdapter.java
@@ -20,26 +20,19 @@
  * Please contact Codename One through http://www.codenameone.com/ if you
  * need additional information or have any questions.
  */
-package com.codename1.ai.vision;
+package com.codename1.impl.android.ai;
 
-/// Creates reusable on-device OCR analyzers. The default recognizes the Latin
-/// script; select {@link VisionOptions#textScript(TextScript)} to read Chinese,
-/// Devanagari, Japanese or Korean text.
-public final class TextRecognizer extends AbstractVisionAnalyzer<TextRecognitionResult> {
-    /// Creates an analyzer using the platform default backend and options,
-    /// reading the Latin script.
-    /// @see VisionOptions
-    public TextRecognizer() {
-        this(null);
-    }
+import com.google.mlkit.vision.text.chinese.ChineseTextRecognizerOptions;
 
-    /// Creates a reusable analyzer with explicit backend and result options.
-    /// The writing system comes from
-    /// {@link VisionOptions#textScript(TextScript)}.
-    ///
-    /// @param options configuration captured by this analyzer; {@code null}
-    ///        uses defaults
-    public TextRecognizer(VisionOptions options) {
-        super(VisionFeature.TEXT_RECOGNITION, options);
+/**
+ * ML Kit Chinese text recognition, covering Simplified and Traditional
+ * Chinese. Kept in its own source file so the text-recognition-chinese ML
+ * Kit dependency is packaged only for an application that selects {@code
+ * TextScript.chinese()}.
+ */
+final class AndroidTextRecognitionChineseAdapter
+        extends AndroidTextRecognitionAdapter {
+    AndroidTextRecognitionChineseAdapter() {
+        super(new ChineseTextRecognizerOptions.Builder().build());
     }
 }

--- a/Ports/Android/src/com/codename1/impl/android/ai/AndroidTextRecognitionDevanagariAdapter.java
+++ b/Ports/Android/src/com/codename1/impl/android/ai/AndroidTextRecognitionDevanagariAdapter.java
@@ -20,26 +20,19 @@
  * Please contact Codename One through http://www.codenameone.com/ if you
  * need additional information or have any questions.
  */
-package com.codename1.ai.vision;
+package com.codename1.impl.android.ai;
 
-/// Creates reusable on-device OCR analyzers. The default recognizes the Latin
-/// script; select {@link VisionOptions#textScript(TextScript)} to read Chinese,
-/// Devanagari, Japanese or Korean text.
-public final class TextRecognizer extends AbstractVisionAnalyzer<TextRecognitionResult> {
-    /// Creates an analyzer using the platform default backend and options,
-    /// reading the Latin script.
-    /// @see VisionOptions
-    public TextRecognizer() {
-        this(null);
-    }
+import com.google.mlkit.vision.text.devanagari.DevanagariTextRecognizerOptions;
 
-    /// Creates a reusable analyzer with explicit backend and result options.
-    /// The writing system comes from
-    /// {@link VisionOptions#textScript(TextScript)}.
-    ///
-    /// @param options configuration captured by this analyzer; {@code null}
-    ///        uses defaults
-    public TextRecognizer(VisionOptions options) {
-        super(VisionFeature.TEXT_RECOGNITION, options);
+/**
+ * ML Kit Devanagari text recognition, covering Hindi, Marathi, Nepali and
+ * Sanskrit. Kept in its own source file so the text-recognition-devanagari
+ * ML Kit dependency is packaged only for an application that selects
+ * {@code TextScript.devanagari()}.
+ */
+final class AndroidTextRecognitionDevanagariAdapter
+        extends AndroidTextRecognitionAdapter {
+    AndroidTextRecognitionDevanagariAdapter() {
+        super(new DevanagariTextRecognizerOptions.Builder().build());
     }
 }

--- a/Ports/Android/src/com/codename1/impl/android/ai/AndroidTextRecognitionJapaneseAdapter.java
+++ b/Ports/Android/src/com/codename1/impl/android/ai/AndroidTextRecognitionJapaneseAdapter.java
@@ -20,26 +20,19 @@
  * Please contact Codename One through http://www.codenameone.com/ if you
  * need additional information or have any questions.
  */
-package com.codename1.ai.vision;
+package com.codename1.impl.android.ai;
 
-/// Creates reusable on-device OCR analyzers. The default recognizes the Latin
-/// script; select {@link VisionOptions#textScript(TextScript)} to read Chinese,
-/// Devanagari, Japanese or Korean text.
-public final class TextRecognizer extends AbstractVisionAnalyzer<TextRecognitionResult> {
-    /// Creates an analyzer using the platform default backend and options,
-    /// reading the Latin script.
-    /// @see VisionOptions
-    public TextRecognizer() {
-        this(null);
-    }
+import com.google.mlkit.vision.text.japanese.JapaneseTextRecognizerOptions;
 
-    /// Creates a reusable analyzer with explicit backend and result options.
-    /// The writing system comes from
-    /// {@link VisionOptions#textScript(TextScript)}.
-    ///
-    /// @param options configuration captured by this analyzer; {@code null}
-    ///        uses defaults
-    public TextRecognizer(VisionOptions options) {
-        super(VisionFeature.TEXT_RECOGNITION, options);
+/**
+ * ML Kit Japanese text recognition, covering kanji, hiragana and katakana.
+ * Kept in its own source file so the text-recognition-japanese ML Kit
+ * dependency is packaged only for an application that selects {@code
+ * TextScript.japanese()}.
+ */
+final class AndroidTextRecognitionJapaneseAdapter
+        extends AndroidTextRecognitionAdapter {
+    AndroidTextRecognitionJapaneseAdapter() {
+        super(new JapaneseTextRecognizerOptions.Builder().build());
     }
 }

--- a/Ports/Android/src/com/codename1/impl/android/ai/AndroidTextRecognitionKoreanAdapter.java
+++ b/Ports/Android/src/com/codename1/impl/android/ai/AndroidTextRecognitionKoreanAdapter.java
@@ -20,26 +20,19 @@
  * Please contact Codename One through http://www.codenameone.com/ if you
  * need additional information or have any questions.
  */
-package com.codename1.ai.vision;
+package com.codename1.impl.android.ai;
 
-/// Creates reusable on-device OCR analyzers. The default recognizes the Latin
-/// script; select {@link VisionOptions#textScript(TextScript)} to read Chinese,
-/// Devanagari, Japanese or Korean text.
-public final class TextRecognizer extends AbstractVisionAnalyzer<TextRecognitionResult> {
-    /// Creates an analyzer using the platform default backend and options,
-    /// reading the Latin script.
-    /// @see VisionOptions
-    public TextRecognizer() {
-        this(null);
-    }
+import com.google.mlkit.vision.text.korean.KoreanTextRecognizerOptions;
 
-    /// Creates a reusable analyzer with explicit backend and result options.
-    /// The writing system comes from
-    /// {@link VisionOptions#textScript(TextScript)}.
-    ///
-    /// @param options configuration captured by this analyzer; {@code null}
-    ///        uses defaults
-    public TextRecognizer(VisionOptions options) {
-        super(VisionFeature.TEXT_RECOGNITION, options);
+/**
+ * ML Kit Korean text recognition, covering hangul and hanja. Kept in its
+ * own source file so the text-recognition-korean ML Kit dependency is
+ * packaged only for an application that selects {@code
+ * TextScript.korean()}.
+ */
+final class AndroidTextRecognitionKoreanAdapter
+        extends AndroidTextRecognitionAdapter {
+    AndroidTextRecognitionKoreanAdapter() {
+        super(new KoreanTextRecognizerOptions.Builder().build());
     }
 }

--- a/Ports/Android/src/com/codename1/impl/android/ai/AndroidVisionImpl.java
+++ b/Ports/Android/src/com/codename1/impl/android/ai/AndroidVisionImpl.java
@@ -25,6 +25,7 @@ package com.codename1.impl.android.ai;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 
+import com.codename1.ai.vision.TextScript;
 import com.codename1.ai.vision.VisionException;
 import com.codename1.ai.vision.VisionFeature;
 import com.codename1.ai.vision.VisionImage;
@@ -43,7 +44,7 @@ import com.google.mlkit.vision.common.InputImage;
 public final class AndroidVisionImpl extends VisionImpl {
     private volatile boolean closed;
     private AndroidVisionAdapter adapter;
-    private VisionFeature adapterFeature;
+    private String adapterClassName;
 
     @Override
     public boolean isSupported(VisionFeature feature, String backendId) {
@@ -63,10 +64,22 @@ public final class AndroidVisionImpl extends VisionImpl {
         final VisionOptions optionSnapshot = new VisionOptions()
                 .backend(options.getBackend())
                 .minimumConfidence(options.getMinimumConfidence())
-                .maximumResults(options.getMaximumResults());
+                .maximumResults(options.getMaximumResults())
+                .textScript(options.getTextScript());
         if (!isSupported(feature, backendId)) {
             out.error(new VisionException(VisionException.UNSUPPORTED,
                     feature + " is not included in this Android build"));
+            return out;
+        }
+        final String adapterType = adapterClass(feature,
+                optionSnapshot.getTextScript());
+        if (!isClassPresent(adapterType)) {
+            // The script model is a separate ML Kit artifact selected at build
+            // time. Name the selector rather than the feature: the recognizer
+            // itself is present, it is this script that was never asked for.
+            out.error(new VisionException(VisionException.UNSUPPORTED,
+                    "TextScript." + optionSnapshot.getTextScript()
+                            + "() is not included in this Android build"));
             return out;
         }
         Display.getInstance().scheduleBackgroundTask(new Runnable() {
@@ -80,8 +93,8 @@ public final class AndroidVisionImpl extends VisionImpl {
                                         + "or RGBA8888 data"));
                         return;
                     }
-                    adapter(feature).analyze(decoded.input, decoded.width,
-                            decoded.height, optionSnapshot,
+                    adapter(adapterType).analyze(decoded.input,
+                            decoded.width, decoded.height, optionSnapshot,
                             (AsyncResource) out);
                 } catch (Throwable cause) {
                     error(out, new VisionException(
@@ -94,18 +107,18 @@ public final class AndroidVisionImpl extends VisionImpl {
         return out;
     }
 
-    private synchronized AndroidVisionAdapter adapter(VisionFeature feature)
+    private synchronized AndroidVisionAdapter adapter(String className)
             throws Exception {
         if (closed) {
             throw new IllegalStateException("Vision backend is closed");
         }
         if (adapter == null) {
             adapter = (AndroidVisionAdapter) Class.forName(
-                    adapterClass(feature)).newInstance();
-            adapterFeature = feature;
-        } else if (adapterFeature != feature) {
-            throw new IllegalStateException(
-                    "A vision backend instance cannot analyze multiple features");
+                    className).newInstance();
+            adapterClassName = className;
+        } else if (!adapterClassName.equals(className)) {
+            throw new IllegalStateException("A vision backend instance cannot "
+                    + "analyze multiple features or writing systems");
         }
         return adapter;
     }
@@ -198,6 +211,35 @@ public final class AndroidVisionImpl extends VisionImpl {
         } catch (Throwable ignored) {
             return false;
         }
+    }
+
+    /**
+     * Resolves the adapter for a feature, honouring the writing system when the
+     * feature is text recognition. ML Kit ships one recognizer artifact per
+     * script, so each script maps to its own adapter class; a script the build
+     * never packaged simply has no class, which the caller reports as
+     * unsupported.
+     */
+    private static String adapterClass(VisionFeature feature,
+                                       TextScript script) {
+        if (feature != VisionFeature.TEXT_RECOGNITION || script == null) {
+            return adapterClass(feature);
+        }
+        String prefix = "com.codename1.impl.android.ai.AndroidTextRecognition";
+        String id = script.getId();
+        if ("chinese".equals(id)) {
+            return prefix + "ChineseAdapter";
+        }
+        if ("devanagari".equals(id)) {
+            return prefix + "DevanagariAdapter";
+        }
+        if ("japanese".equals(id)) {
+            return prefix + "JapaneseAdapter";
+        }
+        if ("korean".equals(id)) {
+            return prefix + "KoreanAdapter";
+        }
+        return adapterClass(feature);
     }
 
     private static String adapterClass(VisionFeature feature) {

--- a/Ports/iOSPort/nativeSources/CN1Vision.m
+++ b/Ports/iOSPort/nativeSources/CN1Vision.m
@@ -208,6 +208,21 @@ static NSString *cn1VisionError(NSError *error) {
     });
 }
 
+/*
+ * A capability failure rather than a runtime one: the analysis cannot run
+ * because this build or this OS lacks the model, not because it tried and
+ * broke. The symbolic code rides alongside the message so IOSVisionImpl can
+ * raise VisionException.UNSUPPORTED -- matching what Android reports for the
+ * same condition -- instead of leaving callers to pattern-match on English
+ * text to decide whether the ML Kit fallback is worth trying.
+ */
+static NSString *cn1VisionUnsupported(NSString *message) {
+    return cn1VisionJSON(@{
+        @"error": message,
+        @"errorCode": @"unsupported"
+    });
+}
+
 #if defined(CN1_HAS_MLKIT_VISION)
 static UIImageOrientation cn1UIImageOrientation(int rotation) {
     switch (rotation) {
@@ -292,9 +307,9 @@ static NSString *cn1MLKitVisionPerform(NSData *data, CGImageRef rawImage,
         if (scriptClassName != nil) {
             Class scriptClass = NSClassFromString(scriptClassName);
             if (scriptClass == nil) {
-                return cn1VisionJSON(@{@"error": [NSString stringWithFormat:
+                return cn1VisionUnsupported([NSString stringWithFormat:
                         @"The ML Kit %@ text model is not linked into this "
-                         "build", textScript]});
+                         "build", textScript]);
             }
             textOptions = [[scriptClass alloc] init];
         }
@@ -628,11 +643,11 @@ static NSString *cn1VisionPerform(NSData *data, CGImageRef rawImage,
                     // Latin OCR over the page and return confident nonsense,
                     // so refuse instead: the caller can select the ML Kit
                     // backend, which carries its own script model.
-                    return cn1VisionJSON(@{@"error": [NSString stringWithFormat:
+                    return cn1VisionUnsupported([NSString stringWithFormat:
                             @"Apple Vision on this OS version does not "
                              "recognize the %@ script. Select "
                              "VisionBackends.mlKitTextRecognition() to use the "
-                             "ML Kit model instead.", textScript]});
+                             "ML Kit model instead.", textScript]);
                 }
                 request.recognitionLanguages = languages;
                 request.usesLanguageCorrection = YES;

--- a/Ports/iOSPort/nativeSources/CN1Vision.m
+++ b/Ports/iOSPort/nativeSources/CN1Vision.m
@@ -246,8 +246,33 @@ static NSString *cn1MLKitBarcodeFormat(MLKBarcodeFormat format) {
 }
 #endif
 
+#if defined(CN1_HAS_MLKIT_TEXT)
+/*
+ * ML Kit ships one recognizer model per writing system, each in its own pod.
+ * The class is looked up by name rather than imported so this file keeps
+ * compiling for a build that linked only some of them -- a missing model is a
+ * nil Class, which the caller reports as unsupported.
+ */
+static NSString *cn1MLKitTextOptionsClassName(NSString *script) {
+    if ([script isEqualToString:@"chinese"]) {
+        return @"MLKChineseTextRecognizerOptions";
+    }
+    if ([script isEqualToString:@"devanagari"]) {
+        return @"MLKDevanagariTextRecognizerOptions";
+    }
+    if ([script isEqualToString:@"japanese"]) {
+        return @"MLKJapaneseTextRecognizerOptions";
+    }
+    if ([script isEqualToString:@"korean"]) {
+        return @"MLKKoreanTextRecognizerOptions";
+    }
+    return nil;
+}
+#endif
+
 static NSString *cn1MLKitVisionPerform(NSData *data, CGImageRef rawImage,
-                                       int feature, int rotation) {
+                                       int feature, int rotation,
+                                       NSString *textScript) {
 #if defined(CN1_HAS_MLKIT_VISION)
     UIImage *image = rawImage == NULL ? [UIImage imageWithData:data]
             : [UIImage imageWithCGImage:rawImage];
@@ -262,8 +287,19 @@ static NSString *cn1MLKitVisionPerform(NSData *data, CGImageRef rawImage,
 
     if (feature == 0) {
 #if defined(CN1_HAS_MLKIT_TEXT)
-        MLKTextRecognizer *recognizer = [MLKTextRecognizer textRecognizerWithOptions:
-                [[MLKTextRecognizerOptions alloc] init]];
+        id textOptions = [[MLKTextRecognizerOptions alloc] init];
+        NSString *scriptClassName = cn1MLKitTextOptionsClassName(textScript);
+        if (scriptClassName != nil) {
+            Class scriptClass = NSClassFromString(scriptClassName);
+            if (scriptClass == nil) {
+                return cn1VisionJSON(@{@"error": [NSString stringWithFormat:
+                        @"The ML Kit %@ text model is not linked into this "
+                         "build", textScript]});
+            }
+            textOptions = [[scriptClass alloc] init];
+        }
+        MLKTextRecognizer *recognizer =
+                [MLKTextRecognizer textRecognizerWithOptions:textOptions];
         __block MLKText *result = nil;
         [recognizer processImage:vision completion:^(MLKText *text, NSError *error) {
             result = text;
@@ -511,8 +547,68 @@ static NSString *cn1ApplePoseLandmarkName(
     return name ?: @"unknown";
 }
 
+/*
+ * Primary language subtags whose text is written in a given script. Apple
+ * Vision is configured by language rather than by script, and which languages
+ * it recognizes grows with the OS, so the request is asked what it supports
+ * and the answer is filtered here instead of hard-coding a list per release.
+ */
+static NSArray<NSString *> *cn1VisionScriptSubtags(NSString *script) {
+    if ([script isEqualToString:@"chinese"]) {
+        return @[@"zh", @"yue"];
+    }
+    if ([script isEqualToString:@"devanagari"]) {
+        return @[@"hi", @"mr", @"ne", @"sa"];
+    }
+    if ([script isEqualToString:@"japanese"]) {
+        return @[@"ja"];
+    }
+    if ([script isEqualToString:@"korean"]) {
+        return @[@"ko"];
+    }
+    return nil;
+}
+
+static NSArray<NSString *> *cn1VisionSupportedLanguages(
+        VNRecognizeTextRequest *request) {
+    NSError *listError = nil;
+    if (@available(iOS 15.0, *)) {
+        return [request supportedRecognitionLanguagesAndReturnError:&listError];
+    }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    return [VNRecognizeTextRequest
+            supportedRecognitionLanguagesForTextRecognitionLevel:
+                    request.recognitionLevel
+            revision:request.revision
+            error:&listError];
+#pragma clang diagnostic pop
+}
+
+/*
+ * Every supported language written in the requested script, in the order the
+ * OS listed them. Matching is on the primary subtag so a regional or script
+ * variant such as ja-JP or zh-Hans is picked up without enumerating them.
+ */
+static NSArray<NSString *> *cn1VisionLanguagesForScript(
+        VNRecognizeTextRequest *request, NSString *script) {
+    NSArray<NSString *> *subtags = cn1VisionScriptSubtags(script);
+    if (subtags == nil) {
+        return @[];
+    }
+    NSMutableArray<NSString *> *selected = [NSMutableArray array];
+    for (NSString *language in cn1VisionSupportedLanguages(request) ?: @[]) {
+        NSString *primary = [language componentsSeparatedByString:@"-"].firstObject;
+        if (primary != nil && [subtags containsObject:primary]) {
+            [selected addObject:language];
+        }
+    }
+    return selected;
+}
+
 static NSString *cn1VisionPerform(NSData *data, CGImageRef rawImage,
-                                  int feature, int rotation) {
+                                  int feature, int rotation,
+                                  NSString *textScript) {
     NSError *error = nil;
     VNImageRequestHandler *handler = rawImage == NULL
             ? [[VNImageRequestHandler alloc] initWithData:data
@@ -524,6 +620,23 @@ static NSString *cn1VisionPerform(NSData *data, CGImageRef rawImage,
         if (@available(iOS 13.0, *)) {
             VNRecognizeTextRequest *request = [[VNRecognizeTextRequest alloc] init];
             request.recognitionLevel = VNRequestTextRecognitionLevelAccurate;
+            if (cn1VisionScriptSubtags(textScript) != nil) {
+                NSArray<NSString *> *languages =
+                        cn1VisionLanguagesForScript(request, textScript);
+                if (languages.count == 0) {
+                    // Leaving the request on its default languages would run
+                    // Latin OCR over the page and return confident nonsense,
+                    // so refuse instead: the caller can select the ML Kit
+                    // backend, which carries its own script model.
+                    return cn1VisionJSON(@{@"error": [NSString stringWithFormat:
+                            @"Apple Vision on this OS version does not "
+                             "recognize the %@ script. Select "
+                             "VisionBackends.mlKitTextRecognition() to use the "
+                             "ML Kit model instead.", textScript]});
+                }
+                request.recognitionLanguages = languages;
+                request.usesLanguageCorrection = YES;
+            }
             if (![handler performRequests:@[request] error:&error]) {
                 return cn1VisionError(error);
             }
@@ -886,11 +999,11 @@ static CGImageRef cn1VisionCreateRawImage(NSData *data, int width, int height,
 }
 #endif
 
-JAVA_OBJECT com_codename1_impl_ios_IOSNative_cn1VisionAnalyze___byte_1ARRAY_int_boolean_int_int_int_int_R_java_lang_String(
+JAVA_OBJECT com_codename1_impl_ios_IOSNative_cn1VisionAnalyze___byte_1ARRAY_int_boolean_int_int_int_int_java_lang_String_R_java_lang_String(
         CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject,
         JAVA_OBJECT encodedImage, JAVA_INT feature, JAVA_BOOLEAN mlKit,
         JAVA_INT rotation, JAVA_INT width, JAVA_INT height,
-        JAVA_INT frameFormat) {
+        JAVA_INT frameFormat, JAVA_OBJECT textScript) {
 #if defined(INCLUDE_CN1_VISION) && !TARGET_OS_WATCH && !TARGET_OS_TV
     if (encodedImage == JAVA_NULL) {
         return fromNSString(CN1_THREAD_GET_STATE_PASS_ARG
@@ -904,9 +1017,11 @@ JAVA_OBJECT com_codename1_impl_ios_IOSNative_cn1VisionAnalyze___byte_1ARRAY_int_
         return fromNSString(CN1_THREAD_GET_STATE_PASS_ARG
                 @"{\"error\":\"Invalid raw vision image\"}");
     }
+    NSString *script = textScript == JAVA_NULL ? @"latin"
+            : toNSString(CN1_THREAD_GET_STATE_PASS_ARG textScript);
     NSString *result = mlKit
-            ? cn1MLKitVisionPerform(data, rawImage, feature, rotation)
-            : cn1VisionPerform(data, rawImage, feature, rotation);
+            ? cn1MLKitVisionPerform(data, rawImage, feature, rotation, script)
+            : cn1VisionPerform(data, rawImage, feature, rotation, script);
     if (rawImage != NULL) CGImageRelease(rawImage);
     return fromNSString(CN1_THREAD_GET_STATE_PASS_ARG result);
 #else

--- a/Ports/iOSPort/nativeSources/CN1Vision.m
+++ b/Ports/iOSPort/nativeSources/CN1Vision.m
@@ -46,6 +46,32 @@
 #import <MLKitTextRecognitionCommon/MLKitTextRecognitionCommon.h>
 #define CN1_HAS_MLKIT_TEXT 1
 #endif
+/*
+ * One pod per writing system, each imported only when the build linked it.
+ *
+ * These must be real symbol references rather than an NSClassFromString
+ * lookup. The pods link as static frameworks -- the builder passes -ObjC only
+ * for ads builds or the ios.objC hint -- so an options class that nothing
+ * references is dropped by the linker, and the lookup would then return nil on
+ * a build whose Podfile did include the model. Naming the class here also gets
+ * it spell-checked by the compiler instead of at runtime.
+ */
+#if __has_include(<MLKitTextRecognitionChinese/MLKitTextRecognitionChinese.h>)
+#import <MLKitTextRecognitionChinese/MLKitTextRecognitionChinese.h>
+#define CN1_HAS_MLKIT_TEXT_CHINESE 1
+#endif
+#if __has_include(<MLKitTextRecognitionDevanagari/MLKitTextRecognitionDevanagari.h>)
+#import <MLKitTextRecognitionDevanagari/MLKitTextRecognitionDevanagari.h>
+#define CN1_HAS_MLKIT_TEXT_DEVANAGARI 1
+#endif
+#if __has_include(<MLKitTextRecognitionJapanese/MLKitTextRecognitionJapanese.h>)
+#import <MLKitTextRecognitionJapanese/MLKitTextRecognitionJapanese.h>
+#define CN1_HAS_MLKIT_TEXT_JAPANESE 1
+#endif
+#if __has_include(<MLKitTextRecognitionKorean/MLKitTextRecognitionKorean.h>)
+#import <MLKitTextRecognitionKorean/MLKitTextRecognitionKorean.h>
+#define CN1_HAS_MLKIT_TEXT_KOREAN 1
+#endif
 #if __has_include(<MLKitBarcodeScanning/MLKitBarcodeScanning.h>)
 #import <MLKitBarcodeScanning/MLKitBarcodeScanning.h>
 #define CN1_HAS_MLKIT_BARCODE 1
@@ -223,6 +249,13 @@ static NSString *cn1VisionUnsupported(NSString *message) {
     });
 }
 
+/*
+ * Defined further down with the Apple Vision helpers; both backends use a
+ * non-nil result as "a writing system other than the Latin default was
+ * selected", so the set of recognized script ids stays in one place.
+ */
+static NSArray<NSString *> *cn1VisionScriptSubtags(NSString *script);
+
 #if defined(CN1_HAS_MLKIT_VISION)
 static UIImageOrientation cn1UIImageOrientation(int rotation) {
     switch (rotation) {
@@ -263,24 +296,32 @@ static NSString *cn1MLKitBarcodeFormat(MLKBarcodeFormat format) {
 
 #if defined(CN1_HAS_MLKIT_TEXT)
 /*
- * ML Kit ships one recognizer model per writing system, each in its own pod.
- * The class is looked up by name rather than imported so this file keeps
- * compiling for a build that linked only some of them -- a missing model is a
- * nil Class, which the caller reports as unsupported.
+ * The recognizer options for a writing system, or nil when this build did not
+ * link that model. Latin needs no entry: it is the base recognizer's own
+ * options, which the caller supplies.
  */
-static NSString *cn1MLKitTextOptionsClassName(NSString *script) {
+static MLKCommonTextRecognizerOptions *cn1MLKitTextScriptOptions(
+        NSString *script) {
+#if defined(CN1_HAS_MLKIT_TEXT_CHINESE)
     if ([script isEqualToString:@"chinese"]) {
-        return @"MLKChineseTextRecognizerOptions";
+        return [[MLKChineseTextRecognizerOptions alloc] init];
     }
+#endif
+#if defined(CN1_HAS_MLKIT_TEXT_DEVANAGARI)
     if ([script isEqualToString:@"devanagari"]) {
-        return @"MLKDevanagariTextRecognizerOptions";
+        return [[MLKDevanagariTextRecognizerOptions alloc] init];
     }
+#endif
+#if defined(CN1_HAS_MLKIT_TEXT_JAPANESE)
     if ([script isEqualToString:@"japanese"]) {
-        return @"MLKJapaneseTextRecognizerOptions";
+        return [[MLKJapaneseTextRecognizerOptions alloc] init];
     }
+#endif
+#if defined(CN1_HAS_MLKIT_TEXT_KOREAN)
     if ([script isEqualToString:@"korean"]) {
-        return @"MLKKoreanTextRecognizerOptions";
+        return [[MLKKoreanTextRecognizerOptions alloc] init];
     }
+#endif
     return nil;
 }
 #endif
@@ -302,16 +343,15 @@ static NSString *cn1MLKitVisionPerform(NSData *data, CGImageRef rawImage,
 
     if (feature == 0) {
 #if defined(CN1_HAS_MLKIT_TEXT)
-        id textOptions = [[MLKTextRecognizerOptions alloc] init];
-        NSString *scriptClassName = cn1MLKitTextOptionsClassName(textScript);
-        if (scriptClassName != nil) {
-            Class scriptClass = NSClassFromString(scriptClassName);
-            if (scriptClass == nil) {
+        MLKCommonTextRecognizerOptions *textOptions =
+                [[MLKTextRecognizerOptions alloc] init];
+        if (cn1VisionScriptSubtags(textScript) != nil) {
+            textOptions = cn1MLKitTextScriptOptions(textScript);
+            if (textOptions == nil) {
                 return cn1VisionUnsupported([NSString stringWithFormat:
                         @"The ML Kit %@ text model is not linked into this "
                          "build", textScript]);
             }
-            textOptions = [[scriptClass alloc] init];
         }
         MLKTextRecognizer *recognizer =
                 [MLKTextRecognizer textRecognizerWithOptions:textOptions];

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSNative.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSNative.java
@@ -543,7 +543,7 @@ public final class IOSNative {
     native boolean cn1VisionIsSupported(int feature, boolean mlKit);
     native String cn1VisionAnalyze(byte[] imageData, int feature, boolean mlKit,
                                    int rotationDegrees, int width, int height,
-                                   int frameFormat);
+                                   int frameFormat, String textScript);
     native boolean cn1LanguageIsSupported(int feature, boolean mlKit);
     native String cn1LanguageIdentify(String text, float minimumConfidence,
                                       boolean mlKit);

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSVisionImpl.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSVisionImpl.java
@@ -29,6 +29,7 @@ import com.codename1.ai.vision.ImageLabel;
 import com.codename1.ai.vision.Pose;
 import com.codename1.ai.vision.SegmentationMask;
 import com.codename1.ai.vision.TextRecognitionResult;
+import com.codename1.ai.vision.TextScript;
 import com.codename1.ai.vision.VisionException;
 import com.codename1.ai.vision.VisionFeature;
 import com.codename1.ai.vision.VisionImage;
@@ -88,9 +89,11 @@ public final class IOSVisionImpl extends VisionImpl {
                     "Apple Vision requires encoded, NV21, or RGBA8888 input"));
             return out;
         }
+        TextScript script = options.getTextScript();
         analyzeInBackground(out, feature, mlKit, input,
                 image.getRotationDegrees(), width, height, frameFormat,
-                options.getMinimumConfidence(), options.getMaximumResults());
+                options.getMinimumConfidence(), options.getMaximumResults(),
+                script == null ? null : script.getId());
         return out;
     }
 
@@ -103,13 +106,14 @@ public final class IOSVisionImpl extends VisionImpl {
                                                  final int height,
                                                  final int frameFormat,
                                                  final float minimumConfidence,
-                                                 final int maximumResults) {
+                                                 final int maximumResults,
+                                                 final String textScript) {
         Display.getInstance().scheduleBackgroundTask(new Runnable() {
             public void run() {
                 try {
                     String json = IOSImplementation.nativeInstance.cn1VisionAnalyze(
                             input, nativeFeatureId(feature), mlKit,
-                            rotation, width, height, frameFormat);
+                            rotation, width, height, frameFormat, textScript);
                     if (json == null || json.length() == 0) {
                         throw new VisionException(VisionException.BACKEND_ERROR,
                                 "Apple Vision returned no result");

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSVisionImpl.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSVisionImpl.java
@@ -182,7 +182,7 @@ public final class IOSVisionImpl extends VisionImpl {
         Map root = new JSONParser().parseJSON(new StringReader(json));
         Object error = root.get("error");
         if (error != null) {
-            throw new VisionException(VisionException.BACKEND_ERROR, String.valueOf(error));
+            throw new VisionException(errorCode(root), String.valueOf(error));
         }
         List items = (List) root.get("items");
         if (items == null) {
@@ -302,6 +302,21 @@ public final class IOSVisionImpl extends VisionImpl {
             }
         }
         return filtered;
+    }
+
+    /**
+     * Classifies a native failure. The backend tags the failures that are a
+     * missing capability rather than a broken run -- a script this OS cannot
+     * recognize, a model this build did not link -- so they surface as
+     * {@code UNSUPPORTED}, the same code Android reports for the equivalent
+     * case. Callers can then branch on the portable code to offer the ML Kit
+     * fallback instead of matching on the message text. An untagged failure is
+     * a genuine backend error.
+     */
+    @SuppressWarnings("rawtypes")
+    private static int errorCode(Map root) {
+        return "unsupported".equals(stringOrNull(root, "errorCode"))
+                ? VisionException.UNSUPPORTED : VisionException.BACKEND_ERROR;
     }
 
     private static VisionRect rect(Map value) {

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AiAndSpeechOnDeviceSnippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AiAndSpeechOnDeviceSnippet.java
@@ -30,6 +30,7 @@ import com.codename1.ai.language.LanguageBackends;
 import com.codename1.ai.language.LanguageOptions;
 import com.codename1.ai.language.Translator;
 import com.codename1.ai.vision.TextRecognizer;
+import com.codename1.ai.vision.TextScript;
 import com.codename1.ai.vision.VisionBackends;
 import com.codename1.ai.vision.VisionImage;
 import com.codename1.ai.vision.VisionOptions;
@@ -50,6 +51,17 @@ class AiAndSpeechOnDeviceSnippet {
                 .ready(result -> Log.p(result.getText()))
                 .except(error -> Log.e(error));
         // end::ai-and-speech-on-device-vision[]
+    }
+
+    void visionScript() {
+        // tag::ai-and-speech-on-device-vision-script[]
+        TextRecognizer recognizer = new TextRecognizer(new VisionOptions()
+                .textScript(TextScript.japanese()));
+
+        recognizer.process(VisionImage.encoded(jpegBytes))
+                .ready(result -> Log.p(result.getText()))
+                .except(error -> Log.e(error));
+        // end::ai-and-speech-on-device-vision-script[]
     }
 
     void inference() {

--- a/docs/developer-guide/Ai-And-Speech.asciidoc
+++ b/docs/developer-guide/Ai-And-Speech.asciidoc
@@ -294,6 +294,37 @@ and Core Image. iOS can select ML Kit explicitly:
 include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AiAndSpeechOnDeviceSnippet.java[tag=ai-and-speech-on-device-vision,indent=0]
 ----
 
+==== Reading non-Latin text
+
+`TextRecognizer` reads the Latin script by default. Select a writing
+system with `VisionOptions.textScript(...)` to read Chinese, Devanagari,
+Japanese, or Korean:
+
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AiAndSpeechOnDeviceSnippet.java[tag=ai-and-speech-on-device-vision-script,indent=0]
+----
+
+The selector names a script rather than a language, because that is what
+the underlying recognizers are organized by. One script covers every
+language written in it, and each script model also reads the Latin
+characters mixed into the same page. Recognize one script per analyzer;
+create a second analyzer when a screen needs both.
+
+Android maps each script to the matching ML Kit recognizer. Apple
+platforms map it to the Vision recognition languages for that script,
+asking the OS which languages it supports rather than assuming a list.
+When the OS recognizes none of them, the analysis fails with an explicit
+error instead of silently returning Latin OCR of the page. Select
+`VisionBackends.mlKitTextRecognition()` to use ML Kit's model for that
+script on iOS instead.
+
+Each script is a separate model, and referencing `TextScript.japanese()`
+is what adds it: the ML Kit script bundle on Android, and on iOS the
+matching pod when the ML Kit backend was also selected. An application
+that never names a script carries only the Latin model, and one that
+names Japanese does not carry the Korean or Devanagari models.
+
 On an iOS simulator, the Apple barcode backend uses Vision barcode
 request revision 1. Newer simulator runtimes can otherwise complete a
 barcode request without reporting valid QR codes. Physical devices use
@@ -334,6 +365,10 @@ each class the application actually uses:
 | `TextRecognizer`
 | ML Kit text recognition
 | Vision / `GoogleMLKit/TextRecognition`
+
+| `TextScript` (non-Latin)
+| ML Kit bundle for that script
+| Vision recognition languages / `GoogleMLKit/TextRecognition<Script>`
 
 | `BarcodeScanner`
 | ML Kit barcode scanning

--- a/docs/developer-guide/Ai-And-Speech.asciidoc
+++ b/docs/developer-guide/Ai-And-Speech.asciidoc
@@ -305,7 +305,7 @@ Japanese, or Korean:
 include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AiAndSpeechOnDeviceSnippet.java[tag=ai-and-speech-on-device-vision-script,indent=0]
 ----
 
-The selector names a script rather than a language, because that is what
+The selector names a script rather than a language, because that's what
 the underlying recognizers are organized by. One script covers every
 language written in it, and each script model also reads the Latin
 characters mixed into the same page. Recognize one script per analyzer;
@@ -314,16 +314,16 @@ create a second analyzer when a screen needs both.
 Android maps each script to the matching ML Kit recognizer. Apple
 platforms map it to the Vision recognition languages for that script,
 asking the OS which languages it supports rather than assuming a list.
-When the OS recognizes none of them, the analysis fails with an explicit
-error instead of silently returning Latin OCR of the page. Select
-`VisionBackends.mlKitTextRecognition()` to use ML Kit's model for that
-script on iOS instead.
+When the OS recognizes none of them, the analysis fails with
+`VisionException.UNSUPPORTED` rather than returning Latin OCR of the
+page. Select `VisionBackends.mlKitTextRecognition()` to use ML Kit's
+model for that script on iOS instead.
 
 Each script is a separate model, and referencing `TextScript.japanese()`
 is what adds it: the ML Kit script bundle on Android, and on iOS the
 matching pod when the ML Kit backend was also selected. An application
 that never names a script carries only the Latin model, and one that
-names Japanese does not carry the Korean or Devanagari models.
+names Japanese doesn't carry the Korean or Devanagari models.
 
 On an iOS simulator, the Apple barcode backend uses Vision barcode
 request revision 1. Newer simulator runtimes can otherwise complete a

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
@@ -2041,6 +2041,11 @@ public class AndroidGradleBuilder extends Executor {
                     // dependencies and plist entries for every feature,
                     // health included, and is indifferent to what follows.
                     aiAcc.consumeMethod(cls, method);
+                    String scriptAdapter =
+                            androidTextScriptAdapterSource(cls, method);
+                    if (scriptAdapter != null) {
+                        includedAiAdapterSources.add(scriptAdapter);
+                    }
                     // A store method reached through a passed-in HealthStore
                     // never names Health at all, so the facade hook below
                     // cannot see it -- and without this the build skipped the
@@ -6504,6 +6509,10 @@ public class AndroidGradleBuilder extends Executor {
                 "com/codename1/impl/android/ai");
         String[] vision = {
             "AndroidTextRecognitionAdapter.java",
+            "AndroidTextRecognitionChineseAdapter.java",
+            "AndroidTextRecognitionDevanagariAdapter.java",
+            "AndroidTextRecognitionJapaneseAdapter.java",
+            "AndroidTextRecognitionKoreanAdapter.java",
             "AndroidBarcodeScanningAdapter.java",
             "AndroidFaceDetectionAdapter.java",
             "AndroidImageLabelingAdapter.java",
@@ -6572,6 +6581,37 @@ public class AndroidGradleBuilder extends Executor {
         // DocumentScanner is Apple-only. Returning null intentionally prunes
         // the Android vision backend for an app that references only it; the
         // public API then reports UNSUPPORTED without a native dependency.
+        return null;
+    }
+
+    /**
+     * Maps a {@code TextScript} selector call to the adapter source that owns
+     * that ML Kit script model. ML Kit ships one artifact per script, so unlike
+     * the feature adapters these are keyed on the selector method rather than a
+     * class: {@code TextRecognizer} alone says nothing about which scripts the
+     * application reads. Latin is the built-in default and has no separate
+     * source.
+     *
+     * @param cls internal-form owner of the referenced method
+     * @param method referenced method name
+     * @return the adapter source file to retain, or {@code null}
+     */
+    static String androidTextScriptAdapterSource(String cls, String method) {
+        if (!"com/codename1/ai/vision/TextScript".equals(cls)) {
+            return null;
+        }
+        if ("chinese".equals(method)) {
+            return "AndroidTextRecognitionChineseAdapter.java";
+        }
+        if ("devanagari".equals(method)) {
+            return "AndroidTextRecognitionDevanagariAdapter.java";
+        }
+        if ("japanese".equals(method)) {
+            return "AndroidTextRecognitionJapaneseAdapter.java";
+        }
+        if ("korean".equals(method)) {
+            return "AndroidTextRecognitionKoreanAdapter.java";
+        }
         return null;
     }
 

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/AndroidAiSourceSelectionTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/AndroidAiSourceSelectionTest.java
@@ -66,6 +66,33 @@ class AndroidAiSourceSelectionTest {
     }
 
     @Test
+    void selectsOneSourcePerNonLatinTextScript() {
+        assertEquals("AndroidTextRecognitionChineseAdapter.java",
+                AndroidGradleBuilder.androidTextScriptAdapterSource(
+                        "com/codename1/ai/vision/TextScript", "chinese"));
+        assertEquals("AndroidTextRecognitionDevanagariAdapter.java",
+                AndroidGradleBuilder.androidTextScriptAdapterSource(
+                        "com/codename1/ai/vision/TextScript", "devanagari"));
+        assertEquals("AndroidTextRecognitionJapaneseAdapter.java",
+                AndroidGradleBuilder.androidTextScriptAdapterSource(
+                        "com/codename1/ai/vision/TextScript", "japanese"));
+        assertEquals("AndroidTextRecognitionKoreanAdapter.java",
+                AndroidGradleBuilder.androidTextScriptAdapterSource(
+                        "com/codename1/ai/vision/TextScript", "korean"));
+    }
+
+    @Test
+    void latinScriptNeedsNoSeparateSource() {
+        assertNull(AndroidGradleBuilder.androidTextScriptAdapterSource(
+                "com/codename1/ai/vision/TextScript", "latin"),
+                "Latin is what the base recognizer already reads");
+        assertNull(AndroidGradleBuilder.androidTextScriptAdapterSource(
+                "com/codename1/ai/vision/TextScript", "getId"));
+        assertNull(AndroidGradleBuilder.androidTextScriptAdapterSource(
+                "com/codename1/ai/vision/VisionBackends", "japanese"));
+    }
+
+    @Test
     void ignoresSharedApiAndUnrelatedClasses() {
         assertNull(AndroidGradleBuilder.androidAiAdapterSource(
                 "com/codename1/ai/vision/DocumentScanner"),

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/AndroidTextScriptParityTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/AndroidTextScriptParityTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.builders;
+
+import com.codename1.build.shared.PlatformFeatureCatalog;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The four places that must name the same non-Latin OCR scripts agree.
+ *
+ * <p>Nothing else catches a disagreement. The Android AI adapters are
+ * excluded from the port's own compilation and ship as sources compiled
+ * inside the generated app, so a class name typo is not a compile error
+ * here; and the builder deletes any adapter the scan did not ask for, so
+ * an adapter missing from the prune list is deleted from every build and
+ * the feature reports itself unsupported with nothing in the log. The
+ * chain is: the selector method the app calls -> the adapter source the
+ * builder keeps -> the class the port loads -> the ML Kit artifact the
+ * catalog adds.</p>
+ *
+ * <p>Matching on source text is crude, but the mappings live in private
+ * static methods on a builder that cannot be constructed in a unit test.
+ * Crude and load-bearing beats absent.</p>
+ */
+class AndroidTextScriptParityTest {
+    /** The non-Latin scripts. Latin needs no separate model anywhere. */
+    private static final String[] SCRIPTS = {
+        "chinese", "devanagari", "japanese", "korean"
+    };
+
+    private static String read(File file) throws Exception {
+        assertTrue(file.exists(),
+                "source must be readable: " + file.getAbsolutePath());
+        return new String(Files.readAllBytes(file.toPath()),
+                StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void everyScriptAdapterSourceExistsAndSurvivesPruning() throws Exception {
+        String builder = read(new File(
+                "src/main/java/com/codename1/builders/AndroidGradleBuilder.java"));
+        for (String script : SCRIPTS) {
+            String source = AndroidGradleBuilder.androidTextScriptAdapterSource(
+                    "com/codename1/ai/vision/TextScript", script);
+            assertTrue(source != null, script + " has no adapter source");
+            assertTrue(new File("../../Ports/Android/src/com/codename1/impl/"
+                    + "android/ai/" + source).exists(),
+                    source + " is selected by the scanner but does not exist");
+            assertTrue(builder.contains("\"" + source + "\""),
+                    source + " is missing from pruneOptionalAiSources, so the"
+                            + " builder deletes it from every build");
+        }
+    }
+
+    @Test
+    void portLoadsTheAdapterClassesTheBuilderKeeps() throws Exception {
+        String impl = read(new File("../../Ports/Android/src/com/codename1/"
+                + "impl/android/ai/AndroidVisionImpl.java"));
+        for (String script : SCRIPTS) {
+            String source = AndroidGradleBuilder.androidTextScriptAdapterSource(
+                    "com/codename1/ai/vision/TextScript", script);
+            String simpleName = source.substring(0,
+                    source.length() - ".java".length());
+            assertTrue(impl.contains("\"" + script + "\""),
+                    "AndroidVisionImpl must recognize the " + script
+                            + " script id");
+            assertTrue(impl.contains(simpleName.substring(
+                            "AndroidTextRecognition".length())),
+                    "AndroidVisionImpl must resolve " + simpleName);
+        }
+    }
+
+    @Test
+    void everyScriptSelectorAddsItsMlKitArtifact() {
+        for (String script : SCRIPTS) {
+            PlatformFeatureCatalog.Accumulator acc =
+                    new PlatformFeatureCatalog.Accumulator();
+            acc.consume("com/codename1/ai/vision/TextRecognizer");
+            acc.consumeMethod("com/codename1/ai/vision/TextScript", script);
+            boolean found = false;
+            for (PlatformFeatureCatalog.Entry entry : acc.hits()) {
+                for (String dependency : entry.androidGradleDeps()) {
+                    found |= dependency.startsWith(
+                            "com.google.mlkit:text-recognition-" + script + ":");
+                }
+            }
+            assertTrue(found, "TextScript." + script + "() must add the "
+                    + script + " ML Kit bundle, or the adapter it keeps will "
+                    + "not compile in the generated app");
+        }
+    }
+}

--- a/maven/core-unittests/src/test/java/com/codename1/ai/vision/VisionApiTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ai/vision/VisionApiTest.java
@@ -31,7 +31,9 @@ import com.codename1.util.SuccessCallback;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -158,6 +160,58 @@ class VisionApiTest extends UITestBase {
         assertEquals(3, backend.options.getMaximumResults());
         recognizer.close();
         assertEquals(1, backend.closeCount);
+    }
+
+    @Test
+    void textScriptDefaultsToNullAndSurvivesTheOptionSnapshot() {
+        RecordingVisionImpl backend = new RecordingVisionImpl();
+        implementation.setVisionImpl(backend);
+        assertNull(new VisionOptions().getTextScript(),
+                "No script means the platform default, not an assumed Latin");
+
+        VisionOptions options = new VisionOptions()
+                .textScript(TextScript.japanese());
+        TextRecognizer recognizer = new TextRecognizer(options);
+        // Mutating the caller's options after construction must not reach the
+        // port: the analyzer holds its own snapshot.
+        options.textScript(TextScript.korean());
+        await(recognizer.process(VisionImage.encoded(new byte[] {1})));
+
+        assertSame(TextScript.japanese(), backend.options.getTextScript());
+        assertEquals("japanese", backend.options.getTextScript().getId());
+        recognizer.close();
+    }
+
+    @Test
+    void everyTextScriptHasItsOwnStableIdentifier() {
+        // The ids are a port-boundary contract: the Android adapter class and
+        // the Apple recognition languages are both selected from them.
+        assertEquals("latin", TextScript.latin().getId());
+        assertEquals("chinese", TextScript.chinese().getId());
+        assertEquals("devanagari", TextScript.devanagari().getId());
+        assertEquals("japanese", TextScript.japanese().getId());
+        assertEquals("korean", TextScript.korean().getId());
+        assertEquals("korean", TextScript.korean().toString());
+
+        Set<String> ids = new HashSet<String>();
+        TextScript[] all = {TextScript.latin(), TextScript.chinese(),
+                TextScript.devanagari(), TextScript.japanese(),
+                TextScript.korean()};
+        for (TextScript script : all) {
+            assertTrue(ids.add(script.getId()), script.getId());
+        }
+    }
+
+    @Test
+    void nullTextScriptRestoresThePlatformDefault() {
+        RecordingVisionImpl backend = new RecordingVisionImpl();
+        implementation.setVisionImpl(backend);
+        TextRecognizer recognizer = new TextRecognizer(new VisionOptions()
+                .textScript(TextScript.chinese())
+                .textScript(null));
+        await(recognizer.process(VisionImage.encoded(new byte[] {1})));
+        assertNull(backend.options.getTextScript());
+        recognizer.close();
     }
 
     @Test

--- a/maven/platform-feature-catalog/src/main/java/com/codename1/build/shared/PlatformFeatureCatalog.java
+++ b/maven/platform-feature-catalog/src/main/java/com/codename1/build/shared/PlatformFeatureCatalog.java
@@ -56,6 +56,8 @@ public final class PlatformFeatureCatalog {
             "com.google.mlkit:smart-reply:17.0.4";
     private static final String MLKIT_SELFIE_SEGMENTATION =
             "com.google.mlkit:segmentation-selfie:16.0.0-beta5";
+    /** Shared version of the per-script ML Kit text recognition bundles. */
+    private static final String MLKIT_TEXT_SCRIPT_VERSION = "16.0.1";
     private static final List<Entry> ENTRIES;
     private static final List<String> CLASS_PREFIXES;
     private static final Set<String> METHOD_KEYS;
@@ -210,6 +212,37 @@ public final class PlatformFeatureCatalog {
                 .iosDependenciesUnsupportedOnMacCatalyst()
                 .iosDependenciesUnsupportedOnArm64Simulator()
                 .description("ML Kit iOS text-recognition backend"));
+
+        // Non-Latin OCR. ML Kit ships one recognizer artifact per script, so a
+        // script is a dependency of its own rather than a runtime flag; Latin
+        // needs no entry because it is what the base recognizer already reads.
+        // On iOS the script model is only fetched for a build that also
+        // selected the ML Kit backend -- Apple Vision reads these scripts
+        // itself through its recognition languages.
+        for (String[] script : new String[][] {
+                {"chinese", "Chinese"},
+                {"devanagari", "Devanagari"},
+                {"japanese", "Japanese"},
+                {"korean", "Korean"}}) {
+            e.add(new Entry("com/codename1/ai/vision/TextRecognizer")
+                    .requiresMethod("com/codename1/ai/vision/TextScript",
+                            script[0])
+                    .androidGradle("com.google.mlkit:text-recognition-"
+                            + script[0] + ":" + MLKIT_TEXT_SCRIPT_VERSION)
+                    .androidMinimumSdk(21)
+                    .description(script[1] + " text recognition"));
+            e.add(new Entry("com/codename1/ai/vision/TextRecognizer")
+                    .requiresMethod("com/codename1/ai/vision/VisionBackends",
+                            "mlKitTextRecognition")
+                    .requiresMethod("com/codename1/ai/vision/TextScript",
+                            script[0])
+                    .iosPod("GoogleMLKit/TextRecognition" + script[1])
+                    .iosMinimumDeploymentTarget("15.5")
+                    .iosDependenciesUnsupportedOnMacCatalyst()
+                    .iosDependenciesUnsupportedOnArm64Simulator()
+                    .description("ML Kit iOS " + script[1]
+                            + " text-recognition model"));
+        }
 
         e.add(new Entry("com/codename1/ai/vision/BarcodeScanner")
                 .iosFrameworks("Vision", "CoreImage")
@@ -477,9 +510,7 @@ public final class PlatformFeatureCatalog {
         Set<String> methodKeys = new LinkedHashSet<String>();
         for (Entry entry : e) {
             classPrefixes.add(entry.classPrefix);
-            if (entry.hasMethodRequirement()) {
-                methodKeys.add(entry.methodOwner + "#" + entry.methodName);
-            }
+            methodKeys.addAll(entry.methodRequirements());
         }
         CLASS_PREFIXES = Collections.unmodifiableList(
                 new ArrayList<String>(classPrefixes));
@@ -662,8 +693,13 @@ public final class PlatformFeatureCatalog {
      */
     public static final class Entry {
         private final String classPrefix;
-        private String methodOwner;
-        private String methodName;
+        /**
+         * Method requirements as {@code owner#name} keys. Every key must be
+         * observed for the entry to fire, so an entry can name a combination
+         * such as "the ML Kit text backend <em>and</em> the Japanese script"
+         * without also firing for either one alone.
+         */
+        private final List<String> methodKeys = new ArrayList<String>();
         private final List<String> iosPods = new ArrayList<String>();
         private final List<IosSpm> iosSpm = new ArrayList<IosSpm>();
         private final List<String> iosFrameworks = new ArrayList<String>();
@@ -691,7 +727,11 @@ public final class PlatformFeatureCatalog {
         }
 
         boolean hasMethodRequirement() {
-            return methodOwner != null;
+            return !methodKeys.isEmpty();
+        }
+
+        List<String> methodRequirements() {
+            return Collections.unmodifiableList(methodKeys);
         }
 
         boolean requirementsMet(Set<String> classes, Set<String> methods) {
@@ -705,20 +745,24 @@ public final class PlatformFeatureCatalog {
             if (!classSeen) {
                 return false;
             }
-            if (!hasMethodRequirement()) {
-                return true;
-            }
-            for (String method : methods) {
-                if (method.equals(methodOwner + "#" + methodName)) {
-                    return true;
+            for (String key : methodKeys) {
+                if (!methods.contains(key)) {
+                    return false;
                 }
             }
-            return false;
+            return true;
         }
 
+        /**
+         * Adds a required method reference. Calling this more than once makes
+         * every named method required, not any of them.
+         *
+         * @param owner internal-form declaring class of the method
+         * @param methodName referenced method name
+         * @return this entry
+         */
         Entry requiresMethod(String owner, String methodName) {
-            this.methodOwner = owner;
-            this.methodName = methodName;
+            methodKeys.add(owner + "#" + methodName);
             return this;
         }
 

--- a/maven/platform-feature-catalog/src/test/java/com/codename1/build/shared/PlatformFeatureCatalogTest.java
+++ b/maven/platform-feature-catalog/src/test/java/com/codename1/build/shared/PlatformFeatureCatalogTest.java
@@ -91,6 +91,57 @@ class PlatformFeatureCatalogTest {
     }
 
     @Test
+    void textScriptSelectorAddsOnlyThatScriptModel() {
+        PlatformFeatureCatalog.Accumulator acc =
+                new PlatformFeatureCatalog.Accumulator();
+        acc.consume("com/codename1/ai/vision/TextRecognizer");
+        acc.consumeMethod("com/codename1/ai/vision/TextScript", "japanese");
+
+        boolean foundJapanese = false;
+        for (PlatformFeatureCatalog.Entry e : acc.hits()) {
+            for (String dependency : e.androidGradleDeps()) {
+                foundJapanese |= dependency.startsWith(
+                        "com.google.mlkit:text-recognition-japanese:");
+                assertFalse(dependency.startsWith(
+                        "com.google.mlkit:text-recognition-korean:"),
+                        "Unselected script models must not be bundled");
+                assertFalse(dependency.startsWith(
+                        "com.google.mlkit:text-recognition-chinese:"),
+                        "Unselected script models must not be bundled");
+            }
+            assertTrue(e.iosPods().isEmpty(),
+                    "Apple Vision reads the script itself; a script selector "
+                            + "alone must not pull an ML Kit pod");
+        }
+        assertTrue(foundJapanese, "expected the Japanese ML Kit bundle");
+    }
+
+    @Test
+    void iosScriptModelNeedsBothTheMlKitBackendAndTheScript() {
+        PlatformFeatureCatalog.Accumulator acc =
+                new PlatformFeatureCatalog.Accumulator();
+        acc.consume("com/codename1/ai/vision/TextRecognizer");
+        acc.consumeMethod("com/codename1/ai/vision/VisionBackends",
+                "mlKitTextRecognition");
+        assertFalse(hasPod(acc, "GoogleMLKit/TextRecognitionJapanese"),
+                "The backend alone must not add a script model");
+
+        acc.consumeMethod("com/codename1/ai/vision/TextScript", "japanese");
+        assertTrue(hasPod(acc, "GoogleMLKit/TextRecognitionJapanese"));
+        assertFalse(hasPod(acc, "GoogleMLKit/TextRecognitionKorean"));
+    }
+
+    private static boolean hasPod(PlatformFeatureCatalog.Accumulator acc,
+                                  String pod) {
+        for (PlatformFeatureCatalog.Entry e : acc.hits()) {
+            if (e.iosPods().contains(pod)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Test
     void currentIosMlKitPodsRequireIos155() {
         PlatformFeatureCatalog.Accumulator acc =
                 new PlatformFeatureCatalog.Accumulator();
@@ -297,7 +348,7 @@ class PlatformFeatureCatalogTest {
                 }
             }
         }
-        assertEquals(22, checked,
+        assertEquals(26, checked,
                 "If an AI dependency is intentionally added or removed, "
                 + "update this lock count after verifying its Android floor");
     }


### PR DESCRIPTION
Closes the RFE in discussion #5555: `com.codename1.ai.vision.TextRecognizer` had no way to say what writing system to read, so it was Latin-only. Android hard-coded ML Kit's Latin `TextRecognizerOptions.DEFAULT_OPTIONS`, and the Apple backend left `VNRecognizeTextRequest` on its default languages. Both frameworks can do better — ML Kit ships a recognizer per script, Apple Vision takes `recognitionLanguages` — the portable API just never exposed the choice.

## The API

```java
TextRecognizer recognizer = new TextRecognizer(
        new VisionOptions().textScript(TextScript.japanese()));
```

New `TextScript` with `latin()` / `chinese()` / `devanagari()` / `japanese()` / `korean()`, plus `VisionOptions.textScript(...)`. It names a **script**, not a language: that is what the underlying recognizers are organized by, and it is the one shape both backends can honour. Each script model also reads the Latin text mixed into the same page.

No existing constructor, signature, or default changes — an app that never names a script behaves exactly as before.

## Per platform

- **Android** — each script maps to its own ML Kit recognizer.
- **Apple Vision** (the iOS default) — sets `recognitionLanguages`, asking `supportedRecognitionLanguagesAndReturnError:` what the OS actually supports rather than hard-coding a per-release list. When the OS supports none of them the analysis **fails with an explicit error** naming `VisionBackends.mlKitTextRecognition()` as the way out. Leaving the request on its defaults would have run Latin OCR over a Japanese page and returned confident nonsense.
- **iOS ML Kit** — resolves the script options class through `NSClassFromString`, so `CN1Vision.m` still compiles whichever pods a given build linked.

## Dependency selection

Like `VisionBackends`, each selector call doubles as a build-time dependency marker, so a build carries only the models it asked for — a Japanese app does not ship the Korean or Devanagari models.

The Android AI adapters compile *inside the generated app*, not in this repo, so each script gets its own adapter source: one `import` per file is exactly what lets `pruneOptionalAiSources` delete the models the app never selects. `PlatformFeatureCatalog.Entry` gained support for several required methods (it held one), so the iOS script pod lands only when the ML Kit backend **and** that script are both selected — Apple Vision reads these scripts itself.

## Verification

Vendor facts were checked against the real artifacts, not the docs alone:

- the four Java options classes and `TextRecognition.getClient(TextRecognizerOptionsInterface)` read out of the published AARs with `javap`
- the four pod subspec names out of the `GoogleMLKit` podspec
- the ObjC options class names out of Google's iOS reference
- the Vision selectors and their availability out of the Xcode SDK headers

Green locally: core-unittests (3 new), catalog tests (2 new), builder tests (5 new), SpotBugs at zero across ios/plugin/core-unittests, the CI quality-report script, `check-cast-semantics.sh`, and `check-native-signatures.sh` — the native gained a `String` argument, so its C name changed. `CN1Vision.m` was syntax-checked against the iOS 26.2 SDK both with and without `INCLUDE_CN1_VISION`, and the Android adapters compiled against stubbed ML Kit APIs.

**A note on the new parity test.** The Android AI adapters are excluded from every build in this repo, so a class-name typo there is not a compile error anywhere — CI stays green and the feature ships inert. `AndroidTextScriptParityTest` ties the chain together instead: selector method → retained adapter source → class the port loads → ML Kit artifact the catalog adds.

## Not verified locally

Both need a device build, and are worth confirming before release:

- the iOS ML Kit branch (needs the pods linked)
- end-to-end recognition of real non-Latin text on device

## Deliberate tradeoff

The Latin model ships in every OCR app, including a Japanese-only one: the base adapter and the no-arg constructor both need it, and the catalog cannot express "unless a script was selected". Documented in the developer guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)