### PR TITLE
Let a Log subclass see its own output on the JS port (issue #5519)

### DIFF
--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -131,6 +131,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.PrintStream;
+import java.io.Writer;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -3684,6 +3686,46 @@ public class HTML5Implementation extends CodenameOneImplementation {
     @Override
     public void systemOut(String content) {
         consoleLog(content);
+    }
+
+    /**
+     * Writes the throwable's trace into the log writer. Without this override the
+     * inherited implementation is an empty method, so {@code Log.e(t)} produced an
+     * entry with no trace in it at all -- half of issue #5519.
+     *
+     * <p>The other ports hand the writer to {@code Throwable.printStackTrace(PrintWriter)},
+     * but this port's {@code java.io} surface has no {@code PrintWriter}, and
+     * {@code getStackTrace()} deliberately returns no frames here: the field behind it
+     * holds a JavaScript {@code Error().stack} (captured for every throwable in
+     * {@code jvm.newObject}), which {@code Throwable.parseStackString} refuses to parse
+     * into Java frames rather than fabricate bogus ones. So capture what
+     * {@code printStackTrace(PrintStream)} renders -- that JavaScript stack, which is
+     * the only trace this port actually has -- and prefix it with {@code toString()} so
+     * the class and message are present the way the other ports print them.</p>
+     */
+    @Override
+    public void printStackTraceToStream(Throwable t, Writer o) {
+        if (t == null || o == null) {
+            return;
+        }
+        try {
+            ByteArrayOutputStream rendered = new ByteArrayOutputStream();
+            PrintStream out = new PrintStream(rendered);
+            t.printStackTrace(out);
+            out.close();
+            o.write(t.toString());
+            o.write("\n");
+            o.write(new String(rendered.toByteArray(), "UTF-8"));
+            o.write("\n");
+        } catch (Throwable err) {
+            // Deliberately Throwable, not IOException: this runs while a failure
+            // is already being reported, and Log.logThrowable only guards its
+            // call with catch(IOException). Letting anything escape here would
+            // turn "the log could not be written" into a second exception thrown
+            // at whoever called Log.e(). There is nowhere better to report it
+            // than the console.
+            consoleLog("printStackTraceToStream failed: " + err);
+        }
     }
     
     /**

--- a/Ports/JavaScriptPort/src/main/webapp/port.js
+++ b/Ports/JavaScriptPort/src/main/webapp/port.js
@@ -2973,6 +2973,16 @@ bindCiFallback("Log.print", [
   // production browser console, so silence it unless the diagnostic
   // toggle is on. User code that wants noisy logs can either route
   // through Log.e() (always surfaced) or load with ?parparDiag=1.
+  //
+  // NOTE this stub SHADOWS the translated ``Log.print`` rather than
+  // falling back to it (see the ``Log.e`` note below for why
+  // ``bindCiFallback`` is not conditional), so text logged through
+  // ``Log.p`` never reaches the ``Writer`` a ``Log`` subclass returns
+  // from ``createWriter()``, and ``Log.getLog()`` stays empty on this
+  // port. That is deliberate for now: the translated method writes every
+  // line through ``Storage`` and drops the level-0 gate above. ``Log.e``
+  // is the path that has to run the real Java code (issue #5519) and it
+  // does -- ``logThrowable`` opens the writer itself.
   const text = message == null ? "" : jvm.toNativeString(message);
   const lv = level | 0;
   if (lv >= 1 && global.console && typeof global.console.error === "function") {
@@ -2985,22 +2995,25 @@ bindCiFallback("Log.print", [
   return null;
 });
 
-// ``Log.e(Throwable)`` is a *static* method, so the translated bytecode
-// invokes it with a single argument (the throwable). Earlier versions of
-// this fallback declared ``function*(__cn1ThisObject, throwable)`` — that
-// shifted the parameter by one slot, ``throwable`` was always
-// ``undefined``, and ``stringifyThrowable`` printed ``"null"``. Real
-// caught exceptions then surfaced in the browser console as the
-// infamous ``Exception: null`` flood. Keep the signature as ``(throwable)``
-// so the actual class/message/stack survives the round-trip.
-bindCiFallback("Log.e", [
-  "cn1_com_codename1_io_Log_e_java_lang_Throwable"
-], function*(throwable) {
-  if (global.console && typeof global.console.error === "function") {
-    global.console.error("Exception: " + (yield* stringifyThrowable(throwable)));
-  }
-  return null;
-});
+// ``Log.e(Throwable)`` deliberately has NO binding here.
+//
+// ``bindCiFallback`` reads like "use this only when the real method is
+// missing", but it is not conditional: ``bindNative`` stashes the
+// translated body in ``jvm.translatedMethods`` and then overwrites the
+// live binding, so anything bound here REPLACES the Codename One method
+// outright. A stub used to sit on ``Log.e`` and print the throwable to
+// ``console.error``. That meant ``Log.e`` never reached
+// ``Log.logThrowable``, which is the only caller of ``Log.getWriter()``
+// -> ``Log.createWriter()``. Every ``Log`` subclass that captures output
+// through its own writer therefore got a writer that was never created;
+// the app-visible symptom in issue #5519 was a ``NullPointerException``
+// raised the moment such a subclass read its (still null) writer back.
+//
+// Nothing is lost by letting the translated method run: ``logThrowable``
+// prints through ``Log.print`` (bound above) and ``Throwable
+// .printStackTrace()``, both of which reach the browser console, and
+// ``HTML5Implementation.printStackTraceToStream`` now feeds the writer
+// the same trace the console gets.
 
 bindCiFallback("NetworkManager.addErrorListener", [
   "cn1_com_codename1_io_NetworkManager_addErrorListener_com_codename1_ui_events_ActionListener"

--- a/docs/website/data/port_status.json
+++ b/docs/website/data/port_status.json
@@ -559,6 +559,15 @@
       ]
     },
     {
+      "id": "logging-diagnostics",
+      "category": "Application runtime",
+      "name": "Logging and diagnostics",
+      "description": "Checks that an installed Log subclass receives the application's own log output and that a caught throwable's trace reaches the writer it supplied.",
+      "tests": [
+        "LogSubclassCaptureTest"
+      ]
+    },
+    {
       "id": "threading",
       "category": "Application runtime",
       "name": "Threading and EDT enforcement",

--- a/docs/website/data/port_status_reports/android.json
+++ b/docs/website/data/port_status_reports/android.json
@@ -56,7 +56,7 @@
   "schema_version": 1,
   "suite_finished": true,
   "summary": {
-    "pass": 178,
+    "pass": 179,
     "fail": 0,
     "skip": 1,
     "not-run": 0
@@ -459,6 +459,10 @@
     },
     "LocalNotificationOverrideTest": {
       "feature": "notifications",
+      "status": "pass"
+    },
+    "LogSubclassCaptureTest": {
+      "feature": "logging-diagnostics",
       "status": "pass"
     },
     "LottieAnimatedScreenshotTest": {

--- a/docs/website/data/port_status_reports/ios-gl.json
+++ b/docs/website/data/port_status_reports/ios-gl.json
@@ -48,7 +48,7 @@
   "schema_version": 1,
   "suite_finished": true,
   "summary": {
-    "pass": 175,
+    "pass": 176,
     "fail": 0,
     "skip": 4,
     "not-run": 0
@@ -451,6 +451,10 @@
     },
     "LocalNotificationOverrideTest": {
       "feature": "notifications",
+      "status": "pass"
+    },
+    "LogSubclassCaptureTest": {
+      "feature": "logging-diagnostics",
       "status": "pass"
     },
     "LottieAnimatedScreenshotTest": {

--- a/docs/website/data/port_status_reports/ios-metal.json
+++ b/docs/website/data/port_status_reports/ios-metal.json
@@ -48,7 +48,7 @@
   "schema_version": 1,
   "suite_finished": true,
   "summary": {
-    "pass": 175,
+    "pass": 176,
     "fail": 0,
     "skip": 4,
     "not-run": 0
@@ -451,6 +451,10 @@
     },
     "LocalNotificationOverrideTest": {
       "feature": "notifications",
+      "status": "pass"
+    },
+    "LogSubclassCaptureTest": {
+      "feature": "logging-diagnostics",
       "status": "pass"
     },
     "LottieAnimatedScreenshotTest": {

--- a/docs/website/data/port_status_reports/javascript.json
+++ b/docs/website/data/port_status_reports/javascript.json
@@ -56,7 +56,7 @@
   "schema_version": 1,
   "suite_finished": true,
   "summary": {
-    "pass": 177,
+    "pass": 178,
     "fail": 0,
     "skip": 2,
     "not-run": 0
@@ -459,6 +459,10 @@
     },
     "LocalNotificationOverrideTest": {
       "feature": "notifications",
+      "status": "pass"
+    },
+    "LogSubclassCaptureTest": {
+      "feature": "logging-diagnostics",
       "status": "pass"
     },
     "LottieAnimatedScreenshotTest": {

--- a/docs/website/data/port_status_reports/linux-arm64.json
+++ b/docs/website/data/port_status_reports/linux-arm64.json
@@ -56,7 +56,7 @@
   "schema_version": 1,
   "suite_finished": true,
   "summary": {
-    "pass": 176,
+    "pass": 177,
     "fail": 0,
     "skip": 3,
     "not-run": 0
@@ -462,6 +462,10 @@
     },
     "LocalNotificationOverrideTest": {
       "feature": "notifications",
+      "status": "pass"
+    },
+    "LogSubclassCaptureTest": {
+      "feature": "logging-diagnostics",
       "status": "pass"
     },
     "LottieAnimatedScreenshotTest": {

--- a/docs/website/data/port_status_reports/linux-x64.json
+++ b/docs/website/data/port_status_reports/linux-x64.json
@@ -56,7 +56,7 @@
   "schema_version": 1,
   "suite_finished": true,
   "summary": {
-    "pass": 176,
+    "pass": 177,
     "fail": 0,
     "skip": 3,
     "not-run": 0
@@ -462,6 +462,10 @@
     },
     "LocalNotificationOverrideTest": {
       "feature": "notifications",
+      "status": "pass"
+    },
+    "LogSubclassCaptureTest": {
+      "feature": "logging-diagnostics",
       "status": "pass"
     },
     "LottieAnimatedScreenshotTest": {

--- a/docs/website/data/port_status_reports/mac-native.json
+++ b/docs/website/data/port_status_reports/mac-native.json
@@ -56,7 +56,7 @@
   "schema_version": 1,
   "suite_finished": true,
   "summary": {
-    "pass": 174,
+    "pass": 175,
     "fail": 0,
     "skip": 5,
     "not-run": 0
@@ -462,6 +462,10 @@
     },
     "LocalNotificationOverrideTest": {
       "feature": "notifications",
+      "status": "pass"
+    },
+    "LogSubclassCaptureTest": {
+      "feature": "logging-diagnostics",
       "status": "pass"
     },
     "LottieAnimatedScreenshotTest": {

--- a/docs/website/data/port_status_reports/tvos.json
+++ b/docs/website/data/port_status_reports/tvos.json
@@ -48,7 +48,7 @@
   "schema_version": 1,
   "suite_finished": true,
   "summary": {
-    "pass": 171,
+    "pass": 172,
     "fail": 0,
     "skip": 8,
     "not-run": 0
@@ -454,6 +454,10 @@
     },
     "LocalNotificationOverrideTest": {
       "feature": "notifications",
+      "status": "pass"
+    },
+    "LogSubclassCaptureTest": {
+      "feature": "logging-diagnostics",
       "status": "pass"
     },
     "LottieAnimatedScreenshotTest": {

--- a/docs/website/data/port_status_reports/watchos.json
+++ b/docs/website/data/port_status_reports/watchos.json
@@ -48,7 +48,7 @@
   "schema_version": 1,
   "suite_finished": true,
   "summary": {
-    "pass": 166,
+    "pass": 167,
     "fail": 0,
     "skip": 13,
     "not-run": 0
@@ -460,6 +460,10 @@
     },
     "LocalNotificationOverrideTest": {
       "feature": "notifications",
+      "status": "pass"
+    },
+    "LogSubclassCaptureTest": {
+      "feature": "logging-diagnostics",
       "status": "pass"
     },
     "LottieAnimatedScreenshotTest": {

--- a/docs/website/data/port_status_reports/windows-arm64.json
+++ b/docs/website/data/port_status_reports/windows-arm64.json
@@ -56,7 +56,7 @@
   "schema_version": 1,
   "suite_finished": true,
   "summary": {
-    "pass": 176,
+    "pass": 177,
     "fail": 0,
     "skip": 3,
     "not-run": 0
@@ -462,6 +462,10 @@
     },
     "LocalNotificationOverrideTest": {
       "feature": "notifications",
+      "status": "pass"
+    },
+    "LogSubclassCaptureTest": {
+      "feature": "logging-diagnostics",
       "status": "pass"
     },
     "LottieAnimatedScreenshotTest": {

--- a/docs/website/data/port_status_reports/windows-x64.json
+++ b/docs/website/data/port_status_reports/windows-x64.json
@@ -56,7 +56,7 @@
   "schema_version": 1,
   "suite_finished": true,
   "summary": {
-    "pass": 176,
+    "pass": 177,
     "fail": 0,
     "skip": 3,
     "not-run": 0
@@ -462,6 +462,10 @@
     },
     "LocalNotificationOverrideTest": {
       "feature": "notifications",
+      "status": "pass"
+    },
+    "LogSubclassCaptureTest": {
+      "feature": "logging-diagnostics",
       "status": "pass"
     },
     "LottieAnimatedScreenshotTest": {

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/Cn1ssDeviceRunner.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/Cn1ssDeviceRunner.java
@@ -436,6 +436,10 @@ public final class Cn1ssDeviceRunner extends DeviceRunner {
             new FloatingToStringTest(),
             new StringFormatTest(),
             new ClipboardRoundTripTest(),
+            // Log is an extension point (subclass + override createWriter) and the
+            // JavaScript port used to shadow Log.e with a console stub, so a
+            // subclass's writer was never created (issue #5519). Assertion-only.
+            new LogSubclassCaptureTest(),
             // External surfaces assertion tests (no screenshots): the serializer wire format
             // round-tripped through JSONParser on the device VM, the timeline-selection helpers
             // the desktop widget renderers use, action dispatch (cold-start queue + EDT

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/LogSubclassCaptureTest.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/LogSubclassCaptureTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.examples.hellocodenameone.tests;
+
+import com.codename1.io.Log;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+
+/**
+ * Regression coverage for codenameone/CodenameOne#5519.
+ *
+ * <p>{@code Log} is an extension point: an app subclasses it, overrides
+ * {@code createWriter()} to hand back its own {@code Writer}, installs the
+ * subclass, and reads the captured text back. That is the documented way to
+ * turn a caught {@code Throwable} into a string, and it is how the reporter's
+ * app got stack traces on every other port.</p>
+ *
+ * <p>It silently stopped working on the JavaScript port, because
+ * {@code port.js} bound a console-printing stub over {@code Log.e(Throwable)}
+ * -- and {@code bindNative} overwrites the translated method rather than
+ * falling back to it. {@code Log.logThrowable} never ran, so
+ * {@code createWriter()} was never called and the subclass read back a null
+ * writer. Nothing failed loudly; the app just got a {@code NullPointerException}
+ * from inside its own logging code.</p>
+ *
+ * <p>The assertions below are deliberately about behaviour a stub cannot fake:
+ * that the port called back into the app's {@code createWriter()}, and that the
+ * trace reached the writer it returned.</p>
+ */
+public class LogSubclassCaptureTest extends BaseTest {
+
+    private static final String PROBE_MESSAGE = "cn1-log-subclass-capture-probe";
+
+    /**
+     * Mirrors the shape of the reproducer attached to the issue: capture the
+     * log into a {@link StringWriter} for the duration of one {@code Log.e}.
+     */
+    private static final class CapturingLog extends Log {
+        private StringWriter captured;
+        private boolean createWriterCalled;
+
+        @Override
+        protected Writer createWriter() throws IOException {
+            createWriterCalled = true;
+            captured = new StringWriter();
+            return captured;
+        }
+    }
+
+    @Override
+    public boolean shouldTakeScreenshot() {
+        return false;
+    }
+
+    @Override
+    public boolean runTest() {
+        Log previousInstance = Log.getInstance();
+        int previousLevel = Log.getLevel();
+        try {
+            CapturingLog capturing = new CapturingLog();
+            Log.install(capturing);
+            Log.e(new IllegalStateException(PROBE_MESSAGE));
+
+            assertTrue(capturing.createWriterCalled,
+                    "Log.e(Throwable) never reached Log.logThrowable: the installed Log "
+                            + "subclass's createWriter() was not called (issue #5519)");
+            assertTrue(capturing.captured != null,
+                    "Log.createWriter() ran but left no writer behind");
+
+            String text = capturing.captured.toString();
+            assertTrue(text != null && text.length() > 0,
+                    "Log.e(Throwable) wrote nothing into the writer the Log subclass returned");
+            assertTrue(text.indexOf("IllegalStateException") >= 0,
+                    "The captured log does not name the thrown class. Captured: " + text);
+            assertTrue(text.indexOf(PROBE_MESSAGE) >= 0,
+                    "The captured log does not carry the exception message. Captured: " + text);
+        } catch (Throwable t) {
+            fail("Log subclass capture test failed: " + t);
+            return false;
+        } finally {
+            Log.install(previousInstance);
+            Log.setLevel(previousLevel);
+        }
+        done();
+        return true;
+    }
+}

--- a/scripts/hellocodenameone/conformance/test_port_status.py
+++ b/scripts/hellocodenameone/conformance/test_port_status.py
@@ -17,7 +17,7 @@ class PortStatusTest(unittest.TestCase):
 
     def test_contract_covers_registered_tests_and_goldens(self):
         counts = port_status.validate(self.manifest)
-        self.assertEqual(179, counts["tests"])
+        self.assertEqual(180, counts["tests"])
         self.assertEqual(1, counts["performance_tests"])
         self.assertGreaterEqual(counts["features"], 54)
         self.assertEqual(11, counts["ports"])

--- a/vm/tests/src/test/java/com/codename1/tools/translator/JavaScriptRuntimeFacadeTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/JavaScriptRuntimeFacadeTest.java
@@ -70,6 +70,7 @@ class JavaScriptRuntimeFacadeTest {
     private static final Path BUFFERED_GRAPHICS_SOURCE = Paths.get("..", "..", "Ports", "JavaScriptPort", "src", "main", "java", "com", "codename1", "impl", "html5", "BufferedGraphics.java");
     private static final Path BOOTSTRAP_SOURCE = Paths.get("..", "..", "Ports", "JavaScriptPort", "src", "main", "java", "com", "codename1", "impl", "html5", "JavaScriptPortBootstrap.java");
     private static final Path STUB_SOURCE = Paths.get("..", "..", "Ports", "JavaScriptPort", "src", "main", "java", "com", "codename1", "impl", "html5", "Stub.java");
+    private static final Path PORT_JS_SOURCE = Paths.get("..", "..", "Ports", "JavaScriptPort", "src", "main", "webapp", "port.js");
 
     @Test
     void extractedFacadeCompilesAndPreservesKeyRuntimeRules() throws Exception {
@@ -1566,5 +1567,38 @@ class JavaScriptRuntimeFacadeTest {
                 "HTML5Implementation.setTransform should not println its inputs on every call");
         assertTrue(!html5Source.contains("CN1JS:HTML5Implementation.scale x="),
                 "HTML5Implementation.scale should not println its inputs on every call");
+    }
+
+    /**
+     * Issue #5519. ``bindCiFallback`` in port.js is not a fallback: bindNative
+     * overwrites the translated method, so binding one of Codename One's own
+     * methods there deletes its Java behaviour. A stub on ``Log.e(Throwable)``
+     * kept ``Log.logThrowable`` from ever running, which meant a ``Log``
+     * subclass's ``createWriter()`` was never called and the app read a null
+     * writer back. Logged output is not the contract here -- calling back into
+     * the app's Log is -- so pin the absence of the binding rather than the
+     * console text, and pin the writer half that has to be fed from the port.
+     *
+     * <p>The behavioural counterpart is LogSubclassCaptureTest in the
+     * hellocodenameone device suite; this one just fails fast and offline.</p>
+     */
+    @Test
+    void javascriptPortRunsTheRealLogEratherThanAConsoleStub() throws Exception {
+        String portJs = new String(Files.readAllBytes(PORT_JS_SOURCE), StandardCharsets.UTF_8);
+        assertFalse(portJs.contains("\"cn1_com_codename1_io_Log_e_java_lang_Throwable\""),
+                "port.js must not bind over Log.e(Throwable): bindNative replaces the translated "
+                        + "method, so Log.logThrowable never runs and a Log subclass's createWriter() "
+                        + "is never called (issue #5519)");
+
+        String html5Source = new String(Files.readAllBytes(HTML5_SOURCE), StandardCharsets.UTF_8);
+        int idx = html5Source.indexOf("public void printStackTraceToStream(Throwable t, Writer o)");
+        assertTrue(idx >= 0,
+                "HTML5Implementation must override printStackTraceToStream; the inherited "
+                        + "implementation is empty, so Log.e writes an entry with no trace in it");
+        String body = html5Source.substring(idx, Math.min(html5Source.length(), idx + 1200));
+        assertTrue(body.contains("t.printStackTrace(out)"),
+                "printStackTraceToStream should render the throwable's own trace");
+        assertTrue(body.contains("o.write(t.toString())"),
+                "printStackTraceToStream should name the class and message the way the other ports do");
     }
 }


### PR DESCRIPTION
Fixes #5519.

## The bug

`Log` is an extension point: subclass it, override `createWriter()` to hand back your own `Writer`, install it, read the text back. That is how the reporter's app turned a caught `Throwable` into a string, and it works on every port except JavaScript.

`port.js` bound a console-printing stub over `Log.e(Throwable)`. Despite the "CiFallback" name that binding is **not** conditional — `bindNative` stashes the translated body in `jvm.translatedMethods` and then overwrites the live binding — so `Log.e` never reached `Log.logThrowable`, which is the only caller of `getWriter()` → `createWriter()`.

The subclass's override was simply never called, so the app read back a writer that was still null:

```java
LogCapture cap = new LogCapture();   // prints "install ..."
Log.setLevel(99);
Log.e(t);                            // JS stub: console.error, returns
return cap.dispose();                // myWriter is still null -> NPE
```

Nothing failed loudly — the log line still appeared in the browser console — so the only symptom was a `NullPointerException` thrown from inside the app's own logging code.

Reproduced on `master` (c2732fd24f) with the reporter's `Dtest.java` shape built into a JS bundle and run headless:

```
CN1REPRO: install ...LogCapture@589e
CN1REPRO: before Log.e
CN1REPRO: after Log.e            <- "createWriter invoked" never printed
CN1REPRO: dispose myWriter=NULL
CN1REPRO: error in getStackTrace java.lang.NullPointerException
```

which matches the screenshots on the issue line for line.

## The fix

**Drop the `Log.e` stub** so the translated method runs. Nothing is lost: `logThrowable` prints through `Log.print` (still bound, see below) and through `Throwable.printStackTrace()`, both of which reach the console.

**Implement `printStackTraceToStream` on `HTML5Implementation`.** The inherited version is an empty method, so even with `Log.e` fixed the entry carried no trace at all — and the issue's expected behaviour is "should produce a stack trace". The other ports hand the writer to `Throwable.printStackTrace(PrintWriter)`, but this port has no `PrintWriter`, and `getStackTrace()` deliberately yields no frames here: the field behind it holds a JavaScript `Error().stack` (captured for every throwable in `jvm.newObject`), which `parseStackString` refuses to turn into fabricated Java frames. So capture what `printStackTrace(PrintStream)` renders — that JS stack is the only trace this port has — prefixed with `toString()` so the class and message read like the other ports.

## Scope note

`Log.print(String,int)` is stubbed the same way and this PR **leaves it stubbed**, with a comment recording why. Un-stubbing it would route every log line through `Storage` and drop the level-0 console-noise gate the stub exists for; `Log.e` is the path that has to run the real Java code, and `logThrowable` opens the writer itself. The remaining consequence is that text logged through `Log.p` still does not reach a `Log` subclass's writer on this port, and `Log.getLog()` stays empty there.

## Verification

Built the hellocodenameone JS bundle from this branch and ran it headless. The new test reaches the real `logThrowable`:

```
CN1SS:INFO:suite starting test=LogSubclassCaptureTest
Exception: java.lang.IllegalStateException - cn1-log-subclass-capture-probe
Error
    at Object.newObject (.../parparvm_runtime.js:3:1202)
    ...
CN1SS:INFO:suite finished test=LogSubclassCaptureTest
```

Covered two ways:

- **`LogSubclassCaptureTest`** (hellocodenameone device suite, assertion-only, no screenshot) asserts on-device that the port called back into the app's `createWriter()` and that the trace landed in the writer it returned. Runs on every port.
- **A source-level guard in `JavaScriptRuntimeFacadeTest`** fails fast and offline if the binding is ever restored. Negative control confirmed: re-adding the symbol makes it fail with the explanatory message.

`scripts/check-copyright-headers.sh`, `check-since-tags.sh`, `check-package-info.sh` and `port_status.py validate` all pass locally.

The `port_status_reports/*.json` entries are the checked-in fallback the per-port CI suites overwrite; they are seeded `pass` here (the convention this repo already follows when a test is added) and the per-port runs on this PR are what confirm them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
