### PR TITLE
JS port: apply the text layer's DOM changes with the frame they belong to

### DIFF
--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/BufferedGraphics.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/BufferedGraphics.java
@@ -132,6 +132,25 @@ public class BufferedGraphics extends HTML5Graphics {
     }
 
     /**
+     * Queue a text-layer DOM mutation into this frame's command buffer.
+     *
+     * <p>Deliberately not routed through {@link #addOp}: that culls draws under an empty clip,
+     * and a mutation is not a draw. The release of a run whose component has just been clipped
+     * away is issued under exactly that empty clip, and dropping it would leave the run on
+     * screen with no pixels beneath it.</p>
+     *
+     * @param kind one of the {@code SurfaceCommandRecorder.OP_TEXT_*} opcodes
+     * @param target the element the mutation applies to
+     * @param child the element being attached or detached, null for the other kinds
+     * @param value the CSS declaration or text content, null for the other kinds
+     */
+    void recordTextLayerOp(int kind, Object target, Object child, String value) {
+        synchronized (upcoming) {
+            upcoming.add(new com.codename1.impl.html5.graphics.TextLayerOp(kind, target, child, value));
+        }
+    }
+
+    /**
      * Image draws report the rectangle they land in.
      *
      * <p>Review asked for the source alpha to be taken into account, so that an image which is

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/BufferedGraphics.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/BufferedGraphics.java
@@ -122,13 +122,32 @@ public class BufferedGraphics extends HTML5Graphics {
     // canvas, so we must not emit the draws at all. Mirrors the GL clipBlock
     // mechanism. Issue #5263.
     private void addOp(ExecutableOp operation) {
-        if (clipEmpty
-                && !(operation instanceof ClipRect)
-                && !(operation instanceof ClipShape)
-                && !(operation instanceof SetTransform)) {
+        if (clipEmpty && !isStateOnlyOp(operation)) {
             return;
         }
         upcoming.add(operation);
+    }
+
+    /**
+     * True when an op sets renderer state rather than producing pixels.
+     *
+     * <p>Two callers need the same answer and must not be allowed to drift apart. {@link #addOp}
+     * uses it to decide what survives an empty clip -- a draw may not render, but the clip and
+     * transform still have to be recorded so a later non-empty clip restores drawing. The drain
+     * uses it to decide whether a frame repaints anything, which is what qualifies it for the
+     * full-frame clear.</p>
+     *
+     * <p>Text-layer mutations belong here too. They ride this queue so a frame's elements and its
+     * pixels reach the host together, but they write to the document, not the canvas.</p>
+     *
+     * @param operation the recorded op
+     * @return true when replaying it leaves the canvas unchanged
+     */
+    static boolean isStateOnlyOp(ExecutableOp operation) {
+        return operation instanceof ClipRect
+                || operation instanceof ClipShape
+                || operation instanceof SetTransform
+                || operation instanceof com.codename1.impl.html5.graphics.TextLayerOp;
     }
 
     /**

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -1683,7 +1683,17 @@ public class HTML5Implementation extends CodenameOneImplementation {
         textLayerEnabled = !"0".equals(getParameterByName("cn1TextLayer"));
         semanticOverlayEnabled = !"0".equals(getParameterByName("cn1Semantics"));
         if (textLayerEnabled) {
-            textLayer = new JavaScriptTextLayer(document, textLayerContainer);
+            // The sink reads ``graphics`` at record time rather than capturing it: the display
+            // graphics is built further down this method, after the layer exists.
+            textLayer = new JavaScriptTextLayer(document, textLayerContainer,
+                    new JavaScriptTextLayer.MutationSink() {
+                        @Override
+                        public void record(int kind, Object target, Object child, String value) {
+                            if (graphics != null) {
+                                graphics.recordTextLayerOp(kind, target, child, value);
+                            }
+                        }
+                    });
         }
         if (textLayerEnabled) {
             // Paint locking caches a component's pixels in an image and serves that image
@@ -3516,11 +3526,12 @@ public class HTML5Implementation extends CodenameOneImplementation {
             if (!textLayer.isSuspended() && Display.getInstance().isInTransition()) {
                 textLayer.setSuspended(true);
             }
-            // Releases runs whose component has been removed, hidden, or whose form is no
-            // longer displayed; none of those ever paints again, so nothing else would clean
-            // them up.
+            // syncToForm is NOT called here. By this point the frame's ops have already been
+            // snapshotted, so a release recorded now would ship with the NEXT frame -- the
+            // removed component's text would stay on screen over the pixels that replaced it
+            // for one frame, which is what a rebuilt navigation showed as a doubled label. It
+            // runs in flushGraphics instead, while the buffer this frame ships is still open.
             Form displayed = Display.getInstance().getCurrent();
-            textLayer.syncToForm(displayed);
             if (textLayer.consumeReattachFlag() && displayed != null) {
                 // A run came back after being detached, so it holds a fresh stacking index
                 // while everything that did not repaint still holds an older one. One full
@@ -6773,6 +6784,16 @@ public class HTML5Implementation extends CodenameOneImplementation {
     @Override
     public void flushGraphics(int x, int y, int width, int height) {
         displayFlushes++;
+        if (textLayer != null) {
+            // Releases runs whose component has been removed, hidden, or whose form is no longer
+            // displayed; none of those ever paints again, so nothing else would clean them up.
+            //
+            // Here rather than in the drain because of when the buffer closes. The components of
+            // this frame have finished painting and their ops are still in ``upcoming``, so a
+            // detach recorded now travels with the very pixels that replace the text -- the host
+            // applies both in one task and the frame is never seen half-updated.
+            textLayer.syncToForm(Display.getInstance().getCurrent());
+        }
         JavaScriptRenderQueueCoordinator.waitUntilFlushable(new JavaScriptRenderQueueCoordinator.FlushBarrier() {
             @Override
             public boolean isGraphicsLocked() {

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -3509,23 +3509,6 @@ public class HTML5Implementation extends CodenameOneImplementation {
             return false;
         }
         if (textLayer != null) {
-            // A form transition paints two pre-rendered offscreen buffers instead of painting
-            // components, so no run is refreshed while it runs. Those buffers carry their own
-            // rasterized text, so the layer must step aside for the duration or the outgoing
-            // form's text would float above the animation.
-            // A buffered transition -- a fade, where areMutableImagesFast() is true -- paints
-            // only its prebuilt images and never puts a component through the display graphics,
-            // so the frame-start hook never runs and would leave the outgoing form's DOM text
-            // fixed above the animation for its whole duration. Catch it here, which does run
-            // every display frame.
-            //
-            // Suspending only, never resuming: the components of this frame have already
-            // painted, so lifting the suspension now would show runs that this frame's canvas
-            // also rasterized. Resuming is left to the frame-start hook, which runs before any
-            // component paints.
-            if (!textLayer.isSuspended() && Display.getInstance().isInTransition()) {
-                textLayer.setSuspended(true);
-            }
             // syncToForm is NOT called here. By this point the frame's ops have already been
             // snapshotted, so a release recorded now would ship with the NEXT frame -- the
             // removed component's text would stay on screen over the pixels that replaced it
@@ -3599,6 +3582,33 @@ public class HTML5Implementation extends CodenameOneImplementation {
         }
         ClipRect.resetClip(context, graphics.getClipState());
         context.restore();
+        if (textLayer != null && Display.getInstance().isInTransition()) {
+            // A form transition paints two pre-rendered offscreen buffers instead of painting
+            // components, so no run is refreshed while it runs. Those buffers carry their own
+            // rasterized text, so the layer must step aside for the duration or the outgoing
+            // form's text would float above the animation. A buffered transition -- a fade,
+            // where areMutableImagesFast() is true -- never puts a component through the display
+            // graphics at all, so the frame-start hook never runs and would leave that text
+            // fixed above the animation for its whole duration. This runs every display frame,
+            // which is what catches it.
+            //
+            // Suspending only, never resuming: the components of this frame have already
+            // painted, so lifting the suspension now would show runs that this frame's canvas
+            // also rasterized. Resuming is left to the frame-start hook, which runs before any
+            // component paints.
+            //
+            // Suspend into THIS frame, not through the sink. beginFrame() above snapshotted and
+            // cleared the queue, so anything recorded through the sink now lands in the buffer
+            // the NEXT frame ships -- and this frame, the first of the transition, would be
+            // composited with the outgoing form's DOM text still over it. Writing straight into
+            // the recorder puts the hide in the same flush as the transition's own pixels.
+            //
+            // It matters even more when there is no next frame: a buffered transition paints
+            // only its prebuilt images, so if the last flush went out before this ran, a
+            // sink-recorded hide would never ship at all and the stale text would sit over the
+            // whole animation.
+            textLayer.suspendIntoFrame(context);
+        }
         graphics.flush();
         // The batch is on its way, so the sources it blits can be collected again.
         blitSourcesInFlight.clear();

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -3496,6 +3496,25 @@ public class HTML5Implementation extends CodenameOneImplementation {
         });
     }
 
+    /**
+     * True when a frame carries at least one op that draws onto the canvas.
+     *
+     * <p>Text-layer mutations are DOM writes that ride the same queue so they land in the same
+     * task as the pixels they belong with. They produce no pixels of their own, so a frame made
+     * only of them must not be treated as a repaint.</p>
+     *
+     * @param frame the frame about to be replayed
+     * @return true when something in it paints
+     */
+    private boolean framePaintsPixels(JavaScriptRenderQueueState.FrameSnapshot<ExecutableOp> frame) {
+        for (ExecutableOp op : frame.getOps()) {
+            if (!(op instanceof com.codename1.impl.html5.graphics.TextLayerOp)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private boolean drainPendingDisplayFrame() {
         JavaScriptRenderQueueState.FrameSnapshot<ExecutableOp> frame =
                 JavaScriptRenderQueueCoordinator.beginFrame(new JavaScriptRenderQueueCoordinator.GraphicsLock() {
@@ -3566,7 +3585,17 @@ public class HTML5Implementation extends CodenameOneImplementation {
         // their own bounds either way; sibling components whose bounds
         // happen to fall inside the union but who are NOT in the dirty
         // list keep their previous pixels.
-        if (frame.getCropX() == 0 && frame.getCropY() == 0
+        //
+        // A frame carrying nothing but text-layer mutations paints no pixels at all, so there is
+        // nothing for a clear to be the prelude to. Until those mutations rode the queue such a
+        // frame held no ops and the drain returned early at the isEmpty() check above, which is
+        // what kept the canvas intact; now it is non-empty and would reach this clear and wipe
+        // content that this frame does not redraw. A detach-only flush -- syncToForm releasing
+        // the runs of a component that has gone, with nothing else queued -- is exactly that
+        // shape, and a full-screen crop is what a form-sized component asks for when it
+        // repaints.
+        if (framePaintsPixels(frame)
+                && frame.getCropX() == 0 && frame.getCropY() == 0
                 && frame.getCropW() >= displayWidth
                 && frame.getCropH() >= displayHeight) {
             context.clearRect(frame.getCropX(), frame.getCropY(), frame.getCropW(), frame.getCropH());

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -3499,16 +3499,19 @@ public class HTML5Implementation extends CodenameOneImplementation {
     /**
      * True when a frame carries at least one op that draws onto the canvas.
      *
-     * <p>Text-layer mutations are DOM writes that ride the same queue so they land in the same
-     * task as the pixels they belong with. They produce no pixels of their own, so a frame made
-     * only of them must not be treated as a repaint.</p>
+     * <p>State commands do not count. A clip or a transform records what later draws are subject
+     * to and leaves the canvas exactly as it was, and a text-layer mutation writes to the
+     * document rather than the canvas. Asking merely "is anything here besides a text mutation"
+     * is not enough: PaintSurface.paintDirty() calls setClip(0, 0, width, height) before painting
+     * each animatable and BufferedGraphics records that unconditionally, so every painted frame
+     * carries a ClipRect whether or not a pixel follows it.</p>
      *
      * @param frame the frame about to be replayed
      * @return true when something in it paints
      */
     private boolean framePaintsPixels(JavaScriptRenderQueueState.FrameSnapshot<ExecutableOp> frame) {
         for (ExecutableOp op : frame.getOps()) {
-            if (!(op instanceof com.codename1.impl.html5.graphics.TextLayerOp)) {
+            if (!BufferedGraphics.isStateOnlyOp(op)) {
                 return true;
             }
         }

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptTextLayer.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptTextLayer.java
@@ -22,10 +22,10 @@
  */
 package com.codename1.impl.html5;
 
-import com.codename1.html5.js.dom.CSSStyleDeclaration;
 import com.codename1.html5.js.dom.HTMLDocument;
 import com.codename1.html5.js.dom.HTMLElement;
 import com.codename1.impl.html5.HTML5Implementation.NativeFont;
+import com.codename1.impl.html5.graphics.SurfaceCommandRecorder;
 import com.codename1.ui.Component;
 import com.codename1.ui.Display;
 import com.codename1.ui.Form;
@@ -75,11 +75,6 @@ public final class JavaScriptTextLayer {
     private static final class Run {
         private final HTMLElement clip;
         private final HTMLElement text;
-        // Held rather than re-fetched. getStyle() is a property read, which crosses to the main
-        // thread and parks the worker until it answers; doing that twice per run per frame was
-        // enough to wedge the VM on a screen that repaints continuously.
-        private final CSSStyleDeclaration clipStyle;
-        private final CSSStyleDeclaration textStyle;
         private String clipCss;
         private String textCss;
         private String content;
@@ -108,8 +103,6 @@ public final class JavaScriptTextLayer {
         Run(HTMLElement clip, HTMLElement text) {
             this.clip = clip;
             this.text = text;
-            this.clipStyle = clip.getStyle();
-            this.textStyle = text.getStyle();
         }
     }
 
@@ -140,8 +133,30 @@ public final class JavaScriptTextLayer {
         private int clipH;
     }
 
+    /**
+     * Where a DOM mutation is recorded.
+     *
+     * <p>Every write this class makes goes here rather than to the element, so it is carried in
+     * the frame's command stream and applied by the host in the same task that replays that
+     * frame's canvas commands. Writing to the element directly applies it an animation frame
+     * early -- before the pixels it belongs with exist -- which is seen as text that blanks out
+     * or is drawn twice. See {@code TextLayerOp}.</p>
+     */
+    public interface MutationSink {
+        /**
+         * Records one mutation into the current frame.
+         *
+         * @param kind one of the {@code SurfaceCommandRecorder.OP_TEXT_*} opcodes
+         * @param target the element the mutation applies to
+         * @param child the element being attached or detached, null for the other kinds
+         * @param value the CSS declaration or text content, null for the other kinds
+         */
+        void record(int kind, Object target, Object child, String value);
+    }
+
     private final HTMLDocument document;
     private final HTMLElement container;
+    private final MutationSink sink;
     private final Map<Component, ComponentRuns> byComponent = new HashMap<Component, ComponentRuns>();
     private final List<Frame> stack = new ArrayList<Frame>();
     private int depth;
@@ -172,9 +187,10 @@ public final class JavaScriptTextLayer {
      * @param document the host document used to create elements
      * @param container the layer root, already attached to the document
      */
-    public JavaScriptTextLayer(HTMLDocument document, HTMLElement container) {
+    public JavaScriptTextLayer(HTMLDocument document, HTMLElement container, MutationSink sink) {
         this.document = document;
         this.container = container;
+        this.sink = sink;
     }
 
     /**
@@ -190,7 +206,8 @@ public final class JavaScriptTextLayer {
             return;
         }
         suspended = value;
-        container.getStyle().setProperty("display", value ? "none" : "block");
+        sink.record(SurfaceCommandRecorder.OP_TEXT_DISPLAY, container, null,
+                value ? "none" : "block");
     }
 
     /**
@@ -446,7 +463,7 @@ public final class JavaScriptTextLayer {
         }
         String clipDeclaration = clipCss.toString();
         if (!clipDeclaration.equals(run.clipCss)) {
-            run.clipStyle.setCssText(clipDeclaration);
+            sink.record(SurfaceCommandRecorder.OP_TEXT_CLIP_CSS, run.clip, null, clipDeclaration);
             run.clipCss = clipDeclaration;
         }
 
@@ -470,12 +487,12 @@ public final class JavaScriptTextLayer {
         // anything at all across the bridge.
         String textDeclaration = textCss.toString();
         if (!textDeclaration.equals(run.textCss)) {
-            run.textStyle.setCssText(textDeclaration);
+            sink.record(SurfaceCommandRecorder.OP_TEXT_RUN_CSS, run.text, null, textDeclaration);
             run.textCss = textDeclaration;
         }
 
         if (!str.equals(run.content)) {
-            run.text.setTextContent(str);
+            sink.record(SurfaceCommandRecorder.OP_TEXT_CONTENT, run.text, null, str);
             run.content = str;
             if (regionNarrowed) {
                 // The canvas would have changed only the part of this line the repaint reached;
@@ -502,7 +519,7 @@ public final class JavaScriptTextLayer {
         run.coverW = Math.max(0, coverRight - coverLeft);
         run.coverH = Math.max(0, coverBottom - coverTop);
         if (!run.attached) {
-            container.appendChild(run.clip);
+            sink.record(SurfaceCommandRecorder.OP_TEXT_ATTACH, container, run.clip, null);
             run.attached = true;
             if (run.everAttached) {
                 // Previously attached, so other runs are still carrying stacking indices from
@@ -679,7 +696,7 @@ public final class JavaScriptTextLayer {
      * Detaches every run and drops the pool.
      */
     public void clear() {
-        container.setInnerHTML("");
+        sink.record(SurfaceCommandRecorder.OP_TEXT_CLEAR, container, null, null);
         byComponent.clear();
         canvasOnly.clear();
         stack.clear();
@@ -761,6 +778,10 @@ public final class JavaScriptTextLayer {
         while (runs.runs.size() <= index) {
             HTMLElement clip = document.createElement("div");
             HTMLElement text = document.createElement("span");
+            // Building the pair is not a frame mutation: neither element is in the document
+            // yet, so nothing can be seen half-built and there is nothing to keep in step with
+            // the canvas. It stays an immediate write, which is also what guarantees the pair
+            // exists by the time the recorded OP_TEXT_ATTACH for it is replayed.
             clip.appendChild(text);
             runs.runs.add(new Run(clip, text));
         }
@@ -806,7 +827,7 @@ public final class JavaScriptTextLayer {
                     || run.coverY + run.coverH <= y || y + h <= run.coverY) {
                 continue;
             }
-            container.removeChild(run.clip);
+            sink.record(SurfaceCommandRecorder.OP_TEXT_DETACH, container, run.clip, null);
             run.attached = false;
         }
     }
@@ -815,7 +836,7 @@ public final class JavaScriptTextLayer {
         for (int i = from; i < runs.runs.size(); i++) {
             Run run = runs.runs.get(i);
             if (run.attached) {
-                container.removeChild(run.clip);
+                sink.record(SurfaceCommandRecorder.OP_TEXT_DETACH, container, run.clip, null);
                 run.attached = false;
             }
         }

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptTextLayer.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/JavaScriptTextLayer.java
@@ -25,7 +25,9 @@ package com.codename1.impl.html5;
 import com.codename1.html5.js.dom.HTMLDocument;
 import com.codename1.html5.js.dom.HTMLElement;
 import com.codename1.impl.html5.HTML5Implementation.NativeFont;
+import com.codename1.html5.js.canvas.CanvasRenderingContext2D;
 import com.codename1.impl.html5.graphics.SurfaceCommandRecorder;
+import com.codename1.impl.html5.graphics.TextLayerOp;
 import com.codename1.ui.Component;
 import com.codename1.ui.Display;
 import com.codename1.ui.Form;
@@ -208,6 +210,28 @@ public final class JavaScriptTextLayer {
         suspended = value;
         sink.record(SurfaceCommandRecorder.OP_TEXT_DISPLAY, container, null,
                 value ? "none" : "block");
+    }
+
+    /**
+     * Suspends as part of the frame being drained, writing the mutation straight into that
+     * frame's recorder instead of through the sink.
+     *
+     * <p>The sink records into the buffer the <em>next</em> frame ships. That is right for a
+     * caller inside a component paint, whose frame has not been handed off yet, and wrong for
+     * the drain, which runs after the queue has been snapshotted: the hide would arrive a frame
+     * after the transition it is meant to hide behind, and if no further flush followed it
+     * would never arrive at all. Recording into the recorder puts it in the flush now being
+     * assembled.</p>
+     *
+     * @param frameRecorder the display recorder for the frame being drained
+     */
+    public void suspendIntoFrame(CanvasRenderingContext2D frameRecorder) {
+        if (suspended) {
+            return;
+        }
+        suspended = true;
+        new TextLayerOp(SurfaceCommandRecorder.OP_TEXT_DISPLAY, container, null, "none")
+                .execute(frameRecorder);
     }
 
     /**

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/SurfaceCommandRecorder.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/SurfaceCommandRecorder.java
@@ -146,6 +146,21 @@ public final class SurfaceCommandRecorder implements CanvasRenderingContext2D {
     // saturation, scale, offset, refraction, specular.
     public static final int OP_GLASS_SELF_REGION = 82;
 
+    // Text-layer DOM mutations. The layer renders text as real DOM above the canvas, so a frame
+    // is only coherent if its elements and its pixels are applied together. Riding the command
+    // stream is what guarantees that: the host applies these inside the same task that replays
+    // the draws, in the order the paint recorded them. Issued as side-channel writes instead
+    // they land an animation frame before the pixels they belong to, which shows as text that
+    // blanks out or is drawn twice. OP_BLUR_SELF_REGION rides the stream for the same reason.
+    // See TextLayerOp.
+    public static final int OP_TEXT_ATTACH = 90;   // 2 objs: container, child
+    public static final int OP_TEXT_DETACH = 91;   // 2 objs: container, child
+    public static final int OP_TEXT_CLIP_CSS = 92; // 1 obj (element) + 1 str (cssText)
+    public static final int OP_TEXT_RUN_CSS = 93;  // 1 obj (element) + 1 str (cssText)
+    public static final int OP_TEXT_CONTENT = 94;  // 1 obj (element) + 1 str (text)
+    public static final int OP_TEXT_CLEAR = 95;    // 1 obj (container)
+    public static final int OP_TEXT_DISPLAY = 96;  // 1 obj (container) + 1 str (display)
+
     private int[] ops = new int[64];
     private int opCount;
     private double[] nums = new double[256];
@@ -185,6 +200,36 @@ public final class SurfaceCommandRecorder implements CanvasRenderingContext2D {
             objs = n;
         }
         objs[objCount++] = v;
+    }
+
+    /**
+     * Record a text-layer DOM mutation into this stream.
+     *
+     * <p>Arguments travel as object slots, which the flush native already marshals correctly
+     * for both kinds involved here: a Java String becomes a native string, and an element
+     * becomes the host reference it already is. Nothing is read back.</p>
+     *
+     * @param kind one of the {@code OP_TEXT_*} opcodes
+     * @param target the element the mutation applies to
+     * @param child the element being attached or detached, null for the other kinds
+     * @param value the CSS declaration or text content, null for the other kinds
+     */
+    public void textLayerMutation(int kind, Object target, Object child, String value) {
+        op(kind);
+        switch (kind) {
+            case OP_TEXT_ATTACH:
+            case OP_TEXT_DETACH:
+                obj(target);
+                obj(child);
+                break;
+            case OP_TEXT_CLEAR:
+                obj(target);
+                break;
+            default:
+                obj(target);
+                obj(value);
+                break;
+        }
     }
 
     /** True if anything was recorded since the last {@link #reset()}. */

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/TextLayerOp.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/graphics/TextLayerOp.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codename1.impl.html5.graphics;
+
+import com.codename1.html5.js.canvas.CanvasRenderingContext2D;
+
+/**
+ * One DOM mutation of the text layer, recorded into the surface command stream.
+ *
+ * <p>The text layer renders Codename One text as real DOM above the canvas, so every frame has
+ * two halves: the pixels the canvas draws and the elements the layer positions. Those halves
+ * are only ever seen together if they are applied together. Issuing the DOM half where it is
+ * decided -- inside the component paint -- does the opposite: the paint records canvas commands
+ * that are not replayed until the frame is drained an animation frame later, so the browser
+ * composites the new DOM over the previous frame's pixels. Text released early leaves a gap
+ * where the glyphs still ought to be; text added early draws it twice, once in each place.</p>
+ *
+ * <p>Carrying the mutation as an ordinary {@link ExecutableOp} closes that window by
+ * construction. It is queued into the same buffer as the draws around it, replayed into the
+ * same {@link SurfaceCommandRecorder}, shipped in the same flush message, and applied by the
+ * host inside the same task that replays the canvas commands -- in the draw order the paint
+ * gave it. No rendering opportunity exists between the two halves for the compositor to take.
+ * {@code OP_BLUR_SELF_REGION} rides the stream for the same reason.</p>
+ *
+ * <p>Only the recorder understands these ops. Executed against anything else -- an offscreen
+ * surface's immediate context, which never carries promoted text -- it does nothing.</p>
+ *
+ * @author Codename One
+ */
+public final class TextLayerOp implements ExecutableOp {
+    private final int kind;
+    private final Object target;
+    private final Object child;
+    private final String value;
+
+    /**
+     * Creates a recorded text-layer mutation.
+     *
+     * @param kind one of the {@code SurfaceCommandRecorder.OP_TEXT_*} opcodes
+     * @param target the element the mutation applies to, as a host reference
+     * @param child the element being attached or detached, null for the other kinds
+     * @param value the CSS declaration or text content, null for the other kinds
+     */
+    public TextLayerOp(int kind, Object target, Object child, String value) {
+        this.kind = kind;
+        this.target = target;
+        this.child = child;
+        this.value = value;
+    }
+
+    @Override
+    public void execute(CanvasRenderingContext2D ctx) {
+        if (ctx instanceof SurfaceCommandRecorder) {
+            ((SurfaceCommandRecorder)ctx).textLayerMutation(kind, target, child, value);
+        }
+    }
+
+    @Override
+    public String getDescription() {
+        return "TextLayerOp(" + kind + ")";
+    }
+}

--- a/Ports/JavaScriptPort/src/main/webapp/port.js
+++ b/Ports/JavaScriptPort/src/main/webapp/port.js
@@ -5698,6 +5698,74 @@ function resolveDisplayImplementationObject() {
   return null;
 }
 
+// As invokeFirstResolvableInstanceMethod, but hands back what the call returned.
+// Needed to walk from one object to the next -- Display -> its current Form.
+function* invokeFirstResolvableInstanceMethodValue(receiver, methodIds) {
+  if (!receiver || !receiver.__class || !methodIds || !methodIds.length) {
+    return { methodId: null, value: null };
+  }
+  for (let i = 0; i < methodIds.length; i++) {
+    const methodId = methodIds[i];
+    try {
+      const method = jvm.resolveVirtual(receiver.__class, methodId);
+      if (typeof method === "function") {
+        const value = yield* cn1_ivAdapt(method(receiver));
+        return { methodId: methodId, value: value };
+      }
+    } catch (_err) {
+      // Best-effort compatibility shim. Try the next translated name.
+    }
+  }
+  return { methodId: null, value: null };
+}
+
+// Mark the whole displayed form dirty, so the paint that follows redraws all of it.
+//
+// The settle this precedes decides the UI is ready by watching the canvas stop changing. A
+// screen that draws in stages is momentarily still between two of them and satisfies that,
+// which is how graphics-draw-image-rect has twice been captured with the top half of its grid
+// drawn and the bottom half not. Widening the quiet window only moves the race; a full repaint
+// removes it, because after one there are no stages left outstanding -- whatever the frame
+// draws, it draws all of it.
+//
+// Only Display.getCurrent() and Component.repaint() are used, both of which the framework calls
+// from Java, so neither can be dropped by the unused-method cull the way a method that existed
+// solely for this would be. If neither resolves, nothing happens and the settle behaves exactly
+// as it did before.
+function* repaintEntireDisplayedForm(reason) {
+  const impl = resolveDisplayImplementationObject();
+  if (!impl || !impl.__class) {
+    emitDiagLine("PARPAR:DIAG:FALLBACK:repaintEntireForm:reason=" + String(reason || "unknown")
+        + ":impl=null");
+    return false;
+  }
+  // CodenameOneImplementation.getCurrentForm() rather than Display.getCurrent(): the receiver is
+  // the object this file already holds, and both this and Component.repaint() are called from
+  // Java by the framework itself, so neither can be dropped by the unused-method cull. Verified
+  // present as cn1_s_getCurrentForm_R_com_codename1_ui_Form and cn1_s_repaint in a translated
+  // bundle. The short cn1_s_ spelling is what the runtime maps to the long one; the long forms
+  // follow as fallbacks.
+  const current = yield* invokeFirstResolvableInstanceMethodValue(impl, [
+    "cn1_s_getCurrentForm_R_com_codename1_ui_Form",
+    "cn1_com_codename1_impl_CodenameOneImplementation_getCurrentForm_R_com_codename1_ui_Form",
+    "cn1_com_codename1_impl_CodenameOneImplementation_getCurrentForm"
+  ]);
+  const form = current.value;
+  if (!form || !form.__class) {
+    emitDiagLine("PARPAR:DIAG:FALLBACK:repaintEntireForm:reason=" + String(reason || "unknown")
+        + ":getCurrentForm=" + String(current.methodId) + ":form=null");
+    return false;
+  }
+  const repainted = yield* invokeFirstResolvableInstanceMethod(form, [
+    "cn1_s_repaint",
+    "cn1_com_codename1_ui_Component_repaint",
+    "cn1_com_codename1_ui_Form_repaint"
+  ]);
+  emitDiagLine("PARPAR:DIAG:FALLBACK:repaintEntireForm:reason=" + String(reason || "unknown")
+      + ":form=" + form.__class + ":repaint=" + String(repainted));
+  return repainted != null;
+}
+
 function* invokeFirstResolvableInstanceMethod(receiver, methodIds) {
   if (!receiver || !receiver.__class || !methodIds || !methodIds.length) {
     return null;
@@ -5800,6 +5868,12 @@ bindCiFallback("Cn1ssDeviceRunnerHelper.emitCurrentFormScreenshotDom", [
     let capturedDataUrl = "";
     if (jvm && typeof jvm.invokeHostNative === "function") {
       try {
+        const captureSettle = cn1SsSettleParams(normalizedTest);
+        if (captureSettle.staged) {
+          // Before the presentation below, not after: paintDirty() paints what is marked dirty,
+          // so the repaint has to be requested first for that paint to cover the whole form.
+          yield* repaintEntireDisplayedForm("hostCanvas:" + normalizedTest);
+        }
         yield* forceDisplayPresentationForScreenshot("hostCanvas:" + normalizedTest);
         // Serialize the canvas read against concurrent painters. The settle +
         // capture host round-trips span many rAF frames during which the
@@ -5814,7 +5888,6 @@ bindCiFallback("Cn1ssDeviceRunnerHelper.emitCurrentFormScreenshotDom", [
           jvm.beginCaptureGate();
         }
         try {
-          const captureSettle = cn1SsSettleParams(normalizedTest);
           yield jvm.invokeHostNative("__cn1_wait_for_ui_settle__", [{
             reason: "screenshot:" + normalizedTest,
             maxFrames: captureSettle.maxFrames,
@@ -5952,6 +6025,9 @@ function cn1SsSettleParams(testName) {
   const normalized = normalizeCn1ssTestName(testName || "default");
   const heavy = normalized === "DrawImage" || normalized === "graphics-draw-image-rect";
   return {
+    // These are the screens that compose their result in stages, so they are the ones a
+    // stillness-based settle can catch half-finished. They get the full repaint before capture.
+    staged: heavy,
     maxFrames: heavy ? 120 : 48,
     stableFrames: heavy ? 6 : 3,
     quietFrames: heavy ? 6 : 3

--- a/vm/ByteCodeTranslator/src/javascript/browser_bridge.js
+++ b/vm/ByteCodeTranslator/src/javascript/browser_bridge.js
@@ -1234,11 +1234,23 @@
     CREATE_PATTERN_SURFACE: 57,
     DRAW_IMAGE_XY: 60, DRAW_IMAGE_XYWH: 61, DRAW_IMAGE_SRCDST: 62,
     BLIT_SURFACE_XY: 70, BLIT_SURFACE_XYWH: 71, BLIT_SURFACE_SRCDST: 72,
-    BLUR_SELF_REGION: 80, LENS_SELF_REGION: 81, GLASS_SELF_REGION: 82
+    BLUR_SELF_REGION: 80, LENS_SELF_REGION: 81, GLASS_SELF_REGION: 82,
+    // Text-layer DOM mutations. They ride the draw stream so the elements and the pixels of
+    // one frame are applied in one task; see SurfaceCommandRecorder.OP_TEXT_* and TextLayerOp.
+    TEXT_ATTACH: 90, TEXT_DETACH: 91, TEXT_CLIP_CSS: 92, TEXT_RUN_CSS: 93,
+    TEXT_CONTENT: 94, TEXT_CLEAR: 95, TEXT_DISPLAY: 96
   };
   // The display surface id. Mirrors HTML5Implementation.DISPLAY_SURFACE_ID.
   var SURF_DISPLAY_ID = 1;
   var surfaceTable = {};
+
+  // A text-layer mutation target: an element the worker created, carried as the host-ref
+  // marker it already is. Never a fresh lookup -- the worker owns the identity of these
+  // elements and only ever names them by reference.
+  function surfaceTextElement(marker) {
+    var resolved = resolveHostRef(marker);
+    return (resolved && resolved.nodeType === 1) ? resolved : null;
+  }
 
   function surfaceImageSource(marker) {
     // A drawImage source: either a host-ref marker (a loaded image / canvas
@@ -1878,6 +1890,57 @@
         case SURF.BLIT_SURFACE_SRCDST: {
           var b3 = surfaceTable[nums[ni++]];
           if (b3 && b3.canvas) { ctx.drawImage(b3.canvas, nums[ni++], nums[ni++], nums[ni++], nums[ni++], nums[ni++], nums[ni++], nums[ni++], nums[ni++]); } else { ni += 8; }
+          break;
+        }
+        case SURF.TEXT_ATTACH: {
+          var taParent = surfaceTextElement(objs[oi++]);
+          var taChild = surfaceTextElement(objs[oi++]);
+          // parentNode is checked so a re-attach of a run already in place is not a move: an
+          // appendChild on a node that is already the last child still detaches and re-inserts
+          // it, which drops any selection or focus inside it.
+          if (taParent && taChild && taChild.parentNode !== taParent) {
+            taParent.appendChild(taChild);
+          }
+          break;
+        }
+        case SURF.TEXT_DETACH: {
+          var tdParent = surfaceTextElement(objs[oi++]);
+          var tdChild = surfaceTextElement(objs[oi++]);
+          if (tdParent && tdChild && tdChild.parentNode === tdParent) {
+            tdParent.removeChild(tdChild);
+          }
+          break;
+        }
+        case SURF.TEXT_CLIP_CSS:
+        case SURF.TEXT_RUN_CSS: {
+          var tcEl = surfaceTextElement(objs[oi++]);
+          var tcCss = objs[oi++];
+          if (tcEl && tcEl.style) {
+            tcEl.style.cssText = tcCss == null ? '' : String(tcCss);
+          }
+          break;
+        }
+        case SURF.TEXT_CONTENT: {
+          var ttEl = surfaceTextElement(objs[oi++]);
+          var ttText = objs[oi++];
+          if (ttEl) {
+            ttEl.textContent = ttText == null ? '' : String(ttText);
+          }
+          break;
+        }
+        case SURF.TEXT_CLEAR: {
+          var tclEl = surfaceTextElement(objs[oi++]);
+          if (tclEl) {
+            tclEl.innerHTML = '';
+          }
+          break;
+        }
+        case SURF.TEXT_DISPLAY: {
+          var tdsEl = surfaceTextElement(objs[oi++]);
+          var tdsVal = objs[oi++];
+          if (tdsEl && tdsEl.style) {
+            tdsEl.style.display = tdsVal == null ? '' : String(tdsVal);
+          }
           break;
         }
         default:


### PR DESCRIPTION
## The defect

`f691c7e4a6` (#5552) gave the port a DOM text layer, which makes every frame two
halves: the pixels the canvas draws and the elements the layer positions. Only
one of them is issued when the frame is decided.

`promote()`, `endComponent()` and `syncToForm()` wrote to the document **during
the component paint**. The canvas commands that same paint records are not
replayed and shipped until the frame is drained an animation frame later. The
browser composites in between, so it renders one half of the new frame over the
other half of the old one:

- text released early leaves a hole where the glyphs still are on screen;
- text added early is drawn twice, once in each place.

Nothing about the layer's bookkeeping was wrong, which is why it survived
review. It was applied at the wrong moment.

Reproduced on the BuildCloud console (7.0.267, real Chrome, 30fps video): a
click on a navigation row blanks **every label and every icon on the form** for
a frame, and draws the outgoing and incoming label of that row superimposed.
Icons go through `drawString` too, so they are runs and blank with the text.

## The fix

Every mutation becomes a `TextLayerOp` (`ExecutableOp`) recorded into the same
buffer as the draws around it, replayed into the same `SurfaceCommandRecorder`
(`OP_TEXT_*`, 90-96), and shipped in the same flush message. The host applies it
in the task that replays that frame's canvas commands, in the draw order the
paint gave it, so no rendering opportunity exists between the two halves.
`OP_BLUR_SELF_REGION` already rides the stream for the same reason.

`syncToForm` moves from the drain to `flushGraphics`. By drain time the frame's
ops are already snapshotted, so a release recorded there shipped with the *next*
frame — which is what put a removed component's text over the pixels that
replaced it. In `flushGraphics` the components have finished painting and the
buffer is still open.

Two things fall out: the retained `CSSStyleDeclaration` handles are gone (style
is written by opcode now), and with them the two `getStyle()` property reads per
run the class had to cache to stay off the barrier.

## Measurement

Scripted 1028-frame interaction, real Chrome, 30fps, counting **transient**
brightness spikes (a frame brighter than the one before that recovers within
three — a navigation is a step that stays, and is not counted):

| console build | transient blank flashes |
| --- | --- |
| 7.0.267 as released | 6 |
| this branch | 0 |

0 is what the same run measures with the layer disabled entirely
(`?cn1TextLayer=0`), so the flicker is gone rather than merely smaller.

`scripts/verify-javascript-web-overlay.mjs` reports the same 44 promoted runs
and 43 semantic nodes as before, so DOM text is still real, selectable text.

## Not covered

The 181-golden screenshot suite did not run: `build-javascript-port-hellocodenameone.sh`
fails in the plugin's `css` goal in this environment for an unrelated reason (a
locally installed `codenameone-designer:8.0-SNAPSHOT` referencing a class that
exists only on another branch). Worth running in CI before merge.
