### PR TITLE
Give the build hints screen a scrolling list instead of one enormous page (issue #5602)

### DIFF
--- a/scripts/settings/common/src/main/css/theme.css
+++ b/scripts/settings/common/src/main/css/theme.css
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 #Constants {
     includeNativeBool: true;
     defaultSourceDPIInt: "0";
@@ -202,6 +224,42 @@ SettingsFilterRow, SettingsFilterRowDark, SettingsList, SettingsListDark {
     padding: 0;
     margin: 0;
 }
+/* The desktop scrollbar. Its UIIDs are fixed by the look and feel -- the port
+   turns it on with interactiveScrollbars and the theme is asked for "Scroll"
+   and "ScrollThumb" by those exact names -- so unlike every other style here
+   they cannot have a Dark twin that the app switches to. The track is left
+   transparent and the thumb is given a tone that reads on both the white page
+   and the navy one. Without these rules the bar is drawn with an empty style,
+   which is why a list that scrolled perfectly well looked like it had no
+   scrollbar at all. */
+DesktopScroll, DesktopHorizontalScroll {
+    background-color: transparent;
+    padding: 0 0.9mm 0 0.9mm;
+    margin: 0;
+}
+DesktopScrollThumb, DesktopHorizontalScrollThumb {
+    background-color: #7E93BC;
+    cn1-background-type: cn1-round-border;
+    padding: 0;
+    margin: 0;
+}
+DesktopScrollThumb.selected, DesktopHorizontalScrollThumb.selected {
+    background-color: #5C79AE;
+    cn1-background-type: cn1-round-border;
+    padding: 0;
+    margin: 0;
+}
+DesktopScrollThumb.pressed, DesktopHorizontalScrollThumb.pressed {
+    background-color: #4D86FF;
+    cn1-background-type: cn1-round-border;
+    padding: 0;
+    margin: 0;
+}
+SettingsHintSearchCell, SettingsHintSearchCellDark {
+    background-color: transparent;
+    padding: 0;
+    margin: 0 0 0 4mm;
+}
 
 SettingsIconDrop, SettingsIconDropDark {
     border-width: 1px;
@@ -257,12 +315,21 @@ SettingsSwitch.selected, SettingsSwitchDark.selected {
     margin: 0 1.2mm 0 2mm;
 }
 
-SettingsCard, SettingsCardDark, SettingsRow, SettingsRowDark {
+SettingsCard, SettingsCardDark {
     border-width: 1px;
     border-style: solid;
     border-radius: 1mm;
     padding: 3mm 3.2mm 3mm 3.2mm;
     margin: 0 0 1.4mm 0;
+}
+/* A hint row is one of a handful that have to fit between a pinned search box
+   and a pager, so it spends less height on air than a card that scrolls. */
+SettingsRow, SettingsRowDark {
+    border-width: 1px;
+    border-style: solid;
+    border-radius: 1mm;
+    padding: 2.2mm 3.2mm 2.2mm 3.2mm;
+    margin: 0 0 1.2mm 0;
 }
 SettingsCardTitle, SettingsCardTitleDark, SettingsRowTitle, SettingsRowTitleDark {
     background-color: transparent;

--- a/scripts/settings/common/src/main/java/com/codename1/settings/CodenameOneSettings.java
+++ b/scripts/settings/common/src/main/java/com/codename1/settings/CodenameOneSettings.java
@@ -59,6 +59,7 @@ import com.codename1.ui.Label;
 import com.codename1.ui.TextArea;
 import com.codename1.ui.TextField;
 import com.codename1.ui.Toolbar;
+import com.codename1.ui.InfiniteContainer;
 import com.codename1.ui.events.FocusListener;
 import com.codename1.ui.layouts.BorderLayout;
 import com.codename1.ui.layouts.BoxLayout;
@@ -107,6 +108,11 @@ public class CodenameOneSettings extends Lifecycle {
     private int fontDeltaPx;
     private float fontPinchAccumulator = 1f;
     private String hintFilter = "";
+    /// Every hint the current filter matches, in display order. The list builds
+    /// rows from it one batch at a time as the reader scrolls.
+    private final List<BuildHintMetadata> hintModel = new java.util.ArrayList<BuildHintMetadata>();
+    private InfiniteContainer hintList;
+    private Label hintCount;
     private String extensionFilter = "";
     private List<ExtensionDescriptor> extensionCatalog;
     private final Map<String, Boolean> expandedExtensions = new LinkedHashMap<String, Boolean>();
@@ -255,19 +261,42 @@ public class CodenameOneSettings extends Lifecycle {
 
     private void buildShell() {
         form.getContentPane().removeAll();
-        page = new Container(BoxLayout.y());
+        // Build Hints owns its own height instead of growing a scroll region.
+        // There are hundreds of hints and every one of them is a multi-line card,
+        // so the scrolled page was tens of screens tall: reaching the bottom took
+        // a wheel marathon (issue #5602) and every wheel notch repainted a huge
+        // container. That page now pins its search and its pager and fills the
+        // space between them with as many rows as actually fit.
+        boolean fillsViewport = section == Section.BUILD_HINTS;
+        page = new Container(fillsViewport ? new BorderLayout() : BoxLayout.y());
         renderPage();
-        pageViewport = new Container(BoxLayout.y());
-        pageViewport.setScrollableY(true);
+        pageViewport = new Container(fillsViewport ? new BorderLayout() : BoxLayout.y());
+        pageViewport.setScrollableY(!fillsViewport);
         pageViewport.setUIID(uiid("SettingsPage"));
         TableLayout contentLayout = new TableLayout(1, 2);
         Container pageRow = new Container(contentLayout);
-        int contentPercent = Display.getInstance().getDisplayWidth() < 1100 || section == Section.EXTENSIONS ? 100 : 72;
-        pageRow.add(contentLayout.createConstraint(0, 0).widthPercentage(contentPercent), page);
+        // Hints take the full width for the same reason Extensions does: a form
+        // wants a readable measure, a list of cards wants the width. Here it also
+        // buys rows -- a description that wraps into two lines instead of three
+        // is a third of a row's height back, and every row back is one more hint
+        // on the page.
+        int contentPercent = Display.getInstance().getDisplayWidth() < 1100
+                || section == Section.EXTENSIONS || section == Section.BUILD_HINTS ? 100 : 72;
+        // A TableLayout row is as tall as its tallest cell wants to be, so the
+        // page only reaches the bottom of the window when the row is told to.
+        TableLayout.Constraint pageCell = contentLayout.createConstraint(0, 0).widthPercentage(contentPercent);
+        if (fillsViewport) {
+            pageCell.heightPercentage(100);
+        }
+        pageRow.add(pageCell, page);
         if (contentPercent < 100) {
             pageRow.add(contentLayout.createConstraint(0, 1).widthPercentage(100 - contentPercent), new Container());
         }
-        pageViewport.add(pageRow);
+        if (fillsViewport) {
+            pageViewport.add(BorderLayout.CENTER, pageRow);
+        } else {
+            pageViewport.add(pageRow);
+        }
         form.add(BorderLayout.NORTH, configureToolbar());
         form.add(BorderLayout.CENTER, BorderLayout.center(pageViewport).add(BorderLayout.WEST, rail()));
         applyFontScale(form);
@@ -575,22 +604,36 @@ public class CodenameOneSettings extends Lifecycle {
     }
 
     private void renderBuildHints() {
-        page.add(pageTitle("Build Hints", "Search known hints from the developer guide, or add arbitrary build arguments."));
+        Container header = new Container(BoxLayout.y());
+        // Title and search share a line, and the standing subtitle is gone. Every
+        // other page can spend a third of the window explaining itself because it
+        // scrolls; this one does not scroll -- the list inside it does -- so a
+        // line spent on chrome is a line the rows never get back. A search box
+        // labelled "Search build hints" under a heading that says "Build Hints"
+        // was explaining itself twice anyway.
         Container filter = new Container(new BorderLayout());
         filter.setUIID(uiid("SettingsFilterRow"));
+        filter.add(BorderLayout.WEST, new Label("Build Hints", uiid("SettingsPageTitle")));
         TextField search = new TextField(hintFilter, "Search build hints");
         search.setUIID(uiid("SettingsField"));
         search.addDataChangedListener((type, index) -> {
             hintFilter = search.getText() == null ? "" : search.getText();
             renderBuildHintsList();
         });
-        filter.add(BorderLayout.CENTER, search);
-        page.add(filter);
-        page.add(customHintRow());
-        Container list = new Container(BoxLayout.y());
-        list.setName("buildHintsList");
-        list.setUIID(uiid("SettingsList"));
-        page.add(list);
+        Container searchCell = BorderLayout.center(search);
+        searchCell.setUIID(uiid("SettingsHintSearchCell"));
+        filter.add(BorderLayout.CENTER, searchCell);
+        hintCount = new Label("", uiid("SettingsRowMeta"));
+        Container countCell = BorderLayout.center(hintCount);
+        countCell.setUIID(uiid("SettingsHintSearchCell"));
+        filter.add(BorderLayout.EAST, countCell);
+        header.add(filter);
+        header.add(customHintRow());
+        page.add(BorderLayout.NORTH, header);
+        hintList = new HintList();
+        hintList.setName("buildHintsList");
+        hintList.setUIID(uiid("SettingsList"));
+        page.add(BorderLayout.CENTER, hintList);
         renderBuildHintsList();
     }
 
@@ -642,9 +685,50 @@ public class CodenameOneSettings extends Lifecycle {
         return row;
     }
 
+    /// How many rows a page starts by building. The layout shows the ones that
+    /// fit and hides the rest, so this only has to beat the row count of an
+    /// ordinary window -- building the whole catalog is what made this page
+    /// expensive. A window that fits more than this grows its own window through
+    /// `hintPageFitChanged`.
+    /// How many rows the list asks for at a time. Small enough that the first
+    /// screenful is on the display immediately and a filter keystroke costs
+    /// almost nothing, large enough that a fast drag does not out-run it.
+    private static final int HINT_FETCH_BATCH = 20;
+
+    /// The scrolling list of hint rows.
+    ///
+    /// An `InfiniteContainer` because the rows are not the same height -- a
+    /// description wraps to as many lines as it needs, an active row carries an
+    /// editor, an annotation-owned one carries a paragraph -- and because there
+    /// are hundreds of them. It hands out one batch at a time as the reader
+    /// scrolls, so the page costs a screenful of components instead of the whole
+    /// catalog, which is what made scrolling this page painful (issue #5602).
+    ///
+    /// It scrolls; the page around it does not. A scrollable list inside a
+    /// scrollable page is the arrangement that produces the artifacts, because
+    /// two containers both claim the drag.
+    private final class HintList extends InfiniteContainer {
+        HintList() {
+            super(HINT_FETCH_BATCH);
+        }
+
+        @Override
+        public Component[] fetchComponents(int index, int amount) {
+            if (index < 0 || index >= hintModel.size()) {
+                // Null is how this container is told the data ran out; it takes
+                // the progress spinner away rather than asking again.
+                return null;
+            }
+            int end = Math.min(hintModel.size(), index + amount);
+            Component[] batch = new Component[end - index];
+            for (int i = index; i < end; i++) {
+                batch[i - index] = hintRow(hintModel.get(i));
+            }
+            return batch;
+        }
+    }
+
     private void renderBuildHintsList() {
-        Container list = (Container) page.getComponentAt(page.getComponentCount() - 1);
-        list.removeAll();
         Map<String, BuildHintMetadata> rows = new LinkedHashMap<String, BuildHintMetadata>();
         for (String key : settings.buildHintKeys()) {
             BuildHintMetadata meta = buildHints.get(key);
@@ -655,13 +739,42 @@ public class CodenameOneSettings extends Lifecycle {
         for (BuildHintMetadata meta : buildHints.search(hintFilter)) {
             rows.put(meta.name(), meta);
         }
+        hintModel.clear();
         for (BuildHintMetadata meta : rows.values()) {
             if (!meta.matches(hintFilter)) {
                 continue;
             }
-            list.add(hintRow(meta));
+            hintModel.add(meta);
         }
-        list.revalidate();
+        if (hintCount != null) {
+            int total = hintModel.size();
+            hintCount.setText(total == 1 ? "1 hint" : total + " hints");
+        }
+        if (hintList != null) {
+            // Back to the top with the first batch of the new result set. Before
+            // the list is on the form this does nothing and is not needed: the
+            // container fetches its first batch itself when it initializes.
+            hintList.refresh();
+        }
+    }
+
+    /// Rebuilds one row where it stands, after its own controls changed it --
+    /// Add, Save, or the button that removes the declaration.
+    ///
+    /// Not a rebuild of the list. Refreshing the whole thing would drop the
+    /// reader back at the top of the catalog, which is a long way from the row
+    /// they were working on, and it would move that row: an activated hint sorts
+    /// with the project's own hints, at the front. Neither is something the
+    /// reader asked for by pressing Add.
+    private void refreshHintRow(Component row, BuildHintMetadata meta) {
+        Container parent = row == null ? null : row.getParent();
+        if (parent == null) {
+            renderBuildHintsList();
+            return;
+        }
+        Component replacement = hintRow(meta);
+        parent.replace(row, replacement, null);
+        parent.revalidate();
     }
 
     private void animatePage() {
@@ -738,13 +851,16 @@ public class CodenameOneSettings extends Lifecycle {
                 // so that button stays.
                 Container header = new Container(new BorderLayout());
                 header.add(BorderLayout.CENTER, text);
-                header.add(BorderLayout.EAST, removeHintButton(meta));
+                header.add(BorderLayout.EAST, removeHintButton(row, meta));
                 row.add(header);
             } else {
                 row.add(text);
             }
         } else if (active) {
-            text.add(activeHintEditor(meta, value, effectiveType));
+            Container header = new Container(new BorderLayout());
+            header.add(BorderLayout.CENTER, text);
+            header.add(BorderLayout.EAST, activeHintEditor(row, meta, value, effectiveType));
+            row.add(header);
         } else {
             Container controls = new Container(new FlowLayout(Component.LEFT, Component.CENTER));
             controls.setUIID(uiid("SettingsHintEditor"));
@@ -754,7 +870,7 @@ public class CodenameOneSettings extends Lifecycle {
             if (seed != null) {
                 add.addActionListener(e -> {
                     settings.setBuildHint(meta.name(), seed);
-                    renderBuildHintsList();
+                    refreshHintRow(row, meta);
                     animatePage();
                 });
                 controls.add(add);
@@ -788,7 +904,7 @@ public class CodenameOneSettings extends Lifecycle {
                         return;
                     }
                     settings.setBuildHint(meta.name(), canonicalHintValue(meta, typed));
-                    renderBuildHintsList();
+                    refreshHintRow(row, meta);
                     animatePage();
                 });
                 add.addActionListener(e -> {
@@ -804,24 +920,40 @@ public class CodenameOneSettings extends Lifecycle {
             header.add(BorderLayout.EAST, controls);
             row.add(header);
         }
-        if (active && ownedBy == null) {
-            row.add(text);
+        String description = meta.description();
+        if (description != null && description.trim().length() > 0) {
+            TextArea details = new TextArea(description);
+            details.setUIID(uiid("SettingsRowText"));
+            details.setEditable(false);
+            details.setFocusable(false);
+            // One row is the FLOOR, not the size: growByContent takes the area to
+            // the line count the text actually wraps to at this width. The old
+            // floor of two-to-five rows was a guess made before the width was
+            // known, and it padded every short description with blank lines --
+            // affordable on a page that scrolled, and no longer affordable on one
+            // that has to fit rows between a pinned search box and a pager. A
+            // hint with no description now adds nothing at all rather than an
+            // empty line.
+            details.setRows(1);
+            details.setGrowByContent(true);
+            row.add(details);
         }
-        TextArea details = new TextArea(meta.description());
-        details.setUIID(uiid("SettingsRowText"));
-        details.setEditable(false);
-        details.setFocusable(false);
-        details.setRows(descriptionRows(meta.description()));
-        details.setGrowByContent(true);
-        row.add(details);
         return row;
     }
 
-    private Component activeHintEditor(BuildHintMetadata meta, String value, BuildHintType effectiveType) {
-        TableLayout editorLayout = new TableLayout(1, 2);
-        Container editor = new Container(editorLayout);
-        editor.setUIID(uiid("SettingsHintEditor"));
+    /// The control for a hint that is set: a switch, or its value in a field,
+    /// with the button that removes the declaration.
+    ///
+    /// It sits to the RIGHT of the name, on the same line, exactly where the Add
+    /// button sits on a row that is not set yet. It used to be a band of its own
+    /// below the name -- a full row of height whose left 72% was an empty
+    /// spacer. On a page that scrolled that was only ugly; on a page that fits
+    /// rows between a pinned search box and a pager it was a whole hint's worth
+    /// of space per active row.
+    private Component activeHintEditor(Container row, BuildHintMetadata meta, String value,
+            BuildHintType effectiveType) {
         Container controls = new Container(new BorderLayout());
+        controls.setUIID(uiid("SettingsHintEditor"));
         if (effectiveType == BuildHintType.BOOLEAN) {
             Switch toggle = new Switch(uiid("SettingsSwitch"));
             toggle.setValue("true".equalsIgnoreCase(value));
@@ -831,6 +963,11 @@ public class CodenameOneSettings extends Lifecycle {
         } else {
             TextField valueField = new TextField(value, "value");
             valueField.setUIID(uiid(isValidHintValue(meta, value) ? "SettingsField" : "SettingsFieldError"));
+            // Next to the name the field is as wide as it asks to be, and a
+            // TextField asks for its column count. Its old width came from the
+            // 28% cell of a band that no longer exists, so it has to ask for
+            // enough room to show a path or a URL.
+            valueField.setColumns(16);
             configureHintField(valueField, meta);
             valueField.addDataChangedListener((type, index) -> {
                 String next = valueField.getText() == null ? "" : valueField.getText().trim();
@@ -850,10 +987,8 @@ public class CodenameOneSettings extends Lifecycle {
             });
             controls.add(BorderLayout.CENTER, valueField);
         }
-        controls.add(BorderLayout.EAST, removeHintButton(meta));
-        editor.add(editorLayout.createConstraint(0, 0).widthPercentage(72), new Container());
-        editor.add(editorLayout.createConstraint(0, 1).widthPercentage(28), controls);
-        return editor;
+        controls.add(BorderLayout.EAST, removeHintButton(row, meta));
+        return controls;
     }
 
     private BuildHintType effectiveHintType(BuildHintMetadata meta, String value) {
@@ -874,12 +1009,12 @@ public class CodenameOneSettings extends Lifecycle {
     /// One implementation, used by the ordinary editor and by the conflict row:
     /// removing the declaration is the resolution in both, and the second copy
     /// this replaced was the reason the conflict row had no way out at all.
-    private Button removeHintButton(BuildHintMetadata meta) {
+    private Button removeHintButton(Container row, BuildHintMetadata meta) {
         Button remove = new Button("", uiid("SettingsSmallIconButton"));
         remove.setMaterialIcon(FontImage.MATERIAL_DELETE, 2.2f);
         remove.addActionListener(e -> {
             settings.removeBuildHint(meta.name());
-            renderBuildHintsList();
+            refreshHintRow(row, meta);
             animatePage();
         });
         return remove;
@@ -900,20 +1035,6 @@ public class CodenameOneSettings extends Lifecycle {
     /// absence of the line IS the configuration.
     private String defaultHintValue(BuildHintMetadata meta) {
         return meta.type() == BuildHintType.BOOLEAN ? "true" : null;
-    }
-
-    private int descriptionRows(String text) {
-        int len = text == null ? 0 : text.length();
-        if (len > 260) {
-            return 5;
-        }
-        if (len > 170) {
-            return 4;
-        }
-        if (len > 95) {
-            return 3;
-        }
-        return 2;
     }
 
     private void configureHintField(TextField field, BuildHintMetadata meta) {

--- a/scripts/settings/common/src/main/java/com/codename1/settings/CodenameOneSettings.java
+++ b/scripts/settings/common/src/main/java/com/codename1/settings/CodenameOneSettings.java
@@ -780,6 +780,20 @@ public class CodenameOneSettings extends Lifecycle {
         }
     }
 
+    /// Whether the browse list would still hold this hint with no declaration
+    /// behind it -- which is what decides whether its row can be rebuilt where
+    /// it stands or the result set has to be taken again.
+    ///
+    /// Not simply "is it in the catalog". A deprecated alias IS in the catalog,
+    /// so that a declaration of it can still be described, and `search` skips it
+    /// on purpose: an alias and its target are one setting, and offering both
+    /// gives that setting two controls. So an alias is in this list for exactly
+    /// the reason a custom hint is -- the project named it -- and when that name
+    /// goes, so does the row.
+    private boolean isBrowsableHint(BuildHintMetadata meta) {
+        return meta.aliasOf() == null && buildHints.contains(meta.name());
+    }
+
     /// Rebuilds one row where it stands, after its own controls changed it --
     /// Add, Save, or the button that removes the declaration.
     ///
@@ -1036,14 +1050,14 @@ public class CodenameOneSettings extends Lifecycle {
         remove.setMaterialIcon(FontImage.MATERIAL_DELETE, 2.2f);
         remove.addActionListener(e -> {
             settings.removeBuildHint(meta.name());
-            if (buildHints.contains(meta.name())) {
+            if (isBrowsableHint(meta)) {
                 refreshHintRow(row, meta);
             } else {
-                // A hint the catalog has never heard of is in this list for one
-                // reason: the project declared it. Removing that declaration
-                // removes its only reason to be here, so rebuilding the row left
-                // a hint that exists nowhere offering an Add button, and left the
-                // header counting it. The result set has to be taken again.
+                // This row was in the list on the project's account, not the
+                // catalog's, and the declaration that put it there has just gone.
+                // Rebuilding it left a hint nothing offers showing an Add button,
+                // with the header still counting it, so the result set has to be
+                // taken again.
                 renderBuildHintsList();
             }
             animatePage();

--- a/scripts/settings/common/src/main/java/com/codename1/settings/CodenameOneSettings.java
+++ b/scripts/settings/common/src/main/java/com/codename1/settings/CodenameOneSettings.java
@@ -111,7 +111,7 @@ public class CodenameOneSettings extends Lifecycle {
     /// Every hint the current filter matches, in display order. The list builds
     /// rows from it one batch at a time as the reader scrolls.
     private final List<BuildHintMetadata> hintModel = new java.util.ArrayList<BuildHintMetadata>();
-    private InfiniteContainer hintList;
+    private HintList hintList;
     private Label hintCount;
     private String extensionFilter = "";
     private List<ExtensionDescriptor> extensionCatalog;
@@ -712,6 +712,28 @@ public class CodenameOneSettings extends Lifecycle {
             super(HINT_FETCH_BATCH);
         }
 
+        /// Shows the current result set from its first row.
+        ///
+        /// `refresh()` alone does not: `InfiniteContainer` overrides
+        /// `resetScroll()` with an empty body -- deliberately, so that pull to
+        /// refresh does not yank the list out from under the reader -- and that
+        /// is the method `removeAll()` calls. So the old offset survived into
+        /// the new result set, and searching from halfway down a scrolled
+        /// catalog left the scroll position past the end of a short result:
+        /// the header counted two matches and the list showed an empty page.
+        ///
+        /// This holds because every path that reloads the list begins with a
+        /// pointer press -- a click in the search box, a press on Add or on the
+        /// delete button -- and `Form.pointerPressed` cancels a scroll animation
+        /// still in flight before it does anything else. A fling that is still
+        /// gliding writes its own offset straight into the scroll field, past
+        /// any override, so nothing here could out-argue it.
+        void reload() {
+            refresh();
+            setScrollY(0);
+            repaint();
+        }
+
         @Override
         public Component[] fetchComponents(int index, int amount) {
             if (index < 0 || index >= hintModel.size()) {
@@ -754,7 +776,7 @@ public class CodenameOneSettings extends Lifecycle {
             // Back to the top with the first batch of the new result set. Before
             // the list is on the form this does nothing and is not needed: the
             // container fetches its first batch itself when it initializes.
-            hintList.refresh();
+            hintList.reload();
         }
     }
 
@@ -1014,7 +1036,16 @@ public class CodenameOneSettings extends Lifecycle {
         remove.setMaterialIcon(FontImage.MATERIAL_DELETE, 2.2f);
         remove.addActionListener(e -> {
             settings.removeBuildHint(meta.name());
-            refreshHintRow(row, meta);
+            if (buildHints.contains(meta.name())) {
+                refreshHintRow(row, meta);
+            } else {
+                // A hint the catalog has never heard of is in this list for one
+                // reason: the project declared it. Removing that declaration
+                // removes its only reason to be here, so rebuilding the row left
+                // a hint that exists nowhere offering an Add button, and left the
+                // header counting it. The result set has to be taken again.
+                renderBuildHintsList();
+            }
             animatePage();
         });
         return remove;

--- a/scripts/settings/common/src/test/java/com/codename1/settings/SettingsThemeTest.java
+++ b/scripts/settings/common/src/test/java/com/codename1/settings/SettingsThemeTest.java
@@ -131,12 +131,48 @@ public class SettingsThemeTest {
     @Test
     public void activeBuildHintControlsStayAlignedToTheRight() throws Exception {
         String source = Files.readString(APP_SOURCE, StandardCharsets.UTF_8);
-        assertTrue(source.contains("widthPercentage(72), new Container()"));
-        assertTrue(source.contains("widthPercentage(28), controls"));
+        // The controls sit EAST of the name, on the name's own line, which is
+        // where the Add button of an inactive row sits. They used to be a band of
+        // their own below the name, held right by a TableLayout whose left 72%
+        // was an empty spacer; that band cost a full row of height on a page that
+        // now has to fit its rows between a pinned search box and a pager.
+        assertFalse(source.contains("widthPercentage(72), new Container()"));
+        assertTrue(source.contains("header.add(BorderLayout.EAST, activeHintEditor(row, meta, value, effectiveType))"));
         // The delete control is EAST of the editor. The button itself moved into
         // removeHintButton so the conflict row can reuse it -- what this asserts
         // is where it sits, which is unchanged.
-        assertTrue(source.contains("controls.add(BorderLayout.EAST, removeHintButton(meta))"));
+        assertTrue(source.contains("controls.add(BorderLayout.EAST, removeHintButton(row, meta))"));
+    }
+
+    /// The list scrolls; the page around it does not (issue #5602). Two nested
+    /// scrollable containers both claim the drag, which is the arrangement that
+    /// produces scrolling artifacts -- so the search box and the custom hint form
+    /// are pinned and the rows scroll under them.
+    @Test
+    public void buildHintsListScrollsAndThePageAroundItDoesNot() throws Exception {
+        String source = Files.readString(APP_SOURCE, StandardCharsets.UTF_8);
+        assertTrue(source.contains("boolean fillsViewport = section == Section.BUILD_HINTS;"));
+        assertTrue(source.contains("pageViewport.setScrollableY(!fillsViewport);"));
+        assertTrue(source.contains("private final class HintList extends InfiniteContainer"),
+                "The rows must come from an InfiniteContainer: it scrolls, it handles rows "
+                        + "of differing heights, and it builds them a batch at a time instead "
+                        + "of turning the whole catalog into components.");
+        assertTrue(source.contains("hintList.refresh()"),
+                "A new result set must reload the list rather than being appended to it.");
+    }
+
+    /// The desktop scrollbar is drawn from UIIDs the look and feel names itself,
+    /// so it is invisible until the theme gives it a colour -- and it cannot use
+    /// the app's Dark-suffix trick, because nothing asks for a "DesktopScrollDark".
+    @Test
+    public void desktopScrollbarIsStyledForBothThemes() throws Exception {
+        String css = Files.readString(THEME_CSS, StandardCharsets.UTF_8);
+        Set<String> selectors = cssSelectors(css);
+        assertTrue(selectors.contains("DesktopScroll"));
+        assertTrue(selectors.contains("DesktopScrollThumb"));
+        assertFalse(selectors.contains("DesktopScrollThumbDark"),
+                "The scrollbar UIIDs are fixed by the look and feel; a Dark twin is never "
+                        + "asked for, so its colour has to read on both pages.");
     }
 
     @Test
@@ -159,8 +195,8 @@ public class SettingsThemeTest {
                 "The Basic form should use a responsive two-column GridLayout.");
         assertTrue(source.contains("private Container configureToolbar()"),
                 "Native desktop chrome should use a stable top-bar container, not a second Toolbar instance.");
-        assertTrue(source.contains("section == Section.EXTENSIONS ? 100 : 72"),
-                "Extensions should use the full content width while forms retain a readable measure.");
+        assertTrue(source.contains("|| section == Section.EXTENSIONS || section == Section.BUILD_HINTS ? 100 : 72"),
+                "Extensions and Build Hints should use the full content width while forms retain a readable measure.");
     }
 
     @Test

--- a/scripts/settings/common/src/test/java/com/codename1/settings/SettingsThemeTest.java
+++ b/scripts/settings/common/src/test/java/com/codename1/settings/SettingsThemeTest.java
@@ -181,9 +181,14 @@ public class SettingsThemeTest {
                         Pattern.DOTALL).matcher(source).find(),
                 "Reloading has to put the reader back at the first result; refresh() alone "
                         + "leaves the offset of the result set that was replaced.");
-        assertTrue(source.contains("if (buildHints.contains(meta.name())) {"),
-                "Removing a hint the catalog does not know has to take the result set again -- "
-                        + "rebuilding its row in place leaves a row for a hint that no longer exists.");
+        assertTrue(source.contains("if (isBrowsableHint(meta)) {"),
+                "Removing a hint the browse list does not offer has to take the result set "
+                        + "again -- rebuilding its row in place leaves a row for a hint that "
+                        + "nothing offers.");
+        assertTrue(source.contains("return meta.aliasOf() == null && buildHints.contains(meta.name());"),
+                "A deprecated alias is in the catalog so an existing declaration can be "
+                        + "described, and search() skips it deliberately -- so membership of the "
+                        + "catalog alone does not mean a row survives losing its declaration.");
     }
 
     /// The desktop scrollbar is drawn from UIIDs the look and feel names itself,

--- a/scripts/settings/common/src/test/java/com/codename1/settings/SettingsThemeTest.java
+++ b/scripts/settings/common/src/test/java/com/codename1/settings/SettingsThemeTest.java
@@ -157,8 +157,33 @@ public class SettingsThemeTest {
                 "The rows must come from an InfiniteContainer: it scrolls, it handles rows "
                         + "of differing heights, and it builds them a batch at a time instead "
                         + "of turning the whole catalog into components.");
-        assertTrue(source.contains("hintList.refresh()"),
+        assertTrue(source.contains("hintList.reload()"),
                 "A new result set must reload the list rather than being appended to it.");
+    }
+
+    /// Two ways the list could show something that is not the result set.
+    ///
+    /// The scroll offset survives `InfiniteContainer.refresh()`, because that
+    /// class overrides `resetScroll()` with an empty body so pull to refresh
+    /// does not jump -- so a search run from halfway down the scrolled catalog
+    /// left the offset past the end of a short result and the list came up
+    /// blank under a header counting two matches.
+    ///
+    /// And a hint the catalog has never heard of is in the list only because
+    /// the project declares it, so rebuilding its row after the declaration was
+    /// removed left a hint that exists nowhere offering an Add button, with the
+    /// header still counting it.
+    @Test
+    public void theListCannotShowResultsThatAreNoLongerThere() throws Exception {
+        String source = Files.readString(APP_SOURCE, StandardCharsets.UTF_8);
+        assertTrue(source.contains("void reload() {"));
+        assertTrue(Pattern.compile("void reload\\(\\) \\{\\s*refresh\\(\\);\\s*setScrollY\\(0\\);",
+                        Pattern.DOTALL).matcher(source).find(),
+                "Reloading has to put the reader back at the first result; refresh() alone "
+                        + "leaves the offset of the result set that was replaced.");
+        assertTrue(source.contains("if (buildHints.contains(meta.name())) {"),
+                "Removing a hint the catalog does not know has to take the result set again -- "
+                        + "rebuilding its row in place leaves a row for a hint that no longer exists.");
     }
 
     /// The desktop scrollbar is drawn from UIIDs the look and feel names itself,

--- a/scripts/settings/javase/src/desktop/java/com/codename1/settings/CodenameOneSettingsStub.java
+++ b/scripts/settings/javase/src/desktop/java/com/codename1/settings/CodenameOneSettingsStub.java
@@ -239,9 +239,18 @@ public class CodenameOneSettingsStub implements Runnable, WindowListener {
     }
 
     private static void captureOffscreen(File target) throws Exception {
-        BufferedImage image = new BufferedImage(frm.getContentPane().getWidth(),
-                frm.getContentPane().getHeight(), BufferedImage.TYPE_INT_ARGB);
+        // The Codename One canvas renders into a buffer at DEVICE resolution and
+        // blits it 1:1, so an image sized in Swing's logical points catches only
+        // the top left corner of a Retina window at double magnification - the
+        // capture looked like a zoomed crop and hid whatever it cut off. Size the
+        // image by the display scale and the whole content pane lands in it.
+        double scale = displayScale();
+        BufferedImage image = new BufferedImage(
+                Math.max(1, (int) Math.round(frm.getContentPane().getWidth() * scale)),
+                Math.max(1, (int) Math.round(frm.getContentPane().getHeight() * scale)),
+                BufferedImage.TYPE_INT_ARGB);
         Graphics2D graphics = image.createGraphics();
+        graphics.scale(scale, scale);
         frm.getContentPane().paint(graphics);
         graphics.dispose();
         ImageIO.write(image, "png", target);
@@ -269,6 +278,15 @@ public class CodenameOneSettingsStub implements Runnable, WindowListener {
                 System.err.println("On-screen capture skipped: window is not showing");
                 return;
             }
+            // Showing is not the same as frontmost. A Robot grab is a grab of
+            // the SCREEN at these coordinates, so a window that another
+            // application covers writes that application's pixels into a file
+            // named after this one - a diagnostic that shows someone else's
+            // document, and an image that reads as a broken Settings window.
+            if (!frm.isActive()) {
+                System.err.println("On-screen capture skipped: window is not the active window");
+                return;
+            }
             Rectangle bounds = frm.getBounds();
             if (bounds.width <= 0 || bounds.height <= 0) {
                 return;
@@ -278,6 +296,24 @@ public class CodenameOneSettingsStub implements Runnable, WindowListener {
         } catch (Throwable ex) {
             System.err.println("On-screen capture unavailable: " + ex);
         }
+    }
+
+    /// The device pixels per logical point of the screen the window is on, or 1
+    /// when that cannot be read - a capture at the wrong scale is worth more than
+    /// no capture.
+    private static double displayScale() {
+        try {
+            java.awt.GraphicsConfiguration config = frm.getGraphicsConfiguration();
+            if (config != null) {
+                double scale = config.getDefaultTransform().getScaleX();
+                if (scale > 0) {
+                    return scale;
+                }
+            }
+        } catch (Throwable ex) {
+            System.err.println("Display scale unavailable: " + ex);
+        }
+        return 1;
     }
 
     static String onScreenPath(String screenshot) {


### PR DESCRIPTION
Fixes #5602.

## The problem

All 556 build hints were built into multi-line cards and stacked into the page, and the **page** was what scrolled. Reaching the bottom took a wheel marathon, and a scrollable list inside a scrollable page is the arrangement that produces scrolling artifacts, because both containers claim the drag.

## The fix

The page no longer scrolls. The title, the search box and the custom hint form are pinned; the rows scroll under them in an `InfiniteContainer`, which handles rows of differing heights -- a description wraps to as many lines as it needs, an active row carries an editor, an annotation-owned one carries a paragraph -- and builds them twenty at a time as the reader scrolls rather than turning the whole catalog into components.

The desktop scrollbar was already switched on for this app, and invisible: the look and feel asks the theme for `DesktopScroll` and `DesktopScrollThumb` by those exact names, and the Settings theme never styled them, so the bar was painted with an empty style. It is styled now, in a tone that reads on both the light and the dark page -- those UIIDs are fixed by the look and feel, so they cannot use the app's Dark-suffix trick.

## Rows earn their space back

A card that only fits three to a window is a list nobody can read, so:

- the page takes the full width, as Extensions already does; a description that wraps into two lines instead of three is a third of a row's height back
- the control for an active hint (switch, value field, delete) moves onto the name's line, where the Add button of an inactive row already sits. It used to be a band of its own whose left 72% was an empty spacer
- descriptions size to the line count they actually wrap to, instead of a two-to-five row floor guessed before the width was known; a hint with no description now adds nothing at all
- the title and the search box share a line, and the standing subtitle is gone
- hint rows get their own padding rule, tighter than the card they shared it with, so extension cards are untouched

Add, Save and the delete button rebuild **their own row where it stands**. Reloading the list would drop the reader back at the top of the catalog and move the row they were working on, since an activated hint sorts with the project's own hints at the front.

## Two capture bugs found while verifying

Both in the tool's own screenshot support, both fixed here:

- the offscreen paint was sized in logical points while the canvas blits at device resolution, so on a Retina display it captured a magnified top-left corner instead of the window
- the on-screen Robot grab is a grab of the *screen* at the window's coordinates, so a window that another application covered wrote that application's pixels into a file named after this one. It now requires the window to be the active one; the Windows tooling test already handles that by falling back to the offscreen paint

## Verification

`mvn -pl common test -Dcn1.settings.skipTests=false` and the javase module: 176 tests, all green. Three of them are new -- that the list scrolls while the page around it does not, that the scrollbar UIIDs are styled, and the updated assertion on where an active hint's controls sit.

Run by hand on macOS in both themes, at several window sizes: drag scrolling with momentum, wheel scrolling, the scrollbar thumb, the search filter, and Add on a row in the middle of the list (verified by injecting real pointer and wheel events into the canvas rather than driving the machine's mouse).

The Settings theme.css also picks up the standard copyright header it never had -- `check-copyright-headers.sh` gates modified files, and this PR modifies it.
