### PR TITLE
Detect rootless jailbreaks on iOS (palera1n, Dopamine, XinaA15)

### DIFF
--- a/CodenameOne/src/com/codename1/security/DeviceIntegrity.java
+++ b/CodenameOne/src/com/codename1/security/DeviceIntegrity.java
@@ -175,8 +175,12 @@ public final class DeviceIntegrity {
         return Display.getInstance().isDeviceCompromised();
     }
 
-    /// Returns the reason codes behind [#isDeviceCompromised()], e.g. `"root"`, `"frida"`, `"emulator"`,
-    /// `"jailbreak"`. Empty when the device appears clean.
+    /// Returns the reason codes behind [#isDeviceCompromised()]: `"root"`, `"jailbreak"`, `"frida"`
+    /// (any hooking or instrumentation framework, including one caught hooking the detection
+    /// itself), `"emulator"` and `"debugger"`. Empty when the device appears clean.
+    ///
+    /// Nothing is cached, so calling this again before a sensitive operation reports an
+    /// instrumentation framework that attached after launch.
     public static String[] getCompromiseReasons() {
         return Display.getInstance().getCompromiseReasons();
     }

--- a/Ports/iOSPort/nativeSources/CN1JailbreakDetector.h
+++ b/Ports/iOSPort/nativeSources/CN1JailbreakDetector.h
@@ -27,11 +27,37 @@
 /**
  * Runs every jailbreak / hooking probe and returns the ones that fired as a
  * comma separated list of stable codes, or an empty string on a clean device.
- * Codes: dyldInsert, hookLib, jailbreakFile, restrictedWrite, traced.
+ *
+ * Codes, in the order they are probed:
+ *
+ * - `dyldInsert`      DYLD_INSERT_LIBRARIES is set, the classic injection route.
+ * - `hookLib`         a known hooking / tweak-injection library is loaded into
+ *                     the process, or Substrate safe mode is signalled.
+ * - `hookedApi`       the probes below disagree with each other, or a path that
+ *                     exists on every stock device reports absent. Both mean a
+ *                     jailbreak-bypass tweak is filtering our answers, which is
+ *                     itself stronger evidence than any single path hit.
+ * - `jailbreakFile`   a rootful jailbreak artifact is present on disk.
+ * - `rootlessPath`    a rootless bootstrap (`/var/jb`, Procursus) is present.
+ *                     Rootless jailbreaks -- palera1n, Dopamine, XinaA15 -- leave
+ *                     the sealed system volume untouched and install everything
+ *                     under `/var/jb`, so none of the rootful paths exist and
+ *                     `restrictedWrite` cannot fire. This code is what sees them.
+ * - `mountRW`         the root filesystem is mounted writable, or an extra
+ *                     jailbreak filesystem is mounted.
+ * - `restrictedWrite` a write outside the sandbox succeeded.
+ * - `traced`          a debugger is attached to the process.
  *
  * Always compiled, independent of CN1_DETECT_JAILBREAK, because
  * DeviceIntegrity.getCompromiseReasons() surfaces these at runtime without
- * terminating the app. Returns an empty string on the simulator.
+ * terminating the app. Nothing is cached, so a caller may re-probe before a
+ * sensitive operation and see an instrumentation framework that attached after
+ * launch. Returns an empty string on the simulator.
+ *
+ * None of this is a guarantee. Every probe runs on hardware the attacker owns
+ * and can therefore be patched out; the value is in costing more to bypass than
+ * the previous version did, not in being unbypassable. The control that does not
+ * run on hostile hardware is server-verified attestation.
  */
 NSString *cn1JailbreakSignals(void);
 

--- a/Ports/iOSPort/nativeSources/CN1JailbreakDetector.m
+++ b/Ports/iOSPort/nativeSources/CN1JailbreakDetector.m
@@ -70,8 +70,19 @@ typedef NS_ENUM(int, CN1PathState) {
  * The raw lstat syscall number. Reaching past libc matters because the ObjC and
  * libc entry points are precisely what a jailbreak-bypass tweak hooks; the two
  * answers are then compared rather than trusted.
+ *
+ * Left undefined on watchOS and tvOS, where syscall() is marked unavailable in
+ * unistd.h and calling it is a hard compile error, not a warning. This file is
+ * built into the watch and TV targets as well as the phone one, which is how that
+ * turned up -- on the watch first, and on tvOS only because the platform matrix was
+ * widened afterwards rather than fixing the one platform CI had happened to reach.
+ * cn1RawLstat() then takes its documented "cannot answer" path, so the disagreement
+ * check simply has no second opinion there: a lost hook signal on two platforms
+ * nobody jailbreaks, rather than a build that does not compile.
  */
-#if defined(SYS_lstat64)
+#if TARGET_OS_WATCH || TARGET_OS_TV
+/* syscall() is unavailable; cn1RawLstat() answers CN1PathUnknown. */
+#elif defined(SYS_lstat64)
 #define CN1_SYS_LSTAT SYS_lstat64
 #elif defined(SYS_lstat)
 #define CN1_SYS_LSTAT SYS_lstat

--- a/Ports/iOSPort/nativeSources/CN1JailbreakDetector.m
+++ b/Ports/iOSPort/nativeSources/CN1JailbreakDetector.m
@@ -25,9 +25,7 @@
 #import <TargetConditionals.h>
 #import <dlfcn.h>
 #import <errno.h>
-#import <mach/mach.h>
 #import <mach-o/dyld.h>
-#import <mach-o/dyld_images.h>
 #import <stdlib.h>
 #import <string.h>
 #import <sys/mount.h>
@@ -241,53 +239,61 @@ static BOOL cn1ImagePathIsHooking(const char *imagePath, NSArray *needles) {
 }
 
 /**
- * The loaded-image scan, run twice.
+ * The loaded-image scan, asked two ways.
  *
- * The public form walks _dyld_get_image_name(), which is the documented API and
- * therefore the one a bypass tweak hooks. The second walk reads the same table
- * out of dyld_all_image_infos, reached through task_info(TASK_DYLD_INFO), so a
- * tweak has to hook both to stay hidden. When the raw walk sees an injected
- * library that the public walk does not, that gap is reported as hookedApi in
- * addition to hookLib: it says not only that something is injected but that
+ * The first way is _dyld_get_image_name(), the documented API and therefore the
+ * one a bypass tweak hooks. The second is dladdr() on the same image's header,
+ * which reaches the path through an entirely different entry point, so a tweak
+ * that only intercepts the documented route still answers honestly here. When
+ * dladdr sees an injected library that _dyld_get_image_name denies, that gap is
+ * reported as hookedApi in addition to hookLib: not only is something injected,
  * something is actively lying about it.
  *
- * Counts are deliberately not compared. The two tables legitimately differ by an
- * entry or two across OS versions -- dyld itself is in one and not always the
- * other -- so a count check is a false positive waiting for the next iOS release.
+ * Only that direction. dladdr is allowed to fail -- it answers for an address,
+ * not an index -- and reading a failure as a contradiction would let a quirk in
+ * one API terminate the app through a signal the launch gate treats as fatal.
+ *
+ * This deliberately does NOT read dyld_all_image_infos through
+ * task_info(TASK_DYLD_INFO), which is the obvious way to get a second opinion and
+ * was how this was first written. That table is dyld's live one, and the null
+ * check that guards the in-flux window does nothing about the real hazard: a
+ * dlopen on another thread between the check and the walk can move infoArray or
+ * change infoArrayCount underneath the loop. getCompromiseReasons() is called
+ * from the EDT while the rest of the app runs, which is exactly when that can
+ * happen. Crashing a clean device is a worse failure than missing a hook, and
+ * the debugger-facing table is meant to be read with the process suspended.
+ *
+ * Counts are deliberately not compared either. Two enumerations legitimately
+ * differ by an entry or two across OS versions, so a count check is a false
+ * positive waiting for the next iOS release.
  */
 static void cn1ScanLoadedImages(NSMutableArray *signals) {
     NSArray *needles = cn1HookingImageNames();
-    BOOL publicFound = NO;
-    for (uint32_t i = 0; i < _dyld_image_count(); i++) {
-        if (cn1ImagePathIsHooking(_dyld_get_image_name(i), needles)) {
-            publicFound = YES;
+    BOOL namedFound = NO;
+    BOOL addressFound = NO;
+
+    uint32_t count = _dyld_image_count();
+    for (uint32_t i = 0; i < count; i++) {
+        if (!namedFound && cn1ImagePathIsHooking(_dyld_get_image_name(i), needles)) {
+            namedFound = YES;
+        }
+        if (!addressFound) {
+            const struct mach_header *header = _dyld_get_image_header(i);
+            Dl_info info;
+            if (header != NULL && dladdr(header, &info) != 0
+                    && cn1ImagePathIsHooking(info.dli_fname, needles)) {
+                addressFound = YES;
+            }
+        }
+        if (namedFound && addressFound) {
             break;
         }
     }
 
-    BOOL rawFound = NO;
-    struct task_dyld_info dyldInfo;
-    mach_msg_type_number_t infoCount = TASK_DYLD_INFO_COUNT;
-    if (task_info(mach_task_self(), TASK_DYLD_INFO,
-                  (task_info_t) &dyldInfo, &infoCount) == KERN_SUCCESS) {
-        const struct dyld_all_image_infos *all =
-                (const struct dyld_all_image_infos *) (uintptr_t) dyldInfo.all_image_info_addr;
-        // infoArray is briefly NULL while dyld rewrites the table, which is a
-        // normal transient state and not a signal.
-        if (all != NULL && all->infoArray != NULL) {
-            for (uint32_t i = 0; i < all->infoArrayCount; i++) {
-                if (cn1ImagePathIsHooking(all->infoArray[i].imageFilePath, needles)) {
-                    rawFound = YES;
-                    break;
-                }
-            }
-        }
-    }
-
-    if (publicFound || rawFound) {
+    if (namedFound || addressFound) {
         cn1AddSignal(signals, @"hookLib");
     }
-    if (rawFound && !publicFound) {
+    if (addressFound && !namedFound) {
         cn1AddSignal(signals, @"hookedApi");
     }
 }

--- a/Ports/iOSPort/nativeSources/CN1JailbreakDetector.m
+++ b/Ports/iOSPort/nativeSources/CN1JailbreakDetector.m
@@ -24,16 +24,433 @@
 #import "CN1JailbreakDetector.h"
 #import <TargetConditionals.h>
 #import <dlfcn.h>
-#import <sys/sysctl.h>
+#import <errno.h>
+#import <mach/mach.h>
 #import <mach-o/dyld.h>
-#import <unistd.h>
+#import <mach-o/dyld_images.h>
 #import <stdlib.h>
+#import <string.h>
+#import <sys/mount.h>
+#import <sys/param.h>
+#import <sys/stat.h>
+#import <sys/syscall.h>
+#import <sys/sysctl.h>
+#import <unistd.h>
 
 // Note: there is deliberately no fork() probe here. The classic form,
 // "if (fork() == 0) { exit(0); }", terminates the *child* and lets the parent
 // sail on, so it never did what it claimed. Reinstating it correctly would
 // mean calling a restricted syscall that trips App Review static analysis, for
 // a signal the dyld-image and restricted-path probes already carry.
+
+// Everything below the simulator guard is compiled only for a device. The
+// simulator answer is a constant empty string -- it runs on a Mac, where none of
+// these questions mean what they mean on iOS -- and compiling the probes anyway
+// left the build warning about a file full of functions nobody calls.
+#if !(TARGET_IPHONE_SIMULATOR)
+
+// The path probes describe an iOS sandbox that has been broken out of, and a Mac is
+// not that sandbox: /bin/bash and /usr/sbin/sshd ship with macOS and /private is
+// writable there, so on Mac Catalyst they fire on a stock machine -- and an app that
+// asks isJailbrokenDevice() at startup, as ours does, then refuses to launch on every
+// Mac. The instrumentation probes are outside this guard, because an injected dylib
+// or a hooking library means the same thing wherever it is loaded.
+#if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
+
+/**
+ * What a single existence probe concluded. The three-way answer is the point:
+ * a sandbox denial is not the same answer as ENOENT, and reading it as "absent"
+ * would make two probes that were both simply refused look like they disagreed.
+ */
+typedef NS_ENUM(int, CN1PathState) {
+    CN1PathUnknown = 0,
+    CN1PathAbsent  = 1,
+    CN1PathPresent = 2
+};
+
+/**
+ * The raw lstat syscall number. Reaching past libc matters because the ObjC and
+ * libc entry points are precisely what a jailbreak-bypass tweak hooks; the two
+ * answers are then compared rather than trusted.
+ */
+#if defined(SYS_lstat64)
+#define CN1_SYS_LSTAT SYS_lstat64
+#elif defined(SYS_lstat)
+#define CN1_SYS_LSTAT SYS_lstat
+#endif
+
+static CN1PathState cn1StateFromResult(int rc, int savedErrno) {
+    if (rc == 0) {
+        return CN1PathPresent;
+    }
+    // Only ENOENT/ENOTDIR are the filesystem saying "there is nothing here".
+    // Everything else -- EPERM from the sandbox, EACCES on a parent directory,
+    // ENOSYS from a syscall this kernel does not implement -- means the probe
+    // failed to answer, and treating that as absent both loses the signal and
+    // manufactures disagreements between probes that were both just refused.
+    if (savedErrno == ENOENT || savedErrno == ENOTDIR) {
+        return CN1PathAbsent;
+    }
+    return CN1PathUnknown;
+}
+
+/**
+ * lstat through libc. Deliberately lstat and not stat: on a rootless jailbreak
+ * /var/jb is a symlink onto a mounted bootstrap, and a semi-tethered device that
+ * has been rebooted without re-jailbreaking still carries the symlink while the
+ * target is gone. stat() follows the link and reports nothing; lstat() sees the
+ * link itself, which is the evidence that matters.
+ */
+static CN1PathState cn1LibcLstat(const char *path) {
+    struct stat st;
+    errno = 0;
+    int rc = lstat(path, &st);
+    return cn1StateFromResult(rc, errno);
+}
+
+/**
+ * The same question asked below libc. A tweak that hooks lstat() but not the raw
+ * trap answers differently here, and that difference is reported as hookedApi.
+ */
+static CN1PathState cn1RawLstat(const char *path) {
+#ifdef CN1_SYS_LSTAT
+    struct stat st;
+    memset(&st, 0, sizeof(st));
+    errno = 0;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    int rc = (int) syscall(CN1_SYS_LSTAT, path, &st);
+#pragma clang diagnostic pop
+    return cn1StateFromResult(rc == 0 ? 0 : -1, errno);
+#else
+    (void) path;
+    return CN1PathUnknown;
+#endif
+}
+
+/**
+ * Existence according to the two Foundation/POSIX entry points a tweak is most
+ * likely to hook. Both follow symlinks, so neither can take part in the
+ * disagreement check -- an unreachable symlink target makes them legitimately
+ * differ from lstat on a device with no tweak at all. They contribute presence
+ * only: another way for a path to be seen, never a reason to cry hook.
+ */
+static CN1PathState cn1FollowingProbes(const char *path) {
+    errno = 0;
+    CN1PathState viaAccess = cn1StateFromResult(access(path, F_OK), errno);
+    if (viaAccess == CN1PathPresent) {
+        return CN1PathPresent;
+    }
+    NSString *objcPath = [NSString stringWithUTF8String:path];
+    if (objcPath != nil && [[NSFileManager defaultManager] fileExistsAtPath:objcPath]) {
+        return CN1PathPresent;
+    }
+    return viaAccess;
+}
+
+/**
+ * Whether `path` exists, asked four ways. `hookSuspected` is set when the two
+ * lstat probes -- which must agree on any untampered device, since they ask the
+ * kernel the identical question -- did not.
+ */
+static BOOL cn1PathPresent(const char *path, BOOL *hookSuspected) {
+    CN1PathState viaLibc = cn1LibcLstat(path);
+    CN1PathState viaRaw = cn1RawLstat(path);
+    if (hookSuspected != NULL
+            && ((viaLibc == CN1PathPresent && viaRaw == CN1PathAbsent)
+                || (viaLibc == CN1PathAbsent && viaRaw == CN1PathPresent))) {
+        *hookSuspected = YES;
+    }
+    if (viaLibc == CN1PathPresent || viaRaw == CN1PathPresent) {
+        return YES;
+    }
+    return cn1FollowingProbes(path) == CN1PathPresent;
+}
+
+#endif // !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
+
+/**
+ * Appends a signal code once. The probes below can reach the same conclusion
+ * from several directions -- three rootless paths, or a /var/jb mount and the
+ * symlink that names it -- and a caller splitting the result on commas should
+ * not have to fold duplicates back out.
+ */
+static void cn1AddSignal(NSMutableArray *signals, NSString *code) {
+    if (![signals containsObject:code]) {
+        [signals addObject:code];
+    }
+}
+
+/**
+ * Lowercased fragments of the file name of anything that hooks, injects, or
+ * exists only to defeat this file. Matched as substrings against the lowercased
+ * path of every loaded image, so a version suffix or an install prefix does not
+ * matter. `/var/jb/` is in the list because an image loaded out of the rootless
+ * bootstrap is conclusive regardless of what it is called.
+ */
+static NSArray *cn1HookingImageNames(void) {
+    static NSArray *names = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        names = @[
+            @"/var/jb/",
+            @"substrate.dylib",          // also MobileSubstrate/CydiaSubstrate
+            @"substrateinserter.dylib",
+            @"substrateloader.dylib",
+            @"libsubstrate.dylib",
+            @"libsubstitute.dylib",      // Substitute, the Electra-era injector
+            @"libhooker.dylib",          // libhooker, the Chimera/Odyssey injector
+            @"libblackjack",             // libhooker's loader
+            @"ellekit",                  // the rootless injector palera1n ships
+            @"tweakinject",              // ElleKit's dylib list / loader
+            @"libertylite.dylib",
+            @"tsprotector",
+            @"fridagadget",
+            @"frida-agent",
+            @"libcycript",
+            @"cynject",
+            @"rocketbootstrap",
+            @"sslkillswitch",
+            @"shadow.dylib",             // the bypass tweak, not a system name
+            @"choicy",
+            @"libsandy",
+            @"flyjb",
+            @"preferenceloader"
+        ];
+    });
+    return names;
+}
+
+static BOOL cn1ImagePathIsHooking(const char *imagePath) {
+    if (imagePath == NULL) {
+        return NO;
+    }
+    NSString *path = [NSString stringWithUTF8String:imagePath];
+    if (path == nil) {
+        return NO;
+    }
+    NSString *lowered = [path lowercaseString];
+    for (NSString *needle in cn1HookingImageNames()) {
+        if ([lowered containsString:needle]) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
+/**
+ * The loaded-image scan, run twice.
+ *
+ * The public form walks _dyld_get_image_name(), which is the documented API and
+ * therefore the one a bypass tweak hooks. The second walk reads the same table
+ * out of dyld_all_image_infos, reached through task_info(TASK_DYLD_INFO), so a
+ * tweak has to hook both to stay hidden. When the raw walk sees an injected
+ * library that the public walk does not, that gap is reported as hookedApi in
+ * addition to hookLib: it says not only that something is injected but that
+ * something is actively lying about it.
+ *
+ * Counts are deliberately not compared. The two tables legitimately differ by an
+ * entry or two across OS versions -- dyld itself is in one and not always the
+ * other -- so a count check is a false positive waiting for the next iOS release.
+ */
+static void cn1ScanLoadedImages(NSMutableArray *signals) {
+    BOOL publicFound = NO;
+    for (uint32_t i = 0; i < _dyld_image_count(); i++) {
+        if (cn1ImagePathIsHooking(_dyld_get_image_name(i))) {
+            publicFound = YES;
+            break;
+        }
+    }
+
+    BOOL rawFound = NO;
+    struct task_dyld_info dyldInfo;
+    mach_msg_type_number_t infoCount = TASK_DYLD_INFO_COUNT;
+    if (task_info(mach_task_self(), TASK_DYLD_INFO,
+                  (task_info_t) &dyldInfo, &infoCount) == KERN_SUCCESS) {
+        const struct dyld_all_image_infos *all =
+                (const struct dyld_all_image_infos *) (uintptr_t) dyldInfo.all_image_info_addr;
+        // infoArray is briefly NULL while dyld rewrites the table, which is a
+        // normal transient state and not a signal.
+        if (all != NULL && all->infoArray != NULL) {
+            for (uint32_t i = 0; i < all->infoArrayCount; i++) {
+                if (cn1ImagePathIsHooking(all->infoArray[i].imageFilePath)) {
+                    rawFound = YES;
+                    break;
+                }
+            }
+        }
+    }
+
+    if (publicFound || rawFound) {
+        cn1AddSignal(signals, @"hookLib");
+    }
+    if (rawFound && !publicFound) {
+        cn1AddSignal(signals, @"hookedApi");
+    }
+}
+
+#if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX // rationale above, at the first region
+/**
+ * Rootful jailbreak artifacts: files that only exist once the sealed system
+ * volume has been modified.
+ */
+static NSArray *cn1RootfulPaths(void) {
+    return @[
+        @"/Applications/Cydia.app",
+        @"/Applications/Sileo.app",
+        @"/Applications/Zebra.app",
+        @"/Applications/Filza.app",
+        @"/Library/MobileSubstrate/MobileSubstrate.dylib",
+        @"/usr/lib/libsubstitute.dylib",
+        @"/usr/lib/libhooker.dylib",
+        @"/usr/lib/substrate/SubstrateLoader.dylib",
+        @"/usr/libexec/cydia",
+        @"/usr/sbin/sshd",
+        @"/bin/bash",
+        @"/etc/apt",
+        @"/private/var/lib/apt/",
+        @"/var/lib/undecimus",
+        @"/var/checkra1n.dmg",
+        @"/var/binpack",
+        @"/.installed_unc0ver",
+        @"/.bootstrapped_electra"
+    ];
+}
+
+/**
+ * Rootless jailbreak artifacts. A rootless jailbreak leaves the signed system
+ * volume sealed and bootstraps Procursus into /var/jb instead, so every path
+ * above is genuinely absent and the sandbox-escape write genuinely fails. Before
+ * this list a palera1n/Dopamine device produced no signals at all, which is
+ * exactly the miss a customer reported on palera1n 2.1.1 rootless.
+ *
+ * /var/jb comes first and is the one that matters; the rest are here so that
+ * deleting or hiding the symlink alone is not enough.
+ */
+static NSArray *cn1RootlessPaths(void) {
+    return @[
+        @"/var/jb",
+        @"/var/jb/usr/lib/TweakInject.dylib",
+        @"/var/jb/usr/lib/libellekit.dylib",
+        @"/var/jb/Applications/Sileo.app",
+        @"/var/jb/etc/apt",
+        @"/var/jb/usr/bin/dpkg",
+        @"/var/jb/bin/sh",
+        @"/private/preboot/jb",
+        @"/private/preboot/procursus"
+    ];
+}
+
+/**
+ * Paths that exist on every stock device. A probe reporting all of these absent
+ * -- absent, not denied -- is not reading the real filesystem, which means a
+ * filter is sitting in front of it. Framework bundles and SystemVersion.plist
+ * are on disk even on modern iOS, unlike the dylibs that now live only in the
+ * shared cache and would make a terrible canary.
+ */
+static NSArray *cn1CanaryPaths(void) {
+    return @[
+        @"/System/Library/CoreServices/SystemVersion.plist",
+        @"/System/Library/Frameworks/Foundation.framework"
+    ];
+}
+
+static void cn1ScanFilesystem(NSMutableArray *signals) {
+    BOOL hookSuspected = NO;
+
+    for (NSString *path in cn1RootfulPaths()) {
+        if (cn1PathPresent([path fileSystemRepresentation], &hookSuspected)) {
+            cn1AddSignal(signals, @"jailbreakFile");
+        }
+    }
+    for (NSString *path in cn1RootlessPaths()) {
+        if (cn1PathPresent([path fileSystemRepresentation], &hookSuspected)) {
+            cn1AddSignal(signals, @"rootlessPath");
+        }
+    }
+    // Every canary has to come back absent, not just one. A blanket filter hides
+    // them all, whereas a future iOS that merely relocates one file would, under
+    // an "any" rule, make this fatal signal fire on every stock device -- turning
+    // an OS update into an app that refuses to launch. The conjunction is what
+    // makes it safe to derive a fatal signal from a hard-coded path list.
+    NSArray *canaries = cn1CanaryPaths();
+    BOOL everyCanaryAbsent = canaries.count > 0;
+    for (NSString *path in canaries) {
+        const char *canaryPath = [path fileSystemRepresentation];
+        BOOL canaryHook = NO;
+        if (cn1PathPresent(canaryPath, &canaryHook)) {
+            everyCanaryAbsent = NO;
+        } else if (cn1LibcLstat(canaryPath) != CN1PathAbsent
+                && cn1RawLstat(canaryPath) != CN1PathAbsent) {
+            // Denied rather than missing. A sandbox refusal also leaves
+            // cn1PathPresent returning NO, and counting that as evidence of a
+            // filter would accuse a device where nothing is wrong.
+            everyCanaryAbsent = NO;
+        }
+        if (canaryHook) {
+            hookSuspected = YES;
+        }
+    }
+    if (everyCanaryAbsent) {
+        hookSuspected = YES;
+    }
+
+    if (hookSuspected) {
+        cn1AddSignal(signals, @"hookedApi");
+    }
+
+    // Writing outside the sandbox should be impossible. This still only fires on
+    // a rootful jailbreak -- a rootless one leaves / read-only, which is the
+    // whole point of the name -- so it is a corroborating signal, not a primary.
+    NSString *testPath = @"/private/cn1JailbreakTest.txt";
+    NSError *error = nil;
+    BOOL wroteFile = [@"Test" writeToFile:testPath atomically:YES
+                                 encoding:NSUTF8StringEncoding error:&error];
+    if (wroteFile && error == nil) {
+        [[NSFileManager defaultManager] removeItemAtPath:testPath error:nil];
+        cn1AddSignal(signals, @"restrictedWrite");
+    }
+}
+
+/**
+ * The mount table. Two independent things are visible here and neither needs a
+ * path to be guessed correctly:
+ *
+ * - A writable root filesystem. Stock iOS seals / read-only; a rootful jailbreak
+ *   has to remount it to install anything.
+ * - An extra mounted filesystem belonging to a bootstrap. A rootless jailbreak
+ *   mounts its Procursus image and binds it in, and the mount point says so even
+ *   if every file under it were somehow hidden from lstat.
+ */
+static void cn1ScanMounts(NSMutableArray *signals) {
+    struct statfs rootFs;
+    if (statfs("/", &rootFs) == 0 && (rootFs.f_flags & MNT_RDONLY) == 0) {
+        cn1AddSignal(signals, @"mountRW");
+    }
+
+    int count = getfsstat(NULL, 0, MNT_NOWAIT);
+    if (count <= 0) {
+        return;
+    }
+    size_t bytes = (size_t) count * sizeof(struct statfs);
+    struct statfs *mounts = (struct statfs *) malloc(bytes);
+    if (mounts == NULL) {
+        return;
+    }
+    count = getfsstat(mounts, (int) bytes, MNT_NOWAIT);
+    for (int i = 0; i < count; i++) {
+        const char *mountPoint = mounts[i].f_mntonname;
+        if (strstr(mountPoint, "/var/jb") != NULL
+                || strstr(mountPoint, "procursus") != NULL) {
+            cn1AddSignal(signals, @"rootlessPath");
+            break;
+        }
+    }
+    free(mounts);
+}
+#endif // !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
+
+#endif // !(TARGET_IPHONE_SIMULATOR)
 
 NSString *cn1JailbreakSignals(void) {
 #if (TARGET_IPHONE_SIMULATOR)
@@ -43,66 +460,22 @@ NSString *cn1JailbreakSignals(void) {
 
     // Dynamic library injection, as used by Frida/Objection and friends.
     if (getenv("DYLD_INSERT_LIBRARIES") != NULL) {
-        [signals addObject:@"dyldInsert"];
+        cn1AddSignal(signals, @"dyldInsert");
+    }
+
+    // Substrate's safe mode. Set by the injector itself, so it says a tweak
+    // loader is present even in the run where it declined to inject.
+    if (getenv("_MSSafeMode") != NULL || getenv("_SafeMode") != NULL) {
+        cn1AddSignal(signals, @"hookLib");
     }
 
     // Known hooking / jailbreak-bypass libraries loaded into the process.
-    NSArray *bypassLibraries = @[
-        @"LibertyLite.dylib",
-        @"Substrate.dylib",
-        @"MobileSubstrate.dylib",
-        @"SubstrateInserter.dylib",
-        @"tsProtector.dylib",
-        @"FridaGadget"
-    ];
-    for (uint32_t i = 0; i < _dyld_image_count(); i++) {
-        const char *imageName = _dyld_get_image_name(i);
-        if (imageName == NULL) {
-            continue;
-        }
-        NSString *libraryName = [NSString stringWithUTF8String:imageName];
-        for (NSString *bypassLibrary in bypassLibraries) {
-            if ([libraryName containsString:bypassLibrary]) {
-                [signals addObject:@"hookLib"];
-                i = _dyld_image_count();
-                break;
-            }
-        }
-    }
+    cn1ScanLoadedImages(signals);
 
-    // The two filesystem probes below describe an iOS sandbox that has been broken out
-    // of, and a Mac is not that sandbox. /bin/bash and /usr/sbin/sshd ship with macOS and
-    // /private is writable there, so on Mac Catalyst both fire on a stock machine -- and
-    // an app that asks isJailbrokenDevice() at startup, as ours does, refuses to launch on
-    // every Mac. The instrumentation probes on either side of this stay, because an
-    // injected dylib or a hooking library means the same thing wherever it is loaded.
+    // Skipped on Mac Catalyst -- see the rationale on the region these two live in.
 #if !TARGET_OS_MACCATALYST && !TARGET_OS_OSX
-    // Files that only exist once the sandbox has been broken out of.
-    NSArray *restrictedPaths = @[
-        @"/Applications/Cydia.app",
-        @"/Library/MobileSubstrate/MobileSubstrate.dylib",
-        @"/usr/sbin/sshd",
-        @"/bin/bash",
-        @"/etc/apt",
-        @"/private/var/lib/apt/"
-    ];
-    NSFileManager *fileManager = [NSFileManager defaultManager];
-    for (NSString *path in restrictedPaths) {
-        if ([fileManager fileExistsAtPath:path]) {
-            [signals addObject:@"jailbreakFile"];
-            break;
-        }
-    }
-
-    // Writing outside the sandbox should be impossible.
-    NSString *testPath = @"/private/cn1JailbreakTest.txt";
-    NSError *error = nil;
-    BOOL wroteFile = [@"Test" writeToFile:testPath atomically:YES
-                                 encoding:NSUTF8StringEncoding error:&error];
-    if (wroteFile && error == nil) {
-        [fileManager removeItemAtPath:testPath error:nil];
-        [signals addObject:@"restrictedWrite"];
-    }
+    cn1ScanFilesystem(signals);
+    cn1ScanMounts(signals);
 #endif
 
     // A debugger or instrumentation tool attached to the process.
@@ -111,7 +484,7 @@ NSString *cn1JailbreakSignals(void) {
     int name[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PID, getpid()};
     if (sysctl(name, 4, &info, &size, NULL, 0) == 0
             && (info.kp_proc.p_flag & P_TRACED) != 0) {
-        [signals addObject:@"traced"];
+        cn1AddSignal(signals, @"traced");
     }
 
     return [signals componentsJoinedByString:@","];
@@ -129,11 +502,19 @@ NSString *cn1JailbreakSignals(void) {
  * launch gate terminated every ordinary debug session on a project that leaves
  * ios.detectJailbreak on. That reads as "the app crashes on device", and the usual fix a
  * developer reaches for is turning the protection off.
+ *
+ * Everything else in the list is fatal, `hookedApi` included: a probe disagreeing with
+ * itself, or a stock system path reporting absent, only happens when something is
+ * rewriting the answers, and a device carrying a detection-bypass tweak is precisely the
+ * device this gate exists to refuse.
  */
 static BOOL cn1IsJailbreakSignal(NSString *signal) {
     return [signal isEqualToString:@"dyldInsert"]
         || [signal isEqualToString:@"hookLib"]
+        || [signal isEqualToString:@"hookedApi"]
         || [signal isEqualToString:@"jailbreakFile"]
+        || [signal isEqualToString:@"rootlessPath"]
+        || [signal isEqualToString:@"mountRW"]
         || [signal isEqualToString:@"restrictedWrite"];
 }
 
@@ -147,7 +528,11 @@ void cn1DetectJailbreakBypassesAndExit(void) {
     }
     if (fatal.count > 0) {
         NSLog(@"Jailbreak bypass detected: %@", [fatal componentsJoinedByString:@","]);
-        exit(0);
+        // Non-zero, because exit(0) tells the OS and any crash reporter that the app
+        // finished normally -- so a refused launch on a compromised device was
+        // indistinguishable in the logs from a clean one, which is the one place this
+        // gate is supposed to leave a trace.
+        exit(EXIT_FAILURE);
     }
 }
 #endif

--- a/Ports/iOSPort/nativeSources/CN1JailbreakDetector.m
+++ b/Ports/iOSPort/nativeSources/CN1JailbreakDetector.m
@@ -189,39 +189,41 @@ static void cn1AddSignal(NSMutableArray *signals, NSString *code) {
  * bootstrap is conclusive regardless of what it is called.
  */
 static NSArray *cn1HookingImageNames(void) {
-    static NSArray *names = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        names = @[
-            @"/var/jb/",
-            @"substrate.dylib",          // also MobileSubstrate/CydiaSubstrate
-            @"substrateinserter.dylib",
-            @"substrateloader.dylib",
-            @"libsubstrate.dylib",
-            @"libsubstitute.dylib",      // Substitute, the Electra-era injector
-            @"libhooker.dylib",          // libhooker, the Chimera/Odyssey injector
-            @"libblackjack",             // libhooker's loader
-            @"ellekit",                  // the rootless injector palera1n ships
-            @"tweakinject",              // ElleKit's dylib list / loader
-            @"libertylite.dylib",
-            @"tsprotector",
-            @"fridagadget",
-            @"frida-agent",
-            @"libcycript",
-            @"cynject",
-            @"rocketbootstrap",
-            @"sslkillswitch",
-            @"shadow.dylib",             // the bypass tweak, not a system name
-            @"choicy",
-            @"libsandy",
-            @"flyjb",
-            @"preferenceloader"
-        ];
-    });
-    return names;
+    // Autoreleased and rebuilt per scan, deliberately. This file is compiled
+    // without ARC -- the app target sets CLANG_ENABLE_OBJC_ARC = NO -- so caching
+    // the literal in a dispatch_once static stores an object nobody retained, and
+    // iosJailbreakSignals() wraps its call in POOL_BEGIN/POOL_END. The first call
+    // would leave the static dangling and the foreground recheck would scan the
+    // loaded images through freed memory. The cost this avoids is one array per
+    // scan, not per image: the scan hoists it and passes it down.
+    return @[
+        @"/var/jb/",
+        @"substrate.dylib",          // also MobileSubstrate/CydiaSubstrate
+        @"substrateinserter.dylib",
+        @"substrateloader.dylib",
+        @"libsubstrate.dylib",
+        @"libsubstitute.dylib",      // Substitute, the Electra-era injector
+        @"libhooker.dylib",          // libhooker, the Chimera/Odyssey injector
+        @"libblackjack",             // libhooker's loader
+        @"ellekit",                  // the rootless injector palera1n ships
+        @"tweakinject",              // ElleKit's dylib list / loader
+        @"libertylite.dylib",
+        @"tsprotector",
+        @"fridagadget",
+        @"frida-agent",
+        @"libcycript",
+        @"cynject",
+        @"rocketbootstrap",
+        @"sslkillswitch",
+        @"shadow.dylib",             // the bypass tweak, not a system name
+        @"choicy",
+        @"libsandy",
+        @"flyjb",
+        @"preferenceloader"
+    ];
 }
 
-static BOOL cn1ImagePathIsHooking(const char *imagePath) {
+static BOOL cn1ImagePathIsHooking(const char *imagePath, NSArray *needles) {
     if (imagePath == NULL) {
         return NO;
     }
@@ -230,7 +232,7 @@ static BOOL cn1ImagePathIsHooking(const char *imagePath) {
         return NO;
     }
     NSString *lowered = [path lowercaseString];
-    for (NSString *needle in cn1HookingImageNames()) {
+    for (NSString *needle in needles) {
         if ([lowered containsString:needle]) {
             return YES;
         }
@@ -254,9 +256,10 @@ static BOOL cn1ImagePathIsHooking(const char *imagePath) {
  * other -- so a count check is a false positive waiting for the next iOS release.
  */
 static void cn1ScanLoadedImages(NSMutableArray *signals) {
+    NSArray *needles = cn1HookingImageNames();
     BOOL publicFound = NO;
     for (uint32_t i = 0; i < _dyld_image_count(); i++) {
-        if (cn1ImagePathIsHooking(_dyld_get_image_name(i))) {
+        if (cn1ImagePathIsHooking(_dyld_get_image_name(i), needles)) {
             publicFound = YES;
             break;
         }
@@ -273,7 +276,7 @@ static void cn1ScanLoadedImages(NSMutableArray *signals) {
         // normal transient state and not a signal.
         if (all != NULL && all->infoArray != NULL) {
             for (uint32_t i = 0; i < all->infoArrayCount; i++) {
-                if (cn1ImagePathIsHooking(all->infoArray[i].imageFilePath)) {
+                if (cn1ImagePathIsHooking(all->infoArray[i].imageFilePath, needles)) {
                     rawFound = YES;
                     break;
                 }

--- a/Ports/iOSPort/nativeSources/CodenameOne_GLAppDelegate.m
+++ b/Ports/iOSPort/nativeSources/CodenameOne_GLAppDelegate.m
@@ -372,6 +372,15 @@ static NSUserActivity *cn1PendingLaunchActivity = nil;
 
 - (void)cn1ApplicationWillEnterForeground
 {
+#ifdef CN1_DETECT_JAILBREAK
+    // Again, on every return from the background. A launch-time-only gate is
+    // trivially stepped around: background the app, attach the instrumentation
+    // to the running process, bring it back. This hook is not called on the
+    // initial launch -- iOS goes straight to didBecomeActive: there -- so the
+    // gate still runs exactly once per foreground, and the probes are a
+    // sub-millisecond handful of syscalls.
+    cn1DetectJailbreakBypassesAndExit();
+#endif
     if (cn1IsHiddenInBackground) {
         [CodenameOne_GLViewController instance].view.hidden = NO;
     }

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
@@ -12898,7 +12898,10 @@ public class IOSImplementation extends CodenameOneImplementation {
      *
      * <p>Hooking is left out for the same reason it is reported separately: a hooking
      * framework is evidence of instrumentation, which usually accompanies a jailbreak but
-     * is not one, and callers that want the broader question have the broader method.</p>
+     * is not one, and callers that want the broader question have the broader method.
+     * The one hooking signal that does count here is {@code hookedApi} -- the native
+     * probes catching each other being lied to -- because a detection-bypass tweak is not
+     * something that gets installed on a device that has nothing to hide.</p>
      */
     @Override
     public boolean isJailbrokenDevice() {
@@ -12912,19 +12915,37 @@ public class IOSImplementation extends CodenameOneImplementation {
     }
 
     /**
-     * The legacy probe. Only ever returns true when the app also declares cydia
-     * in ios.applicationQueriesSchemes -- on iOS 9 and up canOpenURL returns
-     * false for undeclared schemes regardless of what is installed. That is why
-     * it cannot be the primary signal, but apps that do declare it would
-     * regress if it were dropped.
+     * URL schemes registered by the apps a jailbreak installs. Only ever returns true
+     * when the app also declares the scheme in ios.applicationQueriesSchemes -- on iOS 9
+     * and up canOpenURL returns false for an undeclared scheme regardless of what is
+     * installed -- which is why this cannot be the primary signal. The
+     * {@code ios.detectJailbreak} build hint declares all of them for you.
+     *
+     * <p>Cydia alone was the whole list, and Cydia is the package manager of a rootful
+     * jailbreak nobody has shipped for current iOS. A rootless device runs Sileo, so the
+     * probe looked for the one front end that was certain not to be there.</p>
      */
-    private boolean cydiaProbe() {
-        try {
-            Boolean b = canExecute("cydia://package/com.example.package");
-            return b != null && b.booleanValue();
-        } catch (Throwable t) {
-            return false;
+    private static final String[] JAILBREAK_URL_SCHEMES = {
+        "cydia://package/com.example.package",
+        "sileo://package/com.example.package",
+        "zbra://packages/com.example.package",
+        "filza://view",
+        "undecimus://",
+        "activator://"
+    };
+
+    private boolean packageManagerProbe() {
+        for (int i = 0; i < JAILBREAK_URL_SCHEMES.length; i++) {
+            try {
+                Boolean b = canExecute(JAILBREAK_URL_SCHEMES[i]);
+                if (b != null && b.booleanValue()) {
+                    return true;
+                }
+            } catch (Throwable t) {
+                // A scheme the OS refuses to parse says nothing about the next one.
+            }
         }
+        return false;
     }
 
     /**
@@ -12945,6 +12966,17 @@ public class IOSImplementation extends CodenameOneImplementation {
                     // framework so app code does not need a per-platform branch.
                     out.add("frida");
                 }
+            } else if ("hookedApi".equals(s)) {
+                // Counts as both. Something is hooking us, which is the "frida"
+                // bucket; and what it is hooking is jailbreak detection, which
+                // only happens on a device that has a jailbreak to hide.
+                if (!out.contains("frida")) {
+                    out.add("frida");
+                }
+                if (!jailbreakReported) {
+                    jailbreakReported = true;
+                    out.add("jailbreak");
+                }
             } else if ("traced".equals(s)) {
                 out.add("debugger");
             } else if (!jailbreakReported) {
@@ -12954,12 +12986,12 @@ public class IOSImplementation extends CodenameOneImplementation {
         }
         // Always, not only when the native probes found nothing. Those two sets of
         // evidence are independent: the native side checks hard-coded paths and dyld,
-        // and the cydia scheme catches installs those miss -- so gating one on the other
+        // and the URL schemes catch installs those miss -- so gating one on the other
         // being empty meant a single unrelated signal suppressed it. A debugger alone
         // was enough: `traced` made the list non-empty, the probe was skipped, and a
-        // jailbreak only cydia could see went unreported. Which is how a developer
+        // jailbreak only the scheme could see went unreported. Which is how a developer
         // running under Xcode ends up being told their jailbroken device is clean.
-        if (!jailbreakReported && cydiaProbe()) {
+        if (!jailbreakReported && packageManagerProbe()) {
             out.add("jailbreak");
         }
         return out.toArray(new String[out.size()]);

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
@@ -12924,14 +12924,23 @@ public class IOSImplementation extends CodenameOneImplementation {
      * <p>Cydia alone was the whole list, and Cydia is the package manager of a rootful
      * jailbreak nobody has shipped for current iOS. A rootless device runs Sileo, so the
      * probe looked for the one front end that was certain not to be there.</p>
+     *
+     * <p>Kept deliberately short, and it must stay that way. Every entry is spent out of
+     * the app's LSApplicationQueriesSchemes budget, which iOS caps at 25 for an app linked
+     * against the iOS 27 SDK -- a secondary probe is not entitled to a quarter of it.
+     * Adding a scheme here means adding it to
+     * {@code IPhoneBuilder.JAILBREAK_QUERY_SCHEMES} too, or it is declared nowhere and
+     * silently answers false.</p>
+     *
+     * <p>This probe also has a shelf life: canOpenURL: is deprecated as of iOS 27. It
+     * still works and Apple has named no removal date, but the native probes in
+     * CN1JailbreakDetector are the ones to invest in.</p>
      */
     private static final String[] JAILBREAK_URL_SCHEMES = {
         "cydia://package/com.example.package",
         "sileo://package/com.example.package",
         "zbra://packages/com.example.package",
-        "filza://view",
-        "undecimus://",
-        "activator://"
+        "filza://view"
     };
 
     private boolean packageManagerProbe() {

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
@@ -12925,6 +12925,11 @@ public class IOSImplementation extends CodenameOneImplementation {
      * jailbreak nobody has shipped for current iOS. A rootless device runs Sileo, so the
      * probe looked for the one front end that was certain not to be there.</p>
      *
+     * <p>Most valuable first, matching {@code IPhoneBuilder.JAILBREAK_QUERY_SCHEMES},
+     * which declares only as many as the app's scheme budget has room for and takes them
+     * from the front. Reordering one list without the other means probing for a scheme
+     * that was never declared, which answers false and looks like a clean device.</p>
+     *
      * <p>Kept deliberately short, and it must stay that way. Every entry is spent out of
      * the app's LSApplicationQueriesSchemes budget, which iOS caps at 25 for an app linked
      * against the iOS 27 SDK -- a secondary probe is not entitled to a quarter of it.
@@ -12937,10 +12942,10 @@ public class IOSImplementation extends CodenameOneImplementation {
      * CN1JailbreakDetector are the ones to invest in.</p>
      */
     private static final String[] JAILBREAK_URL_SCHEMES = {
-        "cydia://package/com.example.package",
         "sileo://package/com.example.package",
+        "filza://view",
         "zbra://packages/com.example.package",
-        "filza://view"
+        "cydia://package/com.example.package"
     };
 
     private boolean packageManagerProbe() {

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
@@ -176,6 +176,24 @@ public class IPhoneBuilder extends Executor {
         return xcodeVersion >= 27 ? 25 : 50;
     }
 
+    /// Entries the Info.plist renderer appends to this array on its own, after every
+    /// caller here has had its say.
+    ///
+    /// Counted rather than ignored because a ceiling that the renderer then walks past is
+    /// not a ceiling. The renderer adds `fbauth2` and `gplus` off exactly these two hints,
+    /// so an app within two of the cap and using Facebook or Google sign-in would have
+    /// been told its schemes fit and then shipped a plist where they did not.
+    private int reservedApplicationQueriesSchemes(BuildRequest request) {
+        int reserved = 0;
+        if (request.getArg("facebook.appId", null) != null) {
+            reserved++;
+        }
+        if (request.getArg("ios.gplus.clientId", null) != null) {
+            reserved++;
+        }
+        return reserved;
+    }
+
     /// Adds `schemes` to ios.applicationQueriesSchemes, entry by entry.
     ///
     /// Entry by entry rather than as a substring, because a project that already queries
@@ -206,7 +224,7 @@ public class IPhoneBuilder extends Executor {
         }
         java.util.List<String> missing = new ArrayList<String>();
         java.util.List<String> overCap = new ArrayList<String>();
-        int cap = applicationQueriesSchemeCap();
+        int cap = applicationQueriesSchemeCap() - reservedApplicationQueriesSchemes(request);
         for (String scheme : schemes) {
             if (declared.contains(scheme)) {
                 continue;
@@ -229,8 +247,9 @@ public class IPhoneBuilder extends Executor {
         }
         if (!overCap.isEmpty()) {
             log("ios.applicationQueriesSchemes already holds " + declared.size()
-                    + " entries and iOS honours at most " + cap + " for this SDK, so "
-                    + overCap + " was not added. " + why);
+                    + " entries and this build has room for " + cap
+                    + " (iOS honours at most " + applicationQueriesSchemeCap()
+                    + " for this SDK), so " + overCap + " was not added. " + why);
         }
         if (alreadyInjected != null) {
             if (!missing.isEmpty()) {

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
@@ -159,10 +159,17 @@ public class IPhoneBuilder extends Executor {
     /// the iOS 27 SDK -- so a secondary probe taking a quarter of it is not a reasonable
     /// trade. `undecimus` and `activator` were dropped on that basis: unc0ver is the
     /// iOS 11-14 era and Activator is a tweak rather than evidence of one. What is left
-    /// covers rootful (cydia), rootless (sileo), the alternative package manager (zbra)
-    /// and the file browser almost every jailbroken device carries (filza).
+    /// covers rootless (sileo), the file browser almost every jailbroken device carries
+    /// (filza), the alternative package manager (zbra) and rootful (cydia).
+    ///
+    /// THE ORDER IS LOAD-BEARING, most valuable first. When the cap below leaves room for
+    /// only some of these, the ones at the front are the ones declared. Cydia was first
+    /// and it is the worst of the four: it belongs to a rootful jailbreak nobody ships
+    /// for current iOS, so an app with one slot left spent it on the obsolete probe and
+    /// dropped Sileo -- silently reproducing, in the fix, the exact rootless blind spot
+    /// the fix is for.
     static final String[] JAILBREAK_QUERY_SCHEMES = {
-        "cydia", "sileo", "zbra", "filza"
+        "sileo", "filza", "zbra", "cydia"
     };
 
     /// How many LSApplicationQueriesSchemes entries iOS honours.

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
@@ -146,6 +146,76 @@ public class IPhoneBuilder extends Executor {
     // pull in HealthKit or its entitlement.
     private boolean usesHealth;
     private boolean usesHealthStore;
+    /// The URL schemes a jailbreak's package managers and file browsers register.
+    /// Probed by IOSImplementation.getCompromiseReasons(), and dead weight without the
+    /// declaration below: since iOS 9, canOpenURL: answers false for any scheme the app
+    /// has not listed, whatever is installed. Cydia was the only one the runtime asked
+    /// about, and Cydia belongs to a rootful jailbreak nobody ships for current iOS --
+    /// a rootless device runs Sileo, so the probe looked for the one front end certain
+    /// not to be there.
+    static final String[] JAILBREAK_QUERY_SCHEMES = {
+        "cydia", "sileo", "zbra", "filza", "undecimus", "activator"
+    };
+
+    /// Adds `schemes` to ios.applicationQueriesSchemes, entry by entry.
+    ///
+    /// Entry by entry rather than as a substring, because a project that already queries
+    /// `sileo-installer` contains "sileo", and skipping on that basis leaves the exact
+    /// scheme canOpenURL: is asked about undeclared -- which is the failure this exists
+    /// to prevent, and it fails silently.
+    ///
+    /// A project that declares the array through ios.plistInject is left alone and told
+    /// so. The plist renderer emits its own LSApplicationQueriesSchemes key for this hint
+    /// without looking at the injected fragment, so writing the hint as well would put
+    /// the key in the plist twice -- and a plist with a duplicate key is not a plist that
+    /// reliably keeps either value.
+    private void declareApplicationQueriesSchemes(BuildRequest request,
+            String[] schemes, String why) {
+        java.util.List<String> alreadyInjected =
+                WatchNativeBuilder.injectedPlistKeys(request)
+                        .contains("LSApplicationQueriesSchemes")
+                        ? WatchNativeBuilder.injectedPlistStringArray(request,
+                                "LSApplicationQueriesSchemes")
+                        : null;
+        String queries = request.getArg("ios.applicationQueriesSchemes", "");
+        java.util.List<String> declared = new ArrayList<String>();
+        for (String entry : queries.split(",")) {
+            String trimmed = entry.trim();
+            if (trimmed.length() > 0) {
+                declared.add(trimmed);
+            }
+        }
+        java.util.List<String> missing = new ArrayList<String>();
+        for (String scheme : schemes) {
+            if (declared.contains(scheme)) {
+                continue;
+            }
+            if (alreadyInjected != null) {
+                if (!alreadyInjected.contains(scheme)) {
+                    missing.add(scheme);
+                }
+                continue;
+            }
+            declared.add(scheme);
+        }
+        if (alreadyInjected != null) {
+            if (!missing.isEmpty()) {
+                log("ios.plistInject already declares LSApplicationQueriesSchemes, so "
+                        + missing + " was not added for you. Add those entries to that "
+                        + "array or " + why);
+            }
+            return;
+        }
+        StringBuilder joined = new StringBuilder();
+        for (String entry : declared) {
+            if (joined.length() > 0) {
+                joined.append(",");
+            }
+            joined.append(entry);
+        }
+        request.putArgument("ios.applicationQueriesSchemes", joined.toString());
+    }
+
     /// Treats a blank hint as missing.
     private static String trimToNull(String v) {
         if (v == null) {
@@ -2968,6 +3038,13 @@ public class IPhoneBuilder extends Executor {
             File jailbreakH = new File(buildinRes, "CN1JailbreakDetector.h");
             if (jailbreakH.exists() && detectJailbreak) {
                 replaceInFile(jailbreakH, "//#define CN1_DETECT_JAILBREAK", "#define CN1_DETECT_JAILBREAK");
+                // The native probes in that header need nothing from the plist. The
+                // URL-scheme probe on the Java side does, and gets no error when the
+                // declaration is missing -- canOpenURL: simply answers false, so the
+                // check reports a clean device and nobody finds out.
+                declareApplicationQueriesSchemes(request, JAILBREAK_QUERY_SCHEMES,
+                        "DeviceIntegrity.getCompromiseReasons() will not see a "
+                        + "jailbreak that only its package manager reveals.");
             }
 
             // ios.appAttest compiles the DeviceCheck-backed App Attest native code

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
@@ -153,9 +153,28 @@ public class IPhoneBuilder extends Executor {
     /// about, and Cydia belongs to a rootful jailbreak nobody ships for current iOS --
     /// a rootless device runs Sileo, so the probe looked for the one front end certain
     /// not to be there.
+    ///
+    /// Four, not the obvious longer list. These entries are spent out of the app's
+    /// budget, not ours -- iOS caps the array, at 25 entries for an app linked against
+    /// the iOS 27 SDK -- so a secondary probe taking a quarter of it is not a reasonable
+    /// trade. `undecimus` and `activator` were dropped on that basis: unc0ver is the
+    /// iOS 11-14 era and Activator is a tweak rather than evidence of one. What is left
+    /// covers rootful (cydia), rootless (sileo), the alternative package manager (zbra)
+    /// and the file browser almost every jailbroken device carries (filza).
     static final String[] JAILBREAK_QUERY_SCHEMES = {
-        "cydia", "sileo", "zbra", "filza", "undecimus", "activator"
+        "cydia", "sileo", "zbra", "filza"
     };
+
+    /// How many LSApplicationQueriesSchemes entries iOS honours.
+    ///
+    /// The cap keys off the SDK the app was LINKED against, not the OS it runs on: 50 for
+    /// iOS 15 and later, 25 for iOS 27 and later. Going over does not fail the build --
+    /// canOpenURL: simply answers false for the entries past the cap, which is the same
+    /// silent wrong answer this declaration exists to prevent, except now it is the app's
+    /// own schemes that quietly stop resolving.
+    private int applicationQueriesSchemeCap() {
+        return xcodeVersion >= 27 ? 25 : 50;
+    }
 
     /// Adds `schemes` to ios.applicationQueriesSchemes, entry by entry.
     ///
@@ -186,6 +205,8 @@ public class IPhoneBuilder extends Executor {
             }
         }
         java.util.List<String> missing = new ArrayList<String>();
+        java.util.List<String> overCap = new ArrayList<String>();
+        int cap = applicationQueriesSchemeCap();
         for (String scheme : schemes) {
             if (declared.contains(scheme)) {
                 continue;
@@ -196,7 +217,20 @@ public class IPhoneBuilder extends Executor {
                 }
                 continue;
             }
+            // Ours are the ones that give way. A project near the cap is already
+            // spending it on schemes its features need, and appending past the cap
+            // would not buy this probe anything anyway -- iOS ignores the overflow --
+            // while pushing the app's own entries into the ignored region.
+            if (declared.size() >= cap) {
+                overCap.add(scheme);
+                continue;
+            }
             declared.add(scheme);
+        }
+        if (!overCap.isEmpty()) {
+            log("ios.applicationQueriesSchemes already holds " + declared.size()
+                    + " entries and iOS honours at most " + cap + " for this SDK, so "
+                    + overCap + " was not added. " + why);
         }
         if (alreadyInjected != null) {
             if (!missing.isEmpty()) {

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
@@ -3099,12 +3099,9 @@ public class IPhoneBuilder extends Executor {
             if (jailbreakH.exists() && detectJailbreak) {
                 replaceInFile(jailbreakH, "//#define CN1_DETECT_JAILBREAK", "#define CN1_DETECT_JAILBREAK");
                 // The native probes in that header need nothing from the plist. The
-                // URL-scheme probe on the Java side does, and gets no error when the
-                // declaration is missing -- canOpenURL: simply answers false, so the
-                // check reports a clean device and nobody finds out.
-                declareApplicationQueriesSchemes(request, JAILBREAK_QUERY_SCHEMES,
-                        "DeviceIntegrity.getCompromiseReasons() will not see a "
-                        + "jailbreak that only its package manager reveals.");
+                // URL-scheme probe on the Java side does, and its declaration is made
+                // further down, just before the plist is rendered -- see the call beside
+                // injectToPlist().
             }
 
             // ios.appAttest compiles the DeviceCheck-backed App Attest native code
@@ -5475,6 +5472,25 @@ public class IPhoneBuilder extends Executor {
                         replaceAllInFile(pbx, "SDKROOT = iphoneos;", "OTHER_LDFLAGS = \"-ObjC\";\n				SDKROOT = iphoneos;");
 
                     }
+                }
+
+                // Last, deliberately, and this is the only correct place for it.
+                //
+                // These schemes exist so canOpenURL: can answer honestly about a
+                // jailbroken device; without the declaration iOS answers false
+                // whatever is installed. But they are also the LOWEST priority thing
+                // in the array, because iOS honours a limited number of entries and
+                // ignores the rest -- so everything the app actually needs has to
+                // claim its slots first. Declared beside the jailbreak header
+                // instead, this ran before the Smart Home block appended
+                // com.apple.Home, and a project at the cap got sileo as its last
+                // honoured entry and com.apple.Home as an ignored one: a security
+                // probe silently costing the app a feature it asked for. Anything
+                // else that adds a scheme belongs above this line.
+                if (detectJailbreak) {
+                    declareApplicationQueriesSchemes(request, JAILBREAK_QUERY_SCHEMES,
+                            "DeviceIntegrity.getCompromiseReasons() will not see a "
+                            + "jailbreak that only its package manager reveals.");
                 }
 
                 injectToPlist(tmpFile, resDir, request);

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/IPhoneBuilderJailbreakSchemesTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/IPhoneBuilderJailbreakSchemesTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.builders;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/// The runtime half of jailbreak detection asks canOpenURL: about the package
+/// managers a jailbreak installs, and since iOS 9 that question answers false for
+/// any scheme the app has not declared -- with no error, no warning, and a clean
+/// verdict on a jailbroken device. So the declaration is not a nicety; it is the
+/// difference between the probe working and the probe lying.
+///
+/// These pin the merge, because every failure mode here is silent.
+class IPhoneBuilderJailbreakSchemesTest {
+
+    private static BuildRequest request(String... kv) {
+        BuildRequest r = new BuildRequest();
+        r.setMainClass("MyApp");
+        r.setPackageName("com.example");
+        for (int i = 0; i < kv.length; i += 2) {
+            r.putArgument(kv[i], kv[i + 1]);
+        }
+        return r;
+    }
+
+    private static List<String> declare(BuildRequest r) throws Exception {
+        Method m = IPhoneBuilder.class.getDeclaredMethod(
+                "declareApplicationQueriesSchemes", BuildRequest.class,
+                String[].class, String.class);
+        m.setAccessible(true);
+        m.invoke(new IPhoneBuilder(), r, IPhoneBuilder.JAILBREAK_QUERY_SCHEMES, "why");
+        String hint = r.getArg("ios.applicationQueriesSchemes", "");
+        return hint.length() == 0 ? java.util.Collections.<String>emptyList()
+                : Arrays.asList(hint.split(","));
+    }
+
+    @Test
+    void aProjectWithNoSchemesGetsEveryOne() throws Exception {
+        List<String> got = declare(request());
+        assertEquals(Arrays.asList(IPhoneBuilder.JAILBREAK_QUERY_SCHEMES), got);
+    }
+
+    /// Sileo is the one that matters. Cydia was the entire list before, and Cydia
+    /// belongs to a rootful jailbreak nobody ships for current iOS -- so on the
+    /// rootless device a customer actually reported, the probe was asking after the
+    /// single front end guaranteed not to be installed.
+    @Test
+    void sileoIsDeclared() throws Exception {
+        assertTrue(declare(request()).contains("sileo"));
+    }
+
+    @Test
+    void theProjectsOwnSchemesSurvive() throws Exception {
+        List<String> got = declare(request("ios.applicationQueriesSchemes",
+                "com.apple.Home,fb-messenger"));
+        assertEquals("com.apple.Home", got.get(0));
+        assertEquals("fb-messenger", got.get(1));
+        assertTrue(got.containsAll(Arrays.asList(IPhoneBuilder.JAILBREAK_QUERY_SCHEMES)));
+    }
+
+    @Test
+    void aSchemeAlreadyDeclaredIsNotDuplicated() throws Exception {
+        List<String> got = declare(request("ios.applicationQueriesSchemes", "sileo,filza"));
+        assertEquals(1, java.util.Collections.frequency(got, "sileo"));
+        assertEquals(1, java.util.Collections.frequency(got, "filza"));
+    }
+
+    /// Entry by entry, not as a substring. A project querying "sileo-installer"
+    /// contains the text "sileo", and skipping on that basis would leave the exact
+    /// scheme canOpenURL: is asked about undeclared -- the silent failure this
+    /// whole merge exists to prevent.
+    @Test
+    void aLongerSchemeThatContainsOursIsNotMistakenForIt() throws Exception {
+        List<String> got = declare(request("ios.applicationQueriesSchemes", "sileo-installer"));
+        assertTrue(got.contains("sileo-installer"));
+        assertTrue(got.contains("sileo"));
+    }
+
+    @Test
+    void whitespaceAroundAnExistingEntryStillCounts() throws Exception {
+        List<String> got = declare(request("ios.applicationQueriesSchemes", " sileo , zbra "));
+        assertEquals(1, java.util.Collections.frequency(got, "sileo"));
+        assertEquals(1, java.util.Collections.frequency(got, "zbra"));
+    }
+
+    /// A project that declares the array through ios.plistInject owns it. The plist
+    /// renderer emits its own LSApplicationQueriesSchemes key for this hint without
+    /// reading the injected fragment, so setting the hint as well would put the key
+    /// in the plist twice -- and a plist with a duplicate key is not one that
+    /// reliably keeps either value.
+    @Test
+    void anInjectedArrayIsLeftAlone() throws Exception {
+        BuildRequest r = request("ios.plistInject",
+                "<key>LSApplicationQueriesSchemes</key><array>"
+                + "<string>cydia</string><string>sileo</string></array>");
+        assertTrue(declare(r).isEmpty());
+        assertFalse(r.getArg("ios.applicationQueriesSchemes", "").contains("filza"));
+    }
+
+    /// A fragment that merely MENTIONS the key -- in a comment, or inside an
+    /// unrelated string -- declares nothing. Reading that as a declaration would
+    /// skip the hint and ship a plist with no schemes at all.
+    @Test
+    void aCommentMentioningTheKeyIsNotADeclaration() throws Exception {
+        BuildRequest r = request("ios.plistInject",
+                "<!-- we set LSApplicationQueriesSchemes elsewhere -->"
+                + "<key>UIFileSharingEnabled</key><true/>");
+        assertTrue(declare(r).containsAll(
+                Arrays.asList(IPhoneBuilder.JAILBREAK_QUERY_SCHEMES)));
+    }
+}

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/IPhoneBuilderJailbreakSchemesTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/IPhoneBuilderJailbreakSchemesTest.java
@@ -203,4 +203,25 @@ class IPhoneBuilderJailbreakSchemesTest {
         BuildRequest r = request("ios.applicationQueriesSchemes", ownSchemes(60));
         assertEquals(60, declare(r, 26).size());
     }
+
+    /// The plist renderer appends fbauth2 and gplus off these two hints AFTER this
+    /// merge runs, so a ceiling that ignores them is one the renderer walks straight
+    /// past -- and the app is told its schemes fit while shipping a plist where they
+    /// do not.
+    @Test
+    void roomIsLeftForTheSchemesTheRendererAppends() throws Exception {
+        List<String> plain = declare(request("ios.applicationQueriesSchemes", ownSchemes(48)), 26);
+        assertEquals(50, plain.size());
+
+        List<String> withFacebook = declare(request(
+                "ios.applicationQueriesSchemes", ownSchemes(48),
+                "facebook.appId", "12345"), 26);
+        assertEquals(49, withFacebook.size());
+
+        List<String> withBoth = declare(request(
+                "ios.applicationQueriesSchemes", ownSchemes(48),
+                "facebook.appId", "12345",
+                "ios.gplus.clientId", "abc.apps.googleusercontent.com"), 26);
+        assertEquals(48, withBoth.size());
+    }
 }

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/IPhoneBuilderJailbreakSchemesTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/IPhoneBuilderJailbreakSchemesTest.java
@@ -207,6 +207,50 @@ class IPhoneBuilderJailbreakSchemesTest {
         assertFalse(got.contains("cydia"));
     }
 
+    /// Ours are declared LAST, after every other scheme the builder adds.
+    ///
+    /// Not a style preference. iOS honours a limited number of entries and ignores the
+    /// rest, so whoever claims a slot last is whoever loses it. These schemes are the
+    /// lowest priority thing in the array -- a secondary security probe -- while the
+    /// others are features the app asked for. Declared beside the jailbreak header, this
+    /// ran before the Smart Home block appended com.apple.Home, so a project at the cap
+    /// got sileo as its last honoured entry and com.apple.Home as an ignored one, and
+    /// SmartHome.openEcosystemApp() then reported Home missing on a device that had it.
+    ///
+    /// Checked against the source because the invariant is an ordering inside one long
+    /// method, which no amount of unit testing the merge itself can pin.
+    @Test
+    void ourSchemesAreDeclaredAfterEveryOtherSchemeAddition() throws Exception {
+        File f = new File("src/main/java/com/codename1/builders/IPhoneBuilder.java");
+        assertTrue(f.exists(), "builder source must be readable: " + f.getAbsolutePath());
+        String src = new String(java.nio.file.Files.readAllBytes(f.toPath()),
+                java.nio.charset.StandardCharsets.UTF_8);
+
+        int ours = src.indexOf(
+                "declareApplicationQueriesSchemes(request, JAILBREAK_QUERY_SCHEMES");
+        assertTrue(ours > 0, "the jailbreak schemes must be declared somewhere");
+        int render = src.indexOf("injectToPlist(tmpFile, resDir, request)");
+        assertTrue(ours < render, "declared before the plist is rendered");
+
+        // Every other writer of the hint has to have had its say already. The one
+        // inside declareApplicationQueriesSchemes itself is this merge writing its own
+        // result, so it is not a competitor.
+        java.util.regex.Matcher m = java.util.regex.Pattern.compile(
+                "putArgument\\(\"ios\\.applicationQueriesSchemes\"[,\\s]*([^;]*);")
+                .matcher(src);
+        int others = 0;
+        while (m.find()) {
+            if (m.group(1).contains("joined.toString()")) {
+                continue;
+            }
+            others++;
+            assertTrue(m.start() < ours, "a scheme added at offset " + m.start()
+                    + " claims its slot after the jailbreak schemes at " + ours
+                    + "; move it above that call or it is the one iOS drops");
+        }
+        assertTrue(others > 0, "expected to find the Smart Home addition to compare against");
+    }
+
     /// The builder declares the schemes and IOSImplementation probes them, from two
     /// hand-maintained lists. They have to carry the same schemes in the same order:
     /// only as many as fit are declared, taken from the front, so a probe whose scheme

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/IPhoneBuilderJailbreakSchemesTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/IPhoneBuilderJailbreakSchemesTest.java
@@ -24,6 +24,7 @@ package com.codename1.builders;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
@@ -179,22 +180,56 @@ class IPhoneBuilderJailbreakSchemesTest {
     @Test
     void theCapTightensForTheIos27Sdk() throws Exception {
         assertTrue(declare(request("ios.applicationQueriesSchemes", ownSchemes(24)), 26)
-                .contains("filza"));
+                .contains("cydia"));
         List<String> got = declare(request("ios.applicationQueriesSchemes", ownSchemes(24)), 27);
         assertEquals(25, got.size());
-        assertTrue(got.contains("cydia"));
-        assertFalse(got.contains("filza"));
+        assertFalse(got.contains("cydia"));
     }
 
-    /// Partial room is used, not discarded: the first entries fit and the rest are
-    /// reported. Priority order matters here -- cydia and sileo come first.
+    /// The single most important property of the order. An app with one slot left must
+    /// spend it on the rootless package manager, because rootless is the case that goes
+    /// undetected without it. Cydia held this position once, which meant the narrowest
+    /// builds kept the obsolete rootful probe and dropped the one this change exists for.
+    @Test
+    void sileoSurvivesWhenOnlyOneSlotIsLeft() throws Exception {
+        List<String> got = declare(request("ios.applicationQueriesSchemes", ownSchemes(24)), 27);
+        assertTrue(got.contains("sileo"));
+    }
+
+    /// Partial room is used, not discarded: the entries at the front fit and the rest
+    /// are reported.
     @Test
     void asManyAsFitAreAdded() throws Exception {
         List<String> got = declare(request("ios.applicationQueriesSchemes", ownSchemes(48)), 26);
         assertEquals(50, got.size());
-        assertTrue(got.contains("cydia"));
         assertTrue(got.contains("sileo"));
-        assertFalse(got.contains("zbra"));
+        assertTrue(got.contains("filza"));
+        assertFalse(got.contains("cydia"));
+    }
+
+    /// The builder declares the schemes and IOSImplementation probes them, from two
+    /// hand-maintained lists. They have to carry the same schemes in the same order:
+    /// only as many as fit are declared, taken from the front, so a probe whose scheme
+    /// sits further down the runtime list than the builder's is asking about something
+    /// that was never declared -- and canOpenURL: answers false for that, which reads
+    /// as a clean device.
+    @Test
+    void theRuntimeProbeListMatchesTheDeclaredOne() throws Exception {
+        File f = new File("../../Ports/iOSPort/src/com/codename1/impl/ios/"
+                + "IOSImplementation.java");
+        assertTrue(f.exists(), "the iOS port must be readable: " + f.getAbsolutePath());
+        String src = new String(java.nio.file.Files.readAllBytes(f.toPath()),
+                java.nio.charset.StandardCharsets.UTF_8);
+        int at = src.indexOf("JAILBREAK_URL_SCHEMES = {");
+        assertTrue(at > 0, "JAILBREAK_URL_SCHEMES not found in IOSImplementation");
+        String body = src.substring(at, src.indexOf("};", at));
+        java.util.List<String> runtime = new java.util.ArrayList<String>();
+        java.util.regex.Matcher m =
+                java.util.regex.Pattern.compile("\"([a-z0-9]+)://").matcher(body);
+        while (m.find()) {
+            runtime.add(m.group(1));
+        }
+        assertEquals(Arrays.asList(IPhoneBuilder.JAILBREAK_QUERY_SCHEMES), runtime);
     }
 
     /// A project already over the cap on its own is left exactly as it is.

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/IPhoneBuilderJailbreakSchemesTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/IPhoneBuilderJailbreakSchemesTest.java
@@ -52,14 +52,34 @@ class IPhoneBuilderJailbreakSchemesTest {
     }
 
     private static List<String> declare(BuildRequest r) throws Exception {
+        return declare(r, 26);
+    }
+
+    private static List<String> declare(BuildRequest r, int xcodeVersion) throws Exception {
+        IPhoneBuilder b = new IPhoneBuilder();
+        java.lang.reflect.Field xc = IPhoneBuilder.class.getDeclaredField("xcodeVersion");
+        xc.setAccessible(true);
+        xc.setInt(b, xcodeVersion);
         Method m = IPhoneBuilder.class.getDeclaredMethod(
                 "declareApplicationQueriesSchemes", BuildRequest.class,
                 String[].class, String.class);
         m.setAccessible(true);
-        m.invoke(new IPhoneBuilder(), r, IPhoneBuilder.JAILBREAK_QUERY_SCHEMES, "why");
+        m.invoke(b, r, IPhoneBuilder.JAILBREAK_QUERY_SCHEMES, "why");
         String hint = r.getArg("ios.applicationQueriesSchemes", "");
         return hint.length() == 0 ? java.util.Collections.<String>emptyList()
                 : Arrays.asList(hint.split(","));
+    }
+
+    /// `n` schemes of the project's own, none of them ours.
+    private static String ownSchemes(int n) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < n; i++) {
+            if (i > 0) {
+                sb.append(",");
+            }
+            sb.append("app").append(i);
+        }
+        return sb.toString();
     }
 
     @Test
@@ -135,5 +155,52 @@ class IPhoneBuilderJailbreakSchemesTest {
                 + "<key>UIFileSharingEnabled</key><true/>");
         assertTrue(declare(r).containsAll(
                 Arrays.asList(IPhoneBuilder.JAILBREAK_QUERY_SCHEMES)));
+    }
+
+    // ------------------------------------------------------------------
+    // The cap
+    // ------------------------------------------------------------------
+
+    /// iOS honours at most 50 LSApplicationQueriesSchemes entries for an app linked
+    /// against the iOS 15 SDK or later, and 25 from the iOS 27 SDK. Past that,
+    /// canOpenURL: answers false -- so appending blindly would not help this probe and
+    /// would push the project's own schemes into the ignored region.
+    @Test
+    void ourSchemesGiveWayRatherThanPushTheProjectPastTheCap() throws Exception {
+        BuildRequest r = request("ios.applicationQueriesSchemes", ownSchemes(50));
+        List<String> got = declare(r, 26);
+        assertEquals(50, got.size());
+        assertFalse(got.contains("sileo"));
+        // The project keeps every one of its own.
+        assertTrue(got.contains("app0"));
+        assertTrue(got.contains("app49"));
+    }
+
+    @Test
+    void theCapTightensForTheIos27Sdk() throws Exception {
+        assertTrue(declare(request("ios.applicationQueriesSchemes", ownSchemes(24)), 26)
+                .contains("filza"));
+        List<String> got = declare(request("ios.applicationQueriesSchemes", ownSchemes(24)), 27);
+        assertEquals(25, got.size());
+        assertTrue(got.contains("cydia"));
+        assertFalse(got.contains("filza"));
+    }
+
+    /// Partial room is used, not discarded: the first entries fit and the rest are
+    /// reported. Priority order matters here -- cydia and sileo come first.
+    @Test
+    void asManyAsFitAreAdded() throws Exception {
+        List<String> got = declare(request("ios.applicationQueriesSchemes", ownSchemes(48)), 26);
+        assertEquals(50, got.size());
+        assertTrue(got.contains("cydia"));
+        assertTrue(got.contains("sileo"));
+        assertFalse(got.contains("zbra"));
+    }
+
+    /// A project already over the cap on its own is left exactly as it is.
+    @Test
+    void aProjectAlreadyOverTheCapIsNotTouched() throws Exception {
+        BuildRequest r = request("ios.applicationQueriesSchemes", ownSchemes(60));
+        assertEquals(60, declare(r, 26).size());
     }
 }


### PR DESCRIPTION
`ios.detectJailbreak=true` did not fire on a device jailbroken with **palera1n 2.1.1 rootless** (iPhone 8 Plus, iOS 16.7.11), reported by a bank running a pen test. The gate was wired correctly — the build server flips `CN1_DETECT_JAILBREAK` and `CodenameOne_GLAppDelegate` calls the probe — so this was a detection miss, not a configuration problem.

## Why every probe missed

Rootless defeats all five, by construction. palera1n, Dopamine and XinaA15 leave the signed system volume sealed and bootstrap Procursus into `/var/jb`, injecting with ElleKit and shipping Sileo.

| Probe | Why it missed |
|---|---|
| `DYLD_INSERT_LIBRARIES` | Not how anything is injected any more |
| dyld image scan | Substrate-era list; rootless uses ElleKit, which is not in it |
| 6 restricted paths | All rootful. Under `/var/jb` they are genuinely absent, and the package manager is Sileo, not Cydia |
| write to `/private/` | The rootfs stays read-only. That is what "rootless" means |
| `P_TRACED` | Not set, and non-fatal by design |

The detector returned an empty signal string and the app launched.

## What replaces it

Beyond adding the `/var/jb` path set (and the modern rootful one — Sileo, Zebra, Filza, libsubstitute, libhooker, unc0ver/Electra/checkra1n markers):

- **`lstat`, never `-[NSFileManager fileExistsAtPath:]`.** `stat`, `access` and `NSFileManager` all follow symlinks; `/var/jb` *is* a symlink, and on a rebooted semi-tethered device its target is gone while the link remains. All three report nothing there; `lstat` sees it. `NSFileManager` is also the single most-hooked call in every detection-bypass tweak.
- **The probes are compared against each other rather than trusted.** libc `lstat` and the raw trap ask the kernel an identical question, so on an untampered device they cannot disagree; when they do, something is rewriting the answers → `hookedApi`. The loaded-image walk gets the same treatment: the documented `_dyld_get_image_name()` that a tweak hooks, checked against `dyld_all_image_infos` read out of `task_info(TASK_DYLD_INFO)`. Counts are deliberately *not* compared — the two tables legitimately differ across OS versions.
- **Existence is a three-way answer.** A sandbox `EPERM` is not `ENOENT`; folding them together loses the signal *and* manufactures disagreements between two probes that were each simply refused.
- **The mount table**, which needs no path guessed correctly: a writable root filesystem, and the bootstrap image a rootless jailbreak has to mount.

New signal codes: `rootlessPath`, `mountRW`, `hookedApi`. They map onto the existing cross-platform reasons, so `DeviceIntegrity.getCompromiseReasons()` gains no new vocabulary for app code.

## The one judgement call

The canary check — stock paths whose absence would mean a filter is in front of us — requires **all** of them absent, not any. `hookedApi` is fatal in the gate, so an "any" rule would turn a future iOS that merely relocates one file into an app that refuses to launch. This is not hypothetical: the first version used `UIKit.framework`, which does not exist on macOS, and it fired on a clean machine during testing.

## Also here

- **`ios.detectJailbreak` now declares `LSApplicationQueriesSchemes`.** Since iOS 9, `canOpenURL:` answers false for an undeclared scheme whatever is installed, with no error — so the runtime URL probe was reporting clean devices regardless of what was on them. And it only ever asked about `cydia`, the package manager of a rootful jailbreak nobody ships for current iOS.
- **The gate re-runs when the app returns from the background**, closing background-then-attach. iOS does not call that hook on the initial launch, so it is still once per foreground.
- **`exit(EXIT_FAILURE)`** rather than `exit(0)`, which told the OS and any crash reporter that a refused launch had finished normally.

## Honesty about scope

None of this is a guarantee, and the reporting device is an A10 with an unpatchable bootrom. Every probe runs on hardware the attacker owns; the value is costing more to bypass than the previous version did. The control that does not run on hostile hardware is server-verified attestation, which we already ship — that framing is in the header docs so the next reader does not oversell it.

## Verification

- Detector compiles clean at `-Wall -Wextra` across device / simulator / Mac Catalyst, gate on and off, ARC and MRR.
- The symlink and canary behaviour were confirmed by compiling the `.m` into a macOS binary with the platform guards defeated and running it — a dangling symlink gives `lstat` present, `stat`/`access`/`NSFileManager` all MISSED. That harness is how the canary bug was found.
- `ios`, `core-unittests` and `codenameone-maven-plugin` verify with **zero** SpotBugs findings.
- Plugin suite: 872 passing, including 8 new tests pinning the scheme merge (the `sileo-installer` substring trap and the `ios.plistInject` collision among them).

**Not verified on hardware.** There is no jailbroken device here, so the on-device confirmation is still outstanding — worth `ls -la /var/jb` from the reporter's device before we tell them it is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
