### PR TITLE
Wait for the EXP-004 preview route to settle, not just to answer once

### DIFF
--- a/docs/website/workers/exp004-telemetry/test/integration.mjs
+++ b/docs/website/workers/exp004-telemetry/test/integration.mjs
@@ -124,8 +124,8 @@ async function waitFor(url, process) {
  */
 async function readSnapshot(baseUrl) {
   const deadline = Date.now() + 30_000;
-  let lastFailure = "no attempt completed";
   for (;;) {
+    let failure;
     try {
       const response = await fetch(`${baseUrl}/api/exp004/snapshot`);
       const contentType = response.headers.get("content-type") || "";
@@ -133,14 +133,14 @@ async function readSnapshot(baseUrl) {
         return await response.json();
       }
       const body = (await response.text()).slice(0, 200).replace(/\s+/g, " ");
-      lastFailure = `${response.status} `
+      failure = `${response.status} `
         + `${contentType || "with no content-type"}: ${body}`;
     } catch (error) {
-      lastFailure = error.message;
+      failure = error.message;
     }
     if (Date.now() >= deadline) {
       throw new Error(
-        `GET /api/exp004/snapshot never returned the worker's JSON: ${lastFailure}`);
+        `GET /api/exp004/snapshot never returned the worker's JSON: ${failure}`);
     }
     await new Promise((resolve) => setTimeout(resolve, 250));
   }

--- a/docs/website/workers/exp004-telemetry/test/integration.mjs
+++ b/docs/website/workers/exp004-telemetry/test/integration.mjs
@@ -7,6 +7,9 @@ import { fileURLToPath } from "node:url";
 
 const workerDir = fileURLToPath(new URL("..", import.meta.url));
 const localUrl = "http://127.0.0.1:8797";
+// How long the deployed route has to keep answering correctly before the
+// suite trusts it. Cloudflare propagation is per-request, not a switch.
+const ROUTE_SETTLE_MS = 10_000;
 
 async function snapshotIsLive(url) {
   const response = await fetch(`${url}/api/exp004/snapshot`);
@@ -51,42 +54,96 @@ async function collectNotReady(url) {
 }
 
 /*
+ * One healthy round, on both verbs. Returns null when that round passed,
+ * otherwise a description of what was not ready.
+ */
+async function probeOnce(url) {
+  if (!await snapshotIsLive(url)) {
+    return "GET /api/exp004/snapshot is not serving the EXP-004 snapshot yet";
+  }
+  const notReady = await collectNotReady(url);
+  return notReady === null ? null : `GET /api/exp004/snapshot is live but ${notReady}`;
+}
+
+/*
  * Cloudflare answers a request for a freshly deployed workers.dev route with
- * its own 404 until that route has propagated, and the two verbs do not
- * become live together: GET /api/exp004/snapshot can already be serving while
- * the first POST is still 404. Waiting on the GET alone therefore returns
- * about a second after `wrangler deploy` prints the URL and leaves the run's
- * first POST to fail as a 404 where the worker itself would have answered 403
- * or 400. Every assertion after the snapshot block is a POST, so whichever one
- * happened to land first was the one that failed, which is why this looked
- * random across branches rather than like one broken endpoint. Probe both
- * verbs, and report which half was still not ready when the deadline passed.
+ * its own 404, or a plain HTML error page, until that route has propagated -
+ * and propagation is neither monotonic nor global. One healthy round proves
+ * nothing about the next request: a run that had just seen the snapshot serve
+ * JSON and the collect endpoint return its own 403 went on to get
+ * `<!DOCTYPE html>` from that same snapshot URL 0.75s later.
+ *
+ * So readiness is not "a probe passed", it is "the route has been answering
+ * correctly for a while". Both verbs must keep passing for ROUTE_SETTLE_MS
+ * without a single miss; any failure restarts that clock. The suite's POSTs
+ * record telemetry, so they cannot be retried without distorting the counts it
+ * asserts - waiting for the route to settle is the only lever that does not
+ * change what is being tested.
  */
 async function waitFor(url, process) {
   const deadline = Date.now() + 90_000;
+  let healthySince = null;
   let lastFailure = "no probe completed";
   while (Date.now() < deadline) {
     if (process && process.exitCode !== null) {
       throw new Error(`wrangler exited before becoming ready (${process.exitCode})`);
     }
+    let failure;
     try {
-      if (!await snapshotIsLive(url)) {
-        lastFailure = "GET /api/exp004/snapshot is not serving the EXP-004 snapshot yet";
-      } else {
-        const notReady = await collectNotReady(url);
-        if (notReady === null) {
-          return;
-        }
-        lastFailure = `GET /api/exp004/snapshot is live but ${notReady}`;
-      }
+      failure = await probeOnce(url);
     } catch (error) {
       // The local runtime or remote hostname is still becoming ready.
-      lastFailure = `probe failed: ${error.message}`;
+      failure = `probe failed: ${error.message}`;
+    }
+    if (failure === null) {
+      if (healthySince === null) {
+        healthySince = Date.now();
+      }
+      const healthyFor = Date.now() - healthySince;
+      if (healthyFor >= ROUTE_SETTLE_MS) {
+        return;
+      }
+      lastFailure = `the route has only been healthy for ${healthyFor}ms of the `
+        + `${ROUTE_SETTLE_MS}ms it has to hold`;
+    } else {
+      healthySince = null;
+      lastFailure = failure;
     }
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
   throw new Error(
     `timed out waiting for the EXP-004 telemetry worker: ${lastFailure}`);
+}
+
+/*
+ * A bare `.json()` on the snapshot turns an edge error page into
+ * "SyntaxError: Unexpected token '<'" from deep inside undici, which names
+ * neither the URL nor the status. Check what came back, say so when it is not
+ * ours, and retry: this GET is idempotent, so unlike the POSTs it can be
+ * repeated without changing a single count the suite asserts on.
+ */
+async function readSnapshot(baseUrl) {
+  const deadline = Date.now() + 30_000;
+  let lastFailure = "no attempt completed";
+  for (;;) {
+    try {
+      const response = await fetch(`${baseUrl}/api/exp004/snapshot`);
+      const contentType = response.headers.get("content-type") || "";
+      if (response.ok && contentType.includes("application/json")) {
+        return await response.json();
+      }
+      const body = (await response.text()).slice(0, 200).replace(/\s+/g, " ");
+      lastFailure = `${response.status} `
+        + `${contentType || "with no content-type"}: ${body}`;
+    } catch (error) {
+      lastFailure = error.message;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `GET /api/exp004/snapshot never returned the worker's JSON: ${lastFailure}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
 }
 
 /*
@@ -179,7 +236,7 @@ async function stopProcess(child) {
 
 async function verify(baseUrl) {
   const testStartedAt = Date.now();
-  const initial = await fetch(`${baseUrl}/api/exp004/snapshot`).then((r) => r.json());
+  const initial = await readSnapshot(baseUrl);
   assert.equal(initial.experiment_id, "EXP-004");
   assert.equal(initial.original_experiment_start, "2026-08-27T04:35:14.000Z");
   assert.equal(initial.coverage_complete_from_original_start, false);
@@ -279,7 +336,7 @@ async function verify(baseUrl) {
   });
   await expectStatus(ownershipDownload, 202, "ownership download");
 
-  const snapshot = await fetch(`${baseUrl}/api/exp004/snapshot`).then((r) => r.json());
+  const snapshot = await readSnapshot(baseUrl);
   assert.deepEqual(snapshot.counts, {
     ownership: { exposures: 1, downloads: 1 },
     reach: { exposures: 1, downloads: 1 },


### PR DESCRIPTION
Follow-up to #5620. That change made the suite wait until **both** verbs answered correctly before starting. It was still not enough, and the next failure showed why.

## Evidence

Run [33186782540](https://github.com/codenameone/CodenameOne/actions/runs/33186782540/job/98901713940):

```
16:10:18.729  Deployed ... https://cn1-exp004-pr-5619-....workers.dev
16:10:19.481  SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON
                  at async verify (.../test/integration.mjs:182:19)
```

**0.75 s.** In that window the probe had already seen `GET /api/exp004/snapshot` serve JSON *and* `POST /api/exp004/collect` return the worker's own 403 with `forbidden_browser_context`. `verify()`'s very first snapshot GET — the same URL, moments later — came back as an HTML error page.

So propagation of a new `workers.dev` route is **per-request, not a switch**. My model in #5620 ("once routed, it's routed") was wrong: one healthy round says nothing about the next request.

## Fix

Readiness is no longer "a probe passed", it is "the route has been answering correctly for a while". Both verbs must keep passing for `ROUTE_SETTLE_MS` (10 s) with no miss; **any** failure restarts the clock.

The suite's POSTs record telemetry and cannot be retried without distorting the counts it asserts, so settling is the only lever that does not change what is being tested. The snapshot GET *is* idempotent, so it gets a bounded retry — and a check on what actually came back, because a bare `.json()` rendered that HTML page as `SyntaxError: Unexpected token '<'` from inside undici, naming neither the URL nor the status.

## Verification

- `node test/integration.mjs` against `wrangler dev`: passes, 12.6 s (the settle window is the added cost).
- Settle clock really resets: injecting a probe that fails every other round makes the run time out (`timed out waiting for the EXP-004 telemetry worker: injected flap`) instead of starting.
- `readSnapshot` exercised directly: recovers after two error pages, and when the endpoint stays broken fails with
  `GET /api/exp004/snapshot never returned the worker's JSON: 530 text/html: <!DOCTYPE html> <html>error</html>`.

## Residual risk, stated plainly

A hiccup arriving after ten continuous healthy seconds would still fail a POST assertion. That is not fully closable without making the telemetry POSTs retryable, which would change what the suite measures. It will now report the response body, so it is one read to diagnose rather than a bare status mismatch.

Unblocks the `build` check on #5619.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
