### PR TITLE
Tell the truth about orientation on tvOS and watchOS

### DIFF
--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
@@ -7823,9 +7823,19 @@ public class IOSImplementation extends CodenameOneImplementation {
     }
     
     
+    /// tvOS and watchOS have no rotatable device orientation. IOSNative's
+    /// lockOrientation compiles the rotation away on both of those slices and
+    /// only records the requested lock, so answering true here promised callers
+    /// something the port cannot deliver. Anything that then waited for the
+    /// rotation to land waited for an event that could never arrive: an Apple TV
+    /// frame is landscape by construction, so a poll for portrait never settles
+    /// and burns its entire budget before giving up. That is what pushed
+    /// OrientationLockScreenshotTest past the compliance suite's per-test
+    /// timeout on tvOS. Reporting the truth sends those callers down their
+    /// fixed-orientation path immediately instead.
     @Override
     public boolean canForceOrientation() {
-        return true;
+        return !isWatch() && !isTV();
     }
 
     /*@Override


### PR DESCRIPTION
## The symptom

The public port-status table shows tvOS failing one test, and it is the one that makes least sense on a television:

```
OrientationLockScreenshotTest -> fail
  "failed due to timeout waiting for DONE stage=capture-requested"
```

It is not a rendering failure. The run log says `[cn1ss] Test 'landscape': Matches stored reference.`, and the ws-server log shows `test=landscape` delivered **twice** with an identical hash — the capture succeeded, the test then failed to report DONE, and `shouldRetryAfterCaptureTimeout` reproduced both halves on the retry.

## The cause

`IOSImplementation.canForceOrientation()` returned `true` unconditionally, on every Apple slice. But `IOSNative.m` compiles the rotation away on TV and watch:

```c
#else
    // watchOS/tvOS have no device orientation / UIViewController rotation.
    orientationLock = n1 ? 1 : 2;
#endif // !TARGET_OS_WATCH && !TARGET_OS_TV
```

So `lockOrientation` is a no-op that only records the request, while the port still claimed it could force the orientation.

Every consumer treats `false` as "fixed-orientation platform, take the immediate path" — including the guard in `OrientationLockScreenshotTest.restorePortrait()`, whose own comment names tvOS explicitly:

```java
// Fixed-orientation platforms (desktop, Linux/Mac windows, tvOS,
// browser) never rotated in the first place and can NEVER satisfy the
// portrait check ... finish immediately.
if (!CN.canForceOrientation()) { onDone.run(); return; }
```

The guard never fired. `isPortrait()` is `getDisplayWidth() < getActualDisplayHeight()` and the Apple TV frame is 3840x2160, so the predicate it then waits on is unsatisfiable.

## The budget

| leg | cost |
|---|---|
| pre-capture settle | 1500 ms |
| capture round-trip | variable |
| `RESTORE_POLL_ATTEMPTS` 200 x 100 ms — unsatisfiable on tvOS | **20 000 ms** |
| `POST_PORTRAIT_SETTLE_MS` | 1000 ms |

About 22.5s against the flat 30s `TEST_TIMEOUT_MS_NATIVE`, with no per-test exemption in `testTimeoutMs()`. Roughly seven seconds of headroom on *every* tvOS run. The test has not changed since July; the tvOS suite grew from 163 to 170 passing tests over the last two days and finally ate the margin. This is a deterministic dead loop that was living inside its slack, not a flake.

## The fix

Report the truth:

```java
public boolean canForceOrientation() {
    return !isWatch() && !isTV();
}
```

`isWatch()`/`isTV()` already exist and are backed by natives that resolve to compile-time constants per slice.

This also clears two smaller instances of the same shape that were merely staying inside their budgets:

- `LandscapeCapture.restorePortrait()` burned 40 x 100 ms on tvOS (Media360Panorama).
- `LandscapeCapture.awaitLandscape()` and `OrientationLockScreenshotTest`'s landscape leg burned 40 x 100 ms and 80 x 100 ms respectively on watchOS, waiting for a landscape that can never arrive.

`BaseTest.captureBlockedByOrientation()` is unaffected on both platforms — it already bails on `!suiteBaselinePortrait` (tvOS) and on `CN.isPortrait()` (watchOS).

## Verification

- `mvn -pl ios -am install` builds clean.
- SpotBugs on the `ios` module: 0 findings.
- No golden regeneration needed: the captured frames were always the fixed-orientation ones, they are just reached sooner. The tvOS `landscape` golden already matched byte-for-byte in the failing run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
