### PR TITLE
Wait for the EXP-004 preview route to accept POSTs before testing it

### DIFF
--- a/docs/website/workers/exp004-telemetry/test/integration.mjs
+++ b/docs/website/workers/exp004-telemetry/test/integration.mjs
@@ -8,25 +8,89 @@ import { fileURLToPath } from "node:url";
 const workerDir = fileURLToPath(new URL("..", import.meta.url));
 const localUrl = "http://127.0.0.1:8797";
 
+async function snapshotIsLive(url) {
+  const response = await fetch(`${url}/api/exp004/snapshot`);
+  if (!response.ok || !(response.headers.get("content-type") || "")
+    .includes("application/json")) {
+    return false;
+  }
+  const payload = await response.json();
+  return payload.experiment_id === "EXP-004";
+}
+
+/*
+ * A cross-site Origin is refused by hasSameOriginBrowserContext before the
+ * worker reads the body or reaches the counter, so this probe costs one
+ * rejected request and records nothing however often the poll loop runs it.
+ * Any status other than 404 means the route is serving: the worker's own
+ * router cannot answer 404 for a POST to this path.
+ */
+async function collectIsRouted(url) {
+  const response = await post(url, {
+    event: "Exp004OwnershipExposure",
+    event_id: crypto.randomUUID(),
+    session_key: crypto.randomUUID(),
+  }, "https://example.com");
+  return response.status !== 404;
+}
+
+/*
+ * Cloudflare answers a request for a freshly deployed workers.dev route with
+ * its own 404 until that route has propagated, and the two verbs do not
+ * become live together: GET /api/exp004/snapshot can already be serving while
+ * the first POST is still 404. Waiting on the GET alone therefore returns
+ * about a second after `wrangler deploy` prints the URL and leaves the run's
+ * first POST to fail as a 404 where the worker itself would have answered 403
+ * or 400. Every assertion after the snapshot block is a POST, so whichever one
+ * happened to land first was the one that failed, which is why this looked
+ * random across branches rather than like one broken endpoint. Probe both
+ * verbs, and report which half was still not ready when the deadline passed.
+ */
 async function waitFor(url, process) {
   const deadline = Date.now() + 90_000;
+  let lastFailure = "no probe completed";
   while (Date.now() < deadline) {
     if (process && process.exitCode !== null) {
       throw new Error(`wrangler exited before becoming ready (${process.exitCode})`);
     }
     try {
-      const response = await fetch(`${url}/api/exp004/snapshot`);
-      if (response.ok && (response.headers.get("content-type") || "")
-        .includes("application/json")) {
-        const payload = await response.json();
-        if (payload.experiment_id === "EXP-004") return;
+      if (!await snapshotIsLive(url)) {
+        lastFailure = "GET /api/exp004/snapshot is not serving the EXP-004 snapshot yet";
+      } else if (await collectIsRouted(url)) {
+        return;
+      } else {
+        lastFailure = "GET /api/exp004/snapshot is live but POST /api/exp004/collect "
+          + "still answers 404, so the route has not propagated";
       }
     } catch (error) {
       // The local runtime or remote hostname is still becoming ready.
+      lastFailure = `probe failed: ${error.message}`;
     }
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
-  throw new Error("timed out waiting for the EXP-004 telemetry worker");
+  throw new Error(
+    `timed out waiting for the EXP-004 telemetry worker: ${lastFailure}`);
+}
+
+/*
+ * assert.equal on response.status alone reports "404 !== 403" and drops the
+ * body, which is the difference between "the edge has not routed us yet" and
+ * "the worker rejected the payload". Keep the body in the failure message; the
+ * response is left unread when the status matches so callers can still parse
+ * it.
+ */
+async function expectStatus(response, expected, what) {
+  if (response.status === expected) {
+    return response;
+  }
+  let body;
+  try {
+    body = (await response.text()).slice(0, 400);
+  } catch (error) {
+    body = `<body unreadable: ${error.message}>`;
+  }
+  assert.fail(
+    `${what}: expected ${expected}, got ${response.status} with body ${body}`);
 }
 
 async function post(baseUrl, body, origin = "https://www.codenameone.com") {
@@ -51,7 +115,7 @@ async function enroll(baseUrl, sessionKey, arm) {
     },
     body: JSON.stringify({ session_key: sessionKey, arm }),
   });
-  assert.equal(response.status, 201);
+  await expectStatus(response, 201, `enroll ${sessionKey} into ${arm}`);
   const payload = await response.json();
   assert.match(payload.submission_token, /^[0-9a-f-]{36}$/);
   return payload.submission_token;
@@ -116,14 +180,14 @@ async function verify(baseUrl) {
     event_id: crypto.randomUUID(),
     session_key: crypto.randomUUID(),
   }, "https://example.com");
-  assert.equal(forbidden.status, 403);
+  await expectStatus(forbidden, 403, "cross-site exposure POST");
 
   const invalid = await post(baseUrl, {
     event: "Exp004UnknownExposure",
     event_id: crypto.randomUUID(),
     session_key: crypto.randomUUID(),
   });
-  assert.equal(invalid.status, 400);
+  await expectStatus(invalid, 400, "unknown event name POST");
 
   const ownershipSession = crypto.randomUUID();
   const ownershipToken = await enroll(baseUrl, ownershipSession, "ownership");
@@ -139,10 +203,10 @@ async function verify(baseUrl) {
     submission_token: ownershipToken,
   };
   const firstExposure = await post(baseUrl, ownershipExposure);
-  assert.equal(firstExposure.status, 202);
+  await expectStatus(firstExposure, 202, "first ownership exposure");
   assert.equal((await firstExposure.json()).accepted, true);
   const duplicateExposure = await post(baseUrl, ownershipExposure);
-  assert.equal(duplicateExposure.status, 200);
+  await expectStatus(duplicateExposure, 200, "duplicate ownership exposure");
   assert.equal((await duplicateExposure.json()).accepted, false);
 
   const reachSession = crypto.randomUUID();
@@ -153,7 +217,7 @@ async function verify(baseUrl) {
     session_key: reachSession,
     submission_token: crypto.randomUUID(),
   });
-  assert.equal(unauthorized.status, 401);
+  await expectStatus(unauthorized, 401, "reach exposure with a foreign token");
 
   const futureDated = await post(baseUrl, {
     event: "Exp004ReachExposure",
@@ -162,7 +226,7 @@ async function verify(baseUrl) {
     session_key: reachSession,
     submission_token: reachToken,
   });
-  assert.equal(futureDated.status, 400);
+  await expectStatus(futureDated, 400, "future dated reach exposure");
 
   const reachDownload = await post(baseUrl, {
     event: "Exp004ReachDownload",
@@ -170,7 +234,7 @@ async function verify(baseUrl) {
     session_key: reachSession,
     submission_token: reachToken,
   });
-  assert.equal(reachDownload.status, 202);
+  await expectStatus(reachDownload, 202, "reach download");
   assert.deepEqual(await reachDownload.json(), {
     accepted: true,
     recovered_exposure: true,
@@ -187,7 +251,7 @@ async function verify(baseUrl) {
     session_key: reachSession,
     submission_token: reachToken,
   });
-  assert.equal(correctedReachExposure.status, 202);
+  await expectStatus(correctedReachExposure, 202, "corrected reach exposure");
   assert.equal((await correctedReachExposure.json()).accepted, true);
 
   const ownershipDownload = await post(baseUrl, {
@@ -196,7 +260,7 @@ async function verify(baseUrl) {
     session_key: ownershipSession,
     submission_token: ownershipToken,
   });
-  assert.equal(ownershipDownload.status, 202);
+  await expectStatus(ownershipDownload, 202, "ownership download");
 
   const snapshot = await fetch(`${baseUrl}/api/exp004/snapshot`).then((r) => r.json());
   assert.deepEqual(snapshot.counts, {

--- a/docs/website/workers/exp004-telemetry/test/integration.mjs
+++ b/docs/website/workers/exp004-telemetry/test/integration.mjs
@@ -22,16 +22,32 @@ async function snapshotIsLive(url) {
  * A cross-site Origin is refused by hasSameOriginBrowserContext before the
  * worker reads the body or reaches the counter, so this probe costs one
  * rejected request and records nothing however often the poll loop runs it.
- * Any status other than 404 means the route is serving: the worker's own
- * router cannot answer 404 for a POST to this path.
+ *
+ * Readiness is that exact 403 and its body, not merely "not a 404". A Worker
+ * whose bindings are still initializing, or an edge that is having a bad
+ * minute, answers 5xx; treating anything non-404 as ready would let waitFor
+ * return on one of those and hand the transient error straight to the first
+ * assertion -- the failure this whole probe exists to stop. Only
+ * forbidden_browser_context proves the request reached our handler and ran it.
+ *
+ * Returns null once ready, otherwise a description of what answered instead.
  */
-async function collectIsRouted(url) {
+async function collectNotReady(url) {
   const response = await post(url, {
     event: "Exp004OwnershipExposure",
     event_id: crypto.randomUUID(),
     session_key: crypto.randomUUID(),
   }, "https://example.com");
-  return response.status !== 404;
+  if (response.status !== 403) {
+    return `POST /api/exp004/collect answered ${response.status}, not the 403 the `
+      + "live handler returns for a cross-site Origin";
+  }
+  const payload = await response.json().catch(() => null);
+  if (!payload || payload.error !== "forbidden_browser_context") {
+    return "POST /api/exp004/collect answered 403 without the worker's "
+      + "forbidden_browser_context body, so something ahead of the worker refused it";
+  }
+  return null;
 }
 
 /*
@@ -56,11 +72,12 @@ async function waitFor(url, process) {
     try {
       if (!await snapshotIsLive(url)) {
         lastFailure = "GET /api/exp004/snapshot is not serving the EXP-004 snapshot yet";
-      } else if (await collectIsRouted(url)) {
-        return;
       } else {
-        lastFailure = "GET /api/exp004/snapshot is live but POST /api/exp004/collect "
-          + "still answers 404, so the route has not propagated";
+        const notReady = await collectNotReady(url);
+        if (notReady === null) {
+          return;
+        }
+        lastFailure = `GET /api/exp004/snapshot is live but ${notReady}`;
       }
     } catch (error) {
       // The local runtime or remote hostname is still becoming ready.


### PR DESCRIPTION
The *Deploy and verify isolated EXP-004 counter preview* step added in #5613 is red on every PR, and it fails at a **different** assertion on each branch:

| run | branch | assertion | got |
| --- | --- | --- | --- |
| 33179482182 | issue-5612-side-menu-theme-refresh | `forbidden.status === 403` | 404 |
| 33179593630 | device-runtime | `invalid.status === 400` | 404 |

That is one cause, not several.

## Root cause

Cloudflare answers a request for a freshly deployed `workers.dev` route with its own 404 until the route has propagated, and the verbs do not go live together. `waitFor` polled only `GET /api/exp004/snapshot`, so it returned about a second after `wrangler deploy` printed the URL -- in run 33179482182, **1.4 s** elapsed between the URL being printed and the assertion failing -- while `POST /api/exp004/collect` was still 404.

Every assertion after the snapshot block is a POST, so whichever one landed first is the one that failed. Hence the moving assertion and the appearance of a flake.

The worker's own router cannot return 404 for a POST to that path (`src/index.js:314` matches on pathname *and* method, and falls through to 404 only when neither matches), so the 404 was always the edge, never the code under test.

## Fix

- `waitFor` probes both verbs. The POST probe sends a cross-site `Origin`, which `hasSameOriginBrowserContext` refuses **before** the worker reads the body or reaches the Durable Object, so it can run on every poll without recording an event or touching the rate limiter.
- The timeout message now names which half was still not ready.
- Status assertions go through `expectStatus`, which puts the response body in the failure message. `404 !== 403` cannot distinguish an unrouted edge from a payload the worker rejected; `{"error":"not_found"}` vs `{"error":"invalid_event"}` can. The response is left unread when the status matches, so the call sites that parse the body still work.

## Verification

- `node test/integration.mjs` against `wrangler dev`: **passes** (`EXP-004 local Durable Object integration passed`).
- Non-vacuity: inverting the POST probe to `status === 404` makes the run time out with the new diagnostic --
  `timed out waiting for the EXP-004 telemetry worker: GET /api/exp004/snapshot is live but POST /api/exp004/collect still answers 404, so the route has not propagated`
  -- so the probe is really consulted rather than passing by accident.
- `expectStatus` checked directly: failure renders `cross-site exposure POST: expected 403, got 404 with body {"error":"not_found"}`, and a matching response is still parseable by the caller.

Unblocks #5619 and the other branches currently red on this step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
