### PR TITLE
Restore signup-first website funnel

### DIFF
--- a/.github/workflows/website-docs.yml
+++ b/.github/workflows/website-docs.yml
@@ -211,9 +211,10 @@ jobs:
           node docs/website/scripts/test-initializr-download-bridge.mjs \
             docs/website/public/initializr-app/com_codename1_initializr_WebsiteThemeNative.js
 
-      - name: Validate website experiment telemetry
+      - name: Validate website conversion telemetry
         run: |
           set -euo pipefail
+          node docs/website/scripts/test-signup-funnel.mjs docs/website/public
           node docs/website/scripts/test-cn1-exp-004.mjs
           node docs/website/scripts/test-cn1-crisp-events.mjs
 

--- a/docs/website/assets/css/extended/cn1-home.css
+++ b/docs/website/assets/css/extended/cn1-home.css
@@ -2,14 +2,3 @@
  * The homepage and shared navigation styles moved to zz-cn1-design-system.css.
  * Keep this file as a stable Hugo asset entry point for downstream overrides.
  */
-.cn1-exp004-copy--reach {
-  display: none;
-}
-
-html[data-cn1-exp004-arm="reach"] .cn1-exp004-copy--ownership {
-  display: none;
-}
-
-html[data-cn1-exp004-arm="reach"] .cn1-exp004-copy--reach {
-  display: block;
-}

--- a/docs/website/assets/js/cn1-crisp.js
+++ b/docs/website/assets/js/cn1-crisp.js
@@ -5,7 +5,6 @@
   const CONSENT_TTL_DAYS = 365;
   const CONVERSION_ARRIVAL_KEY = "cn1-conversion-arrival-v1";
   const OSS_ATTRIBUTION_KEY = "cn1-oss-attribution-v1";
-  const EXP004_STORAGE_KEY = "cn1-exp-004-arm-v1";
   const EXP004_COUNTER_SESSION_KEY = "cn1-exp-004-counter-session-v1";
   const EXP004_COUNTER_TOKEN_KEY = "cn1-exp-004-counter-token-v1";
   const EXP004_COUNTER_EVENT_PREFIX = "cn1-exp-004-counter-event-v1-";
@@ -122,17 +121,10 @@
       return null;
     }
     const experiment = window.cn1Exp004;
-    if (experiment && experiment.telemetryEnabled === false) {
+    if (!experiment || experiment.telemetryEnabled === false) {
       return null;
     }
-    let arm = experiment && experiment.arm;
-    if (arm !== "ownership" && arm !== "reach") {
-      try {
-        arm = localStorage.getItem(EXP004_STORAGE_KEY);
-      } catch (e) {
-        return null;
-      }
-    }
+    const arm = experiment.arm;
     if (arm !== "ownership" && arm !== "reach") {
       return null;
     }

--- a/docs/website/hugo.toml
+++ b/docs/website/hugo.toml
@@ -189,6 +189,6 @@ weight = 90
 
 [[menu.main]]
 identifier = "create-project"
-name = "Create Project"
-url = "/initializr/"
+name = "Sign Up"
+url = "https://cloud.codenameone.com/register"
 weight = 100

--- a/docs/website/layouts/_default/compare.html
+++ b/docs/website/layouts/_default/compare.html
@@ -6,7 +6,7 @@
     <h1>Native apps from Java, without a browser or scripting bridge.</h1>
     <p>Codename One runs Java on Android's native runtime and translates Java bytecode to C for a native iOS build. You keep one UI and application codebase, use the Java ecosystem, and ship without royalties or a platform vendor setting the framework agenda.</p>
     <div class="cn1-action-row">
-      {{ partial "cn1-cta.html" (dict "label" "Create a Java project" "href" "/initializr/" "event" "compare-project") }}
+      {{ partial "cn1-cta.html" (dict "label" "Create a free account" "href" "https://cloud.codenameone.com/register" "event" "compare-signup") }}
       {{ partial "cn1-cta.html" (dict "label" "See the architecture" "href" "#matrix" "variant" "secondary") }}
     </div>
   </header>
@@ -86,8 +86,8 @@
   </section>
 
   <section class="cn1-v2-final cn1-compare-final">
-    <div><p class="cn1-eyebrow">Keep the codebase</p><h2>Create a Java project and test the architecture yourself.</h2><p>The framework is open source and royalty free. The free cloud tier includes 100 free cloud build credits each month.</p></div>
-    <div class="cn1-action-row">{{ partial "cn1-cta.html" (dict "label" "Create a Java project" "href" "/initializr/" "event" "compare-final-project") }}</div>
+    <div><p class="cn1-eyebrow">Keep the codebase</p><h2>Create a free account and test the architecture yourself.</h2><p>The framework is open source and royalty free. The free cloud tier includes 100 free cloud build credits each month.</p></div>
+    <div class="cn1-action-row">{{ partial "cn1-cta.html" (dict "label" "Create a free account" "href" "https://cloud.codenameone.com/register" "event" "compare-final-signup") }}</div>
   </section>
 </article>
 {{- end -}}

--- a/docs/website/layouts/_default/pricing.html
+++ b/docs/website/layouts/_default/pricing.html
@@ -27,7 +27,7 @@
       <li><strong>8.5 MB</strong><span>user JAR limit</span></li>
       <li><strong>JavaScript</strong><span>cloud and local web builds</span></li>
     </ul>
-    {{ partial "cn1-cta.html" (dict "label" "Create a free project" "href" "/initializr/" "event" "pricing-free-project") }}
+    {{ partial "cn1-cta.html" (dict "label" "Create a free account" "href" "https://cloud.codenameone.com/register" "event" "pricing-free-signup") }}
   </section>
 
   <section class="cn1-pricing-controls" data-billing-toggle>

--- a/docs/website/layouts/index.html
+++ b/docs/website/layouts/index.html
@@ -2,18 +2,13 @@
 <div class="cn1-home-v2">
   <section class="cn1-v2-hero">
     <div class="cn1-v2-hero__copy">
-      <p class="cn1-eyebrow cn1-exp004-copy cn1-exp004-copy--ownership">Native, and you own the UI</p>
-      <h1 class="cn1-exp004-copy cn1-exp004-copy--ownership">Native apps in Java<br><span>A UI you control</span></h1>
-      <p class="cn1-v2-hero__lead cn1-exp004-copy cn1-exp004-copy--ownership">
+      <p class="cn1-eyebrow">Native, and you own the UI</p>
+      <h1>Native apps in Java<br><span>A UI you control</span></h1>
+      <p class="cn1-v2-hero__lead">
         Codename One compiles one Java codebase into native apps across mobile, desktop, web, watch, TV, and vehicles. Its UI ships with your app instead of being restyled by the platform after release.
       </p>
-      <p class="cn1-eyebrow cn1-exp004-copy cn1-exp004-copy--reach">One Java project across every screen</p>
-      <h1 class="cn1-exp004-copy cn1-exp004-copy--reach">Ship one feature once<br><span>Reach every target</span></h1>
-      <p class="cn1-v2-hero__lead cn1-exp004-copy cn1-exp004-copy--reach">
-        Codename One compiles one Java codebase for iOS, Android, desktop, web, watch, TV, and vehicles. Application logic and UI stay shared, so you fix and ship the feature once.
-      </p>
       <div class="cn1-action-row">
-        {{ partial "cn1-cta.html" (dict "label" "Create a Java project" "href" "/initializr/" "event" "home-primary-project") }}
+        {{ partial "cn1-cta.html" (dict "label" "Create a free account" "href" "https://cloud.codenameone.com/register" "event" "home-primary-signup") }}
         {{ partial "cn1-cta.html" (dict "label" "View source on GitHub" "href" "https://github.com/codenameone/CodenameOne" "variant" "secondary" "external" true) }}
       </div>
       <p class="cn1-v2-hero__note">GPLv2 with the Classpath Exception. Free for commercial use. No royalties.</p>
@@ -194,11 +189,11 @@ app.show();</code></pre>
   <section class="cn1-v2-final">
     <div>
       <p class="cn1-eyebrow">Start with the real thing</p>
-      <h2>Create the project. Run it locally. Build for iOS.</h2>
-      <p>The framework is open source and free to use commercially. Initializr generates a Maven project you can run locally, then build with local or cloud toolchains.</p>
+      <h2>Create your account. Build for iOS.</h2>
+      <p>The framework is open source and free to use commercially. A free account includes 100 cloud build credits each month, including iOS builds without a Mac.</p>
     </div>
     <div class="cn1-action-row">
-      {{ partial "cn1-cta.html" (dict "label" "Create a Java project" "href" "/initializr/" "event" "home-final-project") }}
+      {{ partial "cn1-cta.html" (dict "label" "Create a free account" "href" "https://cloud.codenameone.com/register" "event" "home-final-signup") }}
       {{ partial "cn1-cta.html" (dict "label" "Follow the build guide" "href" "/getting-started/" "variant" "secondary") }}
     </div>
   </section>

--- a/docs/website/layouts/partials/extend_head.html
+++ b/docs/website/layouts/partials/extend_head.html
@@ -1,8 +1,4 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
-{{- if .IsHome -}}
-  {{- $cn1Exp004 := resources.Get "js/cn1-exp-004.js" | minify | fingerprint -}}
-<script src="{{ $cn1Exp004.RelPermalink }}" integrity="{{ $cn1Exp004.Data.Integrity }}"></script>
-{{- end -}}
 {{- if eq .Layout "developer-guide" -}}
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   {{- $asciidoctorCssPath := "static/developer-guide/asciidoctor-scoped.css" -}}

--- a/docs/website/scripts/test-cn1-crisp-events.mjs
+++ b/docs/website/scripts/test-cn1-crisp-events.mjs
@@ -39,7 +39,8 @@ function load(
   hostname = "www.codenameone.com",
   legacyConsent = null,
   sessionStore = storage(),
-  fetchHandler = null
+  fetchHandler = null,
+  exposeExperiment = true
 ) {
   const timers = [];
   const timerDelays = [];
@@ -123,7 +124,7 @@ function load(
       return timers.length;
     },
   };
-  if (experimentArm) {
+  if (experimentArm && exposeExperiment) {
     window.cn1Exp004 = {
       id: "EXP-004",
       arm: experimentArm,
@@ -187,6 +188,17 @@ function normalizedCounterBody(options) {
     body.occurred_at = "<occurred_at>";
   }
   return body;
+}
+
+{
+  const state = load(
+    "accepted", "", "/", "reach", true, "www.codenameone.com", null,
+    storage(), null, false
+  );
+  assert.equal(eventCommands(state).length, 0,
+    "a retired experiment must not resume from a stale stored assignment");
+  assert.equal(state.fetches.length, 0,
+    "a retired experiment must not send exposure telemetry");
 }
 
 {

--- a/docs/website/scripts/test-signup-funnel.mjs
+++ b/docs/website/scripts/test-signup-funnel.mjs
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const publicDir = path.resolve(process.argv[2] || "docs/website/public");
+const registerUrl = "https://cloud.codenameone.com/register";
+
+function page(name) {
+  const file = name === "home"
+    ? path.join(publicDir, "index.html")
+    : path.join(publicDir, name, "index.html");
+  assert.ok(fs.existsSync(file), `missing generated ${name} page: ${file}`);
+  return fs.readFileSync(file, "utf8");
+}
+
+function assertSignupCta(html, event) {
+  const link = new RegExp(
+    `<a[^>]+href=["']${registerUrl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}["'][^>]+data-cn1-conversion=["']${event}["']|` +
+    `<a[^>]+data-cn1-conversion=["']${event}["'][^>]+href=["']${registerUrl.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}["']`,
+    "i"
+  );
+  assert.match(html, link, `${event} must send directly to registration`);
+}
+
+const home = page("home");
+const pricing = page("pricing");
+const compare = page("compare");
+
+assertSignupCta(home, "home-primary-signup");
+assertSignupCta(home, "home-final-signup");
+assertSignupCta(pricing, "pricing-free-signup");
+assertSignupCta(compare, "compare-signup");
+assertSignupCta(compare, "compare-final-signup");
+
+assert.match(home, /<a[^>]+href=["']https:\/\/cloud\.codenameone\.com\/register["'][^>]*>[\s\S]*?Sign Up/i,
+  "the global header must expose registration");
+assert.match(home, /href=["']\/initializr\/["']/i,
+  "Initializr must remain available as an explicit project-generation tool");
+assert.doesNotMatch(home, /cn1-exp-004/i,
+  "the retired download experiment must not enroll new homepage visitors");
+
+for (const html of [home, pricing, compare]) {
+  assert.doesNotMatch(html, /(?:home-(?:primary|final)|pricing-free|compare(?:-final)?)-project/i,
+    "primary funnel CTAs must not regress to the project-first route");
+}
+
+console.log(`Validated signup-first routing in ${publicDir}`);


### PR DESCRIPTION
## Summary

- route the homepage, pricing, comparison, and global header conversion CTAs directly to BuildCloud registration
- keep Initializr available as an explicit project-generation tool in Tools, Getting Started, the footer, and documentation
- stop new EXP-004 enrollment because its Initializr-download outcome is incompatible with the corrected signup-first path
- prevent stale browser assignments from resuming the retired experiment
- add a rendered-output regression test that fails if primary funnel CTAs return to the project-first route

## Why

The signup dry spell did not track the size of the website traffic decline, and the public registration/OAuth entry points remained healthy. The strongest actionable gap was the July change that replaced direct free-account CTAs with Initializr links. That allowed high-intent visitors to generate a project without entering the observable BuildCloud signup funnel.

This restores signup as the explicit activation step while preserving Initializr for visitors who deliberately choose project generation. Existing EXP-004 observations remain historical, but the experiment no longer enrolls visitors because its download denominator is no longer valid for this funnel.

## Verification

- live registration endpoint returned HTTP 200 and exposed password, GitHub, and Google account creation
- Hugo 0.151.2 rendered 1,284 pages successfully
- `node docs/website/scripts/test-signup-funnel.mjs /tmp/cn1-signup-first-funnel-public`
- `node docs/website/scripts/test-cn1-exp-004.mjs`
- `node docs/website/scripts/test-cn1-crisp-events.mjs`
- `node scripts/website/validate_compare_page.mjs /tmp/cn1-signup-first-funnel-public`
- `git diff --check`
