### PR TITLE
Weak references on the JavaScript port were strong ones (and never held anything)

### DIFF
--- a/.github/workflows/scripts-javascript.yml
+++ b/.github/workflows/scripts-javascript.yml
@@ -22,6 +22,7 @@ on:
       - 'scripts/run-javascript-headless-browser.mjs'
       - 'scripts/run-javascript-lifecycle-tests.mjs'
       - 'scripts/test-javascript-surface-replay.mjs'
+      - 'scripts/test-javascript-weak-refs.mjs'
       - 'scripts/run-javascript-lifecycle-tests.sh'
       - 'scripts/verify-javascript-lens-parity.mjs'
       - 'scripts/build-javascript-port-hellocodenameone.sh'
@@ -47,6 +48,7 @@ on:
       - 'scripts/run-javascript-headless-browser.mjs'
       - 'scripts/run-javascript-lifecycle-tests.mjs'
       - 'scripts/test-javascript-surface-replay.mjs'
+      - 'scripts/test-javascript-weak-refs.mjs'
       - 'scripts/run-javascript-lifecycle-tests.sh'
       - 'scripts/verify-javascript-lens-parity.mjs'
       - 'scripts/build-javascript-port-hellocodenameone.sh'
@@ -138,6 +140,14 @@ jobs:
       # the ParparVM build.
       - name: Surface command replay guards
         run: node scripts/test-javascript-surface-replay.mjs
+
+      # Same placement rationale: node: builtins only, so it runs before the
+      # ParparVM build and fails in seconds. Guards createSoftWeakRef /
+      # extractHardRef in port.js -- the token has to be a real WeakRef, because
+      # the WeakMap it used to be held its referent as the map VALUE, which is a
+      # strong edge and made every "weak" cache in the framework unreclaimable.
+      - name: Weak reference guards
+        run: node scripts/test-javascript-weak-refs.mjs
 
       - name: Cache codenameone-tools
         uses: actions/cache@v5

--- a/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
+++ b/Ports/JavaScriptPort/src/main/java/com/codename1/impl/html5/HTML5Implementation.java
@@ -11043,12 +11043,15 @@ public class HTML5Implementation extends CodenameOneImplementation {
         
     }
 
-    /// Caches any object, not just a `JSObject`.
+    /// Caches any object, not just a `JSObject`, behind a reference the browser's
+    /// collector is genuinely free to clear.
+    ///
+    /// Two things had to be true for this to mean anything, and neither was.
     ///
     /// The cached value used to have to be a `JSObject` and everything else fell
     /// through to `super`, which answers `new WeakReference(o)`. ParparVM's
-    /// `WeakReference` never holds what it was constructed with, so that branch is a
-    /// reference that is empty the moment it is made -- and the framework's caches
+    /// `WeakReference` never held what it was constructed with, so that branch was a
+    /// reference that was empty the moment it was made -- and the framework's caches
     /// are built on ordinary Java objects, not `JSObject`s, so that was every one of
     /// them. `EncodedImage` was the visible casualty: `getInternal()` keeps the
     /// decoded picture in one of these, so a permanent miss made it hand the bytes
@@ -11058,17 +11061,30 @@ public class HTML5Implementation extends CodenameOneImplementation {
     /// about a third of runs, each run missing a different subset of the cells that
     /// draw the same EncodedImage.
     ///
-    /// A Java object reaches a `@JSBody` script as its own JS representation, which
-    /// is a perfectly good WeakMap value, so nothing about the mechanism needed the
-    /// `JSObject` bound -- only the declared type did.
+    /// The JS side was then built on a `WeakMap` keyed by a throwaway token, with the
+    /// referent as the map VALUE. A `WeakMap` holds keys weakly and values strongly,
+    /// so the referent was reachable for exactly as long as the token this method
+    /// returns -- which is to say, for exactly as long as an ordinary strong field.
+    /// Nothing was reclaimable, and the callers that own the token map rather than
+    /// borrow it (`CacheMap.weakCache`, `com.codename1.ui.util.WeakHashMap`, both
+    /// plain hashtables that drop an entry only on explicit remove/clear) grew
+    /// without bound. The token is now a `WeakRef`, whose `deref()` is `get()`.
     @Override
     public Object createSoftWeakRef(Object o) {
         if (useES6WeakRefs()) {
             if (o == null) {
                 return new JSObjectWrapper();
             }
+            JSObject token = createSoftWeakRefImpl(o);
+            if (token == null) {
+                // The native declined this referent (no WeakRef in this realm, or a
+                // shape it cannot target). Falling back is the difference between a
+                // strong ref that works and a token that reads back null forever,
+                // which is an invisible permanent cache miss.
+                return super.createSoftWeakRef(o);
+            }
             JSObjectWrapper keyOut = new JSObjectWrapper();
-            keyOut.o = createSoftWeakRefImpl(o);
+            keyOut.o = token;
             return keyOut;
         } else {
             return super.createSoftWeakRef(o);
@@ -11077,13 +11093,13 @@ public class HTML5Implementation extends CodenameOneImplementation {
 
     /// Reads back whatever `#createSoftWeakRef(Object)` handed out.
     ///
-    /// Dispatches on the shape of the token rather than on the WeakMap being
-    /// available now, which is what the two used to disagree about: create fell
-    /// through to `super` for anything it could not put in the map, extract did not,
-    /// so a `super` token came back null however alive its referent was. The token is
-    /// the only thing that says which side made it, so it is the only thing worth
-    /// asking. Tested with `instanceof` rather than a cast because a failed cast does
-    /// not throw under ParparVM.
+    /// Dispatches on the shape of the token rather than on `WeakRef` being available
+    /// now, which is what the two used to disagree about: create fell through to
+    /// `super` for anything it could not store, extract did not, so a `super` token
+    /// came back null however alive its referent was. The token is the only thing
+    /// that says which side made it, so it is the only thing worth asking. Tested
+    /// with `instanceof` rather than a cast because a failed cast does not throw
+    /// under ParparVM.
     @Override
     public Object extractHardRef(Object o) {
         if (o == null) {
@@ -11096,25 +11112,45 @@ public class HTML5Implementation extends CodenameOneImplementation {
         return super.extractHardRef(o);
     }
 
-    /// Whether the ES6 WeakMap path is both wanted and available.
+    /// Whether the ES6 weak-reference path is both wanted and available.
+    ///
+    /// Resolved once. The callers are hot -- `Image`'s scale cache, `Border`'s
+    /// round-rect cache and every `EncodedImage` decode go through
+    /// `createSoftWeakRef` -- and this was a `Display.getProperty` string compare
+    /// plus a native call on every single one of them. A benign race between two
+    /// threads resolving it costs one extra probe and reaches the same answer.
     private boolean useES6WeakRefs() {
-        return Display.getInstance().getProperty("javascript.useES6WeakRefs", "true").equals("true")
-                && isWeakMapSupported();
+        if (!weakRefsResolved) {
+            weakRefsUsable = Display.getInstance().getProperty("javascript.useES6WeakRefs", "true").equals("true")
+                    && isWeakRefSupported();
+            weakRefsResolved = true;
+        }
+        return weakRefsUsable;
     }
-    
-    
-    
+
+    private boolean weakRefsResolved;
+    private boolean weakRefsUsable;
+
     private static class JSObjectWrapper {
         JSObject o;
     }
-    
-    @JSBody(params={}, script="return window.WeakMap !== undefined;")
-    private static native boolean isWeakMapSupported();
-    
-    @JSBody(params={"o"}, script="var key={}; window.cn1GlobalWeakMap.set(key, o); return key;")
+
+    // These three @JSBody scripts are shadowed at runtime: port.js binds the same
+    // natives with bindNative and its override replaces the emitted body. They are
+    // kept, and kept correct, precisely because that binding is by mangled name --
+    // a signature drift silently un-binds it, and what runs then is whatever is
+    // written here. The previous versions could not survive that: they reached for
+    // `window.cn1GlobalWeakMap`, a global that only ever existed on the main thread
+    // while these natives run in the worker, so an un-binding turned a cache miss
+    // into a thrown TypeError. The translator unwraps object arguments and wraps the
+    // result on this path, so the script sees and returns plain JS values.
+    @JSBody(params={}, script="return typeof WeakRef === 'function';")
+    private static native boolean isWeakRefSupported();
+
+    @JSBody(params={"o"}, script="return (typeof WeakRef === 'function' && o != null && (typeof o === 'object' || typeof o === 'function')) ? new WeakRef(o) : null;")
     private native static JSObject createSoftWeakRefImpl(Object o);
-    
-    @JSBody(params={"key"}, script="return window.cn1GlobalWeakMap.has(key) ? window.cn1GlobalWeakMap.get(key) : null")
+
+    @JSBody(params={"key"}, script="if(key == null || typeof key.deref !== 'function') { return null; } var v = key.deref(); return v === undefined ? null : v;")
     private native static Object extractHardRefImpl(JSObject key);
     
     @JSBody(params={}, script="return window.cn1IsPreview === true")

--- a/Ports/JavaScriptPort/src/main/webapp/js/fontmetrics.js
+++ b/Ports/JavaScriptPort/src/main/webapp/js/fontmetrics.js
@@ -676,7 +676,6 @@ window.console = window.console || {
   log: function () {}
 };
 
-window.cn1GlobalWeakMap = (window.WeakMap === undefined) ? null : new WeakMap();
 window.cn1_native_interfaces = {};
 window.cn1_get_native_interfaces = function() {
   return window.cn1_native_interfaces;  

--- a/Ports/JavaScriptPort/src/main/webapp/port.js
+++ b/Ports/JavaScriptPort/src/main/webapp/port.js
@@ -1781,11 +1781,15 @@ bindNative(["cn1_com_codename1_impl_html5_HTML5Implementation_getBrowserLanguage
   return jvm.createStringLiteral(String(value));
 });
 
+// The probe has to ask about the primitive we actually use. It used to ask
+// about WeakMap, which every engine since 2015 has and which tells you nothing
+// about WeakRef (ES2021: Chrome 84, Firefox 79, Safari 14.1). Keep this name in
+// step with HTML5Implementation.isWeakRefSupported.
 bindNative([
-  "cn1_com_codename1_impl_html5_HTML5Implementation_isWeakMapSupported_R_boolean",
-  "cn1_com_codename1_impl_html5_HTML5Implementation_isWeakMapSupported___R_boolean"
+  "cn1_com_codename1_impl_html5_HTML5Implementation_isWeakRefSupported_R_boolean",
+  "cn1_com_codename1_impl_html5_HTML5Implementation_isWeakRefSupported___R_boolean"
 ], function() {
-  return typeof WeakMap === "function" ? 1 : 0;
+  return typeof WeakRef === "function" ? 1 : 0;
 });
 
 // ===================================================================
@@ -2025,44 +2029,51 @@ bindNative([
   return null;
 });
 
-// The cached value is declared java.lang.Object, not JSObject: the framework's
-// caches hold ordinary Java objects and the JSObject-only spelling sent every one
-// of them down the WeakReference fallback, which under ParparVM never holds its
-// referent. Keep these names in step with HTML5Implementation.createSoftWeakRefImpl
-// -- ParparVM encodes the whole signature here, so a stale name binds nothing.
+// createSoftWeakRef must hand back a token that does NOT keep its referent alive.
+// This used to be built on a WeakMap: a fresh {} was the key, the referent was the
+// VALUE, and the key came back to Java as the token. A WeakMap holds its keys
+// weakly and its values STRONGLY, so that is backwards -- Java parks the token in
+// EncodedImage.cache / Image.scaleCache / Border's round-rect cache, the token
+// keeps the key alive, the live key keeps the entry alive, and the entry holds the
+// referent strongly. The result had exactly the lifetime of a plain field: nothing
+// was ever reclaimable, and the two call sites that own the token map rather than
+// borrow it -- CacheMap.weakCache and com.codename1.ui.util.WeakHashMap, both plain
+// hashtables that only ever drop an entry on explicit remove/clear -- grew without
+// bound. WeakRef (ES2021) is the direct analogue of java.lang.ref.WeakReference and
+// is what belongs here: the token IS the WeakRef, and deref() is get().
+//
+// Keep these names in step with HTML5Implementation.createSoftWeakRefImpl --
+// ParparVM encodes the whole signature here, so a stale name binds nothing and the
+// (correct, but slower to notice) @JSBody twin in the Java file runs instead.
 bindNative([
   "cn1_com_codename1_impl_html5_HTML5Implementation_createSoftWeakRefImpl_java_lang_Object_R_com_codename1_html5_js_JSObject",
   "cn1_com_codename1_impl_html5_HTML5Implementation_createSoftWeakRefImpl___java_lang_Object_R_com_codename1_html5_js_JSObject"
 ], function(objectRef) {
-  if (typeof WeakMap !== "function") {
+  if (typeof WeakRef !== "function") {
     return null;
   }
-  const win = global.window || global;
-  if (!(win.cn1GlobalWeakMap instanceof WeakMap)) {
-    win.cn1GlobalWeakMap = new WeakMap();
+  const referent = jvm.unwrapJsValue(objectRef);
+  // new WeakRef(x) throws TypeError for a non-object target. A VM object is
+  // always an object, but returning null rather than throwing means an
+  // unforeseen shape degrades to the Java-side strong fallback instead of
+  // taking down whatever was trying to cache.
+  if (referent == null || (typeof referent !== "object" && typeof referent !== "function")) {
+    return null;
   }
-  const key = {};
-  win.cn1GlobalWeakMap.set(key, jvm.unwrapJsValue(objectRef));
-  return jvm.wrapJsObject(key, "com_codename1_html5_js_JSObject");
+  return jvm.wrapJsObject(new WeakRef(referent), "com_codename1_html5_js_JSObject");
 });
 
 bindNative([
   "cn1_com_codename1_impl_html5_HTML5Implementation_extractHardRefImpl_com_codename1_html5_js_JSObject_R_java_lang_Object",
   "cn1_com_codename1_impl_html5_HTML5Implementation_extractHardRefImpl___com_codename1_html5_js_JSObject_R_java_lang_Object"
 ], function(keyRef) {
-  if (typeof WeakMap !== "function") {
+  const token = jvm.unwrapJsValue(keyRef);
+  if (token == null || typeof token.deref !== "function") {
     return null;
   }
-  const win = global.window || global;
-  const weakMap = win.cn1GlobalWeakMap;
-  if (!(weakMap instanceof WeakMap)) {
-    return null;
-  }
-  const key = jvm.unwrapJsValue(keyRef);
-  if (key == null || !weakMap.has(key)) {
-    return null;
-  }
-  const value = weakMap.get(key);
+  // deref() answers undefined once the referent has been collected; == null
+  // covers both that and an explicitly stored null.
+  const value = token.deref();
   if (value == null) {
     return null;
   }

--- a/scripts/test-javascript-weak-refs.mjs
+++ b/scripts/test-javascript-weak-refs.mjs
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+//
+// Regression gate for createSoftWeakRef / extractHardRef in port.js.
+//
+// Display.createSoftWeakRef is the framework's one way of saying "cache this,
+// but let the collector have it back". EncodedImage's decode cache, Image's
+// scale cache, Border's round-rect cache, Resources' cached resource,
+// CacheMap.weakCache and com.codename1.ui.util.WeakHashMap are all built on it.
+//
+// The JavaScript port used to implement it with a WeakMap: a throwaway {} was
+// the key, the referent was the VALUE, and the key travelled back to Java as
+// the token. That is the wrong way round -- a WeakMap holds its keys weakly and
+// its values STRONGLY -- so the referent stayed reachable for exactly as long as
+// the token, which is exactly as long as an ordinary strong field. Nothing was
+// ever reclaimable, and the two callers that OWN the token map rather than
+// borrow it (CacheMap.weakCache and WeakHashMap, both plain hashtables that drop
+// an entry only on an explicit remove/clear) therefore grew without bound.
+//
+// The fix is WeakRef, which is the direct analogue of java.lang.ref.WeakReference.
+// This test drives the two bindNative callbacks out of port.js against a stub
+// jvm, so it runs in milliseconds and needs no browser.
+//
+// Note what is deliberately NOT asserted here: that a referent is actually
+// collected. That needs --expose-gc and a GC to happen to run, which is a timing
+// assertion and would be flaky. What IS asserted is the property the bug was
+// about and which decides the outcome: the token is a real WeakRef holding the
+// referent as its target, and no strong container anywhere retains it.
+//
+// Usage: node scripts/test-javascript-weak-refs.mjs
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import vm from 'node:vm';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const portPath = join(here, '..', 'Ports', 'JavaScriptPort', 'src', 'main', 'webapp', 'port.js');
+const source = readFileSync(portPath, 'utf8');
+
+/**
+ * Extract the `bindNative([...], function(...) {...});` call whose name list
+ * contains `nativeName`, by brace matching from the bindNative that precedes it.
+ */
+function extractBinding(nativeName) {
+  const marker = source.indexOf('"' + nativeName + '"');
+  if (marker < 0) {
+    throw new Error('port.js no longer binds ' + nativeName
+      + ' -- ParparVM binds natives by mangled name, so a rename here silently '
+      + 'un-binds the native and the @JSBody twin runs instead');
+  }
+  const start = source.lastIndexOf('bindNative(', marker);
+  if (start < 0) {
+    throw new Error('no bindNative call precedes ' + nativeName);
+  }
+  let depth = 0;
+  let seenBody = false;
+  for (let i = start; i < source.length; i++) {
+    const c = source[i];
+    if (c === '(') {
+      depth++;
+      seenBody = true;
+    } else if (c === ')') {
+      depth--;
+      if (seenBody && depth === 0) {
+        return source.slice(start, i + 1);
+      }
+    }
+  }
+  throw new Error('unbalanced parens extracting ' + nativeName);
+}
+
+const CREATE = 'cn1_com_codename1_impl_html5_HTML5Implementation_createSoftWeakRefImpl_java_lang_Object_R_com_codename1_html5_js_JSObject';
+const EXTRACT = 'cn1_com_codename1_impl_html5_HTML5Implementation_extractHardRefImpl_com_codename1_html5_js_JSObject_R_java_lang_Object';
+const SUPPORTED = 'cn1_com_codename1_impl_html5_HTML5Implementation_isWeakRefSupported_R_boolean';
+
+/** A VM object as the translated code sees one: it carries a __classDef. */
+function vmObject(name) {
+  return { __classDef: { name: name }, __class: name, __id: name };
+}
+
+/**
+ * Stand-in for the pieces of the runtime the two bindings touch. wrapJsObject
+ * is the real one's contract: a foreign JS value gets a Java-visible wrapper
+ * whose __jsValue is that value, cached in a WeakMap so the same value wraps to
+ * the same wrapper.
+ */
+function makeJvm() {
+  const wrappers = new WeakMap();
+  return {
+    wrapped: [],
+    unwrapJsValue(value) {
+      return value && value.__jsValue !== undefined ? value.__jsValue : value;
+    },
+    wrapJsObject(value, expectedClass) {
+      if (value == null || (typeof value !== 'object' && typeof value !== 'function')) {
+        return value;
+      }
+      let wrapper = wrappers.get(value);
+      if (!wrapper) {
+        wrapper = { __jsValue: value, __class: expectedClass || 'com_codename1_html5_js_JSObject' };
+        wrappers.set(value, wrapper);
+      }
+      this.wrapped.push(wrapper);
+      return wrapper;
+    },
+    inferJsObjectClass(value, expectedClass) {
+      return expectedClass || 'com_codename1_html5_js_JSObject';
+    },
+  };
+}
+
+/** Load the two bindings into a sandbox whose globals we control. */
+function loadBindings({ withWeakRef }) {
+  const bound = {};
+  const sandbox = {
+    console,
+    WeakMap,
+    WeakRef: withWeakRef ? WeakRef : undefined,
+    jvm: makeJvm(),
+    bindNative(names, fn) {
+      for (const name of names) {
+        bound[name] = fn;
+      }
+    },
+  };
+  // `global` is what the bindings reach for when they want the realm object;
+  // in the worker it is `self`. Give them one that is NOT the sandbox itself so
+  // any stray write to a "global weak map" is visible to the assertions below.
+  sandbox.global = { window: {} };
+  vm.createContext(sandbox);
+  vm.runInContext(
+    extractBinding(SUPPORTED) + '\n'
+    + extractBinding(CREATE) + '\n'
+    + extractBinding(EXTRACT) + '\n',
+    sandbox);
+  return { bound, sandbox };
+}
+
+const failures = [];
+
+function check(label, condition, detail) {
+  if (condition) {
+    console.log('  ok   ' + label);
+  } else {
+    console.log('  FAIL ' + label + (detail ? ' -- ' + detail : ''));
+    failures.push(label);
+  }
+}
+
+console.log('weak references: the token must be a WeakRef, not a strong map entry');
+
+// ---------------------------------------------------------------- WeakRef present
+{
+  const { bound, sandbox } = loadBindings({ withWeakRef: true });
+  const create = bound[CREATE];
+  const extract = bound[EXTRACT];
+  const supported = bound[SUPPORTED];
+
+  check('the support probe reports WeakRef, not WeakMap', supported() === 1,
+    'probe returned ' + supported());
+
+  const referent = vmObject('com_codename1_ui_Image');
+  const token = create(referent);
+
+  check('create answers a token', token != null && typeof token === 'object',
+    String(token));
+
+  const inner = sandbox.jvm.unwrapJsValue(token);
+  check('the token IS a WeakRef (this is the whole fix)', inner instanceof WeakRef,
+    'token holds ' + Object.prototype.toString.call(inner));
+  check('the WeakRef targets the referent', inner instanceof WeakRef && inner.deref() === referent);
+
+  check('extract answers the identical referent -- not a re-wrapped shell',
+    extract(token) === referent, String(extract(token)));
+
+  // The regression itself: the old implementation parked the referent as the
+  // VALUE of a WeakMap hung off the realm object, which is a strong edge.
+  check('no global weak map is created on the realm',
+    sandbox.global.cn1GlobalWeakMap === undefined
+    && sandbox.global.window.cn1GlobalWeakMap === undefined,
+    'realm gained ' + String(sandbox.global.cn1GlobalWeakMap)
+      + ' / ' + String(sandbox.global.window.cn1GlobalWeakMap));
+
+  // The token is the only thing Java holds. Nothing that survives this call may
+  // name the referent through a strong own property, or the WeakRef is decorative.
+  const strongOwners = sandbox.jvm.wrapped.filter(
+    (w) => w.__jsValue === referent);
+  check('nothing wraps the referent itself in a strong holder',
+    strongOwners.length === 0, strongOwners.length + ' strong wrapper(s)');
+
+  // A collected referent reads back as a miss rather than throwing: deref()
+  // answers undefined, which is the shape extract must survive.
+  const collected = sandbox.jvm.wrapJsObject({ deref() { return undefined; } },
+    'com_codename1_html5_js_JSObject');
+  check('a collected referent extracts as null', extract(collected) === null,
+    String(extract(collected)));
+
+  // Repeated create for the same referent must not alias: each token is its own
+  // reference, exactly as `new WeakReference(o)` is each time it is called.
+  const second = create(referent);
+  check('two tokens for one referent are distinct references',
+    second !== token && sandbox.jvm.unwrapJsValue(second) !== inner);
+  check('both tokens still resolve to the referent',
+    extract(second) === referent && extract(token) === referent);
+
+  // A foreign JS value (not a VM object) must round-trip through the wrapper path.
+  const foreign = { hostThing: true };
+  const foreignToken = create(foreign);
+  const back = extract(foreignToken);
+  check('a foreign JS value round-trips wrapped',
+    back != null && sandbox.jvm.unwrapJsValue(back) === foreign, String(back));
+
+  // A primitive cannot be a WeakRef target; declining is what lets the Java side
+  // fall back to a strong ref instead of the native throwing a TypeError.
+  let threw = null;
+  let primitiveToken;
+  try {
+    primitiveToken = create(42);
+  } catch (e) {
+    threw = e;
+  }
+  check('a non-object referent is declined, not thrown on',
+    threw === null && primitiveToken === null,
+    threw ? String(threw) : String(primitiveToken));
+
+  check('a null token extracts as null', extract(null) === null);
+}
+
+// ---------------------------------------------------------------- WeakRef absent
+{
+  const { bound, sandbox } = loadBindings({ withWeakRef: false });
+
+  check('the support probe reports false without WeakRef', bound[SUPPORTED]() === 0);
+
+  let threw = null;
+  let token;
+  try {
+    token = bound[CREATE](vmObject('com_codename1_ui_Image'));
+  } catch (e) {
+    threw = e;
+  }
+  check('create declines rather than throwing when WeakRef is missing',
+    threw === null && token === null, threw ? String(threw) : String(token));
+  check('no global weak map is created on the fallback path either',
+    sandbox.global.cn1GlobalWeakMap === undefined
+    && sandbox.global.window.cn1GlobalWeakMap === undefined);
+}
+
+if (failures.length) {
+  console.error('\nFAILED: ' + failures.length + ' assertion(s)');
+  process.exit(1);
+}
+console.log('\nAll weak reference assertions passed.');

--- a/vm/JavaAPI/src/java/lang/ref/WeakReference.java
+++ b/vm/JavaAPI/src/java/lang/ref/WeakReference.java
@@ -31,9 +31,23 @@ public class WeakReference extends java.lang.ref.Reference{
     
     /**
      * Creates a new weak reference that refers to the given object.
+     * <p>
+     * Note that ParparVM's collector has no notion of a weak root: it never
+     * clears this field, so the referent lives exactly as long as the
+     * reference object does and {@link #get()} keeps answering it until
+     * {@link Reference#clear()} is called by hand. That is a legal (if
+     * pessimistic) implementation of the contract -- "may be cleared" is not
+     * "must be cleared" -- and it is what the callers need. What is NOT legal
+     * is the reverse: this constructor used to assign the field to itself
+     * ({@code this.objReference = objReference}) and drop {@code ref} on the
+     * floor, so every reference was born empty and {@code get()} was hardwired
+     * to null. Everything built on
+     * {@code CodenameOneImplementation.createSoftWeakRef} -- the EncodedImage
+     * decode cache, Image's scale cache, Border's round-rect cache -- was then
+     * a cache that could never hit.
      */
     public WeakReference(java.lang.Object ref){
-         this.objReference = objReference;
+         this.objReference = ref;
     }
 
     Object getImpl() {

--- a/vm/tests/src/test/java/com/codename1/tools/translator/JavascriptRuntimeSemanticsTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/JavascriptRuntimeSemanticsTest.java
@@ -257,6 +257,30 @@ class JavascriptRuntimeSemanticsTest {
 
     @ParameterizedTest
     @org.junit.jupiter.params.provider.MethodSource("com.codename1.tools.translator.BytecodeInstructionIntegrationTest#provideCompilerConfigs")
+    void weakReferenceHoldsTheReferentItWasConstructedWith(CompilerHelper.CompilerConfig config) throws Exception {
+        // ParparVM's java.lang.ref.WeakReference constructor assigned the field
+        // to itself and dropped its argument, so get() was hardwired to null on
+        // every reference the VM ever made. Nothing at build time can see that,
+        // and the failure downstream is silent: everything built on
+        // CodenameOneImplementation.createSoftWeakRef -- the EncodedImage decode
+        // cache, Image's scale cache, Border's round-rect cache -- degrades to a
+        // cache that never hits rather than to an error. On the JavaScript port
+        // the EncodedImage case is visible, because a permanent miss hands the
+        // bytes back to the browser on every draw and paints nothing until the
+        // decode lands, with no repaint scheduled for when it does.
+        //
+        // This runs the real vm/JavaAPI class through the translator and the
+        // worker runtime, which is the only place the bug was observable.
+        WorkerRunResult result = translateAndRunFixture(config, "JsWeakReferenceApp.java", "JsWeakReferenceApp");
+
+        assertEquals(511, result.result,
+                "WeakReference must answer the referent it was constructed with until it is cleared. raw="
+                        + result.rawMessage + " err=" + result.errorMessage);
+        assertTrue(result.errorMessage == null || result.errorMessage.isEmpty(), "Worker should not emit an error message");
+    }
+
+    @ParameterizedTest
+    @org.junit.jupiter.params.provider.MethodSource("com.codename1.tools.translator.BytecodeInstructionIntegrationTest#provideCompilerConfigs")
     void executesBroaderJavaApiCoverageInWorkerRuntime(CompilerHelper.CompilerConfig config) throws Exception {
         WorkerRunResult result = translateAndRunFixture(config, "JsJavaApiCoverageApp.java", "JsJavaApiCoverageApp");
 

--- a/vm/tests/src/test/resources/com/codename1/tools/translator/JsWeakReferenceApp.java
+++ b/vm/tests/src/test/resources/com/codename1/tools/translator/JsWeakReferenceApp.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+
+/**
+ * java.lang.ref.WeakReference under the translated runtime.
+ *
+ * ParparVM ships its own java.lang.ref in vm/JavaAPI, and its WeakReference
+ * constructor used to assign the field to itself and drop the argument, so
+ * every reference was born empty and get() was hardwired to null. Nothing
+ * catches that at build time: it compiles, it links, and it turns every cache
+ * built on CodenameOneImplementation.createSoftWeakRef -- the EncodedImage
+ * decode cache above all -- into a cache that can never hit.
+ *
+ * The collector has no weak roots, so a reference here holds its referent until
+ * it is cleared by hand. That is the pessimistic half of the contract and is
+ * what these assertions pin down; what they exist to catch is the other half
+ * going missing again.
+ */
+public class JsWeakReferenceApp {
+    static int result;
+
+    public static void main(String[] args) throws Exception {
+        int mask = 0;
+
+        // The referent the constructor was given is the referent get() answers.
+        Object referent = new StringBuilder("cn1").toString();
+        WeakReference ref = new WeakReference(referent);
+        if (ref.get() == referent) {
+            mask |= 1;
+        }
+
+        // Identity, not equality: a reference must hand back the very object it
+        // was handed, which is what every cache built on it relies on.
+        if (ref.get() != null && "cn1".equals(ref.get())) {
+            mask |= 2;
+        }
+
+        // clear() is the only thing that empties a reference on this VM.
+        ref.clear();
+        if (ref.get() == null) {
+            mask |= 4;
+        }
+
+        // Two references over one referent are independent.
+        Object shared = new Object();
+        WeakReference first = new WeakReference(shared);
+        WeakReference second = new WeakReference(shared);
+        first.clear();
+        if (first.get() == null && second.get() == shared) {
+            mask |= 8;
+        }
+
+        // A null referent is legal and reads back as null rather than throwing.
+        WeakReference empty = new WeakReference(null);
+        if (empty.get() == null) {
+            mask |= 16;
+        }
+
+        // Through the abstract supertype, which is how the framework's
+        // extractHardRef reaches it.
+        Object viaBase = new Object();
+        Reference base = new WeakReference(viaBase);
+        if (base.get() == viaBase) {
+            mask |= 32;
+        }
+        base.clear();
+        if (base.get() == null) {
+            mask |= 64;
+        }
+
+        // Distinct referents do not alias each other -- the self-assigning
+        // constructor made every reference read the same (null) field, so a
+        // test that only ever used one referent could not tell them apart.
+        Object a = new StringBuilder("a").toString();
+        Object b = new StringBuilder("b").toString();
+        WeakReference refA = new WeakReference(a);
+        WeakReference refB = new WeakReference(b);
+        if (refA.get() == a && refB.get() == b && refA.get() != refB.get()) {
+            mask |= 128;
+        }
+
+        // A reference survives being stored and read back out of a field.
+        holder = new WeakReference(a);
+        if (holder.get() == a) {
+            mask |= 256;
+        }
+
+        result = mask;
+        System.exit(mask);
+    }
+
+    static WeakReference holder;
+}


### PR DESCRIPTION
`Display.createSoftWeakRef` is the framework's one way of saying "cache this, but let the collector have it back". `EncodedImage`'s decode cache, `Image`'s scale cache, `Border`'s round-rect cache, `Resources`' cached resource, `CacheMap.weakCache` and `com.codename1.ui.util.WeakHashMap` are all built on it. On the JavaScript port neither half of it worked, and the two failures hid each other: the fast path retained everything forever, and the fallback retained nothing at all.

## The WeakMap was used backwards

`createSoftWeakRefImpl` made a throwaway `{}` the KEY and stored the referent as the VALUE. A `WeakMap` holds keys weakly and values **strongly**, so the referent stayed reachable for exactly as long as the token -- which Java parks in the very field the cache lives in. That is the lifetime of an ordinary strong reference; nothing was ever reclaimable.

The callers that own the token map rather than borrow it made it worse than a stuck valve: `CacheMap.weakCache` and `WeakHashMap` are plain hashtables that drop an entry only on an explicit `remove`/`clear`, so on this port they grew without bound.

The token is now a `WeakRef` (ES2021 -- Chrome 84, Firefox 79, Safari 14.1), which is the direct analogue of `java.lang.ref.WeakReference`: `deref()` is `get()`.

## The fallback returned null forever

Anything the fast path declined went to `super.createSoftWeakRef`, i.e. `new java.lang.ref.WeakReference(o)` -- and ParparVM's constructor read `this.objReference = objReference`, assigning the field to itself and dropping its argument, so every reference the VM ever made was born empty. It compiles, it links, and it degrades silently: every cache built on it simply never hits.

`EncodedImage` is where that becomes visible, because `getInternal()` keeps the decoded picture in one of these and a permanent miss hands the bytes back to the browser on every draw, painting nothing until the decode lands and scheduling no repaint for when it does.

The iOS port is unaffected by this fix: `IOSImplementation` overrides `createSoftWeakRef` with its own strong `softReferenceMap` and never constructs a `WeakReference`.

## Also here, all on the same path

- The support probe asked about `WeakMap`, which every engine has had since 2015 and which says nothing about `WeakRef`. It now asks about `WeakRef`, and is renamed to match; `port.js` binds natives by mangled name, so the binding moved with it.
- The three `@JSBody` scripts are shadowed at runtime by `port.js`'s `bindNative` overrides, and were wrong if that ever stopped being true: they reached for `window.cn1GlobalWeakMap`, a global that only ever existed on the main thread while these natives run in the worker, so an un-binding turned a cache miss into a thrown `TypeError`. They are rewritten as correct twins of the bindings rather than deleted, because a signature drift is exactly when they run. `cn1GlobalWeakMap` itself is gone; nothing reads it now.
- A null from `createSoftWeakRefImpl` used to be stored as the token, which reads back null forever -- an invisible permanent miss. It falls back to the strong reference instead.
- `useES6WeakRefs` did a `Display.getProperty` string compare plus a native call on every single call, on paths as hot as every `EncodedImage` decode. Resolved once.

## Gates

Both were checked to fail against the code they replace, not just to pass against the new code.

- `scripts/test-javascript-weak-refs.mjs` drives the two `bindNative` callbacks out of `port.js` against a stub `jvm`. It asserts the token IS a `WeakRef` holding the referent, that no global map retains anything, and that a missing `WeakRef` or a non-object referent is declined rather than thrown on. Re-injecting the old WeakMap bodies fails 6 of its assertions. It deliberately does **not** assert that a referent is collected: that needs `--expose-gc` and a GC to happen to run, which is a timing assertion. Wired into `scripts-javascript.yml` beside the surface-replay guard, ahead of the ParparVM build so it fails in seconds.
- `JsWeakReferenceApp` runs the real `vm/JavaAPI` class through the translator and the worker runtime, which is the only place the constructor bug was observable. With the self-assignment restored it returns 84 instead of 511 on all five compiler configs.

## Verified locally

- `mvn -pl parparvm -am package` -- `HTML5Implementation` compiles; the rebuilt `parparvm-java-api.jar` shows `aload_1` where it used to show `getfield`/`putfield` of the same field.
- `JavascriptRuntimeSemanticsTest` in full: 177 run, 0 failures (1 pre-existing skip).
- `JavascriptNativeAuditTest`, `JavascriptCn1CoreNativeAuditTest`, `JavascriptCn1CoreCompletenessTest`: 8 run, 0 failures -- the native rename is clean.
- `jsport-canvas-barrier-reads.py`, `check-control-characters.py`, `check-copyright-headers.sh`, `check-since-tags.sh`: clean.

Not run locally: the full `build-javascript-port-hellocodenameone.sh` bundle, which needs the whole `8.0-SNAPSHOT` framework installed. The browser and screenshot suites in `scripts-javascript.yml` cover it on this PR. The wrapper layer was checked by reading `port.js`'s `jsoRegistry.inferFn` instead: a `WeakRef` matches none of its probes and resolves to `com_codename1_html5_js_JSObject`, exactly as the old `{}` token did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)