### PR TITLE
Drain the GC's grace pass as it walks, ending the overflow spiral (issue #5537)

### DIFF
--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -554,6 +554,35 @@ static void cn1ReportPacingParks(void) {
             minHead < 0 ? -1L : minHead / 1024);
 }
 
+// Mark-worklist overflow accounting, reported by CN1_LOG_GC_OVERFLOW at exit and
+// asserted on by GcOverflowSpiralIntegrationTest. Overflow is a correctness backstop that is
+// meant to be rare: recovering from it costs a full O(heap) rescan, so a workload that
+// overflows EVERY cycle has a collector several times slower than the one it is supposed
+// to have -- the runaway of issue #5537. The cycle count is the direct signal for that,
+// and unlike a footprint reading it is a property of the code rather than of how much
+// RAM the machine running it happened to have free.
+static _Atomic long cn1GcOverflowCycles = 0;
+static _Atomic long cn1GcGraceDrains = 0;
+static _Atomic int cn1GcOverflowTrace = -1;
+static int cn1GcOverflowTraceOn(void) {
+    int on = atomic_load_explicit(&cn1GcOverflowTrace, memory_order_relaxed);
+    if(on < 0) {
+        on = getenv("CN1_LOG_GC_OVERFLOW") ? 1 : 0;
+        atomic_store_explicit(&cn1GcOverflowTrace, on, memory_order_relaxed);
+    }
+    return on;
+}
+
+static void cn1ReportGcOverflow(void) {
+    if(!cn1GcOverflowTraceOn()) {
+        return;
+    }
+    fprintf(stderr, "[GC-OVERFLOW] overflowCycles=%ld graceDrains=%ld cycles=%d\n",
+            atomic_load_explicit(&cn1GcOverflowCycles, memory_order_relaxed),
+            atomic_load_explicit(&cn1GcGraceDrains, memory_order_relaxed),
+            currentGcMarkValue);
+}
+
 static void cn1ReportLowMemoryParks(void) {
     if(!cn1LowMemoryTraceOn()) {
         return;
@@ -1319,9 +1348,16 @@ long gcMarkNewObjectCount = 0;
 // without racing the others on this flag.
 static __thread JAVA_BOOLEAN gcCurrentlyMaturing = JAVA_FALSE;
 #endif
-// Forward (tentative) declaration -- the real definition is below near the worklist;
-// the belt pass in codenameOneGCMark forces it to trigger the full BiBOP rescan.
+// Forward (tentative) declarations -- the real definitions are below near the worklist.
+// The belt pass in codenameOneGCMark forces the overflow flag to trigger the full BiBOP
+// rescan, and the grace pass reads the cursor to drain before it can overflow (see the
+// interleaved drain there). The size macro is hoisted with them for the same reason;
+// its rationale stays at the worklist definition.
+#ifndef CN1_GC_MARK_WORKLIST_SIZE
+#define CN1_GC_MARK_WORKLIST_SIZE 65536
+#endif
 static JAVA_BOOLEAN gcMarkWorklistOverflow;
+static int gcMarkWorklistTop;
 static _Atomic JAVA_BOOLEAN gcMarkOverflowSeen = JAVA_FALSE;
 #ifndef CN1_DISABLE_BIBOP
 // Forward declarations -- defined below; the grace-subtree pass in codenameOneGCMark
@@ -1412,6 +1448,15 @@ static JAVA_BOOLEAN cn1SweepRemoving;
 static __thread int cn1GcTrustedRoots = 0;
 #define CN1_GC_TRUSTED_BEGIN() int __cn1TrustSaved = cn1GcTrustedRoots; cn1GcTrustedRoots = 1
 #define CN1_GC_TRUSTED_END()   cn1GcTrustedRoots = __cn1TrustSaved
+// An untrusted HOLE inside a trusted walk, for a pass that has to drain the mark
+// worklist part-way through its registry walk (the grace passes). BEGIN/END cannot
+// express that: they save and restore a block-scoped local, so a pair inside the walk
+// would shadow the walk's own saved value and would restore whatever the ENCLOSING
+// window held rather than the "untrusted" a drain requires. Trust is a property of the
+// POINTERS being read -- authoritative in a registry walk, arbitrary in a drain that
+// follows child words out of mark functions -- so the two really are independent here.
+#define CN1_GC_TRUSTED_SUSPEND() cn1GcTrustedRoots = 0
+#define CN1_GC_TRUSTED_RESUME()  cn1GcTrustedRoots = 1
 #endif
 
 void codenameOneGCMark() {
@@ -1807,9 +1852,43 @@ void codenameOneGCMark() {
             }
             CN1_GC_TRUSTED_END();
             gp = atomic_load_explicit(&gp->nextAll, memory_order_acquire);
+            // DRAIN AS WE GO (issue #5537). This pass pushes EVERY fresh object on
+            // every page, and "fresh" means "allocated since the last cycle" -- a
+            // number set by the mutator's allocation rate, not by the live set. A
+            // thread churning short-lived objects produces far more than the worklist
+            // holds (65536 entries against ~500K fresh objects per cycle on the
+            // reporter's game-tree search), so pushing the whole walk before draining
+            // once overflowed the worklist as a matter of course.
+            //
+            // Overflow is survivable but ruinously expensive: it arms the belt, whose
+            // recovery pass is a full O(heap) rescan. That makes the cycle several
+            // times longer, which lets the mutator produce several times more fresh
+            // objects before the next one, which overflows again -- the collector
+            // never returns to the fast path, RSS climbs without bound (measured 90MB
+            // to 6.2GB in 20 seconds with a live set of a few hundred bytes) and the
+            // app is killed by the iOS per-process ceiling, or, once the process-budget
+            // pacing of #5563 holds it under that ceiling, parks on every allocation
+            // and appears frozen. Both were reported on this issue.
+            //
+            // Draining between pages costs nothing that the end-of-pass drain would
+            // not have cost anyway -- the same objects are scanned, just sooner -- and
+            // it bounds the cursor, so the pass cannot overflow by volume. It must run
+            // OUTSIDE the trusted window: a drain follows child words out of arbitrary
+            // mark functions, which is exactly what the resolve guard is there for.
+            if(gcMarkWorklistTop >= CN1_GC_MARK_WORKLIST_SIZE / 2) {
+                atomic_fetch_add_explicit(&cn1GcGraceDrains, 1, memory_order_relaxed);
+                gcMarkDrain(d);
+            }
         }
         gcMarkDrain(d);
     }
+    // A single page's slot walk runs between two of those checks, so the worklist must
+    // have room for a whole page of pushes above the drain threshold. True by a wide
+    // margin at the defaults (2048 slots against 32768 of headroom); asserted so that
+    // raising CN1_BIBOP_PAGE_SIZE or shrinking the worklist fails the build instead of
+    // quietly restoring the overflow spiral above.
+    _Static_assert(CN1_BIBOP_PAGE_SIZE / 32 <= CN1_GC_MARK_WORKLIST_SIZE / 2,
+                   "a BiBOP page's slots must fit in the grace pass's worklist headroom");
 #endif
 
     // GRACE-SUBTREE MARKING, LEGACY HALF (same correctness argument as the page
@@ -1847,6 +1926,20 @@ void codenameOneGCMark() {
                && go->__codenameOneParentClsReference != 0
                && go->__codenameOneParentClsReference->markFunction != 0) {
                 gcMarkObject(d, go, JAVA_FALSE);
+                // Same interleaved drain as the page walk above, and for the same
+                // reason: the number of fresh entries here is set by the allocation
+                // rate (everything over CN1_BIBOP_MAX_OBJECT lands in this table, as
+                // does everything the survivor-heavy bypass diverts off the page
+                // heap), so a busy cycle can push more of them than the worklist
+                // holds and drop the collector into the overflow spiral described
+                // there. Checked only on a push, since nothing else moves the cursor,
+                // and outside the trusted window for the reason spelled out below.
+                if(gcMarkWorklistTop >= CN1_GC_MARK_WORKLIST_SIZE / 2) {
+                    atomic_fetch_add_explicit(&cn1GcGraceDrains, 1, memory_order_relaxed);
+                    CN1_GC_TRUSTED_SUSPEND();
+                    gcMarkDrain(d);
+                    CN1_GC_TRUSTED_RESUME();
+                }
             }
         }
         // Trust covers ONLY the registry walk above. Every fresh entry is already
@@ -6343,6 +6436,9 @@ static int cn1ForceVisitedTestAndSet(JAVA_OBJECT obj, int key) {
 // can have more). Smaller sizes still work via the heap-rescan slow path, but the
 // rescan adds non-trivial cost and the path is harder to test, so the default errs
 // on the side of avoiding overflow for any normal app.
+// (The #define itself is hoisted to the forward-declaration block far above, next to
+// gcMarkWorklistTop, because the grace pass needs it; this #ifndef is what keeps a
+// -D override authoritative in both places.)
 #ifndef CN1_GC_MARK_WORKLIST_SIZE
 #define CN1_GC_MARK_WORKLIST_SIZE 65536
 #endif
@@ -6458,7 +6554,13 @@ static void gcMarkFlushLocal(struct gcMarkLocalBuffer* lb) {
     for(int i = 0 ; i < lb->count ; i++) {
         if(gcMarkWorklistTop >= CN1_GC_MARK_WORKLIST_SIZE) {
             gcMarkWorklistOverflow = JAVA_TRUE;
-            atomic_store_explicit(&gcMarkOverflowSeen, JAVA_TRUE, memory_order_release);
+            // EXCHANGE, so the counter below reads once per CYCLE rather than once per
+            // dropped push: what an overflow costs is the belt's O(heap) rescan, and
+            // that runs once however many pushes were dropped. Only ever executed on
+            // the overflow path, so the atomic RMW is off every normal mark.
+            if(!atomic_exchange_explicit(&gcMarkOverflowSeen, JAVA_TRUE, memory_order_release)) {
+                atomic_fetch_add_explicit(&cn1GcOverflowCycles, 1, memory_order_relaxed);
+            }
             break;
         }
         gcMarkWorklist[gcMarkWorklistTop] = lb->entries[i];
@@ -6487,7 +6589,10 @@ static inline void gcMarkWorklistPush(JAVA_OBJECT obj, JAVA_BOOLEAN force) {
     // Serial path: identical to the original single-threaded push.
     if(gcMarkWorklistTop >= CN1_GC_MARK_WORKLIST_SIZE) {
         gcMarkWorklistOverflow = JAVA_TRUE;
-        atomic_store_explicit(&gcMarkOverflowSeen, JAVA_TRUE, memory_order_release);
+        // See the matching exchange in gcMarkFlushLocal.
+        if(!atomic_exchange_explicit(&gcMarkOverflowSeen, JAVA_TRUE, memory_order_release)) {
+            atomic_fetch_add_explicit(&cn1GcOverflowCycles, 1, memory_order_relaxed);
+        }
         return;
     }
     gcMarkWorklist[gcMarkWorklistTop].obj = obj;
@@ -7860,6 +7965,7 @@ void initConstantPool() {
     // hook. Both are no-ops unless their environment variable is set.
     atexit(cn1ReportLowMemoryParks);
     atexit(cn1ReportPacingParks);
+    atexit(cn1ReportGcOverflow);
     cn1StartSimulatedMemoryWarnings();
 
     // it will wait two seconds unless an explicit GC occurs

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -563,6 +563,23 @@ static void cn1ReportPacingParks(void) {
 // RAM the machine running it happened to have free.
 static _Atomic long cn1GcOverflowCycles = 0;
 static _Atomic long cn1GcGraceDrains = 0;
+// Calls to the FULL gcMarkDrain, which rescans allObjectsInHeap from index 0 every time.
+// A cycle makes a fixed handful of them by construction (roots, each grace pass, the
+// belt, the SATB fixpoint), so this figure tracks the cycle count and nothing else.
+// Cheap enough to leave in: one relaxed increment on a path that already walks the whole
+// heap.
+static _Atomic long cn1GcFullDrains = 0;
+// Of those, the ones made while a GRACE PASS is running. Exactly one per pass -- the full
+// drain that ends it -- and that is the point: the passes ALSO drain periodically to keep
+// the worklist from overflowing, and those drains must be worklist-only. Pointing them at
+// gcMarkDrain instead makes the cost of a pass quadratic in the heap; measured as a Mac
+// Catalyst screenshot suite that never finished a single collection, with the EDT stacked
+// up in the pacing park behind it. A count that tracks the number of periodic drains
+// rather than the number of passes is that regression, and it is a property of the code
+// rather than a timing, so it fails the same way on any machine.
+static _Atomic long cn1GcGraceFullDrains = 0;
+// Set only while a grace pass is running, on the GC thread that runs it.
+static __thread int cn1GcInGracePass = 0;
 static _Atomic int cn1GcOverflowTrace = -1;
 static int cn1GcOverflowTraceOn(void) {
     int on = atomic_load_explicit(&cn1GcOverflowTrace, memory_order_relaxed);
@@ -577,9 +594,12 @@ static void cn1ReportGcOverflow(void) {
     if(!cn1GcOverflowTraceOn()) {
         return;
     }
-    fprintf(stderr, "[GC-OVERFLOW] overflowCycles=%ld graceDrains=%ld cycles=%d\n",
+    fprintf(stderr, "[GC-OVERFLOW] overflowCycles=%ld graceDrains=%ld fullDrains=%ld"
+                    " graceFullDrains=%ld cycles=%d\n",
             atomic_load_explicit(&cn1GcOverflowCycles, memory_order_relaxed),
             atomic_load_explicit(&cn1GcGraceDrains, memory_order_relaxed),
+            atomic_load_explicit(&cn1GcFullDrains, memory_order_relaxed),
+            atomic_load_explicit(&cn1GcGraceFullDrains, memory_order_relaxed),
             currentGcMarkValue);
 }
 
@@ -1290,6 +1310,9 @@ static void cn1DrainDeadThreadPending() {
     unlockCriticalSection();
 }
 static void gcMarkDrain(CODENAME_ONE_THREAD_STATE);
+// Worklist-only drain (no heap rescan) -- see its definition for why the two are
+// separate functions and which callers may use which.
+static void gcMarkDrainWorklist(CODENAME_ONE_THREAD_STATE);
 // Parallel variant of gcMarkDrain: fans the transitive mark-drain out across a small
 // pool of worker threads. Falls back to the serial gcMarkDrain when only one marker
 // is configured. Defined further down (after gcMarkDrain). See the big comment block
@@ -1829,6 +1852,7 @@ void codenameOneGCMark() {
 #else
         CN1BibopPage* gp = atomic_load_explicit(&bibopAllPages, memory_order_acquire);
 #endif
+        cn1GcInGracePass = 1;   // see cn1GcGraceFullDrains
         while(gp != 0) {
 #ifndef CN1_BIBOP_NO_FASTSWEEP
             if(__atomic_load_n(&gp->gcAllocedSinceSweep, __ATOMIC_RELAXED) == JAVA_FALSE) {
@@ -1875,12 +1899,19 @@ void codenameOneGCMark() {
             // it bounds the cursor, so the pass cannot overflow by volume. It must run
             // OUTSIDE the trusted window: a drain follows child words out of arbitrary
             // mark functions, which is exactly what the resolve guard is there for.
+            //
+            // gcMarkDrainWorklist, NOT gcMarkDrain: the latter also rescans
+            // allObjectsInHeap from index 0 on every call, which is affordable a few
+            // times a cycle and quadratic for a caller that drains periodically. Doing
+            // it here hung the Mac Catalyst suite outright. The pass still ends with a
+            // full gcMarkDrain, which is what closes the fixpoint.
             if(gcMarkWorklistTop >= CN1_GC_MARK_WORKLIST_SIZE / 2) {
                 atomic_fetch_add_explicit(&cn1GcGraceDrains, 1, memory_order_relaxed);
-                gcMarkDrain(d);
+                gcMarkDrainWorklist(d);
             }
         }
         gcMarkDrain(d);
+        cn1GcInGracePass = 0;
     }
     // A single page's slot walk runs between two of those checks, so the worklist must
     // have room for a whole page of pushes above the drain threshold. True by a wide
@@ -1915,6 +1946,7 @@ void codenameOneGCMark() {
 #ifdef CN1_GC_VERIFY
     { extern const char* cn1GcMarkPhase; cn1GcMarkPhase = "legacy-grace-pass"; }
 #endif
+        cn1GcInGracePass = 1;   // see cn1GcGraceFullDrains
         int gt = currentSizeOfAllObjectsInHeap;
         for(int gi = 0 ; gi < gt ; gi++) {
             JAVA_OBJECT go = allObjectsInHeap[gi];
@@ -1937,7 +1969,7 @@ void codenameOneGCMark() {
                 if(gcMarkWorklistTop >= CN1_GC_MARK_WORKLIST_SIZE / 2) {
                     atomic_fetch_add_explicit(&cn1GcGraceDrains, 1, memory_order_relaxed);
                     CN1_GC_TRUSTED_SUSPEND();
-                    gcMarkDrain(d);
+                    gcMarkDrainWorklist(d);
                     CN1_GC_TRUSTED_RESUME();
                 }
             }
@@ -1949,6 +1981,7 @@ void codenameOneGCMark() {
         // whose fields can dangle. That is precisely what the guard exists to stop.
         CN1_GC_TRUSTED_END();
         gcMarkDrain(d);
+        cn1GcInGracePass = 0;
     }
 #endif /* CN1_DISABLE_LEGACY_GRACE -- A/B escape hatch, mirrors CN1_DISABLE_SATB */
 
@@ -7290,73 +7323,99 @@ static JAVA_BOOLEAN cn1BibopRescanStep() {
 // starved, leaving their children unmarked and freeing reachable memory at sweep.
 // BiBOP page slots are NOT in allObjectsInHeap, so once an overflow is seen the rescan
 // additionally walks the page registry (cn1BibopRescan*) under the same fixed point.
+// Run the mark functions of everything currently on the worklist, and of everything they
+// push, until it is empty. NOTHING else -- no heap rescan, no fixpoint, no adopt-buffer
+// registration. That distinction is the whole reason this exists as its own function
+// (issue #5537).
+//
+// gcMarkDrain below is not "drain the worklist": every call to it also walks
+// allObjectsInHeap from index 0 and re-pushes every object already marked this cycle, so
+// that a marked-but-unscanned object left behind by an overflow gets its mark function
+// run. That is right for the handful of times a cycle calls it, and catastrophic for a
+// caller that needs to drain PERIODICALLY: the grace pass drains once per half-worklist,
+// which on a real app turned one O(table) rescan per cycle into hundreds of them. The
+// collector then never finished a cycle, mutators piled up in the pacing park, and the
+// app hung -- measured on the Mac Catalyst screenshot suite, where the legacy table is a
+// live UI rather than the handful of objects a translated micro-benchmark holds.
+//
+// Callers that need the fixpoint still call gcMarkDrain; a pass that only needs room in
+// the worklist calls this. Anything this leaves behind is picked up by the full drain
+// that ends the same pass.
+static void gcMarkDrainWorklist(CODENAME_ONE_THREAD_STATE) {
+    while(gcMarkWorklistTop > 0) {
+        gcMarkWorklistTop--;
+        JAVA_OBJECT obj = gcMarkWorklist[gcMarkWorklistTop].obj;
+        JAVA_BOOLEAN force = gcMarkWorklist[gcMarkWorklistTop].force;
+#ifdef CN1_BIBOP_VALIDATE
+        // The (serial) mark drain crashed here calling obj->parentCls->markFunction
+        // on an object whose parentCls is a non-null GARBAGE pointer (fp jumped into
+        // libc). A live, correctly-enqueued object always carries gcMark ==
+        // currentGcMarkValue (gcMarkObject stamps it BEFORE pushing) or -1 (grace),
+        // and a real clazz's markFunction lies in the app text (never a libc/heap
+        // address). Abort AT the source with the full object + fp state so the next
+        // run says whether this is a freed/reused slot (stale gcMark) or a
+        // corrupted-parentCls object.
+        {
+            gcMarkFunctionPointer __vfp = (obj != JAVA_NULL && !CN1_IS_TAGGED(obj)
+                && obj->__codenameOneParentClsReference != 0)
+                ? obj->__codenameOneParentClsReference->markFunction : (gcMarkFunctionPointer)0;
+            int __vmark = (obj != JAVA_NULL && !CN1_IS_TAGGED(obj)) ? obj->__codenameOneGcMark : -999;
+            int __vhp = (obj != JAVA_NULL && !CN1_IS_TAGGED(obj)) ? obj->__heapPosition : -999;
+            // A real markFunction lives in the app text segment; anchor off a
+            // known app function (&gcMarkObject) and flag any fp more than 256MB
+            // away (the observed garbage fp was a libc-range address).
+            uintptr_t __anchor = (uintptr_t)(void*)&gcMarkObject;
+            uintptr_t __fpv = (uintptr_t)(void*)__vfp;
+            int __fpBad = (__vfp != 0) &&
+                ((__fpv > __anchor ? __fpv - __anchor : __anchor - __fpv) > (256ULL << 20));
+            if(obj == JAVA_NULL || CN1_IS_TAGGED(obj) ||
+               obj->__codenameOneParentClsReference == 0 ||
+               (__vhp != CN1_BIBOP_HEAP_POS && __vhp != CN1_BIBOP_ADOPTED && __vhp < -1) ||
+               (__vmark != currentGcMarkValue && __vmark != -1) ||
+               __fpBad) {
+                fprintf(stderr, "CN1BIBOP MARKDRAIN CORRUPT: obj=%p tagged=%d parentCls=%p "
+                        "markFn=%p heapPosition=%d gcMark=%d curMark=%d FREE_MARK=%d force=%d\n",
+                        (void*)obj, (int)CN1_IS_TAGGED(obj),
+                        (obj && !CN1_IS_TAGGED(obj)) ? (void*)obj->__codenameOneParentClsReference : (void*)0,
+                        (void*)__vfp, __vhp, __vmark, currentGcMarkValue,
+                        CN1_BIBOP_FREE_MARK, (int)force);
+                fflush(stderr);
+                abort();
+            }
+        }
+#endif
+        gcMarkFunctionPointer fp = obj->__codenameOneParentClsReference->markFunction;
+        if(fp != 0) {
+#ifdef CN1_BIBOP_VALIDATE
+            gcMarkCurrentDrainObj = obj;
+#endif
+#if CN1_ADOPT_POLICY != 0 && !defined(CN1_DISABLE_BIBOP)
+            // Cascade: if this object has been MATURED, mature the children its mark
+            // function is about to mark, so the whole reachable subtree graduates
+            // together (never half a tree). Restored after the call.
+            JAVA_BOOLEAN __savedMaturing = gcCurrentlyMaturing;
+            gcCurrentlyMaturing = (obj->__heapPosition == CN1_BIBOP_ADOPTED) ? JAVA_TRUE : __savedMaturing;
+#endif
+            fp(threadStateData, obj, force);
+#if CN1_ADOPT_POLICY != 0 && !defined(CN1_DISABLE_BIBOP)
+            gcCurrentlyMaturing = __savedMaturing;
+#endif
+        }
+    }
+}
+
 static void gcMarkDrain(CODENAME_ONE_THREAD_STATE) {
+    atomic_fetch_add_explicit(&cn1GcFullDrains, 1, memory_order_relaxed);
+    if(cn1GcInGracePass) {
+        atomic_fetch_add_explicit(&cn1GcGraceFullDrains, 1, memory_order_relaxed);
+    }
     int rescanCursor = 0;
 #ifndef CN1_DISABLE_BIBOP
     JAVA_BOOLEAN bibopActive = JAVA_FALSE;
     JAVA_BOOLEAN bibopDone = JAVA_TRUE;
 #endif
     while(JAVA_TRUE) {
-        while(gcMarkWorklistTop > 0) {
-            gcMarkWorklistTop--;
-            JAVA_OBJECT obj = gcMarkWorklist[gcMarkWorklistTop].obj;
-            JAVA_BOOLEAN force = gcMarkWorklist[gcMarkWorklistTop].force;
-#ifdef CN1_BIBOP_VALIDATE
-            // The (serial) mark drain crashed here calling obj->parentCls->markFunction
-            // on an object whose parentCls is a non-null GARBAGE pointer (fp jumped into
-            // libc). A live, correctly-enqueued object always carries gcMark ==
-            // currentGcMarkValue (gcMarkObject stamps it BEFORE pushing) or -1 (grace),
-            // and a real clazz's markFunction lies in the app text (never a libc/heap
-            // address). Abort AT the source with the full object + fp state so the next
-            // run says whether this is a freed/reused slot (stale gcMark) or a
-            // corrupted-parentCls object.
-            {
-                gcMarkFunctionPointer __vfp = (obj != JAVA_NULL && !CN1_IS_TAGGED(obj)
-                    && obj->__codenameOneParentClsReference != 0)
-                    ? obj->__codenameOneParentClsReference->markFunction : (gcMarkFunctionPointer)0;
-                int __vmark = (obj != JAVA_NULL && !CN1_IS_TAGGED(obj)) ? obj->__codenameOneGcMark : -999;
-                int __vhp = (obj != JAVA_NULL && !CN1_IS_TAGGED(obj)) ? obj->__heapPosition : -999;
-                // A real markFunction lives in the app text segment; anchor off a
-                // known app function (&gcMarkObject) and flag any fp more than 256MB
-                // away (the observed garbage fp was a libc-range address).
-                uintptr_t __anchor = (uintptr_t)(void*)&gcMarkObject;
-                uintptr_t __fpv = (uintptr_t)(void*)__vfp;
-                int __fpBad = (__vfp != 0) &&
-                    ((__fpv > __anchor ? __fpv - __anchor : __anchor - __fpv) > (256ULL << 20));
-                if(obj == JAVA_NULL || CN1_IS_TAGGED(obj) ||
-                   obj->__codenameOneParentClsReference == 0 ||
-                   (__vhp != CN1_BIBOP_HEAP_POS && __vhp != CN1_BIBOP_ADOPTED && __vhp < -1) ||
-                   (__vmark != currentGcMarkValue && __vmark != -1) ||
-                   __fpBad) {
-                    fprintf(stderr, "CN1BIBOP MARKDRAIN CORRUPT: obj=%p tagged=%d parentCls=%p "
-                            "markFn=%p heapPosition=%d gcMark=%d curMark=%d FREE_MARK=%d force=%d\n",
-                            (void*)obj, (int)CN1_IS_TAGGED(obj),
-                            (obj && !CN1_IS_TAGGED(obj)) ? (void*)obj->__codenameOneParentClsReference : (void*)0,
-                            (void*)__vfp, __vhp, __vmark, currentGcMarkValue,
-                            CN1_BIBOP_FREE_MARK, (int)force);
-                    fflush(stderr);
-                    abort();
-                }
-            }
-#endif
-            gcMarkFunctionPointer fp = obj->__codenameOneParentClsReference->markFunction;
-            if(fp != 0) {
-#ifdef CN1_BIBOP_VALIDATE
-                gcMarkCurrentDrainObj = obj;
-#endif
-#if CN1_ADOPT_POLICY != 0 && !defined(CN1_DISABLE_BIBOP)
-                // Cascade: if this object has been MATURED, mature the children its mark
-                // function is about to mark, so the whole reachable subtree graduates
-                // together (never half a tree). Restored after the call.
-                JAVA_BOOLEAN __savedMaturing = gcCurrentlyMaturing;
-                gcCurrentlyMaturing = (obj->__heapPosition == CN1_BIBOP_ADOPTED) ? JAVA_TRUE : __savedMaturing;
-#endif
-                fp(threadStateData, obj, force);
-#if CN1_ADOPT_POLICY != 0 && !defined(CN1_DISABLE_BIBOP)
-                gcCurrentlyMaturing = __savedMaturing;
-#endif
-            }
-        }
+        gcMarkDrainWorklist(threadStateData);
 #ifndef CN1_DISABLE_BIBOP
 #if CN1_ADOPT_POLICY != 0
         // A rescan drain can mature more descendants. Register each batch before

--- a/vm/tests/src/test/java/com/codename1/tools/translator/GcOverflowSpiralIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/GcOverflowSpiralIntegrationTest.java
@@ -1,0 +1,385 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.tools.translator;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Regression guard for the mark-worklist overflow spiral of issue #5537.
+ *
+ * <p>The GC's grace pass walks the BiBOP page registry every cycle and marks every object
+ * allocated since the last one -- a fresh object can already be linked into the live
+ * graph, so it and its subtree have to survive. How many that is depends on the mutator's
+ * ALLOCATION RATE, not on the live set, and the pass pushed all of them onto a fixed
+ * 65536-entry worklist before draining any of it. A thread churning small short-lived
+ * objects produces several times that per cycle, so the worklist overflowed as a matter
+ * of course.</p>
+ *
+ * <p>Overflow is survivable -- the dropped entries are already marked, and the belt
+ * re-discovers their children -- but the belt is a full O(heap) rescan. It makes the
+ * cycle several times longer, the mutator produces proportionally more fresh objects
+ * before the next cycle, and that one overflows for certain: the collector never returns
+ * to its fast path. Measured on this workload before the fix, on an idle laptop:
+ * footprint 90MB to 6.2GB in 20 seconds against a live set of a few hundred bytes, cycle
+ * time 6ms to 750ms, and every cycle after the first tip overflowing. On an iPad that is
+ * a kill by the per-process ceiling; with #5563's pacing holding the process under that
+ * ceiling it is instead a thread parked on nearly every allocation, which is the frozen
+ * app the reporter saw next.</p>
+ *
+ * <p>The fix drains the worklist as the pass walks, so it cannot overflow by sheer
+ * volume. What is asserted is that property -- ZERO overflow cycles -- rather than a
+ * footprint number, because overflow is a property of the code while a peak is largely a
+ * property of the runner.</p>
+ *
+ * <p>The run is made under a simulated per-process ceiling
+ * ({@code CN1_SIMULATE_PROC_MEMORY_LIMIT}), which is both the situation the bug was
+ * reported from and the only shape that is safe to run unattended. Off a ceiling the
+ * pacing cap is a fraction of the HOST's free RAM, so on a developer Mac with tens of
+ * gigabytes spare this workload is licensed to build up more than ten gigabytes of
+ * garbage before anything stalls it -- with or without the fix, since that is the pacing
+ * policy rather than the defect under test. (On Linux and Windows the same run is bounded
+ * by the 72MB static cap, because cn1_available_memory has no host reading there.)</p>
+ *
+ * <p>Measured on this workload with the interleaved drain ablated out and everything else
+ * in place, under the same ceiling: 77 of 150 cycles overflowed, the mutator parked 72
+ * times, the run took 10.2s and rode 64MB from the ceiling. With the fix: 0 of 440 cycles
+ * overflowed, zero parks, 6.8s, 174MB of headroom left. Both finish -- what a regression
+ * costs here is the collector, not the result.</p>
+ *
+ * <p>Tagged {@code benchmark}: it needs a translate-and-build and churns several GB.</p>
+ */
+@Tag("benchmark")
+class GcOverflowSpiralIntegrationTest {
+
+    /**
+     * Bound on a single translated-binary run. The workload takes a few seconds; this is
+     * two orders of magnitude above that, so it can only be reached by a run that is not
+     * progressing -- which is itself one of the reported symptoms, so a timeout here is a
+     * result rather than an infrastructure problem.
+     */
+    private static final long VM_RUN_TIMEOUT_SECONDS = 300;
+
+    /**
+     * Synthetic per-process ceiling, standing in for the iPad's. Well above what this
+     * workload needs when the collector keeps up (it settles around 315MB), and the only
+     * configuration in which the run is bounded on every host -- see the class comment.
+     * {@code cn1ProcFootprintBytes} backs the hook with phys_footprint on Apple and
+     * /proc/self/statm on Linux; where neither exists (Windows) the hook is inert and the
+     * run falls back to the 72MB static volume cap, which bounds it just as well.
+     */
+    private static final long SIMULATED_LIMIT_BYTES = 512L * 1024 * 1024;
+
+    @Test
+    void aChurningWorkerNeverOverflowsTheMarkWorklist() throws Exception {
+        Parser.cleanup();
+
+        List<Path> tempDirs = new ArrayList<>();
+        try {
+            runSpiralLoad(tempDirs);
+        } finally {
+            for (Path dir : tempDirs) {
+                deleteRecursively(dir);
+            }
+        }
+    }
+
+    private void runSpiralLoad(List<Path> tempDirs) throws Exception {
+        Path sourceDir = Files.createTempDirectory("gc-overflow-sources");
+        Path classesDir = Files.createTempDirectory("gc-overflow-classes");
+        Path javaApiDir = Files.createTempDirectory("gc-overflow-javaapi");
+        tempDirs.add(sourceDir);
+        tempDirs.add(classesDir);
+        tempDirs.add(javaApiDir);
+
+        Path source = sourceDir.resolve("GcOverflowSpiralApp.java");
+        Files.write(source, loadAppSource().getBytes(StandardCharsets.UTF_8));
+
+        CompilerHelper.CompilerConfig config = selectCompiler();
+        if (config == null) {
+            fail("No compatible compiler available for the GC overflow spiral test");
+        }
+        assertTrue(CompilerHelper.isJavaApiCompatible(config),
+                "JDK " + config.jdkVersion + " must target matching bytecode level for JavaAPI");
+
+        CompilerHelper.compileJavaAPI(javaApiDir, config);
+
+        List<String> compileArgs = new ArrayList<>();
+        compileArgs.add("-source");
+        compileArgs.add(config.targetVersion);
+        compileArgs.add("-target");
+        compileArgs.add(config.targetVersion);
+        if (CompilerHelper.useClasspath(config)) {
+            compileArgs.add("-classpath");
+            compileArgs.add(javaApiDir.toString());
+        } else {
+            compileArgs.add("-bootclasspath");
+            compileArgs.add(javaApiDir.toString());
+            compileArgs.add("-Xlint:-options");
+        }
+        compileArgs.add("-d");
+        compileArgs.add(classesDir.toString());
+        compileArgs.add(source.toString());
+
+        assertEquals(0, CompilerHelper.compile(config.jdkHome, compileArgs),
+                "GcOverflowSpiralApp should compile. " + CompilerHelper.getLastErrorLog());
+
+        String javaResult = extractLine(runJavaMain(config, classesDir, javaApiDir), "RESULT=");
+        assertTrue(javaResult.startsWith("RESULT="), "JavaSE should produce RESULT=");
+
+        CompilerHelper.copyDirectory(javaApiDir, classesDir);
+
+        Path outputDir = Files.createTempDirectory("gc-overflow-output");
+        tempDirs.add(outputDir);
+        CleanTargetIntegrationTest.runTranslator(classesDir, outputDir, "GcOverflowSpiralApp");
+
+        Path distDir = outputDir.resolve("dist");
+        Path cmakeLists = distDir.resolve("CMakeLists.txt");
+        assertTrue(Files.exists(cmakeLists), "Translator should emit a CMake project");
+        CleanTargetIntegrationTest.replaceLibraryWithExecutableTarget(cmakeLists, "GcOverflowSpiralApp-src");
+
+        Path buildDir = distDir.resolve("build");
+        Files.createDirectories(buildDir);
+        List<String> cmakeArgs = new ArrayList<>(Arrays.asList(
+                "cmake", "-S", distDir.toString(), "-B", buildDir.toString(),
+                "-DCMAKE_BUILD_TYPE=Release"));
+        cmakeArgs.addAll(CompilerHelper.cmakeToolchainArgs());
+        CleanTargetIntegrationTest.runCommand(cmakeArgs, distDir);
+        CleanTargetIntegrationTest.runCommand(Arrays.asList("cmake", "--build", buildDir.toString()), distDir);
+
+        Path executable = buildDir.resolve(CompilerHelper.executableName("GcOverflowSpiralApp"));
+        assertTrue(Files.exists(executable), "ParparVM build should produce a runnable executable");
+
+        Map<String, String> env = new HashMap<String, String>();
+        env.put("CN1_LOG_GC_OVERFLOW", "1");
+        env.put("CN1_LOG_PACING_PARKS", "1");
+        env.put("CN1_SIMULATE_PROC_MEMORY_LIMIT", Long.toString(SIMULATED_LIMIT_BYTES));
+        String output = runVm(executable, buildDir, env);
+
+        assertTrue(output.contains("GC_OVERFLOW_SPIRAL_DONE"),
+                "The search must finish. Output: " + output);
+        assertEquals(javaResult, extractLine(output, "RESULT="),
+                "JavaSE and ParparVM should agree\n--- ParparVM ---\n" + output);
+
+        long overflowCycles = parseTrace(output, "overflowCycles=");
+        long graceDrains = parseTrace(output, "graceDrains=");
+        long cycles = parseTrace(output, "cycles=");
+        long peakKb = parseValue(output, "PEAK_FOOTPRINT_KB=");
+        System.err.println("[GcOverflowSpiralIntegrationTest] cycles=" + cycles
+                + " overflowCycles=" + overflowCycles + " graceDrains=" + graceDrains
+                + " peakKb=" + peakKb + " elapsedMs=" + parseValue(output, "ELAPSED_MS="));
+
+        // THE PROPERTY UNDER TEST. Not "few" overflows: none. This workload's live set is
+        // one path through the tree, so nothing here can legitimately fill a worklist
+        // sized for a whole constant pool -- every overflow would be pure allocation
+        // volume, and each one costs the belt's full O(heap) rescan.
+        assertEquals(0, overflowCycles,
+                "The mark worklist overflowed on " + overflowCycles + " of " + cycles
+                        + " collection cycles. Each overflow arms the belt's O(heap)"
+                        + " rescan, which lengthens the cycle, which leaves more fresh"
+                        + " objects for the next one to push -- the issue-5537 spiral, at"
+                        + " the end of which the process is killed by the iOS memory"
+                        + " ceiling or parked on nearly every allocation under it."
+                        + "\n--- run ---\n" + output);
+
+        // AND THAT THE FIX IS WHAT PREVENTED IT. Zero overflows is also what a run that
+        // never allocated much would report, so the guard needs evidence that the pass
+        // actually reached the drain threshold and drained instead of overflowing.
+        assertTrue(graceDrains > 0,
+                "The grace pass never drained mid-walk, so this workload never pushed"
+                        + " enough to approach the worklist limit and the assertion above"
+                        + " proves nothing. Check that the app still allocates small"
+                        + " reference-carrying objects at volume.\n--- run ---\n" + output);
+
+        // AND THE USER-VISIBLE PROPERTY the collector is there to provide: a live set of
+        // one path through a game tree stays inside a ceiling this workload never needs
+        // to approach. Under a real ceiling, crossing it is the process being killed.
+        assertTrue(peakKb < SIMULATED_LIMIT_BYTES / 1024,
+                "Peaked at " + peakKb + "KB against a "
+                        + (SIMULATED_LIMIT_BYTES / (1024 * 1024)) + "MB process budget,"
+                        + " so on a device this process would have been killed.\n--- run ---\n"
+                        + output);
+    }
+
+    private long parseTrace(String output, String key) {
+        for (String line : output.split("\\R")) {
+            if (line.startsWith("[GC-OVERFLOW] ")) {
+                for (String token : line.trim().split("\\s+")) {
+                    if (token.startsWith(key)) {
+                        return Long.parseLong(token.substring(key.length()).trim());
+                    }
+                }
+            }
+        }
+        fail("VM did not report " + key + " -- the CN1_LOG_GC_OVERFLOW tracer did not fire,"
+                + " so the guard cannot observe whether the worklist overflowed. Output: "
+                + output);
+        return -1;
+    }
+
+    /** Same preference order as the other translate-and-build guards. */
+    private CompilerHelper.CompilerConfig selectCompiler() {
+        String[] preferredTargets = {"11", "17", "21", "25", "1.8"};
+        for (String target : preferredTargets) {
+            List<CompilerHelper.CompilerConfig> configs = CompilerHelper.getAvailableCompilers(target);
+            for (CompilerHelper.CompilerConfig config : configs) {
+                if (CompilerHelper.isJavaApiCompatible(config)) {
+                    return config;
+                }
+            }
+        }
+        return null;
+    }
+
+    private long parseValue(String output, String prefix) {
+        String line = extractLine(output, prefix);
+        if (line.isEmpty()) {
+            fail("Missing " + prefix + " in output: " + output);
+        }
+        return Long.parseLong(line.substring(prefix.length()).trim());
+    }
+
+    private String extractLine(String output, String prefix) {
+        for (String line : output.split("\\R")) {
+            if (line.startsWith(prefix)) {
+                return line.trim();
+            }
+        }
+        return "";
+    }
+
+    private String loadAppSource() throws Exception {
+        java.io.InputStream in = GcOverflowSpiralIntegrationTest.class
+                .getResourceAsStream("/com/codename1/tools/translator/GcOverflowSpiralApp.java");
+        assertNotNull(in, "GcOverflowSpiralApp.java test resource should exist");
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
+            return reader.lines().collect(Collectors.joining("\n")) + "\n";
+        }
+    }
+
+    private String runJavaMain(CompilerHelper.CompilerConfig config, Path classesDir, Path javaApiDir)
+            throws Exception {
+        String javaExe = config.jdkHome.resolve("bin").resolve("java").toString();
+        if (System.getProperty("os.name").toLowerCase().contains("win")) {
+            javaExe += ".exe";
+        }
+        ProcessBuilder pb = new ProcessBuilder(javaExe, "-cp",
+                classesDir + System.getProperty("path.separator") + javaApiDir,
+                "GcOverflowSpiralApp");
+        pb.redirectErrorStream(true);
+        Process process = pb.start();
+        String output;
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+            output = reader.lines().collect(Collectors.joining("\n"));
+        }
+        assertEquals(0, process.waitFor(), "JVM run should exit cleanly. Output: " + output);
+        return output;
+    }
+
+    /**
+     * Runs the translated binary under a bounded wait, draining its output concurrently.
+     * Both halves matter: a regressed collector's failure mode under a budget is a run
+     * that never finishes, so the wait is bounded and the child killed on expiry, and the
+     * drain runs on its own thread so a child that fills the pipe buffer cannot deadlock
+     * against our wait.
+     */
+    private String runVm(Path executable, Path workingDir, Map<String, String> env) throws Exception {
+        ProcessBuilder builder = new ProcessBuilder(executable.toString());
+        builder.directory(workingDir.toFile());
+        builder.environment().putAll(env);
+        builder.redirectErrorStream(true);
+        final Process process = builder.start();
+
+        final StringBuilder captured = new StringBuilder();
+        Thread drain = new Thread(() -> {
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    synchronized (captured) {
+                        captured.append(line).append('\n');
+                    }
+                }
+            } catch (Exception e) {
+                // The stream ends abruptly when a timed-out child is destroyed; whatever
+                // was captured before that is exactly what we want to report.
+            }
+        });
+        drain.setDaemon(true);
+        drain.start();
+
+        boolean exited = process.waitFor(VM_RUN_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        if (!exited) {
+            process.destroyForcibly();
+            process.waitFor(10, TimeUnit.SECONDS);
+        }
+        drain.join(10_000);
+        String output;
+        synchronized (captured) {
+            output = captured.toString();
+        }
+
+        assertTrue(exited,
+                "ParparVM run did not finish within " + VM_RUN_TIMEOUT_SECONDS + "s (env "
+                        + env + "). For this guard that is a result: a collector stuck in"
+                        + " the overflow spiral under a memory budget parks the allocating"
+                        + " thread on nearly every allocation. Output so far: " + output);
+        assertEquals(0, process.exitValue(),
+                "ParparVM run should exit cleanly (env " + env + "). Output: " + output);
+        return output;
+    }
+
+    private static void deleteRecursively(Path path) throws Exception {
+        if (!Files.exists(path)) {
+            return;
+        }
+        Files.walk(path)
+                .sorted((a, b) -> b.getNameCount() - a.getNameCount())
+                .forEach(p -> {
+                    try {
+                        Files.deleteIfExists(p);
+                    } catch (Exception e) {
+                        // best effort cleanup of a temp tree
+                    }
+                });
+    }
+}

--- a/vm/tests/src/test/java/com/codename1/tools/translator/GcOverflowSpiralIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/GcOverflowSpiralIntegrationTest.java
@@ -229,6 +229,26 @@ class GcOverflowSpiralIntegrationTest {
                         + " proves nothing. Check that the app still allocates small"
                         + " reference-carrying objects at volume.\n--- run ---\n" + output);
 
+        // AND THAT THE PERIODIC DRAIN STAYED CHEAP. gcMarkDrain is not "drain the
+        // worklist": every call also rescans allObjectsInHeap from index 0 and re-runs the
+        // mark function of everything already marked. That is affordable for the ONE call
+        // that ends each grace pass and quadratic for a caller that drains periodically --
+        // the first cut at this fix pointed the interleaved drain at it, passed every test
+        // here, and hung the Mac Catalyst screenshot suite outright, whose retained graph
+        // is a live UI rather than a micro-benchmark's handful of objects. So the count of
+        // full drains taken INSIDE a grace pass must track the number of passes (two per
+        // cycle) and not the number of periodic drains, which is far larger.
+        long graceFullDrains = parseTrace(output, "graceFullDrains=");
+        long fullDrains = parseTrace(output, "fullDrains=");
+        assertTrue(graceFullDrains <= 2 * cycles + 4,
+                "The grace passes made " + graceFullDrains + " full heap-rescanning drains"
+                        + " across " + cycles + " cycles, where two per cycle -- one to end"
+                        + " each pass -- is all they may make. The extra ones are periodic"
+                        + " drains calling gcMarkDrain instead of gcMarkDrainWorklist, which"
+                        + " makes a pass quadratic in the heap; that is what hung the Mac"
+                        + " Catalyst suite. (graceDrains=" + graceDrains + " fullDrains="
+                        + fullDrains + ")\n--- run ---\n" + output);
+
         // AND THE USER-VISIBLE PROPERTY the collector is there to provide: a live set of
         // one path through a game tree stays inside a ceiling this workload never needs
         // to approach. Under a real ceiling, crossing it is the process being killed.

--- a/vm/tests/src/test/resources/com/codename1/tools/translator/GcOverflowSpiralApp.java
+++ b/vm/tests/src/test/resources/com/codename1/tools/translator/GcOverflowSpiralApp.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+/**
+ * The second shape of issue #5537: a deep game-tree search on a worker thread whose
+ * allocation is almost entirely short-lived SMALL objects, with a live set of one path
+ * through the tree.
+ *
+ * <p>Small is the whole point, and it is what makes this a different workload from
+ * {@code ProcessBudgetPacingApp}, whose blocks are all above CN1_BIBOP_MAX_OBJECT and so
+ * take the legacy calloc path. Everything here is a page-resident BiBOP object, which
+ * puts it in front of the grace pass: the collector walks the page registry every cycle
+ * and marks every object allocated since the last one, because a fresh object may
+ * already be linked into the live graph. The number of those is set by the mutator's
+ * ALLOCATION RATE, not by the live set -- and the pass used to push all of them onto a
+ * fixed 65536-entry mark worklist before draining any of it.</p>
+ *
+ * <p>Once that overflows, the collector arms its belt: a full O(heap) rescan to recover
+ * marked-but-unscanned objects. That makes the cycle several times longer, the mutator
+ * produces proportionally more fresh objects before the next cycle, and the next cycle
+ * overflows for certain. The collector never returns to the fast path. Measured on this
+ * workload before the fix: footprint 90MB -> 6.2GB in 20 seconds, cycle time 6ms -> 750ms,
+ * against a live set of a few hundred bytes. On device that is a kill by the iOS
+ * per-process ceiling; with the process-budget pacing of #5563 holding the process under
+ * that ceiling, it is instead a thread that parks on nearly every allocation, which is
+ * the "GC pauses become effectively continuous" the reporter saw next.</p>
+ *
+ * <p>The shape is tuned so the overflow is not marginal. Each node allocates one board
+ * copy plus a short chain of Move objects, so a 24MB collection interval covers roughly
+ * 190K fresh objects that carry references -- three times the worklist -- and the
+ * unfixed collector overflows on essentially every cycle rather than on the unlucky
+ * ones. Move carries references because only a non-leaf object is pushed; a board of
+ * ints is a leaf and never reaches the worklist.</p>
+ *
+ * <p>Deterministic by construction: a fixed number of rounds rather than a wall-clock
+ * budget, so RESULT can be compared against the same program on a stock JVM.</p>
+ */
+public class GcOverflowSpiralApp {
+
+    /** Board payload. 64 ints + header is ~272 bytes: a BiBOP size class, and a leaf. */
+    private static final int BOARD_CELLS = 64;
+
+    /** Branching factor and depth of the synthetic search. */
+    private static final int BRANCH = 6;
+    private static final int DEPTH = 5;
+
+    /** Move objects allocated per node. See the class comment: this is what oversubscribes
+     * the worklist, since only reference-carrying objects are pushed by the grace pass. */
+    private static final int MOVES_PER_NODE = 4;
+
+    /** Top-level searches. Sized for a few seconds and a few hundred collection cycles. */
+    private static final int ROUNDS = 50;
+
+    /** Distinct root moves explored per round. */
+    private static final int ROOT_MOVES = 64;
+
+    /** Footprint sample cadence, in nodes visited. Cheap next to the allocation it follows. */
+    private static final int SAMPLE_EVERY_NODES = 100000;
+
+    /** One node of the search: small, short-lived, and carrying references. */
+    static final class Move {
+        int from;
+        int to;
+        int score;
+        int[] board;
+        Move next;
+    }
+
+    static long nodes = 0;
+    static long peakKb = 0;
+    static long checksum = 0;
+    static long sampleCountdown = SAMPLE_EVERY_NODES;
+
+    public static void main(String[] args) {
+        System.out.println("CONFIG branch=" + BRANCH + " depth=" + DEPTH
+                + " movesPerNode=" + MOVES_PER_NODE + " rounds=" + ROUNDS);
+        long baselineKb = footprintKb();
+        peakKb = baselineKb;
+        System.out.println("BASELINE_FOOTPRINT_KB=" + baselineKb);
+
+        // On a WORKER thread, as the reporter's search is. The GC's grace pass and its
+        // root scanning both treat a non-EDT thread differently enough that running this
+        // on the main thread would not be the same test.
+        Thread worker = new Thread(new Runnable() {
+            public void run() {
+                long sum = 0;
+                int[] root = new int[BOARD_CELLS];
+                for (int r = 0; r < ROUNDS; r++) {
+                    for (int i = 0; i < ROOT_MOVES; i++) {
+                        sum += search(root, DEPTH, i + r);
+                    }
+                }
+                checksum = sum;
+            }
+        });
+        long startMs = System.currentTimeMillis();
+        worker.start();
+        try {
+            worker.join();
+        } catch (InterruptedException e) {
+        }
+        long elapsedMs = System.currentTimeMillis() - startMs;
+
+        System.out.println("PEAK_FOOTPRINT_KB=" + peakKb);
+        System.out.println("BASELINE_KB=" + baselineKb);
+        System.out.println("NODES=" + nodes);
+        System.out.println("ELAPSED_MS=" + elapsedMs);
+        System.out.println("RESULT=" + checksum);
+        System.out.println("GC_OVERFLOW_SPIRAL_DONE");
+    }
+
+    /**
+     * Recursive search. Every level copies the board and builds a small chain of moves,
+     * all of it dead the moment the level returns -- the allocation shape of a game-tree
+     * search with no transposition table.
+     */
+    private static int search(int[] board, int depth, int seed) {
+        nodes++;
+        if (--sampleCountdown <= 0) {
+            sampleCountdown = SAMPLE_EVERY_NODES;
+            long kb = footprintKb();
+            if (kb > peakKb) {
+                peakKb = kb;
+            }
+        }
+        if (depth == 0) {
+            int s = 0;
+            for (int i = 0; i < BOARD_CELLS; i++) {
+                s += board[i] * (i + 1);
+            }
+            return s & 0xff;
+        }
+        int best = -1;
+        for (int b = 0; b < BRANCH; b++) {
+            int[] child = new int[BOARD_CELLS];
+            for (int i = 0; i < BOARD_CELLS; i++) {
+                child[i] = board[i];
+            }
+            child[(seed + b * depth) & (BOARD_CELLS - 1)] = depth + b;
+            Move head = null;
+            for (int m = 0; m < MOVES_PER_NODE; m++) {
+                Move mv = new Move();
+                mv.from = seed;
+                mv.to = b + m;
+                mv.board = child;
+                mv.next = head;
+                head = mv;
+            }
+            int v = search(child, depth - 1, seed + b);
+            head.score = v;
+            if (v > best) {
+                best = v;
+            }
+        }
+        return best;
+    }
+
+    /**
+     * This process's phys_footprint in KB. Runtime.totalMemory() reports physical RAM and
+     * Runtime.freeMemory() reports physical RAM minus phys_footprint, so the difference is
+     * the footprint -- the same figure the kernel charges an app against. On a stock JVM
+     * the expression means something else entirely, which is why the JavaSE leg of the
+     * harness compares only RESULT.
+     */
+    private static long footprintKb() {
+        Runtime r = Runtime.getRuntime();
+        return (r.totalMemory() - r.freeMemory()) / 1024;
+    }
+}

--- a/vm/tests/src/test/resources/com/codename1/tools/translator/GcOverflowSpiralApp.java
+++ b/vm/tests/src/test/resources/com/codename1/tools/translator/GcOverflowSpiralApp.java
@@ -52,6 +52,11 @@
  * ones. Move carries references because only a non-leaf object is pushed; a board of
  * ints is a leaf and never reaches the worklist.</p>
  *
+ * <p>It also holds a retained legacy population for the whole run (see
+ * {@code LEGACY_BLOCKS}), so the collector's table walks cost something. Without that,
+ * this app cannot distinguish a periodic drain that is cheap from one that rescans the
+ * whole heap every time -- and the second is what hung a real app.</p>
+ *
  * <p>Deterministic by construction: a fixed number of rounds rather than a wall-clock
  * budget, so RESULT can be compared against the same program on a stock JVM.</p>
  */
@@ -77,6 +82,29 @@ public class GcOverflowSpiralApp {
     /** Footprint sample cadence, in nodes visited. Cheap next to the allocation it follows. */
     private static final int SAMPLE_EVERY_NODES = 100000;
 
+    /**
+     * A RETAINED legacy population, held for the whole run. Not decoration: every one of
+     * these is above CN1_BIBOP_MAX_OBJECT, so it lives in allObjectsInHeap, and the
+     * collector's full drain walks that table from index 0 on EVERY call, re-running the
+     * mark function of everything already marked. A workload whose table holds only what
+     * a translated hello-world allocates cannot tell a cheap periodic drain from an
+     * O(heap) one -- which is precisely how a first cut at this fix passed here and then
+     * hung the Mac Catalyst screenshot suite, whose table is a live UI.
+     *
+     * <p>REFERENCE-CARRYING on purpose. The rescan only re-pushes objects that have a
+     * mark function, so a population of primitive arrays is skipped and costs nothing:
+     * an earlier version of this app used byte[] and measured the two drains as equally
+     * fast. Object[] has a mark function that walks every slot, which is what a real
+     * app's retained graph looks like to the collector.</p>
+     */
+    private static final int LEGACY_BLOCKS = 256;
+
+    /** References per retained block: 128 * 8 bytes + header is over the 512 threshold. */
+    private static final int LEGACY_BLOCK_REFS = 128;
+
+    /** Held in a static so nothing here is collectable. */
+    static Object[][] legacyLiveSet;
+
     /** One node of the search: small, short-lived, and carrying references. */
     static final class Move {
         int from;
@@ -94,6 +122,20 @@ public class GcOverflowSpiralApp {
     public static void main(String[] args) {
         System.out.println("CONFIG branch=" + BRANCH + " depth=" + DEPTH
                 + " movesPerNode=" + MOVES_PER_NODE + " rounds=" + ROUNDS);
+        legacyLiveSet = new Object[LEGACY_BLOCKS][];
+        for (int i = 0; i < LEGACY_BLOCKS; i++) {
+            Object[] block = new Object[LEGACY_BLOCK_REFS];
+            // Every slot filled, so the mark function has real references to follow
+            // rather than nulls it can skip.
+            for (int j = 0; j < LEGACY_BLOCK_REFS; j++) {
+                Move held = new Move();
+                held.from = i;
+                held.to = j;
+                block[j] = held;
+            }
+            legacyLiveSet[i] = block;
+        }
+
         long baselineKb = footprintKb();
         peakKb = baselineKb;
         System.out.println("BASELINE_FOOTPRINT_KB=" + baselineKb);
@@ -125,7 +167,10 @@ public class GcOverflowSpiralApp {
         System.out.println("BASELINE_KB=" + baselineKb);
         System.out.println("NODES=" + nodes);
         System.out.println("ELAPSED_MS=" + elapsedMs);
-        System.out.println("RESULT=" + checksum);
+        // Keeps the population reachable to the end, and folds it into RESULT so the
+        // JavaSE comparison covers it too.
+        Move lastHeld = (Move) legacyLiveSet[LEGACY_BLOCKS - 1][LEGACY_BLOCK_REFS - 1];
+        System.out.println("RESULT=" + (checksum + lastHeld.from + lastHeld.to));
         System.out.println("GC_OVERFLOW_SPIRAL_DONE");
     }
 


### PR DESCRIPTION
A deep game-tree search that #5563 saved from an `EXC_RESOURCE` kill came back **frozen** instead -- GC pauses growing longer and more frequent until they were effectively continuous, with the simulator's footprint climbing to gigabytes while the app retained nothing. Both readings are the same defect, and it sits *under* the one #5563 fixed rather than beside it.

## Root cause

Every cycle the grace pass walks the BiBOP page registry and marks every object allocated since the last cycle -- a fresh object may already be linked into the live graph, so it and its subtree have to survive. How many that is depends on the mutator's **allocation rate**, not on the live set, and the pass pushed all of them onto a fixed 65536-entry worklist before draining any of it. A worker churning small short-lived objects produces several times that per cycle, so the worklist overflowed as a matter of course.

Overflow is survivable -- the dropped entries are already marked and the belt re-discovers their children -- but the belt is a full O(heap) rescan. It makes the cycle several times longer, the mutator leaves proportionally more fresh objects for the next one, and that one overflows for certain. The collector never returns to its fast path.

Every symptom on the issue follows from that one loop:

| symptom | mechanism |
|---|---|
| iPad killed at 1.42GB | the spiral, before any ceiling protection existed |
| app freezes, GC "effectively continuous" | #5563's pacing holds the process under the ceiling, so the spiral parks the mutator on nearly every allocation instead |
| simulator footprint climbing to GBs | same spiral where no per-process ceiling exists to bound it |

## The change

Both grace passes -- the page registry and the legacy table -- drain when the worklist reaches half capacity. That costs nothing the end-of-pass drain would not have cost anyway (the same objects are scanned, only sooner); what it buys is a cursor that cannot run away.

The drain runs **outside** the trusted window, via a new `CN1_GC_TRUSTED_SUSPEND/RESUME` pair (`BEGIN/END` save and restore a block-scoped local and so cannot express a hole inside a walk): a drain follows child words out of arbitrary mark functions, which is precisely what the resolve guard exists for. A `_Static_assert` pins the remaining assumption -- that a whole page of slots fits above the drain threshold -- so raising `CN1_BIBOP_PAGE_SIZE` fails the build rather than quietly restoring the spiral.

## Measured

Repro of the reporter's shape: worker thread, tree search, live set of one path through the tree.

**Realistic version, no ceiling:**

| | master | this PR |
|---|---|---|
| peak footprint | 6.2 GB | 231 MB |
| GC cycle time | 6ms -> 750ms | flat ~6ms |
| nodes searched | 189M | 247M |

**Heavier version under a 512MB simulated ceiling (the device case):**

| | master | this PR |
|---|---|---|
| cycles that overflowed | 77 of 150 | **0 of 440** |
| mutator parks (the "frozen" symptom) | 72 | 0 |
| wall clock | 10.2s | 6.8s |
| worst-case headroom left | 64 MB | 174 MB |

## Test

`GcOverflowSpiralIntegrationTest` asserts zero overflow cycles under a simulated ceiling, and that the pass actually reached its drain threshold -- otherwise the first assertion would pass on a run that never allocated. Ablating the drain and leaving everything else in place fails it with 77 overflows. Overflow cycles are counted through a new env-gated `[GC-OVERFLOW]` tracer, taken with an exchange on the existing flag so it reads once per cycle rather than once per dropped push.

Green locally: 519 non-benchmark ParparVM tests, and all 8 benchmark tests including `GcHeapIntegrity`, `LargeArrayGc`, `BibopPageFloor` and `ProcessBudgetPacing`.

## Not addressed here

Off a per-process ceiling the pacing cap is still a fraction of the **host's** free RAM, so on a RAM-rich Mac a sufficiently extreme allocator can build gigabytes of garbage before anything stalls it. A live-set-relative cap and an absolute cap were both measured and rejected -- each cost 2-4x throughput, because a volume-cap park waits out a whole collection while the footprint-based admission used under a real ceiling is both bounded and free. Extending that admission to hosts that have a footprint probe but no ceiling is the right fix and needs its own benchmarking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)