### PR TITLE
Correct the docs that still say Codename One comes from Maven Central

### DIFF
--- a/docs/demos/common/src/main/snippets/developer-guide/maven-getting-started.xml
+++ b/docs/demos/common/src/main/snippets/developer-guide/maven-getting-started.xml
@@ -21,3 +21,32 @@
 // tag::maven-getting-started-xml-003[]
 <!-- INJECT DEPENDENCIES -->
 // end::maven-getting-started-xml-003[]
+
+// tag::maven-getting-started-xml-004[]
+<settings>
+    <profiles>
+        <profile>
+            <id>codenameone</id>
+            <repositories>
+                <repository>
+                    <id>codenameone</id>
+                    <url>https://repo.codenameone.com/maven2</url>
+                    <releases><enabled>true</enabled></releases>
+                    <snapshots><enabled>false</enabled></snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>codenameone-plugins</id>
+                    <url>https://repo.codenameone.com/maven2</url>
+                    <releases><enabled>true</enabled></releases>
+                    <snapshots><enabled>false</enabled></snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
+    <activeProfiles>
+        <activeProfile>codenameone</activeProfile>
+    </activeProfiles>
+</settings>
+// end::maven-getting-started-xml-004[]

--- a/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
+++ b/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
@@ -102,13 +102,13 @@ include::_generated-build-hints.adoc[]
 
 By default a cloud build always uses the current Codename One release. With a _versioned build_ you can instead pin the build to a specific previously released framework version, so you get reproducible output over time. This helps when stabilizing a release, supporting an older app, or isolating a regression: if an app that built correctly in the past starts failing, rebuilding against the last known good version tells you whether the change came from your code or from the framework and build server.
 
-Set the `build.cn1Version` build hint to the version you want to target. Versions use the standard Maven release scheme published to Maven Central, for example `7.0.182`:
+Set the `build.cn1Version` build hint to the version you want to target. Versions use the standard Maven release scheme, for example `7.0.182`:
 
 ----
 codename1.arg.build.cn1Version=7.0.182
 ----
 
-The build server fetches that version's framework artifacts from Maven Central and builds against them. To keep your simulator and local compile classpath aligned with the same release, set the matching `cn1.version` in your project `pom.xml`.
+The build server fetches that version's framework artifacts from the Codename One Maven repository and builds against them, falling back to Maven Central for releases published before the move. To keep your simulator and local compile classpath aligned with the same release, set the matching `cn1.version` in your project `pom.xml`.
 
 Versioned builds are a Pro and Enterprise feature, and how far back you can target depends on the subscription tier:
 

--- a/docs/developer-guide/Game-Builder.asciidoc
+++ b/docs/developer-guide/Game-Builder.asciidoc
@@ -83,7 +83,7 @@ include::../demos/common/src/main/snippets/developer-guide/game-builder.sh[tag=g
 ----
 
 The editor itself is delivered through Maven: the goal resolves the
-`com.codenameone:codenameone-gamebuilder` artifact from Maven Central (the same mechanism
+`com.codenameone:codenameone-gamebuilder` artifact from the Codename One Maven repository (the same mechanism
 that ships the Designer / CSS-compiler jar with the plugin), so there is no separate
 install step. The `cn1:gamebuilder` goal only applies to Java 17 Codename One projects.
 

--- a/docs/developer-guide/Maven-Creating-CN1Libs.adoc
+++ b/docs/developer-guide/Maven-Creating-CN1Libs.adoc
@@ -283,7 +283,7 @@ Right-click on the "root" module in the project explorer and select _Run as_ > _
 
 image::img/eclipse-build-cn1lib.png[]
 
-TIP: If the build fails for any reason, check to make sure that your project is using the latest version of the Codename One plugin. You can do this by opening the _pom.xml_ file, and changing the `cn1.version` and `cn1.plugin.version` properties to reference the latest version. Check for the latest version https://search.maven.org/artifact/com.codenameone/codenameone[here].
+TIP: If the build fails for any reason, check to make sure that your project is using the latest version of the Codename One plugin. You can do this by opening the _pom.xml_ file, and changing the `cn1.version` and `cn1.plugin.version` properties to reference the latest version. Check for the latest version, listed as `<release>` in the https://repo.codenameone.com/maven2/com/codenameone/codenameone-core/maven-metadata.xml[repository metadata].
 
 
 ===== Building the Legacy.cnlib file

--- a/docs/developer-guide/Maven-Getting-Started.adoc
+++ b/docs/developer-guide/Maven-Getting-Started.adoc
@@ -22,6 +22,7 @@ fast with a friendly message if it's older than 11. Build-only goals (such as
 [#creating-app-project]
 === Creating a new project
 
+[#codenameone-initializr]
 ==== Codename One initializr
 
 The easiest way to create a new project is to use the https://www.codenameone.com/initializr[Codename One initializr].
@@ -48,6 +49,31 @@ See https://shannah.github.io/cn1app-archetype-kotlin-template/getting-started.h
 
 ==== Generating a new project from the command-line
 
+[#configure-repository]
+===== Configuring the Codename One repository
+
+Codename One releases are published to the Codename One Maven repository at
+`https://repo.codenameone.com/maven2`, not to Maven Central. A generated project declares
+that repository in its own `pom.xml`, so once you have a project nothing further is needed.
+
+The commands in this section run *before* there is a project, so Maven has no `pom.xml` to
+read the repository from and searches only Maven Central. Central still serves every
+version published before the move, so these commands keep working, but they can't see a
+release published after it. Add the repository to your Maven settings once, in
+`~/.m2/settings.xml` (`%USERPROFILE%\.m2\settings.xml` on Windows), and they can:
+
+[source,xml]
+----
+include::../demos/common/src/main/snippets/developer-guide/maven-getting-started.xml[tag=maven-getting-started-xml-004,indent=0]
+----
+
+Both lists are needed. Maven resolves ordinary dependencies through `<repositories>` and
+build plugins through `<pluginRepositories>`, and the commands below invoke the Codename
+One plugin directly, which is the second list.
+
+TIP: <<codenameone-initializr,Codename One Initializr>> needs none of this. It builds the
+project on the server and hands you one that already declares the repository.
+
 [#cn1app-archetype-example]
 ===== Bare-bones Java project
 
@@ -62,6 +88,8 @@ This will generate a project in the current directory. The project's directory w
 
 
 NOTE: If you haven't used Maven archetypes before, this snippet may be confusing. See https://maven.apache.org/guides/introduction/introduction-to-archetypes.html[Introduction to Maven Archetypes] to get up to speed.
+
+NOTE: `-DarchetypeVersion=LATEST` resolves against whichever repositories Maven knows about. Without the settings from <<configure-repository>>, Maven Central is the only one, so the newest archetype it can offer is the last one published before the move. The generated project is still correct -- it declares the Codename One repository, so `mvn cn1:update` moves it to a current release -- but configuring the repository first gets you there directly.
 
 This command uses the <<#cn1app-archetype>> which has the following Maven coordinates:
 
@@ -93,7 +121,7 @@ Like the `archetype:generate` goal, this will create the project in a directory 
 
 Some notes here:
 
-. The `com.codenameone:codenameone-maven-plugin:{cn1-plugin-release-version}:generate-app-project` argument is the fully qualified goal name for the `generate-app-project`. This is necessary since you aren't running this goal in the context of any existing project. You should adjust the version number (`{cn1-plugin-release-version}`) to reflect the latest available Codename One version, listed as `<release>` in the https://repo.codenameone.com/maven2/com/codenameone/codenameone-maven-plugin/maven-metadata.xml[repository metadata].
+. The `com.codenameone:codenameone-maven-plugin:{cn1-plugin-release-version}:generate-app-project` argument is the fully qualified goal name for the `generate-app-project`. This is necessary since you aren't running this goal in the context of any existing project. You should adjust the version number (`{cn1-plugin-release-version}`) to reflect the latest available Codename One version, listed as `<release>` in the https://repo.codenameone.com/maven2/com/codenameone/codenameone-maven-plugin/maven-metadata.xml[repository metadata]. Because there is no project here, Maven finds that version only if you have <<configure-repository,configured the Codename One repository>> in your Maven settings.
 . The `archetypeGroupId`, `archetypeArtifactId`, and `archetypeVersion` parameters are the same as when using the `archetype:generate` goal, and they will (almost) always refer to the <<cn1app-archetype>>.
 . The `groupId`, `artifactId`, and `version` work the same as for the `archetype:generate` goal. That's, that they specify the coordinates for your newly created project.
 . The `mainName` specifies the Main class name for your app. This is the class name, and shouldn't include the full package. For example, `MyApp`, not "com.example.MyApp"

--- a/docs/developer-guide/Maven-Getting-Started.adoc
+++ b/docs/developer-guide/Maven-Getting-Started.adoc
@@ -93,7 +93,7 @@ Like the `archetype:generate` goal, this will create the project in a directory 
 
 Some notes here:
 
-. The `com.codenameone:codenameone-maven-plugin:{cn1-plugin-release-version}:generate-app-project` argument is the fully qualified goal name for the `generate-app-project`. This is necessary since you aren't running this goal in the context of any existing project. You should adjust the version number (`{cn1-plugin-release-version}`) to reflect the https://search.maven.org/search?q=a:codenameone-maven-plugin[latest available Codename One version on Maven Central].
+. The `com.codenameone:codenameone-maven-plugin:{cn1-plugin-release-version}:generate-app-project` argument is the fully qualified goal name for the `generate-app-project`. This is necessary since you aren't running this goal in the context of any existing project. You should adjust the version number (`{cn1-plugin-release-version}`) to reflect the latest available Codename One version, listed as `<release>` in the https://repo.codenameone.com/maven2/com/codenameone/codenameone-maven-plugin/maven-metadata.xml[repository metadata].
 . The `archetypeGroupId`, `archetypeArtifactId`, and `archetypeVersion` parameters are the same as when using the `archetype:generate` goal, and they will (almost) always refer to the <<cn1app-archetype>>.
 . The `groupId`, `artifactId`, and `version` work the same as for the `archetype:generate` goal. That's, that they specify the coordinates for your newly created project.
 . The `mainName` specifies the Main class name for your app. This is the class name, and shouldn't include the full package. For example, `MyApp`, not "com.example.MyApp"

--- a/docs/developer-guide/Maven-Updating-Codename-One.adoc
+++ b/docs/developer-guide/Maven-Updating-Codename-One.adoc
@@ -1,6 +1,6 @@
 [#updating]
 == Updating Codename One
-Codename One releases new versions weekly on Maven central. It's recommended that you stay up to date with the latest version as much as possible to ensure compatibility with the Codename One build server, which is always running the latest version.
+Codename One releases new versions weekly to the Codename One Maven repository. It's recommended that you stay up to date with the latest version as much as possible to ensure compatibility with the Codename One build server, which is always running the latest version.
 
 You can use the <<update-goal, update goal>> to update both the Codename One libraries, and the Codename One dependencies in your project.
 
@@ -53,7 +53,7 @@ For example, Open the `pom.xml` file, and look for the following:
 include::../demos/common/src/main/snippets/developer-guide/maven-updating-codename-one.xml[tag=maven-updating-codename-one-xml-001,indent=0]
 ----
 
-Change these values to reflect the latest version of the `codenameone-maven-plugin` found https://search.maven.org/artifact/com.codenameone/codenameone-maven-plugin[here].
+Change these values to reflect the latest version of the `codenameone-maven-plugin`, listed as `<release>` in the https://repo.codenameone.com/maven2/com/codenameone/codenameone-maven-plugin/maven-metadata.xml[repository metadata]. The <<update-goal, update goal>> reads the same metadata and edits both properties for you.
 
 NOTE: Updating the `cn1.plugin.version` and `cn1.version` properties manually will update the Maven dependencies for your project but it won't update the other Codename One tools such as the GUI builder, and the Build Server Client, which are managed outside of Maven. You should use the <<update-goal>> as described at the beginning of <<updating, this section>> to perform a "full" update.
 

--- a/docs/developer-guide/Working-With-CodenameOne-Sources.asciidoc
+++ b/docs/developer-guide/Working-With-CodenameOne-Sources.asciidoc
@@ -34,7 +34,7 @@ The default build runs every module and its unit tests. Append `-DskipTests`
 if you want to skip the test phases to speed up local builds.
 
 The version printed by Maven will end with `-SNAPSHOT` when you build
-from the `master` branch. Release builds from Maven Central omit the suffix.
+from the `master` branch. Published releases omit the suffix.
 
 === Installing the Maven archetypes
 
@@ -82,13 +82,13 @@ include::../demos/common/src/main/snippets/developer-guide/working-with-codename
 ----
 
 Open the project in your IDE and build or run it. Maven will resolve the local
-snapshot instead of downloading the latest release from Maven Central.
+snapshot instead of downloading the latest published release.
 
 === Why build from source
 
 Building the SDK yourself gives you:
 
-* Immediate access to fixes and features before they reach Maven Central.
+* Immediate access to fixes and features before they reach a release.
 * The ability to inspect, debug, and change the framework when you need custom
  behavior.
 * A path to contribute improvements back to the Codename One core.

--- a/docs/developer-guide/appendix_goal_generate_app_project.adoc
+++ b/docs/developer-guide/appendix_goal_generate_app_project.adoc
@@ -14,7 +14,7 @@ Because there is no existing project, you will need to provide the full maven pa
 include::../demos/common/src/main/snippets/developer-guide/appendix-goal-generate-app-project.sh[tag=appendix-goal-generate-app-project-bash-001,indent=0]
 ----
 
-NOTE: Substitute the https://search.maven.org/artifact/com.codenameone/codenameone-maven-plugin[latest Codename One plugin version] for the `$CN1VERSION` in the above example.
+NOTE: Substitute the latest Codename One plugin version, listed as `<release>` in the https://repo.codenameone.com/maven2/com/codenameone/codenameone-maven-plugin/maven-metadata.xml[repository metadata], for the `$CN1VERSION` in the above example.
 
 NOTE: This command is formatted for the bash prompt (for example, Linux or Mac). It will work on Windows also if you use bash. If you're on Windows and are using PowerShell or the regular command prompt, then you'll need to modify the command slightly. In particular, the entire command would need to be on a single line. (Remove the '\' at the end of each line, and merge lines together, with space between the command-line flags)
 

--- a/docs/developer-guide/appendix_goal_generate_app_project.adoc
+++ b/docs/developer-guide/appendix_goal_generate_app_project.adoc
@@ -14,7 +14,7 @@ Because there is no existing project, you will need to provide the full maven pa
 include::../demos/common/src/main/snippets/developer-guide/appendix-goal-generate-app-project.sh[tag=appendix-goal-generate-app-project-bash-001,indent=0]
 ----
 
-NOTE: Substitute the latest Codename One plugin version, listed as `<release>` in the https://repo.codenameone.com/maven2/com/codenameone/codenameone-maven-plugin/maven-metadata.xml[repository metadata], for the `$CN1VERSION` in the above example.
+NOTE: Substitute the latest Codename One plugin version, listed as `<release>` in the https://repo.codenameone.com/maven2/com/codenameone/codenameone-maven-plugin/maven-metadata.xml[repository metadata], for the `$CN1VERSION` in the above example. Because this goal runs outside any project, Maven can only find that version if you have configured the Codename One repository in your Maven settings; see the _Configuring the Codename One repository_ section of <<creating-app-project,Creating a new project>>.
 
 NOTE: This command is formatted for the bash prompt (for example, Linux or Mac). It will work on Windows also if you use bash. If you're on Windows and are using PowerShell or the regular command prompt, then you'll need to modify the command slightly. In particular, the entire command would need to be on a single line. (Remove the '\' at the end of each line, and merge lines together, with space between the command-line flags)
 

--- a/docs/developer-guide/appendix_goal_generate_cn1lib_project.adoc
+++ b/docs/developer-guide/appendix_goal_generate_cn1lib_project.adoc
@@ -19,7 +19,7 @@ You can run the `generate-cn1lib-project` goal as follows:
 include::../demos/common/src/main/snippets/developer-guide/appendix-goal-generate-cn1lib-project.sh[tag=appendix-goal-generate-cn1lib-project-bash-001,indent=0]
 ----
 
-NOTE: Make sure you substitute the latest `codenameone-maven-plugin` version, listed as `<release>` in the https://repo.codenameone.com/maven2/com/codenameone/codenameone-maven-plugin/maven-metadata.xml[repository metadata], for the `$CN1VERSION` in this command.
+NOTE: Make sure you substitute the latest `codenameone-maven-plugin` version, listed as `<release>` in the https://repo.codenameone.com/maven2/com/codenameone/codenameone-maven-plugin/maven-metadata.xml[repository metadata], for the `$CN1VERSION` in this command. Because this goal runs outside any project, Maven can only find that version if you have configured the Codename One repository in your Maven settings; see the _Configuring the Codename One repository_ section of <<creating-app-project,Creating a new project>>.
 
 Some notes about this command as shown above:
 

--- a/docs/developer-guide/appendix_goal_generate_cn1lib_project.adoc
+++ b/docs/developer-guide/appendix_goal_generate_cn1lib_project.adoc
@@ -19,7 +19,7 @@ You can run the `generate-cn1lib-project` goal as follows:
 include::../demos/common/src/main/snippets/developer-guide/appendix-goal-generate-cn1lib-project.sh[tag=appendix-goal-generate-cn1lib-project-bash-001,indent=0]
 ----
 
-NOTE: Make sure you substitute the https://search.maven.org/search?q=a:codenameone-maven-plugin[latest codenameone-maven-plugin version] for the `$CN1VERSION` in this command.
+NOTE: Make sure you substitute the latest `codenameone-maven-plugin` version, listed as `<release>` in the https://repo.codenameone.com/maven2/com/codenameone/codenameone-maven-plugin/maven-metadata.xml[repository metadata], for the `$CN1VERSION` in this command.
 
 Some notes about this command as shown above:
 

--- a/docs/developer-guide/appendix_goal_update.adoc
+++ b/docs/developer-guide/appendix_goal_update.adoc
@@ -13,7 +13,7 @@ include::../demos/common/src/main/snippets/developer-guide/appendix-goal-update.
 **Parameters**
 
 newVersion::
-(Optional) The version to update to. This should be a version number available on Maven central. Will accept a value of "LATEST" to cause it to resolve to the latest version available on Maven central.
+(Optional) The version to update to. This should be a published Codename One version. Will accept a value of "LATEST" to cause it to resolve to the latest version in the Codename One Maven repository. `LATEST` never downgrades a project: if the newest version offered is older than the one the project already uses, the goal reports it and leaves `cn1.version` and `cn1.plugin.version` untouched.
 +
 If this parameter is omitted, then it will be implicitly set to `LATEST`, but it won't update the `cn1.version` or `cn1.plugin.version` properties if they're set to a SNAPSHOT version.
 

--- a/docs/website/content/blog/maven-central-cloudflare-r2.md
+++ b/docs/website/content/blog/maven-central-cloudflare-r2.md
@@ -11,6 +11,8 @@ series: ["release-2026-07-31"]
 
 ![Codename One Maven artifacts move through a staged Central and Cloudflare R2 migration](/blog/maven-central-cloudflare-r2.jpg)
 
+> **Editor's note, August 28, 2026.** The migration described below is complete. The dual-publish window ran as planned and new releases now go to the Codename One repository only. Maven Central keeps every version published before today and nothing has been removed from it, so existing projects pinned to one of those versions are unaffected. A project needs the repository block shown below to see releases published from today onward; generated projects have had it since the Initializr change. The rest of this post is left as written.
+
 Codename One is starting a staged move from Maven Central to a repository we operate on Cloudflare R2.
 
 This is not a story about Maven Central being bad. Sonatype runs expensive public infrastructure and has every right to define usage limits or sell a commercial service. Our release shape is simply a bad fit for those limits, and passing that infrastructure bill to Codename One users would make less sense than serving the same signed Maven layout ourselves.

--- a/docs/website/content/howdoi/how-do-i-get-repeatable-builds-build-against-a-consistent-version-of-codename-one-use-the-versioning-feature.md
+++ b/docs/website/content/howdoi/how-do-i-get-repeatable-builds-build-against-a-consistent-version-of-codename-one-use-the-versioning-feature.md
@@ -15,11 +15,11 @@ thumbnail: https://www.codenameone.com/wp-content/uploads/2020/09/hqdefault-4-1.
 {{< youtube "w7xvlw3rI6Y" >}}
 Repeatable builds matter when you are trying to stabilize a release, investigate a regression, or keep a production app on a known-good Codename One version instead of automatically moving with the latest server-side changes. Versioned builds are the feature designed for that job.
 
-The core idea is simple. Instead of always building against the current Codename One release, you tell the build server to target a specific published Codename One version. The native build is then performed using the framework artifacts for that exact release, which the build server fetches from Maven Central. If your application built and ran correctly against that version before, you have a way to stay there while you validate later updates on your own schedule.
+The core idea is simple. Instead of always building against the current Codename One release, you tell the build server to target a specific published Codename One version. The native build is then performed using the framework artifacts for that exact release, which the build server fetches from the Codename One Maven repository. If your application built and ran correctly against that version before, you have a way to stay there while you validate later updates on your own schedule.
 
 ## How to enable a versioned build
 
-Set the `build.cn1Version` build hint to the Maven release version you want to target. Versions follow the standard Maven scheme published to Maven Central, for example `7.0.182`.
+Set the `build.cn1Version` build hint to the Maven release version you want to target. Versions follow the standard Maven scheme, for example `7.0.182`. Releases published before the move to the Codename One Maven repository still resolve from Maven Central, so any version the feature accepted before it still accepts.
 
 In a Maven project, add the hint to `codenameone_settings.properties` using the `codename1.arg.` prefix:
 

--- a/maven/integration-tests/validate_generated_repositories.py
+++ b/maven/integration-tests/validate_generated_repositories.py
@@ -24,11 +24,12 @@
 
 """Guard that every project-scaffolding path declares the Codename One repository.
 
-Codename One releases are moving off Maven Central to the repository at
-https://repo.codenameone.com/maven2. A generated project that does not declare it
-resolves normally today -- Central still has every published version -- and then
-silently stops seeing new releases after the cutover. The failure is therefore
-invisible at generation time, which is exactly why it needs a build-time gate.
+Codename One releases are published to the repository at
+https://repo.codenameone.com/maven2, not to Maven Central. A generated project that
+does not declare it still resolves every version published before the cutover, because
+Central keeps those, and then silently stops seeing new releases. The failure is
+therefore invisible at generation time, which is exactly why it needs a build-time
+gate.
 
 Both lists are checked because Maven resolves ordinary dependencies through
 <repositories> and build plugins through <pluginRepositories>. A project holding only

--- a/scripts/initializr/common/src/main/resources/skill/references/java-api-subset.md
+++ b/scripts/initializr/common/src/main/resources/skill/references/java-api-subset.md
@@ -6,7 +6,7 @@ This document tells you (1) how to discover what *is* supported, and (2) where t
 
 ## How to discover the supported API
 
-The supported API surface is defined by two artifacts that the Codename One Maven plugin resolves from Maven Central. The `bytecode-compliance` goal compares your compiled bytecode against both jars and fails on anything not present.
+The supported API surface is defined by two artifacts that the Codename One Maven plugin resolves from the Codename One Maven repository. The `bytecode-compliance` goal compares your compiled bytecode against both jars and fails on anything not present.
 
 | Artifact | What's inside |
 | --- | --- |

--- a/scripts/initializr/common/src/main/resources/skill/references/snapshot-builds.md
+++ b/scripts/initializr/common/src/main/resources/skill/references/snapshot-builds.md
@@ -1,14 +1,14 @@
 # Building Against a Codename One SNAPSHOT From Git
 
-**This is an edge case.** Most projects should consume Codename One from Maven Central — pinned to a released version, no compilation of the framework itself, no surprises. Reach for the snapshot workflow only when you need to test an in-flight CN1 fix, reproduce a bug against the latest code, or contribute a patch.
+**This is an edge case.** Most projects should consume Codename One from the Codename One Maven repository (`https://repo.codenameone.com/maven2`, which generated projects already declare) — pinned to a released version, no compilation of the framework itself, no surprises. Reach for the snapshot workflow only when you need to test an in-flight CN1 fix, reproduce a bug against the latest code, or contribute a patch.
 
 ## When to use a SNAPSHOT
 
 - You are reproducing a bug against the latest CN1 framework commit to confirm it still happens before reporting it.
 - You are patching CN1 itself and want to validate the patch in this project before opening a PR upstream.
-- The fix you need landed in the CN1 repo but hasn't shipped to Maven Central yet.
+- The fix you need landed in the CN1 repo but hasn't shipped in a release yet.
 
-For day-to-day app development against a stable release, **don't do this** — pin to the latest Central release in `pom.xml` and rely on the normal Maven resolution path. SNAPSHOTs change without warning and can break the build.
+For day-to-day app development against a stable release, **don't do this** — pin to the latest release in `pom.xml` and rely on the normal Maven resolution path. SNAPSHOTs change without warning and can break the build.
 
 ## The workflow
 
@@ -81,7 +81,7 @@ mvn -pl common cn1:run        # picks up the freshly-installed SNAPSHOT
 
 `-pl <module>` targets just the module you changed, instead of rebuilding the whole framework each iteration.
 
-## Reverting to a Maven Central release
+## Reverting to a published release
 
 When you're done, set the versions back to whatever release you want to pin. Drop the `-SNAPSHOT`:
 

--- a/scripts/initializr/common/src/test/java/com/codename1/initializr/model/GeneratorModelMatrixTest.java
+++ b/scripts/initializr/common/src/test/java/com/codename1/initializr/model/GeneratorModelMatrixTest.java
@@ -212,10 +212,10 @@ public class GeneratorModelMatrixTest extends AbstractTest {
     }
 
     /**
-     * Codename One releases are moving off Maven Central to repo.codenameone.com, so a
-     * generated project must declare that repository. Losing it is invisible at
-     * generation time -- Central still serves every already-published version -- and
-     * only surfaces after the cutover, as a project that never sees a new release.
+     * Codename One releases are published to repo.codenameone.com, not Maven Central, so
+     * a generated project must declare that repository. Losing it is invisible at
+     * generation time -- Central still serves every version published before the
+     * cutover -- and surfaces only as a project that never sees a new release.
      *
      * Both lists are asserted because Maven resolves dependencies through
      * &lt;repositories&gt; and build plugins through &lt;pluginRepositories&gt;: a


### PR DESCRIPTION
Follow-up to #5611. Releases now go to the Codename One Maven repository, so the pages telling users to look on Maven Central for a version — or saying the build server fetches framework artifacts from there — are wrong. They were accurate when written; the cutover made them stale.

## What changed

- **Versioned builds** (developer guide + the how-do-i page) said the build server fetches from Central. It asks the Codename One repository first and falls back to Central for pre-cutover releases, which is what the pages now say.
- **Six "check search.maven.org for the latest version" links** pointed at a search index that will never show a release published from now on. They now name the `<release>` element of the repository's own `maven-metadata.xml`, and the update page also points at the goal that reads the same metadata and edits both properties for you.
- **The `update` goal's `newVersion` parameter** said `LATEST` resolves to the newest version on Central. It resolves against the Codename One repository, and now documents that `LATEST` will not downgrade a project.
- The **Game Builder** page, the **build-from-source** page and two **agent-skill references** described Central as where the framework comes from.

## What deliberately did not change

**Everything about cn1libs.** `googlemaps-lib` and the rest are separate repositories, still published to Central and absent from ours — verified, not assumed:

```
googlemaps-lib             central=200  r2=404
codenameone-maven-plugin   central=200  r2=200
```

So the guidance on finding, consuming and publishing libraries on Central is correct as written. Only the framework and plugin moved, and conflating the two would make these pages wrong in the other direction.

**The blog post body.** Per instruction, the migration post gets an editor's note and nothing else — its date table and its predictions stand as written. 2 lines added, 0 removed.

## Wording

"Codename One **Maven** repository" rather than "Codename One repository" throughout: the guide already uses the latter for the git repository a few lines away, and my first pass introduced that ambiguity.

## Gates

Run locally, each proved non-vacuous before trusting the pass:

| Gate | Result | Non-vacuity probe |
|---|---|---|
| Blog prose gate | passes vs `origin/master` | — |
| Vale (9 guide files) | 0 findings | flagged a planted `Microsoft.Wordiness` violation |
| LanguageTool (9 guide files) | `status=ok total=0` | found 3 planted misspellings |
| asciidoctor render | all 9 clean | — |
| absolute-`codenameone.com` link policy | clean for both changed website files | — |

The `status=ok` matters: LanguageTool fails open under JDK 8 and reports `total: 0` without ever starting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)