### PR TITLE
Wait for the release on the Codename One repository, not Maven Central

### DIFF
--- a/.github/workflows/initializr-cn1-version-pr.yml
+++ b/.github/workflows/initializr-cn1-version-pr.yml
@@ -56,29 +56,49 @@ jobs:
           echo "developer-guide.pdf did not appear on release $RELEASE_TAG within 30 minutes"
           exit 1
 
-      - name: Wait for codenameone-maven-plugin on Maven Central
+      - name: Wait for the release to be published
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
+          R2_BASE_URL: https://repo.codenameone.com/maven2
         run: |
-          # PR-triggered workflows like cn1playground-language and
-          # archetype-smoke try to resolve com.codenameone:codenameone-maven-plugin
-          # at the new version from Maven Central as soon as the PR opens.
-          # Sonatype Central -> repo1.maven.org propagation can take 30+
-          # minutes after publish, so wait for the artifact to be visible
-          # before creating the PR.
+          # PR-triggered workflows like cn1playground-language and archetype-smoke
+          # resolve com.codenameone:codenameone-maven-plugin at the new version as soon
+          # as the PR opens, so this waits for the release to exist before creating it.
+          #
+          # This polled Maven Central, which releases no longer go to: it waited the
+          # full 30 minutes for an artifact that is never coming and failed every
+          # release. Releases are published to the Codename One repository now.
+          #
+          # It waits on the release COMPLETION MARKER, not just the plugin pom. The
+          # marker is written only once the core reactor and all four editors are
+          # uploaded and verified, so it means "this release is whole" -- something
+          # Central never offered, where an artifact could be visible while the rest of
+          # the release was still uploading. The pom is checked too, since that is what
+          # the downstream jobs actually resolve.
+          #
+          # The wait is still generous. There is no propagation delay any more, but the
+          # release workflow runs on the tag push while this one runs on the release
+          # event, so this can start while the release is still uploading.
+          #
+          # Cache-busted: Cloudflare caches 404s on the custom domain, so a poll that
+          # starts a moment too early would otherwise keep seeing its own cached miss.
           set +e
           version="${RELEASE_TAG#v}"
-          url="https://repo1.maven.org/maven2/com/codenameone/codenameone-maven-plugin/${version}/codenameone-maven-plugin-${version}.pom"
+          marker="${R2_BASE_URL}/com/codenameone/_cn1-releases/${version}/complete"
+          pom="${R2_BASE_URL}/com/codenameone/codenameone-maven-plugin/${version}/codenameone-maven-plugin-${version}.pom"
           for i in $(seq 1 90); do
-            code=$(curl -s -o /dev/null -w "%{http_code}" "$url")
-            if [ "$code" = "200" ]; then
-              echo "codenameone-maven-plugin ${version} is on Maven Central"
+            cb="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${i}"
+            marker_code=$(curl -s -o /dev/null -w "%{http_code}" "${marker}?cb=${cb}")
+            pom_code=$(curl -s -o /dev/null -w "%{http_code}" "${pom}?cb=${cb}")
+            if [ "$marker_code" = "200" ] && [ "$pom_code" = "200" ]; then
+              echo "Release ${version} is complete and codenameone-maven-plugin is published"
               exit 0
             fi
-            echo "[$i/90] Waiting for codenameone-maven-plugin ${version} on Maven Central (last code=$code)"
+            echo "[$i/90] Waiting for release ${version} (marker=$marker_code, plugin=$pom_code)"
             sleep 20
           done
-          echo "codenameone-maven-plugin ${version} did not appear on Maven Central within 30 minutes"
+          echo "Release ${version} was not complete within 30 minutes." >&2
+          echo "Check the Release workflow for this tag: a missing marker means it did not finish." >&2
           exit 1
 
       - name: Update Initializr Codename One versions


### PR DESCRIPTION
Fixes the failure in [run 33147442940](https://github.com/codenameone/CodenameOne/actions/runs/33147442940) — the first release after the cutover, and the first thing the cutover broke.

## What happened

The `Wait for codenameone-maven-plugin on Maven Central` step polls `repo1.maven.org` for the new version. Releases no longer go there, so it waited the full 30 minutes for an artifact that is never coming and failed the job.

```
Central plugin pom for 7.0.268: HTTP 404   <- and always will be
```

**Consequence:** the job failed before `Update Initializr Codename One versions` ran, so the version-bump PR was never opened. The Initializr is still pinned to the last pre-cutover release and stays there until this merges and the bump runs for 7.0.268.

## The fix

Polls the Codename One repository, and waits on the **release completion marker** rather than only the plugin pom. The marker is written once the core reactor and all four editors are uploaded and verified, so it means *this release is whole* — a signal Central never offered, where an artifact could be visible while the rest of the release was still uploading. That race is exactly what the original wait was written to survive, so the new check is strictly stronger. The pom is checked alongside it because that is what the downstream jobs resolve.

The 30-minute budget stays: propagation delay is gone, but `release.yml` runs on the tag push while this runs on the release event, so this can start mid-upload.

Cache-busted per iteration — Cloudflare caches 404s on the custom domain, and a poll starting a moment early would otherwise reread its own cached miss and reproduce the same 30-minute failure for a release that *had* published.

## Verification

| Version | New poll | Note |
|---|---|---|
| 7.0.268 | **PASS** (marker=200, plugin=200) | the release this job failed on |
| 7.0.267 | PASS | pre-cutover, dual published |
| 9.9.999 | keeps waiting (404/404) | does not falsely pass |

## Also audited

This was the **only** remaining Maven Central dependency for Codename One artifacts across all workflows. The two other `repo.maven.apache.org` mentions are comments about an unrelated authorization failure.

Separately confirmed the release pipeline itself is healthy: `release.yml` ran once for 7.0.268 and succeeded, and 7.0.268 is on R2 with its completion marker and `<release>` metadata advanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)