### PR TITLE
Measure successful Initializr downloads

### DIFF
--- a/.github/workflows/website-docs.yml
+++ b/.github/workflows/website-docs.yml
@@ -182,7 +182,13 @@ jobs:
           test -f docs/website/public/playground/index.html
 
       - name: Validate Initializr JS bundle output
-        run: test -f docs/website/public/initializr-app/index.html
+        run: |
+          set -euo pipefail
+          test -f docs/website/public/initializr-app/index.html
+          rg -q 'notifyProjectDownloaded' docs/website/public/initializr-app/translated_app.js
+          rg -q 'cn1-initializr-project-downloaded' \
+            docs/website/public/initializr-app/com_codename1_initializr_WebsiteThemeNative.js
+          rg -q 'cn1-initializr-project-downloaded' docs/website/public/initializr/index.html
 
       - name: Validate Playground JS bundle output
         run: test -f docs/website/public/playground-app/index.html

--- a/.github/workflows/website-docs.yml
+++ b/.github/workflows/website-docs.yml
@@ -185,10 +185,10 @@ jobs:
         run: |
           set -euo pipefail
           test -f docs/website/public/initializr-app/index.html
-          rg -q 'downloadProject' docs/website/public/initializr-app/translated_app.js
-          rg -q 'cn1-initializr-project-downloaded' \
+          grep -Fq 'downloadProject' docs/website/public/initializr-app/translated_app.js
+          grep -Fq 'cn1-initializr-project-downloaded' \
             docs/website/public/initializr-app/com_codename1_initializr_WebsiteThemeNative.js
-          rg -q 'cn1-initializr-project-downloaded' docs/website/public/initializr/index.html
+          grep -Fq 'cn1-initializr-project-downloaded' docs/website/public/initializr/index.html
           node docs/website/scripts/test-initializr-download-bridge.mjs \
             docs/website/public/initializr-app/com_codename1_initializr_WebsiteThemeNative.js
 

--- a/.github/workflows/website-docs.yml
+++ b/.github/workflows/website-docs.yml
@@ -185,10 +185,12 @@ jobs:
         run: |
           set -euo pipefail
           test -f docs/website/public/initializr-app/index.html
-          rg -q 'notifyProjectDownloaded' docs/website/public/initializr-app/translated_app.js
+          rg -q 'downloadProject' docs/website/public/initializr-app/translated_app.js
           rg -q 'cn1-initializr-project-downloaded' \
             docs/website/public/initializr-app/com_codename1_initializr_WebsiteThemeNative.js
           rg -q 'cn1-initializr-project-downloaded' docs/website/public/initializr/index.html
+          node docs/website/scripts/test-initializr-download-bridge.mjs \
+            docs/website/public/initializr-app/com_codename1_initializr_WebsiteThemeNative.js
 
       - name: Validate Playground JS bundle output
         run: test -f docs/website/public/playground-app/index.html

--- a/docs/website/assets/js/cn1-crisp.js
+++ b/docs/website/assets/js/cn1-crisp.js
@@ -187,6 +187,9 @@
   crispEvents.gettingStartedDwell = (data) => scheduleCrispEvent(
     "GettingStartedDwell", 20000, data
   );
+  crispEvents.initializrProjectDownloaded = (data) => requestCrispEvent(
+    "InitializrProjectDownloaded", data || { page: "/initializr/" }
+  );
   crispEvents.pricingEvaluator = (data) => {
     const firePricing = () => requestCrispEvent("PricingEvaluator", data);
     window.setTimeout(firePricing, 30000);

--- a/docs/website/layouts/_default/initializr.html
+++ b/docs/website/layouts/_default/initializr.html
@@ -226,12 +226,17 @@ body.cn1-initializr-page-body .main {
     });
 
     window.addEventListener("message", function (evt) {
-      if (evt.source !== frame.contentWindow || !evt.data || evt.data.type !== "cn1-initializr-ui-ready") {
+      if (evt.source !== frame.contentWindow || !evt.data) {
         return;
       }
-      window.requestAnimationFrame(function () {
-        hideLoader();
-      });
+      if (evt.data.type === "cn1-initializr-ui-ready") {
+        window.requestAnimationFrame(function () {
+          hideLoader();
+        });
+      } else if (evt.data.type === "cn1-initializr-project-downloaded" &&
+                 window.cn1CrispEvents && window.cn1CrispEvents.initializrProjectDownloaded) {
+        window.cn1CrispEvents.initializrProjectDownloaded({ page: "/initializr/" });
+      }
     });
   }
 })();

--- a/docs/website/scripts/test-cn1-crisp-events.mjs
+++ b/docs/website/scripts/test-cn1-crisp-events.mjs
@@ -127,6 +127,23 @@ function events(state) {
 }
 
 {
+  const state = load("accepted");
+  state.window.cn1CrispEvents.initializrProjectDownloaded({ page: "/initializr/" });
+
+  const recorded = events(state);
+  assert.equal(recorded.length, 1, "an accepted project download should be queued once");
+  assert.equal(recorded[0][0], "InitializrProjectDownloaded");
+  assert.deepEqual(JSON.parse(JSON.stringify(recorded[0][1])), { page: "/initializr/" });
+}
+
+{
+  const state = load("declined");
+  state.window.cn1CrispEvents.initializrProjectDownloaded({ page: "/initializr/" });
+  assert.equal(eventCommands(state).length, 0,
+    "a project download must not be recorded without analytics consent");
+}
+
+{
   const state = load(null);
   state.window.cn1CrispEvents.signingScreenView({ page: "/signing/" });
   assert.equal(eventCommands(state).length, 0, "an event must wait for a consent choice");

--- a/docs/website/scripts/test-initializr-download-bridge.mjs
+++ b/docs/website/scripts/test-initializr-download-bridge.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import vm from "node:vm";
+
+const sourcePath = process.argv[2]
+  || new URL("../../../scripts/initializr/javascript/src/main/javascript/com_codename1_initializr_WebsiteThemeNative.js", import.meta.url);
+const source = fs.readFileSync(sourcePath, "utf8");
+
+function loadBridge(click) {
+  const nativeInterfaces = {};
+  const posts = [];
+  const actions = [];
+  const parent = {
+    postMessage(message) {
+      actions.push("post");
+      posts.push(message);
+    }
+  };
+  const body = {
+    appendChild(anchor) {
+      actions.push("append");
+      anchor.parentNode = body;
+    },
+    removeChild(anchor) {
+      actions.push("remove");
+      anchor.parentNode = null;
+    }
+  };
+  const window = {
+    parent,
+    document: {
+      body,
+      createElement() {
+        return {
+          click() {
+            actions.push("click");
+            click();
+          }
+        };
+      }
+    },
+    matchMedia() {
+      return { matches: false };
+    }
+  };
+
+  vm.runInNewContext(source, {
+    window,
+    cn1_get_native_interfaces: () => nativeInterfaces
+  });
+
+  return {
+    bridge: nativeInterfaces.com_codename1_initializr_WebsiteThemeNative,
+    posts,
+    actions
+  };
+}
+
+function invokeDownload(state) {
+  let result;
+  state.bridge.downloadProject__java_lang_String_java_lang_String(
+    "sample.zip",
+    "data:application/octet-stream;base64,AA==",
+    { complete(value) { result = value; } }
+  );
+  return result;
+}
+
+{
+  const state = loadBridge(() => {});
+  assert.equal(invokeDownload(state), true);
+  assert.deepEqual(state.actions, ["append", "click", "remove", "post"]);
+  assert.deepEqual(
+    JSON.parse(JSON.stringify(state.posts)),
+    [{ type: "cn1-initializr-project-downloaded" }]
+  );
+}
+
+{
+  const state = loadBridge(() => { throw new Error("blocked"); });
+  assert.equal(invokeDownload(state), false);
+  assert.deepEqual(state.actions, ["append", "click", "remove"]);
+  assert.deepEqual(state.posts, []);
+}
+
+console.log("Initializr download bridge tests passed");

--- a/scripts/initializr/common/src/main/java/com/codename1/initializr/WebsiteThemeNative.java
+++ b/scripts/initializr/common/src/main/java/com/codename1/initializr/WebsiteThemeNative.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.initializr;
 
 import com.codename1.system.NativeInterface;
@@ -5,7 +27,7 @@ import com.codename1.system.NativeInterface;
 public interface WebsiteThemeNative extends NativeInterface {
     boolean isDarkMode();
     void notifyUiReady();
-    void notifyProjectDownloaded();
+    boolean downloadProject(String fileName, String dataUrl);
 
     /// Horizontal clearance, in CSS pixels, that the host page's chat launcher
     /// (Crisp) currently needs at the bottom-right, or 0 when it is hidden. The

--- a/scripts/initializr/common/src/main/java/com/codename1/initializr/WebsiteThemeNative.java
+++ b/scripts/initializr/common/src/main/java/com/codename1/initializr/WebsiteThemeNative.java
@@ -5,6 +5,7 @@ import com.codename1.system.NativeInterface;
 public interface WebsiteThemeNative extends NativeInterface {
     boolean isDarkMode();
     void notifyUiReady();
+    void notifyProjectDownloaded();
 
     /// Horizontal clearance, in CSS pixels, that the host page's chat launcher
     /// (Crisp) currently needs at the bottom-right, or 0 when it is hidden. The

--- a/scripts/initializr/common/src/main/java/com/codename1/initializr/model/GeneratorModel.java
+++ b/scripts/initializr/common/src/main/java/com/codename1/initializr/model/GeneratorModel.java
@@ -23,8 +23,10 @@
 package com.codename1.initializr.model;
 
 import com.codename1.components.ToastBar;
+import com.codename1.initializr.WebsiteThemeNative;
 import com.codename1.io.Log;
 import com.codename1.io.Util;
+import com.codename1.system.NativeLookup;
 import com.codename1.util.StringUtil;
 import net.sf.zipme.CRC32;
 import net.sf.zipme.ZipEntry;
@@ -165,6 +167,7 @@ public class GeneratorModel {
             return;
         }
         if (downloadBytesAsFile(fileName, bytes)) {
+            notifyWebsiteProjectDownloaded();
             return;
         }
 
@@ -189,6 +192,14 @@ public class GeneratorModel {
             }
         }
         execute(filePath);
+    }
+
+    /** Tell the embedding website only after the browser accepted the ZIP download. */
+    private static void notifyWebsiteProjectDownloaded() {
+        WebsiteThemeNative nativeBridge = NativeLookup.create(WebsiteThemeNative.class);
+        if (nativeBridge != null && nativeBridge.isSupported()) {
+            nativeBridge.notifyProjectDownloaded();
+        }
     }
 
     private static String describeError(Throwable ex) {

--- a/scripts/initializr/common/src/main/java/com/codename1/initializr/model/GeneratorModel.java
+++ b/scripts/initializr/common/src/main/java/com/codename1/initializr/model/GeneratorModel.java
@@ -166,8 +166,10 @@ public class GeneratorModel {
             ToastBar.showErrorMessage("Couldn't build the project: " + describeError(ex));
             return;
         }
+        if (downloadWebsiteProject(fileName, bytes)) {
+            return;
+        }
         if (downloadBytesAsFile(fileName, bytes)) {
-            notifyWebsiteProjectDownloaded();
             return;
         }
 
@@ -194,11 +196,18 @@ public class GeneratorModel {
         execute(filePath);
     }
 
-    /** Tell the embedding website only after the browser accepted the ZIP download. */
-    private static void notifyWebsiteProjectDownloaded() {
+    /** Use the website bridge so the metric is emitted only after its download handler succeeds. */
+    private static boolean downloadWebsiteProject(String fileName, byte[] bytes) {
         WebsiteThemeNative nativeBridge = NativeLookup.create(WebsiteThemeNative.class);
-        if (nativeBridge != null && nativeBridge.isSupported()) {
-            nativeBridge.notifyProjectDownloaded();
+        if (nativeBridge == null || !nativeBridge.isSupported()) {
+            return false;
+        }
+        try {
+            String dataUrl = "data:application/octet-stream;base64,"
+                    + com.codename1.util.Base64.encodeNoNewline(bytes);
+            return nativeBridge.downloadProject(fileName, dataUrl);
+        } catch (Throwable t) {
+            return false;
         }
     }
 

--- a/scripts/initializr/javascript/src/main/javascript/com_codename1_initializr_WebsiteThemeNative.js
+++ b/scripts/initializr/javascript/src/main/javascript/com_codename1_initializr_WebsiteThemeNative.js
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 (function(exports){
 
 var o = {};
@@ -89,15 +111,40 @@ var o = {};
         }
     };
 
-    o.notifyProjectDownloaded_ = function(callback) {
+    o.downloadProject__java_lang_String_java_lang_String = function(fileName, dataUrl, callback) {
+        var anchor = null;
+        try {
+            var doc = window.document;
+            if (!doc || !doc.body || !dataUrl) {
+                callback.complete(false);
+                return;
+            }
+            anchor = doc.createElement("a");
+            anchor.href = dataUrl;
+            anchor.download = fileName || "codename-one-project.zip";
+            doc.body.appendChild(anchor);
+            anchor.click();
+        } catch (downloadError) {
+            callback.complete(false);
+            return;
+        } finally {
+            try {
+                if (anchor && anchor.parentNode) {
+                    anchor.parentNode.removeChild(anchor);
+                }
+            } catch (ignored) {
+                // Cleanup must not change a successful download acknowledgement.
+            }
+        }
+
         try {
             if (window.parent && window.parent !== window && window.parent.postMessage) {
                 window.parent.postMessage({ type: "cn1-initializr-project-downloaded" }, "*");
             }
         } catch (ignored) {
-            // A download must never fail because the embedding page is unavailable.
+            // The download succeeded even if the optional embedding page is unavailable.
         }
-        callback.complete();
+        callback.complete(true);
     };
 
     // Horizontal clearance (CSS px) the host page's Crisp chat launcher needs at

--- a/scripts/initializr/javascript/src/main/javascript/com_codename1_initializr_WebsiteThemeNative.js
+++ b/scripts/initializr/javascript/src/main/javascript/com_codename1_initializr_WebsiteThemeNative.js
@@ -89,6 +89,17 @@ var o = {};
         }
     };
 
+    o.notifyProjectDownloaded_ = function(callback) {
+        try {
+            if (window.parent && window.parent !== window && window.parent.postMessage) {
+                window.parent.postMessage({ type: "cn1-initializr-project-downloaded" }, "*");
+            }
+        } catch (ignored) {
+            // A download must never fail because the embedding page is unavailable.
+        }
+        callback.complete();
+    };
+
     // Horizontal clearance (CSS px) the host page's Crisp chat launcher needs at
     // the bottom-right, so the generate button can be nudged left of it. The
     // default Crisp launcher bubble (~64px) sits ~24px from the page edge;


### PR DESCRIPTION
## Summary

- record a consent-gated Crisp event only after the Initializr JavaScript download path succeeds
- relay the completed download from the embedded app to the host page without user or project data
- assert in website CI that the translated app, native bridge, and host listener all contain the production event path

## Verification

- production-equivalent website build with Initializr enabled and other embedded apps disabled
- generated `translated_app.js` contains the acknowledged `downloadProject` bridge
- generated native bridge and `/initializr/` page contain `cn1-initializr-project-downloaded`
- generated bridge regression proves a failed anchor click returns false and emits no event
- `node docs/website/scripts/test-cn1-crisp-events.mjs`
- `node --check scripts/initializr/javascript/src/main/javascript/com_codename1_initializr_WebsiteThemeNative.js`
- Initializr common Maven tests on Java 8
- repository copyright-header check

The generated Initializr bundle is intentionally not committed; the website workflow rebuilds it from repository sources for previews and production deployment.
