### PR TITLE
Three CI failures: a cache that never hit, a leaked test window, an unrecorded erratum

### DIFF
--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -11043,35 +11043,63 @@ public class HTML5Implementation extends CodenameOneImplementation {
         
     }
 
+    /// Caches any object, not just a `JSObject`.
+    ///
+    /// The cached value used to have to be a `JSObject` and everything else fell
+    /// through to `super`, which answers `new WeakReference(o)`. ParparVM's
+    /// `WeakReference` never holds what it was constructed with, so that branch is a
+    /// reference that is empty the moment it is made -- and the framework's caches
+    /// are built on ordinary Java objects, not `JSObject`s, so that was every one of
+    /// them. `EncodedImage` was the visible casualty: `getInternal()` keeps the
+    /// decoded picture in one of these, so a permanent miss made it hand the bytes
+    /// back to the browser on EVERY draw and paint nothing until that decode landed,
+    /// with no repaint scheduled for when it did. That is a picture that can stay
+    /// blank on screen, and in CI it was `graphics-draw-image-rect` differing in
+    /// about a third of runs, each run missing a different subset of the cells that
+    /// draw the same EncodedImage.
+    ///
+    /// A Java object reaches a `@JSBody` script as its own JS representation, which
+    /// is a perfectly good WeakMap value, so nothing about the mechanism needed the
+    /// `JSObject` bound -- only the declared type did.
     @Override
     public Object createSoftWeakRef(Object o) {
-        if (Display.getInstance().getProperty("javascript.useES6WeakRefs", "true").equals("true")
-                && isWeakMapSupported()
-                && (o == null || o instanceof JSObject)) {
+        if (useES6WeakRefs()) {
             if (o == null) {
                 return new JSObjectWrapper();
             }
-            JSObject key = createSoftWeakRefImpl((JSObject)o);
             JSObjectWrapper keyOut = new JSObjectWrapper();
-            keyOut.o = key;
+            keyOut.o = createSoftWeakRefImpl(o);
             return keyOut;
         } else {
             return super.createSoftWeakRef(o);
         }
     }
 
+    /// Reads back whatever `#createSoftWeakRef(Object)` handed out.
+    ///
+    /// Dispatches on the shape of the token rather than on the WeakMap being
+    /// available now, which is what the two used to disagree about: create fell
+    /// through to `super` for anything it could not put in the map, extract did not,
+    /// so a `super` token came back null however alive its referent was. The token is
+    /// the only thing that says which side made it, so it is the only thing worth
+    /// asking. Tested with `instanceof` rather than a cast because a failed cast does
+    /// not throw under ParparVM.
     @Override
     public Object extractHardRef(Object o) {
-        if (Display.getInstance().getProperty("javascript.useES6WeakRefs", "true").equals("true") && isWeakMapSupported()) {
-            if (o==null || !(o instanceof JSObjectWrapper)) {
-                return null;
-            }
-            JSObjectWrapper w = (JSObjectWrapper)o;
-            
-            return w.o == null ? null : extractHardRefImpl(w.o);
-        } else {
-            return super.extractHardRef(o);
+        if (o == null) {
+            return null;
         }
+        if (o instanceof JSObjectWrapper) {
+            JSObjectWrapper w = (JSObjectWrapper)o;
+            return w.o == null ? null : extractHardRefImpl(w.o);
+        }
+        return super.extractHardRef(o);
+    }
+
+    /// Whether the ES6 WeakMap path is both wanted and available.
+    private boolean useES6WeakRefs() {
+        return Display.getInstance().getProperty("javascript.useES6WeakRefs", "true").equals("true")
+                && isWeakMapSupported();
     }
     
     
@@ -11084,10 +11112,10 @@ public class HTML5Implementation extends CodenameOneImplementation {
     private static native boolean isWeakMapSupported();
     
     @JSBody(params={"o"}, script="var key={}; window.cn1GlobalWeakMap.set(key, o); return key;")
-    private native static JSObject createSoftWeakRefImpl(JSObject o);
+    private native static JSObject createSoftWeakRefImpl(Object o);
     
     @JSBody(params={"key"}, script="return window.cn1GlobalWeakMap.has(key) ? window.cn1GlobalWeakMap.get(key) : null")
-    private native static JSObject extractHardRefImpl(JSObject key);
+    private native static Object extractHardRefImpl(JSObject key);
     
     @JSBody(params={}, script="return window.cn1IsPreview === true")
     private native static boolean isPreview_();

--- a/Ports/JavaScriptPort/src/main/webapp/port.js
+++ b/Ports/JavaScriptPort/src/main/webapp/port.js
@@ -2025,9 +2025,14 @@ bindNative([
   return null;
 });
 
+// The cached value is declared java.lang.Object, not JSObject: the framework's
+// caches hold ordinary Java objects and the JSObject-only spelling sent every one
+// of them down the WeakReference fallback, which under ParparVM never holds its
+// referent. Keep these names in step with HTML5Implementation.createSoftWeakRefImpl
+// -- ParparVM encodes the whole signature here, so a stale name binds nothing.
 bindNative([
-  "cn1_com_codename1_impl_html5_HTML5Implementation_createSoftWeakRefImpl_com_codename1_html5_js_JSObject_R_com_codename1_html5_js_JSObject",
-  "cn1_com_codename1_impl_html5_HTML5Implementation_createSoftWeakRefImpl___com_codename1_html5_js_JSObject_R_com_codename1_html5_js_JSObject"
+  "cn1_com_codename1_impl_html5_HTML5Implementation_createSoftWeakRefImpl_java_lang_Object_R_com_codename1_html5_js_JSObject",
+  "cn1_com_codename1_impl_html5_HTML5Implementation_createSoftWeakRefImpl___java_lang_Object_R_com_codename1_html5_js_JSObject"
 ], function(objectRef) {
   if (typeof WeakMap !== "function") {
     return null;
@@ -2042,8 +2047,8 @@ bindNative([
 });
 
 bindNative([
-  "cn1_com_codename1_impl_html5_HTML5Implementation_extractHardRefImpl_com_codename1_html5_js_JSObject_R_com_codename1_html5_js_JSObject",
-  "cn1_com_codename1_impl_html5_HTML5Implementation_extractHardRefImpl___com_codename1_html5_js_JSObject_R_com_codename1_html5_js_JSObject"
+  "cn1_com_codename1_impl_html5_HTML5Implementation_extractHardRefImpl_com_codename1_html5_js_JSObject_R_java_lang_Object",
+  "cn1_com_codename1_impl_html5_HTML5Implementation_extractHardRefImpl___com_codename1_html5_js_JSObject_R_java_lang_Object"
 ], function(keyRef) {
   if (typeof WeakMap !== "function") {
     return null;
@@ -2058,7 +2063,14 @@ bindNative([
     return null;
   }
   const value = weakMap.get(key);
-  return value == null ? null : jvm.wrapJsObject(value, jvm.inferJsObjectClass(value, null));
+  if (value == null) {
+    return null;
+  }
+  // A stored Java object is already a VM object: wrapping it again would hand the
+  // caller a JSObject shell around its own instance, and the cast back to the type
+  // it cached would not throw to say so. Only a genuinely foreign JS value needs a
+  // wrapper.
+  return value.__classDef ? value : jvm.wrapJsObject(value, jvm.inferJsObjectClass(value, null));
 });
 
 bindNative(["cn1_com_codename1_impl_html5_HTML5Implementation_debugFlag_java_lang_String_R_boolean", "cn1_com_codename1_impl_html5_HTML5Implementation_debugFlag___java_lang_String_R_boolean"], function(name) {

--- a/docs/website/data/port_status_supplement.json
+++ b/docs/website/data/port_status_supplement.json
@@ -2,12 +2,15 @@
   "skip_reasons": [
     {
       "test": "CameraApiTest",
-      "reason": "The unattended runner cannot respond to operating-system camera permission prompts or provide stable physical-camera input. The test therefore avoids opening a real session on targets where doing so could hang CI or produce nondeterministic frames.",
+      "reason": "The unattended runner cannot respond to operating-system camera permission prompts or provide stable physical-camera input, and some ports have no camera backend at all to open a session with. The test therefore avoids opening a real session on those targets, where doing so could hang CI or produce nondeterministic frames.",
       "platform_support": "A skipped camera test does not mean the Codename One port is unsupported. Every listed target remains a supported port; camera availability is a separate runtime capability and depends on the device, permissions, and camera backend.",
       "verification": "The native camera implementations are compiled in their port builds and exercised with granted permissions on real hardware or an interactive browser. Deterministic API assertions use the synthetic camera backend outside this portability table.",
       "reason_codes": [
         {
           "prefix": "needs-runtime-permission-on-"
+        },
+        {
+          "prefix": "no-camera-backend-on-"
         },
         {
           "prefix": "no-host-webcam-capture-on-win",

--- a/maven/core-unittests/src/test/java/com/codename1/junit/UITestBase.java
+++ b/maven/core-unittests/src/test/java/com/codename1/junit/UITestBase.java
@@ -144,6 +144,7 @@ public abstract class UITestBase {
     @AfterEach
     protected void tearDownDisplay() throws Exception {
         DisplayTest.flushEdt();
+        disposeLeftoverWindows();
         resetUIManager();
         com.codename1.ui.Toolbar.setGlobalToolbar(false);
         if (implementation != null) {
@@ -182,6 +183,68 @@ public abstract class UITestBase {
         // the singleton reset above cannot reach.
         resetDisplayBooleanArrayField("selectionPressed");
         resetDisplayIntField("dragPathLength", 0);
+    }
+
+    /// Takes down any native window the test left open.
+    ///
+    /// `Desktop` is a process-wide singleton (`Desktop.INSTANCE`) holding one
+    /// mutable `windows` list, and nothing else here clears it. A test that opens
+    /// a window and does not dispose it -- because it asserted its way out early,
+    /// or because the dispose it asked for was marshalled onto the dispatch thread
+    /// and had not run yet -- therefore hands its window to every test that follows,
+    /// in this class and in every class after it in the same JVM. The next test to
+    /// count windows counts one too many, which is how WindowTest failed on master
+    /// at 66b82a0f with `anOwnedWindowIsDisposedWithItsOwner` expecting 2 and
+    /// getting 3, while the commits either side of it passed on identical code.
+    ///
+    /// A leaked window is worse than a wrong count when it is modal: it holds the
+    /// release the dispatch thread is waiting for, so the serial-call queue stops
+    /// draining and the next class reports every test as
+    /// "FormTest timed out after 5000ms" with a `pendingSerialCalls` count that
+    /// climbs test by test -- a live dispatch thread with nothing getting through.
+    ///
+    /// Runs before `implementation.reset()`, which nulls the window manager that
+    /// `dispose()` needs to reach the peer, and is followed by another flush
+    /// because disposing fires window events and those listeners queue work.
+    private void disposeLeftoverWindows() throws Exception {
+        if (!Display.isInitialized() || !Display.getInstance().isEdt()) {
+            // dispose() marshals itself onto the dispatch thread when called from
+            // anywhere else, so off-EDT the disposal would land after the next test
+            // has already started -- exactly the leak this exists to close.
+            return;
+        }
+        com.codename1.ui.Window[] open = com.codename1.ui.Desktop.getInstance().getWindows();
+        if (open.length == 0) {
+            return;
+        }
+        for (com.codename1.ui.Window w : open) {
+            try {
+                w.dispose();
+            } catch (RuntimeException ignored) {
+                // A window whose peer never opened can throw on the way down. It is
+                // the registry entry that has to go, and the loop below removes it
+                // whether or not dispose() got that far.
+            }
+        }
+        // dispose() deregisters, so this is normally empty already. It is not when a
+        // window failed to open and was registered without a peer to tear down, and
+        // leaving that entry behind would defeat the whole method.
+        Field windows = com.codename1.ui.Desktop.class.getDeclaredField("windows");
+        windows.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        List<Object> registry = (List<Object>) windows.get(com.codename1.ui.Desktop.getInstance());
+        if (registry != null) {
+            synchronized (registry) {
+                registry.clear();
+            }
+        }
+        // deregisterWindow() drops the focus alongside the registry entry; clearing
+        // the list behind its back would leave a disposed window still answering
+        // Desktop.getFocusedWindow(), which is what a Dialog resolves its host from.
+        Field focused = com.codename1.ui.Desktop.class.getDeclaredField("focusedWindow");
+        focused.setAccessible(true);
+        focused.set(com.codename1.ui.Desktop.getInstance(), null);
+        DisplayTest.flushEdt();
     }
 
     private void resetDisplayBooleanArrayField(String name) {

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/graphics/DrawImage.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/graphics/DrawImage.java
@@ -60,6 +60,17 @@ public class DrawImage extends AbstractGraphicsScreenshotTest {
     /// ready the port answers a placeholder size, which is what this reads.
     /// Every other port decodes synchronously and answers true on the first
     /// call.
+    /// Note the `encoded` half of this is not a decode test and cannot be made into
+    /// one: `EncodedImage.createFromImage` assigns the width from the source picture
+    /// at construction, so `getWidth()` answers from that field and never reaches the
+    /// decode. It stays here to say the object exists. What keeps this picture
+    /// deterministic is that `createFromImage` also caches the source image, so
+    /// `getInternal()` reuses it rather than handing the bytes back to the browser --
+    /// which is the whole of it, and is why a port whose soft-reference cache never
+    /// returned anything (the JavaScript one, until HTML5Implementation stopped
+    /// sending every non-JSObject down a WeakReference that holds nothing) redrew
+    /// this cell from a fresh asynchronous decode on every single paint and left it
+    /// blank whenever the shot beat the decode.
     private boolean asyncImagesReady(int size) {
         return fromBytes != null && encoded != null
                 && fromBytes.getWidth() == size && encoded.getWidth() == size;


### PR DESCRIPTION
Three separate CI failures, each with its own commit. Rationale lives in the code
comments and the commit messages; this is the summary and the evidence.

## A cache that never hit, on the JavaScript port

`graphics-draw-image-rect` differed in 23 of 67 completed runs of the JavaScript
screenshot suite between Aug 30 and Sep 1, on four branches. Four separate commits
produced both a pass and a failure from the same tree, so it is not a regression in
anything anyone pushed.

Pulling the artifacts apart, every missing cell in both runs I examined is the same
`EncodedImage`, at three different sizes, and the subset that goes missing changes
from run to run:

    run A: 2 cells missing   run B: 5 cells missing
    mismatch 0.71%           mismatch 3.71%

`createSoftWeakRef` only used the ES6 WeakMap when the value was a `JSObject`;
everything else fell through to the superclass, which answers `new WeakReference(o)`,
and ParparVM's `WeakReference` never holds what it was constructed with. The
framework's caches hold ordinary Java objects, so every one of them was a guaranteed
miss. `extractHardRef` then made it unrecoverable: it decided which side to read from
by asking whether the WeakMap exists now rather than by looking at the token it was
handed, so a superclass token came back null however alive its referent was.

`EncodedImage.getInternal()` keeps its decoded picture in one of these, so a permanent
miss made it hand the bytes back to the browser on every single draw. A browser decode
is asynchronous and nothing repaints when it lands, so the cell can stay blank -- in an
app, not only in a screenshot.

A Java object reaches a `@JSBody` script as its own JS representation, which is a
perfectly good WeakMap value, so only the declared type needed widening. The map still
lets go when its key does: this buys the cache hit without trading it for retention.

**Not done here, and worth a decision:** `vm/JavaAPI`'s `WeakReference` constructor is
`this.objReference = objReference`, a self-assignment, so the class is empty from birth
on every ParparVM target including iOS. Making it hold would turn every weak cache in
the framework into a retaining one there, where `IOSImplementation` already keeps its
own unbounded map instead. That is a runtime-semantics change and does not belong in
this PR.

## A test's leftover window reaching the tests after it

`Desktop` is a process-wide singleton with one mutable window list and nothing cleared
it between tests. A window left open is handed to every test that follows, in its own
class and every class after it in the same JVM.

That is the `PR CI` failure on master at 66b82a0f, where
`WindowTest.anOwnedWindowIsDisposedWithItsOwner` expected two windows and counted three
while the commits either side passed on identical code. It also has a second, louder
shape: a leaked *modal* window holds the release the dispatch thread waits for, so the
serial-call queue stops draining and the next class reports every test as "FormTest
timed out after 5000ms" with a `pendingSerialCalls` count climbing test by test.

Five clean local runs of the full suite, before and after:

| | master | with this commit |
| --- | --- | --- |
| clean runs | 1 / 5 | 5 / 5 |
| failure | `StorageImageAsyncTest` x3, `pendingSerialCalls` 1 -> 4 -> 7 | none |
| tests executed | 6074 | 6074 (754 classes, 0 skipped) |

Same test count both ways, so nothing was skipped into passing.

## An erratum nobody recorded

`CameraApiTest` asks the port whether it has a camera before it asks which platform it
is, and skips with `reason=no-camera-backend-on-<platform>` when the answer is no. No
erratum named that code, so the nightly port-status coverage gate has failed on the
macOS report ever since. Not flaky -- broken, every night.

Run against the live `port-status-data` reports:

    without: macos: skipped without an erratum ... CameraApiTest   exit 1
    with:    Every registered test reported a result on all 12 ports.  exit 0

The prefix is registered unscoped because the test emits it as a capability question
rather than a list of platform names, so the next port in that position is covered
without anyone remembering to name it.

## Verification

Locally: the port-status gate both ways as above; the core-unittests A/B above; the 83
conformance tests; `node --check`, surface-replay, lens-parity, canvas-barrier-lint and
the control-character gate.

The JavaScript-port commit is the one local runs have not covered -- its build was
interrupted partway. CI's screenshot suite is the check, and because that gate fails
about a third of the time today, one green run is not evidence. It needs several.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
