### PR TITLE
JS port: device pixel ratio for breakpoints, and a millimetre that means the same thing at every ratio

### DIFF
--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -4605,9 +4605,42 @@ public class HTML5Implementation extends CodenameOneImplementation {
     @Override
     public int convertToPixels(int dipCount, boolean horizontal) {
         if (ppi == 0) {
-            ppi = JavaScriptDisplayMetrics.pixelsPerMillimeter(getDeviceDensity());
+            ppi = millimetreScale();
         }
         return (int) Math.round(((float) dipCount) * ppi);
+    }
+
+    /**
+     * Device pixels per millimetre, taken from the display's actual pixel ratio.
+     *
+     * <p>Deliberately not {@code pixelsPerMillimeter(getDeviceDensity())}. That table sorts a
+     * display into one of nine Android-shaped buckets and reads a nominal dpi out of it, which
+     * only lands on Codename One's own baseline of 160dpi-per-CSS-pixel at ratios 1 and 2.
+     * Everywhere else it misses, and by a lot: ratio 3 falls in the HD bucket and is rendered
+     * 12.5% too large, ratio 2.5 lands in the same bucket and is 35% too large, and ratio 1.5 --
+     * ordinary on Android and on Windows at 150% scaling -- falls back to MEDIUM and is a third
+     * too small. A millimetre is a physical length, so it should cover the same amount of screen
+     * whatever the ratio; instead it stepped between displays.</p>
+     *
+     * <p>A browser does not need to guess at any of this. It reports the ratio exactly, so the
+     * baseline scaled by it is the answer, and a millimetre is then the same size at every ratio.
+     * {@link #getDeviceDensity()} keeps its buckets: that one picks which resolution of an image
+     * to load, which is a genuine choice between a handful of assets.</p>
+     *
+     * <p>An explicit {@code ?density=} override is honoured as given -- someone forcing a density
+     * is asking for that density, not for a correction to it.</p>
+     */
+    private double millimetreScale() {
+        int override = getDensityOverride();
+        if (override > 0) {
+            return JavaScriptDisplayMetrics.pixelsPerMillimeter(override);
+        }
+        double ratio = getDevicePixelRatio();
+        if (ratio <= 0) {
+            ratio = 1;
+        }
+        return ratio * JavaScriptDisplayMetrics.pixelsPerMillimeter(
+                JavaScriptDisplayMetrics.DENSITY_MEDIUM);
     }
     
     @JSBody(params={}, script="var ua = navigator.userAgent.toLowerCase(); \n" +

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -4306,6 +4306,16 @@ public class HTML5Implementation extends CodenameOneImplementation {
             String v = mainLocationPart("hostname");
             return v != null ? v : ((WindowLocation)Window.current().getLocation()).getHostname();
         }
+        // The ratio between the device pixels Codename One addresses and the CSS pixels the page
+        // is laid out in. Since 7.0.267 this port reports getDisplayWidth() in device pixels, so
+        // it draws at native resolution -- which also means a width compared against a constant
+        // written in CSS pixels now moves with the display's pixel ratio. An application that
+        // wants a layout breakpoint has to divide by this to get back to the units its threshold
+        // was written in; nothing else it can reach is exact, because getDeviceDensity() buckets
+        // the ratio and convertToPixels() therefore steps rather than scales.
+        if ("browser.window.devicePixelRatio".equals(key)) {
+            return String.valueOf(getDevicePixelRatio());
+        }
         if ("browser.timezone".equals(key)) {
             String tz = detectTimezone();
             return tz != null ? tz : defaultValue;


### PR DESCRIPTION
Two consequences of #5552's native-resolution change that were left behind, both
found while chasing a broken responsive layout in the BuildCloud console.

Independent of #5629 — different files, different failure, no ordering between them.

## 1. Application code cannot write a width breakpoint any more

`getDisplayWidth()` reports device pixels, and since 7.0.267 this port reports
them too rather than CSS pixels. A threshold written in CSS pixels therefore
moves with the display: a 390pt phone at ratio 3 reports **1170**, so *"is this
narrower than 600"* answers **no** on a phone. The console lost its phone layout
exactly that way, and could no longer be made to appear in a browser's
responsive mode — which keeps a desktop User-Agent, so a UA check does not save
you, and applies a pixel ratio.

Nothing already reachable answers the question. `getDeviceDensity()` buckets the
ratio, so anything derived from it steps rather than scales. The ratio itself is
what is needed and the browser knows it exactly, so this exposes it beside the
other `browser.window.*` properties.

## 2. A millimetre was not the same size at every ratio

`convertToPixels()` read a nominal dpi out of one of nine Android-shaped density
buckets. That only lands on Codename One's 160dpi-per-CSS-pixel baseline at
ratios 1 and 2:

| ratio | bucket | effective dpi | |
| --- | --- | --- | --- |
| 1 | MEDIUM 160 | 160 | ok |
| **1.5** | MEDIUM 160 | 107 | **33% too small** |
| 2 | VERY_HIGH 320 | 160 | ok |
| **2.5** | HD 540 | 216 | **35% too large** |
| **3** | HD 540 | 180 | **12.5% too large** |

Ratio 1.5 is ordinary — plenty of Android hardware, and Windows at 150% scaling.
Ratio 3 is every recent iPhone.

Measured on the console at 390pt, text rendered **13.9–25.8 CSS px at ratios 1
and 2** and **15.6–29.1 at ratio 3**. After the change the same screen measures
13.9–25.8 at ratios 1, 1.5, 2, 2.5 and 3 alike. Verified in both Chromium and
Firefox.

`getDeviceDensity()` keeps its buckets deliberately: that one picks which
resolution of an image to load, a real choice between a handful of assets that
wants to be quantised. This is a continuous conversion and does not. An explicit
`?density=` override is still honoured exactly as given.

## Blast radius — please read before merging

The second commit changes rendering for **every JavaScript-port app at any ratio
other than 1 or 2**. At 3x everything gets 12.5% smaller; at 1.5x a third
larger. That is the correction, but it is not a quiet one, and it will move
screenshot goldens for any app not captured at ratio 1.

The first commit adds a property and changes no behaviour.

## Known gap, not addressed here

`refreshDevicePixelRatio()` is wired to the resize event, on the reasoning that
resize is when the ratio can change. A ratio can change without one — a
browser's responsive mode switching device profile is the case that prompted
this. A `matchMedia('(resolution: Ndppx)')` listener would catch it. Left alone
because it is a separate change with its own risk.
