### PR TITLE
Add the GPL+Classpath header LibraryHintMergerTest was merged without

### DIFF
--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/LibraryHintMergerTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/LibraryHintMergerTest.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.maven;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
Follow-up to #5569.

`check-copyright-headers` ran against that PR and failed on `LibraryHintMergerTest.java`. The PR merged before the fix landed on its branch, so master now carries a file the gate rejects — and because the gate checks the files a PR touches, the failure is inherited by whoever edits that file next rather than showing up on master.

The file copied the shape of `RichPropertiesReaderTest`, which predates the gate and is grandfathered rather than exempt.

Verified locally:

```
$ scripts/check-copyright-headers.sh --base 7b645fd0e8 --head HEAD
check-copyright-headers: 4 file(s) passed; 0 explicitly excluded.
```

(Worth noting for anyone reproducing: running the script with an uncommitted working tree diffs an empty range and reports `0 file(s) passed` — a pass that checked nothing. Commit first.)