### PR TITLE
The certificate wizard's scrollbar was drawn inside out (issue #5636)

### DIFF
--- a/scripts/certificatewizard/common/src/main/css/theme.css
+++ b/scripts/certificatewizard/common/src/main/css/theme.css
@@ -3,16 +3,25 @@
  * CN1 CSS uses UIIDs, not web selectors; sizes are density-independent mm.
  */
 
+#Constants {
+    /* A desktop tool wants a scrollbar that stays where you can grab it, not one
+       that fades out the moment scrolling stops. */
+    fadeScrollBarBool: false;
+    /* Size the check box in millimetres instead of letting it inherit the label
+       font height, which made it smaller than the word next to it. */
+    checkBoxIconSizeMM: "3.6";
+}
+
 Form, CWForm {
     background-color: #F3F4F7;
     color: #112247;
     font-family: "native:MainRegular";
-    font-size: 2.75mm;
+    font-size: 2.9mm;
 }
 Label, Button, TextField, TextArea, CheckBox {
     color: #112247;
     font-family: "native:MainRegular";
-    font-size: 2.75mm;
+    font-size: 2.9mm;
 }
 CWChrome {
     background-color: #FFFFFF;
@@ -40,7 +49,7 @@ CWStatus {
     padding: 1.0mm 2.5mm 1.0mm 2.5mm;
     margin: 0.3mm;
     font-family: "native:MainBold";
-    font-size: 2.45mm;
+    font-size: 2.6mm;
 }
 CWStatusOff {
     background: cn1-pill-border;
@@ -49,7 +58,7 @@ CWStatusOff {
     padding: 1.0mm 2.5mm 1.0mm 2.5mm;
     margin: 0.3mm;
     font-family: "native:MainBold";
-    font-size: 2.45mm;
+    font-size: 2.6mm;
 }
 CWToolbarButton {
     background-color: #FFFFFF;
@@ -67,7 +76,7 @@ CWToolbarActions {
 CWEmail {
     background-color: transparent;
     color: #7F8AA3;
-    font-size: 2.45mm;
+    font-size: 2.6mm;
     padding: 1mm;
 }
 CWBody {
@@ -82,7 +91,7 @@ CWNavLabel {
     background-color: transparent;
     color: #A0A8BA;
     font-family: "native:MainBold";
-    font-size: 2.1mm;
+    font-size: 2.3mm;
     padding: 2.2mm 1.4mm 0.8mm 1.4mm;
 }
 CWNav {
@@ -91,7 +100,7 @@ CWNav {
     padding: 1.7mm 1.8mm 1.7mm 1.8mm;
     margin: 0.25mm 0 0.25mm 0;
     border-radius: 1.6mm;
-    font-size: 2.65mm;
+    font-size: 2.8mm;
 }
 CWNavSelected {
     background-color: #E8F0FF;
@@ -100,7 +109,7 @@ CWNavSelected {
     margin: 0.25mm 0 0.25mm 0;
     border-radius: 1.6mm;
     font-family: "native:MainBold";
-    font-size: 2.65mm;
+    font-size: 2.8mm;
 }
 CWPage {
     background-color: #F3F4F7;
@@ -116,7 +125,7 @@ CWPageTitle {
 CWSub {
     background-color: transparent;
     color: #7F8AA3;
-    font-size: 2.55mm;
+    font-size: 2.7mm;
     padding: 0 0 2.2mm 0;
 }
 CWCard {
@@ -136,7 +145,7 @@ CWCardTitle {
 CWCardMeta {
     background-color: transparent;
     color: #7F8AA3;
-    font-size: 2.35mm;
+    font-size: 2.55mm;
     padding: 0.2mm 0 0.2mm 0;
 }
 CWCardRow {
@@ -161,7 +170,7 @@ CWMetricNumber {
 CWMetricLabel {
     background-color: transparent;
     color: #7F8AA3;
-    font-size: 2.35mm;
+    font-size: 2.55mm;
     padding: 0.4mm 0 0 0;
 }
 CWActionRow {
@@ -177,11 +186,11 @@ CWActionGrid {
 CWPrimary {
     background: cn1-pill-border;
     background-color: #B8D532;
-    color: #FFFFFF;
+    color: #16220A;
     padding: 1.35mm 3.1mm 1.35mm 3.1mm;
     margin: 0.4mm;
     font-family: "native:MainBold";
-    font-size: 2.45mm;
+    font-size: 2.6mm;
     border-radius: 3.2mm;
     text-align: center;
 }
@@ -192,7 +201,7 @@ CWAccent {
     padding: 1.35mm 3.1mm 1.35mm 3.1mm;
     margin: 0.4mm;
     font-family: "native:MainBold";
-    font-size: 2.45mm;
+    font-size: 2.6mm;
     border-radius: 3.2mm;
     text-align: center;
 }
@@ -205,7 +214,7 @@ CWOutline {
     padding: 1.25mm 2.8mm 1.25mm 2.8mm;
     margin: 0.4mm;
     font-family: "native:MainBold";
-    font-size: 2.45mm;
+    font-size: 2.6mm;
     text-align: center;
 }
 CWDanger {
@@ -217,7 +226,7 @@ CWDanger {
     padding: 1.25mm 2.8mm 1.25mm 2.8mm;
     margin: 0.4mm;
     font-family: "native:MainBold";
-    font-size: 2.45mm;
+    font-size: 2.6mm;
     text-align: center;
 }
 CWDisabled {
@@ -229,7 +238,7 @@ CWDisabled {
     padding: 1.35mm 3.1mm 1.35mm 3.1mm;
     margin: 0.4mm;
     font-family: "native:MainBold";
-    font-size: 2.45mm;
+    font-size: 2.6mm;
     text-align: center;
 }
 CWField {
@@ -244,12 +253,12 @@ CWFieldHint {
     background-color: transparent;
     color: #A0A8BA;
     padding: 1.4mm;
-    font-size: 2.75mm;
+    font-size: 2.9mm;
 }
 CWFieldLabel {
     background-color: transparent;
     color: #7F8AA3;
-    font-size: 2.35mm;
+    font-size: 2.55mm;
     padding: 0.7mm 0 0.4mm 0;
 }
 CWFilterRow {
@@ -269,7 +278,7 @@ CWFilterField {
     border: none;
     padding: 1.1mm 1.4mm 1.1mm 1.4mm;
     margin: 0;
-    font-size: 2.45mm;
+    font-size: 2.6mm;
 }
 CWFilterClear {
     background-color: transparent;
@@ -286,7 +295,7 @@ CWTableHeader {
     background-color: transparent;
     color: #7F8AA3;
     font-family: "native:MainBold";
-    font-size: 2.1mm;
+    font-size: 2.3mm;
     padding: 1.0mm 1.2mm 1.2mm 1.2mm;
 }
 CWRow {
@@ -302,12 +311,12 @@ CWCellMain {
     background-color: transparent;
     color: #112247;
     font-family: "native:MainBold";
-    font-size: 2.65mm;
+    font-size: 2.8mm;
 }
 CWCellSub {
     background-color: transparent;
     color: #7F8AA3;
-    font-size: 2.25mm;
+    font-size: 2.45mm;
 }
 CWPillOk {
     background-color: #E7F4EC;
@@ -315,7 +324,7 @@ CWPillOk {
     padding: 0.8mm 1.9mm 0.8mm 1.9mm;
     border-radius: 1.4mm;
     font-family: "native:MainBold";
-    font-size: 2.2mm;
+    font-size: 2.4mm;
 }
 CWPillWarn {
     background-color: #FDF1DC;
@@ -323,7 +332,7 @@ CWPillWarn {
     padding: 0.8mm 1.9mm 0.8mm 1.9mm;
     border-radius: 1.4mm;
     font-family: "native:MainBold";
-    font-size: 2.2mm;
+    font-size: 2.4mm;
 }
 CWPillBad {
     background-color: #FBE9E9;
@@ -331,7 +340,7 @@ CWPillBad {
     padding: 0.8mm 1.9mm 0.8mm 1.9mm;
     border-radius: 1.4mm;
     font-family: "native:MainBold";
-    font-size: 2.2mm;
+    font-size: 2.4mm;
 }
 CWPillMuted {
     background-color: #F7F8FB;
@@ -339,7 +348,7 @@ CWPillMuted {
     padding: 0.8mm 1.9mm 0.8mm 1.9mm;
     border-radius: 1.4mm;
     font-family: "native:MainBold";
-    font-size: 2.2mm;
+    font-size: 2.4mm;
 }
 CWBanner {
     background-color: #E8F0FF;
@@ -386,7 +395,7 @@ CWChoice {
     border-radius: 1.8mm;
     padding: 1.8mm;
     margin: 0.7mm 0 0.7mm 0;
-    font-size: 2.55mm;
+    font-size: 2.7mm;
 }
 CWChoiceSelected {
     background-color: #E8F0FF;
@@ -395,7 +404,7 @@ CWChoiceSelected {
     border-radius: 1.8mm;
     padding: 1.8mm;
     margin: 0.7mm 0 0.7mm 0;
-    font-size: 2.55mm;
+    font-size: 2.7mm;
 }
 CWSegment {
     background: cn1-pill-border;
@@ -406,18 +415,19 @@ CWSegment {
     padding: 1.15mm 2.4mm 1.15mm 2.4mm;
     margin: 0.25mm;
     font-family: "native:MainBold";
-    font-size: 2.35mm;
+    font-size: 2.55mm;
     text-align: center;
 }
 CWSegmentSelected {
     background: cn1-pill-border;
     background-color: #2F6BFF;
     color: #FFFFFF;
+    border: 0.25mm solid #2F6BFF;
     border-radius: 3.2mm;
     padding: 1.15mm 2.4mm 1.15mm 2.4mm;
     margin: 0.25mm;
     font-family: "native:MainBold";
-    font-size: 2.35mm;
+    font-size: 2.55mm;
     text-align: center;
 }
 
@@ -429,62 +439,62 @@ CWDarkToggle {
     padding: 1.0mm 2.0mm 1.0mm 2.0mm;
     margin: 0.3mm;
     font-family: "native:MainBold";
-    font-size: 2.45mm;
+    font-size: 2.6mm;
     text-align: center;
 }
 
 DarkForm, DarkCWForm {
-    background-color: #071B4D;
-    color: #F5F8FF;
+    background-color: #0F1626;
+    color: #EEF2F8;
     font-family: "native:MainRegular";
-    font-size: 2.75mm;
+    font-size: 2.9mm;
 }
 DarkLabel, DarkButton, DarkTextField, DarkTextArea, DarkCheckBox {
-    color: #F5F8FF;
+    color: #EEF2F8;
     font-family: "native:MainRegular";
-    font-size: 2.75mm;
+    font-size: 2.9mm;
 }
 DarkCWChrome {
-    background-color: #102B66;
-    border-bottom: 0.25mm solid #33518C;
+    background-color: #1A2233;
+    border-bottom: 0.25mm solid #3A465E;
     padding: 1.5mm 2.8mm 1.5mm 2.8mm;
 }
 DarkCWTitle {
     background-color: transparent;
-    color: #F5F8FF;
+    color: #EEF2F8;
     font-family: "native:MainBold";
     font-size: 3.0mm;
     padding: 0.6mm 1.5mm 0.6mm 1.5mm;
 }
 DarkCWLogo {
     background-color: transparent;
-    color: #F5F8FF;
+    color: #EEF2F8;
     font-family: "native:MainBold";
     font-size: 3.1mm;
     padding: 0.8mm 1mm 0.8mm 0;
 }
 DarkCWStatus {
     background: cn1-pill-border;
-    background-color: #143B66;
-    color: #5FD08A;
+    background-color: #1F3329;
+    color: #6FDC9A;
     padding: 1.0mm 2.5mm 1.0mm 2.5mm;
     margin: 0.3mm;
     font-family: "native:MainBold";
-    font-size: 2.45mm;
+    font-size: 2.6mm;
 }
 DarkCWStatusOff {
     background: cn1-pill-border;
-    background-color: #173A7A;
-    color: #A8B8DA;
+    background-color: #26314A;
+    color: #A9B6CC;
     padding: 1.0mm 2.5mm 1.0mm 2.5mm;
     margin: 0.3mm;
     font-family: "native:MainBold";
-    font-size: 2.45mm;
+    font-size: 2.6mm;
 }
 DarkCWToolbarButton {
-    background-color: #102B66;
-    color: #F5F8FF;
-    border: 0.25mm solid #33518C;
+    background-color: #1A2233;
+    color: #EEF2F8;
+    border: 0.25mm solid #3A465E;
     border-radius: 1.6mm;
     padding: 1.2mm;
     margin: 0.45mm;
@@ -496,102 +506,102 @@ DarkCWToolbarActions {
 }
 DarkCWEmail {
     background-color: transparent;
-    color: #A8B8DA;
-    font-size: 2.45mm;
+    color: #A9B6CC;
+    font-size: 2.6mm;
     padding: 1mm;
 }
 DarkCWBody {
-    background-color: #071B4D;
+    background-color: #0F1626;
 }
 DarkCWSidebar {
-    background-color: #102B66;
-    border-right: 0.25mm solid #33518C;
+    background-color: #1A2233;
+    border-right: 0.25mm solid #3A465E;
     padding: 2.0mm 1.5mm 2.0mm 1.5mm;
 }
 DarkCWNavLabel {
     background-color: transparent;
-    color: #7E93BC;
+    color: #8B98AE;
     font-family: "native:MainBold";
-    font-size: 2.1mm;
+    font-size: 2.3mm;
     padding: 2.2mm 1.4mm 0.8mm 1.4mm;
 }
 DarkCWNav {
-    background-color: #102B66;
-    color: #A8B8DA;
+    background-color: #1A2233;
+    color: #A9B6CC;
     padding: 1.7mm 1.8mm 1.7mm 1.8mm;
     margin: 0.25mm 0 0.25mm 0;
     border-radius: 1.6mm;
-    font-size: 2.65mm;
+    font-size: 2.8mm;
 }
 DarkCWNavSelected {
-    background-color: #173A7A;
-    color: #4D86FF;
+    background-color: #26314A;
+    color: #5C93FF;
     padding: 1.7mm 1.8mm 1.7mm 1.8mm;
     margin: 0.25mm 0 0.25mm 0;
     border-radius: 1.6mm;
     font-family: "native:MainBold";
-    font-size: 2.65mm;
+    font-size: 2.8mm;
 }
 DarkCWPage {
-    background-color: #071B4D;
+    background-color: #0F1626;
     padding: 4.0mm 5.0mm 6.0mm 5.0mm;
 }
 DarkCWPageTitle {
     background-color: transparent;
-    color: #F5F8FF;
+    color: #EEF2F8;
     font-family: "native:MainBold";
     font-size: 4.5mm;
     padding: 0 0 0.5mm 0;
 }
 DarkCWSub {
     background-color: transparent;
-    color: #A8B8DA;
-    font-size: 2.55mm;
+    color: #A9B6CC;
+    font-size: 2.7mm;
     padding: 0 0 2.2mm 0;
 }
 DarkCWCard {
-    background-color: #102B66;
-    border: 0.25mm solid #33518C;
+    background-color: #1A2233;
+    border: 0.25mm solid #3A465E;
     border-radius: 1.8mm;
     padding: 2.4mm;
     margin: 1.0mm 0 1.4mm 0;
 }
 DarkCWCardTitle {
     background-color: transparent;
-    color: #F5F8FF;
+    color: #EEF2F8;
     font-family: "native:MainBold";
     font-size: 2.8mm;
     padding: 0.5mm 0 0.4mm 0;
 }
 DarkCWCardMeta {
     background-color: transparent;
-    color: #A8B8DA;
-    font-size: 2.35mm;
+    color: #A9B6CC;
+    font-size: 2.55mm;
     padding: 0.2mm 0 0.2mm 0;
 }
 DarkCWCardRow {
-    background-color: #102B66;
-    border-top: 0.25mm solid #33518C;
+    background-color: #1A2233;
+    border-top: 0.25mm solid #3A465E;
     padding: 1.0mm 0 1.0mm 0;
     margin: 0;
 }
 DarkCWMetric {
-    background-color: #102B66;
-    border: 0.25mm solid #33518C;
+    background-color: #1A2233;
+    border: 0.25mm solid #3A465E;
     border-radius: 1.8mm;
     padding: 2.5mm;
     margin: 0.8mm;
 }
 DarkCWMetricNumber {
     background-color: transparent;
-    color: #F5F8FF;
+    color: #EEF2F8;
     font-family: "native:MainBold";
     font-size: 5.2mm;
 }
 DarkCWMetricLabel {
     background-color: transparent;
-    color: #A8B8DA;
-    font-size: 2.35mm;
+    color: #A9B6CC;
+    font-size: 2.55mm;
     padding: 0.4mm 0 0 0;
 }
 DarkCWActionRow {
@@ -607,79 +617,79 @@ DarkCWActionGrid {
 DarkCWPrimary {
     background: cn1-pill-border;
     background-color: #B8D532;
-    color: #FFFFFF;
+    color: #16220A;
     padding: 1.35mm 3.1mm 1.35mm 3.1mm;
     margin: 0.4mm;
     font-family: "native:MainBold";
-    font-size: 2.45mm;
+    font-size: 2.6mm;
     border-radius: 3.2mm;
     text-align: center;
 }
 DarkCWAccent {
     background: cn1-pill-border;
-    background-color: #4D86FF;
+    background-color: #5C93FF;
     color: #FFFFFF;
     padding: 1.35mm 3.1mm 1.35mm 3.1mm;
     margin: 0.4mm;
     font-family: "native:MainBold";
-    font-size: 2.45mm;
+    font-size: 2.6mm;
     border-radius: 3.2mm;
     text-align: center;
 }
 DarkCWOutline {
     background: cn1-pill-border;
-    background-color: #102B66;
-    color: #F5F8FF;
-    border: 0.25mm solid #33518C;
+    background-color: #1A2233;
+    color: #EEF2F8;
+    border: 0.25mm solid #3A465E;
     border-radius: 3.2mm;
     padding: 1.25mm 2.8mm 1.25mm 2.8mm;
     margin: 0.4mm;
     font-family: "native:MainBold";
-    font-size: 2.45mm;
+    font-size: 2.6mm;
     text-align: center;
 }
 DarkCWDanger {
     background: cn1-pill-border;
-    background-color: #102B66;
+    background-color: #1A2233;
     color: #FF7A7A;
-    border: 0.25mm solid #33518C;
+    border: 0.25mm solid #3A465E;
     border-radius: 3.2mm;
     padding: 1.25mm 2.8mm 1.25mm 2.8mm;
     margin: 0.4mm;
     font-family: "native:MainBold";
-    font-size: 2.45mm;
+    font-size: 2.6mm;
     text-align: center;
 }
 DarkCWDisabled {
     background: cn1-pill-border;
-    background-color: #163575;
-    color: #7890C0;
-    border: 0.25mm solid #33518C;
+    background-color: #26314A;
+    color: #8B98AE;
+    border: 0.25mm solid #3A465E;
     border-radius: 3.2mm;
     padding: 1.35mm 3.1mm 1.35mm 3.1mm;
     margin: 0.4mm;
     font-family: "native:MainBold";
-    font-size: 2.45mm;
+    font-size: 2.6mm;
     text-align: center;
 }
 DarkCWField {
-    background-color: #0E2A61;
-    color: #F5F8FF;
-    border: 0.25mm solid #33518C;
+    background-color: #141B2B;
+    color: #EEF2F8;
+    border: 0.25mm solid #3A465E;
     border-radius: 1.4mm;
     padding: 1.4mm;
     margin: 0.5mm 0 1.2mm 0;
 }
 DarkCWFieldHint {
     background-color: transparent;
-    color: #A8B8DA;
+    color: #A9B6CC;
     padding: 1.4mm;
-    font-size: 2.75mm;
+    font-size: 2.9mm;
 }
 DarkCWFieldLabel {
     background-color: transparent;
-    color: #A8B8DA;
-    font-size: 2.35mm;
+    color: #A9B6CC;
+    font-size: 2.55mm;
     padding: 0.7mm 0 0.4mm 0;
 }
 DarkCWFilterRow {
@@ -687,23 +697,23 @@ DarkCWFilterRow {
     padding: 0 0 1.2mm 0;
 }
 DarkCWFilterWrap {
-    background-color: #0E2A61;
-    border: 0.25mm solid #33518C;
+    background-color: #141B2B;
+    border: 0.25mm solid #3A465E;
     border-radius: 1.4mm;
     padding: 0;
     margin: 0.4mm 0.8mm 0.4mm 0;
 }
 DarkCWFilterField {
-    background-color: #0E2A61;
-    color: #F5F8FF;
+    background-color: #141B2B;
+    color: #EEF2F8;
     border: none;
     padding: 1.1mm 1.4mm 1.1mm 1.4mm;
     margin: 0;
-    font-size: 2.45mm;
+    font-size: 2.6mm;
 }
 DarkCWFilterClear {
     background-color: transparent;
-    color: #A8B8DA;
+    color: #A9B6CC;
     padding: 1.0mm;
     margin: 0;
 }
@@ -714,14 +724,14 @@ DarkCWTableBody {
 }
 DarkCWTableHeader {
     background-color: transparent;
-    color: #A8B8DA;
+    color: #A9B6CC;
     font-family: "native:MainBold";
-    font-size: 2.1mm;
+    font-size: 2.3mm;
     padding: 1.0mm 1.2mm 1.2mm 1.2mm;
 }
 DarkCWRow {
-    background-color: #102B66;
-    border-top: 0.25mm solid #33518C;
+    background-color: #1A2233;
+    border-top: 0.25mm solid #3A465E;
     padding: 1.5mm 1.2mm 1.5mm 1.2mm;
 }
 DarkCWTableCell {
@@ -730,65 +740,65 @@ DarkCWTableCell {
 }
 DarkCWCellMain {
     background-color: transparent;
-    color: #F5F8FF;
+    color: #EEF2F8;
     font-family: "native:MainBold";
-    font-size: 2.65mm;
+    font-size: 2.8mm;
 }
 DarkCWCellSub {
     background-color: transparent;
-    color: #A8B8DA;
-    font-size: 2.25mm;
+    color: #A9B6CC;
+    font-size: 2.45mm;
 }
 DarkCWPillOk {
-    background-color: #143B66;
-    color: #5FD08A;
+    background-color: #1F3329;
+    color: #6FDC9A;
     padding: 0.8mm 1.9mm 0.8mm 1.9mm;
     border-radius: 1.4mm;
     font-family: "native:MainBold";
-    font-size: 2.2mm;
+    font-size: 2.4mm;
 }
 DarkCWPillWarn {
-    background-color: #173A7A;
-    color: #A8B8DA;
+    background-color: #3A2E14;
+    color: #E8B15A;
     padding: 0.8mm 1.9mm 0.8mm 1.9mm;
     border-radius: 1.4mm;
     font-family: "native:MainBold";
-    font-size: 2.2mm;
+    font-size: 2.4mm;
 }
 DarkCWPillBad {
-    background-color: #3A2442;
-    color: #FF7A7A;
+    background-color: #3A2024;
+    color: #FF8A8A;
     padding: 0.8mm 1.9mm 0.8mm 1.9mm;
     border-radius: 1.4mm;
     font-family: "native:MainBold";
-    font-size: 2.2mm;
+    font-size: 2.4mm;
 }
 DarkCWPillMuted {
-    background-color: #163575;
-    color: #A8B8DA;
+    background-color: #26314A;
+    color: #A9B6CC;
     padding: 0.8mm 1.9mm 0.8mm 1.9mm;
     border-radius: 1.4mm;
     font-family: "native:MainBold";
-    font-size: 2.2mm;
+    font-size: 2.4mm;
 }
 DarkCWBanner {
-    background-color: #173A7A;
-    color: #F5F8FF;
+    background-color: #26314A;
+    color: #EEF2F8;
     border-radius: 1.8mm;
     padding: 2.0mm;
     margin: 0 0 2.2mm 0;
 }
 DarkCWBannerWarn {
-    background-color: #34355E;
-    color: #E0A94E;
-    border: 0.25mm solid #735F38;
+    background-color: #3A2E14;
+    color: #E8B15A;
+    border: 0.25mm solid #5C4820;
     border-radius: 1.8mm;
     padding: 2.0mm;
     margin: 0 0 2.2mm 0;
 }
 DarkCWModal {
-    background-color: #102B66;
-    border: 0.25mm solid #33518C;
+    background-color: #1A2233;
+    border: 0.25mm solid #3A465E;
     border-radius: 2.2mm;
     padding: 2.6mm;
 }
@@ -799,7 +809,7 @@ DarkCWDialogContent {
 }
 DarkCWModalTitle {
     background-color: transparent;
-    color: #F5F8FF;
+    color: #EEF2F8;
     font-family: "native:MainBold";
     font-size: 3.4mm;
     padding: 0 0 1.4mm 0;
@@ -810,54 +820,141 @@ DarkCWDialogActions {
     margin: 1.0mm 0 0 0;
 }
 DarkCWChoice {
-    background-color: #102B66;
-    color: #F5F8FF;
-    border: 0.25mm solid #33518C;
+    background-color: #1A2233;
+    color: #EEF2F8;
+    border: 0.25mm solid #3A465E;
     border-radius: 1.8mm;
     padding: 1.8mm;
     margin: 0.7mm 0 0.7mm 0;
-    font-size: 2.55mm;
+    font-size: 2.7mm;
 }
 DarkCWChoiceSelected {
-    background-color: #173A7A;
-    color: #F5F8FF;
-    border: 0.25mm solid #33518C;
+    background-color: #26314A;
+    color: #EEF2F8;
+    border: 0.25mm solid #3A465E;
     border-radius: 1.8mm;
     padding: 1.8mm;
     margin: 0.7mm 0 0.7mm 0;
-    font-size: 2.55mm;
+    font-size: 2.7mm;
 }
 DarkCWSegment {
     background: cn1-pill-border;
-    background-color: #102B66;
-    color: #F5F8FF;
-    border: 0.25mm solid #33518C;
+    background-color: #1A2233;
+    color: #EEF2F8;
+    border: 0.25mm solid #3A465E;
     border-radius: 3.2mm;
     padding: 1.15mm 2.4mm 1.15mm 2.4mm;
     margin: 0.25mm;
     font-family: "native:MainBold";
-    font-size: 2.35mm;
+    font-size: 2.55mm;
     text-align: center;
 }
 DarkCWSegmentSelected {
     background: cn1-pill-border;
-    background-color: #4D86FF;
+    background-color: #5C93FF;
     color: #FFFFFF;
+    border: 0.25mm solid #5C93FF;
     border-radius: 3.2mm;
     padding: 1.15mm 2.4mm 1.15mm 2.4mm;
     margin: 0.25mm;
     font-family: "native:MainBold";
-    font-size: 2.35mm;
+    font-size: 2.55mm;
     text-align: center;
 }
 DarkCWDarkToggle {
-    background-color: #102B66;
-    color: #F5F8FF;
-    border: 0.25mm solid #33518C;
+    background-color: #1A2233;
+    color: #EEF2F8;
+    border: 0.25mm solid #3A465E;
     border-radius: 1.6mm;
     padding: 1.0mm 2.0mm 1.0mm 2.0mm;
     margin: 0.3mm;
     font-family: "native:MainBold";
-    font-size: 2.45mm;
+    font-size: 2.6mm;
     text-align: center;
+}
+
+/* Components whose UIID the look and feel fixes by name.
+ *
+ * Everything above comes in a light UIID and a "Dark" twin the app swaps
+ * between, because the app owns those UIIDs. These it does not: the look and
+ * feel asks the theme for "Scroll"/"ScrollThumb" (and "DesktopScroll"/
+ * "DesktopScrollThumb" once the port turns on interactive scrollbars) and for
+ * "CheckBox" by those exact names, so a Dark twin would never be looked up.
+ * Their dark values live in the prefers-color-scheme block at the end of this
+ * file, which the CSS compiler emits as $Dark<UIID> entries -- the form the
+ * runtime consults when CN.isDarkMode() is true.
+ *
+ * With no rule at all they were drawn from the blank-theme defaults: a WHITE
+ * track with a BLACK thumb. On a dark page that reads as an inverted bar whose
+ * empty part looks like the thumb, which is issue #5636.
+ */
+Scroll, HorizontalScroll, DesktopScroll, DesktopHorizontalScroll {
+    background-color: transparent;
+    padding: 0 0.9mm 0 0.9mm;
+    margin: 0;
+}
+ScrollThumb, HorizontalScrollThumb, DesktopScrollThumb, DesktopHorizontalScrollThumb {
+    background-color: #AEB7C7;
+    cn1-background-type: cn1-round-border;
+    padding: 0;
+    margin: 0;
+}
+DesktopScrollThumb.selected, DesktopHorizontalScrollThumb.selected {
+    background-color: #8791A6;
+    cn1-background-type: cn1-round-border;
+    padding: 0;
+    margin: 0;
+}
+DesktopScrollThumb.pressed, DesktopHorizontalScrollThumb.pressed {
+    background-color: #2F6BFF;
+    cn1-background-type: cn1-round-border;
+    padding: 0;
+    margin: 0;
+}
+/* The check box glyph is built from the CheckBox style, never from the UIID the
+ * component carries, so these colours are the box and not the label. Unchecked
+ * is a grey outline and checked is the accent fill: at the label's own font
+ * height the two were the same small square in the same colour, which is why a
+ * list of unchecked devices looked like a list of checked ones. */
+CheckBox {
+    color: #8791A6;
+    background-color: transparent;
+}
+CheckBox.selected {
+    color: #2F6BFF;
+    background-color: transparent;
+}
+
+@media (prefers-color-scheme: dark) {
+    Scroll, HorizontalScroll, DesktopScroll, DesktopHorizontalScroll {
+        background-color: transparent;
+        padding: 0 0.9mm 0 0.9mm;
+        margin: 0;
+    }
+    ScrollThumb, HorizontalScrollThumb, DesktopScrollThumb, DesktopHorizontalScrollThumb {
+        background-color: #4E5A72;
+        cn1-background-type: cn1-round-border;
+        padding: 0;
+        margin: 0;
+    }
+    DesktopScrollThumb.selected, DesktopHorizontalScrollThumb.selected {
+        background-color: #6E7C97;
+        cn1-background-type: cn1-round-border;
+        padding: 0;
+        margin: 0;
+    }
+    DesktopScrollThumb.pressed, DesktopHorizontalScrollThumb.pressed {
+        background-color: #5C93FF;
+        cn1-background-type: cn1-round-border;
+        padding: 0;
+        margin: 0;
+    }
+    CheckBox {
+        color: #8B98AE;
+        background-color: transparent;
+    }
+    CheckBox.selected {
+        color: #5C93FF;
+        background-color: transparent;
+    }
 }

--- a/scripts/certificatewizard/common/src/main/css/theme.css
+++ b/scripts/certificatewizard/common/src/main/css/theme.css
@@ -1,4 +1,26 @@
 /*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+/*
  * Certificate Wizard theme adapted from the iOS Signing mock design.
  * CN1 CSS uses UIIDs, not web selectors; sizes are density-independent mm.
  */

--- a/scripts/certificatewizard/common/src/main/css/theme.css
+++ b/scripts/certificatewizard/common/src/main/css/theme.css
@@ -910,9 +910,18 @@ DarkCWDarkToggle {
  * track with a BLACK thumb. On a dark page that reads as an inverted bar whose
  * empty part looks like the thumb, which is issue #5636.
  */
-Scroll, HorizontalScroll, DesktopScroll, DesktopHorizontalScroll {
+/* The track's padding is what SIZES the bar: getVerticalScrollWidth sums the left
+   and right, getHorizontalScrollHeight the top and bottom. One shared rule cannot
+   serve both -- giving the horizontal track the vertical one's padding left it
+   zero pixels high, present but impossible to grab. */
+Scroll, DesktopScroll {
     background-color: transparent;
     padding: 0 0.9mm 0 0.9mm;
+    margin: 0;
+}
+HorizontalScroll, DesktopHorizontalScroll {
+    background-color: transparent;
+    padding: 0.9mm 0 0.9mm 0;
     margin: 0;
 }
 ScrollThumb, HorizontalScrollThumb, DesktopScrollThumb, DesktopHorizontalScrollThumb {
@@ -948,9 +957,14 @@ CheckBox.selected {
 }
 
 @media (prefers-color-scheme: dark) {
-    Scroll, HorizontalScroll, DesktopScroll, DesktopHorizontalScroll {
+    Scroll, DesktopScroll {
         background-color: transparent;
         padding: 0 0.9mm 0 0.9mm;
+        margin: 0;
+    }
+    HorizontalScroll, DesktopHorizontalScroll {
+        background-color: transparent;
+        padding: 0.9mm 0 0.9mm 0;
         margin: 0;
     }
     ScrollThumb, HorizontalScrollThumb, DesktopScrollThumb, DesktopHorizontalScrollThumb {

--- a/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/CertificateWizard.java
+++ b/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/CertificateWizard.java
@@ -1199,11 +1199,19 @@ public class CertificateWizard extends Lifecycle {
             // Only the certificates this profile type can actually be signed with. Offering all
             // of them let a Mac Installer certificate be picked for an iOS App Store profile,
             // which Apple rejects at creation time -- long after the wizard said it was fine.
-            List<SigningState.Certificate> usable = WizardDecisions.compatibleCertificates(state, profileType[0]);
+            // Note this is NOT compatibleCertificates: that one also demands a stored private
+            // key, which creating a profile does not need and which a certificate synced from
+            // Apple often does not have.
+            List<SigningState.Certificate> usable = WizardDecisions.profileCertificateChoices(state, profileType[0]);
             final List<Button> certButtons = new ArrayList<Button>();
             for (SigningState.Certificate cert : usable) {
                 String id = String.valueOf(cert.id());
-                Button pick = choice(cert.displayName(), typeLabel(cert.certificateType()), id.equals(certificateId[0]));
+                // The list is already filtered to one certificate type, so repeating that type on
+                // every row says nothing. The private key is the thing that differs between them,
+                // and saying so here beats discovering it at install time -- the one step that
+                // actually needs it. A Button clips rather than wraps, so this stays short.
+                String detail = cert.privateKeyPresent() ? null : "no stored private key";
+                Button pick = choice(cert.displayName(), detail, id.equals(certificateId[0]));
                 pick.setName("pick.cert." + cert.id());
                 certButtons.add(pick);
                 pick.addActionListener(e -> {
@@ -1217,7 +1225,7 @@ public class CertificateWizard extends Lifecycle {
             }
             if (usable.isEmpty()) {
                 label(c, "No active " + typeLabel(WizardDecisions.requiredCertificateType(profileType[0]))
-                        + " certificate with a private key. Generate one first.", "CWCardMeta");
+                        + " certificate. Generate one first.", "CWCardMeta");
                 Button makeCert = outline("Generate certificate", "btn.profileNeedsCert");
                 makeCert.addActionListener(e -> { d.dispose(); certificateDialog(); });
                 c.add(makeCert);
@@ -1225,12 +1233,17 @@ public class CertificateWizard extends Lifecycle {
 
             if (WizardDecisions.profileRequiresDevices(profileType[0])) {
                 label(c, "Devices", "CWFieldLabel");
+                // Disabled devices are still on the account and Apple rejects a request that
+                // names one, so the picker offers exactly what deviceIdsFor sends. Listing them
+                // and letting "select all" sweep them in made one click enough to build a
+                // request that could not succeed.
+                final List<SigningState.Device> devices = WizardDecisions.usableDevices(state);
                 final List<CheckBox> deviceBoxes = new ArrayList<CheckBox>();
                 Button all = outline("Select all", "modal.profile.selectAllDevices");
                 Button none = outline("Clear", "modal.profile.clearDevices");
                 all.addActionListener(e -> {
                     devs.clear();
-                    for (SigningState.Device dev : state.devices) {
+                    for (SigningState.Device dev : devices) {
                         devs.add(dev.id());
                     }
                     for (CheckBox box : deviceBoxes) {
@@ -1246,7 +1259,7 @@ public class CertificateWizard extends Lifecycle {
                     revalidate.run();
                 });
                 c.add(actionRow(Component.LEFT, all, none));
-                for (SigningState.Device device : state.devices) {
+                for (SigningState.Device device : devices) {
                     CheckBox cb = new CheckBox(device.name() + "   " + device.udid());
                     cb.setName("pick.device." + device.id());
                     cb.setUIID(uiid("CWFieldLabel"));
@@ -1264,8 +1277,8 @@ public class CertificateWizard extends Lifecycle {
                     });
                     c.add(cb);
                 }
-                if (state.devices.isEmpty()) {
-                    label(c, "No devices registered. Register one before creating this profile type.",
+                if (devices.isEmpty()) {
+                    label(c, "No enabled devices. Register one before creating this profile type.",
                             "CWCardMeta");
                 }
             } else {
@@ -2073,10 +2086,8 @@ public class CertificateWizard extends Lifecycle {
         if (!WizardDecisions.profileRequiresDevices(profileType)) {
             return out;
         }
-        for (SigningState.Device d : state.devices) {
-            if ("ENABLED".equals(d.status()) || "ACTIVE".equals(d.status())) {
-                out.add(d.id());
-            }
+        for (SigningState.Device d : WizardDecisions.usableDevices(state)) {
+            out.add(d.id());
         }
         return out;
     }

--- a/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/CertificateWizard.java
+++ b/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/CertificateWizard.java
@@ -141,6 +141,7 @@ public class CertificateWizard extends Lifecycle {
         darkMode = Preferences.get(PREF_DARK_MODE, Boolean.TRUE.equals(CN.isDarkMode()));
         fontDeltaPx = Preferences.get(PREF_FONT_DELTA, 0);
         CN.setDarkMode(Boolean.valueOf(darkMode));
+        applyThemeForCurrentScheme();
         binding = ProjectIO.loadBinding();
         userEmail = firstNonEmpty(System.getProperty("certificatewizard.user"),
                 binding == null ? null : binding.user(), "Not signed in");
@@ -186,6 +187,29 @@ public class CertificateWizard extends Lifecycle {
         buildShell();
         form.show();
         reload();
+    }
+
+    /// Refreshes the theme once the dark flag is known, and on the desktop restores the scrollbar
+    /// the generated stub already asks for.
+    ///
+    /// The stub calls JavaSEPort.setDesktopInteractiveScrollbars(true), and the port injects
+    /// @interactiveScrollBool into the NATIVE theme. This app's theme is a CSS theme that does not
+    /// layer the native one, so installing it replaced the whole property table and took that
+    /// constant with it -- the look and feel then fell back to the thin mobile overlay bar you
+    /// cannot grab, on a desktop tool whose lists are long enough to need one.
+    ///
+    /// The refresh has to come after CN.setDarkMode: the look and feel bakes the check box glyphs
+    /// from the CheckBox style at refresh time, and which of CheckBox / $DarkCheckBox that resolves
+    /// to is read from the dark flag right then. Refreshing earlier coloured the boxes for the
+    /// scheme the platform reported rather than the one the stored preference selects.
+    private void applyThemeForCurrentScheme() {
+        if (!CN.isDesktop()) {
+            UIManager.getInstance().refreshTheme();
+            return;
+        }
+        java.util.Hashtable<String, String> props = new java.util.Hashtable<String, String>();
+        props.put("@interactiveScrollBool", "true");
+        UIManager.getInstance().addThemeProps(props);
     }
 
     private void seedCredentialState() {
@@ -1090,106 +1114,201 @@ public class CertificateWizard extends Lifecycle {
     }
 
     private void newProfileDialog() {
-        InteractionDialog d = modalFrame("New provisioning profile");
-        Container content = new Container(BoxLayout.y());
+        final InteractionDialog d = modalFrame("New provisioning profile");
+        final Container content = new Container(BoxLayout.y());
         content.setScrollableY(true);
         content.setUIID(uiid("CWDialogContent"));
         d.add(BorderLayout.CENTER, content);
 
-        final String[] profileType = {null};
+        // The dialog opens with App Store selected, and now says so in the model as well as on
+        // the segment. It used to paint that segment selected while profileType held null, so
+        // "Create" stayed disabled until you clicked the segment that already looked chosen --
+        // and clicking it a second time silently went back to null. That is the "no combination
+        // of buttons enables Create" half of issue #5636.
+        final String[] profileType = {PROFILE_APP_STORE};
         final String[] bundleId = {null};
         final String[] certificateId = {null};
-        final String[] profileName = {projectDefaults().appName + " App Store"};
         final List<String> certs = new ArrayList<String>();
         final List<String> devs = new ArrayList<String>();
-        final Button[] createRef = new Button[1];
+        // nameEdited: the suggested name follows the profile type until the user writes their own.
+        // settingName: TextField.setText fires the data changed listener, so the suggestion would
+        // otherwise mark itself as the user's edit and stop following after one type change.
+        final boolean[] nameEdited = {false};
+        final boolean[] settingName = {false};
 
-        Button store = segment("iOS App Store", true);
-        Button adhoc = segment("iOS Ad Hoc", false);
-        Button dev = segment("iOS Development", false);
-        Button macStore = segment("Mac App Store", false);
-        Button macDirect = segment("Mac Direct", false);
-        Button macDev = segment("Mac Development", false);
-        Button[] typeButtons = {store, adhoc, dev, macStore, macDirect, macDev};
-        String[] typeValues = {"IOS_APP_STORE", "IOS_APP_ADHOC", "IOS_APP_DEVELOPMENT",
-                "MAC_APP_STORE", "MAC_APP_DIRECT", "MAC_APP_DEVELOPMENT"};
-        label(content, "Profile type", "CWFieldLabel");
-        content.add(actionRow(Component.LEFT, store, adhoc, dev));
-        content.add(actionRow(Component.LEFT, macStore, macDirect, macDev));
+        final Button create = primary("Create", "modal.profile.submit");
+        final TextField name = field("Profile name", "My App App Store");
+        name.setName("field.profileName");
+        name.setText(defaultProfileName(profileType[0]));
+        final Label requirement = new Label("");
+        requirement.setUIID(uiid("CWFieldLabel"));
+        requirement.setName("modal.profile.requirement");
+        requirement.setTextSelectionEnabled(true);
 
-        label(content, "Bundle ID", "CWFieldLabel");
-        List<Button> bundleButtons = new ArrayList<Button>();
-        for (SigningState.BundleId b : state.bundleIds) {
-            Button pick = choice(b.identifier(), b.name(), false);
-            pick.setName("pick.bundle." + b.id());
-            bundleButtons.add(pick);
-            pick.addActionListener(e -> {
-                bundleId[0] = b.id().equals(bundleId[0]) ? null : b.id();
-                updateChoiceButtons(bundleButtons, bundleId[0]);
-                updateCreateProfileButton(createRef[0], profileType[0], bundleId[0], certs, devs, profileName[0]);
-            });
-            content.add(pick);
-        }
-        if (state.bundleIds.isEmpty()) {
-            Button createBundle = outline("Register bundle ID first", "btn.profileNeedsBundle");
-            createBundle.addActionListener(e -> { d.dispose(); bundleDialog(null, null); });
-            content.add(createBundle);
+        final Button[] typeButtons = {
+                segment("iOS App Store", false), segment("iOS Ad Hoc", false), segment("iOS Development", false),
+                segment("Mac App Store", false), segment("Mac Direct", false), segment("Mac Development", false)};
+        final String[] typeValues = {PROFILE_APP_STORE, "IOS_APP_ADHOC", PROFILE_DEVELOPMENT,
+                PROFILE_MAC_STORE, PROFILE_MAC_DIRECT, "MAC_APP_DEVELOPMENT"};
+        for (int i = 0; i < typeButtons.length; i++) {
+            typeButtons[i].setName("pick.type." + typeValues[i].toLowerCase());
         }
 
-        label(content, "Certificate", "CWFieldLabel");
-        List<Button> certButtons = new ArrayList<Button>();
-        for (SigningState.Certificate c : state.certificates) {
-            Button pick = choice(c.displayName(), typeLabel(c.certificateType()), false);
-            pick.setName("pick.cert." + c.id());
-            certButtons.add(pick);
-            pick.addActionListener(e -> {
-                certs.clear();
-                String id = String.valueOf(c.id());
-                if (!id.equals(certificateId[0])) {
+        final Runnable[] rebuild = new Runnable[1];
+        final Runnable revalidate = () -> {
+            updateCreateProfileButton(create, requirement, profileType[0], bundleId[0], certs, devs, name.getText());
+        };
+
+        rebuild[0] = () -> {
+            Container c = content;
+            c.removeAll();
+            // removeAll detaches the rows, not what is inside them, and the segment buttons and
+            // the name field outlive a rebuild so their listeners and typed text survive it.
+            // Re-adding one that still names its old row as its parent is rejected outright.
+            for (Button b : typeButtons) {
+                b.remove();
+            }
+            name.remove();
+            updateSegmentButtons(typeButtons, typeValues, profileType[0]);
+            label(c, "Profile type", "CWFieldLabel");
+            c.add(actionRow(Component.LEFT, typeButtons[0], typeButtons[1], typeButtons[2]));
+            c.add(actionRow(Component.LEFT, typeButtons[3], typeButtons[4], typeButtons[5]));
+
+            label(c, "Bundle ID", "CWFieldLabel");
+            final List<Button> bundleButtons = new ArrayList<Button>();
+            for (SigningState.BundleId b : state.bundleIds) {
+                Button pick = choice(b.identifier(), b.name(), b.id().equals(bundleId[0]));
+                pick.setName("pick.bundle." + b.id());
+                bundleButtons.add(pick);
+                pick.addActionListener(e -> {
+                    // Single select, and re-picking the current one is a no-op rather than a
+                    // silent deselect -- a second click on a chosen row used to clear it.
+                    bundleId[0] = b.id();
+                    updateChoiceButtons(bundleButtons, bundleId[0]);
+                    revalidate.run();
+                });
+                c.add(pick);
+            }
+            if (state.bundleIds.isEmpty()) {
+                Button createBundle = outline("Register bundle ID first", "btn.profileNeedsBundle");
+                createBundle.addActionListener(e -> { d.dispose(); bundleDialog(null, null); });
+                c.add(createBundle);
+            }
+
+            label(c, "Certificate", "CWFieldLabel");
+            // Only the certificates this profile type can actually be signed with. Offering all
+            // of them let a Mac Installer certificate be picked for an iOS App Store profile,
+            // which Apple rejects at creation time -- long after the wizard said it was fine.
+            List<SigningState.Certificate> usable = WizardDecisions.compatibleCertificates(state, profileType[0]);
+            final List<Button> certButtons = new ArrayList<Button>();
+            for (SigningState.Certificate cert : usable) {
+                String id = String.valueOf(cert.id());
+                Button pick = choice(cert.displayName(), typeLabel(cert.certificateType()), id.equals(certificateId[0]));
+                pick.setName("pick.cert." + cert.id());
+                certButtons.add(pick);
+                pick.addActionListener(e -> {
+                    certs.clear();
                     certificateId[0] = id;
-                    certs.add(c.appleCertId());
-                } else {
-                    certificateId[0] = null;
-                }
-                updateChoiceButtons(certButtons, certificateId[0]);
-                updateCreateProfileButton(createRef[0], profileType[0], bundleId[0], certs, devs, profileName[0]);
-            });
-            content.add(pick);
-        }
-        label(content, "Devices", "CWFieldLabel");
-        for (SigningState.Device device : state.devices) {
-            CheckBox cb = new CheckBox(device.name());
-            cb.setName("pick.device." + device.id());
-            cb.setUIID(uiid("CWFieldLabel"));
-            cb.addActionListener(e -> {
-                if (cb.isSelected()) {
-                    if (!devs.contains(device.id())) {
-                        devs.add(device.id());
+                    certs.add(cert.appleCertId());
+                    updateChoiceButtons(certButtons, certificateId[0]);
+                    revalidate.run();
+                });
+                c.add(pick);
+            }
+            if (usable.isEmpty()) {
+                label(c, "No active " + typeLabel(WizardDecisions.requiredCertificateType(profileType[0]))
+                        + " certificate with a private key. Generate one first.", "CWCardMeta");
+                Button makeCert = outline("Generate certificate", "btn.profileNeedsCert");
+                makeCert.addActionListener(e -> { d.dispose(); certificateDialog(); });
+                c.add(makeCert);
+            }
+
+            if (WizardDecisions.profileRequiresDevices(profileType[0])) {
+                label(c, "Devices", "CWFieldLabel");
+                final List<CheckBox> deviceBoxes = new ArrayList<CheckBox>();
+                Button all = outline("Select all", "modal.profile.selectAllDevices");
+                Button none = outline("Clear", "modal.profile.clearDevices");
+                all.addActionListener(e -> {
+                    devs.clear();
+                    for (SigningState.Device dev : state.devices) {
+                        devs.add(dev.id());
                     }
-                } else {
-                    devs.remove(device.id());
+                    for (CheckBox box : deviceBoxes) {
+                        box.setSelected(true);
+                    }
+                    revalidate.run();
+                });
+                none.addActionListener(e -> {
+                    devs.clear();
+                    for (CheckBox box : deviceBoxes) {
+                        box.setSelected(false);
+                    }
+                    revalidate.run();
+                });
+                c.add(actionRow(Component.LEFT, all, none));
+                for (SigningState.Device device : state.devices) {
+                    CheckBox cb = new CheckBox(device.name() + "   " + device.udid());
+                    cb.setName("pick.device." + device.id());
+                    cb.setUIID(uiid("CWFieldLabel"));
+                    cb.setSelected(devs.contains(device.id()));
+                    deviceBoxes.add(cb);
+                    cb.addActionListener(e -> {
+                        if (cb.isSelected()) {
+                            if (!devs.contains(device.id())) {
+                                devs.add(device.id());
+                            }
+                        } else {
+                            devs.remove(device.id());
+                        }
+                        revalidate.run();
+                    });
+                    c.add(cb);
                 }
-                updateCreateProfileButton(createRef[0], profileType[0], bundleId[0], certs, devs, profileName[0]);
-            });
-            content.add(cb);
-        }
-        TextField name = field("Profile name", "My App App Store");
-        name.setText(profileName[0]);
-        content.add(name);
-        Button create = primary("Create", "modal.profile.submit");
-        createRef[0] = create;
+                if (state.devices.isEmpty()) {
+                    label(c, "No devices registered. Register one before creating this profile type.",
+                            "CWCardMeta");
+                }
+            } else {
+                // An App Store or Developer ID profile is not device limited, and the device list
+                // used to be rendered anyway: a screen of check boxes that changed nothing, in
+                // front of the profile name field you actually had to reach.
+                label(c, "Devices", "CWFieldLabel");
+                label(c, profileTypeName(profileType[0])
+                        + " profiles are not limited to specific devices.", "CWCardMeta");
+            }
+
+            label(c, "Profile name", "CWFieldLabel");
+            c.add(name);
+            revalidate.run();
+            c.revalidate();
+        };
+
         name.addDataChangedListener((type, index) -> {
-            profileName[0] = name.getText();
-            updateCreateProfileButton(create, profileType[0], bundleId[0], certs, devs, profileName[0]);
+            if (!settingName[0]) {
+                nameEdited[0] = true;
+            }
+            revalidate.run();
         });
         for (int i = 0; i < typeButtons.length; i++) {
-            final int typeIndex = i;
-            typeButtons[i].setUIID(uiid("CWSegment"));
+            final String value = typeValues[i];
             typeButtons[i].addActionListener(e -> {
-                profileType[0] = typeValues[typeIndex].equals(profileType[0]) ? null : typeValues[typeIndex];
-                updateSegmentButtons(typeButtons, typeValues, profileType[0]);
-                updateCreateProfileButton(create, profileType[0], bundleId[0], certs, devs, name.getText());
-                d.revalidate();
+                if (value.equals(profileType[0])) {
+                    return;
+                }
+                profileType[0] = value;
+                // The certificate list is type specific, so a selection that no longer belongs
+                // has to go with it rather than quietly staying in the request.
+                certificateId[0] = null;
+                certs.clear();
+                if (!nameEdited[0]) {
+                    settingName[0] = true;
+                    try {
+                        name.setText(defaultProfileName(value));
+                    } finally {
+                        settingName[0] = false;
+                    }
+                }
+                rebuild[0].run();
             });
         }
         create.addActionListener(e -> {
@@ -1200,9 +1319,40 @@ public class CertificateWizard extends Lifecycle {
             service.createProfile(name.getText(), profileType[0], bundleId[0], certs, devs,
                     r -> afterMutation(r, "Profile created"));
         });
-        updateCreateProfileButton(create, profileType[0], bundleId[0], certs, devs, name.getText());
-        addDialogFooter(d, create);
+        rebuild[0].run();
+        addDialogFooter(d, create, requirement);
         showLargeModal(d);
+    }
+
+    /// The name a fresh profile of this type gets, so the field is never blank on arrival and
+    /// stops tracking the type the moment the user types their own.
+    private String defaultProfileName(String profileType) {
+        return projectDefaults().appName + " " + profileTypeName(profileType);
+    }
+
+    /// The profile type as a person writes it. [#profileTypeLabel] is the table spelling: it
+    /// strips the platform prefix, so IOS_APP_STORE reduces to "STORE", which is fine in a column
+    /// headed "Type" and reads as a mistake in a sentence or in a suggested profile name.
+    private String profileTypeName(String profileType) {
+        if (PROFILE_APP_STORE.equals(profileType)) {
+            return "App Store";
+        }
+        if ("IOS_APP_ADHOC".equals(profileType)) {
+            return "Ad Hoc";
+        }
+        if (PROFILE_DEVELOPMENT.equals(profileType)) {
+            return "Development";
+        }
+        if (PROFILE_MAC_STORE.equals(profileType)) {
+            return "Mac App Store";
+        }
+        if (PROFILE_MAC_DIRECT.equals(profileType)) {
+            return "Mac Developer ID";
+        }
+        if ("MAC_APP_DEVELOPMENT".equals(profileType)) {
+            return "Mac Development";
+        }
+        return profileTypeLabel(profileType);
     }
 
     private void autoSetupCurrentProject() {
@@ -2444,11 +2594,26 @@ public class CertificateWizard extends Lifecycle {
     }
 
     private void addDialogFooter(InteractionDialog d, Button primaryAction) {
+        addDialogFooter(d, primaryAction, null);
+    }
+
+    /// The footer of a framed dialog. The note sits beside the buttons rather than at the end of
+    /// the scrolling body, so an explanation of why the action is disabled cannot itself be
+    /// below the fold.
+    private void addDialogFooter(InteractionDialog d, Button primaryAction, Component note) {
         Button cancel = outline("Cancel", "modal.cancel");
         cancel.addActionListener(e -> d.dispose());
         Container actions = actionRow(Component.RIGHT, cancel, primaryAction);
         actions.setUIID(uiid("CWDialogActions"));
-        d.add(BorderLayout.SOUTH, actions);
+        if (note == null) {
+            d.add(BorderLayout.SOUTH, actions);
+            return;
+        }
+        Container footer = new Container(new BorderLayout());
+        footer.setUIID(uiid("CWDialogActions"));
+        footer.add(BorderLayout.CENTER, note);
+        footer.add(BorderLayout.EAST, actions);
+        d.add(BorderLayout.SOUTH, footer);
     }
 
     private void showModal(InteractionDialog d) {
@@ -2782,10 +2947,23 @@ public class CertificateWizard extends Lifecycle {
         return button(text, name, "CWDanger");
     }
 
+    /// A single select row. The two halves used to be joined with a newline, which a Button does
+    /// not render -- "com.example.myapp" and "My App" came out as one run of text with no gap.
+    /// The leading glyph is what makes the chosen row obvious at a glance; the tinted background
+    /// alone was easy to miss on a list of rows that already have backgrounds.
     private Button choice(String title, String desc, boolean selected) {
-        Button b = new Button(title + "\n" + desc);
+        String text = desc == null || desc.trim().isEmpty() ? title : title + "   " + desc.trim();
+        Button b = new Button(text);
         b.setUIID(uiid(selected ? "CWChoiceSelected" : "CWChoice"));
+        b.setAlignment(Component.LEFT);
+        b.getAllStyles().setAlignment(Component.LEFT);
+        applyChoiceIcon(b, selected);
         return b;
+    }
+
+    private void applyChoiceIcon(Button b, boolean selected) {
+        FontImage.setMaterialIcon(b, selected ? FontImage.MATERIAL_RADIO_BUTTON_CHECKED
+                : FontImage.MATERIAL_RADIO_BUTTON_UNCHECKED, 3.0f);
     }
 
     private Button segment(String text, boolean selected) {
@@ -2803,17 +2981,24 @@ public class CertificateWizard extends Lifecycle {
             String name = b.getName();
             boolean selected = selectedId != null && name != null && name.endsWith("." + selectedId);
             setScaledUIID(b, selected ? "CWChoiceSelected" : "CWChoice");
+            applyChoiceIcon(b, selected);
         }
     }
 
-    private void updateCreateProfileButton(Button create, String profileType, String bundleId, List<String> certs,
-                                           List<String> devs, String name) {
-        if (create == null) {
-            return;
-        }
+    /// Keeps the create action and the line under it in step. A disabled button with nothing
+    /// saying why is what the reporter of issue #5636 ran into: the only feedback was that
+    /// clicking it did nothing, and the missing input was two sections further up the dialog.
+    private void updateCreateProfileButton(Button create, Label requirement, String profileType, String bundleId,
+                                           List<String> certs, List<String> devs, String name) {
         boolean enabled = WizardDecisions.canCreateProfile(profileType, bundleId, certs, devs, name);
-        create.setEnabled(enabled);
-        setScaledUIID(create, enabled ? "CWPrimary" : "CWDisabled");
+        if (create != null) {
+            create.setEnabled(enabled);
+            setScaledUIID(create, enabled ? "CWPrimary" : "CWDisabled");
+        }
+        if (requirement != null) {
+            String missing = WizardDecisions.describeMissingProfileInput(profileType, bundleId, certs, devs, name);
+            requirement.setText(missing == null ? "" : missing);
+        }
     }
 
     private void setScaledUIID(Component c, String id) {

--- a/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/CertificateWizard.java
+++ b/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/CertificateWizard.java
@@ -1015,19 +1015,42 @@ public class CertificateWizard extends Lifecycle {
         for (int i = 0; i < typeValues.length; i++) {
             typeButtons[i] = segment(WizardDecisions.GENERATABLE_CERTIFICATE_LABELS[i], false);
         }
+        updateSegmentButtons(typeButtons, typeValues, type[0]);
+        final TextField name = field("Display name", "App Store Distribution");
+        name.setName("field.certName");
+        // The suggested name follows the type until the user writes their own. A suggestion that
+        // stays behind is worse than no suggestion: it puts a certificate labelled "DISTRIBUTION"
+        // on the account that is nothing of the kind. settingName guards against
+        // TextField.setText firing the listener and marking the suggestion as the user's edit.
+        final boolean[] nameEdited = {false};
+        final boolean[] settingName = {false};
+        final Runnable suggestName = () -> {
+            if (nameEdited[0]) {
+                return;
+            }
+            settingName[0] = true;
+            try {
+                name.setText(typeLabel(type[0]));
+            } finally {
+                settingName[0] = false;
+            }
+        };
+        suggestName.run();
+        name.addDataChangedListener((changeType, index) -> {
+            if (!settingName[0]) {
+                nameEdited[0] = true;
+            }
+        });
         for (int i = 0; i < typeButtons.length; i++) {
             typeButtons[i].setName("pick.certType." + typeValues[i].toLowerCase());
             final int typeIndex = i;
             typeButtons[i].addActionListener(e -> {
                 type[0] = typeValues[typeIndex];
                 updateSegmentButtons(typeButtons, typeValues, type[0]);
+                suggestName.run();
                 d.revalidate();
             });
         }
-        updateSegmentButtons(typeButtons, typeValues, type[0]);
-        TextField name = field("Display name", "App Store Distribution");
-        name.setName("field.certName");
-        name.setText(typeLabel(type[0]));
         d.add(actionRow(Component.LEFT, typeButtons[0], typeButtons[1], typeButtons[2]));
         d.add(actionRow(Component.LEFT, typeButtons[3], typeButtons[4], typeButtons[5]));
         label(d, "Display name", "CWFieldLabel");
@@ -1179,6 +1202,13 @@ public class CertificateWizard extends Lifecycle {
                 b.remove();
             }
             name.remove();
+            // A device selection outlives the type it was made under, and the picker no longer
+            // shows the ones that stopped being valid -- so it is dropped here, at the one place
+            // every type change goes through, rather than in the click handler that happens to be
+            // the way the type changed today.
+            List<String> stillValid = WizardDecisions.retainUsableDevices(state, profileType[0], devs);
+            devs.clear();
+            devs.addAll(stillValid);
             updateSegmentButtons(typeButtons, typeValues, profileType[0]);
             label(c, "Profile type", "CWFieldLabel");
             c.add(actionRow(Component.LEFT, typeButtons[0], typeButtons[1], typeButtons[2]));

--- a/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/CertificateWizard.java
+++ b/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/CertificateWizard.java
@@ -998,18 +998,25 @@ public class CertificateWizard extends Lifecycle {
     }
 
     private void certificateDialog() {
+        certificateDialog("IOS_DISTRIBUTION");
+    }
+
+    /// Generates a certificate, opening on `initialType`.
+    ///
+    /// Every type [WizardDecisions#requiredCertificateType] can ask for has to be offered here,
+    /// or a caller sent to this dialog to satisfy that requirement cannot satisfy it.
+    /// MAC_APP_DEVELOPMENT was missing, which is exactly what a Mac Development profile needs.
+    private void certificateDialog(String initialType) {
         InteractionDialog d = modal("Generate certificate");
-        final String[] type = {"IOS_DISTRIBUTION"};
+        final String[] type = {initialType == null ? "IOS_DISTRIBUTION" : initialType};
         label(d, "Certificate type", "CWFieldLabel");
-        Button dist = segment("iOS Distribution", true);
-        Button dev = segment("iOS Development", false);
-        Button macStore = segment("Mac App Store", false);
-        Button developerId = segment("Developer ID", false);
-        Button installer = segment("Mac Installer", false);
-        Button[] typeButtons = {dist, dev, macStore, developerId, installer};
-        String[] typeValues = {"IOS_DISTRIBUTION", "IOS_DEVELOPMENT", "MAC_APP_DISTRIBUTION",
-                "DEVELOPER_ID_APPLICATION", "MAC_INSTALLER_DISTRIBUTION"};
+        String[] typeValues = WizardDecisions.GENERATABLE_CERTIFICATE_TYPES;
+        Button[] typeButtons = new Button[typeValues.length];
+        for (int i = 0; i < typeValues.length; i++) {
+            typeButtons[i] = segment(WizardDecisions.GENERATABLE_CERTIFICATE_LABELS[i], false);
+        }
         for (int i = 0; i < typeButtons.length; i++) {
+            typeButtons[i].setName("pick.certType." + typeValues[i].toLowerCase());
             final int typeIndex = i;
             typeButtons[i].addActionListener(e -> {
                 type[0] = typeValues[typeIndex];
@@ -1017,9 +1024,12 @@ public class CertificateWizard extends Lifecycle {
                 d.revalidate();
             });
         }
+        updateSegmentButtons(typeButtons, typeValues, type[0]);
         TextField name = field("Display name", "App Store Distribution");
-        d.add(actionRow(Component.LEFT, dist, dev, macStore));
-        d.add(actionRow(Component.LEFT, developerId, installer));
+        name.setName("field.certName");
+        name.setText(typeLabel(type[0]));
+        d.add(actionRow(Component.LEFT, typeButtons[0], typeButtons[1], typeButtons[2]));
+        d.add(actionRow(Component.LEFT, typeButtons[3], typeButtons[4], typeButtons[5]));
         label(d, "Display name", "CWFieldLabel");
         d.add(name);
         Button gen = primary("Generate", "modal.generateCert.submit");
@@ -1226,8 +1236,12 @@ public class CertificateWizard extends Lifecycle {
             if (usable.isEmpty()) {
                 label(c, "No active " + typeLabel(WizardDecisions.requiredCertificateType(profileType[0]))
                         + " certificate. Generate one first.", "CWCardMeta");
+                // Opens on the type this profile needs. It used to open on the dialog's own
+                // default, and for Mac Development that type was not even offered there -- the
+                // suggested remedy led back to the same disabled form.
+                final String needed = WizardDecisions.requiredCertificateType(profileType[0]);
                 Button makeCert = outline("Generate certificate", "btn.profileNeedsCert");
-                makeCert.addActionListener(e -> { d.dispose(); certificateDialog(); });
+                makeCert.addActionListener(e -> { d.dispose(); certificateDialog(needed); });
                 c.add(makeCert);
             }
 
@@ -1237,7 +1251,7 @@ public class CertificateWizard extends Lifecycle {
                 // names one, so the picker offers exactly what deviceIdsFor sends. Listing them
                 // and letting "select all" sweep them in made one click enough to build a
                 // request that could not succeed.
-                final List<SigningState.Device> devices = WizardDecisions.usableDevices(state);
+                final List<SigningState.Device> devices = WizardDecisions.usableDevices(state, profileType[0]);
                 final List<CheckBox> deviceBoxes = new ArrayList<CheckBox>();
                 Button all = outline("Select all", "modal.profile.selectAllDevices");
                 Button none = outline("Clear", "modal.profile.clearDevices");
@@ -1278,7 +1292,8 @@ public class CertificateWizard extends Lifecycle {
                     c.add(cb);
                 }
                 if (devices.isEmpty()) {
-                    label(c, "No enabled devices. Register one before creating this profile type.",
+                    label(c, "No enabled " + ("MAC_OS".equals(WizardDecisions.devicePlatformFor(profileType[0]))
+                            ? "Mac" : "iOS") + " devices. Register one before creating this profile type.",
                             "CWCardMeta");
                 }
             } else {
@@ -2086,7 +2101,7 @@ public class CertificateWizard extends Lifecycle {
         if (!WizardDecisions.profileRequiresDevices(profileType)) {
             return out;
         }
-        for (SigningState.Device d : WizardDecisions.usableDevices(state)) {
+        for (SigningState.Device d : WizardDecisions.usableDevices(state, profileType)) {
             out.add(d.id());
         }
         return out;

--- a/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/api/MockSigningService.java
+++ b/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/api/MockSigningService.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.certificatewizard.api;
 
 import com.codename1.util.OnComplete;
@@ -29,11 +51,18 @@ public final class MockSigningService implements SigningService {
                 "Mac App Store Distribution", "MACD1140AA92", now + 300L * 86400000L, "ACTIVE", true));
         certificates.add(new SigningState.Certificate(4L, "CERTDEV1", "DEVELOPER_ID_APPLICATION",
                 "Developer ID Application", "DEVID140AA92", now + 300L * 86400000L, "ACTIVE", true));
+        // Reconciled from Apple, so the cloud holds no private key for it. A profile can still be
+        // created against it -- only exporting the .p12 afterwards needs the key.
+        certificates.add(new SigningState.Certificate(5L, "CERTSYNC", "IOS_DISTRIBUTION",
+                "Synced App Store Distribution", "5A3C0D8E22A1", now + 200L * 86400000L, "ACTIVE", false));
         bundles.add(new SigningState.BundleId("BID_A1", "com.example.myapp", "My App", "IOS", true));
         bundles.add(new SigningState.BundleId("BID_B2", "com.example.watch", "Watch App", "IOS", false));
         bundles.add(new SigningState.BundleId("BID_MAC", "com.example.myapp", "My App Mac", "MAC_OS", true));
         devices.add(new SigningState.Device("DEV_1", "Shai's iPhone", "00008120-000A1C3E0C68201E", "IOS", "ENABLED"));
         devices.add(new SigningState.Device("DEV_2", "QA iPad", "00008027-0004450E2688002E", "IOS", "ENABLED"));
+        // A retired device is still on the account and Apple rejects a profile request naming it,
+        // so the pickers have to leave it out.
+        devices.add(new SigningState.Device("DEV_3", "Retired iPhone", "00008030-001A2B3C4D5E6F70", "IOS", "DISABLED"));
         profiles.add(new SigningState.Profile(1L, "PRF_STORE", "My App App Store", "IOS_APP_STORE",
                 "com.example.myapp", "STORE-UUID", now + 312L * 86400000L, "ACTIVE"));
         profiles.add(new SigningState.Profile(2L, "PRF_DEV", "My App Development", "IOS_APP_DEVELOPMENT",

--- a/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/api/WizardDecisions.java
+++ b/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/api/WizardDecisions.java
@@ -157,6 +157,45 @@ public final class WizardDecisions {
                 .replace("DEVELOPER_ID_", "Developer ID ").replace('_', ' ').toLowerCase();
     }
 
+    /// The certificates a profile of this type may be created against.
+    ///
+    /// Deliberately weaker than [#compatibleCertificates]: creating a profile sends only the
+    /// certificate's Apple ID, so a locally stored private key is not needed for it. That key is
+    /// needed to EXPORT the .p12 afterwards, which is why the auto-setup and reuse path insists
+    /// on it -- but insisting on it here hides a perfectly valid certificate that came back from
+    /// a sync with Apple and tells its owner to generate a second one they do not need.
+    ///
+    /// The type match is kept, because that one is not a preference: Apple rejects a profile
+    /// whose certificate is the wrong kind for it.
+    public static List<SigningState.Certificate> profileCertificateChoices(SigningState state, String profileType) {
+        String required = requiredCertificateType(profileType);
+        List<SigningState.Certificate> out = new ArrayList<SigningState.Certificate>();
+        for (SigningState.Certificate c : state.certificates) {
+            if ("ACTIVE".equals(c.status()) && required.equals(c.certificateType()) && c.appleCertId() != null) {
+                out.add(c);
+            }
+        }
+        return out;
+    }
+
+    /// Whether Apple will accept this device in a new profile. A device that has been disabled is
+    /// still listed on the account, and putting its ID in the request gets the whole request
+    /// rejected -- so the same predicate has to decide what a picker OFFERS and what automatic
+    /// setup SENDS, or a "select all" quietly builds a request that cannot succeed.
+    public static boolean isUsableDevice(SigningState.Device device) {
+        return device != null && ("ENABLED".equals(device.status()) || "ACTIVE".equals(device.status()));
+    }
+
+    public static List<SigningState.Device> usableDevices(SigningState state) {
+        List<SigningState.Device> out = new ArrayList<SigningState.Device>();
+        for (SigningState.Device d : state.devices) {
+            if (isUsableDevice(d)) {
+                out.add(d);
+            }
+        }
+        return out;
+    }
+
     public static boolean canCreateProfile(String profileType, String bundleId, List<String> certificateIds,
                                            List<String> deviceIds, String name) {
         if (profileType == null || bundleId == null || certificateIds == null || certificateIds.isEmpty()) {

--- a/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/api/WizardDecisions.java
+++ b/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/api/WizardDecisions.java
@@ -178,18 +178,53 @@ public final class WizardDecisions {
         return out;
     }
 
-    /// Whether Apple will accept this device in a new profile. A device that has been disabled is
-    /// still listed on the account, and putting its ID in the request gets the whole request
-    /// rejected -- so the same predicate has to decide what a picker OFFERS and what automatic
-    /// setup SENDS, or a "select all" quietly builds a request that cannot succeed.
-    public static boolean isUsableDevice(SigningState.Device device) {
-        return device != null && ("ENABLED".equals(device.status()) || "ACTIVE".equals(device.status()));
+    /// The certificate types the wizard can generate, and how they are labelled.
+    ///
+    /// Kept here rather than inside the dialog so the set is one thing: every type
+    /// [#requiredCertificateType] can ask for has to appear in it, or a picker that sends someone
+    /// to the certificate dialog to satisfy that requirement leads them nowhere.
+    public static final String[] GENERATABLE_CERTIFICATE_TYPES = {
+        "IOS_DISTRIBUTION", "IOS_DEVELOPMENT", "MAC_APP_DISTRIBUTION",
+        "MAC_APP_DEVELOPMENT", "DEVELOPER_ID_APPLICATION", "MAC_INSTALLER_DISTRIBUTION"};
+
+    public static final String[] GENERATABLE_CERTIFICATE_LABELS = {
+        "iOS Distribution", "iOS Development", "Mac App Store",
+        "Mac Development", "Developer ID", "Mac Installer"};
+
+    /// Apple's BundleIdPlatform for the devices a profile of this type can name.
+    public static String devicePlatformFor(String profileType) {
+        return profileType != null
+                && (profileType.startsWith("MAC_APP_") || profileType.startsWith("MAC_CATALYST_APP_"))
+                ? "MAC_OS" : "IOS";
     }
 
-    public static List<SigningState.Device> usableDevices(SigningState state) {
+    /// Whether Apple will accept this device in a new profile of this type. A device that has been
+    /// disabled is still listed on the account, and naming it gets the whole request rejected --
+    /// so the same predicate has to decide what a picker OFFERS and what automatic setup SENDS, or
+    /// a "select all" quietly builds a request that cannot succeed. The platform matters the same
+    /// way: an iPhone cannot be named in a Mac development profile.
+    ///
+    /// Note the platform test excludes the KNOWN WRONG one rather than requiring the known right
+    /// one. The field is an untyped string in the API, documented only as "Apple
+    /// BundleIdPlatform", so a value we did not anticipate -- UNIVERSAL, empty, something added
+    /// later -- must not silently empty the picker and make a profile type uncreatable. Offering
+    /// one device too many costs a rejected request; offering none costs the whole flow.
+    public static boolean isUsableDevice(SigningState.Device device, String profileType) {
+        if (device == null || !("ENABLED".equals(device.status()) || "ACTIVE".equals(device.status()))) {
+            return false;
+        }
+        String platform = device.platform();
+        if (platform == null || platform.trim().isEmpty()) {
+            return true;
+        }
+        String wrong = "MAC_OS".equals(devicePlatformFor(profileType)) ? "IOS" : "MAC_OS";
+        return !wrong.equals(platform.trim());
+    }
+
+    public static List<SigningState.Device> usableDevices(SigningState state, String profileType) {
         List<SigningState.Device> out = new ArrayList<SigningState.Device>();
         for (SigningState.Device d : state.devices) {
-            if (isUsableDevice(d)) {
+            if (isUsableDevice(d, profileType)) {
                 out.add(d);
             }
         }

--- a/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/api/WizardDecisions.java
+++ b/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/api/WizardDecisions.java
@@ -221,6 +221,27 @@ public final class WizardDecisions {
         return !wrong.equals(platform.trim());
     }
 
+    /// The subset of `selectedIds` that a profile of this type may still name.
+    ///
+    /// A selection outlives the profile type it was made under: pick devices for iOS Development,
+    /// switch to Mac Development, and the picker correctly stops showing those iPhones while the
+    /// selection quietly keeps them. canCreateProfile then reads a satisfied device requirement
+    /// and the request goes to Apple naming devices of the wrong platform -- invisible, because
+    /// nothing on screen shows them any more.
+    public static List<String> retainUsableDevices(SigningState state, String profileType,
+                                                   List<String> selectedIds) {
+        List<String> out = new ArrayList<String>();
+        if (selectedIds == null || !profileRequiresDevices(profileType)) {
+            return out;
+        }
+        for (SigningState.Device d : usableDevices(state, profileType)) {
+            if (selectedIds.contains(d.id())) {
+                out.add(d.id());
+            }
+        }
+        return out;
+    }
+
     public static List<SigningState.Device> usableDevices(SigningState state, String profileType) {
         List<SigningState.Device> out = new ArrayList<SigningState.Device>();
         for (SigningState.Device d : state.devices) {

--- a/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/api/WizardDecisions.java
+++ b/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/api/WizardDecisions.java
@@ -112,11 +112,40 @@ public final class WizardDecisions {
         return "IOS_DISTRIBUTION";
     }
 
+    /// Whether a certificate of this type can sign a profile that requires `required`.
+    ///
+    /// Not an equality test, because Apple's generic "Apple Development" (DEVELOPMENT) and "Apple
+    /// Distribution" (DISTRIBUTION) types supersede the platform-specific ones and are valid
+    /// wherever those are. An account whose certificates came back from a reconcile holding only
+    /// those was told it had no compatible certificate at all and sent off to generate a
+    /// redundant one. isDevelopmentCertificate in the wizard already counts DEVELOPMENT as a
+    /// development certificate for both platforms, so this is the same reading applied to the
+    /// distribution half.
+    ///
+    /// Deliberately not a "kind" test: DEVELOPER_ID_APPLICATION and MAC_INSTALLER_DISTRIBUTION are
+    /// distribution certificates too, and neither can sign what the other is for. Only the two
+    /// generic types widen anything.
+    public static boolean certificateTypeSatisfies(String required, String certificateType) {
+        if (required == null || certificateType == null) {
+            return false;
+        }
+        if (required.equals(certificateType)) {
+            return true;
+        }
+        if ("DEVELOPMENT".equals(certificateType)) {
+            return "IOS_DEVELOPMENT".equals(required) || "MAC_APP_DEVELOPMENT".equals(required);
+        }
+        if ("DISTRIBUTION".equals(certificateType)) {
+            return "IOS_DISTRIBUTION".equals(required) || "MAC_APP_DISTRIBUTION".equals(required);
+        }
+        return false;
+    }
+
     public static List<SigningState.Certificate> compatibleCertificates(SigningState state, String profileType) {
         String required = requiredCertificateType(profileType);
         List<SigningState.Certificate> out = new ArrayList<SigningState.Certificate>();
         for (SigningState.Certificate c : state.certificates) {
-            if ("ACTIVE".equals(c.status()) && required.equals(c.certificateType())
+            if ("ACTIVE".equals(c.status()) && certificateTypeSatisfies(required, c.certificateType())
                     && c.appleCertId() != null && c.privateKeyPresent()) {
                 out.add(c);
             }
@@ -171,7 +200,8 @@ public final class WizardDecisions {
         String required = requiredCertificateType(profileType);
         List<SigningState.Certificate> out = new ArrayList<SigningState.Certificate>();
         for (SigningState.Certificate c : state.certificates) {
-            if ("ACTIVE".equals(c.status()) && required.equals(c.certificateType()) && c.appleCertId() != null) {
+            if ("ACTIVE".equals(c.status()) && certificateTypeSatisfies(required, c.certificateType())
+                    && c.appleCertId() != null) {
                 out.add(c);
             }
         }

--- a/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/api/WizardDecisions.java
+++ b/scripts/certificatewizard/common/src/main/java/com/codename1/certificatewizard/api/WizardDecisions.java
@@ -124,6 +124,39 @@ public final class WizardDecisions {
         return out;
     }
 
+    /// The one input still missing before a profile can be created, phrased for the user, or null
+    /// when nothing is. Reported in the same order the dialog lays the sections out, so the
+    /// message always points at the first thing above the button rather than at whichever check
+    /// happens to be written first.
+    public static String describeMissingProfileInput(String profileType, String bundleId,
+                                                     List<String> certificateIds, List<String> deviceIds,
+                                                     String name) {
+        if (profileType == null) {
+            return "Choose a profile type to continue.";
+        }
+        if (bundleId == null) {
+            return "Choose the bundle ID this profile is for.";
+        }
+        if (certificateIds == null || certificateIds.isEmpty()) {
+            return "Choose a " + humanCertificateType(requiredCertificateType(profileType)) + " certificate.";
+        }
+        if (profileRequiresDevices(profileType) && (deviceIds == null || deviceIds.isEmpty())) {
+            return "Select at least one device for this profile type.";
+        }
+        if (name == null || name.trim().isEmpty()) {
+            return "Enter a name for the profile.";
+        }
+        return null;
+    }
+
+    private static String humanCertificateType(String certificateType) {
+        if (certificateType == null) {
+            return "signing";
+        }
+        return certificateType.replace("IOS_", "").replace("MAC_", "Mac ")
+                .replace("DEVELOPER_ID_", "Developer ID ").replace('_', ' ').toLowerCase();
+    }
+
     public static boolean canCreateProfile(String profileType, String bundleId, List<String> certificateIds,
                                            List<String> deviceIds, String name) {
         if (profileType == null || bundleId == null || certificateIds == null || certificateIds.isEmpty()) {

--- a/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardDarkThemeTest.java
+++ b/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardDarkThemeTest.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.certificatewizard;
 
 import org.junit.jupiter.api.Test;

--- a/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardDarkThemeTest.java
+++ b/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardDarkThemeTest.java
@@ -139,6 +139,19 @@ class CertificateWizardDarkThemeTest {
                     "DesktopHorizontalScroll"}) {
                 assertEquals("transparent", property(part, uiid, "background-color"),
                         scheme + " " + uiid + " track must not paint over the page");
+                // The track's padding is what sizes the bar, on the axis across it:
+                // getVerticalScrollWidth sums left and right, getHorizontalScrollHeight top and
+                // bottom. Zero on that axis is a bar with no thickness -- drawn, and impossible to
+                // grab -- which is what one rule shared by both axes produced.
+                String[] pad = property(part, uiid, "padding").trim().split("\\s+");
+                assertEquals(4, pad.length, scheme + " " + uiid + " padding needs all four sides");
+                boolean horizontal = uiid.contains("Horizontal");
+                String across = horizontal ? pad[0] : pad[1];
+                String along = horizontal ? pad[1] : pad[0];
+                assertTrue(millimetres(across) > 0,
+                        scheme + " " + uiid + " needs thickness on the axis across the bar");
+                assertEquals(0.0, millimetres(along), 0.0001,
+                        scheme + " " + uiid + " must not pad along the bar");
             }
             for (String uiid : new String[] {"ScrollThumb", "HorizontalScrollThumb", "DesktopScrollThumb",
                     "DesktopHorizontalScrollThumb"}) {
@@ -180,6 +193,14 @@ class CertificateWizardDarkThemeTest {
                     property(css, prefix + "CWSegmentSelected", "border").replaceAll("#[0-9A-Fa-f]{6}", ""),
                     prefix + "CWSegmentSelected must occupy the same box as " + prefix + "CWSegment");
         }
+    }
+
+    private static double millimetres(String value) {
+        String v = value.trim();
+        if (v.endsWith("mm")) {
+            return Double.parseDouble(v.substring(0, v.length() - 2).trim());
+        }
+        return Double.parseDouble(v);
     }
 
     private static int darkBlockStart(String css) {

--- a/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardDarkThemeTest.java
+++ b/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardDarkThemeTest.java
@@ -9,17 +9,18 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class CertificateWizardDarkThemeTest {
-    private static final String DARK_BG_APP = "#071B4D";
-    private static final String DARK_BG_PANEL = "#102B66";
-    private static final String DARK_BG_SUBTLE = "#163575";
-    private static final String DARK_BG_INPUT = "#0E2A61";
-    private static final String DARK_BORDER = "#33518C";
-    private static final String DARK_TEXT = "#F5F8FF";
-    private static final String DARK_TEXT_MUTED = "#A8B8DA";
-    private static final String DARK_ACCENT = "#4D86FF";
+    private static final String DARK_BG_APP = "#0F1626";
+    private static final String DARK_BG_PANEL = "#1A2233";
+    private static final String DARK_BG_SUBTLE = "#26314A";
+    private static final String DARK_BG_INPUT = "#141B2B";
+    private static final String DARK_BORDER = "#3A465E";
+    private static final String DARK_TEXT = "#EEF2F8";
+    private static final String DARK_TEXT_MUTED = "#A9B6CC";
+    private static final String DARK_ACCENT = "#5C93FF";
     private static final String DARK_LIME = "#B8D532";
     private static final String DARK_DANGER = "#FF7A7A";
 
@@ -97,6 +98,74 @@ class CertificateWizardDarkThemeTest {
         }
     }
 
+    /// The look and feel asks for these UIIDs by name, so the app's "Dark" prefix scheme cannot
+    /// reach them. Left undeclared they came from the blank-theme defaults -- a white track with a
+    /// black thumb, which is the inverted scrollbar of issue #5636 -- so both schemes have to
+    /// declare them, dark through the prefers-color-scheme block the compiler turns into $Dark
+    /// entries.
+    @Test
+    void fixedLookAndFeelUiidsAreThemedInBothSchemes() throws IOException {
+        String css = themeCss();
+        String light = css.substring(0, darkBlockStart(css));
+        // Past the "@media (...) {" itself: the block scanner reads brace pairs flat, so leaving
+        // the wrapper in would pair the media brace with the first rule's closing one and swallow
+        // that rule whole.
+        String dark = css.substring(css.indexOf('{', darkBlockStart(css)) + 1);
+        for (String scheme : new String[] {"light", "dark"}) {
+            String part = "light".equals(scheme) ? light : dark;
+            for (String uiid : new String[] {"Scroll", "HorizontalScroll", "DesktopScroll",
+                    "DesktopHorizontalScroll"}) {
+                assertEquals("transparent", property(part, uiid, "background-color"),
+                        scheme + " " + uiid + " track must not paint over the page");
+            }
+            for (String uiid : new String[] {"ScrollThumb", "HorizontalScrollThumb", "DesktopScrollThumb",
+                    "DesktopHorizontalScrollThumb"}) {
+                String thumb = property(part, uiid, "background-color");
+                assertTrue(thumb.startsWith("#"), scheme + " " + uiid + " needs an explicit colour");
+                assertTrue(contrast(thumb, "light".equals(scheme) ? "#FFFFFF" : DARK_BG_PANEL) >= 1.3,
+                        scheme + " " + uiid + " must be visible against the surface it scrolls");
+            }
+            assertTrue(property(part, "CheckBox", "color").startsWith("#"),
+                    scheme + " unchecked check box colour");
+            assertTrue(property(part, "CheckBox.selected", "color").startsWith("#"),
+                    scheme + " checked check box colour");
+            assertNotEquals(property(part, "CheckBox", "color"), property(part, "CheckBox.selected", "color"),
+                    scheme + " checked and unchecked check boxes must not be the same colour");
+        }
+        assertTrue(css.contains("checkBoxIconSizeMM"),
+                "the check box is sized off the label font without this constant, so it ends up "
+                        + "smaller than the word beside it");
+    }
+
+    /// The primary action is a lime pill. White on it lands near 2:1, which is a label you have to
+    /// hunt for rather than read.
+    @Test
+    void primaryButtonLabelIsReadableOnLime() throws IOException {
+        String css = themeCss();
+        for (String uiid : new String[] {"CWPrimary", "DarkCWPrimary"}) {
+            assertTrue(contrast(property(css, uiid, "color"), property(css, uiid, "background-color")) >= 4.5,
+                    uiid + " label contrast");
+        }
+    }
+
+    /// A segmented control that resizes when you select it slides its neighbours out from under
+    /// the pointer, which is why selecting a profile type took a dozen clicks.
+    @Test
+    void segmentKeepsItsBoxWhenSelected() throws IOException {
+        String css = themeCss();
+        for (String prefix : new String[] {"", "Dark"}) {
+            assertEquals(property(css, prefix + "CWSegment", "border").replaceAll("#[0-9A-Fa-f]{6}", ""),
+                    property(css, prefix + "CWSegmentSelected", "border").replaceAll("#[0-9A-Fa-f]{6}", ""),
+                    prefix + "CWSegmentSelected must occupy the same box as " + prefix + "CWSegment");
+        }
+    }
+
+    private static int darkBlockStart(String css) {
+        int i = css.indexOf("@media");
+        assertTrue(i > 0, "prefers-color-scheme block missing");
+        return i;
+    }
+
     @Test
     void darkThemeTextContrastStaysUsable() {
         assertTrue(contrast(DARK_TEXT, DARK_BG_PANEL) >= 7.0, "main text contrast");
@@ -171,7 +240,29 @@ class CertificateWizardDarkThemeTest {
         if (!Files.exists(p)) {
             p = Paths.get(System.getProperty("user.dir"), "src/main/css/theme.css").normalize();
         }
-        return new String(Files.readAllBytes(p), StandardCharsets.UTF_8);
+        return stripComments(new String(Files.readAllBytes(p), StandardCharsets.UTF_8));
+    }
+
+    /// The block scanner below reads a rule's selectors as everything between the previous "}" and
+    /// the next "{", so a comment sitting in that gap becomes part of the first selector and the
+    /// rule stops being found at all.
+    private static String stripComments(String css) {
+        StringBuilder out = new StringBuilder();
+        int pos = 0;
+        while (pos < css.length()) {
+            int start = css.indexOf("/*", pos);
+            if (start < 0) {
+                out.append(css.substring(pos));
+                break;
+            }
+            out.append(css, pos, start);
+            int end = css.indexOf("*/", start + 2);
+            if (end < 0) {
+                break;
+            }
+            pos = end + 2;
+        }
+        return out.toString();
     }
 
     private static double contrast(String foreground, String background) {

--- a/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardModelTest.java
+++ b/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardModelTest.java
@@ -160,6 +160,50 @@ class CertificateWizardModelTest {
         assertEquals(3, WizardDecisions.usableDevices(state, "MAC_APP_DEVELOPMENT").size());
     }
 
+    /// Apple Development and Apple Distribution supersede the platform-specific certificate types
+    /// and are valid wherever those are. An exact type match sent an account holding only those to
+    /// generate a redundant certificate. The widening stops there: two other certificate types are
+    /// also "distribution" and neither signs what the other is for.
+    @Test
+    void appleGenericCertificateTypesSatisfyTheirPlatformSpecificRequirement() {
+        assertTrue(WizardDecisions.certificateTypeSatisfies("IOS_DEVELOPMENT", "DEVELOPMENT"));
+        assertTrue(WizardDecisions.certificateTypeSatisfies("MAC_APP_DEVELOPMENT", "DEVELOPMENT"));
+        assertTrue(WizardDecisions.certificateTypeSatisfies("IOS_DISTRIBUTION", "DISTRIBUTION"));
+        assertTrue(WizardDecisions.certificateTypeSatisfies("MAC_APP_DISTRIBUTION", "DISTRIBUTION"));
+        assertTrue(WizardDecisions.certificateTypeSatisfies("IOS_DISTRIBUTION", "IOS_DISTRIBUTION"));
+
+        assertFalse(WizardDecisions.certificateTypeSatisfies("DEVELOPER_ID_APPLICATION", "DISTRIBUTION"),
+                "Developer ID is not what Apple Distribution replaced");
+        assertFalse(WizardDecisions.certificateTypeSatisfies("IOS_DISTRIBUTION", "MAC_INSTALLER_DISTRIBUTION"),
+                "an installer certificate signs an installer, not an app");
+        assertFalse(WizardDecisions.certificateTypeSatisfies("IOS_DISTRIBUTION", "DEVELOPMENT"));
+        assertFalse(WizardDecisions.certificateTypeSatisfies("IOS_DEVELOPMENT", "DISTRIBUTION"));
+        assertFalse(WizardDecisions.certificateTypeSatisfies(null, "DISTRIBUTION"));
+        assertFalse(WizardDecisions.certificateTypeSatisfies("IOS_DISTRIBUTION", null));
+    }
+
+    /// The picker and automatic setup read one predicate, so an account can never be offered a
+    /// certificate the automatic path would then refuse, or the other way round.
+    @Test
+    void aGenericCertificateReachesBothThePickerAndAutomaticSetup() {
+        long now = System.currentTimeMillis();
+        List<SigningState.Certificate> certs = new ArrayList<SigningState.Certificate>();
+        certs.add(new SigningState.Certificate(1L, "APPLE_GENERIC", "DISTRIBUTION",
+                "Apple Distribution", "SER1", now + 300L * 86400000L, "ACTIVE", true));
+        certs.add(new SigningState.Certificate(2L, "APPLE_INSTALLER", "MAC_INSTALLER_DISTRIBUTION",
+                "Mac Installer", "SER2", now + 300L * 86400000L, "ACTIVE", true));
+        SigningState state = new SigningState(new SigningState.Credential(true, "KEY", "ISSUER"),
+                certs, null, null, null, null, null);
+
+        List<SigningState.Certificate> offered = WizardDecisions.profileCertificateChoices(state, "IOS_APP_STORE");
+        assertEquals(1, offered.size());
+        assertEquals("APPLE_GENERIC", offered.get(0).appleCertId());
+
+        List<SigningState.Certificate> auto = WizardDecisions.compatibleCertificates(state, "IOS_APP_STORE");
+        assertEquals(1, auto.size());
+        assertEquals("APPLE_GENERIC", auto.get(0).appleCertId());
+    }
+
     /// A device selection outlives the profile type it was made under. Once the picker started
     /// hiding devices of the wrong platform, a stale selection became invisible AND still counted:
     /// canCreateProfile saw the requirement met and the request named iPhones in a Mac profile.

--- a/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardModelTest.java
+++ b/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardModelTest.java
@@ -119,24 +119,64 @@ class CertificateWizardModelTest {
     }
 
     /// What the picker offers and what automatic setup sends have to be the same set, or a
-    /// "select all" builds a request naming a disabled device, which Apple rejects whole.
+    /// "select all" builds a request naming a disabled or wrong-platform device, which Apple
+    /// rejects whole.
     @Test
-    void onlyEnabledDevicesAreOffered() {
+    void onlyEnabledDevicesOfTheProfilePlatformAreOffered() {
         List<SigningState.Device> devices = new ArrayList<SigningState.Device>();
         devices.add(new SigningState.Device("DEV_1", "QA iPhone", "UDID1", "IOS", "ENABLED"));
         devices.add(new SigningState.Device("DEV_2", "Old iPad", "UDID2", "IOS", "DISABLED"));
-        devices.add(new SigningState.Device("DEV_3", "Bench Mac", "UDID3", "MAC", "ACTIVE"));
+        devices.add(new SigningState.Device("DEV_3", "Bench Mac", "UDID3", "MAC_OS", "ACTIVE"));
         SigningState state = new SigningState(new SigningState.Credential(true, "KEY", "ISSUER"),
                 null, null, devices, null, null, null);
 
-        List<SigningState.Device> usable = WizardDecisions.usableDevices(state);
+        List<SigningState.Device> ios = WizardDecisions.usableDevices(state, "IOS_APP_DEVELOPMENT");
+        assertEquals(1, ios.size());
+        assertEquals("DEV_1", ios.get(0).id());
 
-        assertEquals(2, usable.size());
-        assertEquals("DEV_1", usable.get(0).id());
-        assertEquals("DEV_3", usable.get(1).id());
-        assertTrue(WizardDecisions.isUsableDevice(devices.get(0)));
-        assertFalse(WizardDecisions.isUsableDevice(devices.get(1)));
-        assertFalse(WizardDecisions.isUsableDevice(null));
+        List<SigningState.Device> mac = WizardDecisions.usableDevices(state, "MAC_APP_DEVELOPMENT");
+        assertEquals(1, mac.size());
+        assertEquals("DEV_3", mac.get(0).id());
+
+        assertEquals("IOS", WizardDecisions.devicePlatformFor("IOS_APP_ADHOC"));
+        assertEquals("MAC_OS", WizardDecisions.devicePlatformFor("MAC_APP_DEVELOPMENT"));
+        assertEquals("MAC_OS", WizardDecisions.devicePlatformFor("MAC_CATALYST_APP_DEVELOPMENT"));
+        assertFalse(WizardDecisions.isUsableDevice(null, "IOS_APP_DEVELOPMENT"));
+    }
+
+    /// The platform field is an untyped string in the API, so an unanticipated value must not
+    /// empty the picker and make a profile type uncreatable -- the rule excludes the known wrong
+    /// platform rather than demanding the known right one.
+    @Test
+    void anUnknownDevicePlatformIsOfferedRatherThanHidden() {
+        List<SigningState.Device> devices = new ArrayList<SigningState.Device>();
+        devices.add(new SigningState.Device("DEV_1", "Universal", "UDID1", "UNIVERSAL", "ENABLED"));
+        devices.add(new SigningState.Device("DEV_2", "No platform", "UDID2", null, "ENABLED"));
+        devices.add(new SigningState.Device("DEV_3", "Blank platform", "UDID3", "  ", "ENABLED"));
+        SigningState state = new SigningState(new SigningState.Credential(true, "KEY", "ISSUER"),
+                null, null, devices, null, null, null);
+
+        assertEquals(3, WizardDecisions.usableDevices(state, "IOS_APP_DEVELOPMENT").size());
+        assertEquals(3, WizardDecisions.usableDevices(state, "MAC_APP_DEVELOPMENT").size());
+    }
+
+    /// Sending someone to the certificate dialog to satisfy requiredCertificateType only helps if
+    /// that dialog can actually produce the type. MAC_APP_DEVELOPMENT could not be, so the Mac
+    /// Development profile's only suggested remedy led straight back to the disabled form.
+    @Test
+    void everyRequiredCertificateTypeCanBeGenerated() {
+        String[] profileTypes = {"IOS_APP_STORE", "IOS_APP_ADHOC", "IOS_APP_DEVELOPMENT",
+                "MAC_APP_STORE", "MAC_APP_DIRECT", "MAC_APP_DEVELOPMENT",
+                "MAC_CATALYST_APP_STORE", "MAC_CATALYST_APP_DIRECT", "MAC_CATALYST_APP_DEVELOPMENT"};
+        // the very array the dialog builds its segments from, so this cannot drift away from it
+        List<String> offered = java.util.Arrays.asList(WizardDecisions.GENERATABLE_CERTIFICATE_TYPES);
+        assertEquals(WizardDecisions.GENERATABLE_CERTIFICATE_TYPES.length,
+                WizardDecisions.GENERATABLE_CERTIFICATE_LABELS.length, "every type needs a label");
+        for (String profileType : profileTypes) {
+            String required = WizardDecisions.requiredCertificateType(profileType);
+            assertTrue(offered.contains(required),
+                    profileType + " requires " + required + ", which the certificate dialog must offer");
+        }
     }
 
     /// The create action is disabled until the request is complete, and the reporter of issue

--- a/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardModelTest.java
+++ b/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardModelTest.java
@@ -90,6 +90,54 @@ class CertificateWizardModelTest {
         assertFalse(WizardDecisions.canCreateProfile("IOS_APP_STORE", "BID1", certs, devices, ""));
     }
 
+    /// The create action is disabled until the request is complete, and the reporter of issue
+    /// #5636 could not tell which of four sections was the incomplete one. The message names the
+    /// FIRST thing missing, reading down the dialog, so following it always moves forward.
+    @Test
+    void missingProfileInputIsNamedInDialogOrder() {
+        List<String> certs = new ArrayList<String>();
+        List<String> devices = new ArrayList<String>();
+        assertTrue(WizardDecisions.describeMissingProfileInput(null, null, certs, devices, "")
+                .contains("profile type"));
+        assertTrue(WizardDecisions.describeMissingProfileInput("IOS_APP_STORE", null, certs, devices, "")
+                .contains("bundle ID"));
+        assertTrue(WizardDecisions.describeMissingProfileInput("IOS_APP_STORE", "BID1", certs, devices, "")
+                .contains("certificate"));
+        certs.add("CERT1");
+        assertTrue(WizardDecisions.describeMissingProfileInput("IOS_APP_STORE", "BID1", certs, devices, "")
+                .contains("name"));
+        assertTrue(WizardDecisions.describeMissingProfileInput("IOS_APP_ADHOC", "BID1", certs, devices, "Adhoc")
+                .contains("device"));
+        devices.add("DEV1");
+        assertNull(WizardDecisions.describeMissingProfileInput("IOS_APP_ADHOC", "BID1", certs, devices, "Adhoc"));
+        assertNull(WizardDecisions.describeMissingProfileInput("IOS_APP_STORE", "BID1", certs, null, "Store"));
+    }
+
+    /// Nothing may report a blocker while canCreateProfile says the request is complete, or the
+    /// dialog would explain a button that is already enabled.
+    @Test
+    void missingProfileInputAgreesWithCreateProfileValidation() {
+        List<String> certs = new ArrayList<String>();
+        certs.add("CERT1");
+        List<String> devices = new ArrayList<String>();
+        devices.add("DEV1");
+        String[] types = {"IOS_APP_STORE", "IOS_APP_ADHOC", "IOS_APP_DEVELOPMENT", "MAC_APP_STORE",
+                "MAC_APP_DIRECT", "MAC_APP_DEVELOPMENT", null};
+        String[] bundles = {null, "BID1"};
+        String[] names = {"", "Profile"};
+        for (String type : types) {
+            for (String bundle : bundles) {
+                for (String name : names) {
+                    for (List<String> devs : java.util.Arrays.asList(new ArrayList<String>(), devices)) {
+                        boolean ok = WizardDecisions.canCreateProfile(type, bundle, certs, devs, name);
+                        String missing = WizardDecisions.describeMissingProfileInput(type, bundle, certs, devs, name);
+                        assertEquals(ok, missing == null, type + "/" + bundle + "/" + name + "/" + devs.size());
+                    }
+                }
+            }
+        }
+    }
+
     @Test
     void projectBindingParsesDescriptor() {
         ProjectBinding b = ProjectBinding.parse("projectDir=/p\nsettings=/p/codenameone_settings.properties\n"

--- a/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardModelTest.java
+++ b/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardModelTest.java
@@ -160,6 +160,45 @@ class CertificateWizardModelTest {
         assertEquals(3, WizardDecisions.usableDevices(state, "MAC_APP_DEVELOPMENT").size());
     }
 
+    /// A device selection outlives the profile type it was made under. Once the picker started
+    /// hiding devices of the wrong platform, a stale selection became invisible AND still counted:
+    /// canCreateProfile saw the requirement met and the request named iPhones in a Mac profile.
+    @Test
+    void deviceSelectionDoesNotSurviveAChangeOfProfilePlatform() {
+        List<SigningState.Device> devices = new ArrayList<SigningState.Device>();
+        devices.add(new SigningState.Device("DEV_1", "QA iPhone", "UDID1", "IOS", "ENABLED"));
+        devices.add(new SigningState.Device("DEV_2", "Retired iPhone", "UDID2", "IOS", "DISABLED"));
+        devices.add(new SigningState.Device("DEV_3", "Bench Mac", "UDID3", "MAC_OS", "ENABLED"));
+        SigningState state = new SigningState(new SigningState.Credential(true, "KEY", "ISSUER"),
+                null, null, devices, null, null, null);
+        List<String> selected = new ArrayList<String>();
+        selected.add("DEV_1");
+        selected.add("DEV_3");
+
+        List<String> forIos = WizardDecisions.retainUsableDevices(state, "IOS_APP_DEVELOPMENT", selected);
+        assertEquals(1, forIos.size());
+        assertEquals("DEV_1", forIos.get(0));
+
+        List<String> forMac = WizardDecisions.retainUsableDevices(state, "MAC_APP_DEVELOPMENT", selected);
+        assertEquals(1, forMac.size());
+        assertEquals("DEV_3", forMac.get(0));
+
+        // and a type that names no devices at all must not carry one along
+        assertTrue(WizardDecisions.retainUsableDevices(state, "IOS_APP_STORE", selected).isEmpty());
+        assertTrue(WizardDecisions.retainUsableDevices(state, "IOS_APP_DEVELOPMENT", null).isEmpty());
+
+        // the whole point: only a selection that survives may satisfy the create check
+        List<String> certs = new ArrayList<String>();
+        certs.add("CERT1");
+        assertTrue(WizardDecisions.canCreateProfile("MAC_APP_DEVELOPMENT", "BID1", certs, forMac, "N"),
+                "the Mac device that survived the switch is a real selection");
+        List<String> onlyIos = new ArrayList<String>();
+        onlyIos.add("DEV_1");
+        assertFalse(WizardDecisions.canCreateProfile("MAC_APP_DEVELOPMENT", "BID1", certs,
+                        WizardDecisions.retainUsableDevices(state, "MAC_APP_DEVELOPMENT", onlyIos), "N"),
+                "a selection of iPhones must not satisfy a Mac profile's device requirement");
+    }
+
     /// Sending someone to the certificate dialog to satisfy requiredCertificateType only helps if
     /// that dialog can actually produce the type. MAC_APP_DEVELOPMENT could not be, so the Mac
     /// Development profile's only suggested remedy led straight back to the disabled form.

--- a/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardModelTest.java
+++ b/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardModelTest.java
@@ -90,6 +90,55 @@ class CertificateWizardModelTest {
         assertFalse(WizardDecisions.canCreateProfile("IOS_APP_STORE", "BID1", certs, devices, ""));
     }
 
+    /// Creating a profile sends the certificate's Apple ID and nothing else, so the picker must
+    /// not apply the export-time private-key rule that compatibleCertificates does -- that hid a
+    /// valid certificate synced from Apple and told its owner to make a second one. The type
+    /// match is a different matter and stays: Apple rejects the wrong kind outright.
+    @Test
+    void profileCertificateChoicesKeepCertificatesWithNoStoredPrivateKey() {
+        long now = System.currentTimeMillis();
+        List<SigningState.Certificate> certs = new ArrayList<SigningState.Certificate>();
+        certs.add(new SigningState.Certificate(1L, "APPLE_NO_KEY", "IOS_DISTRIBUTION",
+                "Synced App Store Certificate", "SER1", now + 300L * 86400000L, "ACTIVE", false));
+        certs.add(new SigningState.Certificate(2L, "APPLE_EXPORTABLE", "IOS_DISTRIBUTION",
+                "Exportable App Store Certificate", "SER2", now + 300L * 86400000L, "ACTIVE", true));
+        certs.add(new SigningState.Certificate(3L, "APPLE_REVOKED", "IOS_DISTRIBUTION",
+                "Revoked", "SER3", now + 300L * 86400000L, "REVOKED", true));
+        certs.add(new SigningState.Certificate(4L, "APPLE_MAC", "MAC_APP_DISTRIBUTION",
+                "Mac App Store", "SER4", now + 300L * 86400000L, "ACTIVE", true));
+        SigningState state = new SigningState(new SigningState.Credential(true, "KEY", "ISSUER"),
+                certs, null, null, null, null, null);
+
+        List<SigningState.Certificate> choices = WizardDecisions.profileCertificateChoices(state, "IOS_APP_STORE");
+
+        assertEquals(2, choices.size(), "both active iOS distribution certificates are offered");
+        assertEquals("APPLE_NO_KEY", choices.get(0).appleCertId());
+        assertEquals("APPLE_EXPORTABLE", choices.get(1).appleCertId());
+        // and the export path is unchanged, because THAT one really does need the key
+        assertEquals(1, WizardDecisions.compatibleCertificates(state, "IOS_APP_STORE").size());
+    }
+
+    /// What the picker offers and what automatic setup sends have to be the same set, or a
+    /// "select all" builds a request naming a disabled device, which Apple rejects whole.
+    @Test
+    void onlyEnabledDevicesAreOffered() {
+        List<SigningState.Device> devices = new ArrayList<SigningState.Device>();
+        devices.add(new SigningState.Device("DEV_1", "QA iPhone", "UDID1", "IOS", "ENABLED"));
+        devices.add(new SigningState.Device("DEV_2", "Old iPad", "UDID2", "IOS", "DISABLED"));
+        devices.add(new SigningState.Device("DEV_3", "Bench Mac", "UDID3", "MAC", "ACTIVE"));
+        SigningState state = new SigningState(new SigningState.Credential(true, "KEY", "ISSUER"),
+                null, null, devices, null, null, null);
+
+        List<SigningState.Device> usable = WizardDecisions.usableDevices(state);
+
+        assertEquals(2, usable.size());
+        assertEquals("DEV_1", usable.get(0).id());
+        assertEquals("DEV_3", usable.get(1).id());
+        assertTrue(WizardDecisions.isUsableDevice(devices.get(0)));
+        assertFalse(WizardDecisions.isUsableDevice(devices.get(1)));
+        assertFalse(WizardDecisions.isUsableDevice(null));
+    }
+
     /// The create action is disabled until the request is complete, and the reporter of issue
     /// #5636 could not tell which of four sections was the incomplete one. The message names the
     /// FIRST thing missing, reading down the dialog, so following it always moves forward.

--- a/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardStructureHarness.java
+++ b/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardStructureHarness.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.certificatewizard;
 
 import com.codename1.certificatewizard.api.MockSigningService;

--- a/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardStructureHarness.java
+++ b/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardStructureHarness.java
@@ -176,6 +176,9 @@ public final class CertificateWizardStructureHarness {
         check(selectedSegment(form, "pick.type.ios_app_store"), "App Store segment starts selected");
         check(find(form, "pick.cert.3") == null,
                 "only certificates the selected profile type can use are offered");
+        check(find(form, "pick.cert.5") != null,
+                "a certificate with no stored private key is still offered: creating a profile "
+                        + "sends its Apple ID, and only the later export needs the key");
         check(find(form, "pick.device.DEV_1") == null,
                 "an App Store profile does not ask for devices");
         Component requirement = find(form, "modal.profile.requirement");
@@ -197,12 +200,14 @@ public final class CertificateWizardStructureHarness {
                 "a distribution certificate is dropped when the type becomes development");
         check(find(form, "pick.cert.2") != null, "the development certificate is offered instead");
         check(find(form, "pick.device.DEV_1") != null, "a development profile asks for devices");
+        check(find(form, "pick.device.DEV_3") == null, "a disabled device is not offered");
         fire(form, "pick.cert.2");
         check(!enabled(form, "modal.profile.submit"), "create waits for the devices it now needs");
         check(requirementText(form).contains("device"), "the missing devices are named");
         fire(form, "modal.profile.selectAllDevices");
         check(selectedCheckBox(form, "pick.device.DEV_1") && selectedCheckBox(form, "pick.device.DEV_2"),
                 "select all checks every device");
+        check(find(form, "pick.device.DEV_3") == null, "select all cannot reach a disabled device");
         check(enabled(form, "modal.profile.submit"), "create enables once devices are selected");
         fire(form, "modal.profile.clearDevices");
         check(!selectedCheckBox(form, "pick.device.DEV_1"), "clear unchecks every device");

--- a/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardStructureHarness.java
+++ b/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardStructureHarness.java
@@ -1,6 +1,7 @@
 package com.codename1.certificatewizard;
 
 import com.codename1.certificatewizard.api.MockSigningService;
+import com.codename1.components.SpanLabel;
 import com.codename1.ui.Button;
 import com.codename1.ui.Command;
 import com.codename1.ui.Component;
@@ -17,6 +18,22 @@ import com.codename1.ui.util.Resources;
 import java.util.ArrayList;
 import java.util.List;
 
+/// Drives the real wizard against the mock signing service and asserts the structure of every
+/// page and of the new-profile dialog. It needs a display, so nothing runs it automatically and
+/// it drifts out of date silently -- run it by hand after touching the UI:
+///
+/// ```
+/// source tools/env.sh
+/// cd scripts/certificatewizard
+/// JAVA_HOME="$JAVA17_HOME" mvn -q install -DskipTests -Pexecutable-jar \
+///     -Dmaven.repo.local=$(git rev-parse --show-toplevel)/.m2-repo
+/// cd javase
+/// CP="target/test-classes:target/classes:$(ls target/libs/*.jar | tr '\n' ':')"
+/// "$JAVA17_HOME/bin/java" -cp "$CP" \
+///     com.codename1.certificatewizard.CertificateWizardStructureHarness
+/// ```
+///
+/// It exits non-zero and lists every failed expectation.
 public final class CertificateWizardStructureHarness {
     private static final List<String> fail = new ArrayList<String>();
 
@@ -43,11 +60,20 @@ public final class CertificateWizardStructureHarness {
                 app[0].runApp();
             }
         });
-        Display.getInstance().callSeriallyAndWait(new Runnable() {
-            public void run() {
-                runChecks(app[0]);
-            }
-        });
+        // One stage per serial call, with the EDT left to run in between. A Container mutated
+        // while the AnimationManager is busy -- which it is for the whole of a dialog's show
+        // animation -- has its removals and additions QUEUED, so a rebuild inside a freshly shown
+        // dialog reads back as if nothing happened. Nothing here is a UI defect; the checks just
+        // have to look after the frame that applies them.
+        Runnable[] stages = {
+            new Runnable() { public void run() { checkShell(app[0]); } },
+            new Runnable() { public void run() { checkNewProfileDialog(app[0]); } },
+            new Runnable() { public void run() { checkRemainingSections(app[0]); } },
+        };
+        for (Runnable stage : stages) {
+            Display.getInstance().callSeriallyAndWait(stage);
+            Thread.sleep(400);
+        }
         System.out.println("[CertificateWizardStructure] failures=" + fail.size());
         for (String f : fail) {
             System.out.println("  FAIL: " + f);
@@ -56,7 +82,7 @@ public final class CertificateWizardStructureHarness {
         System.exit(fail.isEmpty() ? 0 : 1);
     }
 
-    private static void runChecks(CertificateWizard app) {
+    private static void checkShell(CertificateWizard app) {
         Form form = app.getForm();
         check(app.getSection() == CertificateWizard.Section.OVERVIEW, "wizard starts on overview section");
         check(find(form, "btn.refresh") != null, "refresh button present");
@@ -116,13 +142,54 @@ public final class CertificateWizardStructureHarness {
         check(selected(form, "nav.profiles"), "profiles nav selected");
         check(!selected(form, "nav.certificates"), "certificates nav no longer selected");
         fire(form, "btn.newProfile");
+    }
+
+    private static void checkNewProfileDialog(CertificateWizard app) {
+        Form form = app.getForm();
         check(find(form, "modal.profile.submit") != null, "profile modal create action present");
         check(find(form, "pick.bundle.BID_A1") != null, "profile modal bundle choice present");
         check(find(form, "pick.cert.1") != null, "profile modal certificate choice present");
+        // The dialog opens on App Store, and that has to be true of the model and not only of the
+        // segment's styling -- the whole of issue #5636's "Create never enables" is this gap.
+        check(selectedSegment(form, "pick.type.ios_app_store"), "App Store segment starts selected");
+        check(find(form, "pick.cert.3") == null,
+                "only certificates the selected profile type can use are offered");
+        check(find(form, "pick.device.DEV_1") == null,
+                "an App Store profile does not ask for devices");
+        Component requirement = find(form, "modal.profile.requirement");
+        check(requirement instanceof Label && ((Label)requirement).getText().length() > 0,
+                "disabled create action explains what is missing");
         fire(form, "pick.bundle.BID_A1");
+        fire(form, "pick.bundle.BID_A1");
+        check(selectedChoice(form, "pick.bundle.BID_A1"),
+                "re-picking the selected bundle keeps it selected");
         fire(form, "pick.cert.1");
+        check(enabled(form, "modal.profile.submit"),
+                "type, bundle, certificate and a name are enough to create an App Store profile");
+        check(requirementText(form).length() == 0, "no requirement is reported once create is enabled");
+        fire(form, "pick.type.ios_app_development");
+        fire(form, "pick.type.ios_app_development");
+        check(selectedSegment(form, "pick.type.ios_app_development"),
+                "re-picking the selected profile type keeps it selected");
+        check(find(form, "pick.cert.1") == null,
+                "a distribution certificate is dropped when the type becomes development");
+        check(find(form, "pick.cert.2") != null, "the development certificate is offered instead");
+        check(find(form, "pick.device.DEV_1") != null, "a development profile asks for devices");
+        fire(form, "pick.cert.2");
+        check(!enabled(form, "modal.profile.submit"), "create waits for the devices it now needs");
+        check(requirementText(form).contains("device"), "the missing devices are named");
+        fire(form, "modal.profile.selectAllDevices");
+        check(selectedCheckBox(form, "pick.device.DEV_1") && selectedCheckBox(form, "pick.device.DEV_2"),
+                "select all checks every device");
+        check(enabled(form, "modal.profile.submit"), "create enables once devices are selected");
+        fire(form, "modal.profile.clearDevices");
+        check(!selectedCheckBox(form, "pick.device.DEV_1"), "clear unchecks every device");
+        check(!enabled(form, "modal.profile.submit"), "create disables again with no devices");
         fire(form, "modal.cancel");
-        form = app.getForm();
+    }
+
+    private static void checkRemainingSections(CertificateWizard app) {
+        Form form = app.getForm();
         fire(form, "nav.apns");
         check(find(form, "btn.addApns") != null, "APNs add action present");
         fire(form, "nav.mac");
@@ -131,22 +198,21 @@ public final class CertificateWizardStructureHarness {
         check(find(form, "btn.installMacCert.3") != null, "Mac certificate install action present");
         check(find(form, "btn.installMacProfile.3") != null, "Mac profile install action present");
         fire(form, "nav.android");
-        check(find(form, "btn.androidGenerate") != null, "Android keystore generation action present");
-        check(find(form, "field.androidAlias") != null, "Android alias field present");
+        // Generating a keystore writes it into a project's settings, so the form is only offered
+        // once the wizard knows which project that is. This harness runs without a binding, which
+        // is the case that has to explain itself rather than show an inert form.
+        check(find(form, "field.androidAlias") == null,
+                "Android keystore form is withheld without a project binding");
         check(find(form, "field.androidDname") == null, "Android raw distinguished-name field removed");
-        check(find(form, "field.androidCommonName") != null, "Android common name field present");
-        check(find(form, "field.androidOrganization") != null, "Android organization field present");
-        TextField org = (TextField)find(form, "field.androidOrganization");
-        check(org != null && "MyCompany".equals(org.getText()), "Android organization placeholder avoids Codename One");
-        check(find(form, "field.androidCountry") != null, "Android country field present");
+        check(messageText(form).length() > 0, "Android page explains why it cannot install");
         fire(form, "nav.windows");
         check(find(form, "btn.windowsDocs") != null, "Windows signing docs action present");
         fire(form, "nav.maintenance");
         check(find(form, "btn.clearSigningData") != null, "clear signing data action present");
         fire(form, "btn.clearSigningData");
         check(find(form, "modal.confirm") != null, "clear signing data requires confirmation");
-        Component destructiveText = findText(form, "This deletes all cached cloud signing data for this Codename One account. It cannot be undone. Continue?");
-        check(destructiveText != null, "clear signing data warning explains irreversible operation");
+        check(findTextContaining(form, "cannot be undone") != null,
+                "clear signing data warning explains irreversible operation");
         fire(form, "modal.cancel");
         form = app.getForm();
         fire(form, "nav.credential");
@@ -186,9 +252,36 @@ public final class CertificateWizardStructureHarness {
         runCommand(form, "Reset Font Size");
 
         app.showUnhandledEdtError(new RuntimeException("Synthetic EDT failure"));
-        Component edtError = findText(app.getForm(), "Synthetic EDT failure");
-        check(edtError != null, "EDT errors render inline");
-        check(edtError instanceof Label && ((Label)edtError).isTextSelectionEnabled(), "EDT error text is selectable");
+        form = app.getForm();
+        check(messageText(form).contains("Synthetic EDT failure"), "EDT errors render inline");
+        Component edtError = find(form, "page.message");
+        check(edtError instanceof SpanLabel && ((SpanLabel)edtError).isTextSelectionEnabled(),
+                "EDT error text is selectable");
+    }
+
+    private static boolean selectedSegment(Container root, String name) {
+        Component c = find(root, name);
+        return c != null && c.getUIID() != null && c.getUIID().endsWith("CWSegmentSelected");
+    }
+
+    private static boolean selectedChoice(Container root, String name) {
+        Component c = find(root, name);
+        return c != null && c.getUIID() != null && c.getUIID().endsWith("CWChoiceSelected");
+    }
+
+    private static boolean selectedCheckBox(Container root, String name) {
+        Component c = find(root, name);
+        return c instanceof com.codename1.ui.CheckBox && ((com.codename1.ui.CheckBox)c).isSelected();
+    }
+
+    private static boolean enabled(Container root, String name) {
+        Component c = find(root, name);
+        return c != null && c.isEnabled();
+    }
+
+    private static String requirementText(Container root) {
+        Component c = find(root, "modal.profile.requirement");
+        return c instanceof Label ? ((Label)c).getText() : "MISSING";
     }
 
     private static boolean hasCommand(Form form, String commandName) {
@@ -262,6 +355,37 @@ public final class CertificateWizardStructureHarness {
             }
             if (c instanceof Container) {
                 Component out = find((Container)c, name);
+                if (out != null) {
+                    return out;
+                }
+            }
+        }
+        return null;
+    }
+
+    /// The inline page banner. It is a SpanLabel so a whole sentence can wrap, which findText --
+    /// which only ever matches a Label -- cannot see.
+    private static String messageText(Container root) {
+        Component c = find(root, "page.message");
+        if (c instanceof SpanLabel) {
+            String t = ((SpanLabel)c).getText();
+            return t == null ? "" : t;
+        }
+        return "";
+    }
+
+    private static Component findTextContaining(Container root, String text) {
+        for (int i = 0; i < root.getComponentCount(); i++) {
+            Component c = root.getComponentAt(i);
+            if (c instanceof Label && ((Label)c).getText() != null && ((Label)c).getText().contains(text)) {
+                return c;
+            }
+            if (c instanceof SpanLabel && ((SpanLabel)c).getText() != null
+                    && ((SpanLabel)c).getText().contains(text)) {
+                return c;
+            }
+            if (c instanceof Container) {
+                Component out = findTextContaining((Container)c, text);
                 if (out != null) {
                     return out;
                 }

--- a/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardStructureHarness.java
+++ b/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardStructureHarness.java
@@ -244,6 +244,17 @@ public final class CertificateWizardStructureHarness {
         check(find(form, "modal.generateCert.submit") != null, "the remedy opens the certificate dialog");
         check(selectedSegment(form, "pick.certType.mac_app_development"),
                 "and opens it on the type the profile actually needs");
+        String suggested = text(form, "field.certName");
+        check(suggested.contains("MAC APP DEVELOPMENT"),
+                "the suggested name describes that type, not the dialog's old default");
+        fire(form, "pick.certType.ios_development");
+        check(!text(form, "field.certName").equals(suggested),
+                "and follows the type when it changes, instead of labelling one kind of "
+                        + "certificate with the name of another");
+        setText(form, "field.certName", "My own name");
+        fire(form, "pick.certType.ios_distribution");
+        check("My own name".equals(text(form, "field.certName")),
+                "but stops following once the user has written their own");
         fire(form, "modal.cancel");
     }
 
@@ -392,6 +403,16 @@ public final class CertificateWizardStructureHarness {
         } else {
             fail.add("cannot fire " + name);
         }
+    }
+
+    private static String text(Container root, String name) {
+        Component c = find(root, name);
+        if (c instanceof TextField) {
+            String t = ((TextField)c).getText();
+            return t == null ? "" : t;
+        }
+        fail.add("no text field named " + name);
+        return "";
     }
 
     private static void setText(Container root, String name, String value) {

--- a/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardStructureHarness.java
+++ b/scripts/certificatewizard/common/src/test/java/com/codename1/certificatewizard/CertificateWizardStructureHarness.java
@@ -90,6 +90,9 @@ public final class CertificateWizardStructureHarness {
         Runnable[] stages = {
             new Runnable() { public void run() { checkShell(app[0]); } },
             new Runnable() { public void run() { checkNewProfileDialog(app[0]); } },
+            new Runnable() { public void run() { checkMacDevelopmentRemedy(app[0]); } },
+            new Runnable() { public void run() { checkMacDevelopmentDeadEnd(app[0]); } },
+            new Runnable() { public void run() { checkCertificateDialogOpensOnTheNeededType(app[0]); } },
             new Runnable() { public void run() { checkRemainingSections(app[0]); } },
         };
         for (Runnable stage : stages) {
@@ -212,6 +215,35 @@ public final class CertificateWizardStructureHarness {
         fire(form, "modal.profile.clearDevices");
         check(!selectedCheckBox(form, "pick.device.DEV_1"), "clear unchecks every device");
         check(!enabled(form, "modal.profile.submit"), "create disables again with no devices");
+        fire(form, "modal.cancel");
+    }
+
+    private static void checkMacDevelopmentRemedy(CertificateWizard app) {
+        Form form = app.getForm();
+        fire(form, "btn.newProfile");
+    }
+
+    /// The account has no Mac development certificate and no Mac device, so this profile type is
+    /// the one whose empty states have to lead somewhere. The remedy used to open the certificate
+    /// dialog on a type list that did not contain the required one.
+    private static void checkMacDevelopmentDeadEnd(CertificateWizard app) {
+        Form form = app.getForm();
+        fire(form, "pick.type.mac_app_development");
+        check(find(form, "pick.cert.3") == null, "a Mac App Store certificate is not a Mac development one");
+        check(find(form, "btn.profileNeedsCert") != null, "the missing certificate is called out");
+        check(find(form, "pick.device.DEV_1") == null, "an iPhone is not offered for a Mac profile");
+        // and says so, rather than the section simply not being drawn -- which is the reading
+        // that would make the check above pass for the wrong reason
+        check(findTextContaining(form, "No enabled Mac devices") != null,
+                "the empty device list names the platform it wanted");
+        fire(form, "btn.profileNeedsCert");
+    }
+
+    private static void checkCertificateDialogOpensOnTheNeededType(CertificateWizard app) {
+        Form form = app.getForm();
+        check(find(form, "modal.generateCert.submit") != null, "the remedy opens the certificate dialog");
+        check(selectedSegment(form, "pick.certType.mac_app_development"),
+                "and opens it on the type the profile actually needs");
         fire(form, "modal.cancel");
     }
 


### PR DESCRIPTION
Fixes #5636.

## The scrollbar

A CN1 CSS theme is installed with `setThemeProps`, which **replaces** the whole property table -- and `scripts/certificatewizard/common/src/main/css/theme.css` never declared the UIIDs the look and feel asks for by name. `Scroll` and `ScrollThumb` therefore came from `UIManager`'s blank-theme defaults: track background white, `ScrollThumb.bgColor = foreground = 0`. Sampling the reporter's screenshot and a local repro gives the same thing both times -- track `(255,255,255)`, thumb `(0,0,0)`. On a dark page that reads as an inverted bar whose *empty* part looks like the thumb.

The same replacement dropped `@interactiveScrollBool`, which `JavaSEPort.injectDesktopThemeConstants` puts into the *native* theme. `CertificateWizardStub` already sets `APP_DESKTOP_INTERACTIVE_SCROLLBARS = true`, so the declared setting was being silently discarded and the desktop tool got the thin, un-grabbable mobile overlay bar.

These UIIDs cannot use the app's own `DarkXxx` prefix scheme -- the look and feel looks them up by the exact name -- so their dark values live in a `prefers-color-scheme` block, which the CSS compiler emits as `$Dark<UIID>` entries.

## Why "Create" could never be enabled

The dialog painted the first segment selected while `profileType` held `null`. Clicking that segment selected it for real; clicking it again silently went back to `null`. That is the reported "I was unable to find any combination of buttons that changed this from cancel to generate", and the same toggle-on-re-click on the bundle and certificate rows is why "I had to click about 20 times to get this button to light up" (`CWSegmentSelected` also carried no border where `CWSegment` did, so selecting one resized it and shifted its neighbours out from under the pointer).

The rows joined their two halves with `"\n"`, which a `Button` does not render, so they came out as `com.example.myappMy App` and `App Store DistributionDISTRIBUTION`.

The dialog now opens on a type it actually holds; single-select means select; certificates are filtered to the ones that type can be signed with (a Mac Installer certificate could previously be chosen for an iOS App Store profile, which Apple rejects at creation time); the device list appears only for device-limited types, with **Select all** / **Clear**; and a line in the footer, beside the button it explains, names the first missing input.

## Readability

The check box glyph is built from the `CheckBox` style rather than from the UIID the component carries, and only a light rule existed -- in dark mode the box was navy on navy, which is why "until you start checking them, they look like they might all be selected already". Declared in both schemes, sized in millimetres instead of off the label font, unchecked grey vs checked accent. The dark palette moves off the saturated navy onto a neutral slate and every small font size is bumped, for the "tiny white fonts on a medium blue background" half of the report. White on the lime primary button was near 2:1; it is ink now.

## The harness

`CertificateWizardStructureHarness` was failing **9 checks on unmodified master**. Nothing runs it -- it needs a display -- so it had rotted: the Android page is correctly gated on a project binding, the confirmation copy moved, and page banners are `SpanLabel`s that `findText` could never see. All repaired, and the checks are split into stages that let the EDT run between them: `Container` mutations are **queued** while a dialog's show animation holds the `AnimationManager`, so a rebuild inside a freshly shown dialog reads back as if nothing happened. The run command is now in the class javadoc.

## Verification

Built and ran the wizard locally against the mock service, before and after, screenshotting each state; measured the thumb and track colours out of the pixels rather than eyeballing them. `mvn install -Pexecutable-jar`: 48 tests pass, including new coverage for the fixed UIIDs, the contrast rules, the segment box, and `describeMissingProfileInput` (exhaustively cross-checked against `canCreateProfile`). The structure harness is at 0 failures, from 9 on master.

Still open, and not taken on here: nothing in PR CI builds `scripts/certificatewizard`, so none of these tests run before a release tag, and the harness needs a display to run at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)