### PR TITLE
Android 16 stopped calling onBackPressed(), so system back never reached the form stack

### DIFF
--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -5737,9 +5737,15 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
             if (keycode == AndroidImplementation.DROID_IMPL_KEY_BACK) {
                 switch (event.getAction()) {
                     case KeyEvent.ACTION_DOWN:
+                        // Claim the gesture so the activity's
+                        // OnBackInvokedCallback stands down; on Android 16 the
+                        // platform can deliver both for one press. See
+                        // PredictiveBackBridge.
+                        PredictiveBackBridge.keyEventBackStarted();
                         Display.getInstance().keyPressed(keycode);
                         break;
                     case KeyEvent.ACTION_UP:
+                        PredictiveBackBridge.keyEventBackFinished();
                         Display.getInstance().keyReleased(keycode);
                         break;
                 }
@@ -5899,11 +5905,24 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
                                 if (keycode == AndroidImplementation.DROID_IMPL_KEY_BACK || 
                                     (keycode == KeyEvent.KEYCODE_MENU && 
                                         Display.getInstance().getCommandBehavior() != Display.COMMAND_BEHAVIOR_NATIVE)) {
+                                    boolean backKey =
+                                            keycode == AndroidImplementation.DROID_IMPL_KEY_BACK;
                                     switch (event.getAction()) {
                                         case KeyEvent.ACTION_DOWN:
+                                            // Claim the gesture so the
+                                            // activity's OnBackInvokedCallback
+                                            // stands down; on Android 16 the
+                                            // platform can deliver both for one
+                                            // press. See PredictiveBackBridge.
+                                            if (backKey) {
+                                                PredictiveBackBridge.keyEventBackStarted();
+                                            }
                                             Display.getInstance().keyPressed(keycode);
                                             break;
                                         case KeyEvent.ACTION_UP:
+                                            if (backKey) {
+                                                PredictiveBackBridge.keyEventBackFinished();
+                                            }
                                             Display.getInstance().keyReleased(keycode);
                                             break;
                                     }
@@ -11849,6 +11868,21 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
             int keycode = event.getKeyCode();
             keycode = CodenameOneView.internalKeyCodeTranslate(keycode);
             if (keycode == AndroidImplementation.DROID_IMPL_KEY_BACK) {
+                // Claim the gesture so the activity's OnBackInvokedCallback
+                // stands down; on Android 16 the platform can deliver both for
+                // one press. See PredictiveBackBridge. The claim brackets the
+                // DOWN and the UP even though this path answers each of them
+                // with a whole press/release pair of its own.
+                switch (event.getAction()) {
+                    case KeyEvent.ACTION_DOWN:
+                        PredictiveBackBridge.keyEventBackStarted();
+                        break;
+                    case KeyEvent.ACTION_UP:
+                        PredictiveBackBridge.keyEventBackFinished();
+                        break;
+                    default:
+                        break;
+                }
                 Display.getInstance().keyPressed(keycode);
                 Display.getInstance().keyReleased(keycode);
                 return true;

--- a/Ports/Android/src/com/codename1/impl/android/CodenameOneActivity.java
+++ b/Ports/Android/src/com/codename1/impl/android/CodenameOneActivity.java
@@ -68,6 +68,12 @@ public class CodenameOneActivity extends Activity {
 
     private PowerManager.WakeLock wakeLock;
 
+    /// The `android.window.OnBackInvokedCallback` registered for this activity,
+    /// or null on a platform older than Android 13. Held as `Object` because
+    /// the type does not exist in the SDK this port compiles against; see
+    /// [PredictiveBackBridge].
+    private Object onBackInvokedCallback;
+
     /**
      * Overriden by stub, returns the user application instance.
      */
@@ -187,12 +193,42 @@ public class CodenameOneActivity extends Activity {
         nativeMenu = enable;
     }
 
+    /// The legacy entry point for the system back action. Still the only one
+    /// below Android 13, and still the one Android 13 through 15 uses while
+    /// `android:enableOnBackInvokedCallback` defaults to false there. An app
+    /// targeting API 36 on Android 16 or newer never gets here: the platform
+    /// delivers back to the callback [PredictiveBackBridge] registers instead.
     @Override
     public void onBackPressed() {
+        handleBackNavigation();
+    }
+
+    /// Feeds one system back action into Codename One as a back key press and
+    /// release, whichever of the two activity-level entry points delivered it.
+    ///
+    /// The platform picks between `onBackPressed()` and the
+    /// `OnBackInvokedCallback`, never both. What it does deliver alongside the
+    /// callback is the key event itself, which the Codename One canvas also
+    /// turns into a back; [PredictiveBackBridge#claimBackForCallback()] is what
+    /// keeps that pair from popping two forms.
+    void handleBackNavigation() {
+        if (!PredictiveBackBridge.claimBackForCallback()) {
+            // The key-event path is already delivering this gesture; on
+            // Android 16 both can fire for a single press.
+            return;
+        }
+        if (!Display.isInitialized()) {
+            // Back before Codename One is up (or after it has shut down) has
+            // nowhere to go: pushing a key event into Display would throw out
+            // of a system callback. Behave like an activity with no back
+            // handling of its own instead.
+            finish();
+            return;
+        }
         Display.getInstance().keyPressed(AndroidImplementation.DROID_IMPL_KEY_BACK);
         Display.getInstance().keyReleased(AndroidImplementation.DROID_IMPL_KEY_BACK);
     }
-    
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -221,6 +257,15 @@ public class CodenameOneActivity extends Activity {
             System.out.print("This exception is totally valid and here only for debugging purposes");
             t.printStackTrace();
         }
+
+        // Registered last: requestFeature() above has to run before anything
+        // touches the window, and back cannot arrive while onCreate is still
+        // on the stack.
+        onBackInvokedCallback = PredictiveBackBridge.register(this, new Runnable() {
+            public void run() {
+                handleBackNavigation();
+            }
+        });
     }
 
     @Override
@@ -238,6 +283,10 @@ public class CodenameOneActivity extends Activity {
 
     @Override
     protected void onDestroy() {
+        // Before super.onDestroy(): the dispatcher belongs to the window, and
+        // the window is on its way out by the time the superclass returns.
+        PredictiveBackBridge.unregister(this, onBackInvokedCallback);
+        onBackInvokedCallback = null;
         super.onDestroy();
         AndroidNativeUtil.onDestroy();
         if (isBillingEnabled()) {

--- a/Ports/Android/src/com/codename1/impl/android/CodenameOneView.java
+++ b/Ports/Android/src/com/codename1/impl/android/CodenameOneView.java
@@ -586,6 +586,16 @@ public class CodenameOneView {
                     && Display.getInstance().getCommandBehavior() == Display.COMMAND_BEHAVIOR_NATIVE) {
                 return false;
             }
+            if (keyCode == AndroidImplementation.DROID_IMPL_KEY_BACK) {
+                // Claim the gesture so the activity's OnBackInvokedCallback
+                // stands down; on Android 16 the platform can deliver both for
+                // one press. See PredictiveBackBridge.
+                if (down) {
+                    PredictiveBackBridge.keyEventBackStarted();
+                } else {
+                    PredictiveBackBridge.keyEventBackFinished();
+                }
+            }
             if (down) {
                 Display.getInstance().keyPressed(keyCode);
             } else {

--- a/Ports/Android/src/com/codename1/impl/android/PredictiveBackBridge.java
+++ b/Ports/Android/src/com/codename1/impl/android/PredictiveBackBridge.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Codename One in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.impl.android;
+
+import android.app.Activity;
+import android.util.Log;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+/// Registers the ahead-of-time back callback that Android 13 (API 33) introduced
+/// and Android 16 made mandatory, so the system back action keeps reaching
+/// Codename One.
+///
+/// An app that targets API 36 and runs on Android 16 or newer gets predictive
+/// back turned on by default. For such an app the platform stops calling
+/// `Activity.onBackPressed()`: back is delivered to an `OnBackInvokedCallback`
+/// registered on the activity's `OnBackInvokedDispatcher`. With no callback
+/// registered the system takes the action itself and pops the activity off the
+/// task, which leaves the app instead of running the current form's back
+/// command. Measured on an Android 16 emulator, both halves: with no callback
+/// the launcher came forward and `onBackPressed()` was never called; with one,
+/// the callback ran and the app stayed.
+///
+/// The registration has to go through reflection. The Android port compiles
+/// against the android.jar in cn1-binaries, which predates API 33 and has
+/// neither `android.window.OnBackInvokedDispatcher` nor
+/// `android.window.OnBackInvokedCallback` in it; the same sources are compiled
+/// again -- against the app's real compile SDK -- inside every generated Gradle
+/// project, so the code has to satisfy both. The callback interface is
+/// implemented with a `java.lang.reflect.Proxy` for the same reason. Everything
+/// touched here is public SDK API, so no non-SDK-interface restriction applies.
+///
+/// Registering is safe on every device: below API 33 nothing is registered at
+/// all, and on API 33 through 35 the manifest flag
+/// `android:enableOnBackInvokedCallback` still defaults to false, which makes
+/// the platform ignore the registered callback and keep calling
+/// `onBackPressed()` -- measured on an Android 14 emulator with an app
+/// targeting 36, where the callback never fired. So the two ACTIVITY-level
+/// entry points never both fire for one press. The key-event path is a
+/// different matter; see [#keyEventBackStarted()].
+///
+/// An app that has to fall back to the legacy behaviour on Android 16 can say
+/// so with the build hint
+/// `android.xapplication_attr=android:enableOnBackInvokedCallback="false"`,
+/// which is a temporary escape hatch rather than a supported end state.
+///
+/// The IME keeps its own back handling and is unaffected: when the soft
+/// keyboard is up the back key still arrives as `View.onKeyPreIme()`, which is
+/// what [InPlaceEditView] uses to close an in-place editor, and the callback
+/// registered here is not invoked for that press.
+final class PredictiveBackBridge {
+    private static final String TAG = "CodenameOne";
+
+    /// `android.window.OnBackInvokedDispatcher`, absent from the compile SDK.
+    private static final String DISPATCHER_CLASS = "android.window.OnBackInvokedDispatcher";
+
+    /// `android.window.OnBackInvokedCallback`, absent from the compile SDK.
+    private static final String CALLBACK_CLASS = "android.window.OnBackInvokedCallback";
+
+    /// `OnBackInvokedDispatcher.PRIORITY_DEFAULT`. The default priority is what
+    /// an app's own navigation registers with; higher priorities are reserved
+    /// for overlays that must win against it.
+    private static final int PRIORITY_DEFAULT = 0;
+
+    /// API level that introduced the dispatcher.
+    private static final int FIRST_SUPPORTED_SDK = 33;
+
+    /// True while the key-event path is in the middle of a back gesture it is
+    /// already feeding into Codename One. Written and read from the UI thread
+    /// only, but kept behind synchronized accessors so a stale read on a
+    /// device that dispatches from elsewhere cannot turn into a double pop.
+    private static boolean keyEventBackInFlight;
+
+    private PredictiveBackBridge() {
+    }
+
+    /// Records that the key-event path has taken the DOWN half of a system
+    /// back gesture.
+    ///
+    /// Android 16 does not simply replace the key event with the callback. When
+    /// a view in the window holds an input-method connection the platform
+    /// delivers BOTH: the key event still reaches the view hierarchy, and
+    /// `onBackInvoked` fires between its DOWN and UP, milliseconds apart. The
+    /// Codename One canvas is such a view -- [AndroidAsyncView] answers
+    /// `onCreateInputConnection` -- so this is the ordinary case, not a corner
+    /// of it. Feeding Codename One from both paths pops two forms for one
+    /// press, which is how a back on a form with a back command was seen to run
+    /// the command AND then minimize the app from the form underneath.
+    ///
+    /// So the key path stays authoritative whenever it is running, exactly as
+    /// it always was, and the callback stands down for that gesture.
+    static synchronized void keyEventBackStarted() {
+        keyEventBackInFlight = true;
+    }
+
+    /// Records the UP half, ending the gesture the key path owns.
+    static synchronized void keyEventBackFinished() {
+        keyEventBackInFlight = false;
+    }
+
+    /// Whether the callback (or the legacy `onBackPressed()`) should feed this
+    /// back into Codename One.
+    ///
+    /// #### Returns
+    ///
+    /// false when the key-event path has this gesture, in which case the flag
+    /// is also cleared: a DOWN whose UP never arrives would otherwise silence
+    /// every later callback rather than just this one.
+    static synchronized boolean claimBackForCallback() {
+        if (keyEventBackInFlight) {
+            keyEventBackInFlight = false;
+            return false;
+        }
+        return true;
+    }
+
+    /// Registers `onBack` as the activity's back callback.
+    ///
+    /// #### Parameters
+    ///
+    /// - `activity`: the activity whose dispatcher receives the callback
+    /// - `onBack`: run on the UI thread for every system back action the
+    ///   activity receives
+    ///
+    /// #### Returns
+    ///
+    /// the registered callback, to be handed back to
+    /// [#unregister(Activity, Object)], or null when nothing was registered
+    /// because the platform is older than API 33 or the registration failed
+    static Object register(Activity activity, final Runnable onBack) {
+        if (android.os.Build.VERSION.SDK_INT < FIRST_SUPPORTED_SDK || activity == null || onBack == null) {
+            return null;
+        }
+        try {
+            Class callbackClass = Class.forName(CALLBACK_CLASS);
+            Class dispatcherClass = Class.forName(DISPATCHER_CLASS);
+            Object dispatcher = Activity.class.getMethod("getOnBackInvokedDispatcher", new Class[0])
+                    .invoke(activity, new Object[0]);
+            if (dispatcher == null) {
+                return null;
+            }
+            Object callback = Proxy.newProxyInstance(
+                    PredictiveBackBridge.class.getClassLoader(),
+                    new Class[]{callbackClass},
+                    new BackCallbackHandler(onBack));
+            // The method is looked up on the public interface rather than on
+            // the dispatcher's own class: the concrete implementation the
+            // platform hands back is package private, and a Method taken from
+            // it is not accessible to us.
+            dispatcherClass.getMethod("registerOnBackInvokedCallback",
+                            new Class[]{int.class, callbackClass})
+                    .invoke(dispatcher, new Object[]{Integer.valueOf(PRIORITY_DEFAULT), callback});
+            return callback;
+        } catch (Throwable t) {
+            // A failure here is not fatal: onBackPressed() still runs on every
+            // platform that has not switched over, and losing back navigation
+            // is not worth taking the process down for.
+            Log.e(TAG, "Failed to register the predictive back callback", t);
+            return null;
+        }
+    }
+
+    /// Removes a callback previously returned by [#register(Activity, Runnable)].
+    /// A null callback, or one belonging to a platform without the dispatcher,
+    /// is ignored.
+    ///
+    /// #### Parameters
+    ///
+    /// - `activity`: the activity the callback was registered on
+    /// - `callback`: the value [#register(Activity, Runnable)] returned
+    static void unregister(Activity activity, Object callback) {
+        if (callback == null || activity == null
+                || android.os.Build.VERSION.SDK_INT < FIRST_SUPPORTED_SDK) {
+            return;
+        }
+        try {
+            Class callbackClass = Class.forName(CALLBACK_CLASS);
+            Class dispatcherClass = Class.forName(DISPATCHER_CLASS);
+            Object dispatcher = Activity.class.getMethod("getOnBackInvokedDispatcher", new Class[0])
+                    .invoke(activity, new Object[0]);
+            if (dispatcher == null) {
+                return;
+            }
+            dispatcherClass.getMethod("unregisterOnBackInvokedCallback",
+                            new Class[]{callbackClass})
+                    .invoke(dispatcher, new Object[]{callback});
+        } catch (Throwable t) {
+            Log.e(TAG, "Failed to unregister the predictive back callback", t);
+        }
+    }
+
+    /// Backs the `OnBackInvokedCallback` proxy. The interface declares a single
+    /// no-argument `onBackInvoked()`; `equals`, `hashCode` and `toString` reach
+    /// the handler as well and have to be answered here, because a proxy has no
+    /// implementation of its own to fall back on and the dispatcher stores the
+    /// callback in a collection.
+    private static final class BackCallbackHandler implements InvocationHandler {
+        private final Runnable onBack;
+
+        BackCallbackHandler(Runnable onBack) {
+            this.onBack = onBack;
+        }
+
+        public Object invoke(Object proxy, Method method, Object[] args) {
+            String name = method.getName();
+            if ("onBackInvoked".equals(name)) {
+                onBack.run();
+                return null;
+            }
+            if ("equals".equals(name)) {
+                return Boolean.valueOf(proxy == args[0]);
+            }
+            if ("hashCode".equals(name)) {
+                return Integer.valueOf(System.identityHashCode(proxy));
+            }
+            if ("toString".equals(name)) {
+                return "CodenameOneOnBackInvokedCallback";
+            }
+            return null;
+        }
+    }
+}

--- a/docs/website/data/port_status.json
+++ b/docs/website/data/port_status.json
@@ -200,6 +200,15 @@
       ]
     },
     {
+      "id": "system-back-navigation",
+      "category": "Input and lifecycle",
+      "name": "System back navigation",
+      "description": "Checks that the platform's system back action reaches the current form's back command.",
+      "tests": [
+        "SystemBackNavigationTest"
+      ]
+    },
+    {
       "id": "status-bar-events",
       "category": "Input and lifecycle",
       "name": "Status-bar tap events",
@@ -800,6 +809,9 @@
     }
   ],
   "test_scopes": {
+    "SystemBackNavigationTest": [
+      "android"
+    ],
     "WindowLayoutTest": [
       "linux-x64",
       "linux-arm64",

--- a/scripts/device-runner-app/androidTest/DeviceRunnerInstrumentationTest.java
+++ b/scripts/device-runner-app/androidTest/DeviceRunnerInstrumentationTest.java
@@ -40,10 +40,33 @@ import java.io.FileInputStream;
 import java.io.InputStreamReader;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(AndroidJUnit4.class)
 public class DeviceRunnerInstrumentationTest {
     private static final String TAG = "DeviceRunnerTest";
+
+    /// Printed by SystemBackNavigationTest once its probe form is on screen.
+    /// The app cannot press the system back itself -- injecting a system key
+    /// needs a permission no app holds -- so the two halves meet on the log.
+    private static final String BACK_PROBE_READY = "CN1SS:BACKPROBE:READY";
+
+    /// Printed from that probe's back command, i.e. the back action completed
+    /// its trip through the port and the Codename One form stack.
+    private static final String BACK_PROBE_INVOKED = "CN1SS:BACKPROBE:INVOKED";
+
+    /// Printed by the runner as it starts each test. Seeing one is what tells
+    /// the back assertions below that the suite really got going, so "the probe
+    /// never announced" can be reported as the failure it is rather than
+    /// confused with an app that never started.
+    private static final String SUITE_TEST_MARKER = "CN1SS:INFO:suite starting test=";
+
+    /// How long an injected back gets to come back round as a Codename One
+    /// back command. Measured at well under a second on an emulator; the
+    /// margin is for a loaded runner, and it is wider than the suite's 30s
+    /// per-test budget so the runner's one retry re-announces rather than
+    /// races this.
+    private static final long BACK_ANSWER_TIMEOUT_MS = 45_000L;
 
     @Test
     public void launchMainActivityAndWaitForDeviceRunner() throws Exception {
@@ -54,10 +77,62 @@ public class DeviceRunnerInstrumentationTest {
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         context.startActivity(intent);
 
-        boolean finished = waitForDeviceRunner();
-        if (!finished) {
+        SuiteOutcome outcome = waitForDeviceRunner();
+        if (!outcome.finished) {
+            // Soft, and deliberately so: this wait is capped well below the
+            // length of a full suite, and the shell harness picks the
+            // completion marker up afterwards.
             Log.w(TAG, "DeviceRunner did not emit completion marker; proceeding without hard failure");
         }
+        // The back assertions ARE hard. SystemBackNavigationTest runs second,
+        // so a suite that produced any output at all reached it within seconds
+        // -- long before this wait could expire -- and both of these say
+        // something is really wrong rather than merely slow.
+        if (outcome.sawSuiteOutput) {
+            assertTrue("The suite ran but never announced " + BACK_PROBE_READY
+                            + "; SystemBackNavigationTest did not reach its probe form",
+                    outcome.backProbeReady);
+            // Nothing answering the injected back means the system back action
+            // no longer reaches Codename One, which is what Android 16 does to
+            // a port that still relies on Activity.onBackPressed().
+            assertTrue("System back was injected while " + BACK_PROBE_READY
+                            + " was showing, but the app never reported "
+                            + BACK_PROBE_INVOKED
+                            + "; the back action did not reach Codename One",
+                    outcome.backProbeInvoked);
+        }
+    }
+
+    /// Presses the system back the way the hardware key and the three-button
+    /// navigation bar do, through the shell rather than through an accessibility
+    /// action: on Android 16 the framework turns that key into an
+    /// `OnBackInvokedCallback` dispatch, so this is the path the port's callback
+    /// has to survive.
+    private void injectSystemBack() {
+        try {
+            UiAutomation automation = InstrumentationRegistry.getInstrumentation().getUiAutomation();
+            ParcelFileDescriptor pfd = automation.executeShellCommand("input keyevent KEYCODE_BACK");
+            try (FileInputStream fis = new FileInputStream(pfd.getFileDescriptor())) {
+                byte[] buffer = new byte[256];
+                while (fis.read(buffer) > 0) {
+                    // draining the pipe is what lets the command run to completion
+                }
+            } finally {
+                pfd.close();
+            }
+            Log.i(TAG, "Injected KEYCODE_BACK for the back-navigation probe");
+        } catch (Throwable t) {
+            Log.w(TAG, "Could not inject KEYCODE_BACK: " + t);
+        }
+    }
+
+    /// What the log watch below observed, so the assertions can distinguish
+    /// "back never arrived" from "the suite never got that far".
+    private static final class SuiteOutcome {
+        boolean finished;
+        boolean sawSuiteOutput;
+        boolean backProbeReady;
+        boolean backProbeInvoked;
     }
 
     /// Pre-grants POST_NOTIFICATIONS, the way an unattended instrumentation suite has to.
@@ -92,20 +167,53 @@ public class DeviceRunnerInstrumentationTest {
         }
     }
 
-    private boolean waitForDeviceRunner() throws Exception {
+    private SuiteOutcome waitForDeviceRunner() throws Exception {
         final long timeoutMs = 900_000L;
         final String endMarker = "CN1SS:SUITE:FINISHED";
 
+        SuiteOutcome outcome = new SuiteOutcome();
         long deadline = System.currentTimeMillis() + timeoutMs;
+        // Set when a back is injected; nothing answering by then is the answer.
+        long backAnswerDeadline = 0L;
         UiAutomation automation = InstrumentationRegistry.getInstrumentation().getUiAutomation();
         ParcelFileDescriptor pfd = automation.executeShellCommand("logcat -v brief");
         try (FileInputStream fis = new FileInputStream(pfd.getFileDescriptor());
              BufferedReader reader = new BufferedReader(new InputStreamReader(fis))) {
             String line;
             while (System.currentTimeMillis() < deadline) {
+                if (backAnswerDeadline > 0L && !outcome.backProbeInvoked
+                        && System.currentTimeMillis() > backAnswerDeadline) {
+                    // Return now rather than sit out the rest of the suite
+                    // budget. This is not only about speed: an unmigrated port
+                    // LEAVES the activity on a back press, and this
+                    // instrumentation runs inside the app's own process, so
+                    // waiting means the process dies first and the run is
+                    // reported as "Process crashed" -- red, but saying nothing
+                    // about back navigation. Failing here says it.
+                    Log.w(TAG, "No answer to the injected back within the probe window");
+                    return outcome;
+                }
                 if (reader.ready() && (line = reader.readLine()) != null) {
-                    if (line.contains(endMarker)) {
-                        return true;
+                    if (line.contains(SUITE_TEST_MARKER)) {
+                        outcome.sawSuiteOutput = true;
+                    }
+                    if (line.contains(BACK_PROBE_READY)) {
+                        // Injected per announcement rather than once: the
+                        // runner re-runs a test that timed out silently, and a
+                        // second probe has to be answered too. The window is
+                        // wider than that retry (the suite's per-test budget is
+                        // 30s) so the retry's announcement moves the deadline
+                        // rather than racing it.
+                        outcome.backProbeReady = true;
+                        outcome.backProbeInvoked = false;
+                        injectSystemBack();
+                        backAnswerDeadline = System.currentTimeMillis() + BACK_ANSWER_TIMEOUT_MS;
+                    } else if (line.contains(BACK_PROBE_INVOKED)) {
+                        outcome.backProbeInvoked = true;
+                        backAnswerDeadline = 0L;
+                    } else if (line.contains(endMarker)) {
+                        outcome.finished = true;
+                        return outcome;
                     }
                 } else {
                     Thread.sleep(200);
@@ -117,6 +225,6 @@ public class DeviceRunnerInstrumentationTest {
             } catch (Exception ignored) {
             }
         }
-        return false;
+        return outcome;
     }
 }

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/Cn1ssDeviceRunner.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/Cn1ssDeviceRunner.java
@@ -234,6 +234,18 @@ public final class Cn1ssDeviceRunner extends DeviceRunner {
     // every test ends up in the jar without platform-dependent initialization.
     private static final BaseTest[] DEFAULT_TEST_CLASSES = new BaseTest[]{
             new MainScreenScreenshotTest(),
+            // Second, and deliberately near the front: it is the only test
+            // whose input comes from OUTSIDE the app process. The
+            // instrumentation harness watches the log for the probe's
+            // announcement and injects one system back for it, and its own wait
+            // is capped well below the length of a full suite -- a back test at
+            // the end of the list would be reached after that cap had expired,
+            // and the assertion would never run at all. Failing here is also
+            // the loudest place to fail: an unmigrated port leaves the app on a
+            // back press, so nothing after this point produces any output.
+            // Takes no screenshot; every port but Android skips it for want of
+            // a system back action.
+            new SystemBackNavigationTest(),
             // Advertising API: renders a banner + native-ad feed via the
             // deterministic MockAdProvider (cn1-ads-mock) for a pixel-stable shot.
             new AdsScreenshotTest(),

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/SystemBackNavigationTest.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/SystemBackNavigationTest.java
@@ -75,12 +75,13 @@ public class SystemBackNavigationTest extends BaseTest {
     @Override
     public boolean runTest() {
         if (!"and".equals(Display.getInstance().getPlatformName())) {
-            // Scoped to Android in the port-status contract, so no other port's
-            // report carries this test; say so in the log all the same, because
-            // a reader of a suite log should not have to consult the contract
-            // to learn why a test went by in no time.
-            System.out.println("CN1SS:INFO:test=SystemBackNavigationTest status=SKIPPED"
-                    + " reason=no-system-back-action");
+            // Returns quietly, and must: this test is scoped to android in the
+            // port-status contract, so no other port's report has a slot for
+            // it, and port_status.py raises rather than ignore a
+            // "status=SKIPPED" marker naming a test it cannot place -- an
+            // unattributable skip is how a skip once rendered as a pass. A
+            // start/finish line for an out-of-scope test is dropped silently,
+            // so those are all this leaves behind.
             done();
             return true;
         }

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/SystemBackNavigationTest.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/SystemBackNavigationTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Codename One in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.examples.hellocodenameone.tests;
+
+import com.codename1.ui.Command;
+import com.codename1.ui.Display;
+import com.codename1.ui.Form;
+import com.codename1.ui.Label;
+import com.codename1.ui.events.ActionEvent;
+import com.codename1.ui.layouts.BorderLayout;
+
+/// Proves the Android system back action still reaches the Codename One form
+/// stack.
+///
+/// Android 16 turns predictive back on by default for an app that targets API
+/// 36, and the platform then stops calling `Activity.onBackPressed()`: back is
+/// delivered to an `OnBackInvokedCallback`, and without one the system pops the
+/// activity off the task so the current form's back command never runs. Every
+/// Codename One Android build targets API 36, so this is the whole of back
+/// navigation, not an edge case.
+///
+/// The test cannot press back itself -- injecting a system key needs a
+/// permission no app holds -- so it hands that half to the instrumentation
+/// process. It shows a form carrying a back command, announces
+/// `CN1SS:BACKPROBE:READY`, and blocks. `DeviceRunnerInstrumentationTest`
+/// watches the log for that line and injects one back through `UiAutomation`,
+/// which is the same dispatch path the hardware key and the back gesture use.
+/// The back command completing is what ends the test; the instrumentation
+/// fails the run when nothing answers, which is exactly what an unmigrated port
+/// produces.
+///
+/// It runs near the front of the suite rather than at the end, because the
+/// instrumentation's own wait is shorter than a full suite: a probe announced
+/// after that wait expired would be answered by nobody and the assertion would
+/// silently never run.
+///
+/// Every other port skips it: no other platform this suite runs on has a
+/// system back action for the instrumentation to inject.
+public class SystemBackNavigationTest extends BaseTest {
+    /// Printed once the probe form is on screen. The instrumentation process
+    /// blocks on this line before injecting, so the back cannot be delivered
+    /// to whatever form the previous test left behind.
+    static final String READY_MARKER = "CN1SS:BACKPROBE:READY";
+
+    /// Printed from the back command, purely so a failing run shows in the log
+    /// whether the event arrived late or never.
+    static final String INVOKED_MARKER = "CN1SS:BACKPROBE:INVOKED";
+
+    @Override
+    public boolean shouldTakeScreenshot() {
+        return false;
+    }
+
+    @Override
+    public boolean runTest() {
+        if (!"and".equals(Display.getInstance().getPlatformName())) {
+            // Scoped to Android in the port-status contract, so no other port's
+            // report carries this test; say so in the log all the same, because
+            // a reader of a suite log should not have to consult the contract
+            // to learn why a test went by in no time.
+            System.out.println("CN1SS:INFO:test=SystemBackNavigationTest status=SKIPPED"
+                    + " reason=no-system-back-action");
+            done();
+            return true;
+        }
+        Form probeForm = new Form("System Back", new BorderLayout()) {
+            @Override
+            protected void onShowCompleted() {
+                // Announced from onShowCompleted so the injected back lands on
+                // this form rather than on the one it is replacing.
+                System.out.println(READY_MARKER);
+            }
+        };
+        probeForm.add(BorderLayout.CENTER, new Label("Waiting for the system back action"));
+        Command back = new Command("Back") {
+            @Override
+            public void actionPerformed(ActionEvent evt) {
+                // No showBack(): the next test shows its own form, and an
+                // extra back transition here would only be one more animation
+                // for it to start behind.
+                System.out.println(INVOKED_MARKER);
+                done();
+            }
+        };
+        probeForm.setBackCommand(back);
+        probeForm.show();
+        return true;
+    }
+}


### PR DESCRIPTION
Fixes #5665.

## The bug

Google Play has required API 36 since 2026-08-31 and Gradle 8 builds already target it. For an app targeting 36 running on Android 16, the platform stops calling `Activity.onBackPressed()` and delivers back to an `OnBackInvokedCallback` instead. The port had none, so the system took the action itself: back left the app rather than running the current form's back command.

Reproduced on an API 36 emulator, both halves. A probe activity with no callback: `onBackPressed()` never called, launcher comes forward. The same A/B on the real `hellocodenameone` app: probe form up, back injected, back command never runs, app gone.

## The fix

`PredictiveBackBridge` registers the callback at `PRIORITY_DEFAULT` and routes it through the existing `DROID_IMPL_KEY_BACK` press/release path. `CodenameOneActivity` registers at the end of `onCreate` (after `requestFeature`), unregisters before `super.onDestroy()`, and funnels both entry points through one `handleBackNavigation()`.

The registration goes through reflection and a `java.lang.reflect.Proxy` because this port compiles against the pre-API-33 `android.jar` in cn1-binaries, while the very same sources are compiled again -- against the app's real SDK -- inside every generated Gradle project.

## The part the documentation does not say

"`KEYCODE_BACK` is no longer dispatched" holds only while no view in the window has an input-method connection. The Codename One canvas answers `onCreateInputConnection`, so in practice the platform delivers **both**: the key event still reaches the view hierarchy, and `onBackInvoked` fires between its DOWN and UP, milliseconds apart.

Registering the callback and leaving it at that made one press pop a form via the back command **and then** minimize the app from the form underneath. So the four key-event delivery sites (`CodenameOneView.onKeyUpDown`, the relative-layout, WebView and MediaController `dispatchKeyEvent` overrides) claim the gesture and the callback stands down for it. The key path stays authoritative exactly as it always was. A claim the callback consumes is cleared, so a DOWN whose UP never arrives silences one back rather than every later one.

## What does not change

- **API 33-35**: the manifest flag still defaults to false, so the callback is ignored and `onBackPressed()` keeps being called. Verified on an API 34 emulator with an app targeting 36 -- the callback never fired, back delivered exactly once, no double dispatch.
- **Below API 33**: nothing is registered at all.
- **The IME**: with the keyboard up, `onKeyPreIme` still closes the in-place editor and the callback is not invoked for that press. Measured, not assumed.
- **The cloud builder**: no change of its own. `BuildDaemon`'s `build.xml` re-zips `android_port_src.jar` from `Ports/Android/src` on every compile, so a daemon rebuild carries this.

An app that has to fall back can say so with the existing hint, `android.xapplication_attr=android:enableOnBackInvokedCallback="false"` -- a temporary escape hatch, not the migration.

## The test that would have caught it

`SystemBackNavigationTest` runs second in the device-runner suite: it shows a form with a back command and announces `CN1SS:BACKPROBE:READY`. `DeviceRunnerInstrumentationTest` watches the log, injects `KEYCODE_BACK` through `UiAutomation` -- the same dispatch path the hardware key and the back gesture use -- and hard-fails the run when nothing answers within 45s. The app cannot press its own back (injecting a system key needs a permission no app holds), which is why the test is split across the two processes.

It runs near the front because the instrumentation's wait is shorter than a full suite: a probe announced at the end would be answered by nobody and the assertion would silently never run.

**Proven non-vacuous.** Against a build with the registration removed it fails in 62 seconds with `System back was injected while CN1SS:BACKPROBE:READY was showing, but the app never reported CN1SS:BACKPROBE:INVOKED`. Against this branch the full suite run passes. The existing `scripts-android` job already runs an API 36 emulator, so no new CI job is needed. Registered in `port_status.json` and scoped to `android`.

## Local gates

SpotBugs on `android` (0 findings), copyright headers, control characters, the port-status contract and its 83 unit tests all pass.

## Not in this PR

- `OnBackAnimationCallback` (predictive-back progress animations). #5665 lists it as a decision to take after correctness is restored; correctness is restored here.
- Two pre-existing issues found while testing and deliberately left alone: `CN1MediaController.dispatchKeyEvent` delivers a full press+release pair for **both** DOWN and UP (two Codename One backs per press whenever it is on screen), and the device runner's silent-timeout retry re-runs a test on the same instance, which makes non-idempotent tests such as `PartialFlushClipEscape` throw "Component is already contained" instead of retrying. Both reproduce on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
