### PR TITLE
Give a cn1lib's appended build hint a separator, instead of welding it on

### DIFF
--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
@@ -6471,6 +6471,25 @@ public class AndroidGradleBuilder extends Executor {
         debug("Gradle File start\n-------\n");
         debug(gradleProps);
         debug("-------\nGradle File end \n");
+
+        // Two dependency statements run together are valid Groovy -- a method call on the
+        // dependency the first one returned -- so Gradle reports them as "Could not find method
+        // implementation()" against a generated build.gradle line the developer never wrote, and
+        // names neither the hint nor the library that produced it. Say it plainly instead. This
+        // is not only about hand written values: a cn1lib's codenameone_library_appended.properties
+        // used to be concatenated onto the project's own value with no separator, so a project
+        // built by an older Maven plugin still arrives here corrupted.
+        String unseparated = findUnseparatedGradleStatement(request.getArg("android.gradleDep", ""));
+        if (unseparated != null) {
+            log("The android.gradleDep build hint runs two Gradle statements together with no "
+                    + "separator between them, near: " + unseparated + " -- separate them with ';' "
+                    + "or a newline. If you did not write this value by hand, a cn1lib appended a "
+                    + "dependency to it: check your libraries for a "
+                    + "codenameone_library_appended.properties that sets android.gradleDep, and "
+                    + "make sure your own value ends with ';'.");
+            return false;
+        }
+
         File gradleFile = new File(projectDir, "build.gradle");
 
         try {
@@ -7572,6 +7591,36 @@ public class AndroidGradleBuilder extends Executor {
 
     protected String getReleaseCertificateFile() {
         return "android.ks";
+    }
+
+    /**
+     * A Gradle configuration keyword opening a dependency declaration directly after the closing
+     * quote of the previous one, with no ';' or newline between the two.
+     */
+    private static final java.util.regex.Pattern UNSEPARATED_GRADLE_STATEMENT =
+            java.util.regex.Pattern.compile(
+                "['\"][ \\t]*(implementation|api|compile|compileOnly|runtimeOnly"
+                + "|annotationProcessor|kapt|testImplementation|androidTestImplementation"
+                + "|debugImplementation|releaseImplementation)[ \\t]*['\"(]");
+
+    /**
+     * Finds two Gradle dependency statements run together with no separator between them.
+     *
+     * @param gradleDep the android.gradleDep hint value
+     * @return the offending excerpt, or null when the value is well formed
+     */
+    static String findUnseparatedGradleStatement(String gradleDep) {
+        if (gradleDep == null || gradleDep.length() == 0) {
+            return null;
+        }
+        java.util.regex.Matcher matcher = UNSEPARATED_GRADLE_STATEMENT.matcher(gradleDep);
+        if (!matcher.find()) {
+            return null;
+        }
+        int from = Math.max(0, matcher.start() - 40);
+        int to = Math.min(gradleDep.length(), matcher.end() + 40);
+        return (from > 0 ? "..." : "") + gradleDep.substring(from, to)
+                + (to < gradleDep.length() ? "..." : "");
     }
 
     private String addNewlineIfMissing(String s) {

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/CN1BuildMojo.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/CN1BuildMojo.java
@@ -1501,8 +1501,12 @@ public class CN1BuildMojo extends AbstractCN1Mojo {
                             cn1SettingsProps.put(propName, propVal);
                         } else {
                             String existing = cn1SettingsProps.getProperty(propName);
-                            if (!existing.contains(propVal)) {
-                                cn1SettingsProps.setProperty(propName, existing + propVal);
+                            // Separator decided by the hint rather than by whatever the library
+                            // baked into its own value -- see LibraryHintMerger for why a bare
+                            // concatenation welds two Gradle statements into one.
+                            if (!LibraryHintMerger.alreadyContains(propName, existing, propVal)) {
+                                cn1SettingsProps.setProperty(propName,
+                                        LibraryHintMerger.append(propName, existing, propVal));
                             }
                         }
                     }
@@ -1523,6 +1527,19 @@ public class CN1BuildMojo extends AbstractCN1Mojo {
                 }
             }
 
+        }
+
+        // Fail here rather than in Gradle. A dependency hint that ran two statements together
+        // surfaces on the build server as a Groovy MissingMethodException against a generated
+        // build.gradle line, which says nothing about which hint or which library produced it --
+        // and on a cloud build that answer costs a queue slot and a round trip to discover.
+        for (String gradleHint : new String[] {"codename1.arg.android.gradleDep",
+                "codename1.arg.gradleDependencies"}) {
+            String problem = LibraryHintMerger.findUnseparatedStatement(
+                    gradleHint, cn1SettingsProps.getProperty(gradleHint));
+            if (problem != null) {
+                throw new MojoExecutionException(problem);
+            }
         }
 
         // Re-run the hardening pre-flight against the MERGED effective settings: a CN1Lib can supply

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/LibraryHintMerger.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/maven/LibraryHintMerger.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2021, 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.maven;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Joins a build hint contributed by a cn1lib's {@code codenameone_library_appended.properties}
+ * onto the value the project's own {@code codenameone_settings.properties} already carries.
+ *
+ * <p>The merge used to be a bare {@code existing + addition}, which is correct only for the
+ * XML-fragment hints the mechanism was designed around ({@code android.xpermissions} and
+ * friends, where two fragments really do abut). For a hint whose value is a
+ * <em>delimited list</em> it silently welds the last entry of one value onto the first entry
+ * of the next: a project pinning its own Gradle dependencies plus a library adding one more
+ * produced</p>
+ *
+ * <pre>implementation 'com.google.firebase:firebase-messaging:23.2.1'implementation 'com.scottyab:rootbeer-lib:0.0.8'</pre>
+ *
+ * <p>which Gradle parses as a method call on the first dependency and rejects with a Groovy
+ * stack trace naming a {@code build.gradle} line the developer never wrote. Library authors
+ * worked around it by baking a separator into their own value, but the two halves of that
+ * convention never agreed -- CN1JailbreakDetect ships {@code ios.pods} with a <em>leading</em>
+ * comma and {@code android.gradleDep} with a <em>trailing</em> semicolon, and only the leading
+ * one can work, because the library value is always the right-hand side of the join.</p>
+ *
+ * <p>So the separator is decided here, from the hint, rather than by each library guessing.
+ * Values already carrying a separator on the joining edge are accepted as-is rather than
+ * doubled, so libraries written to either convention merge correctly and unchanged.</p>
+ */
+public class LibraryHintMerger {
+
+    /** Prefix every build hint carries inside a settings/library properties file. */
+    private static final String ARG_PREFIX = "codename1.arg.";
+
+    /**
+     * Separator per hint, keyed by the name with {@link #ARG_PREFIX} stripped.
+     *
+     * <p>Read off how the builders themselves split or append each value, not invented here:
+     * {@code IPhoneBuilder} splits {@code ios.pods} and {@code ios.applicationQueriesSchemes}
+     * on {@code ","} and joins {@code ios.add_libs} with {@code ";"}, while every
+     * {@code AndroidGradleBuilder} injection into a Gradle text hint appends a newline-wrapped
+     * statement. A hint absent from this map keeps the historical bare concatenation, which is
+     * what the XML-fragment hints want.</p>
+     */
+    private static final Map<String, String> SEPARATORS = new HashMap<String, String>();
+    static {
+        // A Gradle dependency list. ';' rather than a newline because this is the hint
+        // users hand-edit most, every existing project and cn1lib already writes it that
+        // way, and keeping the value on one line survives any line-oriented tooling that
+        // rewrites codenameone_settings.properties.
+        SEPARATORS.put("android.gradleDep", ";");
+        // Block structured Gradle text, where a statement per line is the only thing that
+        // reads correctly -- and what our own builder injections already append.
+        SEPARATORS.put("gradleDependencies", "\n");
+        SEPARATORS.put("android.topDependency", "\n");
+        SEPARATORS.put("android.repositories", "\n");
+        SEPARATORS.put("android.xgradle", "\n");
+        SEPARATORS.put("android.gradle.androidx", "\n");
+        SEPARATORS.put("android.xgradle_default_config", "\n");
+        SEPARATORS.put("android.gradlePlugin", "\n");
+        SEPARATORS.put("android.supportv4Dep", "\n");
+        // ProGuard/R8 directives are line oriented.
+        SEPARATORS.put("android.proguardKeep", "\n");
+        // Comma-delimited lists.
+        SEPARATORS.put("ios.pods", ",");
+        SEPARATORS.put("ios.applicationQueriesSchemes", ",");
+        // Semicolon-delimited lists.
+        SEPARATORS.put("ios.add_libs", ";");
+        // Attributes spliced into a single XML tag, so they abut with a space rather than
+        // directly -- android:allowBackup="false"android:hardwareAccelerated="true" is not
+        // a well formed tag.
+        SEPARATORS.put("android.xapplication_attr", " ");
+    }
+
+    private LibraryHintMerger() {
+    }
+
+    /**
+     * The separator two values of this hint must be joined with, or an empty string when the
+     * hint's values abut directly (the XML-fragment hints).
+     *
+     * @param propertyName hint name, with or without the {@code codename1.arg.} prefix
+     * @return the separator, never null
+     */
+    public static String separatorFor(String propertyName) {
+        if (propertyName == null) {
+            return "";
+        }
+        String name = propertyName.startsWith(ARG_PREFIX)
+                ? propertyName.substring(ARG_PREFIX.length())
+                : propertyName;
+        String separator = SEPARATORS.get(name);
+        return separator == null ? "" : separator;
+    }
+
+    /**
+     * Whether {@code existing} already declares what {@code addition} would add.
+     *
+     * <p>Compared with the addition's own separators and surrounding whitespace trimmed off,
+     * because a library value's separator is decoration for the join rather than part of the
+     * thing being added -- {@code "implementation 'x:y:1';"} and {@code ";implementation
+     * 'x:y:1'"} both mean the same dependency, and a project that pinned it by hand wrote
+     * neither form exactly.</p>
+     *
+     * @param propertyName hint name, with or without the {@code codename1.arg.} prefix
+     * @param existing the project's current value, may be null
+     * @param addition the library's contribution, may be null
+     * @return true when the addition would be redundant
+     */
+    public static boolean alreadyContains(String propertyName, String existing, String addition) {
+        if (existing == null || addition == null) {
+            return false;
+        }
+        String needle = trimEdges(addition, separatorFor(propertyName));
+        return needle.length() > 0 && existing.contains(needle);
+    }
+
+    /**
+     * Joins a library's contribution onto the project's existing value for a hint.
+     *
+     * @param propertyName hint name, with or without the {@code codename1.arg.} prefix
+     * @param existing the project's current value, may be null
+     * @param addition the library's contribution, may be null
+     * @return the merged value, never null
+     */
+    public static String append(String propertyName, String existing, String addition) {
+        String left = existing == null ? "" : existing;
+        String right = addition == null ? "" : addition;
+        String separator = separatorFor(propertyName);
+        if (separator.length() == 0) {
+            // Historical behaviour, and the right one for an XML fragment.
+            return left + right;
+        }
+        String leftTrimmed = trimEdges(left, separator);
+        String rightTrimmed = trimEdges(right, separator);
+        if (leftTrimmed.length() == 0) {
+            return rightTrimmed;
+        }
+        if (rightTrimmed.length() == 0) {
+            return leftTrimmed;
+        }
+        return leftTrimmed + separator + rightTrimmed;
+    }
+
+    /**
+     * A Gradle configuration keyword opening a dependency declaration, sitting directly after
+     * the closing quote of the previous one with no {@code ;} or newline in between.
+     *
+     * <p>Groovy reads that as a method call on the dependency the previous statement returned,
+     * and reports it as "Could not find method implementation() ... on
+     * DefaultExternalModuleDependency" against a generated {@code build.gradle} line the
+     * developer never wrote. Naming the hint instead is the difference between a one line fix
+     * and reading a Gradle stack trace.</p>
+     */
+    private static final Pattern UNSEPARATED_STATEMENT = Pattern.compile(
+            "['\"][ \\t]*(implementation|api|compile|compileOnly|runtimeOnly|annotationProcessor"
+            + "|kapt|testImplementation|androidTestImplementation|debugImplementation"
+            + "|releaseImplementation)[ \\t]*['\"(]");
+
+    /**
+     * Checks a merged Gradle dependency hint for two declarations run together without a
+     * separator.
+     *
+     * @param propertyName hint name, with or without the {@code codename1.arg.} prefix
+     * @param value the merged value to check, may be null
+     * @return an actionable description of the problem, or null when the value is well formed
+     */
+    public static String findUnseparatedStatement(String propertyName, String value) {
+        if (value == null || value.length() == 0) {
+            return null;
+        }
+        Matcher matcher = UNSEPARATED_STATEMENT.matcher(value);
+        if (!matcher.find()) {
+            return null;
+        }
+        int from = Math.max(0, matcher.start() - 40);
+        int to = Math.min(value.length(), matcher.end() + 40);
+        String excerpt = (from > 0 ? "..." : "") + value.substring(from, to)
+                + (to < value.length() ? "..." : "");
+        return propertyName + " runs two Gradle statements together with no separator between "
+                + "them, which Gradle rejects as a method call on the preceding dependency:\n\n    "
+                + excerpt + "\n\nSeparate them with ';' or a newline. If you did not write this "
+                + "value by hand, a cn1lib appended to it: a library's "
+                + "codenameone_library_appended.properties contributes to this hint, and a "
+                + "library value that carries no leading separator used to be welded onto the "
+                + "end of yours. Update the Codename One Maven plugin, or add a ';' to the end "
+                + "of your own value.";
+    }
+
+    /**
+     * Strips whitespace and the hint's separator from both ends of a value, so the join
+     * decides the separator exactly once regardless of which convention the library followed.
+     */
+    private static String trimEdges(String value, String separator) {
+        String result = value.trim();
+        if (separator.length() == 0) {
+            return result;
+        }
+        boolean changed = true;
+        while (changed && result.length() > 0) {
+            changed = false;
+            if (result.startsWith(separator)) {
+                result = result.substring(separator.length()).trim();
+                changed = true;
+            }
+            if (result.endsWith(separator)) {
+                result = result.substring(0, result.length() - separator.length()).trim();
+                changed = true;
+            }
+        }
+        return result;
+    }
+}

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/AndroidGradleDepSeparatorTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/AndroidGradleDepSeparatorTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.builders;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The builder side half of the android.gradleDep separator guard. It has to stand on its own
+ * because a project built by an older Maven plugin still arrives with the value already welded
+ * together, and the builder is the only thing left that can say so.
+ */
+class AndroidGradleDepSeparatorTest {
+
+    @Test
+    void reportsTheStatementsRunTogether() {
+        // Verbatim from the failing build: the project's own two dependencies, with the
+        // CN1JailbreakDetect library's rootbeer pin concatenated straight onto the end.
+        String excerpt = AndroidGradleBuilder.findUnseparatedGradleStatement(
+                "implementation 'co.infinum:goldeneye:1.1.2';"
+                        + "implementation 'com.google.firebase:firebase-messaging:23.2.1'"
+                        + "implementation 'com.scottyab:rootbeer-lib:0.0.8'");
+
+        assertNotNull(excerpt);
+        assertTrue(excerpt.contains("23.2.1'implementation"), excerpt);
+    }
+
+    @Test
+    void acceptsSeparatedStatements() {
+        assertNull(AndroidGradleBuilder.findUnseparatedGradleStatement(
+                "implementation 'co.infinum:goldeneye:1.1.2';"
+                        + "implementation 'com.google.firebase:firebase-messaging:23.2.1';"
+                        + "implementation 'com.scottyab:rootbeer-lib:0.0.8'"));
+        assertNull(AndroidGradleBuilder.findUnseparatedGradleStatement(
+                "implementation 'a:b:1'\nimplementation 'c:d:2'"));
+    }
+
+    @Test
+    void acceptsTheOtherDeclarationForms() {
+        assertNull(AndroidGradleBuilder.findUnseparatedGradleStatement(
+                "implementation(name:'ZBarScannerLibrary', ext:'aar')"));
+        assertNull(AndroidGradleBuilder.findUnseparatedGradleStatement(
+                "implementation 'com.example:implementation-helper:1.0'"));
+        assertNull(AndroidGradleBuilder.findUnseparatedGradleStatement(
+                "implementation ('com.facebook.android:facebook-android-sdk:16.0.0')"
+                        + "{ exclude module: 'bolts-android' }"));
+    }
+
+    @Test
+    void toleratesEmptyValues() {
+        assertNull(AndroidGradleBuilder.findUnseparatedGradleStatement(null));
+        assertNull(AndroidGradleBuilder.findUnseparatedGradleStatement(""));
+    }
+}

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/LibraryHintMergerTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/LibraryHintMergerTest.java
@@ -1,0 +1,145 @@
+package com.codename1.maven;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * The regression cases here are taken from a real failing customer build: a project whose
+ * codenameone_settings.properties pinned three Gradle dependencies by hand, plus the
+ * CN1JailbreakDetect cn1lib, whose codenameone_library_appended.properties contributes
+ * "implementation 'com.scottyab:rootbeer-lib:0.0.8';" -- a trailing separator, which is the
+ * wrong end for a value that is always the right hand side of the join.
+ */
+public class LibraryHintMergerTest {
+
+    private static final String GRADLE_DEP = "codename1.arg.android.gradleDep";
+
+    /** Exactly what CN1JailbreakDetect ships. */
+    private static final String JAILBREAK_LIB_GRADLE_DEP =
+            "implementation 'com.scottyab:rootbeer-lib:0.0.8';";
+
+    @Test
+    public void gradleDependenciesAreJoinedWithASemicolon() {
+        String merged = LibraryHintMerger.append(GRADLE_DEP,
+                "implementation 'co.infinum:goldeneye:1.1.2';"
+                        + "implementation 'com.google.firebase:firebase-messaging:23.2.1'",
+                JAILBREAK_LIB_GRADLE_DEP);
+
+        assertEquals("implementation 'co.infinum:goldeneye:1.1.2';"
+                + "implementation 'com.google.firebase:firebase-messaging:23.2.1';"
+                + "implementation 'com.scottyab:rootbeer-lib:0.0.8'", merged);
+        assertNull(LibraryHintMerger.findUnseparatedStatement(GRADLE_DEP, merged));
+    }
+
+    @Test
+    public void aLibraryValueWithNoSeparatorAtAllStillMergesCleanly() {
+        // The pre-2024 CN1JailbreakDetect release, which carried no separator either side.
+        String merged = LibraryHintMerger.append(GRADLE_DEP,
+                "implementation 'co.infinum:goldeneye:1.1.2'",
+                "implementation 'com.scottyab:rootbeer-lib:0.0.8'");
+
+        assertEquals("implementation 'co.infinum:goldeneye:1.1.2';"
+                + "implementation 'com.scottyab:rootbeer-lib:0.0.8'", merged);
+    }
+
+    @Test
+    public void aSeparatorIsNeverDoubled() {
+        assertEquals("implementation 'a:b:1';implementation 'c:d:2'",
+                LibraryHintMerger.append(GRADLE_DEP,
+                        "implementation 'a:b:1';", ";implementation 'c:d:2'"));
+    }
+
+    @Test
+    public void anEmptyProjectValueDoesNotLeadWithASeparator() {
+        // ios.pods used to merge to ",DTTJailbreakDetection", whose first comma separated
+        // entry is empty.
+        assertEquals("DTTJailbreakDetection",
+                LibraryHintMerger.append("codename1.arg.ios.pods", "", ",DTTJailbreakDetection"));
+    }
+
+    @Test
+    public void iosPodsAreJoinedWithAComma() {
+        assertEquals("QBImagePickerController ~> 3.4,DTTJailbreakDetection",
+                LibraryHintMerger.append("codename1.arg.ios.pods",
+                        "QBImagePickerController ~> 3.4", ",DTTJailbreakDetection"));
+    }
+
+    @Test
+    public void xmlFragmentHintsStillAbutDirectly() {
+        // The case the mechanism was designed for: two manifest fragments concatenate, and
+        // inserting anything between them would corrupt the XML.
+        String permissions = LibraryHintMerger.append("codename1.arg.android.xpermissions",
+                "<uses-permission android:name=\"android.permission.CAMERA\"/>",
+                "<uses-permission android:name=\"android.permission.VIBRATE\"/>");
+
+        assertEquals("<uses-permission android:name=\"android.permission.CAMERA\"/>"
+                + "<uses-permission android:name=\"android.permission.VIBRATE\"/>", permissions);
+        assertEquals("", LibraryHintMerger.separatorFor("codename1.arg.android.xpermissions"));
+    }
+
+    @Test
+    public void applicationAttributesAreSeparatedByASpace() {
+        assertEquals("android:allowBackup=\"false\" android:hardwareAccelerated=\"true\"",
+                LibraryHintMerger.append("codename1.arg.android.xapplication_attr",
+                        "android:allowBackup=\"false\"",
+                        "android:hardwareAccelerated=\"true\""));
+    }
+
+    @Test
+    public void aDependencyAlreadyPinnedByTheProjectIsNotAddedAgain() {
+        // Why the customer's build worked for years: their settings carried the library's
+        // dependency verbatim, so the library's copy was suppressed. It has to stay suppressed
+        // whichever separator convention the library used.
+        String existing = "implementation 'co.infinum:goldeneye:1.1.2';"
+                + "implementation 'com.scottyab:rootbeer-lib:0.0.8';"
+                + "implementation 'com.google.firebase:firebase-messaging:23.2.1'";
+
+        assertTrue(LibraryHintMerger.alreadyContains(GRADLE_DEP, existing, JAILBREAK_LIB_GRADLE_DEP));
+        assertTrue(LibraryHintMerger.alreadyContains(GRADLE_DEP, existing,
+                ";implementation 'com.scottyab:rootbeer-lib:0.0.8'"));
+        assertFalse(LibraryHintMerger.alreadyContains(GRADLE_DEP, existing,
+                "implementation 'ca.weblite:fridablocker:1.0.10'"));
+    }
+
+    @Test
+    public void theUnseparatedStatementFromTheFailingBuildIsReported() {
+        String broken = "implementation 'co.infinum:goldeneye:1.1.2';"
+                + "implementation 'com.google.firebase:firebase-messaging:23.2.1'"
+                + "implementation 'com.scottyab:rootbeer-lib:0.0.8'";
+
+        String problem = LibraryHintMerger.findUnseparatedStatement(GRADLE_DEP, broken);
+
+        assertNotNull(problem);
+        assertTrue(problem.contains(GRADLE_DEP));
+        assertTrue(problem.contains("com.scottyab:rootbeer-lib:0.0.8"));
+    }
+
+    @Test
+    public void wellFormedDependencyListsAreNotReported() {
+        assertNull(LibraryHintMerger.findUnseparatedStatement(GRADLE_DEP,
+                "implementation 'a:b:1';implementation 'c:d:2'"));
+        assertNull(LibraryHintMerger.findUnseparatedStatement(GRADLE_DEP,
+                "implementation 'a:b:1'\nimplementation 'c:d:2'"));
+        assertNull(LibraryHintMerger.findUnseparatedStatement(GRADLE_DEP,
+                "implementation(name:'ZBarScannerLibrary', ext:'aar')"));
+        // An artifact whose name merely contains a configuration keyword.
+        assertNull(LibraryHintMerger.findUnseparatedStatement(GRADLE_DEP,
+                "implementation 'com.example:implementation-helper:1.0'"));
+        assertNull(LibraryHintMerger.findUnseparatedStatement(GRADLE_DEP, null));
+    }
+
+    @Test
+    public void hintNamesResolveWithOrWithoutTheArgPrefix() {
+        assertEquals(";", LibraryHintMerger.separatorFor("android.gradleDep"));
+        assertEquals(";", LibraryHintMerger.separatorFor(GRADLE_DEP));
+        assertEquals(",", LibraryHintMerger.separatorFor("ios.pods"));
+        assertEquals("\n", LibraryHintMerger.separatorFor("codename1.arg.gradleDependencies"));
+        assertEquals("", LibraryHintMerger.separatorFor("codename1.arg.some.unknown.hint"));
+        assertEquals("", LibraryHintMerger.separatorFor(null));
+    }
+}


### PR DESCRIPTION
A customer's Android build started failing with a Groovy error against a `build.gradle` line they never wrote:

```
Could not find method implementation() for arguments [com.scottyab:rootbeer-lib:0.0.8]
on DefaultExternalModuleDependency{group='com.google.firebase', name='firebase-messaging', ...}
```

because their `android.gradleDep` had arrived as:

```
implementation 'com.google.firebase:firebase-messaging:23.2.1'implementation 'com.scottyab:rootbeer-lib:0.0.8'
```

## Why

`CN1BuildMojo` merged a cn1lib's `codenameone_library_appended.properties` into the project's own value with a bare `existing + propVal`. That is correct for the XML-fragment hints the mechanism was designed around (`android.xpermissions` and friends, where two fragments really do abut) and wrong for every hint whose value is a **delimited list** — it welds the last entry of one value onto the first entry of the next.

Library authors worked around it by baking a separator into their own value, but the convention never agreed with itself. CN1JailbreakDetect ships `ios.pods` with a **leading** comma and `android.gradleDep` with a **trailing** semicolon, and only the leading one can work, because the library value is always the right-hand side of the join. Its trailing `;` was added in 2024 to fix a collision — at the wrong end.

The customer's build had survived for years because their settings pinned the library's dependency by hand, which satisfied `existing.contains(propVal)` and suppressed the library's copy. Deleting that hand-pinned line — which support had told them to do — is what flipped the guard and exposed the join.

## What this does

- **`LibraryHintMerger`** decides the separator from the hint rather than leaving each library to guess. The table is read off how the builders themselves split or append each value (`IPhoneBuilder` splits `ios.pods` on `,` and joins `ios.add_libs` with `;`; `AndroidGradleBuilder` appends newline-wrapped statements to the Gradle text hints). A hint absent from the table keeps the historical bare concatenation, so the XML-fragment hints are untouched. A separator already present on the joining edge is absorbed rather than doubled, so libraries written to **either** convention merge correctly and unchanged.
- The redundancy check now compares with the addition's own separators trimmed, so a project that pinned the dependency by hand still suppresses the library's copy under either spelling.
- `ios.pods` also stops merging to `,DTTJailbreakDetection`, whose first comma-separated entry is empty.

Two guards on top, because the merge fix only helps a project once it upgrades:

- **`CN1BuildMojo`** checks the merged dependency hints before submitting, so a cloud build fails locally in seconds with the hint named and the excerpt quoted, instead of after a queue slot and a Gradle stack trace.
- **`AndroidGradleBuilder`** repeats the check before writing `build.gradle`. A project on an older plugin never gets the merge fix, and the builder is the only thing left that can say what is wrong. (This half needs mirroring into `BuildDaemon` to reach cloud builds — companion PR.)

## Deliberately not changed

The builders' duplicate-coordinate guards still look only at `gradleDependencies`, so a project pinning its own rootbeer still gets ours injected beside it. Making them check `android.gradleDep` too would suppress our injection and leave that project on its older pin — here, back on rootbeer 0.0.8, which has no 16 KB page support. Gradle resolving the duplicate to the higher version is the safer outcome.

## Testing

`mvn -o -B -pl codenameone-maven-plugin verify` on JDK 8: **657 tests, 0 failures, 0 errors**; SpotBugs **0 findings**. 15 tests are new, built from the actual failing values, and cover both conventions, the no-separator library, the never-doubled join, the XML-fragment hints staying byte-identical, and the redundancy check.