### PR TITLE
Ready-made scanners on top of the on-device vision API

### DIFF
--- a/CodenameOne/src/com/codename1/ai/vision/BarcodeFormat.java
+++ b/CodenameOne/src/com/codename1/ai/vision/BarcodeFormat.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.ai.vision;
+
+/// The normalized symbology names {@link Barcode#getFormat()} reports, as
+/// constants instead of literals. Every backend maps its own vendor identifier
+/// onto one of these before the result reaches application code, and reports
+/// {@link #UNKNOWN} for a symbology outside this set.
+///
+/// ```java
+/// scanner.process(VisionImage.encoded(jpeg)).ready(codes -> {
+///     for (Barcode code : codes) {
+///         if (BarcodeFormat.matches(code, BarcodeFormat.QR_CODE)) {
+///             Log.p("QR: " + code.getValue());
+///         } else if (BarcodeFormat.matches(code, BarcodeFormat.EAN_13,
+///                 BarcodeFormat.UPC_A)) {
+///             lookUpProduct(code.getValue());
+///         }
+///     }
+/// });
+/// ```
+public final class BarcodeFormat {
+    /// Aztec two-dimensional code, common on transit tickets.
+    public static final String AZTEC = "AZTEC";
+    /// Codabar linear code, used by libraries and blood banks.
+    public static final String CODABAR = "CODABAR";
+    /// Code 39 linear code.
+    public static final String CODE_39 = "CODE_39";
+    /// Code 93 linear code.
+    public static final String CODE_93 = "CODE_93";
+    /// Code 128 linear code, the usual choice for shipping labels.
+    public static final String CODE_128 = "CODE_128";
+    /// Data Matrix two-dimensional code, common on small parts.
+    public static final String DATA_MATRIX = "DATA_MATRIX";
+    /// EAN-8 retail product code.
+    public static final String EAN_8 = "EAN_8";
+    /// EAN-13 retail product code.
+    public static final String EAN_13 = "EAN_13";
+    /// Interleaved 2 of 5 linear code.
+    public static final String ITF = "ITF";
+    /// PDF417 stacked code, used by driving licences and boarding passes.
+    public static final String PDF417 = "PDF417";
+    /// QR code.
+    public static final String QR_CODE = "QR_CODE";
+    /// UPC-A retail product code.
+    public static final String UPC_A = "UPC_A";
+    /// UPC-E retail product code.
+    public static final String UPC_E = "UPC_E";
+    /// Reported when the backend decoded a code whose symbology has no
+    /// portable name here.
+    public static final String UNKNOWN = "UNKNOWN";
+
+    private BarcodeFormat() {
+    }
+
+    /// Tests a decoded barcode against a set of accepted formats. An empty or
+    /// {@code null} format list accepts every symbology, which is what a
+    /// general-purpose scanner wants.
+    ///
+    /// @param barcode observation to test, or {@code null}
+    /// @param formats accepted format constants
+    /// @return {@code true} when the barcode's format is one of {@code formats}
+    public static boolean matches(Barcode barcode, String... formats) {
+        if (barcode == null) {
+            return false;
+        }
+        if (formats == null || formats.length == 0) {
+            return true;
+        }
+        String format = barcode.getFormat();
+        for (String accepted : formats) {
+            if (accepted != null && accepted.equals(format)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/CodenameOne/src/com/codename1/ai/vision/BarcodeScanner.java
+++ b/CodenameOne/src/com/codename1/ai/vision/BarcodeScanner.java
@@ -22,7 +22,49 @@
  */
 package com.codename1.ai.vision;
 
-/// Creates reusable still-image or live-frame barcode analyzers.
+/// Decodes barcodes and QR codes out of a still image or a camera frame.
+///
+/// Scanning a picture the user already has:
+///
+/// ```java
+/// BarcodeScanner scanner = new BarcodeScanner();
+/// if (!scanner.isSupported()) {
+///     ToastBar.showErrorMessage("This device cannot decode barcodes");
+///     scanner.close();
+///     return;
+/// }
+/// scanner.process(VisionImage.fromFile(photoPath)).ready(codes -> {
+///     for (Barcode code : codes) {
+///         Log.p(code.getFormat() + ": " + code.getValue());
+///     }
+///     scanner.close();
+/// }).except(error -> {
+///     Log.e(error);
+///     scanner.close();
+/// });
+/// ```
+///
+/// For scanning with the camera there is usually no reason to wire this up
+/// yourself. {@link CodeScanner#scan()} is a whole scanner screen in one call,
+/// and {@link VisionCameraView} embeds the live preview in a form of your own:
+///
+/// ```java
+/// VisionCameraView<Barcode[]> view =
+///         new VisionCameraView<Barcode[]>(new BarcodeScanner());
+/// view.setListener(new VisionPipelineListener<Barcode[]>() {
+///     public void result(Barcode[] codes, VisionImage source) {
+///         if (codes.length > 0) {
+///             found(codes[0]);
+///         }
+///     }
+///     public void error(Throwable error) {
+///         Log.e(error);
+///     }
+/// });
+/// ```
+///
+/// Create one analyzer and reuse it for a sequence of images; it keeps the
+/// native detector alive between calls. Close it when you are finished.
 public final class BarcodeScanner extends AbstractVisionAnalyzer<Barcode[]> {
     /// Creates an analyzer using the platform default backend and options.
     /// @see VisionOptions

--- a/CodenameOne/src/com/codename1/ai/vision/CodeScanner.java
+++ b/CodenameOne/src/com/codename1/ai/vision/CodeScanner.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.ai.vision;
+
+import com.codename1.camera.Camera;
+import com.codename1.camera.CameraInfo;
+import com.codename1.ui.Button;
+import com.codename1.ui.Command;
+import com.codename1.ui.Container;
+import com.codename1.ui.Display;
+import com.codename1.ui.FontImage;
+import com.codename1.ui.Form;
+import com.codename1.ui.Toolbar;
+import com.codename1.ui.events.ActionEvent;
+import com.codename1.ui.events.ActionListener;
+import com.codename1.ui.layouts.BorderLayout;
+import com.codename1.ui.layouts.FlowLayout;
+import com.codename1.components.SpanLabel;
+import com.codename1.util.AsyncResource;
+
+/// A ready-made full-screen barcode and QR scanner.
+///
+/// This is the one-call entry point that {@link BarcodeScanner} deliberately
+/// is not. It shows a camera form, decodes codes from the live frames, returns
+/// the first accepted one, and restores the form the application was on. Use
+/// {@link BarcodeScanner} directly when scanning a still image or when the
+/// scanner has to look like the rest of a custom camera screen, and
+/// {@link VisionCameraView} when the preview belongs inside a form of your own.
+///
+/// ```java
+/// if (!CodeScanner.isSupported()) {
+///     ToastBar.showErrorMessage("This device cannot scan codes");
+///     return;
+/// }
+/// CodeScanner.scan().ready(code -> {
+///     if (code == null) {
+///         return;                       // the user pressed back
+///     }
+///     urlField.setText(code.getValue());
+/// }).except(error -> Log.e(error));
+/// ```
+///
+/// Restrict the symbologies, and reword the screen, through
+/// {@link CodeScannerOptions}:
+///
+/// ```java
+/// CodeScanner.scan(new CodeScannerOptions()
+///         .title("Boarding pass")
+///         .hint("Hold the pass flat inside the frame")
+///         .formats(BarcodeFormat.PDF417, BarcodeFormat.AZTEC))
+///     .ready(code -> {
+///         if (code != null) {
+///             checkIn(code.getValue());
+///         }
+///     });
+/// ```
+///
+/// The result completes with {@code null} when the user backs out, which is
+/// how the old `CodeScanner` cn1lib's `scanCanceled()` maps onto an
+/// {@link AsyncResource}. A failure to open the camera or run the decoder
+/// arrives through {@link AsyncResource#except} instead, and closes the
+/// scanner form.
+///
+/// Referencing this class is what tells the build pipeline to package barcode
+/// scanning and the camera, exactly as referencing {@link BarcodeScanner}
+/// does. It adds no other vision model.
+///
+/// **Import the right one.** Two older classes share this simple name and this
+/// class replaces both: the {@code cn1-codescan} cn1lib's
+/// {@code com.codename1.ext.codescan.CodeScanner}, and the long-deprecated
+/// {@link com.codename1.codescan.CodeScanner} in core, whose
+/// {@code getInstance()} returns {@code null} on current targets. Make sure
+/// the import reads:
+///
+/// ```java
+/// import com.codename1.ai.vision.CodeScanner;
+/// ```
+///
+/// Migrating from either is mechanical. The cn1lib's three-method
+/// {@code ScanResult} callback becomes one asynchronous result:
+/// {@code scanCompleted} is {@link AsyncResource#ready}, {@code scanCanceled}
+/// is a {@code null} value, and {@code scanError} is
+/// {@link AsyncResource#except}.
+public final class CodeScanner {
+    private CodeScanner() {
+    }
+
+    /// Whether this device can run the scanner. This is the check to make
+    /// before offering a scan button: it covers both the camera and the
+    /// barcode backend, either of which a target may lack.
+    ///
+    /// @return {@code true} when {@link #scan()} can open a working scanner
+    public static boolean isSupported() {
+        if (!Camera.isSupported()) {
+            return false;
+        }
+        BarcodeScanner scanner = new BarcodeScanner();
+        try {
+            return scanner.isSupported();
+        } finally {
+            scanner.close();
+        }
+    }
+
+    /// Shows the scanner with the default wording, accepting every symbology
+    /// the platform decodes.
+    ///
+    /// @return the first decoded code, or {@code null} if the user backed out
+    public static AsyncResource<Barcode> scan() {
+        return scan(null);
+    }
+
+    /// Shows the scanner configured by {@code options}.
+    ///
+    /// @param options the scanner configuration, or {@code null} for the
+    ///        defaults
+    /// @return the first accepted code, or {@code null} if the user backed out
+    public static AsyncResource<Barcode> scan(CodeScannerOptions options) {
+        return new Session(options == null
+                ? new CodeScannerOptions() : options).show();
+    }
+
+    /// One showing of the scanner form. Holds the state that the camera view,
+    /// the back command, and the result callback all have to agree on, so that
+    /// a code arriving in the same frame the user pressed back cannot deliver
+    /// two results or restore the previous form twice.
+    private static final class Session
+            implements VisionPipelineListener<Barcode[]> {
+        private final CodeScannerOptions options;
+        private final AsyncResource<Barcode> result =
+                new AsyncResource<Barcode>();
+        private final String[] formats;
+        private final VisionCameraView<Barcode[]> view;
+        private Form previous;
+        private Form scannerForm;
+        private boolean finished;
+
+        Session(CodeScannerOptions options) {
+            this.options = options;
+            this.formats = options.getFormats();
+            this.view = new VisionCameraView<Barcode[]>(
+                    new BarcodeScanner(options.getVisionOptions()));
+            this.view.setFacing(options.getFacing());
+        }
+
+        AsyncResource<Barcode> show() {
+            // Installed here rather than in the constructor so `this` does not
+            // escape before the session is fully built.
+            view.setListener(this);
+
+            previous = Display.getInstance().getCurrent();
+            scannerForm = new Form(new BorderLayout());
+            Toolbar toolbar = scannerForm.getToolbar();
+            if (toolbar == null) {
+                toolbar = new Toolbar();
+                scannerForm.setToolbar(toolbar);
+            }
+            if (options.getTitle() != null) {
+                scannerForm.setTitle(options.getTitle());
+            }
+            Command back = Command.create("", null,
+                    new ActionListener<ActionEvent>() {
+                        @Override
+                        public void actionPerformed(ActionEvent event) {
+                            finish(null, null);
+                        }
+                    });
+            toolbar.setBackCommand(back, Toolbar.BackCommandPolicy.ALWAYS);
+            scannerForm.add(BorderLayout.CENTER, view);
+            Container footer = buildFooter();
+            if (footer != null) {
+                scannerForm.add(BorderLayout.SOUTH, footer);
+            }
+            scannerForm.show();
+            // Showing the form installs the toolbar's own menu bar, which
+            // drops a back command registered against the one the form had
+            // before. Re-register it so the Android hardware back button and
+            // the iOS edge swipe dismiss the scanner, not just the arrow.
+            scannerForm.setBackCommand(back);
+            return result;
+        }
+
+        private Container buildFooter() {
+            Container footer = new Container(new BorderLayout());
+            boolean populated = false;
+            if (options.getHint() != null) {
+                footer.add(BorderLayout.CENTER, new SpanLabel(options.getHint()));
+                populated = true;
+            }
+            if (options.isTorchButton() && hasFlash()) {
+                final Button torch = new Button("");
+                FontImage.setMaterialIcon(torch, FontImage.MATERIAL_FLASH_ON);
+                torch.addActionListener(new ActionListener() {
+                    private boolean on;
+
+                    @Override
+                    public void actionPerformed(ActionEvent event) {
+                        on = !on;
+                        view.setTorchEnabled(on);
+                        FontImage.setMaterialIcon(torch, on
+                                ? FontImage.MATERIAL_FLASH_OFF
+                                : FontImage.MATERIAL_FLASH_ON);
+                    }
+                });
+                footer.add(BorderLayout.EAST,
+                        FlowLayout.encloseCenterMiddle(torch));
+                populated = true;
+            }
+            return populated ? footer : null;
+        }
+
+        /// Whether the camera this scan will open has a flash. Asked of the
+        /// enumerated camera rather than the open session, because the footer
+        /// is built before the form is shown and the session does not exist
+        /// yet.
+        ///
+        /// @return {@code true} when a torch toggle is worth offering
+        private boolean hasFlash() {
+            CameraInfo info = Camera.getDefault(options.getFacing());
+            return info != null && info.hasFlash();
+        }
+
+        @Override
+        public void result(Barcode[] codes, VisionImage source) {
+            if (codes == null) {
+                return;
+            }
+            for (Barcode code : codes) {
+                if (code != null && code.getValue() != null
+                        && BarcodeFormat.matches(code, formats)) {
+                    finish(code, null);
+                    return;
+                }
+            }
+        }
+
+        @Override
+        public void error(Throwable error) {
+            finish(null, error);
+        }
+
+        private void finish(Barcode code, Throwable error) {
+            if (finished) {
+                return;
+            }
+            finished = true;
+            view.close();
+            if (previous != null) {
+                previous.showBack();
+            }
+            if (error != null) {
+                result.error(error);
+            } else {
+                result.complete(code);
+            }
+        }
+    }
+}

--- a/CodenameOne/src/com/codename1/ai/vision/CodeScanner.java
+++ b/CodenameOne/src/com/codename1/ai/vision/CodeScanner.java
@@ -111,7 +111,10 @@ public final class CodeScanner {
     ///
     /// @return {@code true} when {@link #scan()} can open a working scanner
     public static boolean isSupported() {
-        if (!Camera.isSupported()) {
+        // Camera.isSupported() only says the port has a backend; a device with
+        // no capture hardware enumerates nothing and the scan would fail
+        // immediately after this method promised it would not.
+        if (!Camera.isSupported() || Camera.getCameras().length == 0) {
             return false;
         }
         BarcodeScanner scanner = new BarcodeScanner();

--- a/CodenameOne/src/com/codename1/ai/vision/CodeScannerOptions.java
+++ b/CodenameOne/src/com/codename1/ai/vision/CodeScannerOptions.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.ai.vision;
+
+import com.codename1.camera.CameraFacing;
+
+/// Configuration for {@link CodeScanner#scan(CodeScannerOptions)}. Every
+/// setting has a working default, so an application usually changes only the
+/// wording and the accepted symbologies.
+///
+/// ```java
+/// CodeScanner.scan(new CodeScannerOptions()
+///         .title("Scan the ticket")
+///         .hint("Hold the QR code inside the frame")
+///         .formats(BarcodeFormat.QR_CODE, BarcodeFormat.AZTEC))
+///     .ready(code -> {
+///         if (code == null) {
+///             return;              // the user pressed back
+///         }
+///         admit(code.getValue());
+///     })
+///     .except(error -> Log.e(error));
+/// ```
+public final class CodeScannerOptions {
+    private String title = "Scan";
+    private String hint = "Point the camera at a code";
+    private String[] formats = new String[0];
+    private CameraFacing facing = CameraFacing.BACK;
+    private boolean torchButton = true;
+    private VisionOptions visionOptions;
+
+    /// Sets the scanner form's title.
+    ///
+    /// @param value the title, or {@code null} for no title
+    /// @return this options object
+    public CodeScannerOptions title(String value) {
+        title = value;
+        return this;
+    }
+
+    /// Sets the instruction shown below the preview.
+    ///
+    /// @param value the instruction, or {@code null} to show none
+    /// @return this options object
+    public CodeScannerOptions hint(String value) {
+        hint = value;
+        return this;
+    }
+
+    /// Restricts which symbologies are accepted, using the
+    /// {@link BarcodeFormat} constants. A code in any other format is ignored
+    /// and scanning continues, which is what an application that expects a
+    /// specific kind of code wants: a stray product barcode in the frame does
+    /// not end the scan. The default accepts every format the backend decodes.
+    ///
+    /// This filters results rather than configuring the detector, so it does
+    /// not make scanning faster.
+    ///
+    /// @param values accepted format constants; empty or {@code null} accepts
+    ///        every format
+    /// @return this options object
+    public CodeScannerOptions formats(String... values) {
+        if (values == null) {
+            formats = new String[0];
+        } else {
+            formats = new String[values.length];
+            System.arraycopy(values, 0, formats, 0, values.length);
+        }
+        return this;
+    }
+
+    /// Selects which camera the scanner opens.
+    ///
+    /// @param value the camera to use, or {@code null} for the back camera
+    /// @return this options object
+    public CodeScannerOptions facing(CameraFacing value) {
+        facing = value == null ? CameraFacing.BACK : value;
+        return this;
+    }
+
+    /// Whether to offer a torch toggle. The button appears only when the open
+    /// camera actually has a flash, so leaving this enabled is safe. The
+    /// default is {@code true}.
+    ///
+    /// @param value whether the toggle may be shown
+    /// @return this options object
+    public CodeScannerOptions torchButton(boolean value) {
+        torchButton = value;
+        return this;
+    }
+
+    /// Passes analyzer options through to the underlying
+    /// {@link BarcodeScanner}, which is how an iOS build selects
+    /// {@link VisionBackends#mlKitBarcodeScanning()} instead of Apple Vision.
+    ///
+    /// @param value analyzer configuration, or {@code null} for the defaults
+    /// @return this options object
+    public CodeScannerOptions visionOptions(VisionOptions value) {
+        visionOptions = value;
+        return this;
+    }
+
+    /// @return the scanner form's title, possibly {@code null}
+    public String getTitle() {
+        return title;
+    }
+
+    /// @return the instruction shown below the preview, possibly {@code null}
+    public String getHint() {
+        return hint;
+    }
+
+    /// @return defensive copy of the accepted formats; empty accepts all
+    public String[] getFormats() {
+        String[] out = new String[formats.length];
+        System.arraycopy(formats, 0, out, 0, formats.length);
+        return out;
+    }
+
+    /// @return the camera the scanner opens
+    public CameraFacing getFacing() {
+        return facing;
+    }
+
+    /// @return whether a torch toggle may be shown
+    public boolean isTorchButton() {
+        return torchButton;
+    }
+
+    /// @return the analyzer configuration, or {@code null} for the defaults
+    public VisionOptions getVisionOptions() {
+        return visionOptions;
+    }
+}

--- a/CodenameOne/src/com/codename1/ai/vision/DocumentScanner.java
+++ b/CodenameOne/src/com/codename1/ai/vision/DocumentScanner.java
@@ -22,7 +22,32 @@
  */
 package com.codename1.ai.vision;
 
-/// Creates reusable document-boundary and perspective-correction analyzers.
+/// Finds a page in a photo and returns it flattened, with the perspective
+/// corrected.
+///
+/// ```java
+/// DocumentScanner scanner = new DocumentScanner();
+/// if (!scanner.isSupported()) {
+///     // Android's document scanner is an interactive Google flow rather than
+///     // an analyzer, so this reports unsupported there.
+///     scanner.close();
+///     return;
+/// }
+/// scanner.process(VisionImage.fromFile(photoPath)).ready(result -> {
+///     for (int i = 0; i < result.getPageCount(); i++) {
+///         pages.add(EncodedImage.create(result.getPage(i)));
+///     }
+///     scanner.close();
+/// }).except(error -> {
+///     Log.e(error);
+///     scanner.close();
+/// });
+/// ```
+///
+/// This is a still-image analyzer: capture the photo however you like -- the
+/// {@link com.codename1.capture.Capture} API, a
+/// {@link com.codename1.camera.CameraSession}, or the gallery -- and hand the
+/// bytes over.
 public final class DocumentScanner extends AbstractVisionAnalyzer<DocumentScanResult> {
     /// Creates an analyzer using the platform default backend and options.
     /// @see VisionOptions

--- a/CodenameOne/src/com/codename1/ai/vision/Face.java
+++ b/CodenameOne/src/com/codename1/ai/vision/Face.java
@@ -31,6 +31,24 @@ import java.util.Map;
 /// <p>Euler angles are expressed in degrees. Bounds and landmark points use
 /// the normalized, top-left-origin coordinate space defined by
 /// {@link VisionRect} and {@link VisionPoint}.</p>
+///
+/// <p>Not every backend fills in every field. {@link #getSmilingProbability()}
+/// and {@link #getTrackingId()} return a negative value when the backend does
+/// not expose them -- Apple Vision reports neither -- and a landmark the
+/// backend could not locate is absent from the map. Test for those rather than
+/// assuming a complete observation.</p>
+///
+/// ```java
+/// FaceDetector detector = new FaceDetector();
+/// detector.process(VisionImage.encoded(jpeg)).ready(faces -> {
+///     for (Face face : faces) {
+///         Rectangle box = face.getBounds().toBounds(photoLabel);
+///         if (face.getSmilingProbability() > 0.7f) {
+///             Log.p("smiling face at " + box);
+///         }
+///     }
+/// }).except(error -> Log.e(error));
+/// ```
 public final class Face {
     private final VisionRect bounds;
     private final Map<String, VisionPoint> landmarks;
@@ -84,6 +102,19 @@ public final class Face {
     /// @return normalized top-left-origin face bounds
     public VisionRect getBounds() {
         return bounds;
+    }
+
+    /// Looks up one named landmark.
+    ///
+    /// A landmark the backend could not locate is absent rather than present
+    /// at a meaningless position, so a {@code null} return means "not found in
+    /// this face", not "unsupported".
+    ///
+    /// @param name one of the {@link FaceLandmarks} constants
+    /// @return the normalized landmark position, or {@code null} when the
+    ///         backend did not report it
+    public VisionPoint getLandmark(String name) {
+        return name == null ? null : landmarks.get(name);
     }
 
     /// @return immutable named landmark map; possibly empty

--- a/CodenameOne/src/com/codename1/ai/vision/FaceDetector.java
+++ b/CodenameOne/src/com/codename1/ai/vision/FaceDetector.java
@@ -22,7 +22,55 @@
  */
 package com.codename1.ai.vision;
 
-/// Creates reusable on-device face analyzers.
+/// Finds faces, their bounding boxes, their head angles, and -- where the
+/// backend supports it -- whether they are smiling.
+///
+/// Counting faces in the live camera, which is the usual shape for a selfie
+/// screen or a "hold still" capture:
+///
+/// ```java
+/// VisionCameraView<Face[]> view =
+///         new VisionCameraView<Face[]>(new FaceDetector());
+/// view.setFacing(CameraFacing.FRONT);
+/// view.setListener(new VisionPipelineListener<Face[]>() {
+///     public void result(Face[] faces, VisionImage source) {
+///         shutter.setEnabled(faces.length == 1);
+///         status.setText(faces.length == 1
+///                 ? "Looking good" : "Fit exactly one face in the frame");
+///     }
+///     public void error(Throwable error) {
+///         Log.e(error);
+///     }
+/// });
+///
+/// Form form = new Form("Selfie", new BorderLayout());
+/// form.add(BorderLayout.CENTER, view);
+/// form.add(BorderLayout.SOUTH, BoxLayout.encloseY(status, shutter));
+/// form.show();
+/// ```
+///
+/// Or over a still image, to crop to the face:
+///
+/// ```java
+/// FaceDetector detector = new FaceDetector();
+/// detector.process(VisionImage.fromImage(photo)).ready(faces -> {
+///     if (faces.length > 0) {
+///         Rectangle box = faces[0].getBounds()
+///                 .toBounds(0, 0, photo.getWidth(), photo.getHeight());
+///         avatar.setIcon(photo.subImage(box.getX(), box.getY(),
+///                 box.getWidth(), box.getHeight(), true));
+///     }
+///     detector.close();
+/// }).except(error -> {
+///     Log.e(error);
+///     detector.close();
+/// });
+/// ```
+///
+/// Read individual landmarks with {@link Face#getLandmark(String)} and the
+/// {@link FaceLandmarks} constants. Not every backend fills in every field:
+/// {@link Face#getSmilingProbability()} and {@link Face#getTrackingId()} are
+/// negative when unavailable.
 public final class FaceDetector extends AbstractVisionAnalyzer<Face[]> {
     /// Creates an analyzer using the platform default backend and options.
     /// @see VisionOptions

--- a/CodenameOne/src/com/codename1/ai/vision/FaceLandmarks.java
+++ b/CodenameOne/src/com/codename1/ai/vision/FaceLandmarks.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.ai.vision;
+
+/// The keys {@link Face#getLandmarks()} uses, as constants instead of
+/// literals. Every backend normalizes its own landmark identifiers onto these
+/// names; a landmark the backend could not locate is absent from the map
+/// rather than present with a meaningless position, so read one through
+/// {@link Face#getLandmark(String)} and check for {@code null}.
+///
+/// ```java
+/// detector.process(VisionImage.fromCameraFrame(frame)).ready(faces -> {
+///     for (Face face : faces) {
+///         VisionPoint left = face.getLandmark(FaceLandmarks.LEFT_EYE);
+///         VisionPoint right = face.getLandmark(FaceLandmarks.RIGHT_EYE);
+///         if (left != null && right != null) {
+///             placeGlasses(left.toPoint(preview), right.toPoint(preview));
+///         }
+///     }
+/// });
+/// ```
+public final class FaceLandmarks {
+    /// Center of the subject's left eye, which appears on the right of the image.
+    public static final String LEFT_EYE = "leftEye";
+    /// Center of the subject's right eye, which appears on the left of the image.
+    public static final String RIGHT_EYE = "rightEye";
+    /// Base of the nose, between the nostrils.
+    public static final String NOSE_BASE = "noseBase";
+    /// Left corner of the mouth.
+    public static final String MOUTH_LEFT = "mouthLeft";
+    /// Right corner of the mouth.
+    public static final String MOUTH_RIGHT = "mouthRight";
+
+    private FaceLandmarks() {
+    }
+}

--- a/CodenameOne/src/com/codename1/ai/vision/ImageLabeler.java
+++ b/CodenameOne/src/com/codename1/ai/vision/ImageLabeler.java
@@ -22,7 +22,32 @@
  */
 package com.codename1.ai.vision;
 
-/// Creates reusable on-device image classifiers.
+/// Classifies what an image contains, as ranked labels with confidences.
+///
+/// ```java
+/// ImageLabeler labeler = new ImageLabeler(new VisionOptions()
+///         .minimumConfidence(0.6f)
+///         .maximumResults(5));
+///
+/// labeler.process(VisionImage.fromFile(photoPath)).ready(labels -> {
+///     StringBuilder summary = new StringBuilder();
+///     for (ImageLabel label : labels) {
+///         summary.append(label.getText())
+///                .append(" (")
+///                .append(Math.round(label.getConfidence() * 100))
+///                .append("%)\n");
+///     }
+///     resultLabel.setText(summary.toString());
+///     labeler.close();
+/// }).except(error -> {
+///     Log.e(error);
+///     labeler.close();
+/// });
+/// ```
+///
+/// The label text is the portable part. {@link ImageLabel#getIndex()} is a
+/// model class index that differs between backends and is {@code -1} on Apple
+/// Vision, so branch on {@link ImageLabel#getText()}.
 public final class ImageLabeler extends AbstractVisionAnalyzer<ImageLabel[]> {
     /// Creates an analyzer using the platform default backend and options.
     /// @see VisionOptions

--- a/CodenameOne/src/com/codename1/ai/vision/Pose.java
+++ b/CodenameOne/src/com/codename1/ai/vision/Pose.java
@@ -30,7 +30,20 @@ package com.codename1.ai.vision;
 /// `leftEar`, `rightEar`, and the `left`/`right` forms of `Shoulder`, `Elbow`,
 /// `Wrist`, `Hip`, `Knee`, and `Ankle`. A backend can additionally report
 /// finer eye, mouth, finger, heel, foot, `neck`, or `root` landmarks using the
-/// same lower-camel-case convention.
+/// same lower-camel-case convention. {@link PoseLandmarks} holds those names
+/// as constants.
+///
+/// ```java
+/// PoseDetector detector = new PoseDetector();
+/// detector.process(VisionImage.fromCameraFrame(frame)).ready(pose -> {
+///     Pose.Landmark wrist = pose.getLandmark(PoseLandmarks.RIGHT_WRIST);
+///     Pose.Landmark shoulder = pose.getLandmark(PoseLandmarks.RIGHT_SHOULDER);
+///     boolean raised = wrist != null && shoulder != null
+///             && wrist.getConfidence() > 0.6f
+///             && wrist.getPosition().getY() < shoulder.getPosition().getY();
+///     repsLabel.setText(raised ? "up" : "down");
+/// });
+/// ```
 public final class Pose {
     private final Landmark[] landmarks;
     private final VisionMetadata metadata;
@@ -52,6 +65,27 @@ public final class Pose {
             System.arraycopy(landmarks, 0, this.landmarks, 0, landmarks.length);
         }
         this.metadata = metadata;
+    }
+
+    /// Looks up one named joint.
+    ///
+    /// Backends detect different subsets of the skeleton, so a {@code null}
+    /// return means "this backend did not report that joint for this frame",
+    /// not "unsupported". Check {@link Landmark#getConfidence()} before
+    /// trusting a position.
+    ///
+    /// @param name one of the {@link PoseLandmarks} constants
+    /// @return the detected joint, or {@code null} when it was not reported
+    public Landmark getLandmark(String name) {
+        if (name == null) {
+            return null;
+        }
+        for (Landmark landmark : landmarks) {
+            if (landmark != null && name.equals(landmark.getName())) {
+                return landmark;
+            }
+        }
+        return null;
     }
 
     /// @return defensive copy of detected body landmarks

--- a/CodenameOne/src/com/codename1/ai/vision/PoseDetector.java
+++ b/CodenameOne/src/com/codename1/ai/vision/PoseDetector.java
@@ -22,7 +22,44 @@
  */
 package com.codename1.ai.vision;
 
-/// Creates reusable body-pose analyzers.
+/// Locates body joints, for rep counting, form feedback, or gesture input.
+///
+/// Counting arm raises from the live camera:
+///
+/// ```java
+/// VisionCameraView<Pose> view =
+///         new VisionCameraView<Pose>(new PoseDetector());
+/// view.setListener(new VisionPipelineListener<Pose>() {
+///     private boolean wasUp;
+///
+///     public void result(Pose pose, VisionImage source) {
+///         Pose.Landmark wrist = pose.getLandmark(PoseLandmarks.RIGHT_WRIST);
+///         Pose.Landmark shoulder =
+///                 pose.getLandmark(PoseLandmarks.RIGHT_SHOULDER);
+///         if (wrist == null || shoulder == null
+///                 || wrist.getConfidence() < 0.6f) {
+///             return;
+///         }
+///         // Y grows downwards, so the wrist being "above" the shoulder is a
+///         // smaller Y.
+///         boolean up = wrist.getPosition().getY()
+///                 < shoulder.getPosition().getY();
+///         if (up && !wasUp) {
+///             reps++;
+///             repLabel.setText(String.valueOf(reps));
+///         }
+///         wasUp = up;
+///     }
+///
+///     public void error(Throwable error) {
+///         Log.e(error);
+///     }
+/// });
+/// ```
+///
+/// Backends detect different subsets of the skeleton, so look joints up by
+/// name with {@link Pose#getLandmark(String)} and handle {@code null} rather
+/// than indexing a fixed array. {@link PoseLandmarks} holds the names.
 public final class PoseDetector extends AbstractVisionAnalyzer<Pose> {
     /// Creates an analyzer using the platform default backend and options.
     /// @see VisionOptions

--- a/CodenameOne/src/com/codename1/ai/vision/PoseLandmarks.java
+++ b/CodenameOne/src/com/codename1/ai/vision/PoseLandmarks.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.ai.vision;
+
+/// The joint names {@link Pose.Landmark#getName()} reports, as constants
+/// instead of literals. Backends detect different subsets of this list: ML Kit
+/// reports the hand and foot detail, Apple Vision reports {@link #NECK} and
+/// {@link #ROOT} that ML Kit does not, and a joint the backend did not report
+/// is simply absent. Read one through {@link Pose#getLandmark(String)} and
+/// check for {@code null} rather than assuming a fixed skeleton.
+///
+/// ```java
+/// detector.process(VisionImage.fromCameraFrame(frame)).ready(pose -> {
+///     Pose.Landmark wrist = pose.getLandmark(PoseLandmarks.RIGHT_WRIST);
+///     Pose.Landmark shoulder = pose.getLandmark(PoseLandmarks.RIGHT_SHOULDER);
+///     if (wrist != null && shoulder != null
+///             && wrist.getConfidence() > 0.6f
+///             && wrist.getPosition().getY() < shoulder.getPosition().getY()) {
+///         Log.p("hand raised");
+///     }
+/// });
+/// ```
+public final class PoseLandmarks {
+    /// Tip of the nose.
+    public static final String NOSE = "nose";
+    /// Inner corner of the left eye.
+    public static final String LEFT_EYE_INNER = "leftEyeInner";
+    /// Center of the left eye.
+    public static final String LEFT_EYE = "leftEye";
+    /// Outer corner of the left eye.
+    public static final String LEFT_EYE_OUTER = "leftEyeOuter";
+    /// Inner corner of the right eye.
+    public static final String RIGHT_EYE_INNER = "rightEyeInner";
+    /// Center of the right eye.
+    public static final String RIGHT_EYE = "rightEye";
+    /// Outer corner of the right eye.
+    public static final String RIGHT_EYE_OUTER = "rightEyeOuter";
+    /// Left ear.
+    public static final String LEFT_EAR = "leftEar";
+    /// Right ear.
+    public static final String RIGHT_EAR = "rightEar";
+    /// Left corner of the mouth.
+    public static final String LEFT_MOUTH = "leftMouth";
+    /// Right corner of the mouth.
+    public static final String RIGHT_MOUTH = "rightMouth";
+    /// Base of the neck. Reported by Apple Vision; ML Kit omits it.
+    public static final String NECK = "neck";
+    /// Left shoulder.
+    public static final String LEFT_SHOULDER = "leftShoulder";
+    /// Right shoulder.
+    public static final String RIGHT_SHOULDER = "rightShoulder";
+    /// Left elbow.
+    public static final String LEFT_ELBOW = "leftElbow";
+    /// Right elbow.
+    public static final String RIGHT_ELBOW = "rightElbow";
+    /// Left wrist.
+    public static final String LEFT_WRIST = "leftWrist";
+    /// Right wrist.
+    public static final String RIGHT_WRIST = "rightWrist";
+    /// Left little finger. Reported by ML Kit; Apple Vision omits it.
+    public static final String LEFT_PINKY = "leftPinky";
+    /// Right little finger. Reported by ML Kit; Apple Vision omits it.
+    public static final String RIGHT_PINKY = "rightPinky";
+    /// Left index finger. Reported by ML Kit; Apple Vision omits it.
+    public static final String LEFT_INDEX = "leftIndex";
+    /// Right index finger. Reported by ML Kit; Apple Vision omits it.
+    public static final String RIGHT_INDEX = "rightIndex";
+    /// Left thumb. Reported by ML Kit; Apple Vision omits it.
+    public static final String LEFT_THUMB = "leftThumb";
+    /// Right thumb. Reported by ML Kit; Apple Vision omits it.
+    public static final String RIGHT_THUMB = "rightThumb";
+    /// Left hip.
+    public static final String LEFT_HIP = "leftHip";
+    /// Right hip.
+    public static final String RIGHT_HIP = "rightHip";
+    /// Midpoint between the hips. Reported by Apple Vision; ML Kit omits it.
+    public static final String ROOT = "root";
+    /// Left knee.
+    public static final String LEFT_KNEE = "leftKnee";
+    /// Right knee.
+    public static final String RIGHT_KNEE = "rightKnee";
+    /// Left ankle.
+    public static final String LEFT_ANKLE = "leftAnkle";
+    /// Right ankle.
+    public static final String RIGHT_ANKLE = "rightAnkle";
+    /// Left heel. Reported by ML Kit; Apple Vision omits it.
+    public static final String LEFT_HEEL = "leftHeel";
+    /// Right heel. Reported by ML Kit; Apple Vision omits it.
+    public static final String RIGHT_HEEL = "rightHeel";
+    /// Ball of the left foot. Reported by ML Kit; Apple Vision omits it.
+    public static final String LEFT_FOOT_INDEX = "leftFootIndex";
+    /// Ball of the right foot. Reported by ML Kit; Apple Vision omits it.
+    public static final String RIGHT_FOOT_INDEX = "rightFootIndex";
+    /// Reported when a backend supplied a joint with no portable name here.
+    public static final String UNKNOWN = "unknown";
+
+    private PoseLandmarks() {
+    }
+}

--- a/CodenameOne/src/com/codename1/ai/vision/SegmentationMask.java
+++ b/CodenameOne/src/com/codename1/ai/vision/SegmentationMask.java
@@ -22,9 +22,25 @@
  */
 package com.codename1.ai.vision;
 
+import com.codename1.ui.Image;
+
 /// Dense per-pixel foreground confidence mask. The confidence array is
 /// row-major with exactly {@code width * height} values in the range 0..1.
 /// It is defensively copied on construction and access.
+///
+/// The mask's resolution is the segmentation model's, not the source image's,
+/// so it is normally smaller than the frame it describes.
+/// {@link #cutOut(Image, float)} and {@link #toMaskImage(int)} rescale it for
+/// you; when reading {@link #getConfidence()} directly, index it with
+/// {@link #getWidth()} and {@link #getHeight()} rather than the frame size.
+///
+/// ```java
+/// SelfieSegmenter segmenter = new SelfieSegmenter();
+/// segmenter.process(VisionImage.encoded(jpeg)).ready(mask -> {
+///     Image person = mask.cutOut(EncodedImage.create(jpeg), 0.6f);
+///     background.getStyle().setBgImage(person);
+/// }).except(error -> Log.e(error));
+/// ```
 public final class SegmentationMask {
     private final int width;
     private final int height;
@@ -81,8 +97,98 @@ public final class SegmentationMask {
         return out;
     }
 
+    /// Reads one mask pixel.
+    ///
+    /// @param x column in the range 0 to {@link #getWidth()} - 1
+    /// @param y row in the range 0 to {@link #getHeight()} - 1
+    /// @return foreground probability in the range 0..1
+    /// @throws IndexOutOfBoundsException if the position is outside the mask
+    public float getConfidenceAt(int x, int y) {
+        if (x < 0 || y < 0 || x >= width || y >= height) {
+            throw new IndexOutOfBoundsException(
+                    "Position " + x + "," + y + " is outside the "
+                    + width + "x" + height + " mask");
+        }
+        return confidence[y * width + x];
+    }
+
+    /// Keeps the foreground of an image and makes the rest transparent.
+    ///
+    /// The mask is sampled with nearest-neighbour scaling, so the result has
+    /// {@code source}'s dimensions no matter what resolution the segmentation
+    /// model produced. Pixels whose confidence is below {@code threshold}
+    /// become fully transparent; the rest keep their original color and alpha.
+    ///
+    /// @param source the image the mask was computed from
+    /// @param threshold minimum foreground confidence to keep, clamped to 0..1
+    /// @return a new image with the background removed
+    /// @throws NullPointerException if {@code source} is {@code null}
+    /// @throws IllegalArgumentException if this mask has no pixels
+    public Image cutOut(Image source, float threshold) {
+        if (source == null) {
+            throw new NullPointerException("source");
+        }
+        requireNonEmpty();
+        int sourceWidth = source.getWidth();
+        int sourceHeight = source.getHeight();
+        int[] pixels = source.getRGB();
+        float limit = clamp(threshold);
+        for (int y = 0; y < sourceHeight; y++) {
+            int row = y * sourceWidth;
+            int maskRow = sample(y, sourceHeight, height) * width;
+            for (int x = 0; x < sourceWidth; x++) {
+                if (confidence[maskRow + sample(x, sourceWidth, width)]
+                        < limit) {
+                    pixels[row + x] &= 0x00ffffff;
+                }
+            }
+        }
+        return Image.createImage(pixels, sourceWidth, sourceHeight);
+    }
+
+    /// Renders the mask itself as a translucent tint, for drawing over the
+    /// frame it describes as a foreground highlight.
+    ///
+    /// Each pixel takes {@code rgb} as its color and the mask confidence as
+    /// its alpha, so a fully confident foreground pixel is opaque and a
+    /// background pixel is invisible. The result has the mask's own
+    /// resolution; draw it scaled to the frame's bounds.
+    ///
+    /// @param rgb tint color as {@code 0xRRGGBB}; any alpha in the value is
+    ///        ignored in favor of the mask
+    /// @return a new image at this mask's resolution
+    /// @throws IllegalArgumentException if this mask has no pixels
+    public Image toMaskImage(int rgb) {
+        requireNonEmpty();
+        int color = rgb & 0x00ffffff;
+        int[] pixels = new int[confidence.length];
+        for (int i = 0; i < pixels.length; i++) {
+            int alpha = Math.round(clamp(confidence[i]) * 255);
+            pixels[i] = (alpha << 24) | color;
+        }
+        return Image.createImage(pixels, width, height);
+    }
+
     /// @return backend metadata, or {@code null} when manually constructed
     public VisionMetadata getMetadata() {
         return metadata;
+    }
+
+    private void requireNonEmpty() {
+        if (width <= 0 || height <= 0) {
+            throw new IllegalArgumentException("Mask has no pixels");
+        }
+    }
+
+    private static int sample(int position, int sourceSize, int maskSize) {
+        int value = position * maskSize / sourceSize;
+        return value >= maskSize ? maskSize - 1 : value;
+    }
+
+    private static float clamp(float value) {
+        if (Float.isNaN(value)) {
+            return 0;
+        }
+        return value < 0 ? 0 : (value > 1 ? 1 : value);
     }
 }

--- a/CodenameOne/src/com/codename1/ai/vision/SelfieSegmenter.java
+++ b/CodenameOne/src/com/codename1/ai/vision/SelfieSegmenter.java
@@ -22,7 +22,27 @@
  */
 package com.codename1.ai.vision;
 
-/// Creates reusable foreground/person segmentation analyzers.
+/// Separates a person from the background, for background replacement or blur.
+///
+/// ```java
+/// SelfieSegmenter segmenter = new SelfieSegmenter();
+/// EncodedImage photo = EncodedImage.create(jpegBytes);
+///
+/// segmenter.process(VisionImage.encoded(jpegBytes)).ready(mask -> {
+///     // Everything below 60% foreground confidence becomes transparent, so
+///     // whatever is painted behind this image shows through.
+///     Image person = mask.cutOut(photo, 0.6f);
+///     preview.setIcon(person);
+///     segmenter.close();
+/// }).except(error -> {
+///     Log.e(error);
+///     segmenter.close();
+/// });
+/// ```
+///
+/// The mask has the model's own resolution rather than the frame's;
+/// {@link SegmentationMask#cutOut(com.codename1.ui.Image, float)} and
+/// {@link SegmentationMask#toMaskImage(int)} rescale it for you.
 public final class SelfieSegmenter extends AbstractVisionAnalyzer<SegmentationMask> {
     /// Creates an analyzer using the platform default backend and options.
     /// @see VisionOptions

--- a/CodenameOne/src/com/codename1/ai/vision/TextRecognizer.java
+++ b/CodenameOne/src/com/codename1/ai/vision/TextRecognizer.java
@@ -22,9 +22,48 @@
  */
 package com.codename1.ai.vision;
 
-/// Creates reusable on-device OCR analyzers. The default recognizes the Latin
-/// script; select {@link VisionOptions#textScript(TextScript)} to read Chinese,
-/// Devanagari, Japanese or Korean text.
+/// Reads the text in an image. The default recognizes the Latin script; select
+/// {@link VisionOptions#textScript(TextScript)} to read Chinese, Devanagari,
+/// Japanese or Korean text.
+///
+/// Reading a photographed receipt or label:
+///
+/// ```java
+/// TextRecognizer recognizer = new TextRecognizer();
+/// recognizer.process(VisionImage.fromFile(photoPath)).ready(result -> {
+///     textArea.setText(result.getText());
+///     recognizer.close();
+/// }).except(error -> {
+///     Log.e(error);
+///     recognizer.close();
+/// });
+/// ```
+///
+/// Reading text out of the live camera and stopping at the first line that
+/// looks like the value you want:
+///
+/// ```java
+/// VisionCameraView<TextRecognitionResult> view =
+///         new VisionCameraView<TextRecognitionResult>(new TextRecognizer());
+/// view.setListener(new VisionPipelineListener<TextRecognitionResult>() {
+///     public void result(TextRecognitionResult text, VisionImage source) {
+///         for (TextRecognitionResult.TextBlock block : text.getBlocks()) {
+///             if (block.getText().startsWith("SN-")) {
+///                 accept(block.getText());
+///                 return;
+///             }
+///         }
+///     }
+///     public void error(Throwable error) {
+///         Log.e(error);
+///     }
+/// });
+/// ```
+///
+/// {@link TextRecognitionResult#getText()} is the whole page in reading order;
+/// {@link TextRecognitionResult#getBlocks()} adds per-region text, confidence,
+/// and normalized bounds. Recognize one script per analyzer -- create a second
+/// analyzer when a screen needs two.
 public final class TextRecognizer extends AbstractVisionAnalyzer<TextRecognitionResult> {
     /// Creates an analyzer using the platform default backend and options,
     /// reading the Latin script.

--- a/CodenameOne/src/com/codename1/ai/vision/VisionCameraView.java
+++ b/CodenameOne/src/com/codename1/ai/vision/VisionCameraView.java
@@ -115,7 +115,11 @@ public class VisionCameraView<T> extends Container implements AutoCloseable {
     ///
     /// @return {@code true} when both the camera and the analyzer are available
     public boolean isSupported() {
-        return Camera.isSupported() && analyzer.isSupported();
+        // Camera.isSupported() only says the port has a backend. A device with
+        // no capture hardware still enumerates nothing, and start() would fail
+        // on a screen this method said was fine to show.
+        return Camera.isSupported() && Camera.getCameras().length > 0
+                && analyzer.isSupported();
     }
 
     /// Selects which camera to open. Takes effect the next time the view is
@@ -207,8 +211,9 @@ public class VisionCameraView<T> extends Container implements AutoCloseable {
             return;
         }
         CameraSession opened;
+        CameraInfo info;
         try {
-            CameraInfo info = Camera.getDefault(facing);
+            info = Camera.getDefault(facing);
             if (info == null) {
                 throw new IllegalStateException(
                         "No camera is available on this device");
@@ -224,7 +229,11 @@ public class VisionCameraView<T> extends Container implements AutoCloseable {
         session = opened;
         cameraView = opened.createView();
         cameraView.setScaleType(scaleType);
-        cameraView.setMirrored(facing == CameraFacing.FRONT);
+        // Mirror on the camera that opened, not the one asked for.
+        // Camera.getDefault falls back to the first available camera when the
+        // requested facing does not exist, and mirroring a rear preview shows
+        // the world reversed.
+        cameraView.setMirrored(info.getFacing() == CameraFacing.FRONT);
         addComponent(BorderLayout.CENTER, cameraView);
         pipeline = new VisionPipeline<T>(opened, shared,
                 new VisionPipelineListener<T>() {

--- a/CodenameOne/src/com/codename1/ai/vision/VisionCameraView.java
+++ b/CodenameOne/src/com/codename1/ai/vision/VisionCameraView.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.ai.vision;
+
+import com.codename1.camera.Camera;
+import com.codename1.camera.CameraFacing;
+import com.codename1.camera.CameraInfo;
+import com.codename1.camera.CameraSession;
+import com.codename1.camera.CameraSessionOptions;
+import com.codename1.camera.CameraView;
+import com.codename1.camera.FlashMode;
+import com.codename1.camera.FrameFormat;
+import com.codename1.camera.ScaleType;
+import com.codename1.ui.Container;
+import com.codename1.ui.Display;
+import com.codename1.ui.layouts.BorderLayout;
+
+/// A live camera preview that runs an analyzer over its frames.
+///
+/// This is the whole camera-to-analyzer pipeline as one component: it opens
+/// the camera when it is shown, streams frames into the analyzer with
+/// keep-only-the-newest backpressure, delivers results on the EDT, and
+/// releases the camera when the form is left. Add it to a form and implement
+/// the listener; there is no session, frame listener, or
+/// {@link VisionImage} conversion to write.
+///
+/// ```java
+/// FaceDetector detector = new FaceDetector();
+/// VisionCameraView<Face[]> view = new VisionCameraView<Face[]>(detector);
+/// view.setFacing(CameraFacing.FRONT);
+/// view.setListener(new VisionPipelineListener<Face[]>() {
+///     public void result(Face[] faces, VisionImage source) {
+///         countLabel.setText(faces.length + " face(s)");
+///     }
+///     public void error(Throwable error) {
+///         Log.e(error);
+///     }
+/// });
+///
+/// Form form = new Form("Faces", new BorderLayout());
+/// form.add(BorderLayout.CENTER, view);
+/// form.add(BorderLayout.SOUTH, countLabel);
+/// form.show();
+/// ```
+///
+/// The analyzer is supplied by the caller rather than named by a feature
+/// constant, which is deliberate: the build pipeline decides which native
+/// vision dependency to package from the analyzer classes an application
+/// references, so constructing the analyzer in application code is what keeps
+/// a face-detection app from also carrying the barcode and pose models.
+///
+/// **The preview is a native view.** Codename One components cannot be painted
+/// over it on every platform -- iOS renders native peers behind the Codename
+/// One layer, Android renders them in front -- so put a scanner's reticle,
+/// hints, and buttons around the preview rather than on top of it. Result
+/// geometry such as {@link Face#getBounds()} can still be drawn in a component
+/// beside the preview using {@link VisionRect#toBounds(com.codename1.ui.Component)}.
+///
+/// One camera session may be open at a time, so a second view (or a
+/// {@link com.codename1.capture.Capture} call) while this one is showing
+/// reports an error to the listener instead of stealing the hardware.
+///
+/// @param <T> the analyzer's result type
+public class VisionCameraView<T> extends Container implements AutoCloseable {
+    private final VisionAnalyzer<T> analyzer;
+    private final NonClosingAnalyzer<T> shared;
+    private CameraFacing facing = CameraFacing.BACK;
+    private ScaleType scaleType = ScaleType.CROP;
+    private int maxFps = 10;
+    private VisionPipelineListener<T> listener;
+    private CameraSession session;
+    private VisionPipeline<T> pipeline;
+    private CameraView cameraView;
+    private boolean closed;
+
+    /// Creates a view that runs {@code analyzer} over the back camera.
+    ///
+    /// The view borrows the analyzer: leaving the form releases the camera but
+    /// keeps the analyzer usable, and {@link #close()} releases it for good.
+    ///
+    /// @param analyzer the reusable analyzer to run over each frame
+    /// @throws NullPointerException if {@code analyzer} is {@code null}
+    public VisionCameraView(VisionAnalyzer<T> analyzer) {
+        super(new BorderLayout());
+        if (analyzer == null) {
+            throw new NullPointerException("analyzer");
+        }
+        this.analyzer = analyzer;
+        this.shared = new NonClosingAnalyzer<T>(analyzer);
+    }
+
+    /// Whether the current platform can open a camera and run this view's
+    /// analyzer. Check this before showing the view: a target without either
+    /// piece reports failures through the listener rather than throwing.
+    ///
+    /// @return {@code true} when both the camera and the analyzer are available
+    public boolean isSupported() {
+        return Camera.isSupported() && analyzer.isSupported();
+    }
+
+    /// Selects which camera to open. Takes effect the next time the view is
+    /// shown; the default is {@link CameraFacing#BACK}.
+    ///
+    /// @param value the camera to prefer, or {@code null} for the back camera
+    public void setFacing(CameraFacing value) {
+        facing = value == null ? CameraFacing.BACK : value;
+    }
+
+    /// @return the camera this view opens
+    public CameraFacing getFacing() {
+        return facing;
+    }
+
+    /// Caps how many frames per second reach the analyzer. Frames arriving
+    /// while an analysis is in flight are dropped in favor of the newest one
+    /// regardless of this value, so the cap mainly saves the camera the work
+    /// of producing frames nothing will read. The default is 10.
+    ///
+    /// @param value frames per second, or {@code 0} for uncapped
+    public void setMaxFps(int value) {
+        maxFps = Math.max(0, value);
+    }
+
+    /// @return the frame rate cap, or {@code 0} when uncapped
+    public int getMaxFps() {
+        return maxFps;
+    }
+
+    /// How the preview is fitted into this component's bounds. The default is
+    /// {@link ScaleType#CROP}, which fills the view the way a camera app does.
+    ///
+    /// @param value the scaling to apply, or {@code null} for the default
+    public void setScaleType(ScaleType value) {
+        scaleType = value == null ? ScaleType.CROP : value;
+        if (cameraView != null) {
+            cameraView.setScaleType(scaleType);
+        }
+    }
+
+    /// @return how the preview is fitted into this component's bounds
+    public ScaleType getScaleType() {
+        return scaleType;
+    }
+
+    /// Installs the callback for analysis results and recoverable failures.
+    /// Both are delivered on the EDT.
+    ///
+    /// @param value the listener, or {@code null} to stop receiving results
+    public void setListener(VisionPipelineListener<T> value) {
+        listener = value;
+    }
+
+    /// @return the installed result listener, or {@code null}
+    public VisionPipelineListener<T> getListener() {
+        return listener;
+    }
+
+    /// The open camera session, for torch, zoom, focus, or a still capture.
+    ///
+    /// @return the session while the view is showing, or {@code null}
+    public CameraSession getSession() {
+        return session;
+    }
+
+    /// Turns the torch on or off, when the open camera has one. A camera
+    /// without a flash ignores this.
+    ///
+    /// @param on whether the torch should be lit
+    public void setTorchEnabled(boolean on) {
+        if (session != null) {
+            session.setFlashMode(on ? FlashMode.TORCH : FlashMode.OFF);
+        }
+    }
+
+    /// @return {@code true} while the camera is open and frames are flowing
+    public boolean isRunning() {
+        return pipeline != null;
+    }
+
+    /// Opens the camera and starts analyzing. Called automatically when the
+    /// view is shown; calling it again while running does nothing.
+    // The session this opens is retained in the `session` field and closed by
+    // stop(); PMD cannot follow ownership across that hand-off.
+    @SuppressWarnings("PMD.CloseResource")
+    public void start() {
+        if (closed || pipeline != null) {
+            return;
+        }
+        CameraSession opened;
+        try {
+            CameraInfo info = Camera.getDefault(facing);
+            if (info == null) {
+                throw new IllegalStateException(
+                        "No camera is available on this device");
+            }
+            opened = Camera.open(info, new CameraSessionOptions()
+                    .frameFormat(FrameFormat.JPEG)
+                    .frameMaxFps(maxFps)
+                    .captureAudio(false));
+        } catch (Throwable error) {
+            notifyError(error);
+            return;
+        }
+        session = opened;
+        cameraView = opened.createView();
+        cameraView.setScaleType(scaleType);
+        cameraView.setMirrored(facing == CameraFacing.FRONT);
+        addComponent(BorderLayout.CENTER, cameraView);
+        pipeline = new VisionPipeline<T>(opened, shared,
+                new VisionPipelineListener<T>() {
+                    @Override
+                    public void result(T value, VisionImage source) {
+                        VisionPipelineListener<T> target = listener;
+                        if (target != null) {
+                            target.result(value, source);
+                        }
+                    }
+
+                    @Override
+                    public void error(Throwable error) {
+                        VisionPipelineListener<T> target = listener;
+                        if (target != null) {
+                            target.error(error);
+                        }
+                    }
+                });
+    }
+
+    /// Stops analyzing and releases the camera, leaving the analyzer usable.
+    /// Called automatically when the view stops being shown.
+    public void stop() {
+        if (pipeline != null) {
+            pipeline.close();
+            pipeline = null;
+        }
+        if (cameraView != null) {
+            removeComponent(cameraView);
+            cameraView = null;
+        }
+        if (session != null) {
+            session.close();
+            session = null;
+        }
+    }
+
+    /// Releases the camera and the analyzer. Use this when the view will not
+    /// be shown again; simply navigating to another form already releases the
+    /// camera. Calling it more than once has no effect.
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        stop();
+        analyzer.close();
+    }
+
+    /// Opens the camera when the view becomes part of a shown form.
+    @Override
+    protected void initComponent() {
+        super.initComponent();
+        start();
+    }
+
+    /// Releases the camera when the view stops being shown.
+    @Override
+    protected void deinitialize() {
+        stop();
+        super.deinitialize();
+    }
+
+    private void notifyError(final Throwable error) {
+        Display.getInstance().callSerially(new Runnable() {
+            @Override
+            public void run() {
+                VisionPipelineListener<T> target = listener;
+                if (target != null) {
+                    target.error(error);
+                }
+            }
+        });
+    }
+
+    /// Hands the pipeline an analyzer it cannot close. The pipeline closes the
+    /// analyzer it owns, and this view is shown and hidden repeatedly with the
+    /// same caller-supplied analyzer, so the real one is released only by
+    /// {@link VisionCameraView#close()}.
+    private static final class NonClosingAnalyzer<T>
+            implements VisionAnalyzer<T> {
+        private final VisionAnalyzer<T> delegate;
+
+        NonClosingAnalyzer(VisionAnalyzer<T> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public boolean isSupported() {
+            return delegate.isSupported();
+        }
+
+        @Override
+        public com.codename1.util.AsyncResource<T> process(VisionImage image) {
+            return delegate.process(image);
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/CodenameOne/src/com/codename1/ai/vision/VisionCameraView.java
+++ b/CodenameOne/src/com/codename1/ai/vision/VisionCameraView.java
@@ -237,8 +237,20 @@ public class VisionCameraView<T> extends Container implements AutoCloseable {
             notifyError(error);
             return;
         }
+        CameraView preview = opened.createView();
+        if (preview.getPreviewPeer() == null) {
+            // A port returns no peer when native preview creation failed, or
+            // when it has no live preview at all. Carrying on would install an
+            // empty view, report isRunning() true, and leave a scanner sitting
+            // on a blank screen with no error ever delivered.
+            opened.close();
+            notifyError(new IllegalStateException(
+                    "The camera opened but this platform could not create a"
+                    + " live preview"));
+            return;
+        }
         session = opened;
-        cameraView = opened.createView();
+        cameraView = preview;
         cameraView.setScaleType(scaleType);
         // Mirror on the camera that opened, not the one asked for.
         // Camera.getDefault falls back to the first available camera when the

--- a/CodenameOne/src/com/codename1/ai/vision/VisionCameraView.java
+++ b/CodenameOne/src/com/codename1/ai/vision/VisionCameraView.java
@@ -125,6 +125,12 @@ public class VisionCameraView<T> extends Container implements AutoCloseable {
     /// Selects which camera to open. Takes effect the next time the view is
     /// shown; the default is {@link CameraFacing#BACK}.
     ///
+    /// A front camera's preview is requested mirrored, the way a selfie view
+    /// behaves. The simulator honors that; the iOS and Android previews do not
+    /// mirror yet. Note also that a device without the requested camera falls
+    /// back to whatever it has, and the mirroring follows the camera that
+    /// actually opened rather than the one asked for.
+    ///
     /// @param value the camera to prefer, or {@code null} for the back camera
     public void setFacing(CameraFacing value) {
         facing = value == null ? CameraFacing.BACK : value;
@@ -152,6 +158,11 @@ public class VisionCameraView<T> extends Container implements AutoCloseable {
 
     /// How the preview is fitted into this component's bounds. The default is
     /// {@link ScaleType#CROP}, which fills the view the way a camera app does.
+    ///
+    /// The simulator honors every mode. The iOS and Android previews render
+    /// fixed at fill-and-crop today, because neither port implements the
+    /// scaling hook yet, so a non-default mode is a request those targets
+    /// currently ignore rather than a promise.
     ///
     /// @param value the scaling to apply, or {@code null} for the default
     public void setScaleType(ScaleType value) {

--- a/CodenameOne/src/com/codename1/ai/vision/VisionException.java
+++ b/CodenameOne/src/com/codename1/ai/vision/VisionException.java
@@ -23,6 +23,29 @@
 package com.codename1.ai.vision;
 
 /// Failure reported by an on-device vision backend.
+///
+/// The code separates "this device will never do this" from "this attempt
+/// failed", which usually calls for different UI:
+///
+/// ```java
+/// recognizer.process(image)
+///     .ready(result -> textArea.setText(result.getText()))
+///     .except(error -> {
+///         if (error instanceof VisionException
+///                 && ((VisionException) error).getCode()
+///                         == VisionException.UNSUPPORTED) {
+///             // Permanent: hide the feature rather than offering a retry.
+///             scanButton.setVisible(false);
+///             return;
+///         }
+///         ToastBar.showErrorMessage("Could not read that image");
+///         Log.e(error);
+///     });
+/// ```
+///
+/// Prefer {@code isSupported()} on the analyzer to reaching this state at all;
+/// {@link #UNSUPPORTED} is the answer to a question that could have been asked
+/// before the screen was shown.
 public class VisionException extends RuntimeException {
     public static final int UNSUPPORTED = 1;
     public static final int INVALID_IMAGE = 2;

--- a/CodenameOne/src/com/codename1/ai/vision/VisionImage.java
+++ b/CodenameOne/src/com/codename1/ai/vision/VisionImage.java
@@ -24,11 +24,37 @@ package com.codename1.ai.vision;
 
 import com.codename1.camera.CameraFrame;
 import com.codename1.camera.FrameFormat;
+import com.codename1.io.FileSystemStorage;
+import com.codename1.io.Util;
+import com.codename1.ui.EncodedImage;
+import com.codename1.ui.Image;
+
+import java.io.IOException;
+import java.io.InputStream;
 
 /// Immutable input for encoded still images or raw camera pixels. Factory
 /// methods defensively copy their arrays. In particular,
 /// {@link #fromCameraFrame(CameraFrame)} detaches from callback-owned buffers
 /// that a camera backend may recycle when the callback returns.
+///
+/// Pick the factory that matches where the image came from:
+///
+/// ```java
+/// // A file: the gallery, or CapturedPhoto.getFilePath()
+/// VisionImage.fromFile(photo.getFilePath());
+///
+/// // An image already in memory
+/// VisionImage.fromImage(label.getIcon());
+///
+/// // Bytes you decoded or downloaded yourself
+/// VisionImage.encoded(jpegBytes);
+///
+/// // A live camera frame, which also carries the frame's rotation
+/// VisionImage.fromCameraFrame(frame);
+/// ```
+///
+/// Only {@link #encoded(byte[], int)} needs a rotation argument, and only when
+/// the stored pixels are not already upright -- this class does not read EXIF.
 public final class VisionImage {
     private final byte[] encodedBytes;
     private final byte[] pixels;
@@ -155,6 +181,69 @@ public final class VisionImage {
         return new VisionImage(encoded, pixels,
                 frame.getWidth(), frame.getHeight(), frame.getRotationDegrees(),
                 frame.getTimestampNanos(), format);
+    }
+
+    /// Reads a JPEG or PNG file from {@link FileSystemStorage} and wraps it
+    /// for analysis. This is the usual bridge from the image picker or from
+    /// {@link com.codename1.camera.CapturedPhoto#getFilePath()} to an
+    /// analyzer.
+    ///
+    /// Like {@link #encoded(byte[])} this assumes the stored pixels are
+    /// already upright and does not parse EXIF. Use
+    /// {@link #encoded(byte[], int)} when a rotation has to be applied.
+    ///
+    /// @param path a FileSystemStorage path
+    /// @return immutable image input
+    /// @throws IOException if the file cannot be read
+    /// @throws IllegalArgumentException if the file is empty
+    // Util.cleanup() in the finally block closes the stream; PMD does not
+    // recognize it as a close.
+    @SuppressWarnings("PMD.CloseResource")
+    public static VisionImage fromFile(String path) throws IOException {
+        InputStream input = FileSystemStorage.getInstance().openInputStream(path);
+        try {
+            return encoded(Util.readInputStream(input));
+        } finally {
+            Util.cleanup(input);
+        }
+    }
+
+    /// Wraps an in-memory Codename One image for analysis.
+    ///
+    /// An {@link EncodedImage} passes its original JPEG or PNG bytes straight
+    /// through, which is both cheaper and higher fidelity than re-encoding.
+    /// Any other image is read as RGBA pixels. Either way the caller's image
+    /// is left untouched.
+    ///
+    /// @param image the image to analyze
+    /// @return immutable image input
+    /// @throws NullPointerException if {@code image} is {@code null}
+    /// @throws IllegalArgumentException if the image has no pixels
+    public static VisionImage fromImage(Image image) {
+        if (image == null) {
+            throw new NullPointerException("image");
+        }
+        if (image instanceof EncodedImage) {
+            byte[] data = ((EncodedImage) image).getImageData();
+            if (data != null && data.length > 0) {
+                return encoded(data);
+            }
+        }
+        int width = image.getWidth();
+        int height = image.getHeight();
+        if (width <= 0 || height <= 0) {
+            throw new IllegalArgumentException("Image has no pixels");
+        }
+        int[] argb = image.getRGB();
+        byte[] rgba = new byte[argb.length * 4];
+        for (int i = 0, offset = 0; i < argb.length; i++, offset += 4) {
+            int pixel = argb[i];
+            rgba[offset] = (byte) (pixel >> 16);
+            rgba[offset + 1] = (byte) (pixel >> 8);
+            rgba[offset + 2] = (byte) pixel;
+            rgba[offset + 3] = (byte) (pixel >> 24);
+        }
+        return pixels(rgba, width, height, FrameFormat.RGBA8888, 0);
     }
 
     /// @return a defensive copy of encoded bytes, or {@code null} for raw input

--- a/CodenameOne/src/com/codename1/ai/vision/VisionOptions.java
+++ b/CodenameOne/src/com/codename1/ai/vision/VisionOptions.java
@@ -25,6 +25,18 @@ package com.codename1.ai.vision;
 /// Common analyzer configuration. An analyzer captures the supplied options
 /// when constructed; reuse it for frames needing the same backend, confidence
 /// threshold, and result limit.
+///
+/// ```java
+/// ImageLabeler labeler = new ImageLabeler(new VisionOptions()
+///         .minimumConfidence(0.6f)   // drop guesses below 60%
+///         .maximumResults(5));       // keep the top five labels
+/// ```
+///
+/// The analyzer snapshots these values, so mutating the options object
+/// afterwards changes nothing -- construct a second analyzer instead. Not
+/// every analyzer reads every setting: {@link #textScript(TextScript)} applies
+/// only to {@link TextRecognizer}, and a backend may ignore a limit it has no
+/// way to enforce.
 public final class VisionOptions {
     private VisionBackend backend = VisionBackends.auto();
     private float minimumConfidence;

--- a/CodenameOne/src/com/codename1/ai/vision/VisionPipeline.java
+++ b/CodenameOne/src/com/codename1/ai/vision/VisionPipeline.java
@@ -34,6 +34,37 @@ import com.codename1.util.SuccessCallback;
 /// slow model cannot build an unbounded queue. Results and errors arrive on
 /// the EDT. The pipeline owns and closes the analyzer but not the camera
 /// session.
+///
+/// Use this when the application already owns a {@link CameraSession} -- it is
+/// taking photos or recording video as well as analyzing. When the screen only
+/// needs a preview that analyzes, {@link VisionCameraView} does the same thing
+/// and owns the session too, which is one less lifecycle to get right.
+///
+/// ```java
+/// CameraSession session = Camera.open(Camera.getDefault(CameraFacing.BACK),
+///         new CameraSessionOptions().frameMaxFps(10).captureAudio(false));
+/// form.add(BorderLayout.CENTER, session.createView());
+///
+/// VisionPipeline<Barcode[]> pipeline = new VisionPipeline<Barcode[]>(
+///         session, new BarcodeScanner(),
+///         new VisionPipelineListener<Barcode[]>() {
+///             public void result(Barcode[] codes, VisionImage source) {
+///                 if (codes.length > 0) {
+///                     found(codes[0].getValue());
+///                 }
+///             }
+///             public void error(Throwable error) {
+///                 Log.e(error);
+///             }
+///         });
+///
+/// // Closing the pipeline detaches the frame listener and closes the
+/// // analyzer. The session is yours to close.
+/// form.addCloseListener(e -> {
+///     pipeline.close();
+///     session.close();
+/// });
+/// ```
 public final class VisionPipeline<T> implements AutoCloseable {
     private final CameraSession session;
     private final VisionAnalyzer<T> analyzer;

--- a/CodenameOne/src/com/codename1/ai/vision/VisionPoint.java
+++ b/CodenameOne/src/com/codename1/ai/vision/VisionPoint.java
@@ -22,9 +22,29 @@
  */
 package com.codename1.ai.vision;
 
+import com.codename1.ui.Component;
+import com.codename1.ui.geom.Point;
+
 /// Immutable point in a normalized, top-left-origin coordinate space. X grows
 /// right and Y grows down; 0 and 1 correspond to image edges, independent of
 /// source pixel dimensions.
+///
+/// {@link #toPoint(int, int, int, int)} converts one back to pixels for
+/// drawing:
+///
+/// ```java
+/// public void paint(Graphics g) {
+///     super.paint(g);
+///     g.setColor(0xff3b30);
+///     for (Face face : lastFaces) {
+///         VisionPoint eye = face.getLandmark(FaceLandmarks.LEFT_EYE);
+///         if (eye != null) {
+///             Point p = eye.toPoint(this);
+///             g.fillArc(p.getX() - 8, p.getY() - 8, 16, 16, 0, 360);
+///         }
+///     }
+/// }
+/// ```
 public final class VisionPoint {
     private final float x;
     private final float y;
@@ -45,5 +65,39 @@ public final class VisionPoint {
     /// @return downward vertical coordinate normalized to input height
     public float getY() {
         return y;
+    }
+
+    /// Maps this normalized point onto a pixel rectangle.
+    ///
+    /// The mapping stretches the whole 0..1 range across {@code width} and
+    /// {@code height}. That is correct when the destination has the same
+    /// aspect ratio as the analyzed image, which is the usual case for an
+    /// image drawn to fit. A live preview scaled with
+    /// {@link com.codename1.camera.ScaleType#CROP} does not: pass the
+    /// rectangle the frame actually occupies rather than the component's own
+    /// bounds.
+    ///
+    /// @param x left edge of the destination rectangle in pixels
+    /// @param y top edge of the destination rectangle in pixels
+    /// @param width destination width in pixels
+    /// @param height destination height in pixels
+    /// @return the corresponding pixel position, rounded to the nearest pixel
+    public Point toPoint(int x, int y, int width, int height) {
+        return new Point(x + Math.round(this.x * width),
+                y + Math.round(this.y * height));
+    }
+
+    /// Maps this normalized point onto a component's absolute on-screen
+    /// bounds, which is the coordinate space a {@code paint} method draws in.
+    ///
+    /// @param target component the analyzed image is displayed in
+    /// @return the corresponding absolute pixel position
+    /// @throws NullPointerException if {@code target} is {@code null}
+    public Point toPoint(Component target) {
+        if (target == null) {
+            throw new NullPointerException("target");
+        }
+        return toPoint(target.getAbsoluteX(), target.getAbsoluteY(),
+                target.getWidth(), target.getHeight());
     }
 }

--- a/CodenameOne/src/com/codename1/ai/vision/VisionRect.java
+++ b/CodenameOne/src/com/codename1/ai/vision/VisionRect.java
@@ -22,9 +22,26 @@
  */
 package com.codename1.ai.vision;
 
+import com.codename1.ui.Component;
+import com.codename1.ui.geom.Rectangle;
+
 /// Immutable normalized rectangle using a top-left origin. X/Y identify the
 /// upper-left corner and width/height are fractions of the oriented input
 /// dimensions. {@link #EMPTY} represents unavailable geometry.
+///
+/// {@link #toBounds(int, int, int, int)} converts one back to pixels for
+/// drawing:
+///
+/// ```java
+/// public void paint(Graphics g) {
+///     super.paint(g);
+///     g.setColor(0x34c759);
+///     for (Barcode code : lastCodes) {
+///         Rectangle r = code.getBounds().toBounds(this);
+///         g.drawRect(r.getX(), r.getY(), r.getWidth(), r.getHeight(), 3);
+///     }
+/// }
+/// ```
 public final class VisionRect {
     public static final VisionRect EMPTY = new VisionRect(0, 0, 0, 0);
 
@@ -63,5 +80,50 @@ public final class VisionRect {
     /// @return height as a fraction of oriented input height
     public float getHeight() {
         return height;
+    }
+
+    /// Whether this rectangle carries no geometry, which is what a backend
+    /// that located a result without reporting where reports.
+    ///
+    /// @return {@code true} when the rectangle has no area
+    public boolean isEmpty() {
+        return width <= 0 || height <= 0;
+    }
+
+    /// Maps this normalized rectangle onto a pixel rectangle.
+    ///
+    /// The mapping stretches the whole 0..1 range across {@code width} and
+    /// {@code height}. That is correct when the destination has the same
+    /// aspect ratio as the analyzed image, which is the usual case for an
+    /// image drawn to fit. A live preview scaled with
+    /// {@link com.codename1.camera.ScaleType#CROP} does not: pass the
+    /// rectangle the frame actually occupies rather than the component's own
+    /// bounds.
+    ///
+    /// @param x left edge of the destination rectangle in pixels
+    /// @param y top edge of the destination rectangle in pixels
+    /// @param width destination width in pixels
+    /// @param height destination height in pixels
+    /// @return the corresponding pixel rectangle, rounded to whole pixels
+    public Rectangle toBounds(int x, int y, int width, int height) {
+        int left = Math.round(this.x * width);
+        int top = Math.round(this.y * height);
+        int right = Math.round((this.x + this.width) * width);
+        int bottom = Math.round((this.y + this.height) * height);
+        return new Rectangle(x + left, y + top, right - left, bottom - top);
+    }
+
+    /// Maps this normalized rectangle onto a component's absolute on-screen
+    /// bounds, which is the coordinate space a {@code paint} method draws in.
+    ///
+    /// @param target component the analyzed image is displayed in
+    /// @return the corresponding absolute pixel rectangle
+    /// @throws NullPointerException if {@code target} is {@code null}
+    public Rectangle toBounds(Component target) {
+        if (target == null) {
+            throw new NullPointerException("target");
+        }
+        return toBounds(target.getAbsoluteX(), target.getAbsoluteY(),
+                target.getWidth(), target.getHeight());
     }
 }

--- a/CodenameOne/src/com/codename1/ai/vision/package-info.java
+++ b/CodenameOne/src/com/codename1/ai/vision/package-info.java
@@ -20,15 +20,90 @@
  * Please contact Codename One through http://www.codenameone.com/ if you
  * need additional information or have any questions.
  */
-/// Vendor-neutral on-device vision APIs for still images and live camera frames.
+/// Vendor-neutral on-device vision APIs for still images and live camera
+/// frames: barcodes and QR codes, OCR, faces, image labels, body pose,
+/// person segmentation, and document correction.
 ///
-/// <p>The automatic backend uses Apple Vision/Core Image on iOS and Mac
-/// Catalyst and ML Kit on Android. Unsupported ports report that through
-/// {@code isSupported()}. Optional backends are selected with
-/// {@link com.codename1.ai.vision.VisionBackends}.</p>
+/// <h2>Start at the level you need</h2>
 ///
-/// <p>Each analyzer is a separate build-time feature. Referencing one analyzer
-/// causes the builder to retain only its platform adapter and native
-/// dependency. {@link com.codename1.ai.vision.VisionPipeline} safely copies
-/// callback-owned camera frames and drops stale pending frames under load.</p>
+/// <p>The package is three layers deep, and most applications only ever touch
+/// the first one.</p>
+///
+/// <p><b>1. A finished screen.</b> {@link com.codename1.ai.vision.CodeScanner}
+/// is a complete barcode and QR scanner in one call. It opens the camera,
+/// decodes, restores the form you came from, and hands back the code -- or
+/// {@code null} if the user backed out. This is the replacement for the old
+/// {@code CodeScanner} cn1lib.</p>
+///
+/// ```java
+/// CodeScanner.scan().ready(code -> {
+///     if (code != null) {
+///         urlField.setText(code.getValue());
+///     }
+/// });
+/// ```
+///
+/// <p><b>2. A live preview inside your own form.</b>
+/// {@link com.codename1.ai.vision.VisionCameraView} is a component that owns
+/// the camera, streams frames through the analyzer you give it, and delivers
+/// results on the EDT. It works with every analyzer, not just barcodes.</p>
+///
+/// ```java
+/// VisionCameraView<Face[]> view =
+///         new VisionCameraView<Face[]>(new FaceDetector());
+/// view.setFacing(CameraFacing.FRONT);
+/// view.setListener(new VisionPipelineListener<Face[]>() {
+///     public void result(Face[] faces, VisionImage source) {
+///         status.setText(faces.length + " face(s)");
+///     }
+///     public void error(Throwable error) {
+///         Log.e(error);
+///     }
+/// });
+/// form.add(BorderLayout.CENTER, view);
+/// ```
+///
+/// <p><b>3. One image at a time.</b> Each analyzer --
+/// {@link com.codename1.ai.vision.TextRecognizer},
+/// {@link com.codename1.ai.vision.BarcodeScanner},
+/// {@link com.codename1.ai.vision.FaceDetector},
+/// {@link com.codename1.ai.vision.ImageLabeler},
+/// {@link com.codename1.ai.vision.PoseDetector},
+/// {@link com.codename1.ai.vision.SelfieSegmenter},
+/// {@link com.codename1.ai.vision.DocumentScanner} -- takes a
+/// {@link com.codename1.ai.vision.VisionImage} and returns a typed result.
+/// Create one, reuse it for a sequence, and close it.</p>
+///
+/// ```java
+/// TextRecognizer recognizer = new TextRecognizer();
+/// recognizer.process(VisionImage.fromFile(path))
+///         .ready(result -> Log.p(result.getText()))
+///         .except(error -> Log.e(error));
+/// ```
+///
+/// <h2>Reading the results</h2>
+///
+/// <p>Bounds and points are normalized to 0..1 rather than pixels, so a result
+/// computed on a camera frame can be drawn over an image of any size.
+/// {@link com.codename1.ai.vision.VisionRect#toBounds(com.codename1.ui.Component)}
+/// and {@link com.codename1.ai.vision.VisionPoint#toPoint(com.codename1.ui.Component)}
+/// convert them back. Names that would otherwise be string literals --
+/// symbologies, face landmarks, body joints -- are constants on
+/// {@link com.codename1.ai.vision.BarcodeFormat},
+/// {@link com.codename1.ai.vision.FaceLandmarks} and
+/// {@link com.codename1.ai.vision.PoseLandmarks}.</p>
+///
+/// <h2>Availability</h2>
+///
+/// <p>Call {@code isSupported()} before offering a feature: availability
+/// depends on the target, the linked backend, and the OS version. The
+/// automatic backend uses Apple Vision/Core Image on iOS and Mac Catalyst and
+/// ML Kit on Android; optional backends are selected with
+/// {@link com.codename1.ai.vision.VisionBackends}. In the simulator the
+/// results are whatever you scripted under <i>Simulate &gt; Vision</i>, so a
+/// scanner screen can be built without a device.</p>
+///
+/// <p>Each analyzer is a separate build-time feature. Referencing one causes
+/// the builder to retain only its platform adapter and native dependency, so
+/// a barcode app does not carry the pose and OCR models.</p>
 package com.codename1.ai.vision;

--- a/CodenameOne/src/com/codename1/camera/Camera.java
+++ b/CodenameOne/src/com/codename1/camera/Camera.java
@@ -56,10 +56,18 @@ import java.io.IOException;
 ///                                   new CameraSessionOptions());
 ///     CameraView v = s.createView();
 ///     // add v to a Form...
-///     s.setFrameListener(frame ->
-///         BarcodeScanner.scan(frame.getJpegBytes()).ready(codes -> { ... }));
+///     s.setFrameListener(frame -> analyze(frame.getJpegBytes()));
 /// }
 /// ```
+///
+/// **For on-device analysis, do not write the frame listener yourself.**
+/// `com.codename1.ai.vision.VisionCameraView` is a component that owns the
+/// session, streams frames into an analyzer with keep-only-the-newest
+/// backpressure, and delivers results on the EDT; and
+/// `com.codename1.ai.vision.CodeScanner` is an entire barcode scanner screen
+/// in one call. Use this class directly when the application drives the
+/// camera itself -- a custom capture UI, video recording, or torch and zoom
+/// control.
 public final class Camera {
     private static final Object ACTIVE_LOCK = new Object();
     private static CameraSession active;

--- a/CodenameOne/src/com/codename1/camera/CameraView.java
+++ b/CodenameOne/src/com/codename1/camera/CameraView.java
@@ -39,11 +39,12 @@ import com.codename1.ui.layouts.BorderLayout;
 /// f.add(BorderLayout.CENTER, view);
 /// f.show();
 ///
-/// session.setFrameListener(frame ->
-///     BarcodeScanner.scan(frame.getJpegBytes()).ready(codes -> {
-///         if (codes.length > 0) Log.p("scanned " + codes[0]);
-///     }));
+/// session.setFrameListener(frame -> analyze(frame.getJpegBytes()));
 /// ```
+///
+/// To run an on-device vision analyzer over the preview, prefer
+/// `com.codename1.ai.vision.VisionCameraView`, which creates and owns this
+/// view along with the frame plumbing.
 ///
 /// The view holds a back-reference to its `CameraSession`; closing the session
 /// while the view is still attached to a form leaves the view rendering its

--- a/CodenameOne/src/com/codename1/camera/CameraView.java
+++ b/CodenameOne/src/com/codename1/camera/CameraView.java
@@ -71,8 +71,13 @@ public final class CameraView extends Container {
 
     /// Whether to horizontally mirror the preview. Usually `true` for front
     /// cameras (matches the "mirror" feel users expect from a selfie view).
+    ///
+    /// A port that cannot mirror its preview records the value without
+    /// changing what is rendered, so `#isMirrored()` can report `true` on a
+    /// preview that looks unmirrored.
     public void setMirrored(boolean m) {
         this.mirrored = m;
+        session.getImpl().setPreviewMirrored(m);
     }
 
     /// True when the preview is horizontally mirrored.
@@ -82,8 +87,13 @@ public final class CameraView extends Container {
 
     /// How the live preview is fitted inside the component bounds.
     /// Defaults to `ScaleType#CROP` (filling the view, cropping at edges).
+    ///
+    /// A port that renders its preview one fixed way records the value
+    /// without changing what is rendered, so `#getScaleType()` can report a
+    /// mode the preview is not actually using.
     public void setScaleType(ScaleType s) {
         this.scaleType = s == null ? ScaleType.CROP : s;
+        session.getImpl().setPreviewScaleType(this.scaleType);
     }
 
     /// Current scale type. Defaults to `ScaleType#CROP`.

--- a/CodenameOne/src/com/codename1/impl/CameraImpl.java
+++ b/CodenameOne/src/com/codename1/impl/CameraImpl.java
@@ -29,6 +29,7 @@ import com.codename1.camera.FlashMode;
 import com.codename1.camera.FrameFormat;
 import com.codename1.camera.FrameListener;
 import com.codename1.camera.PhotoCaptureOptions;
+import com.codename1.camera.ScaleType;
 import com.codename1.ui.PeerComponent;
 import com.codename1.util.AsyncResource;
 
@@ -97,4 +98,25 @@ public abstract class CameraImpl {
     /// Release all native resources for this session. Subsequent calls become
     /// no-ops.
     public abstract void close();
+
+    /// Mirror the live preview horizontally, or stop mirroring it. Called by
+    /// `com.codename1.camera.CameraView#setMirrored(boolean)`.
+    ///
+    /// The default does nothing, which is what a port whose preview cannot be
+    /// mirrored should do: the setting is then recorded and readable but has
+    /// no visual effect. Override to make it visible.
+    ///
+    /// @param mirrored whether the preview should be flipped horizontally
+    public void setPreviewMirrored(boolean mirrored) {
+    }
+
+    /// Fit the live preview into the view's bounds. Called by
+    /// `com.codename1.camera.CameraView#setScaleType(ScaleType)`.
+    ///
+    /// The default does nothing, which is what a port that renders the
+    /// preview one fixed way should do. Override to honor the request.
+    ///
+    /// @param scaleType how the preview should be fitted, never `null`
+    public void setPreviewScaleType(ScaleType scaleType) {
+    }
 }

--- a/Ports/JavaSE/src/com/codename1/impl/javase/JavaSECameraImpl.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JavaSECameraImpl.java
@@ -30,6 +30,7 @@ import com.codename1.camera.CapturedPhoto;
 import com.codename1.camera.FlashMode;
 import com.codename1.camera.FrameFormat;
 import com.codename1.camera.FrameListener;
+import com.codename1.camera.ScaleType;
 import com.codename1.camera.PhotoCaptureOptions;
 import com.codename1.impl.CameraImpl;
 import com.codename1.io.FileSystemStorage;
@@ -94,6 +95,8 @@ public class JavaSECameraImpl extends CameraImpl {
     private ScheduledExecutorService scheduler;
     private ScheduledFuture<?> frameTask;
     private JPanel previewPanel;
+    private volatile boolean previewMirrored;
+    private volatile ScaleType previewScaleType = ScaleType.CROP;
     private CameraSessionOptions options;
     private CameraInfo info;
     private volatile BufferedImage currentFrame;
@@ -149,6 +152,27 @@ public class JavaSECameraImpl extends CameraImpl {
     }
 
     @Override
+    public void setPreviewMirrored(boolean mirrored) {
+        previewMirrored = mirrored;
+        repaintPreview();
+    }
+
+    @Override
+    public void setPreviewScaleType(ScaleType scaleType) {
+        previewScaleType = scaleType == null ? ScaleType.CROP : scaleType;
+        repaintPreview();
+    }
+
+    private void repaintPreview() {
+        final JPanel panel = previewPanel;
+        if (panel != null) {
+            javax.swing.SwingUtilities.invokeLater(new Runnable() {
+                @Override public void run() { panel.repaint(); }
+            });
+        }
+    }
+
+    @Override
     public PeerComponent createPreviewPeer() {
         if (previewPanel == null) {
             previewPanel = new JPanel() {
@@ -156,12 +180,32 @@ public class JavaSECameraImpl extends CameraImpl {
                 protected void paintComponent(java.awt.Graphics g) {
                     super.paintComponent(g);
                     BufferedImage f = currentFrame;
-                    if (f != null) {
-                        g.drawImage(f, 0, 0, getWidth(), getHeight(), null);
-                    } else {
+                    if (f == null) {
                         g.setColor(Color.DARK_GRAY);
                         g.fillRect(0, 0, getWidth(), getHeight());
+                        return;
                     }
+                    java.awt.Rectangle target = fitPreview(
+                            f.getWidth(), f.getHeight(),
+                            getWidth(), getHeight(), previewScaleType);
+                    if (previewScaleType == ScaleType.FIT) {
+                        // Letterboxing leaves bars; the panel's own background
+                        // does not repaint under an opaque child bounds.
+                        g.setColor(Color.BLACK);
+                        g.fillRect(0, 0, getWidth(), getHeight());
+                    }
+                    int left = target.x;
+                    int right = target.x + target.width;
+                    if (previewMirrored) {
+                        // Swapping the destination x coordinates flips the
+                        // image, which is what a selfie preview does.
+                        int swap = left;
+                        left = right;
+                        right = swap;
+                    }
+                    g.drawImage(f, left, target.y, right,
+                            target.y + target.height,
+                            0, 0, f.getWidth(), f.getHeight(), null);
                 }
             };
             previewPanel.setBackground(Color.BLACK);
@@ -231,6 +275,26 @@ public class JavaSECameraImpl extends CameraImpl {
             this.fpsCap = Math.max(1, Math.min(30, maxFps));
             restartScheduler();
         }
+    }
+
+    /// The destination rectangle a frame of {@code srcW}x{@code srcH} occupies
+    /// inside a {@code dstW}x{@code dstH} preview under {@code scaleType}. FIT
+    /// letterboxes, CROP fills and overflows, FILL stretches.
+    static java.awt.Rectangle fitPreview(int srcW, int srcH,
+                                         int dstW, int dstH,
+                                         ScaleType scaleType) {
+        if (srcW <= 0 || srcH <= 0 || scaleType == ScaleType.FILL) {
+            return new java.awt.Rectangle(0, 0, dstW, dstH);
+        }
+        double byWidth = (double) dstW / srcW;
+        double byHeight = (double) dstH / srcH;
+        double scale = scaleType == ScaleType.FIT
+                ? Math.min(byWidth, byHeight)
+                : Math.max(byWidth, byHeight);
+        int width = (int) Math.round(srcW * scale);
+        int height = (int) Math.round(srcH * scale);
+        return new java.awt.Rectangle((dstW - width) / 2, (dstH - height) / 2,
+                width, height);
     }
 
     @Override public void setFlashMode(FlashMode mode) { /* no-op in simulator */ }

--- a/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
@@ -6836,6 +6836,8 @@ public class JavaSEPort extends CodenameOneImplementation {
 
         final JMenu foldableMenu = installFoldableSimulationMenu(simulateMenu, pref);
 
+        final JMenu visionMenu = installVisionSimulationMenu(simulateMenu, pref);
+
         // Mirrors cn1FireStatusBarTap in CodenameOne_GLViewController.m, which
         // synthesizes a tap inside CN1's StatusBar component (the bar at the
         // top of Toolbar created by Toolbar.initTitleBarStatus). The native
@@ -7352,6 +7354,7 @@ public class JavaSEPort extends CodenameOneImplementation {
         simulateMenu.add(shieldMenu);
         simulateMenu.add(nfcMenu);
         simulateMenu.add(foldableMenu);
+        simulateMenu.add(visionMenu);
         simulateMenu.add(statusBarTapDiag);
         simulateMenu.addSeparator();
         simulateMenu.add(darkLightModeMenu);
@@ -8864,6 +8867,182 @@ public class JavaSEPort extends CodenameOneImplementation {
         if (value) {
             JavaSEShieldEngine.ensureRegistered();
         }
+    }
+
+    /// Builds *Simulate &gt; Vision*, which scripts what
+    /// {@link JavaSEVisionImpl} hands back to `com.codename1.ai.vision`
+    /// analyzers. The desktop cannot run the models, so this is what lets a
+    /// scanner screen, an overlay, or a "nothing found" branch be built
+    /// without a device.
+    private JMenu installVisionSimulationMenu(JMenu simulateMenu, final Preferences pref) {
+        JMenu visionMenu = new JMenu("Vision");
+        visionMenu.setToolTipText("Script the results the on-device vision "
+                + "analyzers return in the simulator");
+
+        final JCheckBoxMenuItem supported = new JCheckBoxMenuItem(
+                "Vision Supported", pref.getBoolean("VisionSim.supported", true));
+        JavaSEVisionImpl.simSupported = supported.isSelected();
+        supported.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent ae) {
+                JavaSEVisionImpl.simSupported = supported.isSelected();
+                pref.putBoolean("VisionSim.supported", supported.isSelected());
+            }
+        });
+        visionMenu.add(supported);
+
+        visionMenu.addSeparator();
+
+        JMenu outcomeMenu = new JMenu("Analysis outcome");
+        ButtonGroup outcomeGroup = new ButtonGroup();
+        try {
+            JavaSEVisionImpl.outcome = JavaSEVisionImpl.SimOutcome.valueOf(
+                    pref.get("VisionSim.outcome",
+                            JavaSEVisionImpl.SimOutcome.RESULT.name()));
+        } catch (IllegalArgumentException ex) {
+            JavaSEVisionImpl.outcome = JavaSEVisionImpl.SimOutcome.RESULT;
+        }
+        for (final JavaSEVisionImpl.SimOutcome o
+                : JavaSEVisionImpl.SimOutcome.values()) {
+            final JRadioButtonMenuItem item = new JRadioButtonMenuItem(o.name(),
+                    o == JavaSEVisionImpl.outcome);
+            outcomeGroup.add(item);
+            item.addActionListener(new ActionListener() {
+                @Override
+                public void actionPerformed(ActionEvent ae) {
+                    JavaSEVisionImpl.outcome = o;
+                    pref.put("VisionSim.outcome", o.name());
+                }
+            });
+            outcomeMenu.add(item);
+        }
+        visionMenu.add(outcomeMenu);
+
+        visionMenu.addSeparator();
+
+        JavaSEVisionImpl.barcodeValue = pref.get("VisionSim.barcodeValue",
+                JavaSEVisionImpl.barcodeValue);
+        JMenuItem barcodeValue = new JMenuItem("Set scanned code value...");
+        barcodeValue.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent ae) {
+                String value = JOptionPane.showInputDialog(canvas,
+                        "Value the simulated barcode scanner decodes:",
+                        JavaSEVisionImpl.barcodeValue);
+                if (value != null) {
+                    JavaSEVisionImpl.barcodeValue = value;
+                    pref.put("VisionSim.barcodeValue", value);
+                }
+            }
+        });
+        visionMenu.add(barcodeValue);
+
+        JavaSEVisionImpl.barcodeFormat = pref.get("VisionSim.barcodeFormat",
+                JavaSEVisionImpl.barcodeFormat);
+        JMenu formatMenu = new JMenu("Scanned code format");
+        ButtonGroup formatGroup = new ButtonGroup();
+        String[] formats = {"QR_CODE", "EAN_13", "UPC_A", "CODE_128",
+            "DATA_MATRIX", "PDF417", "AZTEC"};
+        for (final String format : formats) {
+            final JRadioButtonMenuItem item = new JRadioButtonMenuItem(format,
+                    format.equals(JavaSEVisionImpl.barcodeFormat));
+            formatGroup.add(item);
+            item.addActionListener(new ActionListener() {
+                @Override
+                public void actionPerformed(ActionEvent ae) {
+                    JavaSEVisionImpl.barcodeFormat = format;
+                    pref.put("VisionSim.barcodeFormat", format);
+                }
+            });
+            formatMenu.add(item);
+        }
+        visionMenu.add(formatMenu);
+
+        visionMenu.addSeparator();
+
+        JavaSEVisionImpl.recognizedText = pref.get("VisionSim.text",
+                JavaSEVisionImpl.recognizedText);
+        JMenuItem recognizedText = new JMenuItem("Set recognized text...");
+        recognizedText.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent ae) {
+                String value = JOptionPane.showInputDialog(canvas,
+                        "Text the simulated recognizer reads "
+                        + "(\\n separates blocks):",
+                        JavaSEVisionImpl.recognizedText.replace("\n", "\\n"));
+                if (value != null) {
+                    JavaSEVisionImpl.recognizedText = value.replace("\\n", "\n");
+                    pref.put("VisionSim.text", JavaSEVisionImpl.recognizedText);
+                }
+            }
+        });
+        visionMenu.add(recognizedText);
+
+        JavaSEVisionImpl.imageLabels = pref.get("VisionSim.labels",
+                JavaSEVisionImpl.imageLabels);
+        JMenuItem imageLabels = new JMenuItem("Set image labels...");
+        imageLabels.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent ae) {
+                String value = JOptionPane.showInputDialog(canvas,
+                        "Comma separated label:confidence pairs:",
+                        JavaSEVisionImpl.imageLabels);
+                if (value != null) {
+                    JavaSEVisionImpl.imageLabels = value;
+                    pref.put("VisionSim.labels", value);
+                }
+            }
+        });
+        visionMenu.add(imageLabels);
+
+        visionMenu.addSeparator();
+
+        JavaSEVisionImpl.faceCount = pref.getInt("VisionSim.faces",
+                JavaSEVisionImpl.faceCount);
+        JMenu faceMenu = new JMenu("Detected faces");
+        ButtonGroup faceGroup = new ButtonGroup();
+        for (int i = 0; i <= 3; i++) {
+            final int count = i;
+            final JRadioButtonMenuItem item = new JRadioButtonMenuItem(
+                    String.valueOf(count), count == JavaSEVisionImpl.faceCount);
+            faceGroup.add(item);
+            item.addActionListener(new ActionListener() {
+                @Override
+                public void actionPerformed(ActionEvent ae) {
+                    JavaSEVisionImpl.faceCount = count;
+                    pref.putInt("VisionSim.faces", count);
+                }
+            });
+            faceMenu.add(item);
+        }
+        visionMenu.add(faceMenu);
+
+        final JCheckBoxMenuItem smiling = new JCheckBoxMenuItem(
+                "Faces are smiling", pref.getBoolean("VisionSim.smiling", true));
+        JavaSEVisionImpl.smilingProbability = smiling.isSelected() ? .8f : .1f;
+        smiling.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent ae) {
+                JavaSEVisionImpl.smilingProbability =
+                        smiling.isSelected() ? .8f : .1f;
+                pref.putBoolean("VisionSim.smiling", smiling.isSelected());
+            }
+        });
+        visionMenu.add(smiling);
+
+        final JCheckBoxMenuItem pose = new JCheckBoxMenuItem(
+                "Body pose detected", pref.getBoolean("VisionSim.pose", true));
+        JavaSEVisionImpl.poseDetected = pose.isSelected();
+        pose.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent ae) {
+                JavaSEVisionImpl.poseDetected = pose.isSelected();
+                pref.putBoolean("VisionSim.pose", pose.isSelected());
+            }
+        });
+        visionMenu.add(pose);
+
+        return visionMenu;
     }
 
     private JMenu installNfcSimulationMenu(JMenu simulateMenu, final Preferences pref) {
@@ -16255,6 +16434,15 @@ public class JavaSEPort extends CodenameOneImplementation {
     @Override
     public com.codename1.impl.ARImpl createARImpl() {
         return new JavaSEARImpl();
+    }
+
+    /// The desktop has no on-device vision models, so the simulator serves the
+    /// results scripted in *Simulate &gt; Vision* instead of reporting every
+    /// analyzer as unsupported. That keeps scanner and overlay code buildable
+    /// without a device.
+    @Override
+    public com.codename1.impl.VisionImpl createVisionImpl() {
+        return new JavaSEVisionImpl();
     }
     
     private void captureMulti(final com.codename1.ui.events.ActionListener response, final String[] imageTypes, final String desc) {

--- a/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEVisionImpl.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEVisionImpl.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.impl.javase;
+
+import com.codename1.ai.vision.Barcode;
+import com.codename1.ai.vision.DocumentScanResult;
+import com.codename1.ai.vision.Face;
+import com.codename1.ai.vision.ImageLabel;
+import com.codename1.ai.vision.Pose;
+import com.codename1.ai.vision.SegmentationMask;
+import com.codename1.ai.vision.TextRecognitionResult;
+import com.codename1.ai.vision.VisionException;
+import com.codename1.ai.vision.VisionFeature;
+import com.codename1.ai.vision.VisionImage;
+import com.codename1.ai.vision.VisionMetadata;
+import com.codename1.ai.vision.VisionOptions;
+import com.codename1.ai.vision.VisionPoint;
+import com.codename1.ai.vision.VisionRect;
+import com.codename1.impl.VisionImpl;
+import com.codename1.ui.Display;
+import com.codename1.util.AsyncResource;
+
+import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
+import java.util.Map;
+
+/// Scriptable simulator backend for `com.codename1.ai.vision`.
+///
+/// The desktop has no on-device vision models, so instead of reporting every
+/// analyzer as unsupported -- which leaves a scanner screen impossible to
+/// build without a device -- this backend returns whatever the developer
+/// scripted in *Simulate &gt; Vision*. The results carry plausible geometry so
+/// overlay, debounce, and "what happens when nothing is found" code can be
+/// written and debugged in the simulator.
+///
+/// The values are process-wide and driven from the menu, exactly like
+/// `JavaSENfc`'s virtual tag. Nothing here runs on a device.
+///
+/// @hidden
+public class JavaSEVisionImpl extends VisionImpl {
+    /// Outcome the next analysis produces, whatever the feature.
+    public enum SimOutcome {
+        /// Return the scripted result for the requested feature.
+        RESULT,
+        /// Return an empty result: no codes, no faces, no text.
+        NOTHING_FOUND,
+        /// Fail with `VisionException.UNSUPPORTED`, the way a target without
+        /// that model behaves.
+        UNSUPPORTED,
+        /// Fail with `VisionException.BACKEND_ERROR`.
+        ERROR
+    }
+
+    /// Whether the simulated device has any vision support at all. When false
+    /// every `isSupported()` call returns false, which is what a port with no
+    /// vision backend looks like.
+    public static volatile boolean simSupported = true;
+    /// Outcome applied to the next -- and every subsequent -- analysis.
+    public static volatile SimOutcome outcome = SimOutcome.RESULT;
+    /// Value the simulated barcode scanner decodes.
+    public static volatile String barcodeValue = "https://www.codenameone.com/";
+    /// Symbology the simulated barcode scanner reports.
+    public static volatile String barcodeFormat = "QR_CODE";
+    /// Text the simulated recognizer reads.
+    public static volatile String recognizedText = "Codename One\nOn-device OCR";
+    /// How many faces the simulated detector finds.
+    public static volatile int faceCount = 1;
+    /// Smile probability reported for each simulated face.
+    public static volatile float smilingProbability = 0.8f;
+    /// Comma-separated `label:confidence` pairs the simulated classifier returns.
+    public static volatile String imageLabels =
+            "person:0.94,indoor:0.71,computer:0.55";
+    /// Whether the simulated pose detector finds a body.
+    public static volatile boolean poseDetected = true;
+
+    private boolean closed;
+
+    /// @param feature the analyzer's feature
+    /// @param backendId the selected backend id
+    /// @return whether the simulated device supports that pair
+    @Override
+    public boolean isSupported(VisionFeature feature, String backendId) {
+        return !closed && simSupported;
+    }
+
+    /// Produces the scripted result for `feature`, delivered asynchronously on
+    /// the EDT so that timing-sensitive application code behaves the way it
+    /// will on a device.
+    ///
+    /// @param feature the analyzer's feature
+    /// @param backendId the selected backend id
+    /// @param image the input, used only for its dimensions
+    /// @param options the analyzer's options
+    /// @param <T> the analyzer's result type
+    /// @return the scripted asynchronous result
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> AsyncResource<T> analyze(VisionFeature feature, String backendId,
+                                        VisionImage image, VisionOptions options) {
+        final AsyncResource<T> result = new AsyncResource<T>();
+        if (closed) {
+            result.error(new VisionException(VisionException.BACKEND_ERROR,
+                    "Vision backend is closed"));
+            return result;
+        }
+        final SimOutcome requested = outcome;
+        if (requested == SimOutcome.UNSUPPORTED) {
+            result.error(new VisionException(VisionException.UNSUPPORTED,
+                    feature + " is not supported by the simulated device"));
+            return result;
+        }
+        if (requested == SimOutcome.ERROR) {
+            result.error(new VisionException(VisionException.BACKEND_ERROR,
+                    "Simulated " + feature + " failure"));
+            return result;
+        }
+        final Object value = build(feature, requested, image);
+        if (value == null) {
+            result.error(new VisionException(VisionException.UNSUPPORTED,
+                    feature + " has no simulated result"));
+            return result;
+        }
+        Display.getInstance().callSerially(new Runnable() {
+            @Override
+            public void run() {
+                result.complete((T) value);
+            }
+        });
+        return result;
+    }
+
+    /// Releases the simulated backend. Idempotent.
+    @Override
+    public void close() {
+        closed = true;
+    }
+
+    private static Object build(VisionFeature feature, SimOutcome requested,
+                                VisionImage image) {
+        boolean empty = requested == SimOutcome.NOTHING_FOUND;
+        switch (feature) {
+            case BARCODE_SCANNING:
+                return empty ? new Barcode[0] : barcodes();
+            case TEXT_RECOGNITION:
+                return empty ? TextRecognitionResult.EMPTY : text();
+            case FACE_DETECTION:
+                return empty ? new Face[0] : faces();
+            case IMAGE_LABELING:
+                return empty ? new ImageLabel[0] : labels();
+            case POSE_DETECTION:
+                return empty || !poseDetected
+                        ? new Pose(new Pose.Landmark[0], metadata())
+                        : pose();
+            case SELFIE_SEGMENTATION:
+                return mask(empty);
+            case DOCUMENT_SCANNING:
+                return document(empty, image);
+            default:
+                return null;
+        }
+    }
+
+    private static VisionMetadata metadata() {
+        Map<String, String> values = new HashMap<String, String>();
+        values.put("simulated", "true");
+        return new VisionMetadata("simulator", values);
+    }
+
+    private static Barcode[] barcodes() {
+        VisionRect bounds = new VisionRect(.3f, .35f, .4f, .3f);
+        VisionPoint[] corners = {
+            new VisionPoint(.3f, .35f), new VisionPoint(.7f, .35f),
+            new VisionPoint(.7f, .65f), new VisionPoint(.3f, .65f)
+        };
+        String value = barcodeValue;
+        byte[] raw = new byte[0];
+        if (value != null) {
+            try {
+                raw = value.getBytes("UTF-8");
+            } catch (UnsupportedEncodingException impossible) {
+                raw = new byte[0];
+            }
+        }
+        return new Barcode[] {
+            new Barcode(value, barcodeFormat, raw, bounds, corners, metadata())
+        };
+    }
+
+    private static TextRecognitionResult text() {
+        String value = recognizedText == null ? "" : recognizedText;
+        String[] lines = value.split("\n");
+        TextRecognitionResult.TextBlock[] blocks =
+                new TextRecognitionResult.TextBlock[lines.length];
+        float lineHeight = lines.length == 0 ? 0 : .6f / lines.length;
+        for (int i = 0; i < lines.length; i++) {
+            blocks[i] = new TextRecognitionResult.TextBlock(lines[i], .9f,
+                    new VisionRect(.1f, .2f + i * lineHeight, .8f,
+                            lineHeight * .8f), "en");
+        }
+        return new TextRecognitionResult(value, blocks, metadata());
+    }
+
+    private static Face[] faces() {
+        int count = Math.max(0, faceCount);
+        Face[] out = new Face[count];
+        float width = count == 0 ? 0 : Math.min(.35f, .8f / count);
+        for (int i = 0; i < count; i++) {
+            float left = .1f + i * (width + .05f);
+            VisionRect bounds = new VisionRect(left, .25f, width, width * 1.3f);
+            Map<String, VisionPoint> landmarks =
+                    new HashMap<String, VisionPoint>();
+            landmarks.put("leftEye",
+                    new VisionPoint(left + width * .7f, .25f + width * .4f));
+            landmarks.put("rightEye",
+                    new VisionPoint(left + width * .3f, .25f + width * .4f));
+            landmarks.put("noseBase",
+                    new VisionPoint(left + width * .5f, .25f + width * .7f));
+            landmarks.put("mouthLeft",
+                    new VisionPoint(left + width * .7f, .25f + width * 1f));
+            landmarks.put("mouthRight",
+                    new VisionPoint(left + width * .3f, .25f + width * 1f));
+            out[i] = new Face(bounds, landmarks, 0, 0, 0,
+                    smilingProbability, i, metadata());
+        }
+        return out;
+    }
+
+    private static ImageLabel[] labels() {
+        String value = imageLabels == null ? "" : imageLabels.trim();
+        if (value.length() == 0) {
+            return new ImageLabel[0];
+        }
+        String[] parts = value.split(",");
+        ImageLabel[] out = new ImageLabel[parts.length];
+        for (int i = 0; i < parts.length; i++) {
+            String part = parts[i].trim();
+            int colon = part.lastIndexOf(':');
+            String text = colon < 0 ? part : part.substring(0, colon);
+            float confidence = .5f;
+            if (colon >= 0) {
+                try {
+                    confidence = Float.parseFloat(part.substring(colon + 1));
+                } catch (NumberFormatException ignored) {
+                    text = part;
+                }
+            }
+            out[i] = new ImageLabel(text.trim(), confidence, i, metadata());
+        }
+        return out;
+    }
+
+    private static Pose pose() {
+        // A rough standing figure, enough to exercise skeleton drawing.
+        String[] names = {
+            "nose", "leftShoulder", "rightShoulder", "leftElbow", "rightElbow",
+            "leftWrist", "rightWrist", "leftHip", "rightHip", "leftKnee",
+            "rightKnee", "leftAnkle", "rightAnkle"
+        };
+        float[][] positions = {
+            {.50f, .12f}, {.62f, .28f}, {.38f, .28f}, {.68f, .44f},
+            {.32f, .44f}, {.72f, .58f}, {.28f, .58f}, {.58f, .56f},
+            {.42f, .56f}, {.59f, .74f}, {.41f, .74f}, {.60f, .92f},
+            {.40f, .92f}
+        };
+        Pose.Landmark[] landmarks = new Pose.Landmark[names.length];
+        for (int i = 0; i < names.length; i++) {
+            landmarks[i] = new Pose.Landmark(names[i],
+                    new VisionPoint(positions[i][0], positions[i][1]), .9f);
+        }
+        return new Pose(landmarks, metadata());
+    }
+
+    private static SegmentationMask mask(boolean empty) {
+        int width = 64;
+        int height = 64;
+        float[] confidence = new float[width * height];
+        if (!empty) {
+            // A centered ellipse standing in for the subject.
+            float cx = width / 2f;
+            float cy = height / 2f;
+            float rx = width * .28f;
+            float ry = height * .42f;
+            for (int y = 0; y < height; y++) {
+                for (int x = 0; x < width; x++) {
+                    float dx = (x - cx) / rx;
+                    float dy = (y - cy) / ry;
+                    float d = dx * dx + dy * dy;
+                    confidence[y * width + x] = d <= 1
+                            ? Math.min(1f, 1.2f - d * .3f) : 0f;
+                }
+            }
+        }
+        return new SegmentationMask(width, height, confidence, metadata());
+    }
+
+    private static DocumentScanResult document(boolean empty, VisionImage image) {
+        if (empty) {
+            return new DocumentScanResult(new byte[0][], metadata());
+        }
+        byte[] page = image == null ? null : image.getEncodedBytes();
+        if (page == null || page.length == 0) {
+            return new DocumentScanResult(new byte[0][], metadata());
+        }
+        // The simulator has no perspective correction; the "corrected" page is
+        // the page it was handed, which is enough to wire up a review screen.
+        return new DocumentScanResult(new byte[][] {page}, metadata());
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/VisionSnippets.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/VisionSnippets.java
@@ -1,0 +1,362 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets;
+
+import com.codename1.ai.vision.Barcode;
+import com.codename1.ai.vision.BarcodeFormat;
+import com.codename1.ai.vision.BarcodeScanner;
+import com.codename1.ai.vision.CodeScanner;
+import com.codename1.ai.vision.CodeScannerOptions;
+import com.codename1.ai.vision.DocumentScanner;
+import com.codename1.ai.vision.Face;
+import com.codename1.ai.vision.FaceDetector;
+import com.codename1.ai.vision.ImageLabel;
+import com.codename1.ai.vision.ImageLabeler;
+import com.codename1.ai.vision.Pose;
+import com.codename1.ai.vision.PoseDetector;
+import com.codename1.ai.vision.PoseLandmarks;
+import com.codename1.ai.vision.SegmentationMask;
+import com.codename1.ai.vision.SelfieSegmenter;
+import com.codename1.ai.vision.TextRecognitionResult;
+import com.codename1.ai.vision.TextRecognizer;
+import com.codename1.ai.vision.VisionCameraView;
+import com.codename1.ai.vision.VisionImage;
+import com.codename1.ai.vision.VisionOptions;
+import com.codename1.ai.vision.VisionPipelineListener;
+import com.codename1.camera.CameraFacing;
+import com.codename1.components.ToastBar;
+import com.codename1.io.Log;
+import com.codename1.ui.Button;
+import com.codename1.ui.EncodedImage;
+import com.codename1.ui.Form;
+import com.codename1.ui.Graphics;
+import com.codename1.ui.Image;
+import com.codename1.ui.Label;
+import com.codename1.ui.TextArea;
+import com.codename1.ui.geom.Rectangle;
+import com.codename1.ui.layouts.BorderLayout;
+import com.codename1.ui.layouts.BoxLayout;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Compiled source snippets for the on-device vision guide chapter. */
+public class VisionSnippets {
+    private String photoPath;
+    private byte[] jpegBytes;
+    private Label resultLabel;
+    private Label statusLabel;
+    private TextArea textArea;
+    private Label preview;
+    private Button shutter;
+    private int reps;
+
+    /** The whole scanner screen, in one call. */
+    public void codeScanner() {
+        // tag::vision-code-scanner[]
+        if (!CodeScanner.isSupported()) {
+            ToastBar.showErrorMessage("This device cannot scan codes");
+            return;
+        }
+
+        CodeScanner.scan().ready(code -> {
+            if (code == null) {
+                return;                       // the user backed out
+            }
+            resultLabel.setText(code.getValue());
+        }).except(error -> Log.e(error));
+        // end::vision-code-scanner[]
+    }
+
+    /** The same screen, restricted to the codes this app actually wants. */
+    public void codeScannerOptions() {
+        // tag::vision-code-scanner-options[]
+        CodeScanner.scan(new CodeScannerOptions()
+                .title("Boarding pass")
+                .hint("Hold the pass flat inside the frame")
+                .formats(BarcodeFormat.PDF417, BarcodeFormat.AZTEC))
+            .ready(code -> {
+                if (code != null) {
+                    checkIn(code.getValue());
+                }
+            })
+            .except(error -> Log.e(error));
+        // end::vision-code-scanner-options[]
+    }
+
+    /** A live preview inside a form of your own, analyzing every frame. */
+    public void cameraView() {
+        // tag::vision-camera-view[]
+        FaceDetector detector = new FaceDetector();
+        VisionCameraView<Face[]> view = new VisionCameraView<>(detector);
+        view.setFacing(CameraFacing.FRONT);
+        view.setListener(new VisionPipelineListener<Face[]>() {
+            @Override
+            public void result(Face[] faces, VisionImage source) {
+                shutter.setEnabled(faces.length == 1);
+                statusLabel.setText(faces.length == 1
+                        ? "Looking good"
+                        : "Fit exactly one face in the frame");
+            }
+
+            @Override
+            public void error(Throwable error) {
+                Log.e(error);
+            }
+        });
+
+        Form form = new Form("Selfie", new BorderLayout());
+        form.add(BorderLayout.CENTER, view);
+        form.add(BorderLayout.SOUTH, BoxLayout.encloseY(statusLabel, shutter));
+        form.show();
+        // The camera is opened when the form is shown and released when the
+        // user navigates away. Call view.close() when the screen is finished
+        // with for good, which also releases the detector.
+        // end::vision-camera-view[]
+    }
+
+    /** Decoding codes out of a picture the user already has. */
+    public void stillBarcode() throws IOException {
+        // tag::vision-still-barcode[]
+        BarcodeScanner scanner = new BarcodeScanner();
+        scanner.process(VisionImage.fromFile(photoPath)).ready(codes -> {
+            for (Barcode code : codes) {
+                if (BarcodeFormat.matches(code, BarcodeFormat.EAN_13,
+                        BarcodeFormat.UPC_A)) {
+                    lookUpProduct(code.getValue());
+                }
+            }
+            scanner.close();
+        }).except(error -> {
+            Log.e(error);
+            scanner.close();
+        });
+        // end::vision-still-barcode[]
+    }
+
+    /** Reading the text out of a photographed receipt or label. */
+    public void recognizeText() throws IOException {
+        // tag::vision-text[]
+        TextRecognizer recognizer = new TextRecognizer();
+        recognizer.process(VisionImage.fromFile(photoPath)).ready(result -> {
+            textArea.setText(result.getText());
+            recognizer.close();
+        }).except(error -> {
+            Log.e(error);
+            recognizer.close();
+        });
+        // end::vision-text[]
+    }
+
+    /** Live OCR that stops at the first block matching the expected shape. */
+    public void recognizeTextLive() {
+        // tag::vision-text-live[]
+        VisionCameraView<TextRecognitionResult> view =
+                new VisionCameraView<>(new TextRecognizer());
+        view.setListener(new VisionPipelineListener<TextRecognitionResult>() {
+            @Override
+            public void result(TextRecognitionResult text, VisionImage source) {
+                for (TextRecognitionResult.TextBlock block : text.getBlocks()) {
+                    // Every frame is analyzed until one block looks like the
+                    // value being hunted for.
+                    if (block.getText().startsWith("SN-")) {
+                        accept(block.getText());
+                        return;
+                    }
+                }
+            }
+
+            @Override
+            public void error(Throwable error) {
+                Log.e(error);
+            }
+        });
+        // end::vision-text-live[]
+    }
+
+    /** Cropping a photo down to the face it contains. */
+    public void detectFaceInPhoto() {
+        // tag::vision-face-still[]
+        Image photo = EncodedImage.create(jpegBytes);
+        FaceDetector detector = new FaceDetector();
+        detector.process(VisionImage.fromImage(photo)).ready(faces -> {
+            if (faces.length > 0) {
+                Rectangle box = faces[0].getBounds()
+                        .toBounds(0, 0, photo.getWidth(), photo.getHeight());
+                preview.setIcon(photo.subImage(box.getX(), box.getY(),
+                        box.getWidth(), box.getHeight(), true));
+            }
+            detector.close();
+        }).except(error -> {
+            Log.e(error);
+            detector.close();
+        });
+        // end::vision-face-still[]
+    }
+
+    /** Classifying what an image contains. */
+    public void labelImage() throws IOException {
+        // tag::vision-labels[]
+        ImageLabeler labeler = new ImageLabeler(new VisionOptions()
+                .minimumConfidence(0.6f)
+                .maximumResults(5));
+
+        labeler.process(VisionImage.fromFile(photoPath)).ready(labels -> {
+            StringBuilder summary = new StringBuilder();
+            for (ImageLabel label : labels) {
+                summary.append(label.getText())
+                       .append(" (")
+                       .append(Math.round(label.getConfidence() * 100))
+                       .append("%)\n");
+            }
+            resultLabel.setText(summary.toString());
+            labeler.close();
+        }).except(error -> {
+            Log.e(error);
+            labeler.close();
+        });
+        // end::vision-labels[]
+    }
+
+    /** Counting arm raises from the live camera. */
+    public void countReps() {
+        // tag::vision-pose[]
+        VisionCameraView<Pose> view = new VisionCameraView<>(new PoseDetector());
+        view.setListener(new VisionPipelineListener<Pose>() {
+            private boolean wasUp;
+
+            @Override
+            public void result(Pose pose, VisionImage source) {
+                Pose.Landmark wrist = pose.getLandmark(PoseLandmarks.RIGHT_WRIST);
+                Pose.Landmark shoulder =
+                        pose.getLandmark(PoseLandmarks.RIGHT_SHOULDER);
+                if (wrist == null || shoulder == null
+                        || wrist.getConfidence() < 0.6f) {
+                    return;                    // this frame did not see the arm
+                }
+                // Y grows downwards, so "above" is the smaller value.
+                boolean up = wrist.getPosition().getY()
+                        < shoulder.getPosition().getY();
+                if (up && !wasUp) {
+                    reps++;
+                    statusLabel.setText(String.valueOf(reps));
+                }
+                wasUp = up;
+            }
+
+            @Override
+            public void error(Throwable error) {
+                Log.e(error);
+            }
+        });
+        // end::vision-pose[]
+    }
+
+    /** Removing the background from a selfie. */
+    public void removeBackground() {
+        // tag::vision-segmentation[]
+        EncodedImage photo = EncodedImage.create(jpegBytes);
+        SelfieSegmenter segmenter = new SelfieSegmenter();
+
+        segmenter.process(VisionImage.encoded(jpegBytes)).ready(mask -> {
+            // Below 60% foreground confidence becomes transparent, so whatever
+            // is painted behind this image shows through.
+            Image person = mask.cutOut(photo, 0.6f);
+            preview.setIcon(person);
+            segmenter.close();
+        }).except(error -> {
+            Log.e(error);
+            segmenter.close();
+        });
+        // end::vision-segmentation[]
+    }
+
+    /** Flattening a photographed page. */
+    public void scanDocument() throws IOException {
+        // tag::vision-document[]
+        DocumentScanner scanner = new DocumentScanner();
+        if (!scanner.isSupported()) {
+            // Google's Android document scanner is an interactive flow rather
+            // than an analyzer, so Android reports this unsupported.
+            scanner.close();
+            return;
+        }
+        scanner.process(VisionImage.fromFile(photoPath)).ready(result -> {
+            List<Image> pages = new ArrayList<>();
+            for (int i = 0; i < result.getPageCount(); i++) {
+                pages.add(EncodedImage.create(result.getPage(i)));
+            }
+            show(pages);
+            scanner.close();
+        }).except(error -> {
+            Log.e(error);
+            scanner.close();
+        });
+        // end::vision-document[]
+    }
+
+    /** Drawing normalized result geometry over the image it was found in. */
+    // tag::vision-overlay[]
+    class FaceOverlay extends Label {
+        private Face[] faces = new Face[0];
+
+        FaceOverlay(Image photo) {
+            super(photo);
+        }
+
+        void setFaces(Face[] value) {
+            faces = value;
+            repaint();
+        }
+
+        @Override
+        public void paint(Graphics g) {
+            super.paint(g);
+            g.setColor(0x34c759);
+            for (Face face : faces) {
+                // Results are normalized to 0..1, so the same observation maps
+                // onto whatever size this component happens to be.
+                Rectangle r = face.getBounds().toBounds(this);
+                g.drawRect(r.getX(), r.getY(), r.getWidth(), r.getHeight(), 3);
+            }
+        }
+    }
+    // end::vision-overlay[]
+
+    private void checkIn(String value) {
+        Log.p("checking in " + value);
+    }
+
+    private void lookUpProduct(String value) {
+        Log.p("looking up " + value);
+    }
+
+    private void accept(String value) {
+        Log.p("accepted " + value);
+    }
+
+    private void show(List<Image> pages) {
+        Log.p("showing " + pages.size() + " page(s)");
+    }
+}

--- a/docs/developer-guide/Ai-And-Speech.asciidoc
+++ b/docs/developer-guide/Ai-And-Speech.asciidoc
@@ -337,6 +337,12 @@ navigates away, so a form transition can't leave the hardware held.
 `close()` additionally releases the analyzer, for a screen that's
 finished with for good.
 
+NOTE: `setScaleType(...)`, and the mirroring a front camera asks for, are
+honored in the simulator. The iOS and Android previews render fixed at
+fill-and-crop and unmirrored, because neither port implements the
+preview-scaling hook on `CameraImpl` yet. Treat both as requests rather
+than guarantees on a device.
+
 WARNING: The preview is a native view, and Codename One components can't
 be painted over it on every platform -- iOS renders native peers behind
 the Codename One layer, Android renders them in front. Put a reticle,

--- a/docs/developer-guide/Ai-And-Speech.asciidoc
+++ b/docs/developer-guide/Ai-And-Speech.asciidoc
@@ -273,18 +273,209 @@ language.
 
 === On-device vision
 
-The vision API accepts JPEG, PNG, NV21, or RGBA8888 data through
-`VisionImage`. `VisionImage.fromCameraFrame(frame)` is normally the
-best way to connect a camera because it copies the frame's
-callback-owned buffers and preserves the frame rotation before analysis
-becomes asynchronous. For an encoded gallery or file image whose pixels
-need an EXIF display rotation, use
-`VisionImage.encoded(bytes, rotationDegrees)`; the one-argument overload
-assumes the stored pixels are already upright and doesn't inspect EXIF
-metadata. Each analyzer returns stable Codename One result types. Bounds
-and points use normalized coordinates in the range 0 through 1.
-`VisionOptions.minimumConfidence(...)` clamps finite and infinite values to
-that range and rejects NaN.
+The vision API is three layers deep, and most applications only need the
+first one. Start with the finished screen, drop to a component when the
+screen has to look like your own, and drop to a single analyzer when you
+are working on one image at a time.
+
+==== Scanning a barcode or QR code
+
+`CodeScanner` is an entire scanner screen in one call. It opens the
+camera, decodes, restores the form you came from, and hands back the
+code. This is the replacement for the `cn1-codescan` cn1lib:
+
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/VisionSnippets.java[tag=vision-code-scanner,indent=0]
+----
+
+The result completes with `null` when the user backs out -- the cn1lib's
+`scanCanceled()` -- and fails through `except` when the camera cannot be
+opened, which is its `scanError()`. There is no third callback to
+implement.
+
+`CodeScannerOptions` rewords the screen and restricts which symbologies
+end the scan, so a stray product barcode in the frame doesn't complete a
+QR scan:
+
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/VisionSnippets.java[tag=vision-code-scanner-options,indent=0]
+----
+
+The `BarcodeFormat` constants are the portable symbology names every
+backend maps onto, so no format literals are needed.
+
+IMPORTANT: Three classes share the name `CodeScanner`. Import
+`com.codename1.ai.vision.CodeScanner`. The other two are the
+`cn1-codescan` cn1lib's `com.codename1.ext.codescan.CodeScanner` and the
+long-deprecated `com.codename1.codescan.CodeScanner` in core, whose
+`getInstance()` returns `null` on current targets.
+
+==== Analyzing the live camera
+
+`VisionCameraView` is a component that owns the camera and runs an
+analyzer over its frames. It handles the session, the frame conversion,
+the keep-only-the-newest backpressure, and the hop back to the EDT; the
+application implements one listener. It works with every analyzer, not
+just barcodes:
+
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/VisionSnippets.java[tag=vision-camera-view,indent=0]
+----
+
+The analyzer is constructed by the application rather than named by a
+feature constant. That is deliberate: the builders decide which native
+vision dependency to package from the analyzer classes an application
+references, so building the analyzer in your own code is what keeps a
+face-detection app from also carrying the barcode and pose models.
+
+The camera opens when the view is shown and is released when the user
+navigates away, so a form transition cannot leave the hardware held.
+`close()` additionally releases the analyzer, for a screen that is
+finished with for good.
+
+WARNING: The preview is a native view, and Codename One components cannot
+be painted over it on every platform -- iOS renders native peers behind
+the Codename One layer, Android renders them in front. Put a reticle,
+hints, and buttons around the preview rather than on top of it. Result
+geometry can still be drawn over a *still* image, as below.
+
+==== The analyzers
+
+Each analyzer takes a `VisionImage` and returns a typed result. Create
+one, reuse it across a sequence of images, and close it when finished.
+Check `isSupported()` before offering the feature: availability depends
+on the target, the linked backend, and the OS version.
+
+`VisionImage` accepts JPEG, PNG, NV21, or RGBA8888 data.
+`VisionImage.fromFile(path)` reads a gallery or captured photo,
+`VisionImage.fromImage(image)` takes one already in memory -- passing an
+`EncodedImage`'s original bytes straight through rather than re-encoding
+-- and `VisionImage.fromCameraFrame(frame)` copies a live frame's
+callback-owned buffers and preserves its rotation.
+
+`BarcodeScanner` decodes codes from a still image:
+
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/VisionSnippets.java[tag=vision-still-barcode,indent=0]
+----
+
+`TextRecognizer` reads text. Over a file:
+
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/VisionSnippets.java[tag=vision-text,indent=0]
+----
+
+Or from the live camera, stopping at the first block that looks like the
+value being hunted for:
+
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/VisionSnippets.java[tag=vision-text-live,indent=0]
+----
+
+`FaceDetector` returns bounds, head angles, and named landmarks. Cropping
+a photo to the face it contains:
+
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/VisionSnippets.java[tag=vision-face-still,indent=0]
+----
+
+Read individual landmarks with `face.getLandmark(...)` and the
+`FaceLandmarks` constants. Not every backend fills in every field:
+`getSmilingProbability()` and `getTrackingId()` are negative when
+unavailable, and Apple Vision reports neither.
+
+`ImageLabeler` classifies what an image contains:
+
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/VisionSnippets.java[tag=vision-labels,indent=0]
+----
+
+The label text is the portable part. `ImageLabel.getIndex()` is a model
+class index that differs between backends and is `-1` on Apple Vision, so
+branch on `getText()`.
+
+`PoseDetector` locates body joints. Backends detect different subsets of
+the skeleton, so look joints up by name and handle a missing one:
+
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/VisionSnippets.java[tag=vision-pose,indent=0]
+----
+
+`SelfieSegmenter` separates a person from the background.
+`SegmentationMask.cutOut(...)` applies the mask to the source image and
+rescales it, since the mask has the model's resolution rather than the
+frame's:
+
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/VisionSnippets.java[tag=vision-segmentation,indent=0]
+----
+
+`SegmentationMask.toMaskImage(rgb)` renders the mask itself as a
+translucent tint, for highlighting the subject rather than cutting it out.
+
+`DocumentScanner` flattens a photographed page:
+
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/VisionSnippets.java[tag=vision-document,indent=0]
+----
+
+==== Drawing the results
+
+Bounds and points are normalized to the range 0 through 1 rather than
+pixels, so one observation maps onto an image of any size.
+`VisionRect.toBounds(component)` and `VisionPoint.toPoint(component)`
+convert them into the absolute coordinates a `paint` method draws in:
+
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/VisionSnippets.java[tag=vision-overlay,indent=0]
+----
+
+The mapping stretches the whole 0..1 range across the destination, which
+is right when the destination has the same aspect ratio as the analyzed
+image. A live preview scaled with `ScaleType.CROP` does not, which is the
+other half of why overlays belong on still images.
+
+==== Scripting results in the simulator
+
+The desktop has no on-device vision models. Rather than report every
+analyzer as unsupported -- which would leave a scanner screen impossible
+to build without a device -- the simulator returns whatever you script
+under *Simulate > Vision*:
+
+* *Vision Supported* turns the whole API off, so the `isSupported()`
+  branch can be exercised.
+* *Analysis outcome* switches between the scripted result, an empty
+  result, `VisionException.UNSUPPORTED`, and a backend error. Every
+  screen needs the "nothing found" and "it failed" paths, and this is how
+  to reach them.
+* The remaining items set the scripted values: the decoded code and its
+  format, the recognized text, the image labels, how many faces are found
+  and whether they are smiling, and whether a body pose is detected.
+
+The scripted results carry plausible geometry, so overlay and debounce
+code can be written and debugged before the app ever reaches a device.
+Nothing in this section applies to a device build.
+
+==== Backends and options
+
+An image whose stored pixels are not already upright needs its rotation
+declared: `VisionImage.encoded(bytes, rotationDegrees)`. The one-argument
+overload, and `fromFile(...)`, assume the pixels are upright and do not
+inspect EXIF metadata; `fromCameraFrame(...)` takes the rotation from the
+frame. `VisionOptions.minimumConfidence(...)` clamps finite and infinite
+values to the range 0 through 1 and rejects NaN.
 
 Android uses ML Kit. iOS and Mac native builds default to Apple Vision
 and Core Image. iOS can select ML Kit explicitly:
@@ -370,7 +561,7 @@ each class the application actually uses:
 | ML Kit bundle for that script
 | Vision recognition languages / `GoogleMLKit/TextRecognition<Script>`
 
-| `BarcodeScanner`
+| `BarcodeScanner`, `CodeScanner`
 | ML Kit barcode scanning
 | Vision / `GoogleMLKit/BarcodeScanning`
 
@@ -394,6 +585,12 @@ each class the application actually uses:
 | Unsupported for still images
 | Core Image perspective correction
 |===
+
+`CodeScanner` selects the same barcode dependency `BarcodeScanner` does,
+because it builds one internally; an application that references only the
+ready-made screen still gets the decoder. `CodeScanner` and
+`VisionCameraView` additionally select the camera natives, so neither has
+to be paired with a `com.codename1.camera` reference to work.
 
 The optional iOS ML Kit pod is added only when both the analyzer and its
 feature-specific selector are referenced. For example,

--- a/docs/developer-guide/Ai-And-Speech.asciidoc
+++ b/docs/developer-guide/Ai-And-Speech.asciidoc
@@ -290,7 +290,7 @@ include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/V
 ----
 
 The result completes with `null` when the user backs out -- the cn1lib's
-`scanCanceled()` -- and fails through `except` when the camera cannot be
+`scanCanceled()` -- and fails through `except` when the camera can't be
 opened, which is its `scanError()`. There is no third callback to
 implement.
 
@@ -316,7 +316,8 @@ long-deprecated `com.codename1.codescan.CodeScanner` in core, whose
 
 `VisionCameraView` is a component that owns the camera and runs an
 analyzer over its frames. It handles the session, the frame conversion,
-the keep-only-the-newest backpressure, and the hop back to the EDT; the
+the dropping of frames that inference has fallen behind, and the hop
+back to the EDT; the
 application implements one listener. It works with every analyzer, not
 just barcodes:
 
@@ -326,17 +327,17 @@ include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/V
 ----
 
 The analyzer is constructed by the application rather than named by a
-feature constant. That is deliberate: the builders decide which native
+feature constant. That's deliberate: the builders decide which native
 vision dependency to package from the analyzer classes an application
 references, so building the analyzer in your own code is what keeps a
 face-detection app from also carrying the barcode and pose models.
 
 The camera opens when the view is shown and is released when the user
-navigates away, so a form transition cannot leave the hardware held.
-`close()` additionally releases the analyzer, for a screen that is
+navigates away, so a form transition can't leave the hardware held.
+`close()` additionally releases the analyzer, for a screen that's
 finished with for good.
 
-WARNING: The preview is a native view, and Codename One components cannot
+WARNING: The preview is a native view, and Codename One components can't
 be painted over it on every platform -- iOS renders native peers behind
 the Codename One layer, Android renders them in front. Put a reticle,
 hints, and buttons around the preview rather than on top of it. Result
@@ -442,9 +443,9 @@ convert them into the absolute coordinates a `paint` method draws in:
 include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/VisionSnippets.java[tag=vision-overlay,indent=0]
 ----
 
-The mapping stretches the whole 0..1 range across the destination, which
-is right when the destination has the same aspect ratio as the analyzed
-image. A live preview scaled with `ScaleType.CROP` does not, which is the
+The mapping stretches the whole normalized range across the destination,
+which is right when the destination has the same aspect ratio as the analyzed
+image. A live preview scaled with `ScaleType.CROP` doesn't, which is the
 other half of why overlays belong on still images.
 
 ==== Scripting results in the simulator
@@ -462,7 +463,7 @@ under *Simulate > Vision*:
   to reach them.
 * The remaining items set the scripted values: the decoded code and its
   format, the recognized text, the image labels, how many faces are found
-  and whether they are smiling, and whether a body pose is detected.
+  and whether they're smiling, and whether a body pose is detected.
 
 The scripted results carry plausible geometry, so overlay and debounce
 code can be written and debugged before the app ever reaches a device.
@@ -470,9 +471,9 @@ Nothing in this section applies to a device build.
 
 ==== Backends and options
 
-An image whose stored pixels are not already upright needs its rotation
+An image whose stored pixels aren't already upright needs its rotation
 declared: `VisionImage.encoded(bytes, rotationDegrees)`. The one-argument
-overload, and `fromFile(...)`, assume the pixels are upright and do not
+overload, and `fromFile(...)`, assume the pixels are upright and don't
 inspect EXIF metadata; `fromCameraFrame(...)` takes the rotation from the
 frame. `VisionOptions.minimumConfidence(...)` clamps finite and infinite
 values to the range 0 through 1 and rejects NaN.

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
@@ -6663,7 +6663,12 @@ public class AndroidGradleBuilder extends Executor {
         if ("com/codename1/ai/vision/TextRecognizer".equals(cls)) {
             return "AndroidTextRecognitionAdapter.java";
         }
-        if ("com/codename1/ai/vision/BarcodeScanner".equals(cls)) {
+        if ("com/codename1/ai/vision/BarcodeScanner".equals(cls)
+                || "com/codename1/ai/vision/CodeScanner".equals(cls)) {
+            // CodeScanner is the ready-made scanner screen built on top of
+            // BarcodeScanner. An app that only references the high-level class
+            // never names BarcodeScanner itself, so it has to select the same
+            // adapter or the feature ships inert.
             return "AndroidBarcodeScanningAdapter.java";
         }
         if ("com/codename1/ai/vision/FaceDetector".equals(cls)) {

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
@@ -1364,7 +1364,9 @@ public class IPhoneBuilder extends Executor {
                     // so the old modal Capture API (which only sets
                     // INCLUDE_CAMERA_USAGE) does not pull in the new
                     // AVFoundation-based CN1Camera natives.
-                    if (!usesCn1Camera && cls.indexOf("com/codename1/camera/") == 0) {
+                    if (!usesCn1Camera
+                            && (cls.indexOf("com/codename1/camera/") == 0
+                                || isCameraBackedVisionClass(cls))) {
                         usesCn1Camera = true;
                     }
                     // Augmented reality (com.codename1.ar.*). Gated on actual
@@ -7535,11 +7537,24 @@ public class IPhoneBuilder extends Executor {
     private static boolean isVisionAnalyzerClass(String cls) {
         return "com/codename1/ai/vision/TextRecognizer".equals(cls)
                 || "com/codename1/ai/vision/BarcodeScanner".equals(cls)
+                || "com/codename1/ai/vision/CodeScanner".equals(cls)
                 || "com/codename1/ai/vision/FaceDetector".equals(cls)
                 || "com/codename1/ai/vision/ImageLabeler".equals(cls)
                 || "com/codename1/ai/vision/PoseDetector".equals(cls)
                 || "com/codename1/ai/vision/SelfieSegmenter".equals(cls)
                 || "com/codename1/ai/vision/DocumentScanner".equals(cls);
+    }
+
+    /// The vision classes that drive the camera themselves. An app using one
+    /// of these never names {@code com.codename1.camera} directly, so without
+    /// this the AVFoundation natives behind the preview would be left out of
+    /// the build.
+    ///
+    /// @param cls internal-form class name seen by the scan
+    /// @return whether referencing it means the app opens a camera
+    private static boolean isCameraBackedVisionClass(String cls) {
+        return "com/codename1/ai/vision/CodeScanner".equals(cls)
+                || "com/codename1/ai/vision/VisionCameraView".equals(cls);
     }
 
     private static boolean isLanguageFeatureClass(String cls) {

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/HighLevelVisionDependencyTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/HighLevelVisionDependencyTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.builders;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A convenience class in {@code com.codename1.ai.vision} that builds an
+ * analyzer for the caller is still selected by both builders.
+ *
+ * <p>Nothing else catches this. The builders decide which native vision
+ * dependency to package by scanning the <em>application's</em> classes for the
+ * concrete analyzer types, and core is not part of that scan. So an app that
+ * references only {@code CodeScanner} never names {@code BarcodeScanner}, the
+ * scan sees no barcode analyzer, the Android adapter is pruned and the iOS
+ * natives are left out -- and the build is green while the feature is
+ * inert on the device. The same trap swallows the camera natives for a class
+ * that opens a camera without the app naming {@code com.codename1.camera}.</p>
+ *
+ * <p>This test walks the vision sources rather than a hand-written list, so a
+ * convenience class added later fails here until it is mapped.</p>
+ */
+class HighLevelVisionDependencyTest {
+    /** The concrete analyzers the builders key their dependencies on. */
+    private static final String[] ANALYZERS = {
+        "TextRecognizer", "BarcodeScanner", "FaceDetector", "ImageLabeler",
+        "PoseDetector", "SelfieSegmenter", "DocumentScanner"
+    };
+
+    private static final File VISION_DIR = new File(
+            "../../CodenameOne/src/com/codename1/ai/vision");
+
+    private static String read(File file) throws Exception {
+        assertTrue(file.exists(),
+                "source must be readable: " + file.getAbsolutePath());
+        return new String(Files.readAllBytes(file.toPath()),
+                StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Strips comments so a javadoc sample does not read as a real reference.
+     * {@code TextScript}'s documentation constructs a {@code TextRecognizer}
+     * to show how a script is selected, which is not the class depending on
+     * the analyzer.
+     */
+    private static String code(File file) throws Exception {
+        String body = read(file);
+        StringBuilder out = new StringBuilder(body.length());
+        int i = 0;
+        while (i < body.length()) {
+            if (body.startsWith("/*", i)) {
+                int end = body.indexOf("*/", i + 2);
+                i = end < 0 ? body.length() : end + 2;
+            } else if (body.startsWith("//", i)) {
+                int end = body.indexOf('\n', i);
+                i = end < 0 ? body.length() : end;
+            } else {
+                out.append(body.charAt(i));
+                i++;
+            }
+        }
+        return out.toString();
+    }
+
+    /**
+     * Vision classes that construct an analyzer themselves, paired with the
+     * analyzer they construct.
+     */
+    private static List<String[]> analyzerBuildingClasses() throws Exception {
+        assertTrue(VISION_DIR.isDirectory(),
+                "vision sources must be readable: "
+                        + VISION_DIR.getAbsolutePath());
+        List<String[]> out = new ArrayList<String[]>();
+        File[] sources = VISION_DIR.listFiles();
+        assertNotNull(sources);
+        for (File source : sources) {
+            String name = source.getName();
+            if (!name.endsWith(".java")) {
+                continue;
+            }
+            String simple = name.substring(0, name.length() - ".java".length());
+            if (isAnalyzer(simple)) {
+                continue;
+            }
+            String body = code(source);
+            for (String analyzer : ANALYZERS) {
+                if (body.contains("new " + analyzer + "(")) {
+                    out.add(new String[] {simple, analyzer});
+                }
+            }
+        }
+        return out;
+    }
+
+    private static boolean isAnalyzer(String simpleName) {
+        for (String analyzer : ANALYZERS) {
+            if (analyzer.equals(simpleName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Test
+    void aConvenienceClassSelectsTheSameAndroidAdapterAsItsAnalyzer()
+            throws Exception {
+        List<String[]> classes = analyzerBuildingClasses();
+        assertTrue(!classes.isEmpty(),
+                "CodeScanner builds a BarcodeScanner, so the scan of the "
+                        + "vision sources must not come back empty -- an empty "
+                        + "result means this test stopped testing anything");
+        for (String[] pair : classes) {
+            String expected = AndroidGradleBuilder.androidAiAdapterSource(
+                    "com/codename1/ai/vision/" + pair[1]);
+            assertNotNull(expected, pair[1] + " has no Android adapter");
+            assertEquals(expected,
+                    AndroidGradleBuilder.androidAiAdapterSource(
+                            "com/codename1/ai/vision/" + pair[0]),
+                    pair[0] + " builds a " + pair[1] + " but does not select"
+                            + " its Android adapter, so the adapter is pruned"
+                            + " and the feature reports itself unsupported");
+        }
+    }
+
+    @Test
+    void aConvenienceClassIsAlsoAVisionFeatureOnIos() throws Exception {
+        String builder = read(new File(
+                "src/main/java/com/codename1/builders/IPhoneBuilder.java"));
+        for (String[] pair : analyzerBuildingClasses()) {
+            assertTrue(builder.contains(
+                    "\"com/codename1/ai/vision/" + pair[0] + "\""),
+                    pair[0] + " builds a " + pair[1] + " but IPhoneBuilder"
+                            + " never names it, so an app referencing only the"
+                            + " convenience class gets no vision natives");
+        }
+    }
+
+    @Test
+    void aVisionClassThatOpensTheCameraSelectsTheCameraNatives()
+            throws Exception {
+        String builder = read(new File(
+                "src/main/java/com/codename1/builders/IPhoneBuilder.java"));
+        File[] sources = VISION_DIR.listFiles();
+        assertNotNull(sources);
+        int checked = 0;
+        for (File source : sources) {
+            String name = source.getName();
+            if (!name.endsWith(".java")) {
+                continue;
+            }
+            String body = code(source);
+            // VisionPipeline consumes a session the application opened; the
+            // classes this guards are the ones that call Camera.open
+            // themselves, directly or through VisionCameraView.
+            if (!body.contains("Camera.open(")
+                    && !body.contains("new VisionCameraView")) {
+                continue;
+            }
+            String simple = name.substring(0, name.length() - ".java".length());
+            checked++;
+            assertTrue(builder.contains(
+                    "\"com/codename1/ai/vision/" + simple + "\""),
+                    simple + " opens a camera but IPhoneBuilder never names"
+                            + " it, so usesCn1Camera stays false and the"
+                            + " AVFoundation preview natives are left out");
+        }
+        assertTrue(checked > 0,
+                "VisionCameraView opens the camera, so this scan must not come"
+                        + " back empty");
+    }
+}

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/HighLevelVisionDependencyTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/HighLevelVisionDependencyTest.java
@@ -22,6 +22,7 @@
  */
 package com.codename1.builders;
 
+import com.codename1.build.shared.PlatformFeatureCatalog;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -165,14 +166,72 @@ class HighLevelVisionDependencyTest {
         }
     }
 
+    /** The Android artifacts the catalog adds for one class. */
+    private static List<String> androidDeps(String simpleName) {
+        List<String> out = new ArrayList<String>();
+        for (PlatformFeatureCatalog.Entry entry : PlatformFeatureCatalog
+                .matchesFor("com/codename1/ai/vision/" + simpleName)) {
+            out.addAll(entry.androidGradleDeps());
+        }
+        return out;
+    }
+
     @Test
-    void aVisionClassThatOpensTheCameraSelectsTheCameraNatives()
+    void aConvenienceClassCarriesItsAnalyzersOwnDependencies()
             throws Exception {
-        String builder = read(new File(
-                "src/main/java/com/codename1/builders/IPhoneBuilder.java"));
+        // Retaining the adapter source is only half of it. The adapter is
+        // compiled inside the generated app against an artifact the catalog
+        // adds, so a convenience class that selects the adapter without
+        // selecting the artifact produces a project that does not compile.
+        for (String[] pair : analyzerBuildingClasses()) {
+            List<String> analyzer = androidDeps(pair[1]);
+            assertTrue(!analyzer.isEmpty(),
+                    pair[1] + " has no catalog Android dependency");
+            List<String> convenience = androidDeps(pair[0]);
+            for (String dep : analyzer) {
+                assertTrue(convenience.contains(dep),
+                        pair[0] + " builds a " + pair[1] + " but the catalog"
+                                + " does not add " + dep + " for it, so the"
+                                + " retained adapter has nothing to compile"
+                                + " against");
+            }
+        }
+    }
+
+    @Test
+    void aVisionClassThatOpensTheCameraCarriesTheCameraDependencies()
+            throws Exception {
+        // Same trap one level over: an app that references only CodeScanner or
+        // VisionCameraView never names com.codename1.camera, so the camera
+        // entry never fires and the preview opens on hardware the build did
+        // not provision.
+        for (String simple : cameraOpeningClasses()) {
+            List<String> deps = androidDeps(simple);
+            assertTrue(deps.contains("androidx.camera:camera-core:1.3.4"),
+                    simple + " opens a camera but the catalog adds no CameraX"
+                            + " artifact for it");
+            boolean permission = false;
+            boolean avFoundation = false;
+            for (PlatformFeatureCatalog.Entry entry : PlatformFeatureCatalog
+                    .matchesFor("com/codename1/ai/vision/" + simple)) {
+                permission |= entry.androidPermissions()
+                        .contains("android.permission.CAMERA");
+                avFoundation |= entry.iosFrameworks().contains("AVFoundation");
+            }
+            assertTrue(permission,
+                    simple + " opens a camera but the catalog requests no"
+                            + " CAMERA permission for it");
+            assertTrue(avFoundation,
+                    simple + " opens a camera but the catalog links no"
+                            + " AVFoundation for it");
+        }
+    }
+
+    /** Vision classes that call Camera.open, directly or through the view. */
+    private static List<String> cameraOpeningClasses() throws Exception {
+        List<String> out = new ArrayList<String>();
         File[] sources = VISION_DIR.listFiles();
         assertNotNull(sources);
-        int checked = 0;
         for (File source : sources) {
             String name = source.getName();
             if (!name.endsWith(".java")) {
@@ -180,22 +239,30 @@ class HighLevelVisionDependencyTest {
             }
             String body = code(source);
             // VisionPipeline consumes a session the application opened; the
-            // classes this guards are the ones that call Camera.open
+            // classes this finds are the ones that call Camera.open
             // themselves, directly or through VisionCameraView.
-            if (!body.contains("Camera.open(")
-                    && !body.contains("new VisionCameraView")) {
-                continue;
+            if (body.contains("Camera.open(")
+                    || body.contains("new VisionCameraView")) {
+                out.add(name.substring(0, name.length() - ".java".length()));
             }
-            String simple = name.substring(0, name.length() - ".java".length());
-            checked++;
+        }
+        assertTrue(!out.isEmpty(),
+                "VisionCameraView opens the camera, so this scan must not come"
+                        + " back empty");
+        return out;
+    }
+
+    @Test
+    void aVisionClassThatOpensTheCameraSelectsTheCameraNatives()
+            throws Exception {
+        String builder = read(new File(
+                "src/main/java/com/codename1/builders/IPhoneBuilder.java"));
+        for (String simple : cameraOpeningClasses()) {
             assertTrue(builder.contains(
                     "\"com/codename1/ai/vision/" + simple + "\""),
                     simple + " opens a camera but IPhoneBuilder never names"
                             + " it, so usesCn1Camera stays false and the"
                             + " AVFoundation preview natives are left out");
         }
-        assertTrue(checked > 0,
-                "VisionCameraView opens the camera, so this scan must not come"
-                        + " back empty");
     }
 }

--- a/maven/core-unittests/src/test/java/com/codename1/ai/vision/CodeScannerTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ai/vision/CodeScannerTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.ai.vision;
+
+import com.codename1.junit.UITestBase;
+import com.codename1.ui.Command;
+import com.codename1.ui.Display;
+import com.codename1.ui.Form;
+import com.codename1.ui.events.ActionEvent;
+import com.codename1.util.AsyncResource;
+import com.codename1.util.SuccessCallback;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The ready-made scanner screen: what an application gets from one call, and
+ * what it gets when the user backs out or the camera refuses to open.
+ */
+class CodeScannerTest extends UITestBase {
+    private FakeCameraImpl camera;
+    private FakeVisionImpl vision;
+
+    @BeforeEach
+    void installBackends() {
+        camera = new FakeCameraImpl();
+        vision = new FakeVisionImpl();
+        implementation.setCameraImpl(camera);
+        implementation.setVisionImpl(vision);
+    }
+
+    @Test
+    void supportNeedsBothTheCameraAndTheBarcodeBackend() {
+        assertTrue(CodeScanner.isSupported());
+
+        vision.supported = false;
+        assertFalse(CodeScanner.isSupported(),
+                "a target without a barcode backend cannot scan");
+
+        vision.supported = true;
+        implementation.setCameraImpl(null);
+        assertFalse(CodeScanner.isSupported(),
+                "a target without a camera cannot scan");
+    }
+
+    @Test
+    void theFirstDecodedCodeEndsTheScanAndRestoresThePreviousForm() {
+        Form caller = new Form("Caller");
+        caller.show();
+        flushSerialCalls();
+
+        vision.result = new Barcode[] {
+            new Barcode("https://codenameone.com", BarcodeFormat.QR_CODE,
+                    null, VisionRect.EMPTY, null)
+        };
+        Recorder recorder = new Recorder(CodeScanner.scan());
+        flushSerialCalls();
+        assertNotSame(caller, Display.getInstance().getCurrent(),
+                "the scanner shows its own form");
+
+        camera.deliver(new byte[] {1, 2, 3});
+        flushSerialCalls();
+
+        assertEquals(1, recorder.values.size());
+        assertNotNull(recorder.values.get(0));
+        assertEquals("https://codenameone.com",
+                recorder.values.get(0).getValue());
+        assertSame(caller, Display.getInstance().getCurrent(),
+                "the caller's form comes back");
+        assertNull(camera.frameListener,
+                "the camera is released once the scan ends");
+    }
+
+    @Test
+    void aCodeInAnUnwantedFormatDoesNotEndTheScan() {
+        new Form("Caller").show();
+        flushSerialCalls();
+
+        vision.result = new Barcode[] {
+            new Barcode("4006381333931", BarcodeFormat.EAN_13, null,
+                    VisionRect.EMPTY, null)
+        };
+        Recorder recorder = new Recorder(CodeScanner.scan(
+                new CodeScannerOptions().formats(BarcodeFormat.QR_CODE)));
+        flushSerialCalls();
+
+        camera.deliver(new byte[] {1});
+        flushSerialCalls();
+        assertTrue(recorder.values.isEmpty(),
+                "a stray product barcode must not end a QR scan");
+
+        vision.result = new Barcode[] {
+            new Barcode("wanted", BarcodeFormat.QR_CODE, null,
+                    VisionRect.EMPTY, null)
+        };
+        camera.deliver(new byte[] {2});
+        flushSerialCalls();
+        assertEquals(1, recorder.values.size());
+        assertEquals("wanted", recorder.values.get(0).getValue());
+    }
+
+    @Test
+    void aFrameWithNoCodeKeepsScanning() {
+        new Form("Caller").show();
+        flushSerialCalls();
+
+        vision.result = new Barcode[0];
+        Recorder recorder = new Recorder(CodeScanner.scan());
+        flushSerialCalls();
+
+        camera.deliver(new byte[] {1});
+        camera.deliver(new byte[] {2});
+        flushSerialCalls();
+        assertTrue(recorder.values.isEmpty());
+        assertTrue(recorder.errors.isEmpty());
+    }
+
+    @Test
+    void backingOutCompletesWithNullRatherThanFailing() {
+        Form caller = new Form("Caller");
+        caller.show();
+        flushSerialCalls();
+
+        vision.result = new Barcode[0];
+        Recorder recorder = new Recorder(CodeScanner.scan());
+        flushSerialCalls();
+
+        Form scanner = Display.getInstance().getCurrent();
+        Command back = scanner.getBackCommand();
+        assertNotNull(back, "the scanner must be dismissable, including with"
+                + " the Android hardware back button");
+        scanner.dispatchCommand(back, new ActionEvent(back));
+        flushSerialCalls();
+
+        assertEquals(1, recorder.values.size());
+        assertNull(recorder.values.get(0), "cancelling is a null result");
+        assertTrue(recorder.errors.isEmpty());
+        assertSame(caller, Display.getInstance().getCurrent());
+    }
+
+    @Test
+    void aCameraThatCannotOpenFailsTheScanAndLeavesTheScreen() {
+        Form caller = new Form("Caller");
+        caller.show();
+        flushSerialCalls();
+        camera.openFailure = new IOException("permission denied");
+
+        Recorder recorder = new Recorder(CodeScanner.scan());
+        // Two drains: showing the form opens the camera, and the failure that
+        // open reports is delivered on the next EDT cycle.
+        flushSerialCalls();
+        flushSerialCalls();
+
+        assertTrue(recorder.values.isEmpty());
+        assertEquals(1, recorder.errors.size());
+        assertSame(caller, Display.getInstance().getCurrent(),
+                "a scanner that cannot open must not strand the user on an"
+                        + " empty screen");
+    }
+
+    @Test
+    void optionsDefendTheirFormatArray() {
+        String[] formats = {BarcodeFormat.QR_CODE};
+        CodeScannerOptions options = new CodeScannerOptions().formats(formats);
+        formats[0] = BarcodeFormat.EAN_13;
+        assertEquals(BarcodeFormat.QR_CODE, options.getFormats()[0]);
+        options.getFormats()[0] = BarcodeFormat.EAN_13;
+        assertEquals(BarcodeFormat.QR_CODE, options.getFormats()[0]);
+        assertEquals(0, options.formats((String[]) null).getFormats().length);
+    }
+
+    /** Collects whatever the scan resolves to. */
+    private static final class Recorder {
+        final List<Barcode> values = new ArrayList<Barcode>();
+        final List<Throwable> errors = new ArrayList<Throwable>();
+
+        Recorder(AsyncResource<Barcode> resource) {
+            resource.ready(new SuccessCallback<Barcode>() {
+                public void onSucess(Barcode value) {
+                    values.add(value);
+                }
+            }).except(new SuccessCallback<Throwable>() {
+                public void onSucess(Throwable error) {
+                    errors.add(error);
+                }
+            });
+        }
+    }
+}

--- a/maven/core-unittests/src/test/java/com/codename1/ai/vision/CodeScannerTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ai/vision/CodeScannerTest.java
@@ -22,6 +22,7 @@
  */
 package com.codename1.ai.vision;
 
+import com.codename1.camera.CameraInfo;
 import com.codename1.junit.UITestBase;
 import com.codename1.ui.Command;
 import com.codename1.ui.Display;
@@ -72,6 +73,13 @@ class CodeScannerTest extends UITestBase {
         implementation.setCameraImpl(null);
         assertFalse(CodeScanner.isSupported(),
                 "a target without a camera cannot scan");
+
+        // A backend that enumerates nothing is the camera-less device: the
+        // port has an implementation, the hardware does not exist, and the
+        // scan would fail immediately after this said it would not.
+        implementation.setCameraImpl(camera);
+        camera.cameras = new CameraInfo[0];
+        assertFalse(CodeScanner.isSupported());
     }
 
     @Test

--- a/maven/core-unittests/src/test/java/com/codename1/ai/vision/FakeCameraImpl.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ai/vision/FakeCameraImpl.java
@@ -31,6 +31,7 @@ import com.codename1.camera.FlashMode;
 import com.codename1.camera.FrameFormat;
 import com.codename1.camera.FrameListener;
 import com.codename1.camera.PhotoCaptureOptions;
+import com.codename1.camera.ScaleType;
 import com.codename1.impl.CameraImpl;
 import com.codename1.ui.PeerComponent;
 import com.codename1.util.AsyncResource;
@@ -55,6 +56,8 @@ class FakeCameraImpl extends CameraImpl {
     boolean captureAudio;
     FrameListener frameListener;
     FlashMode lastFlashMode;
+    Boolean previewMirrored;
+    ScaleType previewScaleType;
 
     void deliver(byte[] jpeg) {
         FrameListener listener = frameListener;
@@ -103,6 +106,16 @@ class FakeCameraImpl extends CameraImpl {
     @Override
     public void setFrameListener(FrameListener listener, FrameFormat format, int maxFps) {
         frameListener = listener;
+    }
+
+    @Override
+    public void setPreviewMirrored(boolean mirrored) {
+        previewMirrored = Boolean.valueOf(mirrored);
+    }
+
+    @Override
+    public void setPreviewScaleType(ScaleType scaleType) {
+        previewScaleType = scaleType;
     }
 
     @Override

--- a/maven/core-unittests/src/test/java/com/codename1/ai/vision/FakeCameraImpl.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ai/vision/FakeCameraImpl.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.ai.vision;
+
+import com.codename1.camera.CameraFacing;
+import com.codename1.camera.CameraFrame;
+import com.codename1.camera.CameraInfo;
+import com.codename1.camera.CameraSessionOptions;
+import com.codename1.camera.CapturedPhoto;
+import com.codename1.camera.FlashMode;
+import com.codename1.camera.FrameFormat;
+import com.codename1.camera.FrameListener;
+import com.codename1.camera.PhotoCaptureOptions;
+import com.codename1.impl.CameraImpl;
+import com.codename1.ui.PeerComponent;
+import com.codename1.util.AsyncResource;
+
+import java.io.IOException;
+
+/**
+ * Hand-written {@link CameraImpl} double for the high-level vision tests. One
+ * instance backs both the enumeration probe and the opened session, which is
+ * how {@code TestCodenameOneImplementation.setCameraImpl} hands the same
+ * backend to every {@code Camera} call.
+ */
+class FakeCameraImpl extends CameraImpl {
+    CameraInfo[] cameras = {
+        new CameraInfo("back", CameraFacing.BACK, null, null, true, true),
+        new CameraInfo("front", CameraFacing.FRONT, null, null, false, true)
+    };
+    IOException openFailure;
+    String openedCameraId;
+    int openCount;
+    int closeCount;
+    boolean captureAudio;
+    FrameListener frameListener;
+    FlashMode lastFlashMode;
+
+    void deliver(byte[] jpeg) {
+        FrameListener listener = frameListener;
+        if (listener != null) {
+            listener.onFrame(new CameraFrame(jpeg, null, 4, 3, 0, 1L,
+                    FrameFormat.JPEG));
+        }
+    }
+
+    @Override
+    public CameraInfo[] enumerateCameras() {
+        return cameras;
+    }
+
+    @Override
+    public void open(String cameraId, CameraSessionOptions opts) throws IOException {
+        if (openFailure != null) {
+            throw openFailure;
+        }
+        openedCameraId = cameraId;
+        captureAudio = opts != null && opts.isCaptureAudio();
+        openCount++;
+    }
+
+    @Override
+    public PeerComponent createPreviewPeer() {
+        return null;
+    }
+
+    @Override
+    public void takePhoto(PhotoCaptureOptions opts, AsyncResource<CapturedPhoto> result) {
+        result.complete(new CapturedPhoto(new byte[] {1}, "file://photo.jpg", 4, 3));
+    }
+
+    @Override
+    public void startVideoRecording(String filePath, boolean audio) {
+    }
+
+    @Override
+    public void stopVideoRecording(AsyncResource<String> result) {
+        if (result != null) {
+            result.complete("file://video.mp4");
+        }
+    }
+
+    @Override
+    public void setFrameListener(FrameListener listener, FrameFormat format, int maxFps) {
+        frameListener = listener;
+    }
+
+    @Override
+    public void setFlashMode(FlashMode mode) {
+        lastFlashMode = mode;
+    }
+
+    @Override
+    public void setZoom(float ratio) {
+    }
+
+    @Override
+    public void focus(float xNorm, float yNorm) {
+    }
+
+    @Override
+    public void pause() {
+    }
+
+    @Override
+    public void resume() {
+    }
+
+    @Override
+    public void close() {
+        closeCount++;
+    }
+}

--- a/maven/core-unittests/src/test/java/com/codename1/ai/vision/FakeCameraImpl.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ai/vision/FakeCameraImpl.java
@@ -58,6 +58,7 @@ class FakeCameraImpl extends CameraImpl {
     FlashMode lastFlashMode;
     Boolean previewMirrored;
     ScaleType previewScaleType;
+    boolean previewPeerFails;
 
     void deliver(byte[] jpeg) {
         FrameListener listener = frameListener;
@@ -84,7 +85,16 @@ class FakeCameraImpl extends CameraImpl {
 
     @Override
     public PeerComponent createPreviewPeer() {
-        return null;
+        // Ports return null when native preview creation fails; the flag
+        // reproduces that without pretending the happy path also has no peer.
+        return previewPeerFails ? null : new FakePeer();
+    }
+
+    /** Stands in for a native preview view. */
+    static final class FakePeer extends PeerComponent {
+        FakePeer() {
+            super(new Object());
+        }
     }
 
     @Override

--- a/maven/core-unittests/src/test/java/com/codename1/ai/vision/FakeVisionImpl.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ai/vision/FakeVisionImpl.java
@@ -22,32 +22,44 @@
  */
 package com.codename1.ai.vision;
 
+import com.codename1.impl.VisionImpl;
 import com.codename1.util.AsyncResource;
 
-/// Reusable, closable on-device analyzer for still images or camera frames.
-///
-/// This is the type {@link VisionCameraView} is parameterized on, so the
-/// concrete analyzer and its result type travel together:
-///
-/// ```java
-/// VisionAnalyzer<Barcode[]> analyzer = new BarcodeScanner();
-/// VisionCameraView<Barcode[]> view = new VisionCameraView<Barcode[]>(analyzer);
-/// ```
-///
-/// Implementations may retain native detectors and models between calls, so
-/// create one analyzer per stream/workflow and close it when finished.
-/// Backend creation, request scheduling, capability checks, and close are
-/// serialized so a concurrent close cannot leave a newly created backend
-/// attached after the analyzer has closed.
-public interface VisionAnalyzer<T> extends AutoCloseable {
-    /// Tests the exact feature/backend pair configured for this analyzer.
-    /// @return {@code true} when the current target supports it
-    boolean isSupported();
-    /// Starts one asynchronous analysis without uploading the image.
-    /// @param image encoded or raw input
-    /// @return asynchronous typed result delivered on the EDT
-    AsyncResource<T> process(VisionImage image);
-    /// Releases native detector/model resources; further processing fails.
+/**
+ * Hand-written {@link VisionImpl} double. Completes each analysis immediately
+ * with whatever {@link #result} holds, so a test drives the scanner by setting
+ * that field and delivering a camera frame.
+ */
+class FakeVisionImpl extends VisionImpl {
+    boolean supported = true;
+    Object result;
+    Throwable failure;
+    int analyzeCount;
+    int closeCount;
+    VisionFeature lastFeature;
+
     @Override
-    void close();
+    public boolean isSupported(VisionFeature feature, String backendId) {
+        return supported;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> AsyncResource<T> analyze(VisionFeature feature, String backendId,
+                                        VisionImage image, VisionOptions options) {
+        analyzeCount++;
+        lastFeature = feature;
+        AsyncResource<T> out = new AsyncResource<T>();
+        if (failure != null) {
+            out.error(failure);
+        } else {
+            out.complete((T) result);
+        }
+        return out;
+    }
+
+    @Override
+    public void close() {
+        closeCount++;
+    }
 }

--- a/maven/core-unittests/src/test/java/com/codename1/ai/vision/VisionCameraViewTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ai/vision/VisionCameraViewTest.java
@@ -25,6 +25,7 @@ package com.codename1.ai.vision;
 import com.codename1.camera.CameraFacing;
 import com.codename1.camera.CameraInfo;
 import com.codename1.camera.CameraView;
+import com.codename1.camera.ScaleType;
 import com.codename1.junit.UITestBase;
 import com.codename1.ui.Form;
 import com.codename1.ui.layouts.BorderLayout;
@@ -236,6 +237,9 @@ class VisionCameraViewTest extends UITestBase {
 
         assertEquals("back", camera.openedCameraId);
         assertFalse(previewView().isMirrored());
+        // Recording the flag is not enough: it has to reach the port, or the
+        // preview renders unmirrored while isMirrored() claims otherwise.
+        assertEquals(Boolean.FALSE, camera.previewMirrored);
     }
 
     @Test
@@ -246,6 +250,19 @@ class VisionCameraViewTest extends UITestBase {
 
         assertEquals("front", camera.openedCameraId);
         assertTrue(previewView().isMirrored());
+        assertEquals(Boolean.TRUE, camera.previewMirrored);
+    }
+
+    @Test
+    void theScaleTypeReachesThePort() {
+        view = new VisionCameraView<Barcode[]>(new BarcodeScanner());
+        view.setScaleType(ScaleType.FIT);
+        view.start();
+        assertEquals(ScaleType.FIT, camera.previewScaleType);
+
+        // Changing it while running has to reach the port too.
+        view.setScaleType(ScaleType.FILL);
+        assertEquals(ScaleType.FILL, camera.previewScaleType);
     }
 
     private CameraView previewView() {

--- a/maven/core-unittests/src/test/java/com/codename1/ai/vision/VisionCameraViewTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ai/vision/VisionCameraViewTest.java
@@ -165,6 +165,34 @@ class VisionCameraViewTest extends UITestBase {
     }
 
     @Test
+    void aCameraWithNoPreviewIsAFailureRatherThanABlankScreen() {
+        // iOS returns no peer when the native preview view cannot be made and
+        // Android returns none when CameraX cannot be resolved. Installing the
+        // empty view would report isRunning() true and leave CodeScanner
+        // sitting on a blank screen with no error ever delivered.
+        camera.previewPeerFails = true;
+        final List<Throwable> errors = new ArrayList<Throwable>();
+        view = new VisionCameraView<Barcode[]>(new BarcodeScanner());
+        view.setListener(new VisionPipelineListener<Barcode[]>() {
+            public void result(Barcode[] value, VisionImage source) {
+            }
+
+            public void error(Throwable error) {
+                errors.add(error);
+            }
+        });
+
+        view.start();
+        flushSerialCalls();
+
+        assertFalse(view.isRunning());
+        assertNull(view.getSession(), "the opened session must be released");
+        assertEquals(0, view.getComponentCount(),
+                "no empty preview is left behind");
+        assertEquals(1, errors.size());
+    }
+
+    @Test
     void leavingTheFormReleasesTheCameraButKeepsTheAnalyzerUsable() {
         CountingAnalyzer analyzer = new CountingAnalyzer();
         view = new VisionCameraView<Barcode[]>(analyzer);

--- a/maven/core-unittests/src/test/java/com/codename1/ai/vision/VisionCameraViewTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ai/vision/VisionCameraViewTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.ai.vision;
+
+import com.codename1.camera.CameraFacing;
+import com.codename1.junit.UITestBase;
+import com.codename1.ui.Form;
+import com.codename1.ui.layouts.BorderLayout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class VisionCameraViewTest extends UITestBase {
+    private FakeCameraImpl camera;
+    private FakeVisionImpl vision;
+    private VisionCameraView<Barcode[]> view;
+
+    @BeforeEach
+    void installBackends() {
+        camera = new FakeCameraImpl();
+        vision = new FakeVisionImpl();
+        implementation.setCameraImpl(camera);
+        implementation.setVisionImpl(vision);
+    }
+
+    @AfterEach
+    void releaseView() {
+        if (view != null) {
+            view.close();
+            view = null;
+        }
+    }
+
+    @Test
+    void constructionRequiresAnAnalyzer() {
+        assertThrows(NullPointerException.class,
+                () -> new VisionCameraView<Barcode[]>(null));
+    }
+
+    @Test
+    void startOpensTheCameraAndStopReleasesIt() {
+        view = new VisionCameraView<Barcode[]>(new BarcodeScanner());
+        assertFalse(view.isRunning());
+        assertNull(view.getSession());
+
+        view.start();
+        assertTrue(view.isRunning());
+        assertNotNull(view.getSession());
+        assertEquals(1, camera.openCount);
+        assertEquals("back", camera.openedCameraId);
+
+        // Starting twice must not open a second session: the platform allows
+        // only one, and the second open would throw.
+        view.start();
+        assertEquals(1, camera.openCount);
+
+        view.stop();
+        assertFalse(view.isRunning());
+        assertNull(view.getSession());
+    }
+
+    @Test
+    void theScannerNeverAsksForTheMicrophone() {
+        // CameraSessionOptions captures audio by default, which would prompt
+        // for a microphone permission a scanner has no business requesting.
+        view = new VisionCameraView<Barcode[]>(new BarcodeScanner());
+        view.start();
+        assertFalse(camera.captureAudio);
+    }
+
+    @Test
+    void facingSelectsTheCamera() {
+        view = new VisionCameraView<Barcode[]>(new BarcodeScanner());
+        view.setFacing(CameraFacing.FRONT);
+        view.start();
+        assertEquals("front", camera.openedCameraId);
+        assertEquals(CameraFacing.FRONT, view.getFacing());
+
+        view.setFacing(null);
+        assertEquals(CameraFacing.BACK, view.getFacing());
+    }
+
+    @Test
+    void framesReachTheAnalyzerAndResultsReachTheListener() {
+        Barcode[] codes = {
+            new Barcode("hello", BarcodeFormat.QR_CODE, null,
+                    VisionRect.EMPTY, null)
+        };
+        vision.result = codes;
+        final List<Barcode[]> received = new ArrayList<Barcode[]>();
+        view = new VisionCameraView<Barcode[]>(new BarcodeScanner());
+        view.setListener(new VisionPipelineListener<Barcode[]>() {
+            public void result(Barcode[] value, VisionImage source) {
+                received.add(value);
+            }
+
+            public void error(Throwable error) {
+            }
+        });
+        view.start();
+
+        camera.deliver(new byte[] {1, 2, 3});
+        flushSerialCalls();
+
+        assertEquals(1, vision.analyzeCount);
+        assertEquals(VisionFeature.BARCODE_SCANNING, vision.lastFeature);
+        assertEquals(1, received.size());
+        assertSame(codes, received.get(0));
+    }
+
+    @Test
+    void aCameraThatCannotOpenIsReportedToTheListenerRatherThanThrown() {
+        camera.openFailure = new IOException("permission denied");
+        final List<Throwable> errors = new ArrayList<Throwable>();
+        view = new VisionCameraView<Barcode[]>(new BarcodeScanner());
+        view.setListener(new VisionPipelineListener<Barcode[]>() {
+            public void result(Barcode[] value, VisionImage source) {
+            }
+
+            public void error(Throwable error) {
+                errors.add(error);
+            }
+        });
+
+        view.start();
+        flushSerialCalls();
+
+        assertFalse(view.isRunning());
+        assertEquals(1, errors.size());
+    }
+
+    @Test
+    void leavingTheFormReleasesTheCameraButKeepsTheAnalyzerUsable() {
+        CountingAnalyzer analyzer = new CountingAnalyzer();
+        view = new VisionCameraView<Barcode[]>(analyzer);
+        view.start();
+        assertEquals(1, camera.openCount);
+
+        // The pipeline closes the analyzer it was handed. If that were the
+        // caller's analyzer, showing the view a second time would process
+        // into a closed one.
+        view.stop();
+        assertEquals(0, analyzer.closeCount);
+
+        view.start();
+        assertEquals(2, camera.openCount);
+        camera.deliver(new byte[] {1});
+        flushSerialCalls();
+        assertEquals(1, analyzer.processCount);
+
+        view.close();
+        assertEquals(1, analyzer.closeCount);
+        view.close();
+        assertEquals(1, analyzer.closeCount, "close is idempotent");
+        view = null;
+    }
+
+    @Test
+    void showingTheFormStartsTheCameraAndLeavingItStops() {
+        view = new VisionCameraView<Barcode[]>(new BarcodeScanner());
+        Form form = new Form("Scanner", new BorderLayout());
+        form.add(BorderLayout.CENTER, view);
+        form.show();
+        flushSerialCalls();
+        assertTrue(view.isRunning(), "the camera opens when the view is shown");
+
+        new Form("Elsewhere").show();
+        flushSerialCalls();
+        assertFalse(view.isRunning(),
+                "the camera is released when the view stops being shown");
+    }
+
+    @Test
+    void unsupportedIsReportedBeforeTheScreenIsShown() {
+        view = new VisionCameraView<Barcode[]>(new BarcodeScanner());
+        assertTrue(view.isSupported());
+        vision.supported = false;
+        assertFalse(view.isSupported());
+    }
+
+    /** Counts what the view does to a caller-supplied analyzer. */
+    private static final class CountingAnalyzer
+            implements VisionAnalyzer<Barcode[]> {
+        int processCount;
+        int closeCount;
+
+        public boolean isSupported() {
+            return true;
+        }
+
+        public com.codename1.util.AsyncResource<Barcode[]> process(
+                VisionImage image) {
+            processCount++;
+            com.codename1.util.AsyncResource<Barcode[]> out =
+                    new com.codename1.util.AsyncResource<Barcode[]>();
+            out.complete(new Barcode[0]);
+            return out;
+        }
+
+        public void close() {
+            closeCount++;
+        }
+    }
+}

--- a/maven/core-unittests/src/test/java/com/codename1/ai/vision/VisionCameraViewTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ai/vision/VisionCameraViewTest.java
@@ -23,6 +23,8 @@
 package com.codename1.ai.vision;
 
 import com.codename1.camera.CameraFacing;
+import com.codename1.camera.CameraInfo;
+import com.codename1.camera.CameraView;
 import com.codename1.junit.UITestBase;
 import com.codename1.ui.Form;
 import com.codename1.ui.layouts.BorderLayout;
@@ -208,6 +210,48 @@ class VisionCameraViewTest extends UITestBase {
         assertTrue(view.isSupported());
         vision.supported = false;
         assertFalse(view.isSupported());
+    }
+
+    @Test
+    void aBackendWithNoCamerasIsNotSupported() {
+        // Camera.isSupported() is true whenever the port has a backend, which
+        // a camera-less device still does. Reporting support there would have
+        // start() fail on a screen this method said was fine to show.
+        camera.cameras = new CameraInfo[0];
+        view = new VisionCameraView<Barcode[]>(new BarcodeScanner());
+        assertFalse(view.isSupported());
+    }
+
+    @Test
+    void theMirrorFollowsTheCameraThatOpenedNotTheOneRequested() {
+        // Camera.getDefault falls back to the first available camera when the
+        // requested facing does not exist. Mirroring on the request would show
+        // that rear preview reversed.
+        camera.cameras = new CameraInfo[] {
+            new CameraInfo("back", CameraFacing.BACK, null, null, true, true)
+        };
+        view = new VisionCameraView<Barcode[]>(new BarcodeScanner());
+        view.setFacing(CameraFacing.FRONT);
+        view.start();
+
+        assertEquals("back", camera.openedCameraId);
+        assertFalse(previewView().isMirrored());
+    }
+
+    @Test
+    void aFrontCameraPreviewIsMirrored() {
+        view = new VisionCameraView<Barcode[]>(new BarcodeScanner());
+        view.setFacing(CameraFacing.FRONT);
+        view.start();
+
+        assertEquals("front", camera.openedCameraId);
+        assertTrue(previewView().isMirrored());
+    }
+
+    private CameraView previewView() {
+        assertEquals(1, view.getComponentCount(),
+                "the preview is the view's only child while running");
+        return (CameraView) view.getComponentAt(0);
     }
 
     /** Counts what the view does to a caller-supplied analyzer. */

--- a/maven/core-unittests/src/test/java/com/codename1/ai/vision/VisionResultHelpersTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ai/vision/VisionResultHelpersTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.ai.vision;
+
+import com.codename1.junit.UITestBase;
+import com.codename1.ui.EncodedImage;
+import com.codename1.ui.Image;
+import com.codename1.ui.geom.Point;
+import com.codename1.ui.geom.Rectangle;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The result-shaping helpers that turn a raw analyzer observation into
+ * something an application can draw or branch on.
+ */
+class VisionResultHelpersTest extends UITestBase {
+    @Test
+    void formatMatchingAcceptsEverythingWhenNoFilterIsGiven() {
+        Barcode qr = new Barcode("x", BarcodeFormat.QR_CODE, null,
+                VisionRect.EMPTY, null);
+        assertTrue(BarcodeFormat.matches(qr));
+        assertTrue(BarcodeFormat.matches(qr, new String[0]));
+        assertTrue(BarcodeFormat.matches(qr, (String[]) null));
+        assertTrue(BarcodeFormat.matches(qr, BarcodeFormat.EAN_13,
+                BarcodeFormat.QR_CODE));
+        assertFalse(BarcodeFormat.matches(qr, BarcodeFormat.EAN_13));
+        // A null entry in the filter must not match a barcode whose format is
+        // itself unset, which is what a naive equals() ordering would do.
+        Barcode unset = new Barcode("x", null, null, VisionRect.EMPTY, null);
+        assertFalse(BarcodeFormat.matches(unset, (String) null));
+        assertFalse(BarcodeFormat.matches(null, BarcodeFormat.QR_CODE));
+    }
+
+    @Test
+    void normalizedGeometryMapsOntoPixels() {
+        VisionRect rect = new VisionRect(.25f, .5f, .5f, .25f);
+        Rectangle bounds = rect.toBounds(10, 20, 400, 200);
+        assertEquals(110, bounds.getX());
+        assertEquals(120, bounds.getY());
+        assertEquals(200, bounds.getWidth());
+        assertEquals(50, bounds.getHeight());
+
+        Point point = new VisionPoint(.5f, .25f).toPoint(0, 0, 400, 200);
+        assertEquals(200, point.getX());
+        assertEquals(50, point.getY());
+
+        assertTrue(VisionRect.EMPTY.isEmpty());
+        assertFalse(rect.isEmpty());
+        assertThrows(NullPointerException.class, () -> rect.toBounds(null));
+        assertThrows(NullPointerException.class,
+                () -> new VisionPoint(0, 0).toPoint(null));
+    }
+
+    @Test
+    void rectangleEdgesRoundConsistentlySoAdjacentBoxesDoNotOverlap() {
+        // Rounding each edge rather than rounding the width is what keeps a
+        // box that ends where the next begins from gaining a pixel.
+        VisionRect first = new VisionRect(0f, 0f, 1f / 3f, 1f);
+        VisionRect second = new VisionRect(1f / 3f, 0f, 1f / 3f, 1f);
+        Rectangle a = first.toBounds(0, 0, 100, 10);
+        Rectangle b = second.toBounds(0, 0, 100, 10);
+        assertEquals(a.getX() + a.getWidth(), b.getX());
+    }
+
+    @Test
+    void namedLandmarksAreLookedUpWithoutTouchingTheMap() {
+        Map<String, VisionPoint> landmarks = new HashMap<String, VisionPoint>();
+        landmarks.put(FaceLandmarks.LEFT_EYE, new VisionPoint(.6f, .4f));
+        Face face = new Face(new VisionRect(0, 0, 1, 1), landmarks,
+                0, 0, 0, -1, -1);
+        assertNotNull(face.getLandmark(FaceLandmarks.LEFT_EYE));
+        assertEquals(.6f, face.getLandmark(FaceLandmarks.LEFT_EYE).getX());
+        assertNull(face.getLandmark(FaceLandmarks.RIGHT_EYE),
+                "an undetected landmark is absent, not a zero point");
+        assertNull(face.getLandmark(null));
+
+        Pose pose = new Pose(new Pose.Landmark[] {
+            new Pose.Landmark(PoseLandmarks.RIGHT_WRIST,
+                    new VisionPoint(.2f, .3f), .8f),
+            null
+        });
+        assertNotNull(pose.getLandmark(PoseLandmarks.RIGHT_WRIST));
+        assertEquals(.8f,
+                pose.getLandmark(PoseLandmarks.RIGHT_WRIST).getConfidence());
+        assertNull(pose.getLandmark(PoseLandmarks.LEFT_ANKLE));
+        assertNull(pose.getLandmark(null));
+    }
+
+    @Test
+    void maskCutsOutTheForegroundAtItsOwnResolution() {
+        // A 2x1 mask describing a 4x2 image: the left half is foreground.
+        SegmentationMask mask = new SegmentationMask(2, 1,
+                new float[] {.9f, .1f});
+        assertEquals(.9f, mask.getConfidenceAt(0, 0));
+        assertThrows(IndexOutOfBoundsException.class,
+                () -> mask.getConfidenceAt(0, 1));
+
+        int[] source = new int[8];
+        for (int i = 0; i < source.length; i++) {
+            source[i] = 0xff102030;
+        }
+        Image cut = mask.cutOut(Image.createImage(source, 4, 2), .5f);
+        assertEquals(4, cut.getWidth());
+        assertEquals(2, cut.getHeight());
+        int[] pixels = cut.getRGB();
+        assertEquals(0xff102030, pixels[0]);
+        assertEquals(0xff102030, pixels[1]);
+        assertEquals(0, pixels[2] >>> 24, "background must be transparent");
+        assertEquals(0, pixels[3] >>> 24);
+        assertEquals(0, pixels[6] >>> 24, "the second row scales the same way");
+
+        Image tint = mask.toMaskImage(0x00ff00);
+        assertEquals(2, tint.getWidth());
+        assertEquals(1, tint.getHeight());
+        int[] tinted = tint.getRGB();
+        assertEquals(0x00ff00, tinted[0] & 0xffffff);
+        assertTrue((tinted[0] >>> 24) > (tinted[1] >>> 24));
+
+        assertThrows(NullPointerException.class, () -> mask.cutOut(null, .5f));
+        assertThrows(IllegalArgumentException.class,
+                () -> new SegmentationMask(0, 0, new float[0]).toMaskImage(0));
+    }
+
+    @Test
+    void encodedImagesReachTheAnalyzerWithoutBeingReEncoded() {
+        byte[] png = onePixelPng();
+        VisionImage wrapped = VisionImage.fromImage(EncodedImage.create(png));
+        assertArrayEquals(png, wrapped.getEncodedBytes());
+        assertNull(wrapped.getPixels());
+    }
+
+    @Test
+    void otherImagesReachTheAnalyzerAsRgbaPixels() {
+        VisionImage wrapped = VisionImage.fromImage(
+                Image.createImage(new int[] {0x80112233, 0xff445566}, 2, 1));
+        assertNull(wrapped.getEncodedBytes());
+        assertEquals(2, wrapped.getWidth());
+        assertEquals(1, wrapped.getHeight());
+        assertArrayEquals(new byte[] {
+            0x11, 0x22, 0x33, (byte) 0x80,
+            0x44, 0x55, 0x66, (byte) 0xff
+        }, wrapped.getPixels());
+        assertThrows(NullPointerException.class,
+                () -> VisionImage.fromImage(null));
+    }
+
+    private static byte[] onePixelPng() {
+        // The smallest valid PNG; EncodedImage keeps the bytes verbatim, which
+        // is the property under test rather than the pixels.
+        return new byte[] {
+            (byte) 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+            0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+            0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, (byte) 0xc4,
+            (byte) 0x89, 0x00, 0x00, 0x00, 0x0a, 0x49, 0x44, 0x41,
+            0x54, 0x78, (byte) 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00,
+            0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, (byte) 0xb4, 0x00,
+            0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, (byte) 0xae,
+            0x42, 0x60, (byte) 0x82
+        };
+    }
+}

--- a/maven/core-unittests/src/test/java/com/codename1/camera/CameraSessionTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/camera/CameraSessionTest.java
@@ -199,4 +199,27 @@ class CameraSessionTest extends UITestBase {
         flushSerialCalls();
         return value.get();
     }
+    @org.junit.jupiter.api.Test
+    void previewSettingsReachThePortRatherThanOnlyTheGetter() {
+        // Both settings used to be stored on CameraView and read by nobody, so
+        // a front-facing preview rendered unmirrored while isMirrored()
+        // returned true. A port that cannot honor them overrides nothing and
+        // the default no-op keeps that behavior.
+        CameraView view = session.createView();
+
+        view.setMirrored(true);
+        org.junit.jupiter.api.Assertions.assertEquals(
+                Boolean.TRUE, impl.previewMirrored);
+        org.junit.jupiter.api.Assertions.assertTrue(view.isMirrored());
+
+        view.setScaleType(ScaleType.FIT);
+        org.junit.jupiter.api.Assertions.assertEquals(
+                ScaleType.FIT, impl.previewScaleType);
+
+        // null means "the default", and the port is told the resolved value.
+        view.setScaleType(null);
+        org.junit.jupiter.api.Assertions.assertEquals(
+                ScaleType.CROP, impl.previewScaleType);
+    }
+
 }

--- a/maven/core-unittests/src/test/java/com/codename1/camera/RecordingCameraImpl.java
+++ b/maven/core-unittests/src/test/java/com/codename1/camera/RecordingCameraImpl.java
@@ -49,6 +49,8 @@ class RecordingCameraImpl extends CameraImpl {
     float lastFocusX = Float.NaN;
     float lastFocusY = Float.NaN;
     FrameListener lastFrameListener;
+    Boolean previewMirrored;
+    ScaleType previewScaleType;
     boolean frameListenerCleared;
     String videoPath;
     boolean videoAudio;
@@ -100,6 +102,16 @@ class RecordingCameraImpl extends CameraImpl {
         if (listener == null) {
             frameListenerCleared = true;
         }
+    }
+
+    @Override
+    public void setPreviewMirrored(boolean mirrored) {
+        this.previewMirrored = Boolean.valueOf(mirrored);
+    }
+
+    @Override
+    public void setPreviewScaleType(ScaleType scaleType) {
+        this.previewScaleType = scaleType;
     }
 
     @Override

--- a/maven/platform-feature-catalog/src/main/java/com/codename1/build/shared/PlatformFeatureCatalog.java
+++ b/maven/platform-feature-catalog/src/main/java/com/codename1/build/shared/PlatformFeatureCatalog.java
@@ -258,6 +258,28 @@ public final class PlatformFeatureCatalog {
                 .iosDependenciesUnsupportedOnArm64Simulator()
                 .description("ML Kit iOS barcode backend"));
 
+        // CodeScanner is the ready-made scanner screen and builds a
+        // BarcodeScanner internally. An application that references only the
+        // high-level class never names BarcodeScanner, so without its own
+        // entry the generated Android project retains the barcode adapter
+        // source with no com.google.mlkit:barcode-scanning to compile it
+        // against. The camera half is registered further down, beside the
+        // low-level camera entry.
+        e.add(new Entry("com/codename1/ai/vision/CodeScanner")
+                .iosFrameworks("Vision", "CoreImage")
+                .androidGradle("com.google.mlkit:barcode-scanning:17.2.0")
+                .androidMinimumSdk(21)
+                .description("Barcode scanning (ready-made scanner screen)"));
+        e.add(new Entry("com/codename1/ai/vision/CodeScanner")
+                .requiresMethod("com/codename1/ai/vision/VisionBackends",
+                        "mlKitBarcodeScanning")
+                .iosPod("GoogleMLKit/BarcodeScanning")
+                .iosMinimumDeploymentTarget("15.5")
+                .iosDependenciesUnsupportedOnMacCatalyst()
+                .iosDependenciesUnsupportedOnArm64Simulator()
+                .description("ML Kit iOS barcode backend"
+                        + " (ready-made scanner screen)"));
+
         e.add(new Entry("com/codename1/ai/vision/FaceDetector")
                 .iosFrameworks("Vision", "CoreImage")
                 .androidGradle("com.google.mlkit:face-detection:16.1.5")
@@ -401,6 +423,41 @@ public final class PlatformFeatureCatalog {
                 .androidGradle("androidx.camera:camera-video:1.3.4")
                 .androidMinimumSdk(21)
                 .description("Cross-platform camera (preview + frames + photo + video)"));
+
+        // CodeScanner and VisionCameraView drive the camera themselves. An
+        // application using one of them never references
+        // com.codename1.camera, so without these entries it gets no CameraX,
+        // no CAMERA permission and no AVFoundation or privacy string, and the
+        // preview opens on hardware the build never provisioned.
+        //
+        // These deliberately do NOT request the microphone: both classes open
+        // their session with captureAudio(false), and a barcode scanner asking
+        // for RECORD_AUDIO is a privacy smell and an app-review question. The
+        // CameraX artifact list mirrors the low-level entry rather than
+        // trimming to preview-only, because AndroidCameraImpl reflects over
+        // the whole CameraX surface in one class.
+        String[][] cameraBackedVision = {
+            {"com/codename1/ai/vision/CodeScanner",
+             "ready-made barcode scanner screen"},
+            {"com/codename1/ai/vision/VisionCameraView",
+             "live analyzer camera preview"},
+        };
+        for (String[] cameraBacked : cameraBackedVision) {
+            e.add(new Entry(cameraBacked[0])
+                    .iosFrameworks("AVFoundation", "CoreMedia", "CoreVideo")
+                    .iosPlist("NSCameraUsageDescription",
+                             "Used to analyze the camera image on this device.")
+                    .androidPermissions("android.permission.CAMERA")
+                    .androidFeatures("android.hardware.camera",
+                                     "android.hardware.camera.autofocus")
+                    .androidGradle("androidx.camera:camera-core:1.3.4")
+                    .androidGradle("androidx.camera:camera-camera2:1.3.4")
+                    .androidGradle("androidx.camera:camera-lifecycle:1.3.4")
+                    .androidGradle("androidx.camera:camera-view:1.3.4")
+                    .androidGradle("androidx.camera:camera-video:1.3.4")
+                    .androidMinimumSdk(21)
+                    .description("Camera for the " + cameraBacked[1]));
+        }
 
         // First-class Bluetooth (com.codename1.bluetooth.*): CoreBluetooth
         // on iOS with the two privacy strings defaulted only-if-unset via

--- a/maven/platform-feature-catalog/src/test/java/com/codename1/build/shared/PlatformFeatureCatalogTest.java
+++ b/maven/platform-feature-catalog/src/test/java/com/codename1/build/shared/PlatformFeatureCatalogTest.java
@@ -25,6 +25,7 @@ package com.codename1.build.shared;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -348,9 +349,64 @@ class PlatformFeatureCatalogTest {
                 }
             }
         }
-        assertEquals(26, checked,
+        // 27 since CodeScanner carries its own barcode-scanning entry: the
+        // ready-made screen builds a BarcodeScanner internally, and an app
+        // that never names BarcodeScanner still needs the artifact.
+        assertEquals(27, checked,
                 "If an AI dependency is intentionally added or removed, "
                 + "update this lock count after verifying its Android floor");
+    }
+
+    @Test
+    void theReadyMadeScannerCarriesBarcodeScanningAndACamera() {
+        // CodeScanner is a BarcodeScanner plus a camera, and an application
+        // using it references neither. Without its own entries the generated
+        // project keeps the barcode adapter with no artifact to compile it
+        // against, and opens a preview on hardware the build never
+        // provisioned.
+        PlatformFeatureCatalog.Accumulator acc =
+                new PlatformFeatureCatalog.Accumulator();
+        acc.consume("com/codename1/ai/vision/CodeScanner");
+
+        Set<String> android = new LinkedHashSet<String>();
+        Set<String> permissions = new LinkedHashSet<String>();
+        for (PlatformFeatureCatalog.Entry entry : acc.hits()) {
+            android.addAll(entry.androidGradleDeps());
+            permissions.addAll(entry.androidPermissions());
+        }
+
+        assertTrue(android.contains("com.google.mlkit:barcode-scanning:17.2.0"));
+        assertTrue(android.contains("androidx.camera:camera-core:1.3.4"));
+        assertTrue(permissions.contains("android.permission.CAMERA"));
+        assertTrue(acc.iosFrameworks().contains("AVFoundation"));
+        assertTrue(acc.iosFrameworks().contains("Vision"));
+        assertEquals(21, acc.minimumAndroidSdk());
+
+        // A scanner does not record audio, so it must not drag the microphone
+        // permission in the way the general-purpose camera entry does.
+        assertFalse(permissions.contains("android.permission.RECORD_AUDIO"));
+    }
+
+    @Test
+    void theLiveAnalyzerViewCarriesACameraButNoAnalyzer() {
+        // VisionCameraView is analyzer-agnostic: the application constructs
+        // the analyzer, which is what selects that model. The view itself must
+        // add the camera and nothing else.
+        PlatformFeatureCatalog.Accumulator acc =
+                new PlatformFeatureCatalog.Accumulator();
+        acc.consume("com/codename1/ai/vision/VisionCameraView");
+
+        Set<String> android = new LinkedHashSet<String>();
+        for (PlatformFeatureCatalog.Entry entry : acc.hits()) {
+            android.addAll(entry.androidGradleDeps());
+        }
+
+        assertTrue(android.contains("androidx.camera:camera-core:1.3.4"));
+        for (String dependency : android) {
+            assertFalse(dependency.startsWith("com.google.mlkit:"),
+                    "the view must not pull a model the app never asked for: "
+                            + dependency);
+        }
     }
 
     @Test

--- a/scripts/initializr/common/src/main/resources/skill/references/ai-and-speech.md
+++ b/scripts/initializr/common/src/main/resources/skill/references/ai-and-speech.md
@@ -309,6 +309,42 @@ Base class returns `null` / `false` on platforms without an implementation, so y
 
 ## Built-in on-device ML
 
+Scanning a code is one call. `CodeScanner` is a whole scanner screen --
+camera, decode, return to the previous form -- and replaces the old
+`cn1-codescan` cn1lib. Import `com.codename1.ai.vision.CodeScanner`; two
+older classes share the simple name.
+
+```java
+CodeScanner.scan().ready(code -> {
+    if (code != null) {                 // null means the user backed out
+        urlField.setText(code.getValue());
+    }
+}).except(error -> Log.e(error));
+```
+
+`VisionCameraView` is the same wiring as a component, for a preview
+inside your own form, and works with any analyzer:
+
+```java
+VisionCameraView<Face[]> view = new VisionCameraView<>(new FaceDetector());
+view.setFacing(CameraFacing.FRONT);
+view.setListener(new VisionPipelineListener<Face[]>() {
+    public void result(Face[] faces, VisionImage source) {
+        status.setText(faces.length + " face(s)");
+    }
+    public void error(Throwable error) {
+        Log.e(error);
+    }
+});
+form.add(BorderLayout.CENTER, view);
+```
+
+It opens the camera when shown and releases it when the user navigates
+away. The preview is a native view, so put chrome around it rather than
+painting over it.
+
+For one image at a time, use the analyzer directly:
+
 ```java
 new TextRecognizer()
     .process(VisionImage.encoded(jpegBytes))
@@ -325,9 +361,17 @@ Translator.translate("Bonjour", "fr", "en", translationOptions)
     .ready(result -> Log.p(result));
 ```
 
-`VisionImage` accepts JPEG, PNG, NV21, and RGBA8888. Use
-`VisionPipeline` to connect a reusable analyzer to camera frames; it
-copies callback-owned data and drops stale pending frames under load.
+`VisionImage` accepts JPEG, PNG, NV21, and RGBA8888;
+`VisionImage.fromFile(path)` and `VisionImage.fromImage(image)` are the
+usual bridges from a picked photo. Bounds and points are normalized to
+0..1; `VisionRect.toBounds(component)` and
+`VisionPoint.toPoint(component)` convert them to pixels for drawing.
+`BarcodeFormat`, `FaceLandmarks` and `PoseLandmarks` hold the names that
+would otherwise be string literals. Use `VisionPipeline` when the app
+already owns a `CameraSession` and `VisionCameraView` when it does not;
+both copy callback-owned data and drop stale pending frames under load.
+In the simulator the results are whatever is scripted under
+*Simulate > Vision*, so a scanner screen can be built without a device.
 Use `ModelCache.fetch(httpsUrl, cacheKey, sha256)` for models too large
 to bundle. The initial model URL must remain HTTPS. Observable redirects
 are rejected if they downgrade to HTTP; iOS requires the digest because
@@ -343,7 +387,9 @@ Apple symbologies on a device, or select the ML Kit barcode backend.
 
 Dependency selection is per entry point. Referencing `TextRecognizer`
 retains only the Android text adapter/artifact; it does not pull
-barcode, face, labeling, pose, or segmentation. `LanguageIdentifier`,
+barcode, face, labeling, pose, or segmentation. `CodeScanner` selects the
+barcode dependency plus the camera natives, since it builds a
+`BarcodeScanner` and opens a camera itself. `LanguageIdentifier`,
 `Translator`, and `SmartReply` likewise select independent artifacts.
 On iOS, an ML Kit vision pod is selected only when both its analyzer
 and its matching feature-specific selector are referenced. For example,


### PR DESCRIPTION
The vision analyzers replaced the QRScanner/codescan cn1libs but gave up their one-call ergonomics. Scanning a QR code meant wiring `Camera.open` → `CameraSessionOptions` → `FrameListener` → `VisionImage.fromCameraFrame` → `VisionPipeline` → back to the EDT, and results came back as magic strings (`"leftEye"`, `"QR_CODE"`) and normalized floats with no way to draw them. `Camera`'s own javadoc advertised a `BarcodeScanner.scan(...)` that has never existed, which is roughly how discoverable the API was.

This adds the two layers that were missing *above* the analyzers, without touching the analyzer contract.

## One call

```java
CodeScanner.scan().ready(code -> {
    if (code != null) {                 // null means the user backed out
        urlField.setText(code.getValue());
    }
}).except(error -> Log.e(error));
```

A whole scanner screen: camera, decode, restore the previous form. The cn1lib's three `ScanResult` callbacks map onto one `AsyncResource` — `scanCompleted` is `ready`, `scanCanceled` is a `null` value, `scanError` is `except`. `CodeScannerOptions` rewords the screen and restricts the accepted symbologies, so a stray product barcode in the frame does not complete a QR scan.

## One component

`VisionCameraView` is the same wiring as a component, for a preview inside the application's own form, and works with **every** analyzer rather than just barcodes. It opens the camera when shown and releases it when the user navigates away; `close()` additionally releases the analyzer.

The analyzer stays caller-constructed on purpose: the builders decide which native dependency to package from the analyzer classes the *application* references, so naming it in application code is what keeps a face-detection app from also carrying the barcode and pose models.

## Reading a result

No more literals or arithmetic. `BarcodeFormat`, `FaceLandmarks` and `PoseLandmarks` hold the names the backends normalize onto; `Face.getLandmark` / `Pose.getLandmark` look one up; `VisionRect.toBounds(component)` and `VisionPoint.toPoint(component)` turn normalized geometry into the pixels a `paint` method draws in. `SegmentationMask.cutOut(image, threshold)` applies a mask to its source image and rescales it — selfie segmentation was unusable without it — and `VisionImage.fromFile` / `fromImage` bridge a picked photo, passing an `EncodedImage`'s original bytes through instead of re-encoding.

## The part that fails silently

The builders scan the *application's* classes, not core. An app referencing only `CodeScanner` never names `BarcodeScanner`, so the Android adapter would be pruned and the iOS camera natives left out — the build green, the feature inert on the device. `CodeScanner` now selects the barcode adapter and the vision feature, and `CodeScanner` and `VisionCameraView` both select the camera natives. `HighLevelVisionDependencyTest` walks the vision sources rather than a hand-written list, so a convenience class added later fails the test until it is mapped.

## Simulator

`createVisionImpl()` returned `null` on JavaSE, so every analyzer reported itself unsupported on the desktop and a scanner screen could not be built without a device. It now serves whatever is scripted under **Simulate ▸ Vision**, in the shape of the existing Simulate ▸ NFC menu: supported on/off, an outcome switch covering result / nothing-found / `UNSUPPORTED` / backend error, and the scripted values themselves. Results carry plausible geometry, so overlay and debounce code can be written before the app reaches hardware.

## Samples

Every analyzer, every result type that needs one, and `package-info` carry a markdown javadoc sample. `VisionSnippets.java` in `docs/demos` backs twelve tagged regions in `Ai-And-Speech.asciidoc` — compiled and bytecode-compliance-checked by CI, so they cannot rot. `Camera` and `CameraView` lose the `BarcodeScanner.scan` example that never compiled. The initializr skill reference is updated to match.

## Two bugs the new tests found

- `Toolbar.setBackCommand(...)` before `Form.show()` is dropped when the form's toolbar is set explicitly, which left the Android hardware back button doing nothing on the scanner screen. Re-registered after `show()`.
- The torch button originally polled the EDT waiting for the camera session; `CameraInfo.hasFlash()` answers the same question synchronously before the form is shown.

## Verification

- 42 vision/camera core-unittests pass (26 new), plus the 676-test plugin suite.
- Quality gate (`generate-quality-report.py` over SpotBugs/PMD/Checkstyle) exits 0. It caught one SpotBugs and 20 PMD findings in this code; all fixed rather than suppressed, except three `CloseResource` false positives that each carry a comment.
- `check-cast-semantics.sh`, `check-package-info.sh` and `validate-guide-snippets.py` (676 blocks) pass; javadoc builds warning-free for these packages.

Not included: the `scripts/cn1playground` generated access registry (the playground's own Maven build regenerates it, and regenerating it here would pick up ~3,500 lines of unrelated pre-existing drift) and the legacy `Samples/samples` runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
