### PR TITLE
Stop Dark/Light Mode from growing fonts on every toggle

### DIFF
--- a/CodenameOne/src/com/codename1/ui/plaf/UIManager.java
+++ b/CodenameOne/src/com/codename1/ui/plaf/UIManager.java
@@ -83,6 +83,15 @@ public class UIManager {
     /// restore entries that the theme has not overwritten in the meantime.
     private final Map<String, Font> scaledFontOriginals = new HashMap<String, Font>();
     private final Map<String, Font> scaledFontDerived = new HashMap<String, Font>();
+    /// Nesting depth of [#buildTheme]. A theme whose `@includeNativeBool` is
+    /// true makes buildTheme install the native theme, and that goes through
+    /// the full setThemeProps -> buildTheme path again with only the native
+    /// theme's entries in themeProps. The larger-text pass must run once, on
+    /// the outermost build that sees the merged native + app theme; running it
+    /// on the inner build made it clear the rollback bookkeeping for every app
+    /// font it could not see, after which the next refresh scaled the
+    /// already-scaled fonts again. See [#applyLargerTextScaleToThemeFonts].
+    private int buildThemeDepth;
     /// The resource bundle allows us to implicitly localize the UI on the fly, once its
     /// installed all internal application strings query the resource bundle and extract
     /// their values from this table if applicable.
@@ -1827,6 +1836,15 @@ public class UIManager {
     }
 
     private void buildTheme(Hashtable themeProps) {
+        buildThemeDepth++;
+        try {
+            buildThemeImpl(themeProps);
+        } finally {
+            buildThemeDepth--;
+        }
+    }
+
+    private void buildThemeImpl(Hashtable themeProps) {
         // A new theme may change constants that the platform consults while deriving
         // fonts (e.g. a native theme's text letter spacing). Flush the derived-font
         // cache so those fonts are rebuilt against the incoming constants rather than
@@ -1880,7 +1898,9 @@ public class UIManager {
             }
         }
 
-        applyLargerTextScaleToThemeFonts();
+        if (buildThemeDepth == 1) {
+            applyLargerTextScaleToThemeFonts();
+        }
 
         // necessary to clear up the style so we don't get resedue from the previous UI
         defaultStyle = new Style();
@@ -1889,7 +1909,9 @@ public class UIManager {
         defaultStyle = createStyle("", "", false);
         defaultSelectedStyle = new Style(defaultStyle);
         defaultSelectedStyle = createStyle("", "sel#", true);
-        applyLargerTextScaleToDefaultStyles();
+        if (buildThemeDepth == 1) {
+            applyLargerTextScaleToDefaultStyles();
+        }
 
         String overlayThemes = (String) themeProps.get("@OverlayThemes");
         if (overlayThemes != null) {
@@ -2069,6 +2091,9 @@ public class UIManager {
         }
     }
 
+    /// Only [#buildTheme] at depth 1 may call this: the bookkeeping below spans
+    /// the whole merged theme, and a nested `@includeNativeBool` install sees
+    /// only the native theme's half of it. See [#buildThemeDepth].
     private void applyLargerTextScaleToThemeFonts() {
         // Roll back any prior scaling we applied so this pass always derives
         // from the original installed font. Without the rollback, repeated

--- a/maven/core-unittests/src/test/java/com/codename1/testing/TestCodenameOneImplementation.java
+++ b/maven/core-unittests/src/test/java/com/codename1/testing/TestCodenameOneImplementation.java
@@ -62,6 +62,7 @@ import com.codename1.ui.geom.Dimension;
 import com.codename1.ui.util.ImageIO;
 import com.codename1.ui.geom.Rectangle;
 import com.codename1.ui.geom.Shape;
+import com.codename1.ui.plaf.UIManager;
 import com.codename1.util.AsyncResource;
 import java.io.Closeable;
 
@@ -1357,6 +1358,7 @@ public class TestCodenameOneImplementation extends CodenameOneImplementation {
         mutableImagesFast = true;
         largerTextEnabled = false;
         largerTextScale = 1f;
+        nativeTheme = null;
         cameraImpl = null;
         arImpl = null;
         visionImplCreationHook = null;
@@ -2721,6 +2723,31 @@ public class TestCodenameOneImplementation extends CodenameOneImplementation {
 
     public void setNativeFontSchemeSupported(boolean nativeFontSchemeSupported) {
         this.nativeFontSchemeSupported = nativeFontSchemeSupported;
+    }
+
+    /**
+     * Theme installed by {@link #installNativeTheme()}, or null when this
+     * implementation reports no native theme. Lets a test reproduce the
+     * layered {@code @includeNativeBool} install the device ports perform,
+     * where building the app theme re-enters the theme build with only the
+     * native theme's entries visible.
+     */
+    private Hashtable nativeTheme;
+
+    public void setNativeTheme(Hashtable nativeTheme) {
+        this.nativeTheme = nativeTheme;
+    }
+
+    @Override
+    public boolean hasNativeTheme() {
+        return nativeTheme != null;
+    }
+
+    @Override
+    public void installNativeTheme() {
+        if (nativeTheme != null) {
+            UIManager.getInstance().setThemeProps(nativeTheme);
+        }
     }
 
     public void setLargerTextEnabled(boolean largerTextEnabled) {

--- a/maven/core-unittests/src/test/java/com/codename1/ui/plaf/UIManagerLargeTextScaleTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/plaf/UIManagerLargeTextScaleTest.java
@@ -166,4 +166,89 @@ public class UIManagerLargeTextScaleTest extends UITestBase {
         assertEquals(18f, label.getStyle().getFont().getPixelSize(), 0.01f);
     }
 
+
+    /// A theme with `@includeNativeBool: true` -- what every project generated
+    /// by the archetype or Initializr ships -- makes `buildTheme` install the
+    /// native theme first, and that re-enters the whole
+    /// `setThemeProps -> buildTheme` path with only the native theme's entries
+    /// in themeProps. The larger-text pass used to run on that inner build too:
+    /// it could not see any of the app theme's font keys, so its rollback left
+    /// them alone and then cleared the bookkeeping that remembered their
+    /// unscaled originals. The outer build then re-scaled fonts that were
+    /// already scaled, with nothing left to roll back -- so simply toggling
+    /// Dark/Light Mode in the simulator (which calls `refreshTheme`) grew every
+    /// font by the scale factor again, and again, on each toggle. Regression
+    /// cover for issue #5565.
+    @Test
+    public void testRefreshWithNativeThemeDoesNotCompound() {
+        TestCodenameOneImplementation impl = implementation;
+        UIManager manager = UIManager.getInstance();
+        manager.setUseLargerTextScale(true);
+        impl.setLargerTextEnabled(true);
+        impl.setLargerTextScale(1.5f);
+
+        Font nativeFont = Font.createTrueTypeFont(Font.NATIVE_MAIN_REGULAR, Font.NATIVE_MAIN_REGULAR)
+                .derive(10f, Font.STYLE_PLAIN);
+        Hashtable nativeTheme = new Hashtable();
+        nativeTheme.put("Label.font", nativeFont);
+        impl.setNativeTheme(nativeTheme);
+
+        Font appFont = Font.createTrueTypeFont(Font.NATIVE_MAIN_REGULAR, Font.NATIVE_MAIN_REGULAR)
+                .derive(20f, Font.STYLE_PLAIN);
+        Hashtable theme = new Hashtable();
+        theme.put("@includeNativeBool", "true");
+        theme.put("Title.font", appFont);
+        manager.setThemeProps(theme);
+
+        assertEquals(30f, manager.getComponentStyle("Title").getFont().getPixelSize(), 0.01f);
+        assertEquals(15f, manager.getComponentStyle("Label").getFont().getPixelSize(), 0.01f);
+
+        // Every refresh (the Dark/Light Mode menu does one per click) has to be
+        // idempotent -- the size must stay at original * scale, forever.
+        for (int iter = 0; iter < 5; iter++) {
+            manager.refreshTheme();
+            assertEquals(30f, manager.getComponentStyle("Title").getFont().getPixelSize(), 0.01f,
+                    "app theme font must not compound on refresh " + iter);
+            assertEquals(15f, manager.getComponentStyle("Label").getFont().getPixelSize(), 0.01f,
+                    "native theme font must not compound on refresh " + iter);
+        }
+
+        // And the scale must still be reversible after those refreshes.
+        impl.setLargerTextEnabled(false);
+        impl.setLargerTextScale(1.0f);
+        manager.refreshTheme();
+        assertEquals(20f, manager.getComponentStyle("Title").getFont().getPixelSize(), 0.01f);
+        assertEquals(10f, manager.getComponentStyle("Label").getFont().getPixelSize(), 0.01f);
+    }
+
+    /// The same layered install with the scale left at its default must be a
+    /// no-op: repeated refreshes may not touch the fonts at all. Issue #5565.
+    @Test
+    public void testRefreshWithNativeThemeKeepsUnscaledFonts() {
+        TestCodenameOneImplementation impl = implementation;
+        UIManager manager = UIManager.getInstance();
+        manager.setUseLargerTextScale(true);
+        impl.setLargerTextEnabled(false);
+        impl.setLargerTextScale(1.0f);
+
+        Font nativeFont = Font.createTrueTypeFont(Font.NATIVE_MAIN_REGULAR, Font.NATIVE_MAIN_REGULAR)
+                .derive(11f, Font.STYLE_PLAIN);
+        Hashtable nativeTheme = new Hashtable();
+        nativeTheme.put("Label.font", nativeFont);
+        impl.setNativeTheme(nativeTheme);
+
+        Font appFont = Font.createTrueTypeFont(Font.NATIVE_MAIN_REGULAR, Font.NATIVE_MAIN_REGULAR)
+                .derive(22f, Font.STYLE_PLAIN);
+        Hashtable theme = new Hashtable();
+        theme.put("@includeNativeBool", "true");
+        theme.put("Title.font", appFont);
+        manager.setThemeProps(theme);
+
+        for (int iter = 0; iter < 5; iter++) {
+            manager.refreshTheme();
+            assertEquals(22f, manager.getComponentStyle("Title").getFont().getPixelSize(), 0.01f);
+            assertEquals(11f, manager.getComponentStyle("Label").getFont().getPixelSize(), 0.01f);
+        }
+    }
+
 }


### PR DESCRIPTION
Fixes #5565.

## Symptom

In the simulator, every click on **Simulate > Dark/Light Mode** made every font
in the app a little larger, and the only way back was to restart the simulator.

## What actually happens

The Dark/Light menu (like Larger Text and the accessibility toggles) runs
`JavaSEPort.refreshThemeOnly()`, which calls `UIManager.refreshTheme()`. That
re-runs `setThemePropsImpl -> buildTheme` over the currently installed theme
properties.

`buildTheme` scales theme fonts for the "Larger Text" setting through
`applyLargerTextScaleToThemeFonts()`. That pass is written to be idempotent: it
remembers the unscaled original of every font it replaced
(`scaledFontOriginals` / `scaledFontDerived`), rolls the theme back to those
originals, and only then applies the current scale. Without the rollback each
refresh would multiply the previously-derived pixel size -- exactly the reported
symptom.

The rollback was defeated by the `@includeNativeBool` layering that every
generated project uses. When the app theme asks for the native theme,
`buildTheme` calls `Display.installNativeTheme()`, which re-enters the *whole*
`setThemeProps -> buildTheme` path with only the **native** theme's entries in
`themeProps`. That inner build ran the larger-text pass too, and from where it
stood every app-theme font key was simply absent: the identity check
(`current == derived`) failed for all of them, so they were not rolled back --
and then the pass cleared both maps anyway. Control returned to the outer build,
which copied the app's *already-scaled* fonts back into `themeProps` and scaled
them a second time, with no record of the originals left to undo it.

So each theme refresh multiplied every font by the scale factor again. Dark ->
Light -> Dark -> ... and the text grows without bound. Restarting rebuilds the
theme from the resource file, which is why a restart "fixed" it.

## Fix

Run the larger-text passes only on the outermost `buildTheme` -- the one that
sees the merged native + app theme -- via a nesting counter. The inner native
install no longer touches the bookkeeping, so the rollback works and a refresh
is idempotent: fonts land on `original * scale` and stay there no matter how
many times the theme is refreshed.

## Reproducing / verifying

The growth needs font scaling to be active, i.e. a theme that opts in with
`useLargerTextScaleBool: true` (or a `UIManager.setUseLargerTextScale(true)`
call) plus a **Simulate > Larger Text** setting above "Large (default)". That
setting is a sticky simulator preference, so it survives restarts and across
projects.

Measured in the simulator on an archetype-generated app (iPhone X skin, iOS
Modern native theme, Larger Text scale 1.35), dumping the resolved `Title` font
before each Dark/Light click:

before the fix
```
toggle 0  title=108.4px
toggle 1  title=146.3px
toggle 2  title=197.6px
toggle 3  title=266.7px
toggle 4  title=360.1px    ... and on, x1.35 every click
```

after the fix
```
toggle 0  title=108.4px
toggle 1  title=146.3px
toggle 2  title=146.3px
...
toggle 19 title=146.3px
```

## Tests

`UIManagerLargeTextScaleTest` gains two cases that install a native theme
alongside an `@includeNativeBool` app theme -- the shape that triggered this --
and assert that repeated `refreshTheme()` calls neither compound the scaled
fonts nor disturb unscaled ones, and that the scale is still fully reversible
afterwards. `TestCodenameOneImplementation` gains the `hasNativeTheme()` /
`installNativeTheme()` pair needed to model that layering. The first new test
fails on master with `expected: <30.0> but was: <45.0>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
