### PR TITLE
Certificate Wizard: show the real signing error instead of a blanket HTTP 502

### DIFF
--- a/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/CertificateWizard.java
+++ b/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/CertificateWizard.java
@@ -24,6 +24,7 @@ package com.codename1.certificatewizard;
 
 import com.codename1.certificatewizard.api.CloudSigningService;
 import com.codename1.certificatewizard.api.MockSigningService;
+import com.codename1.certificatewizard.api.SigningError;
 import com.codename1.certificatewizard.api.SigningService;
 import com.codename1.certificatewizard.api.SigningState;
 import com.codename1.certificatewizard.api.WizardDecisions;
@@ -32,6 +33,7 @@ import com.codename1.certificatewizard.project.ProjectIO;
 import com.codename1.certificatewizard.project.AndroidKeystoreProvider;
 import com.codename1.certificatewizard.project.SigningAssetInstaller;
 import com.codename1.components.InteractionDialog;
+import com.codename1.components.SpanLabel;
 import com.codename1.components.ToastBar;
 import com.codename1.io.FileSystemStorage;
 import com.codename1.io.Log;
@@ -57,6 +59,7 @@ import com.codename1.ui.layouts.BorderLayout;
 import com.codename1.ui.layouts.BoxLayout;
 import com.codename1.ui.layouts.FlowLayout;
 import com.codename1.ui.layouts.GridLayout;
+import com.codename1.ui.plaf.Border;
 import com.codename1.ui.plaf.UIManager;
 
 import java.io.InputStream;
@@ -107,6 +110,8 @@ public class CertificateWizard extends Lifecycle {
     private Container messageHost;
     private String pageMessage = "";
     private boolean pageMessageWarn;
+    private String pageMessageActionText;
+    private Runnable pageMessageAction;
 
     public static void setServiceForTesting(SigningService s) {
         injectedService = s;
@@ -421,7 +426,7 @@ public class CertificateWizard extends Lifecycle {
         Button cert = outline("Generate certificate", "btn.generateCert");
         cert.addActionListener(e -> certificateDialog());
         Button sync = outline("Sync with Apple", "btn.reconcile");
-        sync.addActionListener(e -> service.reconcile(r -> afterMutation(r, "Synced with Apple")));
+        sync.addActionListener(e -> syncWithApple());
         page.add(actionRow(Component.LEFT, profile, cert, sync));
     }
 
@@ -762,7 +767,7 @@ public class CertificateWizard extends Lifecycle {
         Button add = primary("Generate", "btn.generateCert");
         add.addActionListener(e -> certificateDialog());
         Button sync = outline("Sync with Apple", "btn.reconcile");
-        sync.addActionListener(e -> service.reconcile(r -> afterMutation(r, "Synced with Apple")));
+        sync.addActionListener(e -> syncWithApple());
         page.add(actionRow(Component.LEFT, add, sync));
         Container table = card();
         Container body = tableBody(Section.CERTIFICATES);
@@ -1712,7 +1717,7 @@ public class CertificateWizard extends Lifecycle {
                     showPageMessage("The stored App Store Connect API key is no longer configured on the server. Store a new key to continue.", true);
                 }
             } else {
-                showPageMessage(r.message, true);
+                showPageError(r, this::reload);
             }
         });
     }
@@ -1745,9 +1750,22 @@ public class CertificateWizard extends Lifecycle {
         Preferences.set(PREF_CREDENTIAL_ISSUER_ID, state.credential.issuerId() == null ? "" : state.credential.issuerId());
     }
 
+    /**
+     * "Sync with Apple" -- the call that surfaced the old blanket 502. Retrying
+     * a reconcile is always safe, so a genuinely transient failure gets a
+     * button; a rejected API key gets pointed at the key page instead.
+     */
+    private void syncWithApple() {
+        service.reconcile(r -> afterMutation(r, "Synced with Apple", this::syncWithApple));
+    }
+
     private void afterMutation(SigningService.Result<Void> r, String okMessage) {
+        afterMutation(r, okMessage, null);
+    }
+
+    private void afterMutation(SigningService.Result<Void> r, String okMessage, Runnable retry) {
         if (!r.ok) {
-            showPageMessage(r.message, true);
+            showPageError(r, retry);
             return;
         }
         clearPageMessage();
@@ -1760,7 +1778,7 @@ public class CertificateWizard extends Lifecycle {
             clearPageMessage();
             ToastBar.showMessage("Saved " + r.value, FontImage.MATERIAL_FILE_DOWNLOAD);
         } else {
-            showPageMessage(r.message, true);
+            showPageError(r, null);
         }
     }
 
@@ -1924,13 +1942,40 @@ public class CertificateWizard extends Lifecycle {
     }
 
     private void showPageMessage(String message, boolean warn) {
+        showPageMessage(message, warn, null, null);
+    }
+
+    private void showPageMessage(String message, boolean warn, String actionText, Runnable action) {
         pageMessage = message == null || message.trim().isEmpty() ? "The request failed. Try again later." : message;
         pageMessageWarn = warn;
+        pageMessageActionText = actionText;
+        pageMessageAction = action;
         renderPageMessage();
+    }
+
+    /**
+     * Reports a failed call with the next step attached. The service now
+     * distinguishes "your App Store Connect key needs fixing" from "Apple is
+     * down", so the banner can send the developer somewhere useful instead of
+     * telling them to try again later regardless.
+     */
+    private void showPageError(SigningService.Result<?> r, Runnable retry) {
+        SigningError.Kind kind = r.errorKind();
+        if (kind == SigningError.Kind.CREDENTIAL && section != Section.CREDENTIAL) {
+            showPageMessage(r.message, true, "Open ASC API Key", () -> go(Section.CREDENTIAL));
+            return;
+        }
+        if (retry != null && r.error != null && r.error.retryable()) {
+            showPageMessage(r.message, true, "Try again", retry);
+            return;
+        }
+        showPageMessage(r.message, true);
     }
 
     private void clearPageMessage() {
         pageMessage = "";
+        pageMessageActionText = null;
+        pageMessageAction = null;
         renderPageMessage();
     }
 
@@ -1940,10 +1985,28 @@ public class CertificateWizard extends Lifecycle {
         }
         messageHost.removeAll();
         if (pageMessage != null && pageMessage.length() > 0) {
-            Label l = new Label(pageMessage);
-            l.setUIID(uiid(pageMessageWarn ? "CWBannerWarn" : "CWBanner"));
+            String id = uiid(pageMessageWarn ? "CWBannerWarn" : "CWBanner");
+            // A SpanLabel rather than a Label: these messages are whole
+            // sentences telling the developer what to go and fix, and a Label
+            // would clip them to the width of the banner.
+            SpanLabel l = new SpanLabel(pageMessage);
+            l.setUIID(id);
+            l.setTextUIID(id);
+            l.setName("page.message");
             l.setTextSelectionEnabled(true);
+            TextArea text = l.getTextComponent();
+            text.setUIID(id);
+            text.getAllStyles().setPadding(0, 0, 0, 0);
+            text.getAllStyles().setMargin(0, 0, 0, 0);
+            text.getAllStyles().setBgTransparency(0);
+            text.getAllStyles().setBorder(Border.createEmpty());
             messageHost.add(l);
+            if (pageMessageActionText != null && pageMessageAction != null) {
+                Button act = outline(pageMessageActionText, "page.message.action");
+                final Runnable action = pageMessageAction;
+                act.addActionListener(e -> action.run());
+                messageHost.add(actionRow(Component.LEFT, act));
+            }
         }
         messageHost.revalidate();
     }

--- a/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/api/CloudSigningService.java
+++ b/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/api/CloudSigningService.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.certificatewizard.api;
 
 import com.codename1.certificatewizard.cloud.APNsKeysApi;

--- a/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/api/CloudSigningService.java
+++ b/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/api/CloudSigningService.java
@@ -140,15 +140,18 @@ public final class CloudSigningService implements SigningService {
                                 }
                                 apns[0] = r6.getResponseData();
                                 appGroupsApi.listAppGroups(bearerToken, r7 -> {
-                                    if (authFailure(r7)) {
-                                        callback.completed(Result.ok(SigningState.empty()));
-                                        return;
+                                    // App Groups are additive, and this is the last of
+                                    // the seven calls -- the six before it already
+                                    // proved both the login and the Apple key are good.
+                                    // Failing to list them is no reason to throw the
+                                    // whole account away and show an error instead:
+                                    // Apple answers 404 here for accounts it does not
+                                    // offer the resource to, which failed every refresh,
+                                    // and so every "Sync with Apple" that had just
+                                    // succeeded.
+                                    if (ok(r7)) {
+                                        appGroups[0] = r7.getResponseData();
                                     }
-                                    if (!ok(r7)) {
-                                        callback.completed(Result.fail(error(r7)));
-                                        return;
-                                    }
-                                    appGroups[0] = r7.getResponseData();
                                     callback.completed(Result.ok(toState(cred[0], certs[0], bundles[0],
                                             devices[0], profiles[0], apns[0], appGroups[0])));
                                 });

--- a/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/api/CloudSigningService.java
+++ b/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/api/CloudSigningService.java
@@ -81,7 +81,7 @@ public final class CloudSigningService implements SigningService {
                 return;
             }
             if (!ok(r1)) {
-                callback.completed(Result.fail(message(r1)));
+                callback.completed(Result.fail(error(r1)));
                 return;
             }
             cred[0] = r1.getResponseData();
@@ -95,7 +95,7 @@ public final class CloudSigningService implements SigningService {
                     return;
                 }
                 if (!ok(r2)) {
-                    callback.completed(Result.fail(message(r2)));
+                    callback.completed(Result.fail(error(r2)));
                     return;
                 }
                 certs[0] = r2.getResponseData();
@@ -105,7 +105,7 @@ public final class CloudSigningService implements SigningService {
                         return;
                     }
                     if (!ok(r3)) {
-                        callback.completed(Result.fail(message(r3)));
+                        callback.completed(Result.fail(error(r3)));
                         return;
                     }
                     bundles[0] = r3.getResponseData();
@@ -115,7 +115,7 @@ public final class CloudSigningService implements SigningService {
                             return;
                         }
                         if (!ok(r4)) {
-                            callback.completed(Result.fail(message(r4)));
+                            callback.completed(Result.fail(error(r4)));
                             return;
                         }
                         devices[0] = r4.getResponseData();
@@ -125,7 +125,7 @@ public final class CloudSigningService implements SigningService {
                                 return;
                             }
                             if (!ok(r5)) {
-                                callback.completed(Result.fail(message(r5)));
+                                callback.completed(Result.fail(error(r5)));
                                 return;
                             }
                             profiles[0] = r5.getResponseData();
@@ -135,7 +135,7 @@ public final class CloudSigningService implements SigningService {
                                     return;
                                 }
                                 if (!ok(r6)) {
-                                    callback.completed(Result.fail(message(r6)));
+                                    callback.completed(Result.fail(error(r6)));
                                     return;
                                 }
                                 apns[0] = r6.getResponseData();
@@ -145,7 +145,7 @@ public final class CloudSigningService implements SigningService {
                                         return;
                                     }
                                     if (!ok(r7)) {
-                                        callback.completed(Result.fail(message(r7)));
+                                        callback.completed(Result.fail(error(r7)));
                                         return;
                                     }
                                     appGroups[0] = r7.getResponseData();
@@ -186,7 +186,7 @@ public final class CloudSigningService implements SigningService {
                                OnComplete<Result<Void>> callback) {
         bundleIdsApi.createBundleId(new CreateBundleIdRequest(identifier, name, platform), bearerToken, r -> {
             if (!ok(r)) {
-                callback.completed(Result.fail(message(r)));
+                callback.completed(Result.fail(error(r)));
                 return;
             }
             BundleIdDTO created = r.getResponseData();
@@ -202,7 +202,7 @@ public final class CloudSigningService implements SigningService {
     public void createAppGroup(String identifier, String name, OnComplete<Result<SigningState.AppGroup>> callback) {
         appGroupsApi.createAppGroup(new CreateAppGroupRequest(identifier, name), bearerToken, r -> {
             if (!ok(r)) {
-                callback.completed(Result.<SigningState.AppGroup>fail(message(r)));
+                callback.completed(Result.<SigningState.AppGroup>fail(error(r)));
                 return;
             }
             AppGroupDTO created = r.getResponseData();
@@ -255,7 +255,7 @@ public final class CloudSigningService implements SigningService {
                 .header("Authorization", bearerToken)
                 .onError(evt -> {
                     evt.consume();
-                    callback.completed(Result.fail(networkMessage(evt)));
+                    callback.completed(Result.<String>fail(networkError(evt)));
                 }, false)
                 .onErrorCodeBytes(r -> saveBytes(r, suggestedName, callback))
                 .fetchAsBytes(r -> saveBytes(r, suggestedName, callback));
@@ -266,7 +266,7 @@ public final class CloudSigningService implements SigningService {
         Rest.get(url).header("Authorization", bearerToken)
                 .onError(evt -> {
                     evt.consume();
-                    callback.completed(Result.fail(networkMessage(evt)));
+                    callback.completed(Result.<String>fail(networkError(evt)));
                 }, false)
                 .onErrorCodeBytes(r -> saveBytes(r, suggestedName, callback))
                 .fetchAsBytes(r -> saveBytes(r, suggestedName, callback));
@@ -292,66 +292,51 @@ public final class CloudSigningService implements SigningService {
         return r != null && (r.getResponseCode() == 401 || r.getResponseCode() == 403);
     }
 
-    private static String message(Response<?> r) {
+    /**
+     * The failure behind a non-2xx reply. On an error status the generated REST
+     * client hands us the raw body in {@code getResponseData()} (see the
+     * {@code onErrorCodeString} handler it emits), and the signing service puts
+     * a sentence written for this UI there -- so that body, not a status-derived
+     * guess, is the message wherever it is usable.
+     */
+    private static SigningError error(Response<?> r) {
         if (r == null) {
-            return "No response from server";
+            return SigningError.from(0, null, null);
         }
-        int code = r.getResponseCode();
-        if (authFailure(r)) {
-            return "Codename One login expired. Run the wizard again to refresh the sign-in token.";
+        return SigningError.from(r.getResponseCode(), bodyOf(r), r.getResponseErrorMessage());
+    }
+
+    private static String bodyOf(Response<?> r) {
+        Object data = r.getResponseData();
+        if (data instanceof String) {
+            return (String) data;
         }
-        if (code == 503) {
-            return "Codename One cloud signing service is unavailable (HTTP 503). Try again later.";
-        }
-        if (code >= 500) {
-            return "Codename One cloud signing service failed (HTTP " + code + "). Try again later.";
-        }
-        if (code <= 0) {
-            String transport = r.getResponseErrorMessage();
-            if (isTransportArtifact(transport)) {
-                return "Could not read the server response. Try again later.";
+        if (data instanceof byte[]) {
+            byte[] raw = (byte[]) data;
+            if (raw.length > 0) {
+                try {
+                    return new String(raw, "UTF-8");
+                } catch (java.io.UnsupportedEncodingException ex) {
+                    return null;
+                }
             }
-            return transport == null || transport.isEmpty() ? "Could not reach the Codename One cloud service."
-                    : "Connection failed: " + transport;
         }
-        String msg = r.getResponseErrorMessage();
-        if ((msg == null || msg.isEmpty()) && r.getResponseData() instanceof String) {
-            msg = (String) r.getResponseData();
-        }
-        if (isTransportArtifact(msg)) {
-            return "Request failed (HTTP " + code + "). Try again later.";
-        }
-        return msg == null || msg.isEmpty() ? "HTTP " + r.getResponseCode() : msg;
+        return null;
     }
 
-    private static boolean isTransportArtifact(String msg) {
-        if (msg == null) {
-            return false;
-        }
-        String m = msg.trim().toLowerCase();
-        return m.equals("stream closed") || m.equals("socket closed") || m.equals("unexpected end of stream")
-                || m.equals("premature eof") || m.equals("connection reset");
-    }
-
-    private static String networkMessage(NetworkEvent evt) {
+    private static SigningError networkError(NetworkEvent evt) {
         if (evt == null) {
-            return "Network request failed";
+            return SigningError.from(0, null, null);
         }
         String message = evt.getMessage();
         if ((message == null || message.trim().isEmpty()) && evt.getError() != null) {
             message = evt.getError().getMessage();
         }
-        if (message == null || message.trim().isEmpty()) {
-            message = "Network request failed";
-        }
-        if (evt.getResponseCode() > 0) {
-            return "Codename One cloud request failed (HTTP " + evt.getResponseCode() + "): " + message;
-        }
-        return message;
+        return SigningError.from(evt.getResponseCode(), null, message);
     }
 
     private static void done(Response<?> r, OnComplete<Result<Void>> callback) {
-        callback.completed(ok(r) ? Result.ok(null) : Result.<Void>fail(message(r)));
+        callback.completed(ok(r) ? Result.<Void>ok(null) : Result.<Void>fail(error(r)));
     }
 
     private SigningState toState(AscCredentialStatus cred, List<CertDTO> certs, List<BundleIdDTO> bundles,
@@ -403,7 +388,7 @@ public final class CloudSigningService implements SigningService {
 
     private void saveBytes(Response<byte[]> response, String suggestedName, OnComplete<Result<String>> callback) {
         if (!ok(response)) {
-            callback.completed(Result.fail(message(response)));
+            callback.completed(Result.<String>fail(error(response)));
             return;
         }
         byte[] data = response.getResponseData();

--- a/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/api/SigningError.java
+++ b/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/api/SigningError.java
@@ -1,0 +1,165 @@
+package com.codename1.certificatewizard.api;
+
+/**
+ * Turns an HTTP failure from the Codename One signing service into something
+ * worth showing a developer, plus the kind of thing it is so the wizard can
+ * offer the right next step.
+ *
+ * <p>The cloud service answers with a plain-text sentence written for this
+ * screen, so the body is the message whenever it looks like one. The previous
+ * behaviour -- collapsing every 5xx to "cloud signing service failed (HTTP
+ * 502). Try again later." -- threw that sentence away, which is how a revoked
+ * App Store Connect key ended up being reported as a server fault the developer
+ * was told to wait out.
+ *
+ * <p>Bodies are not trusted blindly: a proxy or CDN sitting in front of the
+ * service answers 5xx with its own HTML page or a stub like {@code error code:
+ * 522}, and neither belongs in the UI.
+ */
+public final class SigningError {
+
+    /** What went wrong, in terms of what the developer can do about it. */
+    public enum Kind {
+        /** The Codename One sign-in expired -- re-run the wizard. */
+        AUTH,
+        /** The stored App Store Connect API key is missing, rejected or under-privileged. */
+        CREDENTIAL,
+        /** The key is fine; Apple refused this particular request. */
+        APPLE_REJECTED,
+        /** Apple no longer has the object; a sync reconciles it. */
+        GONE,
+        /** Apple is rate-limiting; waiting genuinely helps. */
+        RATE_LIMITED,
+        /** The service or Apple is down; waiting genuinely helps. */
+        UNAVAILABLE,
+        /** The request never made it out. */
+        NETWORK,
+        /** Anything else. */
+        OTHER
+    }
+
+    /** Longest server sentence we will render; past this it is not a message. */
+    private static final int MAX_BODY = 600;
+    /** A 5xx body has to look like prose before we believe it explains anything. */
+    private static final int MIN_SENTENCE = 20;
+
+    private final Kind kind;
+    private final String message;
+
+    private SigningError(Kind kind, String message) {
+        this.kind = kind;
+        this.message = message;
+    }
+
+    public Kind kind() {
+        return kind;
+    }
+
+    public String message() {
+        return message;
+    }
+
+    /** True when trying the same thing again in a minute could plausibly work. */
+    public boolean retryable() {
+        return kind == Kind.RATE_LIMITED || kind == Kind.UNAVAILABLE || kind == Kind.NETWORK;
+    }
+
+    /**
+     * @param code             HTTP status, or 0/negative when the request failed to complete
+     * @param body             the response body, if the transport captured one
+     * @param transportMessage the connection-level message, if any
+     */
+    public static SigningError from(int code, String body, String transportMessage) {
+        if (code == 401 || code == 403) {
+            return new SigningError(Kind.AUTH,
+                    "Codename One login expired. Run the wizard again to refresh the sign-in token.");
+        }
+        if (code <= 0) {
+            return new SigningError(Kind.NETWORK, transportFailure(transportMessage));
+        }
+        Kind kind = kindFor(code);
+        String server = usableBody(body, code);
+        return new SigningError(kind, server != null ? server : canned(code, kind));
+    }
+
+    private static Kind kindFor(int code) {
+        if (code == 409) {
+            return Kind.CREDENTIAL;
+        }
+        if (code == 404) {
+            return Kind.GONE;
+        }
+        if (code == 429) {
+            return Kind.RATE_LIMITED;
+        }
+        if (code >= 500) {
+            return Kind.UNAVAILABLE;
+        }
+        if (code == 422 || code == 400) {
+            return Kind.APPLE_REJECTED;
+        }
+        return Kind.OTHER;
+    }
+
+    /**
+     * The body, when it is plainly a message from the signing service rather
+     * than a gateway's error page. For 5xx we additionally insist it reads like
+     * a sentence, because that is exactly where CDNs inject their own stubs.
+     */
+    private static String usableBody(String body, int code) {
+        if (body == null) {
+            return null;
+        }
+        String b = body.trim();
+        if (b.isEmpty() || b.length() > MAX_BODY || b.charAt(0) == '<' || b.charAt(0) == '{'
+                || isTransportArtifact(b)) {
+            return null;
+        }
+        if (code >= 500 && (b.length() < MIN_SENTENCE || b.indexOf(' ') < 0)) {
+            return null;
+        }
+        return b;
+    }
+
+    private static String canned(int code, Kind kind) {
+        switch (kind) {
+            case CREDENTIAL:
+                return "Your App Store Connect API key needs attention before this can work. "
+                        + "Open the ASC API Key page and save a current key.";
+            case GONE:
+                return "Apple no longer has this item. Use \"Sync with Apple\" to bring your account "
+                        + "back in step.";
+            case RATE_LIMITED:
+                return "Apple is rate-limiting requests for your team. Wait a few minutes and try again.";
+            case UNAVAILABLE:
+                return "The Codename One signing service is temporarily unavailable (HTTP " + code
+                        + "). Wait a few minutes and try again.";
+            case APPLE_REJECTED:
+                return "Apple rejected the request (HTTP " + code + ").";
+            default:
+                return "The request failed (HTTP " + code + ").";
+        }
+    }
+
+    private static String transportFailure(String transportMessage) {
+        if (transportMessage == null || transportMessage.trim().isEmpty()) {
+            return "Could not reach the Codename One cloud service. Check your network connection "
+                    + "and try again.";
+        }
+        if (isTransportArtifact(transportMessage)) {
+            return "The connection to the Codename One cloud service dropped before the reply arrived. "
+                    + "Try again.";
+        }
+        return "Connection failed: " + transportMessage.trim();
+    }
+
+    private static boolean isTransportArtifact(String msg) {
+        if (msg == null) {
+            return false;
+        }
+        String m = msg.trim().toLowerCase();
+        return m.equals("stream closed") || m.equals("socket closed") || m.equals("unexpected end of stream")
+                || m.equals("premature eof") || m.equals("connection reset")
+                || m.startsWith("error code:");
+    }
+}

--- a/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/api/SigningError.java
+++ b/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/api/SigningError.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.certificatewizard.api;
 
 /**

--- a/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/api/SigningService.java
+++ b/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/api/SigningService.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.certificatewizard.api;
 
 import com.codename1.util.OnComplete;

--- a/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/api/SigningService.java
+++ b/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/api/SigningService.java
@@ -32,19 +32,34 @@ public interface SigningService {
         public final boolean ok;
         public final T value;
         public final String message;
+        /** What kind of failure this was, so the UI can offer the right next step. Null when ok. */
+        public final SigningError error;
 
-        private Result(boolean ok, T value, String message) {
+        private Result(boolean ok, T value, String message, SigningError error) {
             this.ok = ok;
             this.value = value;
             this.message = message;
+            this.error = error;
         }
 
         public static <T> Result<T> ok(T value) {
-            return new Result<T>(true, value, null);
+            return new Result<T>(true, value, null, null);
         }
 
         public static <T> Result<T> fail(String message) {
-            return new Result<T>(false, null, message == null ? "Operation failed" : message);
+            return new Result<T>(false, null, message == null ? "Operation failed" : message, null);
+        }
+
+        public static <T> Result<T> fail(SigningError error) {
+            if (error == null) {
+                return fail((String) null);
+            }
+            return new Result<T>(false, null, error.message(), error);
+        }
+
+        /** The failure kind, or {@link SigningError.Kind#OTHER} when there is nothing more specific. */
+        public SigningError.Kind errorKind() {
+            return error == null ? SigningError.Kind.OTHER : error.kind();
         }
     }
 }

--- a/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardErrorBannerTest.java
+++ b/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardErrorBannerTest.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.certificatewizard;
+
+import com.codename1.certificatewizard.api.MockSigningService;
+import com.codename1.certificatewizard.api.SigningError;
+import com.codename1.certificatewizard.api.SigningService;
+import com.codename1.certificatewizard.api.SigningState;
+import com.codename1.components.SpanLabel;
+import com.codename1.ui.Button;
+import com.codename1.ui.Component;
+import com.codename1.ui.Container;
+import com.codename1.ui.Display;
+import com.codename1.ui.Form;
+import com.codename1.util.OnComplete;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * "Sync with Apple" is the button the outage report came in on. These drive it
+ * for real and assert that whatever the signing service said reaches the
+ * screen -- the old code showed "cloud signing service failed (HTTP 502). Try
+ * again later." no matter what the body held.
+ */
+class CertificateWizardErrorBannerTest {
+
+    private static final String REVOKED_KEY =
+            "Apple rejected your App Store Connect API key. It has most likely been revoked. Create a new "
+            + "key under Users and Access > Integrations > App Store Connect API, then save it in the wizard.";
+    private static final String APPLE_DOWN =
+            "Codename One could not reach Apple's App Store Connect API. That is usually a brief outage on "
+            + "Apple's side -- wait a few minutes and try again.";
+
+    @BeforeAll
+    static void initDisplay() {
+        if (Display.getInstance() == null || !Display.isInitialized()) {
+            Display.init(null);
+        }
+    }
+
+    @Test
+    void aRejectedKeyReachesTheBannerWithAWayToFixIt() throws Exception {
+        CertificateWizard app = launch(SigningError.from(409, REVOKED_KEY, null));
+
+        onEdt(() -> fire(app.getForm(), "btn.reconcile"));
+
+        Form form = app.getForm();
+        assertTrue(bannerText(form).contains("revoked"), bannerText(form));
+        assertTrue(bannerText(form).contains("Users and Access"), bannerText(form));
+        Button action = (Button) find(form, "page.message.action");
+        assertNotNull(action, "a credential failure should offer a way to the key page");
+        assertTrue(action.getText().contains("ASC API Key"), action.getText());
+    }
+
+    @Test
+    void theKeyActionNavigatesToTheCredentialPage() throws Exception {
+        CertificateWizard app = launch(SigningError.from(409, REVOKED_KEY, null));
+        onEdt(() -> fire(app.getForm(), "btn.reconcile"));
+
+        onEdt(() -> fire(app.getForm(), "page.message.action"));
+
+        assertTrue(app.getSection() == CertificateWizard.Section.CREDENTIAL,
+                "expected the credential page, got " + app.getSection());
+    }
+
+    @Test
+    void anOutageKeepsTheServersExplanationAndOffersARetry() throws Exception {
+        CertificateWizard app = launch(SigningError.from(502, APPLE_DOWN, null));
+
+        onEdt(() -> fire(app.getForm(), "btn.reconcile"));
+
+        Form form = app.getForm();
+        String banner = bannerText(form);
+        assertTrue(banner.contains("outage on Apple's side"), banner);
+        assertTrue(banner.indexOf("Try again later.") < 0, "the old catch-all message is gone: " + banner);
+        Button action = (Button) find(form, "page.message.action");
+        assertNotNull(action, "a transient failure should offer a retry");
+        assertTrue(action.getText().contains("Try again"), action.getText());
+    }
+
+    @Test
+    void applesOwnRejectionNeedsNoButton() throws Exception {
+        String apple = "Apple rejected the request: You already have a current Distribution certificate.";
+        CertificateWizard app = launch(SigningError.from(422, apple, null));
+
+        onEdt(() -> fire(app.getForm(), "btn.reconcile"));
+
+        Form form = app.getForm();
+        assertTrue(bannerText(form).contains("already have a current Distribution certificate"),
+                bannerText(form));
+        assertNull(find(form, "page.message.action"),
+                "nothing to retry and nothing to fix in the key -- no button");
+    }
+
+    /** Long sentences have to wrap; a plain Label would clip them. */
+    @Test
+    void theBannerWrapsAndStaysCopyable() throws Exception {
+        CertificateWizard app = launch(SigningError.from(409, REVOKED_KEY, null));
+
+        onEdt(() -> fire(app.getForm(), "btn.reconcile"));
+
+        Component banner = find(app.getForm(), "page.message");
+        assertTrue(banner instanceof SpanLabel, "the banner must wrap, not clip");
+        assertTrue(((SpanLabel) banner).getTextComponent().isTextSelectionEnabled(),
+                "a developer has to be able to copy the error out");
+    }
+
+    // ---- harness ------------------------------------------------------------
+
+    private static CertificateWizard launch(SigningError failure) throws Exception {
+        final CertificateWizard[] app = new CertificateWizard[1];
+        onEdt(() -> {
+            CertificateWizard.setServiceForTesting(new FailingReconcile(failure));
+            app[0] = new CertificateWizard();
+            app[0].runApp();
+        });
+        return app[0];
+    }
+
+    private static void onEdt(Runnable r) {
+        Display.getInstance().callSeriallyAndWait(r);
+    }
+
+    private static String bannerText(Form form) {
+        Component c = find(form, "page.message");
+        assertNotNull(c, "no error banner on screen");
+        return ((SpanLabel) c).getText();
+    }
+
+    private static void fire(Container root, String name) {
+        Component c = find(root, name);
+        assertNotNull(c, "no component named " + name);
+        ((Button) c).pressed();
+        ((Button) c).released();
+    }
+
+    private static Component find(Container root, String name) {
+        if (name.equals(root.getName())) {
+            return root;
+        }
+        for (int i = 0; i < root.getComponentCount(); i++) {
+            Component c = root.getComponentAt(i);
+            if (name.equals(c.getName())) {
+                return c;
+            }
+            if (c instanceof Container) {
+                Component out = find((Container) c, name);
+                if (out != null) {
+                    return out;
+                }
+            }
+        }
+        return null;
+    }
+
+    /** A mock that succeeds at everything except the call under test. */
+    private static final class FailingReconcile implements SigningService {
+        private final MockSigningService delegate = new MockSigningService();
+        private final SigningError failure;
+
+        FailingReconcile(SigningError failure) {
+            this.failure = failure;
+        }
+
+        public void reconcile(OnComplete<Result<Void>> callback) {
+            callback.completed(Result.<Void>fail(failure));
+        }
+
+        public void refresh(OnComplete<Result<SigningState>> callback) {
+            delegate.refresh(callback);
+        }
+
+        public void saveCredential(String keyId, String issuerId, String p8, OnComplete<Result<Void>> cb) {
+            delegate.saveCredential(keyId, issuerId, p8, cb);
+        }
+
+        public void deleteCredential(OnComplete<Result<Void>> cb) {
+            delegate.deleteCredential(cb);
+        }
+
+        public void createCertificate(String type, String name, OnComplete<Result<Void>> cb) {
+            delegate.createCertificate(type, name, cb);
+        }
+
+        public void revokeCertificate(Long id, OnComplete<Result<Void>> cb) {
+            delegate.revokeCertificate(id, cb);
+        }
+
+        public void createBundleId(String id, String name, String platform, boolean push,
+                OnComplete<Result<Void>> cb) {
+            delegate.createBundleId(id, name, platform, push, cb);
+        }
+
+        public void createAppGroup(String id, String name, OnComplete<Result<SigningState.AppGroup>> cb) {
+            delegate.createAppGroup(id, name, cb);
+        }
+
+        public void enableAppGroupCapability(String bundleId, List<String> groups, OnComplete<Result<Void>> cb) {
+            delegate.enableAppGroupCapability(bundleId, groups, cb);
+        }
+
+        public void registerDevice(String name, String udid, OnComplete<Result<Void>> cb) {
+            delegate.registerDevice(name, udid, cb);
+        }
+
+        public void createProfile(String name, String type, String bundleId, List<String> certs,
+                List<String> devices, OnComplete<Result<Void>> cb) {
+            delegate.createProfile(name, type, bundleId, certs, devices, cb);
+        }
+
+        public void deleteProfile(Long id, OnComplete<Result<Void>> cb) {
+            delegate.deleteProfile(id, cb);
+        }
+
+        public void saveApnsKey(String keyId, String teamId, String p8, String name,
+                OnComplete<Result<Void>> cb) {
+            delegate.saveApnsKey(keyId, teamId, p8, name, cb);
+        }
+
+        public void deleteApnsKey(String keyId, OnComplete<Result<Void>> cb) {
+            delegate.deleteApnsKey(keyId, cb);
+        }
+
+        public void clearSigningData(OnComplete<Result<Void>> cb) {
+            delegate.clearSigningData(cb);
+        }
+
+        public void downloadP12(Long id, String password, String name, OnComplete<Result<String>> cb) {
+            delegate.downloadP12(id, password, name, cb);
+        }
+
+        public void downloadProfile(Long id, String name, OnComplete<Result<String>> cb) {
+            delegate.downloadProfile(id, name, cb);
+        }
+    }
+}

--- a/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/SigningErrorTest.java
+++ b/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/SigningErrorTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.certificatewizard;
+
+import com.codename1.certificatewizard.api.SigningError;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SigningErrorTest {
+
+    private static final String REVOKED =
+            "Apple rejected your App Store Connect API key. It has most likely been revoked, or the Key ID "
+            + "and Issuer ID do not match the .p8 file.";
+
+    @Test
+    void aRejectedKeyIsReportedAsSomethingToFixNotSomethingToWaitOut() {
+        SigningError e = SigningError.from(409, REVOKED, null);
+
+        assertEquals(SigningError.Kind.CREDENTIAL, e.kind());
+        assertEquals(REVOKED, e.message());
+        assertFalse(e.retryable());
+    }
+
+    @Test
+    void applesOwnWordingSurvivesToTheUi() {
+        String apple = "Apple rejected the request: You already have a current Distribution certificate.";
+
+        SigningError e = SigningError.from(422, apple, null);
+
+        assertEquals(SigningError.Kind.APPLE_REJECTED, e.kind());
+        assertEquals(apple, e.message());
+        assertFalse(e.retryable());
+    }
+
+    /**
+     * The regression this whole change exists for: a 5xx used to be flattened
+     * to "cloud signing service failed (HTTP 502). Try again later.", throwing
+     * away whatever the service had said.
+     */
+    @Test
+    void aServerSentenceIsShownEvenOnA5xx() {
+        String explained = "Codename One could not reach Apple's App Store Connect API. That is usually a "
+                + "brief outage on Apple's side -- wait a few minutes and try again.";
+
+        SigningError e = SigningError.from(502, explained, null);
+
+        assertEquals(SigningError.Kind.UNAVAILABLE, e.kind());
+        assertEquals(explained, e.message());
+        assertTrue(e.retryable());
+    }
+
+    @Test
+    void aGatewayErrorPageIsNeverShownToTheDeveloper() {
+        SigningError e = SigningError.from(502,
+                "<html><head><title>502 Bad Gateway</title></head><body>nginx</body></html>", null);
+
+        assertEquals(SigningError.Kind.UNAVAILABLE, e.kind());
+        assertFalse(e.message().contains("<"), e.message());
+        assertTrue(e.message().contains("502"), e.message());
+    }
+
+    @Test
+    void aCdnStubIsNotASentence() {
+        SigningError e = SigningError.from(522, "error code: 522", null);
+
+        assertEquals(SigningError.Kind.UNAVAILABLE, e.kind());
+        assertFalse(e.message().contains("error code"), e.message());
+    }
+
+    @Test
+    void anOverlongBodyIsNotAMessage() {
+        StringBuilder huge = new StringBuilder();
+        for (int i = 0; i < 200; i++) {
+            huge.append("stack frame ");
+        }
+
+        SigningError e = SigningError.from(500, huge.toString(), null);
+
+        assertTrue(e.message().length() < 200, e.message());
+    }
+
+    @Test
+    void expiredCodenameOneLoginIsItsOwnThing() {
+        assertEquals(SigningError.Kind.AUTH, SigningError.from(401, "whatever", null).kind());
+        assertEquals(SigningError.Kind.AUTH, SigningError.from(403, "whatever", null).kind());
+        assertFalse(SigningError.from(401, null, null).retryable());
+    }
+
+    @Test
+    void rateLimitAndOutageBothInviteARetry() {
+        assertTrue(SigningError.from(429, null, null).retryable());
+        assertEquals(SigningError.Kind.RATE_LIMITED, SigningError.from(429, null, null).kind());
+        assertTrue(SigningError.from(503, null, null).retryable());
+    }
+
+    @Test
+    void aDeletedObjectPointsAtASync() {
+        SigningError e = SigningError.from(404, null, null);
+
+        assertEquals(SigningError.Kind.GONE, e.kind());
+        assertTrue(e.message().contains("Sync with Apple"), e.message());
+    }
+
+    @Test
+    void aDroppedConnectionSaysSoWithoutJargon() {
+        SigningError e = SigningError.from(0, null, "Stream closed");
+
+        assertEquals(SigningError.Kind.NETWORK, e.kind());
+        assertFalse(e.message().toLowerCase().contains("stream closed"), e.message());
+        assertTrue(e.retryable());
+    }
+
+    @Test
+    void aRealConnectionErrorKeepsItsDetail() {
+        SigningError e = SigningError.from(0, null, "Unable to resolve host cloud.codenameone.com");
+
+        assertTrue(e.message().contains("cloud.codenameone.com"), e.message());
+    }
+
+    @Test
+    void thereIsAlwaysSomethingToShow() {
+        int[] codes = {0, 400, 401, 403, 404, 409, 422, 429, 500, 502, 503, 522};
+        for (int code : codes) {
+            SigningError e = SigningError.from(code, null, null);
+            assertTrue(e.message() != null && e.message().trim().length() > 10, "code " + code);
+        }
+    }
+}

--- a/scripts/certificatewizard/specs/openapi.json
+++ b/scripts/certificatewizard/specs/openapi.json
@@ -210,7 +210,13 @@
             "$ref": "#/components/responses/Forbidden"
           },
           "409": {
-            "$ref": "#/components/responses/NotConfigured"
+            "$ref": "#/components/responses/AscKeyProblem"
+          },
+          "422": {
+            "$ref": "#/components/responses/AppleRejected"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
           },
           "502": {
             "$ref": "#/components/responses/AppleError"
@@ -244,7 +250,13 @@
             "$ref": "#/components/responses/Forbidden"
           },
           "409": {
-            "$ref": "#/components/responses/NotConfigured"
+            "$ref": "#/components/responses/AscKeyProblem"
+          },
+          "422": {
+            "$ref": "#/components/responses/AppleRejected"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
           },
           "502": {
             "$ref": "#/components/responses/AppleError"
@@ -333,6 +345,12 @@
           "404": {
             "description": "No such certificate"
           },
+          "422": {
+            "$ref": "#/components/responses/AppleRejected"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
           "502": {
             "$ref": "#/components/responses/AppleError"
           }
@@ -364,7 +382,13 @@
             "$ref": "#/components/responses/Forbidden"
           },
           "409": {
-            "$ref": "#/components/responses/NotConfigured"
+            "$ref": "#/components/responses/AscKeyProblem"
+          },
+          "422": {
+            "$ref": "#/components/responses/AppleRejected"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
           },
           "502": {
             "$ref": "#/components/responses/AppleError"
@@ -405,7 +429,13 @@
             "$ref": "#/components/responses/Forbidden"
           },
           "409": {
-            "$ref": "#/components/responses/NotConfigured"
+            "$ref": "#/components/responses/AscKeyProblem"
+          },
+          "422": {
+            "$ref": "#/components/responses/AppleRejected"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
           },
           "502": {
             "$ref": "#/components/responses/AppleError"
@@ -452,7 +482,16 @@
             "$ref": "#/components/responses/Forbidden"
           },
           "409": {
-            "$ref": "#/components/responses/NotConfigured"
+            "$ref": "#/components/responses/AscKeyProblem"
+          },
+          "404": {
+            "$ref": "#/components/responses/AppleGone"
+          },
+          "422": {
+            "$ref": "#/components/responses/AppleRejected"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
           },
           "502": {
             "$ref": "#/components/responses/AppleError"
@@ -485,7 +524,13 @@
             "$ref": "#/components/responses/Forbidden"
           },
           "409": {
-            "$ref": "#/components/responses/NotConfigured"
+            "$ref": "#/components/responses/AscKeyProblem"
+          },
+          "422": {
+            "$ref": "#/components/responses/AppleRejected"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
           },
           "502": {
             "$ref": "#/components/responses/AppleError"
@@ -526,7 +571,13 @@
             "$ref": "#/components/responses/Forbidden"
           },
           "409": {
-            "$ref": "#/components/responses/NotConfigured"
+            "$ref": "#/components/responses/AscKeyProblem"
+          },
+          "422": {
+            "$ref": "#/components/responses/AppleRejected"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
           },
           "502": {
             "$ref": "#/components/responses/AppleError"
@@ -594,7 +645,13 @@
             "$ref": "#/components/responses/Forbidden"
           },
           "409": {
-            "$ref": "#/components/responses/NotConfigured"
+            "$ref": "#/components/responses/AscKeyProblem"
+          },
+          "422": {
+            "$ref": "#/components/responses/AppleRejected"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
           },
           "502": {
             "$ref": "#/components/responses/AppleError"
@@ -637,7 +694,16 @@
             "$ref": "#/components/responses/Forbidden"
           },
           "409": {
-            "$ref": "#/components/responses/NotConfigured"
+            "$ref": "#/components/responses/AscKeyProblem"
+          },
+          "404": {
+            "$ref": "#/components/responses/AppleGone"
+          },
+          "422": {
+            "$ref": "#/components/responses/AppleRejected"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
           },
           "502": {
             "$ref": "#/components/responses/AppleError"
@@ -673,6 +739,12 @@
           "404": {
             "description": "No such profile"
           },
+          "422": {
+            "$ref": "#/components/responses/AppleRejected"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
           "502": {
             "$ref": "#/components/responses/AppleError"
           }
@@ -704,7 +776,13 @@
             "$ref": "#/components/responses/Forbidden"
           },
           "409": {
-            "$ref": "#/components/responses/NotConfigured"
+            "$ref": "#/components/responses/AscKeyProblem"
+          },
+          "422": {
+            "$ref": "#/components/responses/AppleRejected"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
           },
           "502": {
             "$ref": "#/components/responses/AppleError"
@@ -746,7 +824,13 @@
             "$ref": "#/components/responses/Forbidden"
           },
           "409": {
-            "$ref": "#/components/responses/NotConfigured"
+            "$ref": "#/components/responses/AscKeyProblem"
+          },
+          "422": {
+            "$ref": "#/components/responses/AppleRejected"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
           },
           "502": {
             "$ref": "#/components/responses/AppleError"
@@ -885,8 +969,38 @@
       "Forbidden": {
         "description": "Caller is anonymous / not authenticated."
       },
-      "NotConfigured": {
-        "description": "No App Store Connect API key configured for this account yet.",
+      "AscKeyProblem": {
+        "description": "The account's App Store Connect API key is missing, was rejected by Apple (revoked, or the Key ID / Issuer ID do not match the .p8), or lacks the access this call needs. The developer has to fix the stored key -- retrying will not clear it. The body is a plain-text explanation written for them.\n",
+        "content": {
+          "text/plain": {
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "AppleRejected": {
+        "description": "The stored key is fine but Apple refused this particular request (for example \"You already have a current Distribution certificate\"). The body is a plain-text explanation, carrying Apple's own wording where Apple supplied it.\n",
+        "content": {
+          "text/plain": {
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "RateLimited": {
+        "description": "Apple is rate-limiting App Store Connect requests for this team. Retrying after a pause is correct.",
+        "content": {
+          "text/plain": {
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "AppleGone": {
+        "description": "Apple no longer has the object -- it was deleted in the Developer portal. A reconcile brings us back in step.",
         "content": {
           "text/plain": {
             "schema": {
@@ -899,7 +1013,7 @@
         "description": "Secrets vault is not configured on this deployment (no master key), so credentials cannot be stored."
       },
       "AppleError": {
-        "description": "The App Store Connect API rejected the call or was unreachable (upstream failure).",
+        "description": "App Store Connect is down or unreachable, so the call could not be completed. This is the only genuinely upstream failure and the only one worth retrying automatically; anything the developer must act on comes back as 409 or 422 instead.\n",
         "content": {
           "text/plain": {
             "schema": {

--- a/scripts/certificatewizard/specs/openapi.yaml
+++ b/scripts/certificatewizard/specs/openapi.yaml
@@ -136,7 +136,9 @@ paths:
               schema: { $ref: "#/components/schemas/CertDTO" }
         "400": { $ref: "#/components/responses/BadRequest" }
         "403": { $ref: "#/components/responses/Forbidden" }
-        "409": { $ref: "#/components/responses/NotConfigured" }
+        "409": { $ref: "#/components/responses/AscKeyProblem" }
+        "422": { $ref: "#/components/responses/AppleRejected" }
+        "429": { $ref: "#/components/responses/RateLimited" }
         "502": { $ref: "#/components/responses/AppleError" }
 
   /appsec/7.0/apple/certificates/reconcile:
@@ -154,7 +156,9 @@ paths:
                 type: array
                 items: { $ref: "#/components/schemas/CertDTO" }
         "403": { $ref: "#/components/responses/Forbidden" }
-        "409": { $ref: "#/components/responses/NotConfigured" }
+        "409": { $ref: "#/components/responses/AscKeyProblem" }
+        "422": { $ref: "#/components/responses/AppleRejected" }
+        "429": { $ref: "#/components/responses/RateLimited" }
         "502": { $ref: "#/components/responses/AppleError" }
 
   /appsec/7.0/apple/certificates/{id}/p12:
@@ -201,6 +205,8 @@ paths:
         "204": { description: Revoked }
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { description: No such certificate }
+        "422": { $ref: "#/components/responses/AppleRejected" }
+        "429": { $ref: "#/components/responses/RateLimited" }
         "502": { $ref: "#/components/responses/AppleError" }
 
   /appsec/7.0/apple/bundle-ids:
@@ -217,7 +223,9 @@ paths:
                 type: array
                 items: { $ref: "#/components/schemas/BundleIdDTO" }
         "403": { $ref: "#/components/responses/Forbidden" }
-        "409": { $ref: "#/components/responses/NotConfigured" }
+        "409": { $ref: "#/components/responses/AscKeyProblem" }
+        "422": { $ref: "#/components/responses/AppleRejected" }
+        "429": { $ref: "#/components/responses/RateLimited" }
         "502": { $ref: "#/components/responses/AppleError" }
     post:
       tags: [Bundle IDs]
@@ -236,7 +244,9 @@ paths:
               schema: { $ref: "#/components/schemas/BundleIdDTO" }
         "400": { $ref: "#/components/responses/BadRequest" }
         "403": { $ref: "#/components/responses/Forbidden" }
-        "409": { $ref: "#/components/responses/NotConfigured" }
+        "409": { $ref: "#/components/responses/AscKeyProblem" }
+        "422": { $ref: "#/components/responses/AppleRejected" }
+        "429": { $ref: "#/components/responses/RateLimited" }
         "502": { $ref: "#/components/responses/AppleError" }
 
   /appsec/7.0/apple/bundle-ids/{id}/capabilities:
@@ -259,7 +269,10 @@ paths:
         "204": { description: Capability enabled }
         "400": { $ref: "#/components/responses/BadRequest" }
         "403": { $ref: "#/components/responses/Forbidden" }
-        "409": { $ref: "#/components/responses/NotConfigured" }
+        "409": { $ref: "#/components/responses/AscKeyProblem" }
+        "404": { $ref: "#/components/responses/AppleGone" }
+        "422": { $ref: "#/components/responses/AppleRejected" }
+        "429": { $ref: "#/components/responses/RateLimited" }
         "502": { $ref: "#/components/responses/AppleError" }
 
   /appsec/7.0/apple/devices:
@@ -276,7 +289,9 @@ paths:
                 type: array
                 items: { $ref: "#/components/schemas/DeviceDTO" }
         "403": { $ref: "#/components/responses/Forbidden" }
-        "409": { $ref: "#/components/responses/NotConfigured" }
+        "409": { $ref: "#/components/responses/AscKeyProblem" }
+        "422": { $ref: "#/components/responses/AppleRejected" }
+        "429": { $ref: "#/components/responses/RateLimited" }
         "502": { $ref: "#/components/responses/AppleError" }
     post:
       tags: [Devices]
@@ -295,7 +310,9 @@ paths:
               schema: { $ref: "#/components/schemas/DeviceDTO" }
         "400": { $ref: "#/components/responses/BadRequest" }
         "403": { $ref: "#/components/responses/Forbidden" }
-        "409": { $ref: "#/components/responses/NotConfigured" }
+        "409": { $ref: "#/components/responses/AscKeyProblem" }
+        "422": { $ref: "#/components/responses/AppleRejected" }
+        "429": { $ref: "#/components/responses/RateLimited" }
         "502": { $ref: "#/components/responses/AppleError" }
 
   /appsec/7.0/apple/profiles:
@@ -329,7 +346,9 @@ paths:
               schema: { $ref: "#/components/schemas/ProfileDTO" }
         "400": { $ref: "#/components/responses/BadRequest" }
         "403": { $ref: "#/components/responses/Forbidden" }
-        "409": { $ref: "#/components/responses/NotConfigured" }
+        "409": { $ref: "#/components/responses/AscKeyProblem" }
+        "422": { $ref: "#/components/responses/AppleRejected" }
+        "429": { $ref: "#/components/responses/RateLimited" }
         "502": { $ref: "#/components/responses/AppleError" }
 
   /appsec/7.0/apple/profiles/{id}/download:
@@ -350,7 +369,10 @@ paths:
             application/octet-stream:
               schema: { type: string, format: binary }
         "403": { $ref: "#/components/responses/Forbidden" }
-        "409": { $ref: "#/components/responses/NotConfigured" }
+        "409": { $ref: "#/components/responses/AscKeyProblem" }
+        "404": { $ref: "#/components/responses/AppleGone" }
+        "422": { $ref: "#/components/responses/AppleRejected" }
+        "429": { $ref: "#/components/responses/RateLimited" }
         "502": { $ref: "#/components/responses/AppleError" }
 
   /appsec/7.0/apple/profiles/{id}:
@@ -367,6 +389,8 @@ paths:
         "204": { description: Deleted }
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { description: No such profile }
+        "422": { $ref: "#/components/responses/AppleRejected" }
+        "429": { $ref: "#/components/responses/RateLimited" }
         "502": { $ref: "#/components/responses/AppleError" }
 
   /appsec/7.0/apple/app-groups:
@@ -383,7 +407,9 @@ paths:
                 type: array
                 items: { $ref: "#/components/schemas/AppGroupDTO" }
         "403": { $ref: "#/components/responses/Forbidden" }
-        "409": { $ref: "#/components/responses/NotConfigured" }
+        "409": { $ref: "#/components/responses/AscKeyProblem" }
+        "422": { $ref: "#/components/responses/AppleRejected" }
+        "429": { $ref: "#/components/responses/RateLimited" }
         "502": { $ref: "#/components/responses/AppleError" }
     post:
       tags: [App Groups]
@@ -403,7 +429,9 @@ paths:
               schema: { $ref: "#/components/schemas/AppGroupDTO" }
         "400": { $ref: "#/components/responses/BadRequest" }
         "403": { $ref: "#/components/responses/Forbidden" }
-        "409": { $ref: "#/components/responses/NotConfigured" }
+        "409": { $ref: "#/components/responses/AscKeyProblem" }
+        "422": { $ref: "#/components/responses/AppleRejected" }
+        "429": { $ref: "#/components/responses/RateLimited" }
         "502": { $ref: "#/components/responses/AppleError" }
 
   /appsec/7.0/apple/apns-keys:
@@ -483,15 +511,39 @@ components:
           schema: { type: string }
     Forbidden:
       description: Caller is anonymous / not authenticated.
-    NotConfigured:
-      description: No App Store Connect API key configured for this account yet.
+    AscKeyProblem:
+      description: >
+        The account's App Store Connect API key is missing, was rejected by Apple (revoked, or the Key ID /
+        Issuer ID do not match the .p8), or lacks the access this call needs. The developer has to fix the
+        stored key -- retrying will not clear it. The body is a plain-text explanation written for them.
+      content:
+        text/plain:
+          schema: { type: string }
+    AppleRejected:
+      description: >
+        The stored key is fine but Apple refused this particular request (for example "You already have a
+        current Distribution certificate"). The body is a plain-text explanation, carrying Apple's own
+        wording where Apple supplied it.
+      content:
+        text/plain:
+          schema: { type: string }
+    RateLimited:
+      description: Apple is rate-limiting App Store Connect requests for this team. Retrying after a pause is correct.
+      content:
+        text/plain:
+          schema: { type: string }
+    AppleGone:
+      description: Apple no longer has the object -- it was deleted in the Developer portal. A reconcile brings us back in step.
       content:
         text/plain:
           schema: { type: string }
     VaultUnavailable:
       description: Secrets vault is not configured on this deployment (no master key), so credentials cannot be stored.
     AppleError:
-      description: The App Store Connect API rejected the call or was unreachable (upstream failure).
+      description: >
+        App Store Connect is down or unreachable, so the call could not be completed. This is the only
+        genuinely upstream failure and the only one worth retrying automatically; anything the developer
+        must act on comes back as 409 or 422 instead.
       content:
         text/plain:
           schema: { type: string }


### PR DESCRIPTION
A customer reported that for 24 hours, clicking **Sync with Apple** returned:

> Codename One cloud signing service failed (HTTP 502). Try again later.

Their App Store Connect key was fine. So was the sync — it had already succeeded.

## What was happening

Production logs show Apple answering one call with a 404:

```
GET /v1/appGroups?limit=200 status=404 code=NOT_FOUND
detail=The path provided does not match a defined resource type.
```

That is Apple saying the *path* is not a resource type it knows — App Store Connect does not offer App Groups to that account. (A collection that exists but is empty answers 200 with an empty `data` array.)

`CloudSigningService.refresh()` chains seven calls and loads App Groups **last**, and any failure there discarded the six that had already succeeded. `afterMutation` calls `reload()` on *success*, so the reconcile completed, the follow-up refresh died on call seven, and the developer was told to wait out something that had worked.

Two things then made it unreadable: the cloud service reported every Apple failure as `502`, and `CloudSigningService.message()` short-circuited on `code >= 500` and threw the response body away.

## Changes

**`8635e0f09a` — surface what the service actually said.** The generated REST client already hands the callback the raw body on an error status (via the `onErrorCodeString` handler it emits), so the explanation was there all along. `SigningError` now reads it for every status and classifies the failure; the banner renders it with a next step attached — "Open ASC API Key" for a credential problem, "Try again" for something genuinely transient.

Bodies are not trusted blindly: a proxy or CDN in front of the service answers 5xx with its own HTML page or a stub like `error code: 522`, so a 5xx body has to read like prose before it reaches the UI. The banner became a `SpanLabel` because a `Label` clipped these messages to one line, and it stays selectable so the text can be pasted into a support thread.

**`7e432be24d` — stop one optional call from discarding the account.** By the time App Groups load, the six calls before them have proved both the Codename One login and the Apple key are good, so a failure there is treated as "no App Groups". The developer keeps their certificates, bundle IDs, devices, profiles and APNs keys on screen.

Specs track the server contract: `NotConfigured` becomes `AscKeyProblem`, and the Apple-calling paths document 422/429/404 alongside 502. `openapi.json` is regenerated from the yaml it is derived from.

## Tests

38/38 green (`mvn -B test`), including:

- `SigningErrorTest` — the status→message mapping, including the CDN-stub and HTML-error-page cases that must never reach the UI.
- `CertificateWizardErrorBannerTest` — drives the real **Sync with Apple** button and asserts what lands on screen, that the old catch-all string is gone, and that the credential action navigates to the ASC API Key page.

## Related

Server side is BuildCloud #130, which fixes the root cause (`listAppGroups` reads the 404 as "no App Groups") and stops flattening every Apple failure into a 502. Either side alone clears the customer's symptom: the server fix reaches everyone on a released wizard without a client update, and this one fixes a rebuilt wizard without waiting for a deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)