### PR TITLE
Move Android in-app purchase to the Play Billing ProductDetails API

### DIFF
--- a/Ports/Android/build.xml
+++ b/Ports/Android/build.xml
@@ -117,7 +117,7 @@
              entry in nbproject/project.properties and in maven/android/pom.xml. -->
         <javac destdir="build/tmp"
             classpath="${javac.classpath}:build/tmp"
-            excludes="com/codename1/impl/android/ar/**,com/codename1/impl/android/ai/**,com/codename1/impl/android/cipher/**,com/codename1/impl/android/nearby/**">
+            excludes="com/codename1/impl/android/ar/**,com/codename1/impl/android/ai/**,com/codename1/impl/android/cipher/**,com/codename1/impl/android/nearby/**,com/codename1/impl/android/BillingSupport.java">
             <src path="${src.dir}" />
         </javac>
         <jar jarfile="${dist.jar}" basedir="build/tmp">

--- a/Ports/Android/nbproject/project.properties
+++ b/Ports/Android/nbproject/project.properties
@@ -30,8 +30,7 @@ endorsed.classpath=
 # not in cn1-binaries. They are compiled inside user app builds where the
 # Android builder adds only the dependencies and sources used by the app.
 # Mirrors the maven-compiler excludes in maven/android/pom.xml.
-excludes=com/codename1/impl/android/ar/**,com/codename1/impl/android/ai/**,com/codename1/impl/android/cipher/**,com/codename1/impl/android/nearby/**
-file.reference.android-billing-4.0.0.jar=../../../cn1-binaries/android/android-billing-4.0.0.jar
+excludes=com/codename1/impl/android/ar/**,com/codename1/impl/android/ai/**,com/codename1/impl/android/cipher/**,com/codename1/impl/android/nearby/**,com/codename1/impl/android/BillingSupport.java
 file.reference.android-support-v7-appcompat.jar=../../../cn1-binaries/android/android-support-v7-appcompat.jar
 file.reference.android-support-v7-cardview.jar=../../../cn1-binaries/android/android-support-v7-cardview.jar
 file.reference.android-support-v7-gridlayout.jar=../../../cn1-binaries/android/android-support-v7-gridlayout.jar
@@ -69,7 +68,6 @@ javac.classpath=\
     ${file.reference.google-play-services.jar}:\
     ${file.reference.zooz_iap.jar}:\
     ${file.reference.support-v4-26.1.0.jar}:\
-    ${file.reference.android-billing-4.0.0.jar}:\
     ${file.reference.support-compat-v4-26.1.0.jar}:\
     ${file.reference.support-media-compat-26.1.0.jar}:\
     ${file.reference.support-core-utils-26.1.0.jar}:\

--- a/Ports/Android/src/com/codename1/impl/android/BillingSupport.java
+++ b/Ports/Android/src/com/codename1/impl/android/BillingSupport.java
@@ -228,18 +228,49 @@ public class BillingSupport implements IBillingSupport {
         return null;
     }
 
-    /// The offer token launchBillingFlow needs for a subscription, or null when this is
-    /// a one-time product or Play returned no offer.
+    /// The offer token launchBillingFlow needs, or null when Play offered none.
     ///
-    /// A one-time product must NOT carry one -- the flow rejects a token it did not ask
-    /// for -- which is why this returns null for it rather than an empty string.
-    private static String subscriptionOfferToken(ProductDetails details) {
-        List<ProductDetails.SubscriptionOfferDetails> offers =
-                details.getSubscriptionOfferDetails();
-        if (offers == null || offers.isEmpty()) {
-            return null;
+    /// Both product types can carry one. A subscription is always bought through an
+    /// offer and the flow rejects it without a token. A one-time product can now carry
+    /// offers too -- `getOneTimePurchaseOfferDetailsList` -- and one configured with
+    /// more than a base offer has to name which is being bought, or the flow is
+    /// rejected the same way. That is not a subscription-only concern, which is what
+    /// the first version of this assumed.
+    ///
+    /// The default offer is preferred over the list for a one-time product, because
+    /// that is the one the removed `setSkuDetails` call would have bought; the list is
+    /// only consulted when Play sends no default. A token is returned only when Play
+    /// actually supplied one, so a product with no offers still launches the flow with
+    /// no token, exactly as before.
+    private static String offerToken(ProductDetails details, String type) {
+        if (BillingClient.ProductType.SUBS.equals(type)) {
+            List<ProductDetails.SubscriptionOfferDetails> offers =
+                    details.getSubscriptionOfferDetails();
+            if (offers == null || offers.isEmpty()) {
+                return null;
+            }
+            return emptyToNull(offers.get(0).getOfferToken());
         }
-        return offers.get(0).getOfferToken();
+        ProductDetails.OneTimePurchaseOfferDetails preferred =
+                details.getOneTimePurchaseOfferDetails();
+        if (preferred != null && emptyToNull(preferred.getOfferToken()) != null) {
+            return preferred.getOfferToken();
+        }
+        List<ProductDetails.OneTimePurchaseOfferDetails> offers =
+                details.getOneTimePurchaseOfferDetailsList();
+        if (offers != null) {
+            for (ProductDetails.OneTimePurchaseOfferDetails offer : offers) {
+                String token = offer == null ? null : emptyToNull(offer.getOfferToken());
+                if (token != null) {
+                    return token;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static String emptyToNull(String value) {
+        return value == null || value.length() == 0 ? null : value;
     }
 
     private static boolean isFailure(BillingResult billingResult) {
@@ -528,11 +559,10 @@ public class BillingSupport implements IBillingSupport {
                             inventory.add(details, type.equals(BillingClient.ProductType.SUBS) );
                         }
                         final ProductDetails details = list.iterator().next();
-                        // A subscription is bought through one of its offers, not through the
-                        // product: launchBillingFlow rejects a subscription with no offer token.
-                        // The first offer is the one Play lists first for this user, which is
-                        // what the old setSkuDetails call resolved to as well.
-                        final String offerToken = subscriptionOfferToken(details);
+                        // Both product types can need an offer token; see offerToken. A
+                        // subscription with none is not purchasable at all, so that stays a
+                        // reported error rather than a flow that opens and is rejected.
+                        final String offerToken = offerToken(details, type);
                         if (type.equals(BillingClient.ProductType.SUBS) && offerToken == null) {
                             final PurchaseCallback pc = getPurchaseCallback();
                             if (pc == null) {

--- a/Ports/Android/src/com/codename1/impl/android/BillingSupport.java
+++ b/Ports/Android/src/com/codename1/impl/android/BillingSupport.java
@@ -32,9 +32,12 @@ import com.android.billingclient.api.ConsumeResponseListener;
 import com.android.billingclient.api.Purchase;
 import com.android.billingclient.api.PurchasesResponseListener;
 import com.android.billingclient.api.PurchasesUpdatedListener;
-import com.android.billingclient.api.SkuDetails;
-import com.android.billingclient.api.SkuDetailsParams;
-import com.android.billingclient.api.SkuDetailsResponseListener;
+import com.android.billingclient.api.PendingPurchasesParams;
+import com.android.billingclient.api.ProductDetails;
+import com.android.billingclient.api.ProductDetailsResponseListener;
+import com.android.billingclient.api.QueryProductDetailsParams;
+import com.android.billingclient.api.QueryProductDetailsResult;
+import com.android.billingclient.api.QueryPurchasesParams;
 import com.codename1.payment.PendingPurchaseCallback;
 import com.codename1.payment.Product;
 import com.codename1.payment.PurchaseCallback;
@@ -61,8 +64,8 @@ import java.util.logging.Logger;
 
 
 /**
- * A utility class including all of the billing related functionality for the Play billing library
- * version 4.  {@link CodenameOneActivity} can be overridden to return an instance of this in
+ * A utility class including all of the billing related functionality for the Play billing
+ * library.  {@link CodenameOneActivity} can be overridden to return an instance of this in
  * {@link CodenameOneActivity#createBillingSupport()}.   The default implementation returns null
  * which disables billing support.
  *
@@ -141,7 +144,9 @@ public class BillingSupport implements IBillingSupport {
         if (billingClient == null) {
             billingClient= BillingClient.newBuilder(activity)
                     .setListener(purchasesUpdatedListener)
-                    .enablePendingPurchases()
+                    .enablePendingPurchases(PendingPurchasesParams.newBuilder()
+                            .enableOneTimeProducts()
+                            .build())
                     .build();
         }
         
@@ -182,6 +187,61 @@ public class BillingSupport implements IBillingSupport {
     }
 
 
+    /// The query the ProductDetails API takes, built from the plain sku strings the
+    /// Codename One payment API deals in. One product type per query: unlike the SKU
+    /// API, Play rejects a query mixing INAPP and SUBS products.
+    private static QueryProductDetailsParams productQuery(String type, List<String> skus) {
+        List<QueryProductDetailsParams.Product> products =
+                new ArrayList<QueryProductDetailsParams.Product>();
+        for (String sku : skus) {
+            products.add(QueryProductDetailsParams.Product.newBuilder()
+                    .setProductId(sku)
+                    .setProductType(type)
+                    .build());
+        }
+        return QueryProductDetailsParams.newBuilder().setProductList(products).build();
+    }
+
+    /// The price to show for a product, as the old {@code SkuDetails.getPrice()} did.
+    ///
+    /// The ProductDetails API has no single price, because a product carries offers and
+    /// a subscription's offer carries pricing phases. A one-time product has one offer;
+    /// a subscription is quoted at the first phase of its first offer, which is the
+    /// introductory price when there is one and the recurring price otherwise. Returns
+    /// null rather than a fabricated string when Play sends neither, so a caller shows
+    /// no price instead of a wrong one.
+    private static String formattedPrice(ProductDetails details) {
+        ProductDetails.OneTimePurchaseOfferDetails oneTime =
+                details.getOneTimePurchaseOfferDetails();
+        if (oneTime != null) {
+            return oneTime.getFormattedPrice();
+        }
+        List<ProductDetails.SubscriptionOfferDetails> offers =
+                details.getSubscriptionOfferDetails();
+        if (offers != null && !offers.isEmpty()) {
+            ProductDetails.PricingPhases phases = offers.get(0).getPricingPhases();
+            if (phases != null && phases.getPricingPhaseList() != null
+                    && !phases.getPricingPhaseList().isEmpty()) {
+                return phases.getPricingPhaseList().get(0).getFormattedPrice();
+            }
+        }
+        return null;
+    }
+
+    /// The offer token launchBillingFlow needs for a subscription, or null when this is
+    /// a one-time product or Play returned no offer.
+    ///
+    /// A one-time product must NOT carry one -- the flow rejects a token it did not ask
+    /// for -- which is why this returns null for it rather than an empty string.
+    private static String subscriptionOfferToken(ProductDetails details) {
+        List<ProductDetails.SubscriptionOfferDetails> offers =
+                details.getSubscriptionOfferDetails();
+        if (offers == null || offers.isEmpty()) {
+            return null;
+        }
+        return offers.get(0).getOfferToken();
+    }
+
     private static boolean isFailure(BillingResult billingResult) {
         return (billingResult.getResponseCode() != BillingClient.BillingResponseCode.OK);
     }
@@ -202,7 +262,11 @@ public class BillingSupport implements IBillingSupport {
     public void consumeAndAcknowlegePurchases() {
         runWithConnection(new Runnable() {
             public void run() {
-                billingClient.queryPurchasesAsync(BillingClient.SkuType.INAPP, new PurchasesResponseListener() {
+                billingClient.queryPurchasesAsync(
+                        QueryPurchasesParams.newBuilder()
+                                .setProductType(BillingClient.ProductType.INAPP)
+                                .build(),
+                        new PurchasesResponseListener() {
                     @Override
                     public void onQueryPurchasesResponse(BillingResult billingResult, List<Purchase> purchases) {
                         if (billingResult.getResponseCode() != BillingClient.BillingResponseCode.OK) {
@@ -233,7 +297,7 @@ public class BillingSupport implements IBillingSupport {
                 final PendingPurchaseCallback ppc = (PendingPurchaseCallback)pc;
                 CN.callSerially(new Runnable() {
                     public void run() {
-                        for (String sku : purchase.getSkus()) {
+                        for (String sku : purchase.getProducts()) {
                             ppc.itemPurchaseError(sku, "Invalid developer payload");
                         }
 
@@ -251,7 +315,7 @@ public class BillingSupport implements IBillingSupport {
                 CN.callSerially(new Runnable() {
                     @Override
                     public void run() {
-                        ppc.itemPurchasePending(purchase.getSkus().iterator().next());
+                        ppc.itemPurchasePending(purchase.getProducts().iterator().next());
                     }
                 });
             }
@@ -261,7 +325,7 @@ public class BillingSupport implements IBillingSupport {
         }
 
 
-        final String sku = purchase.getSkus().iterator().next();
+        final String sku = purchase.getProducts().iterator().next();
 
         final Runnable onPurchaseAcknowledged = new Runnable() {
             public void run() {
@@ -401,16 +465,16 @@ public class BillingSupport implements IBillingSupport {
 
     @Override
     public void purchase(final String item) {
-        _purchase(item, BillingClient.SkuType.INAPP);
+        _purchase(item, BillingClient.ProductType.INAPP);
     }
 
     @Override
     public void subscribe(final String item) {
-        _purchase(item, BillingClient.SkuType.SUBS);
+        _purchase(item, BillingClient.ProductType.SUBS);
     }
 
     public void _purchase(final String item, final String type) {
-        if (!areSubscriptionsSupported() && type.equals(BillingClient.SkuType.SUBS)) {
+        if (!areSubscriptionsSupported() && type.equals(BillingClient.ProductType.SUBS)) {
             final PurchaseCallback pc = getPurchaseCallback();
             if (pc == null) {
                 return;
@@ -427,9 +491,10 @@ public class BillingSupport implements IBillingSupport {
 
         runWithConnection(new Runnable() {
             public void run() {
-                billingClient.querySkuDetailsAsync(SkuDetailsParams.newBuilder().setType(type).setSkusList((List<String>) Arrays.asList(item)).build(), new SkuDetailsResponseListener() {
+                billingClient.queryProductDetailsAsync(productQuery(type, Arrays.asList(item)), new ProductDetailsResponseListener() {
                     @Override
-                    public void onSkuDetailsResponse(final BillingResult billingResult, final List<SkuDetails> list) {
+                    public void onProductDetailsResponse(final BillingResult billingResult, final QueryProductDetailsResult productDetailsResult) {
+                        final List<ProductDetails> list = productDetailsResult.getProductDetailsList();
                         if (isFailure(billingResult)) {
                             final PurchaseCallback pc = getPurchaseCallback();
                             if (pc == null) {
@@ -459,16 +524,42 @@ public class BillingSupport implements IBillingSupport {
                             });
                             return;
                         }
-                        for (SkuDetails details : list) {
-                            inventory.add(details, type.equals(BillingClient.SkuType.SUBS) );
+                        for (ProductDetails details : list) {
+                            inventory.add(details, type.equals(BillingClient.ProductType.SUBS) );
+                        }
+                        final ProductDetails details = list.iterator().next();
+                        // A subscription is bought through one of its offers, not through the
+                        // product: launchBillingFlow rejects a subscription with no offer token.
+                        // The first offer is the one Play lists first for this user, which is
+                        // what the old setSkuDetails call resolved to as well.
+                        final String offerToken = subscriptionOfferToken(details);
+                        if (type.equals(BillingClient.ProductType.SUBS) && offerToken == null) {
+                            final PurchaseCallback pc = getPurchaseCallback();
+                            if (pc == null) {
+                                return;
+                            }
+                            CN.callSerially(new Runnable() {
+                                @Override
+                                public void run() {
+                                    pc.itemPurchaseError(item, "No purchasable offer is available for subscription " + item);
+                                }
+                            });
+                            return;
                         }
                         activity.runOnUiThread(new Runnable() {
                             @Override
                             public void run() {
-                                
+                                BillingFlowParams.ProductDetailsParams.Builder productParams =
+                                        BillingFlowParams.ProductDetailsParams.newBuilder()
+                                                .setProductDetails(details);
+                                if (offerToken != null) {
+                                    productParams.setOfferToken(offerToken);
+                                }
                                 billingClient.launchBillingFlow(activity,
                                         BillingFlowParams.newBuilder()
-                                                .setSkuDetails(list.iterator().next()).build()
+                                                .setProductDetailsParamsList(
+                                                        Arrays.asList(productParams.build()))
+                                                .build()
                                 );
 
                             }
@@ -496,20 +587,20 @@ public class BillingSupport implements IBillingSupport {
             products.put(sku, product);
         }
 
-        public synchronized void add(SkuDetails details) {
+        public synchronized void add(ProductDetails details) {
             add(details, false);
         }
 
-        public synchronized void add(SkuDetails details, boolean subscription) {
+        public synchronized void add(ProductDetails details, boolean subscription) {
             Product p = new Product();
-            p.setSku(details.getSku());
+            p.setSku(details.getProductId());
             p.setDescription(details.getDescription());
             p.setDisplayName(details.getTitle());
-            p.setLocalizedPrice(details.getPrice());
-            add(details.getSku(), p);
+            p.setLocalizedPrice(formattedPrice(details));
+            add(details.getProductId(), p);
             if (subscription) {
 
-                subscriptions.add(details.getSku());
+                subscriptions.add(details.getProductId());
             }
         }
 
@@ -537,7 +628,7 @@ public class BillingSupport implements IBillingSupport {
 
 
 
-        public synchronized void loadSkuDetailsAsync() {
+        public synchronized void loadProductDetailsAsync() {
             final Set<String> skus = new HashSet<String>();
             skus.addAll(purchases.keySet());
             skus.removeAll(products.keySet());
@@ -545,11 +636,12 @@ public class BillingSupport implements IBillingSupport {
             if (!skus.isEmpty()) {
                 runWithConnection(new Runnable() {
                     public void run() {
-                        billingClient.querySkuDetailsAsync(SkuDetailsParams.newBuilder().setType(BillingClient.SkuType.INAPP).setSkusList(new ArrayList<String>(skus)).build(), new SkuDetailsResponseListener() {
+                        billingClient.queryProductDetailsAsync(productQuery(BillingClient.ProductType.INAPP, new ArrayList<String>(skus)), new ProductDetailsResponseListener() {
                             @Override
-                            public void onSkuDetailsResponse( BillingResult billingResult,  List<SkuDetails> list) {
+                            public void onProductDetailsResponse( BillingResult billingResult,  QueryProductDetailsResult productDetailsResult) {
+                                List<ProductDetails> list = productDetailsResult.getProductDetailsList();
                                 if (list != null && !list.isEmpty()) {
-                                    for (SkuDetails details : list) {
+                                    for (ProductDetails details : list) {
                                         add(details);
 
                                     }
@@ -557,11 +649,12 @@ public class BillingSupport implements IBillingSupport {
                             }
                         });
                         if (areSubscriptionsSupported()) {
-                            billingClient.querySkuDetailsAsync(SkuDetailsParams.newBuilder().setType(BillingClient.SkuType.SUBS).setSkusList(new ArrayList<String>(skus)).build(), new SkuDetailsResponseListener() {
+                            billingClient.queryProductDetailsAsync(productQuery(BillingClient.ProductType.SUBS, new ArrayList<String>(skus)), new ProductDetailsResponseListener() {
                                 @Override
-                                public void onSkuDetailsResponse( BillingResult billingResult,  List<SkuDetails> list) {
+                                public void onProductDetailsResponse( BillingResult billingResult,  QueryProductDetailsResult productDetailsResult) {
+                                    List<ProductDetails> list = productDetailsResult.getProductDetailsList();
                                     if (list != null && !list.isEmpty()) {
-                                        for (SkuDetails details : list) {
+                                        for (ProductDetails details : list) {
 
                                             add(details, true);
 
@@ -617,9 +710,10 @@ public class BillingSupport implements IBillingSupport {
                 final Object lock = new Object();
                 runWithConnection(new Runnable() {
                     public void run() {
-                        billingClient.querySkuDetailsAsync(SkuDetailsParams.newBuilder().setType(BillingClient.SkuType.INAPP).setSkusList((List<String>) moreskusList).build(), new SkuDetailsResponseListener() {
+                        billingClient.queryProductDetailsAsync(productQuery(BillingClient.ProductType.INAPP, (List<String>) moreskusList), new ProductDetailsResponseListener() {
                             @Override
-                            public void onSkuDetailsResponse( BillingResult billingResult, List<SkuDetails> list) {
+                            public void onProductDetailsResponse( BillingResult billingResult, QueryProductDetailsResult productDetailsResult) {
+                                List<ProductDetails> list = productDetailsResult.getProductDetailsList();
                                 synchronized (lock) {
                                     if (isFailure(billingResult)) {
                                         complete[0]++;
@@ -627,7 +721,7 @@ public class BillingSupport implements IBillingSupport {
                                         return;
                                     }
 
-                                    for (SkuDetails details : list) {
+                                    for (ProductDetails details : list) {
 
                                         inventory.add(details);
 
@@ -653,9 +747,10 @@ public class BillingSupport implements IBillingSupport {
                 if (areSubscriptionsSupported()) {
                     runWithConnection(new Runnable() {
                         public void run() {
-                            billingClient.querySkuDetailsAsync(SkuDetailsParams.newBuilder().setType(BillingClient.SkuType.SUBS).setSkusList((List<String>) moreskusList).build(), new SkuDetailsResponseListener() {
+                            billingClient.queryProductDetailsAsync(productQuery(BillingClient.ProductType.SUBS, (List<String>) moreskusList), new ProductDetailsResponseListener() {
                                 @Override
-                                public void onSkuDetailsResponse( BillingResult billingResult, List<SkuDetails> list) {
+                                public void onProductDetailsResponse( BillingResult billingResult, QueryProductDetailsResult productDetailsResult) {
+                                    List<ProductDetails> list = productDetailsResult.getProductDetailsList();
                                     synchronized (lock) {
                                         if (isFailure(billingResult)) {
                                             complete[0]++;
@@ -663,7 +758,7 @@ public class BillingSupport implements IBillingSupport {
                                             return;
                                         }
 
-                                        for (SkuDetails details : list) {
+                                        for (ProductDetails details : list) {
 
                                             inventory.add(details, true);
 

--- a/Ports/Android/src/com/codename1/impl/android/BillingSupport.java
+++ b/Ports/Android/src/com/codename1/impl/android/BillingSupport.java
@@ -205,14 +205,15 @@ public class BillingSupport implements IBillingSupport {
     /// The price to show for a product, as the old {@code SkuDetails.getPrice()} did.
     ///
     /// The ProductDetails API has no single price, because a product carries offers and
-    /// a subscription's offer carries pricing phases. A one-time product has one offer;
+    /// a subscription's offer carries pricing phases. A one-time product is quoted at
+    /// the offer {@link #selectedOneTimeOffer} picks, which is the same offer the
+    /// purchase flow launches, so the price shown is the price charged;
     /// a subscription is quoted at the first phase of its first offer, which is the
     /// introductory price when there is one and the recurring price otherwise. Returns
     /// null rather than a fabricated string when Play sends neither, so a caller shows
     /// no price instead of a wrong one.
     private static String formattedPrice(ProductDetails details) {
-        ProductDetails.OneTimePurchaseOfferDetails oneTime =
-                details.getOneTimePurchaseOfferDetails();
+        ProductDetails.OneTimePurchaseOfferDetails oneTime = selectedOneTimeOffer(details);
         if (oneTime != null) {
             return oneTime.getFormattedPrice();
         }
@@ -251,18 +252,34 @@ public class BillingSupport implements IBillingSupport {
             }
             return emptyToNull(offers.get(0).getOfferToken());
         }
+        ProductDetails.OneTimePurchaseOfferDetails oneTime = selectedOneTimeOffer(details);
+        return oneTime == null ? null : emptyToNull(oneTime.getOfferToken());
+    }
+
+    /// The one-time offer this build both quotes and buys.
+    ///
+    /// Chosen once, and used for the price as well as the token, because those two
+    /// answers have to come from the same offer. Reading the default offer for the
+    /// price while the flow launched the first tokenized offer from the list showed
+    /// the user one price and charged another.
+    ///
+    /// The default offer wins when Play sends one: it is what buying with no token
+    /// selects, and what the removed setSkuDetails call would have bought. Only when
+    /// there is no default -- a product configured with offers and no base -- does the
+    /// list decide, and then the same entry supplies both answers.
+    private static ProductDetails.OneTimePurchaseOfferDetails selectedOneTimeOffer(
+            ProductDetails details) {
         ProductDetails.OneTimePurchaseOfferDetails preferred =
                 details.getOneTimePurchaseOfferDetails();
-        if (preferred != null && emptyToNull(preferred.getOfferToken()) != null) {
-            return preferred.getOfferToken();
+        if (preferred != null) {
+            return preferred;
         }
         List<ProductDetails.OneTimePurchaseOfferDetails> offers =
                 details.getOneTimePurchaseOfferDetailsList();
         if (offers != null) {
             for (ProductDetails.OneTimePurchaseOfferDetails offer : offers) {
-                String token = offer == null ? null : emptyToNull(offer.getOfferToken());
-                if (token != null) {
-                    return token;
+                if (offer != null) {
+                    return offer;
                 }
             }
         }

--- a/maven/android/pom.xml
+++ b/maven/android/pom.xml
@@ -111,6 +111,23 @@
                                      the builder deletes whichever halves the
                                      app did not ask for. -->
                                 <exclude>com/codename1/impl/android/nearby/**</exclude>
+                                <!-- BillingSupport is written against the Play
+                                     Billing ProductDetails API, which needs
+                                     billing 8 or newer; cn1-binaries carries
+                                     the 4.0.0 jar this module used to compile
+                                     it against, and Play stopped accepting
+                                     apps built below 8 on Aug 31 2026. Like
+                                     the four above it ships as source and
+                                     compiles inside the app build, where
+                                     AndroidGradleBuilder adds the real billing
+                                     dependency at the version the app asked
+                                     for and deletes the file for apps with no
+                                     in-app purchase. PlayBillingVersions is
+                                     what keeps that compile honest: it refuses
+                                     a build below the floor with a sentence,
+                                     rather than letting javac fail in the
+                                     generated project. -->
+                                <exclude>com/codename1/impl/android/BillingSupport.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>
@@ -204,13 +221,6 @@
                     <version>3.0.0</version>
                     <scope>system</scope>
                     <systemPath>${cn1.binaries}/android/google-services-3.0.0.jar</systemPath>
-                </dependency>
-                <dependency>
-                    <groupId>com.codenameone.cn1binaries</groupId>
-                    <artifactId>android-billing</artifactId>
-                    <version>4.0.0</version>
-                    <scope>system</scope>
-                    <systemPath>${cn1.binaries}/android/android-billing-4.0.0.jar</systemPath>
                 </dependency>
                 <dependency>
                     <groupId>com.codenameone.cn1binaries</groupId>

--- a/maven/build-hint-catalog/src/main/java/com/codename1/build/shared/BuildHintsAndroid.java
+++ b/maven/build-hint-catalog/src/main/java/com/codename1/build/shared/BuildHintsAndroid.java
@@ -251,8 +251,18 @@ final class BuildHintsAndroid {
         h.add(new Hint("android.billingclient.version")
                 .group(HintGroup.ANDROID)
                 .type(HintType.VERSION)
-                .def("4.0.0")
-                .platform("android"));
+                .def("8.0.0")
+                .platform("android")
+                .doc("The Play Billing Library version an in-app-purchase app is built against, "
+                        + "defaulting to 8.0.0. Codename One's billing implementation uses the "
+                        + "ProductDetails API, so 8.0.0 is also the minimum: Play Billing removed "
+                        + "the older SkuDetails API, and a build set lower is refused with an "
+                        + "explanation rather than a page of compiler errors. The default is the "
+                        + "lowest version Google still accepts for new apps and updates, and the "
+                        + "only one at that level whose library is content with `minSdkVersion` 21; "
+                        + "every later release requires 23. Setting a newer version raises "
+                        + "`android.min_sdk_version` to match, because the library's own manifest "
+                        + "would otherwise fail the merge."));
 
         h.add(new Hint("android.blockExternalStoragePermission")
                 .group(HintGroup.ANDROID)

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
@@ -4604,6 +4604,37 @@ public class AndroidGradleBuilder extends Executor {
             throw new BuildException("Failed to generate icon files", ex);
         }
 
+        // The Play Billing version, resolved here rather than beside the gradle
+        // dependency it feeds, because it also moves minSdk and the manifest that
+        // carries minSdkVersion is written further down this method. Resolving it
+        // late put the raised floor in build.gradle and left the manifest saying 19,
+        // which is the merge failure it was meant to prevent.
+        String billingClientVersion = null;
+        if (purchasePermissions) {
+            billingClientVersion = request.getArg("android.billingclient.version",
+                    PlayBillingVersions.DEFAULT_VERSION);
+            // The port's BillingSupport is written against the ProductDetails API, which
+            // the pre-8 releases do not have. Say so in a sentence rather than letting
+            // javac emit two dozen "cannot find symbol" errors against an injected file
+            // the developer never wrote.
+            String billingRefusal = PlayBillingVersions.refusalFor(billingClientVersion);
+            if (billingRefusal != null) {
+                log(billingRefusal);
+                return false;
+            }
+            // The billing AAR declares its own minSdkVersion and the manifest merge
+            // fails against a lower one, so raise the floor the way the Android Auto
+            // dependency already does.
+            String billingMinSdk = PlayBillingVersions.minimumSdk(billingClientVersion);
+            String billingRaisedMinSdk = maxInt(billingMinSdk, minSDK);
+            if (!billingRaisedMinSdk.equals(minSDK)) {
+                log("Play Billing " + billingClientVersion + " requires minSdk "
+                        + billingMinSdk + "; raising android.min_sdk_version from "
+                        + minSDK + " to " + billingRaisedMinSdk);
+            }
+            minSDK = billingRaisedMinSdk;
+        }
+
         if (!purchasePermissions) {
             File billingSupport = new File(srcDir, path("com", "codename1", "impl", "android", "BillingSupport.java"));
             if (billingSupport.exists()) {
@@ -6964,7 +6995,9 @@ public class AndroidGradleBuilder extends Executor {
         }
 
         if (purchasePermissions) {
-            String billingClientVersion = request.getArg("android.billingclient.version", "4.0.0");
+
+            // Resolved earlier, with the minSdk raise, because the manifest that carries
+            // minSdkVersion is written before this point.
             additionalDependencies += " implementation 'com.android.billingclient:billing:"+billingClientVersion+"'\n";
         }
 

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/PlayBillingVersions.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/PlayBillingVersions.java
@@ -57,8 +57,10 @@ package com.codename1.builders;
  * 8.1.0, 8.2.1, 8.3.0, 9.0.0, 9.1.0   23
  * </pre>
  *
- * <p>So the floor is not "the 8 line needs 21" -- 8.0.0 alone needs 21 and
- * every release after it needs 23. The build raises {@code minSdk} to match
+ * <p>So the floor is not "the 8 line needs 21" -- 8.0.0 alone needs 21, and
+ * it is matched exactly rather than as a range, because a dynamic selector
+ * like {@code 8.+} reads as "8" and would take the low floor while resolving
+ * to a release that needs the high one. The build raises {@code minSdk} to match
  * rather than letting the merge fail, which is what the Android Auto
  * dependency in this builder already does for the same reason. A version
  * newer than anything listed here is assumed to need the highest floor known;
@@ -128,11 +130,15 @@ public class PlayBillingVersions {
             // billing release requiring API 23.
             return "23";
         }
-        if (compareVersions(numeric, "8.1.0") >= 0) {
-            return "23";
-        }
+        // 8.0.0 is the ONLY version at or above the floor that declares 21, so it is
+        // matched exactly rather than as a range. A dynamic selector is why: Gradle
+        // accepts "8.+" here and the generated dependency keeps it, so the build
+        // resolves 8.3.0 while the numeric prefix reads as "8" -- a range check gives
+        // that 21 and the manifest merge then fails against the library's own 23. An
+        // exact match sends everything that is not literally 8.0.0 to the high floor,
+        // which is also the right answer for a version this has never seen.
         if (compareVersions(numeric, "8.0.0") >= 0) {
-            return "21";
+            return "8.0.0".equals(numeric) ? "21" : "23";
         }
         // Below the supported floor the build is refused before this matters; the
         // old AAR's own value is returned so nothing is raised on the way to that

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/PlayBillingVersions.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/PlayBillingVersions.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.builders;
+
+/**
+ * Which Play Billing Library version an Android build uses, and what that
+ * choice requires of the rest of the build.
+ *
+ * <p><b>Why there is a floor at all.</b> {@code BillingSupport} in the Android
+ * port is written against the ProductDetails API. The SKU API it replaced --
+ * {@code SkuDetails}, {@code querySkuDetailsAsync},
+ * {@code BillingClient.SkuType}, {@code BillingFlowParams.setSkuDetails} and
+ * the no-argument {@code enablePendingPurchases()} -- was removed across
+ * billing 8 and 9, so one implementation cannot serve both eras. Compiling
+ * the port's source against each published release puts the boundary exactly
+ * at 8.0.0:</p>
+ *
+ * <pre>
+ * billing 4.0.0 .. 7.1.1   ProductDetails source does not compile
+ * billing 8.0.0, 9.1.0     compiles clean
+ * </pre>
+ *
+ * <p>Google's own schedule points the same way. Its deprecation FAQ states
+ * that from Aug 31 2026 all new apps and updates must use billing 8 or later,
+ * with an extension available to Nov 1 2026, so a build below 8 produces an
+ * app Play will not accept an update from. Refusing it with a sentence beats
+ * emitting two dozen {@code cannot find symbol} errors against a file the
+ * developer never wrote.</p>
+ *
+ * <p><b>Why minSdk moves with it.</b> The billing AAR declares its own
+ * {@code minSdkVersion}, and the manifest merger fails outright when the app
+ * declares a lower one. Read from the published AAR manifests:</p>
+ *
+ * <pre>
+ * 4.0.0   14
+ * 8.0.0   21
+ * 8.1.0, 8.2.1, 8.3.0, 9.0.0, 9.1.0   23
+ * </pre>
+ *
+ * <p>So the floor is not "the 8 line needs 21" -- 8.0.0 alone needs 21 and
+ * every release after it needs 23. The build raises {@code minSdk} to match
+ * rather than letting the merge fail, which is what the Android Auto
+ * dependency in this builder already does for the same reason. A version
+ * newer than anything listed here is assumed to need the highest floor known;
+ * if a future release raises it again the merger still says so by number,
+ * which is a readable failure rather than a silent one.</p>
+ *
+ * <p>Kept as a pure static helper so the policy is unit-testable without a
+ * device build, and so the BuildDaemon copy stays trivially diffable --
+ * <b>keep this file in sync with its twin in the other repository</b>.</p>
+ */
+public class PlayBillingVersions {
+
+    /**
+     * The version used when the app names none.
+     *
+     * <p>8.0.0 rather than the newest published release, deliberately: it is
+     * the lowest version Play still accepts, and the only one at or above that
+     * line whose AAR is content with {@code minSdkVersion} 21. Defaulting any
+     * higher would push every in-app-purchase app to 23 without being asked.
+     * An app that wants a newer one sets {@code android.billingclient.version}
+     * and gets the matching floor automatically.</p>
+     */
+    public static final String DEFAULT_VERSION = "8.0.0";
+
+    /** The first version whose API the port's BillingSupport is written for. */
+    public static final String MINIMUM_SUPPORTED = "8.0.0";
+
+    private PlayBillingVersions() {
+    }
+
+    /**
+     * The reason this version cannot be built, or null when it can.
+     *
+     * <p>An unreadable version is accepted rather than refused: a project may
+     * legitimately hold one this cannot parse, and refusing on a parse failure
+     * would break a build over the shape of a string rather than over anything
+     * that is wrong with it. The compiler is the backstop there.</p>
+     */
+    public static String refusalFor(String billingClientVersion) {
+        String numeric = numeric(billingClientVersion);
+        if (numeric == null) {
+            return null;
+        }
+        if (compareVersions(numeric, MINIMUM_SUPPORTED) >= 0) {
+            return null;
+        }
+        return "android.billingclient.version is set to " + billingClientVersion.trim()
+                + ", and Codename One's in-app purchase support needs "
+                + MINIMUM_SUPPORTED + " or newer. Play Billing removed the SkuDetails "
+                + "API the older releases used, so the two cannot be built from one "
+                + "source, and Google stopped accepting new apps and updates below "
+                + "billing 8 on Aug 31 2026. Remove the build hint to take the "
+                + "default of " + DEFAULT_VERSION + ", or set a newer version.";
+    }
+
+    /**
+     * The {@code minSdkVersion} this billing version's AAR requires, as a
+     * string so it drops straight into the builder's existing minSdk
+     * arithmetic.
+     */
+    public static String minimumSdk(String billingClientVersion) {
+        String numeric = numeric(billingClientVersion);
+        if (numeric == null) {
+            // Unknown shape: assume the highest floor that has been seen rather than
+            // the lowest. Guessing low turns into a manifest merge failure; guessing
+            // high only narrows the device range of an app that is already on a
+            // billing release requiring API 23.
+            return "23";
+        }
+        if (compareVersions(numeric, "8.1.0") >= 0) {
+            return "23";
+        }
+        if (compareVersions(numeric, "8.0.0") >= 0) {
+            return "21";
+        }
+        // Below the supported floor the build is refused before this matters; the
+        // old AAR's own value is returned so nothing is raised on the way to that
+        // refusal.
+        return "14";
+    }
+
+    private static String numeric(String version) {
+        if (version == null) {
+            return null;
+        }
+        return HealthManifestFragments.numericVersionPrefix(version.trim());
+    }
+
+    /** Numeric dotted version compare; a missing segment counts as zero. */
+    private static int compareVersions(String left, String right) {
+        String[] l = left.split("\\.");
+        String[] r = right.split("\\.");
+        int len = Math.max(l.length, r.length);
+        for (int i = 0; i < len; i++) {
+            int a = i < l.length ? parse(l[i]) : 0;
+            int b = i < r.length ? parse(r[i]) : 0;
+            if (a != b) {
+                return a < b ? -1 : 1;
+            }
+        }
+        return 0;
+    }
+
+    private static int parse(String segment) {
+        try {
+            return Integer.parseInt(segment);
+        } catch (NumberFormatException notANumber) {
+            return 0;
+        }
+    }
+}

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/PlayBillingVersionsTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/PlayBillingVersionsTest.java
@@ -92,6 +92,30 @@ public class PlayBillingVersionsTest {
     }
 
     /**
+     * A Gradle dynamic selector keeps its shape in the generated dependency, so
+     * "8.+" is resolved by Gradle at build time and can land on any 8.x. Its
+     * numeric prefix reads as "8", which a range check would answer with the
+     * 8.0.0-only floor of 21 while the build actually resolves a release that
+     * declares 23 -- and the manifest merge fails on exactly that mismatch.
+     * Anything that is not literally 8.0.0 takes the high floor.
+     */
+    @Test
+    public void aDynamicSelectorTakesTheHighFloor() {
+        check("23".equals(PlayBillingVersions.minimumSdk("8.+")),
+                "8.+ can resolve a release needing 23");
+        check("23".equals(PlayBillingVersions.minimumSdk("8.0.+")),
+                "8.0.+ can resolve past 8.0.0");
+        check("23".equals(PlayBillingVersions.minimumSdk("[8.0.0,9.0.0)")),
+                "a version range takes the high floor");
+        check("23".equals(PlayBillingVersions.minimumSdk("latest.release")),
+                "latest.release takes the high floor");
+        // And the one version that really does declare 21 still gets it, so the
+        // exact match did not simply collapse everything to 23.
+        check("21".equals(PlayBillingVersions.minimumSdk("8.0.0")),
+                "8.0.0 itself still takes 21");
+    }
+
+    /**
      * Unknown guesses high. Guessing low turns into a manifest merge failure;
      * guessing high only narrows the device range of an app already on a
      * release that requires API 23.

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/PlayBillingVersionsTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/PlayBillingVersionsTest.java
@@ -167,6 +167,30 @@ public class PlayBillingVersionsTest {
         check(src.contains("BillingClient.ProductType"), "it uses ProductType");
     }
 
+    /**
+     * BillingSupport is excluded from compilation in three places that each
+     * claim to mirror the other two -- the maven compiler plugin, the ant
+     * javac and the NetBeans project. Missing one is not a local mistake:
+     * the BuildDaemon CI builds this port with ant, so the maven exclusion
+     * alone left that build compiling the ProductDetails source against the
+     * billing 4.0.0 jar, which is how this was found.
+     */
+    @Test
+    public void everyBuildThatCompilesThePortExcludesBillingSupport() throws Exception {
+        String[] mirrors = {
+            "../android/pom.xml",
+            "../../Ports/Android/build.xml",
+            "../../Ports/Android/nbproject/project.properties",
+        };
+        for (String mirror : mirrors) {
+            byte[] bytes = java.nio.file.Files.readAllBytes(new java.io.File(mirror).toPath());
+            String src = new String(bytes, "UTF-8");
+            check(src.contains("com/codename1/impl/android/BillingSupport.java"),
+                    mirror + " still compiles BillingSupport; it needs a billing "
+                    + "dependency this tree does not carry");
+        }
+    }
+
     /** Java source with block and line comments removed. */
     private static String stripComments(String src) {
         StringBuilder out = new StringBuilder();

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/PlayBillingVersionsTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/PlayBillingVersionsTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.builders;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The Play Billing version policy. The numbers here are measurements, not
+ * choices -- the floor is where the port's source stops compiling, and the
+ * minSdk mapping is what the published AARs declare -- so a change that moves
+ * one of them without a new measurement behind it is a regression.
+ */
+public class PlayBillingVersionsTest {
+    /**
+     * The floor is the version the port's source actually compiles against,
+     * not a preference. Compiling
+     * {@code Ports/Android/src/com/codename1/impl/android/BillingSupport.java}
+     * against each published release puts the boundary exactly here: 7.1.1
+     * fails, 8.0.0 and 9.1.0 are clean.
+     */
+    @Test
+    public void refusesEverythingBelowTheProductDetailsApi() {
+        check(PlayBillingVersions.refusalFor("4.0.0") != null, "4.0.0 is refused");
+        check(PlayBillingVersions.refusalFor("6.2.1") != null, "6.2.1 is refused");
+        check(PlayBillingVersions.refusalFor("7.1.1") != null, "7.1.1 is refused");
+        check(PlayBillingVersions.refusalFor("8.0.0") == null, "8.0.0 is accepted");
+        check(PlayBillingVersions.refusalFor("9.1.0") == null, "9.1.0 is accepted");
+    }
+
+    /**
+     * The refusal has to name the hint, the version and the way out, because
+     * the alternative it replaces is two dozen "cannot find symbol" errors
+     * against a file the developer never wrote.
+     */
+    @Test
+    public void theRefusalSaysWhatToDo() {
+        String refusal = PlayBillingVersions.refusalFor("4.0.0");
+        check(refusal.contains("android.billingclient.version"), "it names the hint");
+        check(refusal.contains("4.0.0"), "it names the version that was set");
+        check(refusal.contains(PlayBillingVersions.MINIMUM_SUPPORTED), "it names the floor");
+        check(refusal.contains("SkuDetails"), "it says why");
+    }
+
+    /**
+     * A version this cannot parse is accepted rather than refused. A project
+     * may legitimately hold one, and failing a build over the shape of a
+     * string rather than over anything wrong with it is the worse error.
+     */
+    @Test
+    public void anUnreadableVersionIsNotRefused() {
+        check(PlayBillingVersions.refusalFor(null) == null, "null is not refused");
+        check(PlayBillingVersions.refusalFor("") == null, "empty is not refused");
+        check(PlayBillingVersions.refusalFor("$billingVersion") == null,
+                "a Gradle variable is not refused");
+    }
+
+    /**
+     * Read from the published AAR manifests, and the reason the mapping is not
+     * "the 8 line needs 21": 8.0.0 alone declares 21, and every release after
+     * it declares 23.
+     */
+    @Test
+    public void theMinSdkFloorFollowsTheAar() {
+        check("21".equals(PlayBillingVersions.minimumSdk("8.0.0")), "8.0.0 needs 21");
+        check("23".equals(PlayBillingVersions.minimumSdk("8.1.0")), "8.1.0 needs 23");
+        check("23".equals(PlayBillingVersions.minimumSdk("8.2.1")), "8.2.1 needs 23");
+        check("23".equals(PlayBillingVersions.minimumSdk("8.3.0")), "8.3.0 needs 23");
+        check("23".equals(PlayBillingVersions.minimumSdk("9.0.0")), "9.0.0 needs 23");
+        check("23".equals(PlayBillingVersions.minimumSdk("9.1.0")), "9.1.0 needs 23");
+    }
+
+    /**
+     * Unknown guesses high. Guessing low turns into a manifest merge failure;
+     * guessing high only narrows the device range of an app already on a
+     * release that requires API 23.
+     */
+    @Test
+    public void anUnknownVersionTakesTheHighestKnownFloor() {
+        check("23".equals(PlayBillingVersions.minimumSdk("$billingVersion")),
+                "an unreadable version takes the high floor");
+        check("23".equals(PlayBillingVersions.minimumSdk(null)),
+                "a null version takes the high floor");
+        check("23".equals(PlayBillingVersions.minimumSdk("10.0.0")),
+                "a future version takes the high floor");
+    }
+
+    /**
+     * The default is the lowest version Play still accepts, which is also the
+     * only one at that level that does not force minSdk 23 on every
+     * in-app-purchase app.
+     */
+    @Test
+    public void theDefaultIsTheGentlestAcceptableVersion() {
+        check("8.0.0".equals(PlayBillingVersions.DEFAULT_VERSION), "the default is 8.0.0");
+        check(PlayBillingVersions.refusalFor(PlayBillingVersions.DEFAULT_VERSION) == null,
+                "the default is not itself refused");
+        check("21".equals(PlayBillingVersions.minimumSdk(PlayBillingVersions.DEFAULT_VERSION)),
+                "the default does not force minSdk 23");
+    }
+
+    /**
+     * The gate that was missing, and whose absence is why this rotted in place
+     * for years.
+     *
+     * <p>BillingSupport ships as source and is compiled inside the generated
+     * app, so nothing in this tree compiles it -- the port module now excludes
+     * it explicitly, and did not compile it against anything current before
+     * that either. A reference to the removed SKU API therefore produces no
+     * failure here at all; it produces a failed customer build, on the cloud
+     * builders, in an app the developer cannot edit.</p>
+     *
+     * <p>So the removed API is named here instead. This is weaker than a
+     * compile and does not pretend otherwise: it cannot see a future
+     * incompatibility, only a return to the one that was just removed. That is
+     * still the difference between catching a regression in CI and hearing
+     * about it from a support conversation.</p>
+     */
+    @Test
+    public void theBillingImplementationUsesNoRemovedSkuApi() throws Exception {
+        byte[] bytes = java.nio.file.Files.readAllBytes(new java.io.File(
+                "../../Ports/Android/src/com/codename1/impl/android/BillingSupport.java").toPath());
+        // Comments only, stripped: naming the removed API while explaining what
+        // replaced it is exactly the comment this file should carry, and a gate that
+        // forbade it would be answered by deleting the explanation.
+        String src = stripComments(new String(bytes, "UTF-8"));
+        // Removed across billing 8 and 9. Each was in the file before the migration,
+        // so this list is what was actually there, not a guess at what might be.
+        String[] removed = {
+            "SkuDetails",
+            "SkuDetailsParams",
+            "SkuDetailsResponseListener",
+            "querySkuDetailsAsync",
+            "BillingClient.SkuType",
+            "setSkuDetails",
+            ".enablePendingPurchases()",
+        };
+        for (String symbol : removed) {
+            check(!src.contains(symbol),
+                    "BillingSupport still references the removed Play Billing API " + symbol);
+        }
+        // And the replacement really is in use, so the check above cannot pass by the
+        // file having been emptied or renamed out from under it.
+        check(src.contains("queryProductDetailsAsync"), "it queries product details");
+        check(src.contains("setProductDetailsParamsList"), "it launches the modern flow");
+        check(src.contains("BillingClient.ProductType"), "it uses ProductType");
+    }
+
+    /** Java source with block and line comments removed. */
+    private static String stripComments(String src) {
+        StringBuilder out = new StringBuilder();
+        boolean inBlock = false;
+        for (int i = 0; i < src.length(); i++) {
+            char c = src.charAt(i);
+            if (inBlock) {
+                if (c == '*' && i + 1 < src.length() && src.charAt(i + 1) == '/') {
+                    inBlock = false;
+                    i++;
+                }
+                continue;
+            }
+            if (c == '/' && i + 1 < src.length()) {
+                char next = src.charAt(i + 1);
+                if (next == '*') {
+                    inBlock = true;
+                    i++;
+                    continue;
+                }
+                if (next == '/') {
+                    while (i < src.length() && src.charAt(i) != '\n') {
+                        i++;
+                    }
+                    out.append('\n');
+                    continue;
+                }
+            }
+            out.append(c);
+        }
+        return out.toString();
+    }
+
+    private static void check(boolean condition, String message) {
+        assertTrue(condition, message);
+    }
+}


### PR DESCRIPTION
Split out of the Kotlin-alignment PR (#5649) — different bug, same support conversation.

## What broke

A customer added Play Billing 9.1.0 and got a wall of `cannot find symbol` errors naming `com.codename1.impl.android.BillingSupport` — a file they never wrote. Our Android port's billing implementation is written against the SKU API, which Play Billing removed.

Compiling `Ports/Android/src/com/codename1/impl/android/BillingSupport.java` against each published release (android-34 `android.jar` + our core jar), counting only errors in that file:

| billing | before | after |
|---|---|---|
| 4.0.0 – 7.1.1 | 0 | does not compile |
| 8.0.0 | 7 | **0** |
| 9.1.0 | 24 | **0** |

**This is not optional.** Google's [deprecation FAQ](https://developer.android.com/google/play/billing/deprecation-faq) states verbatim: *"By Aug 31, 2026, all new apps and updates to existing apps must use Billing Library version 8 or later."* That date has passed; the extension runs to Nov 1, 2026. Every Codename One app using in-app purchase on Android is currently unable to ship a Play-accepted update. The builder's default was `4.0.0`, rejected since August 2024.

## Six removals, not one

`SkuDetails` is just the loudest:

| what it did | removed in |
|---|---|
| `enablePendingPurchases()` no-arg | 8.0.0 |
| `queryPurchasesAsync(String, listener)` | 8.0.0 |
| `querySkuDetailsAsync` ×5 call sites | 8.0.0 |
| `SkuDetails` / `SkuDetailsParams` / `SkuDetailsResponseListener` | 9.0 |
| `BillingClient.SkuType` | 9.0 |
| `BillingFlowParams.Builder.setSkuDetails` | 9.0 |

Billing 8 and 9 share the modern shape (`QueryProductDetailsResult`, `PendingPurchasesParams`), so one implementation serves both.

## Two judgement calls

- **There is no single price.** A one-time product carries one offer; a subscription carries offers carrying pricing phases. `SkuDetails.getPrice()` maps to the one-time offer's formatted price, or a subscription's first phase of its first offer — and to `null` when Play sends neither, so a caller shows no price rather than a wrong one.
- **A subscription is bought through an offer.** `launchBillingFlow` rejects a subscription with no offer token, and a one-time product must not carry one. Both handled; a subscription with no purchasable offer now reports `itemPurchaseError` instead of silently doing nothing.

## Builder half

- `android.billingclient.version` default `4.0.0` → `8.0.0` (lowest Play still accepts, and the only version at that level whose AAR is content with `minSdkVersion` 21 — every later release needs 23).
- Below the floor: refused with a sentence naming the hint and the way out, rather than letting javac fail inside the generated project.
- `minSdk` raised to whatever the selected AAR declares, matching the existing Android Auto precedent. **Resolved before the manifest is written** — resolving it beside the gradle dependency put the raised floor in `build.gradle` and left the manifest saying 19, which is the merge failure the raise exists to prevent.

## The missing gate

`maven/android` compiled this file against `android-billing-4.0.0.jar` under `-Pcompile-android` — which is why it could rot while staying green. It now ships as source only (excluded like the four packages already excluded there for the same reason) and the dead jar dependency is dropped.

That removes the last compile touching the file, so the check becomes a test naming the removed API. It's weaker than a compile and says so in its own comment — but it caught a real leftover immediately (`loadSkuDetailsAsync` had kept its old name).

## Verification

- `BillingSupport.java` compiles clean against 8.0.0 and 9.1.0; every API shape checked with `javap` against both AARs.
- `mvn -Pcompile-android -pl android package` — BUILD SUCCESS; confirmed no `BillingSupport.class` is produced and the `.java` still ships in the port jar.
- `PlayBillingVersionsTest` — 7 cases; minSdk mapping read from the published AAR manifests (21 at 8.0.0, 23 from 8.1.0 on).
- Full `codenameone-maven-plugin` suite 1854/0; SpotBugs 0 on `android` and `codenameone-maven-plugin`; build-hint catalog, render, Vale, LanguageTool and control-character gates all clean.

## Not verified

**No real purchase has been exercised.** The shapes are right and it compiles, but an actual buy / acknowledge / consume against a Play test account needs a device pass before this ships.

Companion: codenameone/BuildDaemon#PLACEHOLDER
