### PR TITLE
Developer guide: restore the Components chapter's missing code samples

### DIFF
--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava143Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava143Snippet.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava143Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Form myForm = new Form();
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    Component cmp;
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-143[]
+        myForm.getContentPane().add(cmp);
+        // end::the-components-of-codename-one-java-143[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava144Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava144Snippet.java
@@ -91,11 +91,17 @@ class TheComponentsOfCodenameOneJava144Snippet {
     
     void snippet() throws Exception {
         // tag::the-components-of-codename-one-java-144[]
+        Form hi = new Form("Popup Dialog", new BoxLayout(BoxLayout.Y_AXIS));
         Button showDialog = new Button("Show");
-        Dialog d = new Dialog("Title");
-        d.setLayout(new BorderLayout());
-        d.add(BorderLayout.CENTER, new SpanLabel("Dialog Body", "DialogBody"));
-        d.showPopupDialog(showDialog);
+        showDialog.addActionListener(e -> {
+            Dialog d = new Dialog("Title");
+            d.setLayout(new BorderLayout());
+            d.add(BorderLayout.CENTER, new SpanLabel("Dialog Body", "DialogBody"));
+            // the popup points at the button, which must be on screen to have a position
+            d.showPopupDialog(showDialog);
+        });
+        hi.add(showDialog);
+        hi.show();
         // end::the-components-of-codename-one-java-144[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava144Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava144Snippet.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava144Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-144[]
+        Dialog d = new Dialog("Title");
+        d.setLayout(new BorderLayout());
+        d.add(BorderLayout.CENTER, new SpanLabel("Dialog Body", "DialogBody"));
+        d.showPopupDialog(showDialog);
+        // end::the-components-of-codename-one-java-144[]
+    }
+
+    Component showDialog = new Label();
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava144Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava144Snippet.java
@@ -91,6 +91,7 @@ class TheComponentsOfCodenameOneJava144Snippet {
     
     void snippet() throws Exception {
         // tag::the-components-of-codename-one-java-144[]
+        Button showDialog = new Button("Show");
         Dialog d = new Dialog("Title");
         d.setLayout(new BorderLayout());
         d.add(BorderLayout.CENTER, new SpanLabel("Dialog Body", "DialogBody"));
@@ -98,6 +99,5 @@ class TheComponentsOfCodenameOneJava144Snippet {
         // end::the-components-of-codename-one-java-144[]
     }
 
-    Component showDialog = new Label();
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava146Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava146Snippet.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava146Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-146[]
+        Label left = new Label("Left", icon);
+        left.setTextPosition(Component.LEFT);
+        Label right = new Label("Right", icon);
+        right.setTextPosition(Component.RIGHT);
+        Label bottom = new Label("Bottom", icon);
+        bottom.setTextPosition(Component.BOTTOM);
+        Label top = new Label("Top", icon);
+        top.setTextPosition(Component.TOP);
+        hi.add(left).add(right).add(bottom).add(top);
+        // end::the-components-of-codename-one-java-146[]
+    }
+
+    Image icon;
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava146Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava146Snippet.java
@@ -91,6 +91,8 @@ class TheComponentsOfCodenameOneJava146Snippet {
     
     void snippet() throws Exception {
         // tag::the-components-of-codename-one-java-146[]
+        Form hi = new Form("Label Position", new BoxLayout(BoxLayout.Y_AXIS));
+        Image icon = FontImage.createMaterial(FontImage.MATERIAL_INFO, "Label", 3.0f);
         Label left = new Label("Left", icon);
         left.setTextPosition(Component.LEFT);
         Label right = new Label("Right", icon);
@@ -103,6 +105,5 @@ class TheComponentsOfCodenameOneJava146Snippet {
         // end::the-components-of-codename-one-java-146[]
     }
 
-    Image icon;
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava146Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava146Snippet.java
@@ -102,6 +102,7 @@ class TheComponentsOfCodenameOneJava146Snippet {
         Label top = new Label("Top", icon);
         top.setTextPosition(Component.TOP);
         hi.add(left).add(right).add(bottom).add(top);
+        hi.show();
         // end::the-components-of-codename-one-java-146[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava147Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava147Snippet.java
@@ -95,6 +95,9 @@ class TheComponentsOfCodenameOneJava147Snippet {
         TextField num2 = new TextField("", "", 5, TextField.NUMERIC);
         TextField num3 = new TextField("", "", 5, TextField.NUMERIC);
         TextField num4 = new TextField("", "", 5, TextField.NUMERIC);
+        // the first three are trimmed to four by automoveToNext when the fifth
+        // digit arrives; the last one has no successor, so it needs a limit
+        num4.setMaxSize(4);
         automoveToNext(num1, num2);
         automoveToNext(num2, num3);
         automoveToNext(num3, num4);

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava147Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava147Snippet.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava147Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-147[]
+        automoveToNext(num1, num2);
+        automoveToNext(num2, num3);
+        automoveToNext(num3, num4);
+        // end::the-components-of-codename-one-java-147[]
+    }
+
+    TextField num2 = new TextField();
+    TextField num1 = new TextField();
+    TextField num3 = new TextField();
+    TextField num4 = new TextField();
+
+
+    void automoveToNext(TextField a, TextField b) { }
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava147Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava147Snippet.java
@@ -91,16 +91,16 @@ class TheComponentsOfCodenameOneJava147Snippet {
     
     void snippet() throws Exception {
         // tag::the-components-of-codename-one-java-147[]
+        TextField num1 = new TextField("", "", 5, TextField.NUMERIC);
+        TextField num2 = new TextField("", "", 5, TextField.NUMERIC);
+        TextField num3 = new TextField("", "", 5, TextField.NUMERIC);
+        TextField num4 = new TextField("", "", 5, TextField.NUMERIC);
         automoveToNext(num1, num2);
         automoveToNext(num2, num3);
         automoveToNext(num3, num4);
         // end::the-components-of-codename-one-java-147[]
     }
 
-    TextField num2 = new TextField();
-    TextField num1 = new TextField();
-    TextField num3 = new TextField();
-    TextField num4 = new TextField();
 
 
     void automoveToNext(TextField a, TextField b) { }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava148Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava148Snippet.java
@@ -92,8 +92,11 @@ class TheComponentsOfCodenameOneJava148Snippet {
     // tag::the-components-of-codename-one-java-148[]
     private void automoveToNext(final TextField current, final TextField next) {
         current.addDataChangedListener((type, index) -> {
-            if(current.getText().length() == 5) {
-                String val = current.getText();
+            String val = current.getText();
+            // more than one digit can arrive at once from a paste or autofill, so
+            // keep four and hand the whole remainder on -- the next field's own
+            // listener splits it again if it is still too long
+            if(val.length() > 4) {
                 current.stopEditing();
                 current.setText(val.substring(0, 4));
                 next.setText(val.substring(4));

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava148Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava148Snippet.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava148Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    // tag::the-components-of-codename-one-java-148[]
+    private void automoveToNext(final TextField current, final TextField next) {
+        current.addDataChangedListener((type, index) -> {
+            if(current.getText().length() == 5) {
+                current.stopEditing();
+                current.setText(val.substring(0, 4));
+                next.setText(val.substring(4));
+                next.startEditingAsync();
+            }
+        });
+    }
+    // end::the-components-of-codename-one-java-148[]
+
+    String val = "value";
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava148Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava148Snippet.java
@@ -93,6 +93,7 @@ class TheComponentsOfCodenameOneJava148Snippet {
     private void automoveToNext(final TextField current, final TextField next) {
         current.addDataChangedListener((type, index) -> {
             if(current.getText().length() == 5) {
+                String val = current.getText();
                 current.stopEditing();
                 current.setText(val.substring(0, 4));
                 next.setText(val.substring(4));
@@ -102,6 +103,5 @@ class TheComponentsOfCodenameOneJava148Snippet {
     }
     // end::the-components-of-codename-one-java-148[]
 
-    String val = "value";
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava148Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava148Snippet.java
@@ -99,8 +99,13 @@ class TheComponentsOfCodenameOneJava148Snippet {
             if(val.length() > 4) {
                 current.stopEditing();
                 current.setText(val.substring(0, 4));
-                next.setText(val.substring(4));
-                next.startEditingAsync();
+                String rest = val.substring(4);
+                next.setText(rest);
+                if(rest.length() <= 4) {
+                    // a longer remainder means the next field's listener is still
+                    // splitting; let the last one in the chain take the focus
+                    next.startEditingAsync();
+                }
             }
         });
     }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava149Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava149Snippet.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava149Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-149[]
+        searchTextField.putClientProperty("searchField", Boolean.TRUE);
+        sendTextField.putClientProperty("sendButton", Boolean.TRUE);
+        goTextField.putClientProperty("goButton", Boolean.TRUE);
+        // end::the-components-of-codename-one-java-149[]
+    }
+
+    TextField sendTextField = new TextField();
+    TextField goTextField = new TextField();
+    TextField searchTextField = new TextField();
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava150Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava150Snippet.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava150Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-150[]
+        tf.putClientProperty("iosHideToolbar", Boolean.TRUE);
+        // end::the-components-of-codename-one-java-150[]
+    }
+
+    TextField tf = new TextField();
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava151Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava151Snippet.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava151Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-151[]
+        cnt.add(myTextField);
+        // end::the-components-of-codename-one-java-151[]
+    }
+
+    TextField myTextField = new TextField();
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava152Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava152Snippet.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava152Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-152[]
+        cnt.add(ClearableTextField.wrap(myTextField));
+        // end::the-components-of-codename-one-java-152[]
+    }
+
+    TextField myTextField = new TextField();
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava153Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava153Snippet.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava153Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-153[]
+        Validator val = new Validator();
+        val.addConstraint(title, new LengthConstraint(2));
+        val.addConstraint(price, new NumericConstraint(true));
+        // end::the-components-of-codename-one-java-153[]
+    }
+
+    TextField title = new TextField();
+    TextField price = new TextField();
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava154Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava154Snippet.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava154Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-154[]
+        TextModeLayout tl = new TextModeLayout(3, 2);
+        Form f = new Form("Pixel Perfect", tl);
+        TextComponent title = new TextComponent().label("Title");
+        TextComponent price = new TextComponent().label("Price");
+        TextComponent location = new TextComponent().label("Location");
+        PickerComponent date = PickerComponent.createDate(new Date()).label("Date");
+        TextComponent description = new TextComponent().label("Description").multiline(true);
+        Validator val = new Validator();
+        val.addConstraint(title, new LengthConstraint(2));
+        val.addConstraint(price, new NumericConstraint(true));
+        f.add(tl.createConstraint().widthPercentage(60), title);
+        f.add(tl.createConstraint().widthPercentage(40), date);
+        f.add(location);
+        f.add(price);
+        f.add(tl.createConstraint().horizontalSpan(2), description);
+        f.setEditOnShow(title.getField());
+        f.show();
+        // end::the-components-of-codename-one-java-154[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava155Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava155Snippet.java
@@ -106,6 +106,7 @@ class TheComponentsOfCodenameOneJava155Snippet {
         new ButtonGroup(rb1, rb2, rb3);
         rb2.setSelected(true);
         hi.add(cb1).add(cb2).add(cb3).add(cb4).add(rb1).add(rb2).add(rb3);
+        hi.show();
         // end::the-components-of-codename-one-java-155[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava155Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava155Snippet.java
@@ -91,6 +91,8 @@ class TheComponentsOfCodenameOneJava155Snippet {
     
     void snippet() throws Exception {
         // tag::the-components-of-codename-one-java-155[]
+        Form hi = new Form("CheckBox", new BoxLayout(BoxLayout.Y_AXIS));
+        Image icon = FontImage.createMaterial(FontImage.MATERIAL_INFO, "Label", 3.0f);
         CheckBox cb1 = new CheckBox("CheckBox No Icon");
         cb1.setSelected(true);
         CheckBox cb2 = new CheckBox("CheckBox With Icon", icon);
@@ -107,6 +109,5 @@ class TheComponentsOfCodenameOneJava155Snippet {
         // end::the-components-of-codename-one-java-155[]
     }
 
-    Image icon;
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava155Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava155Snippet.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava155Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-155[]
+        CheckBox cb1 = new CheckBox("CheckBox No Icon");
+        cb1.setSelected(true);
+        CheckBox cb2 = new CheckBox("CheckBox With Icon", icon);
+        CheckBox cb3 = new CheckBox("CheckBox Opposite True", icon);
+        CheckBox cb4 = new CheckBox("CheckBox Opposite False", icon);
+        cb3.setOppositeSide(true);
+        cb4.setOppositeSide(false);
+        RadioButton rb1 = new RadioButton("Radio 1");
+        RadioButton rb2 = new RadioButton("Radio 2");
+        RadioButton rb3 = new RadioButton("Radio 3", icon);
+        new ButtonGroup(rb1, rb2, rb3);
+        rb2.setSelected(true);
+        hi.add(cb1).add(cb2).add(cb3).add(cb4).add(rb1).add(rb2).add(rb3);
+        // end::the-components-of-codename-one-java-155[]
+    }
+
+    Image icon;
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava156Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava156Snippet.java
@@ -106,6 +106,7 @@ class TheComponentsOfCodenameOneJava156Snippet {
         RadioButton rb3 = RadioButton.createToggle("Radio 3", icon, bg);
         rb2.setSelected(true);
         hi.add(cb1).add(cb2).add(cb3).add(cb4).add(rb1).add(rb2).add(rb3);
+        hi.show();
         // end::the-components-of-codename-one-java-156[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava156Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava156Snippet.java
@@ -91,6 +91,8 @@ class TheComponentsOfCodenameOneJava156Snippet {
     
     void snippet() throws Exception {
         // tag::the-components-of-codename-one-java-156[]
+        Form hi = new Form("RadioButton", new BoxLayout(BoxLayout.Y_AXIS));
+        Image icon = FontImage.createMaterial(FontImage.MATERIAL_INFO, "Label", 3.0f);
         CheckBox cb1 = CheckBox.createToggle("CheckBox No Icon");
         cb1.setSelected(true);
         CheckBox cb2 = CheckBox.createToggle("CheckBox With Icon", icon);
@@ -107,6 +109,5 @@ class TheComponentsOfCodenameOneJava156Snippet {
         // end::the-components-of-codename-one-java-156[]
     }
 
-    Image icon;
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava156Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava156Snippet.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava156Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-156[]
+        CheckBox cb1 = CheckBox.createToggle("CheckBox No Icon");
+        cb1.setSelected(true);
+        CheckBox cb2 = CheckBox.createToggle("CheckBox With Icon", icon);
+        CheckBox cb3 = CheckBox.createToggle("CheckBox Opposite True", icon);
+        CheckBox cb4 = CheckBox.createToggle("CheckBox Opposite False", icon);
+        cb3.setOppositeSide(true);
+        cb4.setOppositeSide(false);
+        ButtonGroup bg = new ButtonGroup();
+        RadioButton rb1 = RadioButton.createToggle("Radio 1", bg);
+        RadioButton rb2 = RadioButton.createToggle("Radio 2", bg);
+        RadioButton rb3 = RadioButton.createToggle("Radio 3", icon, bg);
+        rb2.setSelected(true);
+        hi.add(cb1).add(cb2).add(cb3).add(cb4).add(rb1).add(rb2).add(rb3);
+        // end::the-components-of-codename-one-java-156[]
+    }
+
+    Image icon;
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava157Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava157Snippet.java
@@ -102,6 +102,7 @@ class TheComponentsOfCodenameOneJava157Snippet {
         RadioButton rb3 = RadioButton.createToggle("Radio 3", bg);
         hi.add(ComponentGroup.enclose(cb1, cb2, cb3, cb4)).
                 add(ComponentGroup.encloseHorizontal(rb1, rb2, rb3));
+        hi.show();
         // end::the-components-of-codename-one-java-157[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava157Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava157Snippet.java
@@ -91,17 +91,18 @@ class TheComponentsOfCodenameOneJava157Snippet {
     
     void snippet() throws Exception {
         // tag::the-components-of-codename-one-java-157[]
+        Form hi = new Form("ComponentGroup", new BoxLayout(BoxLayout.Y_AXIS));
+        CheckBox cb1 = new CheckBox("CheckBox 1");
+        CheckBox cb2 = new CheckBox("CheckBox 2");
+        CheckBox cb3 = new CheckBox("CheckBox 3");
+        CheckBox cb4 = new CheckBox("CheckBox 4");
+        RadioButton rb1 = new RadioButton("Radio 1");
+        RadioButton rb2 = new RadioButton("Radio 2");
+        RadioButton rb3 = new RadioButton("Radio 3");
         hi.add(ComponentGroup.enclose(cb1, cb2, cb3, cb4)).
                 add(ComponentGroup.encloseHorizontal(rb1, rb2, rb3));
         // end::the-components-of-codename-one-java-157[]
     }
 
-    RadioButton rb2 = new RadioButton();
-    RadioButton rb1 = new RadioButton();
-    CheckBox cb2 = new CheckBox();
-    CheckBox cb1 = new CheckBox();
-    RadioButton rb3 = new RadioButton();
-    CheckBox cb3 = new CheckBox();
-    CheckBox cb4 = new CheckBox();
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava157Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava157Snippet.java
@@ -99,6 +99,7 @@ class TheComponentsOfCodenameOneJava157Snippet {
         RadioButton rb1 = new RadioButton("Radio 1");
         RadioButton rb2 = new RadioButton("Radio 2");
         RadioButton rb3 = new RadioButton("Radio 3");
+        new ButtonGroup(rb1, rb2, rb3);
         hi.add(ComponentGroup.enclose(cb1, cb2, cb3, cb4)).
                 add(ComponentGroup.encloseHorizontal(rb1, rb2, rb3));
         // end::the-components-of-codename-one-java-157[]

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava157Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava157Snippet.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava157Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-157[]
+        hi.add(ComponentGroup.enclose(cb1, cb2, cb3, cb4)).
+                add(ComponentGroup.encloseHorizontal(rb1, rb2, rb3));
+        // end::the-components-of-codename-one-java-157[]
+    }
+
+    RadioButton rb2 = new RadioButton();
+    RadioButton rb1 = new RadioButton();
+    CheckBox cb2 = new CheckBox();
+    CheckBox cb1 = new CheckBox();
+    RadioButton rb3 = new RadioButton();
+    CheckBox cb3 = new CheckBox();
+    CheckBox cb4 = new CheckBox();
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava157Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava157Snippet.java
@@ -92,14 +92,14 @@ class TheComponentsOfCodenameOneJava157Snippet {
     void snippet() throws Exception {
         // tag::the-components-of-codename-one-java-157[]
         Form hi = new Form("ComponentGroup", new BoxLayout(BoxLayout.Y_AXIS));
-        CheckBox cb1 = new CheckBox("CheckBox 1");
-        CheckBox cb2 = new CheckBox("CheckBox 2");
-        CheckBox cb3 = new CheckBox("CheckBox 3");
-        CheckBox cb4 = new CheckBox("CheckBox 4");
-        RadioButton rb1 = new RadioButton("Radio 1");
-        RadioButton rb2 = new RadioButton("Radio 2");
-        RadioButton rb3 = new RadioButton("Radio 3");
-        new ButtonGroup(rb1, rb2, rb3);
+        CheckBox cb1 = CheckBox.createToggle("CheckBox 1");
+        CheckBox cb2 = CheckBox.createToggle("CheckBox 2");
+        CheckBox cb3 = CheckBox.createToggle("CheckBox 3");
+        CheckBox cb4 = CheckBox.createToggle("CheckBox 4");
+        ButtonGroup bg = new ButtonGroup();
+        RadioButton rb1 = RadioButton.createToggle("Radio 1", bg);
+        RadioButton rb2 = RadioButton.createToggle("Radio 2", bg);
+        RadioButton rb3 = RadioButton.createToggle("Radio 3", bg);
         hi.add(ComponentGroup.enclose(cb1, cb2, cb3, cb4)).
                 add(ComponentGroup.encloseHorizontal(rb1, rb2, rb3));
         // end::the-components-of-codename-one-java-157[]

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava158Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava158Snippet.java
@@ -91,6 +91,9 @@ class TheComponentsOfCodenameOneJava158Snippet {
     
     void snippet() throws Exception {
         // tag::the-components-of-codename-one-java-158[]
+        Form hi = new Form("MultiButton", new BoxLayout(BoxLayout.Y_AXIS));
+        Image icon = FontImage.createMaterial(FontImage.MATERIAL_INFO, "Label", 3.0f);
+        Image emblem = FontImage.createMaterial(FontImage.MATERIAL_STAR, "Label", 2.0f);
         MultiButton twoLinesNoIcon = new MultiButton("MultiButton");
         twoLinesNoIcon.setTextLine2("Line 2");
         MultiButton oneLineIconEmblem = new MultiButton("Icon + Emblem");
@@ -127,7 +130,5 @@ class TheComponentsOfCodenameOneJava158Snippet {
         // end::the-components-of-codename-one-java-158[]
     }
 
-    Image icon;
-    Image emblem;
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava158Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava158Snippet.java
@@ -127,6 +127,7 @@ class TheComponentsOfCodenameOneJava158Snippet {
                 add(twoLinesIconEmblemHorizontal).
                 add(twoLinesIconCheckBox).
                 add(fourLinesIcon);
+        hi.show();
         // end::the-components-of-codename-one-java-158[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava158Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava158Snippet.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava158Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-158[]
+        MultiButton twoLinesNoIcon = new MultiButton("MultiButton");
+        twoLinesNoIcon.setTextLine2("Line 2");
+        MultiButton oneLineIconEmblem = new MultiButton("Icon + Emblem");
+        oneLineIconEmblem.setIcon(icon);
+        oneLineIconEmblem.setEmblem(emblem);
+        MultiButton twoLinesIconEmblem = new MultiButton("Icon + Emblem");
+        twoLinesIconEmblem.setIcon(icon);
+        twoLinesIconEmblem.setEmblem(emblem);
+        twoLinesIconEmblem.setTextLine2("Line 2");
+
+        MultiButton twoLinesIconEmblemHorizontal = new MultiButton("Icon + Emblem");
+        twoLinesIconEmblemHorizontal.setIcon(icon);
+        twoLinesIconEmblemHorizontal.setEmblem(emblem);
+        twoLinesIconEmblemHorizontal.setTextLine2("Line 2 Horizontal");
+        twoLinesIconEmblemHorizontal.setHorizontalLayout(true);
+
+        MultiButton twoLinesIconCheckBox = new MultiButton("CheckBox");
+        twoLinesIconCheckBox.setIcon(icon);
+        twoLinesIconCheckBox.setCheckBox(true);
+        twoLinesIconCheckBox.setTextLine2("Line 2");
+
+        MultiButton fourLinesIcon = new MultiButton("With Icon");
+        fourLinesIcon.setIcon(icon);
+        fourLinesIcon.setTextLine2("Line 2");
+        fourLinesIcon.setTextLine3("Line 3");
+        fourLinesIcon.setTextLine4("Line 4");
+
+        hi.add(oneLineIconEmblem).
+                add(twoLinesNoIcon).
+                add(twoLinesIconEmblem).
+                add(twoLinesIconEmblemHorizontal).
+                add(twoLinesIconCheckBox).
+                add(fourLinesIcon);
+        // end::the-components-of-codename-one-java-158[]
+    }
+
+    Image icon;
+    Image emblem;
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava159Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava159Snippet.java
@@ -91,12 +91,13 @@ class TheComponentsOfCodenameOneJava159Snippet {
     
     void snippet() throws Exception {
         // tag::the-components-of-codename-one-java-159[]
+        Form hi = new Form("SpanButton", new BoxLayout(BoxLayout.Y_AXIS));
+        Image icon = FontImage.createMaterial(FontImage.MATERIAL_INFO, "Label", 3.0f);
         SpanButton sb = new SpanButton("SpanButton is a composite component (lead component) that looks/acts like a Button but can break lines rather than crop them when the text is very long.");
         sb.setIcon(icon);
         hi.add(sb);
         // end::the-components-of-codename-one-java-159[]
     }
 
-    Image icon;
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava159Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava159Snippet.java
@@ -96,6 +96,7 @@ class TheComponentsOfCodenameOneJava159Snippet {
         SpanButton sb = new SpanButton("SpanButton is a composite component (lead component) that looks/acts like a Button but can break lines rather than crop them when the text is very long.");
         sb.setIcon(icon);
         hi.add(sb);
+        hi.show();
         // end::the-components-of-codename-one-java-159[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava159Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava159Snippet.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava159Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-159[]
+        SpanButton sb = new SpanButton("SpanButton is a composite component (lead component) that looks/acts like a Button but can break lines rather than crop them when the text is very long.");
+        sb.setIcon(icon);
+        hi.add(sb);
+        // end::the-components-of-codename-one-java-159[]
+    }
+
+    Image icon;
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava160Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava160Snippet.java
@@ -105,6 +105,7 @@ class TheComponentsOfCodenameOneJava160Snippet {
         c.setIcon(icon);
         c.setIconPosition(BorderLayout.EAST);
         hi.add(d).add(l).add(r).add(c);
+        hi.show();
         // end::the-components-of-codename-one-java-160[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava160Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava160Snippet.java
@@ -91,6 +91,8 @@ class TheComponentsOfCodenameOneJava160Snippet {
     
     void snippet() throws Exception {
         // tag::the-components-of-codename-one-java-160[]
+        Form hi = new Form("SpanLabel", new BoxLayout(BoxLayout.Y_AXIS));
+        Image icon = FontImage.createMaterial(FontImage.MATERIAL_INFO, "Label", 3.0f);
         SpanLabel d = new SpanLabel("Default SpanLabel that can seamlessly line break when the text is really long.");
         d.setIcon(icon);
         SpanLabel l = new SpanLabel("NORTH Positioned Icon SpanLabel that can seamlessly line break when the text is really long.");
@@ -106,6 +108,5 @@ class TheComponentsOfCodenameOneJava160Snippet {
         // end::the-components-of-codename-one-java-160[]
     }
 
-    Image icon;
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava160Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava160Snippet.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava160Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-160[]
+        SpanLabel d = new SpanLabel("Default SpanLabel that can seamlessly line break when the text is really long.");
+        d.setIcon(icon);
+        SpanLabel l = new SpanLabel("NORTH Positioned Icon SpanLabel that can seamlessly line break when the text is really long.");
+        l.setIcon(icon);
+        l.setIconPosition(BorderLayout.NORTH);
+        SpanLabel r = new SpanLabel("SOUTH Positioned Icon SpanLabel that can seamlessly line break when the text is really long.");
+        r.setIcon(icon);
+        r.setIconPosition(BorderLayout.SOUTH);
+        SpanLabel c = new SpanLabel("EAST Positioned Icon SpanLabel that can seamlessly line break when the text is really long.");
+        c.setIcon(icon);
+        c.setIconPosition(BorderLayout.EAST);
+        hi.add(d).add(l).add(r).add(c);
+        // end::the-components-of-codename-one-java-160[]
+    }
+
+    Image icon;
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava161Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava161Snippet.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava161Snippet {
+
+
+    Object context;
+    TextField url = new TextField();
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-161[]
+        Validator v = new Validator();
+        v.addConstraint(firstName, new LengthConstraint(2)).
+                addConstraint(surname, new LengthConstraint(2)).
+                addConstraint(url, RegexConstraint.validURL()).
+                addConstraint(email, RegexConstraint.validEmail()).
+                addConstraint(phone, new RegexConstraint(phoneRegex, "Must be valid phone number")).
+                addConstraint(num1, new LengthConstraint(4)).
+                addConstraint(num2, new LengthConstraint(4)).
+                addConstraint(num3, new LengthConstraint(4)).
+                addConstraint(num4, new LengthConstraint(4));
+
+        v.addSubmitButtons(submit);
+        // end::the-components-of-codename-one-java-161[]
+    }
+
+    TextField num1 = new TextField();
+    TextField num3 = new TextField();
+    TextField num4 = new TextField();
+    TextField num2 = new TextField();
+
+
+    Button submit = new Button();
+    TextField email = new TextField();
+    TextField surname = new TextField();
+    String phoneRegex = "[0-9-]+";
+    TextField firstName = new TextField();
+    TextField phone = new TextField();
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava161Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava161Snippet.java
@@ -101,6 +101,11 @@ class TheComponentsOfCodenameOneJava161Snippet {
         TextField num3 = new TextField("", "", 5, TextField.NUMERIC);
         TextField num4 = new TextField("", "", 5, TextField.NUMERIC);
         Button submit = new Button("Submit");
+        // the masking from the previous sample still applies to these fields
+        automoveToNext(num1, num2);
+        automoveToNext(num2, num3);
+        automoveToNext(num3, num4);
+        num4.setMaxSize(4);
 
         Validator v = new Validator();
         v.addConstraint(firstName, new LengthConstraint(2)).
@@ -124,5 +129,21 @@ class TheComponentsOfCodenameOneJava161Snippet {
 
 
 
+
+
+    private void automoveToNext(final TextField current, final TextField next) {
+        current.addDataChangedListener((type, index) -> {
+            String val = current.getText();
+            if(val.length() > 4) {
+                current.stopEditing();
+                current.setText(val.substring(0, 4));
+                String rest = val.substring(4);
+                next.setText(rest);
+                if(rest.length() <= 4) {
+                    next.startEditingAsync();
+                }
+            }
+        });
+    }
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava161Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava161Snippet.java
@@ -67,7 +67,6 @@ class TheComponentsOfCodenameOneJava161Snippet {
 
 
     Object context;
-    TextField url = new TextField();
     Object value;
     Object body;
     Object event;
@@ -91,6 +90,17 @@ class TheComponentsOfCodenameOneJava161Snippet {
     
     void snippet() throws Exception {
         // tag::the-components-of-codename-one-java-161[]
+        TextField firstName = new TextField("", "First Name");
+        TextField surname = new TextField("", "Surname");
+        TextField url = new TextField("", "URL", 20, TextField.URL);
+        TextField email = new TextField("", "E-Mail", 20, TextField.EMAILADDR);
+        TextField phone = new TextField("", "Phone", 20, TextField.PHONENUMBER);
+            TextField num1 = new TextField("", "", 5, TextField.NUMERIC);
+        TextField num2 = new TextField("", "", 5, TextField.NUMERIC);
+        TextField num3 = new TextField("", "", 5, TextField.NUMERIC);
+        TextField num4 = new TextField("", "", 5, TextField.NUMERIC);
+        Button submit = new Button("Submit");
+
         Validator v = new Validator();
         v.addConstraint(firstName, new LengthConstraint(2)).
                 addConstraint(surname, new LengthConstraint(2)).
@@ -106,17 +116,8 @@ class TheComponentsOfCodenameOneJava161Snippet {
         // end::the-components-of-codename-one-java-161[]
     }
 
-    TextField num1 = new TextField();
-    TextField num3 = new TextField();
-    TextField num4 = new TextField();
-    TextField num2 = new TextField();
 
 
-    Button submit = new Button();
-    TextField email = new TextField();
-    TextField surname = new TextField();
     String phoneRegex = "[0-9-]+";
-    TextField firstName = new TextField();
-    TextField phone = new TextField();
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava161Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava161Snippet.java
@@ -113,6 +113,11 @@ class TheComponentsOfCodenameOneJava161Snippet {
                 addConstraint(num4, new LengthConstraint(4));
 
         v.addSubmitButtons(submit);
+
+        Form hi = new Form("Validation", new BoxLayout(BoxLayout.Y_AXIS));
+        hi.add(firstName).add(surname).add(url).add(email).add(phone).
+                add(num1).add(num2).add(num3).add(num4).add(submit);
+        hi.show();
         // end::the-components-of-codename-one-java-161[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava161Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava161Snippet.java
@@ -95,6 +95,7 @@ class TheComponentsOfCodenameOneJava161Snippet {
         TextField url = new TextField("", "URL", 20, TextField.URL);
         TextField email = new TextField("", "E-Mail", 20, TextField.EMAILADDR);
         TextField phone = new TextField("", "Phone", 20, TextField.PHONENUMBER);
+        String phoneRegex = "[0-9\\-\\+ ]+";
             TextField num1 = new TextField("", "", 5, TextField.NUMERIC);
         TextField num2 = new TextField("", "", 5, TextField.NUMERIC);
         TextField num3 = new TextField("", "", 5, TextField.NUMERIC);
@@ -123,6 +124,5 @@ class TheComponentsOfCodenameOneJava161Snippet {
 
 
 
-    String phoneRegex = "[0-9-]+";
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava162Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava162Snippet.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava162Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-162[]
+        myContainer.add(new InfiniteProgress());
+        // end::the-components-of-codename-one-java-162[]
+    }
+
+    Container myContainer = new Container();
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava163Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava163Snippet.java
@@ -95,7 +95,7 @@ class TheComponentsOfCodenameOneJava163Snippet {
         try {
             ConnectionRequest r = new ConnectionRequest();
             r.setPost(false);
-            r.setUrl("http://api.nestoria.co.uk/api");
+            r.setUrl("https://api.nestoria.co.uk/api");
             r.addArgument("pretty", "0");
             r.addArgument("action", "search_listings");
             r.addArgument("encoding", "json");

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava163Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava163Snippet.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava163Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    // tag::the-components-of-codename-one-java-163[]
+    int pageNumber = 1;
+    java.util.List<Map<String, Object>> fetchPropertyData(String text) {
+        try {
+            ConnectionRequest r = new ConnectionRequest();
+            r.setPost(false);
+            r.setUrl("http://api.nestoria.co.uk/api");
+            r.addArgument("pretty", "0");
+            r.addArgument("action", "search_listings");
+            r.addArgument("encoding", "json");
+            r.addArgument("listing_type", "buy");
+            r.addArgument("page", "" + pageNumber);
+            pageNumber++;
+            r.addArgument("country", "uk");
+            r.addArgument("place_name", text);
+            NetworkManager.getInstance().addToQueueAndWait(r);
+            Map<String,Object> result = new JSONParser().parseJSON(new InputStreamReader(new ByteArrayInputStream(r.getResponseData()), "UTF-8"));
+            Map<String, Object> response = (Map<String, Object>)result.get("response");
+            return (java.util.List<Map<String, Object>>)response.get("listings");
+        } catch(Exception err) {
+            Log.e(err);
+            return null;
+        }
+    }
+    // end::the-components-of-codename-one-java-163[]
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava164Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava164Snippet.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava164Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-164[]
+        Form hi = new Form("InfiniteScrollAdapter", new BoxLayout(BoxLayout.Y_AXIS));
+
+        Style s = UIManager.getInstance().getComponentStyle("MultiLine1");
+        FontImage p = FontImage.createMaterial(FontImage.MATERIAL_PORTRAIT, s);
+        EncodedImage placeholder = EncodedImage.createFromImage(p.scaled(p.getWidth() * 3, p.getHeight() * 3), false); // <1>
+
+        InfiniteScrollAdapter.createInfiniteScroll(hi.getContentPane(), () -> { // <2>
+            java.util.List<Map<String, Object>> data = fetchPropertyData("Leeds"); // <3>
+            MultiButton[] cmps = new MultiButton[data.size()];
+            for(int iter = 0 ; iter < cmps.length ; iter++) {
+                Map<String, Object> currentListing = data.get(iter);
+                if(currentListing == null) { // <4>
+                    InfiniteScrollAdapter.addMoreComponents(hi.getContentPane(), new Component[0], false);
+                    return;
+                }
+                String thumb_url = (String)currentListing.get("thumb_url");
+                String guid = (String)currentListing.get("guid");
+                String summary = (String)currentListing.get("summary");
+                cmps[iter] = new MultiButton(summary);
+                cmps[iter].setIcon(URLImage.createToStorage(placeholder, guid, thumb_url));
+            }
+            InfiniteScrollAdapter.addMoreComponents(hi.getContentPane(), cmps, true); // <5>
+        }, true); // <6>
+        // end::the-components-of-codename-one-java-164[]
+    }
+
+    java.util.List<Map<String, Object>> fetchPropertyData(String t) { return new ArrayList<>(); }
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava164Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava164Snippet.java
@@ -116,7 +116,7 @@ class TheComponentsOfCodenameOneJava164Snippet {
                 cmps[iter] = new MultiButton(summary);
                 cmps[iter].setIcon(URLImage.createToStorage(placeholder, guid, thumb_url));
             }
-            InfiniteScrollAdapter.addMoreComponents(hi.getContentPane(), cmps, true); // <5>
+            InfiniteScrollAdapter.addMoreComponents(hi.getContentPane(), cmps, !data.isEmpty()); // <5>
         }, true); // <6>
         hi.show();
         // end::the-components-of-codename-one-java-164[]

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava164Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava164Snippet.java
@@ -99,6 +99,10 @@ class TheComponentsOfCodenameOneJava164Snippet {
 
         InfiniteScrollAdapter.createInfiniteScroll(hi.getContentPane(), () -> { // <2>
             java.util.List<Map<String, Object>> data = fetchPropertyData("Leeds"); // <3>
+            if(data == null) { // the fetch failed, so there is nothing more to add
+                InfiniteScrollAdapter.addMoreComponents(hi.getContentPane(), new Component[0], false);
+                return;
+            }
             MultiButton[] cmps = new MultiButton[data.size()];
             for(int iter = 0 ; iter < cmps.length ; iter++) {
                 Map<String, Object> currentListing = data.get(iter);
@@ -114,6 +118,7 @@ class TheComponentsOfCodenameOneJava164Snippet {
             }
             InfiniteScrollAdapter.addMoreComponents(hi.getContentPane(), cmps, true); // <5>
         }, true); // <6>
+        hi.show();
         // end::the-components-of-codename-one-java-164[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava165Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava165Snippet.java
@@ -100,6 +100,10 @@ class TheComponentsOfCodenameOneJava165Snippet {
         InfiniteContainer ic = new InfiniteContainer() {
             @Override
             public Component[] fetchComponents(int index, int amount) {
+                if(index == 0) {
+                    // a pull to refresh asks for the start of the list again
+                    pageNumber = 1;
+                }
                 java.util.List<Map<String, Object>> data = fetchPropertyData("Leeds");
             if(data == null) { // the fetch failed, so there is nothing more to add
                 return null;
@@ -125,5 +129,8 @@ class TheComponentsOfCodenameOneJava165Snippet {
     }
 
     java.util.List<Map<String, Object>> fetchPropertyData(String t) { return new ArrayList<>(); }
+
+
+    int pageNumber = 1;
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava165Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava165Snippet.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava165Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-165[]
+        Form hi = new Form("InfiniteContainer", new BorderLayout());
+
+        Style s = UIManager.getInstance().getComponentStyle("MultiLine1");
+        FontImage p = FontImage.createMaterial(FontImage.MATERIAL_PORTRAIT, s);
+        EncodedImage placeholder = EncodedImage.createFromImage(p.scaled(p.getWidth() * 3, p.getHeight() * 3), false);
+
+        InfiniteContainer ic = new InfiniteContainer() {
+            @Override
+            public Component[] fetchComponents(int index, int amount) {
+                java.util.List<Map<String, Object>> data = fetchPropertyData("Leeds");
+                MultiButton[] cmps = new MultiButton[data.size()];
+                for(int iter = 0 ; iter < cmps.length ; iter++) {
+                    Map<String, Object> currentListing = data.get(iter);
+                    if(currentListing == null) {
+                        return null;
+                    }
+                    String thumb_url = (String)currentListing.get("thumb_url");
+                    String guid = (String)currentListing.get("guid");
+                    String summary = (String)currentListing.get("summary");
+                    cmps[iter] = new MultiButton(summary);
+                    cmps[iter].setIcon(URLImage.createToStorage(placeholder, guid, thumb_url));
+                }
+                return cmps;
+            }
+        };
+        hi.add(BorderLayout.CENTER, ic);
+        // end::the-components-of-codename-one-java-165[]
+    }
+
+    java.util.List<Map<String, Object>> fetchPropertyData(String t) { return new ArrayList<>(); }
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava165Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava165Snippet.java
@@ -117,6 +117,7 @@ class TheComponentsOfCodenameOneJava165Snippet {
             }
         };
         hi.add(BorderLayout.CENTER, ic);
+        hi.show();
         // end::the-components-of-codename-one-java-165[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava165Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava165Snippet.java
@@ -101,6 +101,9 @@ class TheComponentsOfCodenameOneJava165Snippet {
             @Override
             public Component[] fetchComponents(int index, int amount) {
                 java.util.List<Map<String, Object>> data = fetchPropertyData("Leeds");
+            if(data == null) { // the fetch failed, so there is nothing more to add
+                return null;
+            }
                 MultiButton[] cmps = new MultiButton[data.size()];
                 for(int iter = 0 ; iter < cmps.length ; iter++) {
                     Map<String, Object> currentListing = data.get(iter);

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava166Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava166Snippet.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava166Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-166[]
+        form.setScrollable(false);
+        form.setLayout(new BorderLayout());
+        form.add(BorderLayout.CENTER, myList);
+        // end::the-components-of-codename-one-java-166[]
+    }
+
+    com.codename1.ui.List myList = new com.codename1.ui.List();
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava167Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava167Snippet.java
@@ -106,6 +106,7 @@ class TheComponentsOfCodenameOneJava167Snippet {
         DefaultListModel<Map<String, Object>> model = new DefaultListModel<>(data);
         MultiList ml = new MultiList(model);
         hi.add(BorderLayout.CENTER, ml);
+        hi.show();
         // end::the-components-of-codename-one-java-167[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava167Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava167Snippet.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava167Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-167[]
+        Form hi = new Form("MultiList", new BorderLayout());
+
+        ArrayList<Map<String, Object>> data = new ArrayList<>();
+
+        data.add(createListEntry("A Game of Thrones", "1996"));
+        data.add(createListEntry("A Clash Of Kings", "1998"));
+        data.add(createListEntry("A Storm Of Swords", "2000"));
+        data.add(createListEntry("A Feast For Crows", "2005"));
+        data.add(createListEntry("A Dance With Dragons", "2011"));
+        data.add(createListEntry("The Winds of Winter", "2016 (please, please, please)"));
+        data.add(createListEntry("A Dream of Spring", "Ugh"));
+
+        DefaultListModel<Map<String, Object>> model = new DefaultListModel<>(data);
+        MultiList ml = new MultiList(model);
+        hi.add(BorderLayout.CENTER, ml);
+        // end::the-components-of-codename-one-java-167[]
+    }
+
+    Map<String, Object> createListEntry(String name, String date) {
+        Map<String, Object> entry = new HashMap<>();
+        entry.put("Line1", name);
+        entry.put("Line2", date);
+        return entry;
+    }
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava168Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava168Snippet.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava168Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-168[]
+        class GRMMModel implements ListModel<Map<String,Object>> {
+            @Override
+            public Map<String, Object> getItemAt(int index) {
+                int idx = index % 7;
+                switch(idx) {
+                    case 0:
+                        return createListEntry("A Game of Thrones " + index, "1996");
+                    case 1:
+                        return createListEntry("A Clash Of Kings " + index, "1998");
+                    case 2:
+                        return createListEntry("A Storm Of Swords " + index, "2000");
+                    case 3:
+                        return createListEntry("A Feast For Crows " + index, "2005");
+                    case 4:
+                        return createListEntry("A Dance With Dragons " + index, "2011");
+                    case 5:
+                        return createListEntry("The Winds of Winter " + index, "2016 (please, please, please)");
+                    default:
+                        return createListEntry("A Dream of Spring " + index, "Ugh");
+                }
+            }
+
+            @Override
+            public int getSize() {
+                return 1000000;
+            }
+
+            @Override
+            public int getSelectedIndex() {
+                return 0;
+            }
+
+            @Override
+            public void setSelectedIndex(int index) {
+            }
+
+            @Override
+            public void addDataChangedListener(DataChangedListener l) {
+            }
+
+            @Override
+            public void removeDataChangedListener(DataChangedListener l) {
+            }
+
+            @Override
+            public void addSelectionListener(SelectionListener l) {
+            }
+
+            @Override
+            public void removeSelectionListener(SelectionListener l) {
+            }
+
+            @Override
+            public void addItem(Map<String, Object> item) {
+            }
+
+            @Override
+            public void removeItem(int index) {
+            }
+        }
+        // end::the-components-of-codename-one-java-168[]
+    }
+
+    Map<String, Object> createListEntry(String name, String date) {
+        Map<String, Object> entry = new HashMap<>();
+        entry.put("Line1", name);
+        entry.put("Line2", date);
+        return entry;
+    }
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava168Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava168Snippet.java
@@ -92,6 +92,9 @@ class TheComponentsOfCodenameOneJava168Snippet {
     void snippet() throws Exception {
         // tag::the-components-of-codename-one-java-168[]
         class GRMMModel implements ListModel<Map<String,Object>> {
+            private int selection;
+            private final java.util.List<SelectionListener> selectionListeners = new ArrayList<>();
+
             @Override
             public Map<String, Object> getItemAt(int index) {
                 int idx = index % 7;
@@ -120,11 +123,16 @@ class TheComponentsOfCodenameOneJava168Snippet {
 
             @Override
             public int getSelectedIndex() {
-                return 0;
+                return selection;
             }
 
             @Override
             public void setSelectedIndex(int index) {
+                int old = selection;
+                selection = index;
+                for(SelectionListener l : selectionListeners) {
+                    l.selectionChanged(old, index);
+                }
             }
 
             @Override
@@ -137,10 +145,12 @@ class TheComponentsOfCodenameOneJava168Snippet {
 
             @Override
             public void addSelectionListener(SelectionListener l) {
+                selectionListeners.add(l);
             }
 
             @Override
             public void removeSelectionListener(SelectionListener l) {
+                selectionListeners.remove(l);
             }
 
             @Override

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava169Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava169Snippet.java
@@ -92,6 +92,9 @@ class TheComponentsOfCodenameOneJava169Snippet {
     void snippet() throws Exception {
         // tag::the-components-of-codename-one-java-169[]
         MultiList ml = new MultiList(new GRMMModel());
+        Form hi = new Form("Million Entries", new BorderLayout());
+        hi.add(BorderLayout.CENTER, ml);
+        hi.show();
         // end::the-components-of-codename-one-java-169[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava169Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava169Snippet.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava169Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-169[]
+        MultiList ml = new MultiList(new GRMMModel());
+        // end::the-components-of-codename-one-java-169[]
+    }
+
+    class GRMMModel extends DefaultListModel<Map<String, Object>> { }
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava170Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava170Snippet.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+import com.codename1.ui.List;
+
+
+class TheComponentsOfCodenameOneJava170Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    // tag::the-components-of-codename-one-java-170[]
+    public interface ListCellRenderer {
+       //This method is called by the List for each item, when the List paints itself.
+       public Component getListCellRendererComponent(List list, Object value, int index, boolean isSelected);
+
+       //This method returns the List animated focus which is animated when list selection changes
+       public Component getListFocusComponent(List list);
+    }
+    // end::the-components-of-codename-one-java-170[]
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava171Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava171Snippet.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+import com.codename1.ui.List;
+
+
+class TheComponentsOfCodenameOneJava171Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    // tag::the-components-of-codename-one-java-171[]
+    public Component getListCellRendererComponent(List list, Object value, int index, boolean isSelected){
+         return new Label(value.toString());
+    }
+
+    public Component getListFocusComponent(List list){
+         return null;
+    }
+    // end::the-components-of-codename-one-java-171[]
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava172Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava172Snippet.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+import com.codename1.ui.List;
+
+
+class TheComponentsOfCodenameOneJava172Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    // tag::the-components-of-codename-one-java-172[]
+    public Component getListCellRendererComponent(List list, Object value, int index, boolean isSelected){
+          Label l = new Label(value.toString());
+    if (isSelected) {
+                 l.setFocus(true);
+                 l.getAllStyles().setBgTransparency(100);
+             } else {
+                 l.setFocus(false);
+                 l.getAllStyles().setBgTransparency(0);
+            }
+            return l;
+    }   public Component getListFocusComponent(List list){
+          return null;
+    }
+    // end::the-components-of-codename-one-java-172[]
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava173Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava173Snippet.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+import com.codename1.ui.List;
+
+
+class TheComponentsOfCodenameOneJava173Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    // tag::the-components-of-codename-one-java-173[]
+    class MyRenderer extends Label implements ListCellRenderer {
+        public Component getListCellRendererComponent(List list, Object value, int index, boolean isSelected){
+            setText(value.toString());
+            if (isSelected) {
+                setFocus(true);
+                getAllStyles().setBgTransparency(100);
+            } else {
+                setFocus(false);
+                getAllStyles().setBgTransparency(0);
+            }
+            return this;
+        }
+
+        public Component getListFocusComponent(List list) {
+            return this;
+        }
+    }
+    // end::the-components-of-codename-one-java-173[]
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava173Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava173Snippet.java
@@ -105,7 +105,9 @@ class TheComponentsOfCodenameOneJava173Snippet {
         }
 
         public Component getListFocusComponent(List list) {
-            return this;
+            // this renderer highlights the selected row itself, and returning the
+            // rubber stamp would draw the focus overlay with the last row's text
+            return null;
         }
     }
     // end::the-components-of-codename-one-java-173[]

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava174Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava174Snippet.java
@@ -60,6 +60,7 @@ import com.codename1.javascript.*;
 import com.codename1.ui.tree.*;
 import com.codename1.ui.table.*;
 import java.util.*;
+import com.codename1.contacts.*;
 import com.codename1.ui.List;
 
 
@@ -104,7 +105,7 @@ class TheComponentsOfCodenameOneJava174Snippet {
              addComponent(BorderLayout.WEST, pic);
              Container cnt = new Container(new BoxLayout(BoxLayout.Y_AXIS));
              name.getAllStyles().setBgTransparency(0);
-             name.getAllStyles().setFont(Font.createSystemFont(Font.FACE_SYSTEM, Font.STYLE_BOLD, Font.SIZE_MEDIUM));
+             name.getAllStyles().setFont(Font.createTrueTypeFont("native:MainBold"));
              email.getAllStyles().setBgTransparency(0);
              cnt.addComponent(name);
              cnt.addComponent(email);
@@ -116,9 +117,9 @@ class TheComponentsOfCodenameOneJava174Snippet {
          public Component getListCellRendererComponent(List list, Object value, int index, boolean isSelected) {
 
              Contact person = (Contact) value;
-             name.setText(person.getName());
-             email.setText(person.getEmail());
-             pic.setIcon(person.getPic());
+             name.setText(person.getDisplayName());
+             email.setText(person.getPrimaryEmail());
+             pic.setIcon(person.getPhoto());
              return this;
          }
 
@@ -131,10 +132,5 @@ class TheComponentsOfCodenameOneJava174Snippet {
 
 
 
-    class Contact {
-        String getName() { return ""; }
-        String getEmail() { return ""; }
-        Image getPic() { return null; }
-    }
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava174Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava174Snippet.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import java.util.*;
+import com.codename1.ui.List;
+
+
+class TheComponentsOfCodenameOneJava174Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-174[]
+        class ContactsRenderer extends Container implements ListCellRenderer {
+
+         private Label name = new Label("");
+         private Label email = new Label("");
+         private Label pic = new Label("");
+
+         private Label focus = new Label("");
+
+         public ContactsRenderer() {
+             setLayout(new BorderLayout());
+             addComponent(BorderLayout.WEST, pic);
+             Container cnt = new Container(new BoxLayout(BoxLayout.Y_AXIS));
+             name.getAllStyles().setBgTransparency(0);
+             name.getAllStyles().setFont(Font.createSystemFont(Font.FACE_SYSTEM, Font.STYLE_BOLD, Font.SIZE_MEDIUM));
+             email.getAllStyles().setBgTransparency(0);
+             cnt.addComponent(name);
+             cnt.addComponent(email);
+             addComponent(BorderLayout.CENTER, cnt);
+
+             focus.getStyle().setBgTransparency(100);
+         }
+
+         public Component getListCellRendererComponent(List list, Object value, int index, boolean isSelected) {
+
+             Contact person = (Contact) value;
+             name.setText(person.getName());
+             email.setText(person.getEmail());
+             pic.setIcon(person.getPic());
+             return this;
+         }
+
+         public Component getListFocusComponent(List list) {
+             return focus;
+         }
+        }
+        // end::the-components-of-codename-one-java-174[]
+    }
+
+
+
+    class Contact {
+        String getName() { return ""; }
+        String getEmail() { return ""; }
+        Image getPic() { return null; }
+    }
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava175Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava175Snippet.java
@@ -92,12 +92,8 @@ class TheComponentsOfCodenameOneJava175Snippet {
     void snippet() throws Exception {
         // tag::the-components-of-codename-one-java-175[]
         focus.getAllStyles().setBgTransparency(100);
-        try {
-            focus.setIcon(Image.createImage("/duke.png"));
-            focus.setAlignment(Component.RIGHT);
-        } catch (IOException ex) {
-            ex.printStackTrace();
-        }
+        focus.setIcon(FontImage.createMaterial(FontImage.MATERIAL_STAR, "Label", 3.0f));
+        focus.setAlignment(Component.RIGHT);
         // end::the-components-of-codename-one-java-175[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava175Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava175Snippet.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava175Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-175[]
+        focus.getAllStyles().setBgTransparency(100);
+        try {
+            focus.setIcon(Image.createImage("/duke.png"));
+            focus.setAlignment(Component.RIGHT);
+        } catch (IOException ex) {
+            ex.printStackTrace();
+        }
+        // end::the-components-of-codename-one-java-175[]
+    }
+
+    Label focus = new Label("");
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava176Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava176Snippet.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava176Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-176[]
+        map.put("componentName", "Component Value");
+        // end::the-components-of-codename-one-java-176[]
+    }
+
+    Map<String, Object> map = new HashMap<>();
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava177Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava177Snippet.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava177Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-177[]
+        map.put("componentName_uiid", "red");
+        // end::the-components-of-codename-one-java-177[]
+    }
+
+    Map<String, Object> map = new HashMap<>();
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava178Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava178Snippet.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava178Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-178[]
+        map.put("componentName_uiid", "blue");
+        // end::the-components-of-codename-one-java-178[]
+    }
+
+    Map<String, Object> map = new HashMap<>();
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava179Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava179Snippet.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava179Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-179[]
+        Map<String, Object> proto = new HashMap<>();
+        map.put("Line1", "WWWWWWWWWWWWWWWWWWWW");
+        map.put("Line2", "WWWWWWWWWWWWWWWWWWWW");
+        int mm5 = Display.getInstance().convertToPixels(5, true);
+        map.put("icon", Image.createImage(mm5, mm5));
+        myMultiList.setRenderingPrototype(map);
+        // end::the-components-of-codename-one-java-179[]
+    }
+
+    Map<String, Object> map = new HashMap<>();
+
+
+    MultiList myMultiList = new MultiList();
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava179Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava179Snippet.java
@@ -92,15 +92,14 @@ class TheComponentsOfCodenameOneJava179Snippet {
     void snippet() throws Exception {
         // tag::the-components-of-codename-one-java-179[]
         Map<String, Object> proto = new HashMap<>();
-        map.put("Line1", "WWWWWWWWWWWWWWWWWWWW");
-        map.put("Line2", "WWWWWWWWWWWWWWWWWWWW");
+        proto.put("Line1", "WWWWWWWWWWWWWWWWWWWW");
+        proto.put("Line2", "WWWWWWWWWWWWWWWWWWWW");
         int mm5 = Display.getInstance().convertToPixels(5, true);
-        map.put("icon", Image.createImage(mm5, mm5));
-        myMultiList.setRenderingPrototype(map);
+        proto.put("icon", Image.createImage(mm5, mm5));
+        myMultiList.setRenderingPrototype(proto);
         // end::the-components-of-codename-one-java-179[]
     }
 
-    Map<String, Object> map = new HashMap<>();
 
 
     MultiList myMultiList = new MultiList();

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava180Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava180Snippet.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava180Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-180[]
+        Form hi = new Form("ComboBox", new BoxLayout(BoxLayout.Y_AXIS));
+        ComboBox<Map<String, Object>> combo = new ComboBox<> (
+                createListEntry("A Game of Thrones", "1996"),
+                createListEntry("A Clash Of Kings", "1998"),
+                createListEntry("A Storm Of Swords", "2000"),
+                createListEntry("A Feast For Crows", "2005"),
+                createListEntry("A Dance With Dragons", "2011"),
+                createListEntry("The Winds of Winter", "2016 (please, please, please)"),
+                createListEntry("A Dream of Spring", "Ugh"));
+
+        combo.setRenderer(new GenericListCellRenderer<>(new MultiButton(), new MultiButton()));
+        // end::the-components-of-codename-one-java-180[]
+    }
+
+    Map<String, Object> createListEntry(String name, String date) {
+        Map<String, Object> entry = new HashMap<>();
+        entry.put("Line1", name);
+        entry.put("Line2", date);
+        return entry;
+    }
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava180Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava180Snippet.java
@@ -102,6 +102,8 @@ class TheComponentsOfCodenameOneJava180Snippet {
                 createListEntry("A Dream of Spring", "Ugh"));
 
         combo.setRenderer(new GenericListCellRenderer<>(new MultiButton(), new MultiButton()));
+        hi.add(combo);
+        hi.show();
         // end::the-components-of-codename-one-java-180[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava181Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava181Snippet.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava181Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-181[]
+        Form hi = new Form("Star Slider", new BoxLayout(BoxLayout.Y_AXIS));
+        hi.add(FlowLayout.encloseCenter(createStarRankSlider()));
+        hi.show();
+        // end::the-components-of-codename-one-java-181[]
+    }
+
+    Slider createStarRankSlider() { return new Slider(); }
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava182Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava182Snippet.java
@@ -127,6 +127,9 @@ class TheComponentsOfCodenameOneJava182Snippet {
         }
 
         Tree dt = new Tree(new StringArrayTreeModel());
+        Form hi = new Form("Tree", new BorderLayout());
+        hi.add(BorderLayout.CENTER, dt);
+        hi.show();
         // end::the-components-of-codename-one-java-182[]
     }
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava182Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava182Snippet.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava182Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-182[]
+        class StringArrayTreeModel implements TreeModel {
+            String[][] arr = new String[][] {
+                    {"Colors", "Letters", "Numbers"},
+                    {"Red", "Green", "Blue"},
+                    {"A", "B", "C"},
+                    {"1", "2", "3"}
+                };
+
+            public Vector getChildren(Object parent) {
+                if(parent == null) {
+                    Vector v = new Vector();
+                    for(int iter = 0 ; iter < arr[0].length ; iter++) {
+                        v.addElement(arr[0][iter]);
+                    }
+                    return v;
+                }
+                Vector v = new Vector();
+                for(int iter = 0 ; iter < arr[0].length ; iter++) {
+                    if(parent == arr[0][iter]) {
+                        if(arr.length > iter + 1 && arr[iter + 1] != null) {
+                            for(int i = 0 ; i < arr[iter + 1].length ; i++) {
+                                v.addElement(arr[iter + 1][i]);
+                            }
+                        }
+                    }
+                }
+                return v;
+            }
+
+            public boolean isLeaf(Object node) {
+                Vector v = getChildren(node);
+                return v == null || v.size() == 0;
+            }
+        }
+
+        Tree dt = new Tree(new StringArrayTreeModel());
+        // end::the-components-of-codename-one-java-182[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava183Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava183Snippet.java
@@ -92,7 +92,12 @@ class TheComponentsOfCodenameOneJava183Snippet {
     void snippet() throws Exception {
         // tag::the-components-of-codename-one-java-183[]
         Form hi = new Form("XML Tree", new BorderLayout());
+        // any XML you package with the application will do
         InputStream is = Display.getInstance().getResourceAsStream(getClass(), "/build.xml");
+        if(is == null) {
+            Log.p("/build.xml is not packaged with this application");
+            return;
+        }
         try(Reader r = new InputStreamReader(is, "UTF-8");) {
             Element e = new XMLParser().parse(r);
             Tree xmlTree = new Tree(new XMLTreeModel(e)) {

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava183Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava183Snippet.java
@@ -61,6 +61,7 @@ import com.codename1.ui.tree.*;
 import com.codename1.ui.table.*;
 import com.codename1.contacts.*;
 import java.util.*;
+import com.codename1.io.CharArrayReader;
 
 
 class TheComponentsOfCodenameOneJava183Snippet {
@@ -92,13 +93,13 @@ class TheComponentsOfCodenameOneJava183Snippet {
     void snippet() throws Exception {
         // tag::the-components-of-codename-one-java-183[]
         Form hi = new Form("XML Tree", new BorderLayout());
-        // any XML you package with the application will do
-        InputStream is = Display.getInstance().getResourceAsStream(getClass(), "/build.xml");
-        if(is == null) {
-            Log.p("/build.xml is not packaged with this application");
-            return;
-        }
-        try(Reader r = new InputStreamReader(is, "UTF-8");) {
+        // parsed inline here so the sample runs as it stands; in an application
+        // this would come from the network or a packaged resource
+        String xml = "<project name=\"demo\">"
+                + "  <target name=\"compile\"><javac srcdir=\"src\"/></target>"
+                + "  <target name=\"jar\"><zip destfile=\"demo.jar\"/></target>"
+                + "</project>";
+        try(Reader r = new CharArrayReader(xml.toCharArray())) {
             Element e = new XMLParser().parse(r);
             Tree xmlTree = new Tree(new XMLTreeModel(e)) {
                 @Override

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava183Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava183Snippet.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava183Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-183[]
+        Form hi = new Form("XML Tree", new BorderLayout());
+        InputStream is = Display.getInstance().getResourceAsStream(getClass(), "/build.xml");
+        try(Reader r = new InputStreamReader(is, "UTF-8");) {
+            Element e = new XMLParser().parse(r);
+            Tree xmlTree = new Tree(new XMLTreeModel(e)) {
+                @Override
+                protected String childToDisplayLabel(Object child) {
+                    if(child instanceof Element) {
+                        return ((Element)child).getTagName();
+                    }
+                    return child.toString();
+                }
+            };
+            hi.add(BorderLayout.CENTER, xmlTree);
+        } catch(IOException err) {
+            Log.e(err);
+        }
+        // end::the-components-of-codename-one-java-183[]
+    }
+
+    class XMLTreeModel implements TreeModel {
+        public java.util.Vector getChildren(Object parent) { return new java.util.Vector(); }
+        public boolean isLeaf(Object node) { return true; }
+        XMLTreeModel(Element e) { }
+    }
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava183Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava183Snippet.java
@@ -108,6 +108,7 @@ class TheComponentsOfCodenameOneJava183Snippet {
         } catch(IOException err) {
             Log.e(err);
         }
+        hi.show();
         // end::the-components-of-codename-one-java-183[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava183Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava183Snippet.java
@@ -104,7 +104,12 @@ class TheComponentsOfCodenameOneJava183Snippet {
                 @Override
                 protected String childToDisplayLabel(Object child) {
                     if(child instanceof Element) {
-                        return ((Element)child).getTagName();
+                        Element e = (Element)child;
+                        // getTagName() throws for the elements that carry text
+                        if(e.isTextElement()) {
+                            return e.getText();
+                        }
+                        return e.getTagName();
                     }
                     return child.toString();
                 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava184Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava184Snippet.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava184Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-184[]
+        class XMLTreeModel implements TreeModel {
+            private Element root;
+            public XMLTreeModel(Element e) {
+                root = e;
+            }
+
+            public Vector getChildren(Object parent) {
+                if(parent == null) {
+                    Vector c = new Vector();
+                    c.addElement(root);
+                    return c;
+                }
+                Vector result = new Vector();
+                Element e = (Element)parent;
+                for(int iter = 0 ; iter < e.getNumChildren() ; iter++) {
+                    result.addElement(e.getChildAt(iter));
+                }
+                return result;
+            }
+
+            public boolean isLeaf(Object node) {
+                Element e = (Element)node;
+                return e.getNumChildren() == 0;
+            }
+        }
+        // end::the-components-of-codename-one-java-184[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava185Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava185Snippet.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava185Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-185[]
+        Display.getInstance().share(
+                "Check this out!", imagePath, "image/png", sourceRect,
+                result -> handleResult(result));
+        // end::the-components-of-codename-one-java-185[]
+    }
+
+    String imagePath = "/image.png";
+    com.codename1.ui.geom.Rectangle sourceRect = new com.codename1.ui.geom.Rectangle();
+
+
+    void handleResult(com.codename1.share.ShareResult r) { }
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava187Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava187Snippet.java
@@ -94,6 +94,7 @@ class TheComponentsOfCodenameOneJava187Snippet {
         Form hi = new Form("ImageViewer", new BorderLayout());
         ImageViewer iv = new ImageViewer(duke);
         hi.add(BorderLayout.CENTER, iv);
+        hi.show();
         // end::the-components-of-codename-one-java-187[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava187Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava187Snippet.java
@@ -91,6 +91,7 @@ class TheComponentsOfCodenameOneJava187Snippet {
     
     void snippet() throws Exception {
         // tag::the-components-of-codename-one-java-187[]
+        Image duke = FontImage.createMaterial(FontImage.MATERIAL_INFO, "Label", 3.0f);
         Form hi = new Form("ImageViewer", new BorderLayout());
         ImageViewer iv = new ImageViewer(duke);
         hi.add(BorderLayout.CENTER, iv);
@@ -98,6 +99,5 @@ class TheComponentsOfCodenameOneJava187Snippet {
         // end::the-components-of-codename-one-java-187[]
     }
 
-    Image duke;
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava187Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava187Snippet.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava187Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-187[]
+        Form hi = new Form("ImageViewer", new BorderLayout());
+        ImageViewer iv = new ImageViewer(duke);
+        hi.add(BorderLayout.CENTER, iv);
+        // end::the-components-of-codename-one-java-187[]
+    }
+
+    Image duke;
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava188Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava188Snippet.java
@@ -91,6 +91,10 @@ class TheComponentsOfCodenameOneJava188Snippet {
     
     void snippet() throws Exception {
         // tag::the-components-of-codename-one-java-188[]
+        Image red = FontImage.createMaterial(FontImage.MATERIAL_LOOKS_ONE, "Label", 6.0f);
+        Image green = FontImage.createMaterial(FontImage.MATERIAL_LOOKS_TWO, "Label", 6.0f);
+        Image blue = FontImage.createMaterial(FontImage.MATERIAL_LOOKS_3, "Label", 6.0f);
+        Image gray = FontImage.createMaterial(FontImage.MATERIAL_LOOKS_4, "Label", 6.0f);
         ImageViewer iv = new ImageViewer(red);
         iv.setImageList(new DefaultListModel<>(red, green, blue, gray));
         iv.setNavigationArrowsVisible(true);
@@ -99,11 +103,7 @@ class TheComponentsOfCodenameOneJava188Snippet {
         // end::the-components-of-codename-one-java-188[]
     }
 
-    Image red;
 
 
-    Image blue;
-    Image green;
-    Image gray;
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava188Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava188Snippet.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava188Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-188[]
+        ImageViewer iv = new ImageViewer(red);
+        iv.setImageList(new DefaultListModel<>(red, green, blue, gray));
+        iv.setNavigationArrowsVisible(true);
+        iv.setThumbnailsVisible(true);
+        iv.setThumbnailBarHeight(6f); // Optional, defaults to 6mm
+        // end::the-components-of-codename-one-java-188[]
+    }
+
+    Image red;
+
+
+    Image blue;
+    Image green;
+    Image gray;
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava188Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava188Snippet.java
@@ -100,6 +100,9 @@ class TheComponentsOfCodenameOneJava188Snippet {
         iv.setNavigationArrowsVisible(true);
         iv.setThumbnailsVisible(true);
         iv.setThumbnailBarHeight(6f); // Optional, defaults to 6mm
+        Form hi = new Form("ImageViewer", new BorderLayout());
+        hi.add(BorderLayout.CENTER, iv);
+        hi.show();
         // end::the-components-of-codename-one-java-188[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava189Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava189Snippet.java
@@ -119,7 +119,10 @@ class TheComponentsOfCodenameOneJava189Snippet {
                     images[index] = placeholder;
                     Util.downloadUrlToStorageInBackground(imageURLs[index], "list" + index, (e) -> {
                             try {
-                                images[index] = EncodedImage.create(Storage.getInstance().createInputStream("list" + index));
+                                try(InputStream is = Storage.getInstance().createInputStream("list" + index)) {
+                                    // EncodedImage.create reads the stream but does not close it
+                                    images[index] = EncodedImage.create(is);
+                                }
                                 listeners.fireDataChangeEvent(index, DataChangedListener.CHANGED);
                             } catch(IOException err) {
                                 err.printStackTrace();

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava189Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava189Snippet.java
@@ -99,6 +99,7 @@ class TheComponentsOfCodenameOneJava189Snippet {
 
         class ImageList implements ListModel<Image> {
             private int selection;
+            private final java.util.List<SelectionListener> selectionListeners = new ArrayList<>();
             private String[] imageURLs = {
                 "http://awoiaf.westeros.org/images/thumb/9/93/AGameOfThrones.jpg/300px-AGameOfThrones.jpg",
                 "http://awoiaf.westeros.org/images/thumb/3/39/AClashOfKings.jpg/300px-AClashOfKings.jpg",
@@ -137,7 +138,12 @@ class TheComponentsOfCodenameOneJava189Snippet {
             }
 
             public void setSelectedIndex(int index) {
+                int old = selection;
                 selection = index;
+                // ImageViewer swaps the displayed image from this event
+                for(SelectionListener l : selectionListeners) {
+                    l.selectionChanged(old, index);
+                }
             }
 
             public void addDataChangedListener(DataChangedListener l) {
@@ -149,9 +155,11 @@ class TheComponentsOfCodenameOneJava189Snippet {
             }
 
             public void addSelectionListener(SelectionListener l) {
+                selectionListeners.add(l);
             }
 
             public void removeSelectionListener(SelectionListener l) {
+                selectionListeners.remove(l);
             }
 
             public void addItem(Image item) {

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava189Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava189Snippet.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava189Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-189[]
+        Form hi = new Form("ImageViewer", new BorderLayout());
+        final EncodedImage placeholder = EncodedImage.createFromImage(
+                FontImage.createMaterial(FontImage.MATERIAL_SYNC, s).
+                        scaled(300, 300), false);
+
+        class ImageList implements ListModel<Image> {
+            private int selection;
+            private String[] imageURLs = {
+                "http://awoiaf.westeros.org/images/thumb/9/93/AGameOfThrones.jpg/300px-AGameOfThrones.jpg",
+                "http://awoiaf.westeros.org/images/thumb/3/39/AClashOfKings.jpg/300px-AClashOfKings.jpg",
+                "http://awoiaf.westeros.org/images/thumb/2/24/AStormOfSwords.jpg/300px-AStormOfSwords.jpg",
+                "http://awoiaf.westeros.org/images/thumb/a/a3/AFeastForCrows.jpg/300px-AFeastForCrows.jpg",
+                "http://awoiaf.westeros.org/images/7/79/ADanceWithDragons.jpg"
+            };
+            private Image[] images;
+            private EventDispatcher listeners = new EventDispatcher();
+
+            public ImageList() {
+                this.images = new EncodedImage[imageURLs.length];
+            }
+
+            public Image getItemAt(final int index) {
+                if(images[index] == null) {
+                    images[index] = placeholder;
+                    Util.downloadUrlToStorageInBackground(imageURLs[index], "list" + index, (e) -> {
+                            try {
+                                images[index] = EncodedImage.create(Storage.getInstance().createInputStream("list" + index));
+                                listeners.fireDataChangeEvent(index, DataChangedListener.CHANGED);
+                            } catch(IOException err) {
+                                err.printStackTrace();
+                            }
+                    });
+                }
+                return images[index];
+            }
+
+            public int getSize() {
+                return imageURLs.length;
+            }
+
+            public int getSelectedIndex() {
+                return selection;
+            }
+
+            public void setSelectedIndex(int index) {
+                selection = index;
+            }
+
+            public void addDataChangedListener(DataChangedListener l) {
+                listeners.addListener(l);
+            }
+
+            public void removeDataChangedListener(DataChangedListener l) {
+                listeners.removeListener(l);
+            }
+
+            public void addSelectionListener(SelectionListener l) {
+            }
+
+            public void removeSelectionListener(SelectionListener l) {
+            }
+
+            public void addItem(Image item) {
+            }
+
+            public void removeItem(int index) {
+            }
+        };
+
+        ImageList imodel = new ImageList();
+
+        ImageViewer iv = new ImageViewer(imodel.getItemAt(0));
+        iv.setImageList(imodel);
+        hi.add(BorderLayout.CENTER, iv);
+        // end::the-components-of-codename-one-java-189[]
+    }
+
+    Style s = new Style();
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava189Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava189Snippet.java
@@ -91,6 +91,7 @@ class TheComponentsOfCodenameOneJava189Snippet {
     
     void snippet() throws Exception {
         // tag::the-components-of-codename-one-java-189[]
+        Style s = UIManager.getInstance().getComponentStyle("Label");
         Form hi = new Form("ImageViewer", new BorderLayout());
         final EncodedImage placeholder = EncodedImage.createFromImage(
                 FontImage.createMaterial(FontImage.MATERIAL_SYNC, s).
@@ -169,6 +170,5 @@ class TheComponentsOfCodenameOneJava189Snippet {
         // end::the-components-of-codename-one-java-189[]
     }
 
-    Style s = new Style();
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava189Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava189Snippet.java
@@ -101,11 +101,11 @@ class TheComponentsOfCodenameOneJava189Snippet {
             private int selection;
             private final java.util.List<SelectionListener> selectionListeners = new ArrayList<>();
             private String[] imageURLs = {
-                "http://awoiaf.westeros.org/images/thumb/9/93/AGameOfThrones.jpg/300px-AGameOfThrones.jpg",
-                "http://awoiaf.westeros.org/images/thumb/3/39/AClashOfKings.jpg/300px-AClashOfKings.jpg",
-                "http://awoiaf.westeros.org/images/thumb/2/24/AStormOfSwords.jpg/300px-AStormOfSwords.jpg",
-                "http://awoiaf.westeros.org/images/thumb/a/a3/AFeastForCrows.jpg/300px-AFeastForCrows.jpg",
-                "http://awoiaf.westeros.org/images/7/79/ADanceWithDragons.jpg"
+                "https://awoiaf.westeros.org/images/thumb/9/93/AGameOfThrones.jpg/300px-AGameOfThrones.jpg",
+                "https://awoiaf.westeros.org/images/thumb/3/39/AClashOfKings.jpg/300px-AClashOfKings.jpg",
+                "https://awoiaf.westeros.org/images/thumb/2/24/AStormOfSwords.jpg/300px-AStormOfSwords.jpg",
+                "https://awoiaf.westeros.org/images/thumb/a/a3/AFeastForCrows.jpg/300px-AFeastForCrows.jpg",
+                "https://awoiaf.westeros.org/images/7/79/ADanceWithDragons.jpg"
             };
             private Image[] images;
             private EventDispatcher listeners = new EventDispatcher();

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava189Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava189Snippet.java
@@ -165,6 +165,7 @@ class TheComponentsOfCodenameOneJava189Snippet {
         ImageViewer iv = new ImageViewer(imodel.getItemAt(0));
         iv.setImageList(imodel);
         hi.add(BorderLayout.CENTER, iv);
+        hi.show();
         // end::the-components-of-codename-one-java-189[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava190Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava190Snippet.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava190Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-190[]
+        TableLayout tl = new TableLayout(2, 2);
+        Form hi = new Form("ScaleImageButton/Label", tl);
+        Style s = UIManager.getInstance().getComponentStyle("Button");
+        Image icon = FontImage.createMaterial(FontImage.MATERIAL_WARNING, s);
+        ScaleImageLabel fillLabel = new ScaleImageLabel(icon);
+        fillLabel.setBackgroundType(Style.BACKGROUND_IMAGE_SCALED_FILL);
+        ScaleImageButton fillButton = new ScaleImageButton(icon);
+        fillButton.setBackgroundType(Style.BACKGROUND_IMAGE_SCALED_FILL);
+        hi.add(tl.createConstraint().widthPercentage(20), new ScaleImageButton(icon)).
+                add(tl.createConstraint().widthPercentage(80), new ScaleImageLabel(icon)).
+                add(fillLabel).
+                add(fillButton);
+        hi.show();
+        // end::the-components-of-codename-one-java-190[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava191Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava191Snippet.java
@@ -91,6 +91,8 @@ class TheComponentsOfCodenameOneJava191Snippet {
     
     void snippet() throws Exception {
         // tag::the-components-of-codename-one-java-191[]
+        Style s = UIManager.getInstance().getComponentStyle("TitleCommand");
+        Image icon = FontImage.createMaterial(FontImage.MATERIAL_INFO, s);
         Toolbar.setGlobalToolbar(true);
 
         Form hi = new Form("Toolbar", new BoxLayout(BoxLayout.Y_AXIS));
@@ -102,6 +104,5 @@ class TheComponentsOfCodenameOneJava191Snippet {
         // end::the-components-of-codename-one-java-191[]
     }
 
-    Image icon;
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava191Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava191Snippet.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava191Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-191[]
+        Toolbar.setGlobalToolbar(true);
+
+        Form hi = new Form("Toolbar", new BoxLayout(BoxLayout.Y_AXIS));
+        hi.getToolbar().addCommandToLeftBar("Left", icon, (e) -> Log.p("Clicked"));
+        hi.getToolbar().addCommandToRightBar("Right", icon, (e) -> Log.p("Clicked"));
+        hi.getToolbar().addCommandToOverflowMenu("Overflow", icon, (e) -> Log.p("Clicked"));
+        hi.getToolbar().addCommandToSideMenu("Sidemenu", icon, (e) -> Log.p("Clicked"));
+        hi.show();
+        // end::the-components-of-codename-one-java-191[]
+    }
+
+    Image icon;
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava192Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava192Snippet.java
@@ -138,9 +138,9 @@ class TheComponentsOfCodenameOneJava192Snippet {
 
 
 
+    // tag::the-components-of-codename-one-java-192-filter[]
     String currentSearch;
 
-    // tag::the-components-of-codename-one-java-192-filter[]
     void filterContacts(Form hi, String text) {
         if(text == null || text.length() == 0) {
             // clear search

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava192Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava192Snippet.java
@@ -135,6 +135,10 @@ class TheComponentsOfCodenameOneJava192Snippet {
             } else {
                 text = text.toLowerCase();
                 for(Component cmp : hi.getContentPane()) {
+                    if(!(cmp instanceof MultiButton)) {
+                        // the loading indicator is still there until the contacts arrive
+                        continue;
+                    }
                     MultiButton mb = (MultiButton)cmp;
                     String line1 = mb.getTextLine1();
                     String line2 = mb.getTextLine2();

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava192Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava192Snippet.java
@@ -103,6 +103,12 @@ class TheComponentsOfCodenameOneJava192Snippet {
             Contact[] cnts = Display.getInstance().getAllContacts(true, true, true, true, false, false);
             Display.getInstance().callSerially(() -> {
                 hi.removeAll();
+                if(cnts == null) {
+                    // the platform has no contacts API, or access was refused
+                    hi.add(new Label("Contacts are unavailable"));
+                    hi.revalidate();
+                    return;
+                }
                 for(Contact c : cnts) {
                     MultiButton m = new MultiButton();
                     m.setTextLine1(c.getDisplayName());

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava192Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava192Snippet.java
@@ -120,39 +120,52 @@ class TheComponentsOfCodenameOneJava192Snippet {
                     }
                     hi.add(m);
                 }
+                // the query may have been typed while the contacts were loading
+                filterContacts(hi, currentSearch);
                 hi.revalidate();
             });
         });
 
         hi.getToolbar().addSearchCommand(e -> {
-            String text = (String)e.getSource();
-            if(text == null || text.length() == 0) {
-                // clear search
-                for(Component cmp : hi.getContentPane()) {
-                    cmp.setHidden(false);
-                    cmp.setVisible(true);
-                }
-                hi.getContentPane().animateLayout(150);
-            } else {
-                text = text.toLowerCase();
-                for(Component cmp : hi.getContentPane()) {
-                    if(!(cmp instanceof MultiButton)) {
-                        // the loading indicator is still there until the contacts arrive
-                        continue;
-                    }
-                    MultiButton mb = (MultiButton)cmp;
-                    String line1 = mb.getTextLine1();
-                    String line2 = mb.getTextLine2();
-                    boolean show = line1 != null && line1.toLowerCase().indexOf(text) > -1 ||
-                            line2 != null && line2.toLowerCase().indexOf(text) > -1;
-                    mb.setHidden(!show);
-                    mb.setVisible(show);
-                }
-                hi.getContentPane().animateLayout(150);
-            }
+            currentSearch = (String)e.getSource();
+            filterContacts(hi, currentSearch);
         }, 4);
 
         hi.show();
+
         // end::the-components-of-codename-one-java-192[]
     }
+
+
+
+    String currentSearch;
+
+    // tag::the-components-of-codename-one-java-192-filter[]
+    void filterContacts(Form hi, String text) {
+        if(text == null || text.length() == 0) {
+            // clear search
+            for(Component cmp : hi.getContentPane()) {
+                cmp.setHidden(false);
+                cmp.setVisible(true);
+            }
+            hi.getContentPane().animateLayout(150);
+            return;
+        }
+        text = text.toLowerCase();
+        for(Component cmp : hi.getContentPane()) {
+            if(!(cmp instanceof MultiButton)) {
+                // the loading indicator is still there until the contacts arrive
+                continue;
+            }
+            MultiButton mb = (MultiButton)cmp;
+            String line1 = mb.getTextLine1();
+            String line2 = mb.getTextLine2();
+            boolean show = line1 != null && line1.toLowerCase().indexOf(text) > -1 ||
+                    line2 != null && line2.toLowerCase().indexOf(text) > -1;
+            mb.setHidden(!show);
+            mb.setVisible(show);
+        }
+        hi.getContentPane().animateLayout(150);
+    }
+    // end::the-components-of-codename-one-java-192-filter[]
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava192Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava192Snippet.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava192Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-192[]
+        Image duke = null;
+        try {
+            duke = Image.createImage("/duke.png");
+        } catch(IOException err) {
+            Log.e(err);
+        }
+        int fiveMM = Display.getInstance().convertToPixels(5);
+        final Image finalDuke = duke.scaledWidth(fiveMM);
+        Toolbar.setGlobalToolbar(true);
+        Form hi = new Form("Search", BoxLayout.y());
+        hi.add(new InfiniteProgress());
+        Display.getInstance().scheduleBackgroundTask(()-> {
+            // this will take a while...
+            Contact[] cnts = Display.getInstance().getAllContacts(true, true, true, true, false, false);
+            Display.getInstance().callSerially(() -> {
+                hi.removeAll();
+                for(Contact c : cnts) {
+                    MultiButton m = new MultiButton();
+                    m.setTextLine1(c.getDisplayName());
+                    m.setTextLine2(c.getPrimaryPhoneNumber());
+                    Image pic = c.getPhoto();
+                    if(pic != null) {
+                        m.setIcon(pic.fill(finalDuke.getWidth(), finalDuke.getHeight()));
+                    } else {
+                        m.setIcon(finalDuke);
+                    }
+                    hi.add(m);
+                }
+                hi.revalidate();
+            });
+        });
+
+        hi.getToolbar().addSearchCommand(e -> {
+            String text = (String)e.getSource();
+            if(text == null || text.length() == 0) {
+                // clear search
+                for(Component cmp : hi.getContentPane()) {
+                    cmp.setHidden(false);
+                    cmp.setVisible(true);
+                }
+                hi.getContentPane().animateLayout(150);
+            } else {
+                text = text.toLowerCase();
+                for(Component cmp : hi.getContentPane()) {
+                    MultiButton mb = (MultiButton)cmp;
+                    String line1 = mb.getTextLine1();
+                    String line2 = mb.getTextLine2();
+                    boolean show = line1 != null && line1.toLowerCase().indexOf(text) > -1 ||
+                            line2 != null && line2.toLowerCase().indexOf(text) > -1;
+                    mb.setHidden(!show);
+                    mb.setVisible(show);
+                }
+                hi.getContentPane().animateLayout(150);
+            }
+        }, 4);
+
+        hi.show();
+        // end::the-components-of-codename-one-java-192[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava192Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava192Snippet.java
@@ -91,11 +91,12 @@ class TheComponentsOfCodenameOneJava192Snippet {
     
     void snippet() throws Exception {
         // tag::the-components-of-codename-one-java-192[]
-        Image duke = null;
+        Image duke;
         try {
             duke = Image.createImage("/duke.png");
         } catch(IOException err) {
             Log.e(err);
+            return; // without the icon there is nothing to show
         }
         int fiveMM = Display.getInstance().convertToPixels(5);
         final Image finalDuke = duke.scaledWidth(fiveMM);

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava192Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava192Snippet.java
@@ -91,15 +91,10 @@ class TheComponentsOfCodenameOneJava192Snippet {
     
     void snippet() throws Exception {
         // tag::the-components-of-codename-one-java-192[]
-        Image duke;
-        try {
-            duke = Image.createImage("/duke.png");
-        } catch(IOException err) {
-            Log.e(err);
-            return; // without the icon there is nothing to show
-        }
         int fiveMM = Display.getInstance().convertToPixels(5);
-        final Image finalDuke = duke.scaledWidth(fiveMM);
+        // a material icon, so the sample needs no bundled asset
+        final Image finalDuke = FontImage.createMaterial(FontImage.MATERIAL_PORTRAIT, "Label", 3.0f)
+                .scaledWidth(fiveMM);
         Toolbar.setGlobalToolbar(true);
         Form hi = new Form("Search", BoxLayout.y());
         hi.add(new InfiniteProgress());

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava193Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava193Snippet.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava193Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-193[]
+        toolbar.setComponentToSideMenuSouth(myComponent);
+        // end::the-components-of-codename-one-java-193[]
+    }
+
+    Toolbar toolbar = new Toolbar();
+    Component myComponent = new Label();
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava194Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava194Snippet.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava194Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-194[]
+        JSObject window = (JSObject)ctx.get("window");
+        // end::the-components-of-codename-one-java-194[]
+    }
+
+    JavascriptContext ctx = new JavascriptContext(new BrowserComponent());
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava195Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava195Snippet.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava195Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-195[]
+        bc.execute(
+            "callback.onSuccess(3+4)",
+            res -> Log.p("The result was "+res.getInt())
+        );
+        // end::the-components-of-codename-one-java-195[]
+    }
+
+    BrowserComponent bc = new BrowserComponent();
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava196Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava196Snippet.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava196Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-196[]
+        Form hi = new Form("Table", new BorderLayout());
+        TableModel model = new DefaultTableModel(new String[] {"Col 1", "Col 2", "Col 3"}, new Object[][] {
+            {"Row 1", "Row A", "Row X"},
+            {"Row 2", "Row B can now stretch", null},
+            {"Row 3", "Row C", "Row Z"},
+            {"Row 4", "Row D", "Row K"},
+            }) {
+                public boolean isCellEditable(int row, int col) {
+                    return col != 0;
+                }
+            };
+        Table table = new Table(model) {
+            @Override
+            protected TableLayout.Constraint createCellConstraint(Object value, int row, int column) {
+                TableLayout.Constraint con =  super.createCellConstraint(value, row, column);
+                if(row == 1 && column == 1) {
+                    con.setHorizontalSpan(2);
+                }
+                con.setWidthPercentage(33);
+                return con;
+            }
+        };
+        hi.add(BorderLayout.CENTER, table);
+        // end::the-components-of-codename-one-java-196[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava196Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava196Snippet.java
@@ -61,6 +61,7 @@ import com.codename1.ui.tree.*;
 import com.codename1.ui.table.*;
 import com.codename1.contacts.*;
 import java.util.*;
+import com.codename1.ui.BrowserComponent.JSRef;
 
 
 class TheComponentsOfCodenameOneJava196Snippet {
@@ -91,29 +92,11 @@ class TheComponentsOfCodenameOneJava196Snippet {
     
     void snippet() throws Exception {
         // tag::the-components-of-codename-one-java-196[]
-        Form hi = new Form("Table", new BorderLayout());
-        TableModel model = new DefaultTableModel(new String[] {"Col 1", "Col 2", "Col 3"}, new Object[][] {
-            {"Row 1", "Row A", "Row X"},
-            {"Row 2", "Row B can now stretch", null},
-            {"Row 3", "Row C", "Row Z"},
-            {"Row 4", "Row D", "Row K"},
-            }) {
-                public boolean isCellEditable(int row, int col) {
-                    return col != 0;
-                }
-            };
-        Table table = new Table(model) {
-            @Override
-            protected TableLayout.Constraint createCellConstraint(Object value, int row, int column) {
-                TableLayout.Constraint con =  super.createCellConstraint(value, row, column);
-                if(row == 1 && column == 1) {
-                    con.setHorizontalSpan(2);
-                }
-                con.setWidthPercentage(33);
-                return con;
-            }
-        };
-        hi.add(BorderLayout.CENTER, table);
-        // end::the-components-of-codename-one-java-196[]
+        JSRef res = bc.executeAndWait("callback.onSuccess(3+4)");
+        Log.p("The result was "+res.getInt());
+    // end::the-components-of-codename-one-java-196[]
     }
+
+    BrowserComponent bc = new BrowserComponent();
+
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava197Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava197Snippet.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava197Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-197[]
+        bc.execute(
+            "$('#somebutton').click(function(){callback.onSuccess('Button was clicked')})",
+            res -> Log.p(res.toString())
+        );
+        // end::the-components-of-codename-one-java-197[]
+    }
+
+    BrowserComponent bc = new BrowserComponent();
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava198Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava198Snippet.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava198Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-198[]
+        bc.addJSCallback(
+            "$('#somebutton').click(function(){callback.onSuccess('Button was clicked')})",
+            res -> Log.p(res.toString())
+        );
+        // end::the-components-of-codename-one-java-198[]
+    }
+
+    BrowserComponent bc = new BrowserComponent();
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava199Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava199Snippet.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava199Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-199[]
+        bc.execute(
+            "jQuery('#bio').text(${0}); jQuery('#age').text(${1})",
+            new Object[]{
+               "A multi-line\n string with \"quotes\"",
+               27
+            }
+        );
+        // end::the-components-of-codename-one-java-199[]
+    }
+
+    BrowserComponent bc = new BrowserComponent();
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava200Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava200Snippet.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+import com.codename1.ui.BrowserComponent.JSProxy;
+import com.codename1.ui.BrowserComponent.JSRef;
+
+
+class TheComponentsOfCodenameOneJava200Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-200[]
+        JSProxy location = bc.createJSProxy("window.location");
+        // end::the-components-of-codename-one-java-200[]
+    }
+
+    BrowserComponent bc = new BrowserComponent();
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava201Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava201Snippet.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+import com.codename1.ui.BrowserComponent.JSProxy;
+import com.codename1.ui.BrowserComponent.JSRef;
+
+
+class TheComponentsOfCodenameOneJava201Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-201[]
+        location.get("href", res -> Log.p("location.href="+res));
+        // end::the-components-of-codename-one-java-201[]
+    }
+
+    JSProxy location = new BrowserComponent().createJSProxy("window.location");
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava202Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava202Snippet.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+import com.codename1.ui.BrowserComponent.JSProxy;
+import com.codename1.ui.BrowserComponent.JSRef;
+
+
+class TheComponentsOfCodenameOneJava202Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-202[]
+        JSRef href = location.getAndWait("href");
+        Log.p("location.href="+href);
+        // end::the-components-of-codename-one-java-202[]
+    }
+
+    JSProxy location = new BrowserComponent().createJSProxy("window.location");
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava203Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava203Snippet.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+import com.codename1.ui.BrowserComponent.JSProxy;
+import com.codename1.ui.BrowserComponent.JSRef;
+
+
+class TheComponentsOfCodenameOneJava203Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-203[]
+        location.set("href", "http://www.google.com");
+        // end::the-components-of-codename-one-java-203[]
+    }
+
+    JSProxy location = new BrowserComponent().createJSProxy("window.location");
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava203Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava203Snippet.java
@@ -93,7 +93,7 @@ class TheComponentsOfCodenameOneJava203Snippet {
     
     void snippet() throws Exception {
         // tag::the-components-of-codename-one-java-203[]
-        location.set("href", "http://www.google.com");
+        location.set("href", "https://www.google.com");
         // end::the-components-of-codename-one-java-203[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava204Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava204Snippet.java
@@ -93,7 +93,7 @@ class TheComponentsOfCodenameOneJava204Snippet {
     
     void snippet() throws Exception {
         // tag::the-components-of-codename-one-java-204[]
-        location.call("replace", new Object[]{"http://www.google.com"},
+        location.call("replace", new Object[]{"https://www.google.com"},
             res -> Log.p("Return value was "+res)
         );
         // end::the-components-of-codename-one-java-204[]

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava204Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava204Snippet.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+import com.codename1.ui.BrowserComponent.JSProxy;
+import com.codename1.ui.BrowserComponent.JSRef;
+
+
+class TheComponentsOfCodenameOneJava204Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-204[]
+        location.call("replace", new Object[]{"http://www.google.com"},
+            res -> Log.p("Return value was "+res)
+        );
+        // end::the-components-of-codename-one-java-204[]
+    }
+
+    JSProxy location = new BrowserComponent().createJSProxy("window.location");
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava205Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava205Snippet.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava205Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-205[]
+        Form hi = new Form("BrowserComponent", new BorderLayout());
+        BrowserComponent bc = new BrowserComponent();
+        bc.setPage( "<html lang=\"en\">\n" +
+                    "    <head>\n" +
+                    "        <meta charset=\"utf-8\">\n" +
+                    "    </head>\n" +
+                    "    <body >\n" +
+                    "        <p>This will appear twice...</p>\n" +
+                    "    </body>\n" +
+                    "</html>", null);
+        hi.add(BorderLayout.CENTER, bc);
+        bc.addWebEventListener("onLoad", (e) -> {
+            // Create a JavaScript context for this BrowserComponent
+            JavascriptContext ctx = new JavascriptContext(bc);
+
+            String pageContent = (String)ctx.get("document.body.innerHTML");
+            hi.add(BorderLayout.SOUTH, pageContent);
+            hi.revalidate();
+        });
+        hi.show();
+        // end::the-components-of-codename-one-java-205[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava206Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava206Snippet.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava206Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-206[]
+        Double outerWidth = (Double)ctx.get("window.outerWidth");
+        // end::the-components-of-codename-one-java-206[]
+    }
+
+    JavascriptContext ctx = new JavascriptContext(new BrowserComponent());
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava207Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava207Snippet.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava207Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-207[]
+        Form hi = new Form("BrowserComponent", new BorderLayout());
+        BrowserComponent bc = new BrowserComponent();
+        bc.setPage( "<html lang=\"en\">\n" +
+                    "    <head>\n" +
+                    "        <meta charset=\"utf-8\">\n" +
+                    "    </head>\n" +
+                    "    <body >\n" +
+                    "        <p>Please Wait...</p>\n" +
+                    "    </body>\n" +
+                    "</html>", null);
+        hi.add(BorderLayout.CENTER, bc);
+        bc.addWebEventListener("onLoad", (e) -> {
+            // Create a JavaScript context for this BrowserComponent
+            JavascriptContext ctx = new JavascriptContext(bc);
+
+            JSObject jo = (JSObject)ctx.get("window");
+            jo.set("location", "https://www.codenameone.com/");
+        });
+        // end::the-components-of-codename-one-java-207[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava207Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava207Snippet.java
@@ -102,12 +102,17 @@ class TheComponentsOfCodenameOneJava207Snippet {
                     "    </body>\n" +
                     "</html>", null);
         hi.add(BorderLayout.CENTER, bc);
-        bc.addWebEventListener("onLoad", (e) -> {
-            // Create a JavaScript context for this BrowserComponent
-            JavascriptContext ctx = new JavascriptContext(bc);
+        bc.addWebEventListener("onLoad", new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                // the destination fires onLoad too, so stop listening before navigating
+                bc.removeWebEventListener("onLoad", this);
 
-            JSObject jo = (JSObject)ctx.get("window");
-            jo.set("location", "https://www.codenameone.com/");
+                // Create a JavaScript context for this BrowserComponent
+                JavascriptContext ctx = new JavascriptContext(bc);
+
+                JSObject jo = (JSObject)ctx.get("window");
+                jo.set("location", "https://www.codenameone.com/");
+            }
         });
         hi.show();
         // end::the-components-of-codename-one-java-207[]

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava207Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava207Snippet.java
@@ -109,6 +109,7 @@ class TheComponentsOfCodenameOneJava207Snippet {
             JSObject jo = (JSObject)ctx.get("window");
             jo.set("location", "https://www.codenameone.com/");
         });
+        hi.show();
         // end::the-components-of-codename-one-java-207[]
     }
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava208Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava208Snippet.java
@@ -99,6 +99,8 @@ class TheComponentsOfCodenameOneJava208Snippet {
               }
               String[] l = searchLocations(text);
               if(l == null || l.length == 0) {
+                  // otherwise the popup keeps showing the previous query's matches
+                  options.removeAll();
                   return false;
               }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava208Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava208Snippet.java
@@ -100,6 +100,11 @@ class TheComponentsOfCodenameOneJava208Snippet {
                   return false;
               }
               String[] l = searchLocations(text);
+              if(!text.equals(getText())) {
+                  // the wait above pumps the EDT, so the field may have moved on
+                  // and a newer query may already have filled the model
+                  return false;
+              }
               if(l == null || l.length == 0) {
                   // otherwise the popup keeps showing the previous query's matches
                   options.removeAll();

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava208Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava208Snippet.java
@@ -95,6 +95,8 @@ class TheComponentsOfCodenameOneJava208Snippet {
           @Override
           protected boolean filter(String text) {
               if(text.length() == 0) {
+                  // an emptied field must not keep showing the last query's matches
+                  options.removeAll();
                   return false;
               }
               String[] l = searchLocations(text);

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava208Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava208Snippet.java
@@ -78,7 +78,6 @@ class TheComponentsOfCodenameOneJava208Snippet {
     Graphics g;
     GraphicsDevice device;
     Form form;
-    Form hi;
     Container cnt;
     Container myForm;
     Component component;
@@ -89,6 +88,7 @@ class TheComponentsOfCodenameOneJava208Snippet {
     Resources theme;
     
     // tag::the-components-of-codename-one-java-208[]
+      Form hi = new Form("Autocomplete", new BoxLayout(BoxLayout.Y_AXIS));
     public void showForm() {
       final DefaultListModel<String> options = new DefaultListModel<>();
       AutoCompleteTextField ac = new AutoCompleteTextField(options) {

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava208Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava208Snippet.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava208Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    // tag::the-components-of-codename-one-java-208[]
+    public void showForm() {
+      final DefaultListModel<String> options = new DefaultListModel<>();
+      AutoCompleteTextField ac = new AutoCompleteTextField(options) {
+          @Override
+          protected boolean filter(String text) {
+              if(text.length() == 0) {
+                  return false;
+              }
+              String[] l = searchLocations(text);
+              if(l == null || l.length == 0) {
+                  return false;
+              }
+
+              options.removeAll();
+              for(String s : l) {
+                  options.addItem(s);
+              }
+              return true;
+          }
+
+      };
+      ac.setMinimumElementsShownInPopup(5);
+      hi.add(ac);
+      hi.add(new SpanLabel("This demo requires a valid google API key to be set below "
+               + "you can get this key for the webservice (not the native key) by following the instructions here: "
+               + "https://developers.google.com/places/web-service/get-api-key"));
+      hi.add(apiKey);
+      hi.getToolbar().addCommandToRightBar("Get Key", null, e -> Display.getInstance().execute("https://developers.google.com/places/web-service/get-api-key"));
+      hi.show();
+    }
+
+    TextField apiKey = new TextField();
+
+    String[] searchLocations(String text) {
+        try {
+            if(text.length() > 0) {
+                ConnectionRequest r = new ConnectionRequest();
+                r.setPost(false);
+                r.setUrl("https://maps.googleapis.com/maps/api/place/autocomplete/json");
+                r.addArgument("key", apiKey.getText());
+                r.addArgument("input", text);
+                NetworkManager.getInstance().addToQueueAndWait(r);
+                Map<String,Object> result = new JSONParser().parseJSON(new InputStreamReader(new ByteArrayInputStream(r.getResponseData()), "UTF-8"));
+                String[] res = Result.fromContent(result).getAsStringArray("//description");
+                return res;
+            }
+        } catch(Exception err) {
+            Log.e(err);
+        }
+        return null;
+    }
+    // end::the-components-of-codename-one-java-208[]
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava209Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava209Snippet.java
@@ -104,6 +104,9 @@ class TheComponentsOfCodenameOneJava209Snippet {
             cal.add(Calendar.DAY_OF_MONTH, 7);
             picker.setDate(cal.getTime());
         }, Picker.LightweightPopupButtonPlacement.BELOW_SPINNER);
+        Form hi = new Form("Picker", new BoxLayout(BoxLayout.Y_AXIS));
+        hi.add(picker);
+        hi.show();
         // end::the-components-of-codename-one-java-209[]
     }
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava209Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava209Snippet.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+import java.util.Calendar;
+
+
+class TheComponentsOfCodenameOneJava209Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-209[]
+        Picker picker = new Picker();
+        picker.setType(Display.PICKER_TYPE_DATE);
+        picker.setUseLightweightPopup(true);
+        picker.setDate(new Date());
+
+        picker.addLightweightPopupButton("Today", () -> picker.setDate(new Date()));
+
+        picker.addLightweightPopupButton("+7 Days", () -> {
+            Calendar cal = Calendar.getInstance();
+            cal.add(Calendar.DAY_OF_MONTH, 7);
+            picker.setDate(cal.getTime());
+        }, Picker.LightweightPopupButtonPlacement.BELOW_SPINNER);
+        // end::the-components-of-codename-one-java-209[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava210Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava210Snippet.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava210Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-210[]
+        SwipeableContainer swip = new SwipeableContainer(bottom, top);
+        // end::the-components-of-codename-one-java-210[]
+    }
+
+    Component top;
+    Component bottom;
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava211Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava211Snippet.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava211Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+    // tag::the-components-of-codename-one-java-211[]
+        Form hi = new Form("Swipe", new BoxLayout(BoxLayout.Y_AXIS));
+        hi.add(createRankWidget("A Game of Thrones", "1996")).
+            add(createRankWidget("A Clash Of Kings", "1998")).
+            add(createRankWidget("A Storm Of Swords", "2000")).
+            add(createRankWidget("A Feast For Crows", "2005")).
+            add(createRankWidget("A Dance With Dragons", "2011")).
+            add(createRankWidget("The Winds of Winter", "TBD")).
+            add(createRankWidget("A Dream of Spring", "TBD"));
+        hi.show();
+    // end::the-components-of-codename-one-java-211[]
+    }
+
+    // tag::the-components-of-codename-one-java-211-helper[]
+    public SwipeableContainer createRankWidget(String title, String year) {
+        MultiButton button = new MultiButton(title);
+        button.setTextLine2(year);
+        return new SwipeableContainer(FlowLayout.encloseCenterMiddle(createStarRankSlider()),
+                button);
+    }
+    // end::the-components-of-codename-one-java-211-helper[]
+
+    Slider createStarRankSlider() { return new Slider(); }
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava212Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava212Snippet.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava212Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-212[]
+        Form map = new Form("Map");
+        map.setLayout(new BorderLayout());
+        map.setScrollable(false);
+        final MapComponent mc = new MapComponent();
+
+        try {
+           //get the current location from the Location API
+           Location loc = LocationManager.getLocationManager().getCurrentLocation();
+
+          Coord lastLocation = new Coord(loc.getLatitude(), loc.getLongtitude());
+           Image i = Image.createImage("/blue_pin.png");
+           PointsLayer pl = new PointsLayer();
+           pl.setPointIcon(i);
+           PointLayer p = new PointLayer(lastLocation, "You Are Here", i);
+           p.setDisplayName(true);
+           pl.addPoint(p);
+           mc.addLayer(pl);
+        } catch (IOException ex) {
+           ex.printStackTrace();
+        }
+        mc.zoomToLayers();
+
+        map.addComponent(BorderLayout.CENTER, mc);
+        map.addCommand(new BackCommand());
+        map.setBackCommand(new BackCommand());
+        map.show();
+        // end::the-components-of-codename-one-java-212[]
+    }
+
+    class BackCommand extends Command { BackCommand() { super("Back"); } }
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava212Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava212Snippet.java
@@ -101,7 +101,8 @@ class TheComponentsOfCodenameOneJava212Snippet {
            Location loc = LocationManager.getLocationManager().getCurrentLocation();
 
           Coord lastLocation = new Coord(loc.getLatitude(), loc.getLongtitude());
-           Image i = Image.createImage("/blue_pin.png");
+           // a material icon rather than an asset you would have to add
+           Image i = FontImage.createMaterial(FontImage.MATERIAL_PLACE, "Label", 4.0f);
            PointsLayer pl = new PointsLayer();
            pl.setPointIcon(i);
            PointLayer p = new PointLayer(lastLocation, "You Are Here", i);
@@ -114,12 +115,9 @@ class TheComponentsOfCodenameOneJava212Snippet {
         mc.zoomToLayers();
 
         map.addComponent(BorderLayout.CENTER, mc);
-        map.addCommand(new BackCommand());
-        map.setBackCommand(new BackCommand());
         map.show();
         // end::the-components-of-codename-one-java-212[]
     }
 
-    class BackCommand extends Command { BackCommand() { super("Back"); } }
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava212Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava212Snippet.java
@@ -100,15 +100,18 @@ class TheComponentsOfCodenameOneJava212Snippet {
            //get the current location from the Location API
            Location loc = LocationManager.getLocationManager().getCurrentLocation();
 
-          Coord lastLocation = new Coord(loc.getLatitude(), loc.getLongtitude());
-           // a material icon rather than an asset you would have to add
-           Image i = FontImage.createMaterial(FontImage.MATERIAL_PLACE, "Label", 4.0f);
-           PointsLayer pl = new PointsLayer();
-           pl.setPointIcon(i);
-           PointLayer p = new PointLayer(lastLocation, "You Are Here", i);
-           p.setDisplayName(true);
-           pl.addPoint(p);
-           mc.addLayer(pl);
+           // null until the device has a fix, so the map opens without the marker
+           if(loc != null) {
+               Coord lastLocation = new Coord(loc.getLatitude(), loc.getLongtitude());
+               // a material icon rather than an asset you would have to add
+               Image i = FontImage.createMaterial(FontImage.MATERIAL_PLACE, "Label", 4.0f);
+               PointsLayer pl = new PointsLayer();
+               pl.setPointIcon(i);
+               PointLayer p = new PointLayer(lastLocation, "You Are Here", i);
+               p.setDisplayName(true);
+               mc.addLayer(pl);
+               pl.addPoint(p);
+           }
         } catch (IOException ex) {
            ex.printStackTrace();
         }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava213Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava213Snippet.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava213Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    // tag::the-components-of-codename-one-java-213[]
+    /**
+     * Creates a renderer for the specified colors.
+     */
+    private DefaultRenderer buildCategoryRenderer(int[] colors) {
+        DefaultRenderer renderer = new DefaultRenderer();
+        renderer.setLabelsTextSize(15);
+        renderer.setLegendTextSize(15);
+        renderer.setMargins(new int[]{20, 30, 15, 0});
+        for (int color : colors) {
+            SimpleSeriesRenderer r = new SimpleSeriesRenderer();
+            r.setColor(color);
+            renderer.addSeriesRenderer(r);
+        }
+        return renderer;
+    }
+
+    /**
+     * Builds a category series using the provided values.
+     *
+     * @param titles the series titles
+     * @param values the values
+     * @return the category series
+     */
+    protected CategorySeries buildCategoryDataset(String title, double[] values) {
+        CategorySeries series = new CategorySeries(title);
+        int k = 0;
+        for (double value : values) {
+            series.add("Project " + ++k, value);
+        }
+
+        return series;
+    }
+
+    public Form createPieChartForm() {
+
+        // Generate the values
+        double[] values = new double[]{12, 14, 11, 10, 19};
+
+        // Set up the renderer
+        int[] colors = new int[]{ColorUtil.BLUE, ColorUtil.GREEN, ColorUtil.MAGENTA, ColorUtil.YELLOW, ColorUtil.CYAN};
+        DefaultRenderer renderer = buildCategoryRenderer(colors);
+        renderer.setZoomButtonsVisible(true);
+        renderer.setZoomEnabled(true);
+        renderer.setChartTitleTextSize(20);
+        renderer.setDisplayValues(true);
+        renderer.setShowLabels(true);
+        SimpleSeriesRenderer r = renderer.getSeriesRendererAt(0);
+        r.setGradientEnabled(true);
+        r.setGradientStart(0, ColorUtil.BLUE);
+        r.setGradientStop(0, ColorUtil.GREEN);
+        r.setHighlighted(true);
+
+        // Create the chart ... pass the values and renderer to the chart object.
+        PieChart chart = new PieChart(buildCategoryDataset("Project budget", values), renderer);
+
+        // Wrap the chart in a Component so we can add it to a form
+        ChartComponent c = new ChartComponent(chart);
+
+        // Create a form and show it.
+        Form f = new Form("Budget");
+        f.setLayout(new BorderLayout());
+        f.addComponent(BorderLayout.CENTER, c);
+        return f;
+
+    }
+    // end::the-components-of-codename-one-java-213[]
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava214Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava214Snippet.java
@@ -96,6 +96,7 @@ class TheComponentsOfCodenameOneJava214Snippet {
         Calendar cld = new Calendar();
         cld.addActionListener((e) -> Log.p("You picked: " + new Date(cld.getSelectedDay())));
         hi.add(BorderLayout.CENTER, cld);
+        hi.show();
         // end::the-components-of-codename-one-java-214[]
     }
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava214Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava214Snippet.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+import com.codename1.ui.Calendar;
+
+
+class TheComponentsOfCodenameOneJava214Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-214[]
+        Form hi = new Form("Calendar", new BorderLayout());
+        Calendar cld = new Calendar();
+        cld.addActionListener((e) -> Log.p("You picked: " + new Date(cld.getSelectedDay())));
+        hi.add(BorderLayout.CENTER, cld);
+        // end::the-components-of-codename-one-java-214[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava215Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava215Snippet.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava215Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-215[]
+        Status status = ToastBar.getInstance().createStatus();
+        status.setMessage("Downloading your file...");
+        status.show();
+
+        //  ... Later on when download completes
+        status.clear();
+        // end::the-components-of-codename-one-java-215[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava216Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava216Snippet.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava216Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-216[]
+        Status status = ToastBar.getInstance().createStatus();
+        status.setMessage("Hello world");
+        status.setShowProgressIndicator(true);
+        status.show();
+        // end::the-components-of-codename-one-java-216[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava217Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava217Snippet.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava217Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-217[]
+        Status status = ToastBar.getInstance().createStatus();
+        status.setMessage("Hello world");
+        status.setExpires(3000);  // only show the status for 3 seconds, then have it automatically clear
+        status.show();
+        // end::the-components-of-codename-one-java-217[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava218Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava218Snippet.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava218Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::the-components-of-codename-one-java-218[]
+        Status status = ToastBar.getInstance().createStatus();
+        status.setMessage("Hello world");
+        status.showDelayed(300); // Wait 300 ms to show the status
+
+        // ... Some time later, clear the status... This may be before it shows at all
+        status.clear();
+        // end::the-components-of-codename-one-java-218[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava219Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava219Snippet.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.components.ToastBar.Status;
+import com.codename1.maps.layers.*;
+import com.codename1.charts.*;
+import com.codename1.ui.validation.*;
+import com.codename1.xml.*;
+import com.codename1.charts.util.*;
+import com.codename1.javascript.*;
+import com.codename1.ui.tree.*;
+import com.codename1.ui.table.*;
+import com.codename1.contacts.*;
+import java.util.*;
+
+
+class TheComponentsOfCodenameOneJava219Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    // tag::the-components-of-codename-one-java-219[]
+    private Container encloseInMaximizableGrid(Component cmp1, Component cmp2) {
+        GridLayout gl = new GridLayout(2, 1);
+        Container grid = new Container(gl);
+        gl.setHideZeroSized(true);
+
+        grid.add(encloseInMaximize(grid, cmp1)).
+                add(encloseInMaximize(grid, cmp2));
+        return grid;
+    }
+    // end::the-components-of-codename-one-java-219[]
+
+    Container encloseInMaximize(Container c, Component cmp) { return c; }
+
+}

--- a/docs/demos/common/src/main/snippets/developer-guide/the-components-of-codename-one.properties
+++ b/docs/demos/common/src/main/snippets/developer-guide/the-components-of-codename-one.properties
@@ -1,0 +1,9 @@
+// Generated from docs/developer-guide source blocks. Edit the guide snippets here, not inline.
+
+// tag::the-components-of-codename-one-properties-001[]
+PopupDialogArrowBool=true
+PopupDialogArrowTopImage=arrow up image
+PopupDialogArrowBottomImage=arrow down image
+PopupDialogArrowLeftImage=arrow left image
+PopupDialogArrowRightImage=arrow right image
+// end::the-components-of-codename-one-properties-001[]

--- a/docs/demos/common/src/main/snippets/developer-guide/the-components-of-codename-one.properties
+++ b/docs/demos/common/src/main/snippets/developer-guide/the-components-of-codename-one.properties
@@ -2,8 +2,8 @@
 
 // tag::the-components-of-codename-one-properties-001[]
 PopupDialogArrowBool=true
-PopupDialogArrowTopImage=arrow up image
-PopupDialogArrowBottomImage=arrow down image
-PopupDialogArrowLeftImage=arrow left image
-PopupDialogArrowRightImage=arrow right image
+PopupDialogArrowTopImage=arrow-up.png
+PopupDialogArrowBottomImage=arrow-down.png
+PopupDialogArrowLeftImage=arrow-left.png
+PopupDialogArrowRightImage=arrow-right.png
 // end::the-components-of-codename-one-properties-001[]

--- a/docs/developer-guide/The-Components-Of-Codename-One.asciidoc
+++ b/docs/developer-guide/The-Components-Of-Codename-One.asciidoc
@@ -52,6 +52,10 @@ include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/g
 
 A form is a container with a title, a content area, and an optional menu or menu-bar area. When you call methods such as `add` or `remove` on a form, you're invoking something that maps to this:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava143Snippet.java[tag=the-components-of-codename-one-java-143,indent=0]
+----
 
 `Form` is effectively a https://www.codenameone.com/javadoc/com/codename1/ui/Container.html[Container] with a border layout. The north section holds the title area, the south section holds the optional menu bar, and the center stretches as the content pane. Place all components in the content pane.
 
@@ -246,6 +250,10 @@ image::img/components-dialog-blur-no-tint.png[The blur effect is more pronounced
 
 A popup dialog is a common mobile paradigm showing a `Dialog` that points at a specific component. It's a standard `Dialog` that's shown in a unique way:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava144Snippet.java[tag=the-components-of-codename-one-java-144,indent=0]
+----
 
 .Popup Dialog
 image::img/components-dialog-popup.png[Popup Dialog,scaledwidth=20%]
@@ -275,6 +283,10 @@ The block image of the dialog should have empty pixels in the sides to reserve s
 
 You will need to define the following theme constants for the arrow to work:
 
+[source,properties]
+----
+include::../demos/common/src/main/snippets/developer-guide/the-components-of-codename-one.properties[tag=the-components-of-codename-one-properties-001,indent=0]
+----
 
 Then style the `PopupDialog` UIID with the image for the `Dialog` itself.
 
@@ -321,6 +333,10 @@ https://www.codenameone.com/javadoc/com/codename1/ui/Label.html[Label] represent
 
 `Label` text can be positioned in one of 4 locations as such:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava146Snippet.java[tag=the-components-of-codename-one-java-146,indent=0]
+----
 
 .Label positions
 image::img/components-label-text-position.png[Label positions,scaledwidth=20%]
@@ -399,9 +415,17 @@ A common use case when working with text components is the ability to "mask" inp
 
 Masking allows you to accept partial input in one field and implicitly move to the next, this can be used to all types of complex input thanks to the text component API. E.g with the code above you can mask the credit card input so the cursor jumps to the next field implicitly using this code:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava147Snippet.java[tag=the-components-of-codename-one-java-147,indent=0]
+----
 
 Then implement the method `automoveToNext` as:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava148Snippet.java[tag=the-components-of-codename-one-java-148,indent=0]
+----
 
 Notice you can invoke `stopEditing(Runnable)` where you receive a callback as editing is stopped.
 
@@ -421,6 +445,10 @@ TIP: When working with a virtual keyboard it's important that the parent `Contai
 By default, the virtual keyboard on Android has a "Done" button, you can customize it to be a search icon, a send icon,
 or a go icon using a hint such as this:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava149Snippet.java[tag=the-components-of-codename-one-java-149,indent=0]
+----
 
 This will adapt the icon for the action on the keys.
 
@@ -440,6 +468,10 @@ NOTE: This works with 3rd party keyboards too...
 
 For example, this behavior might not be desired so to block that you can do:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava150Snippet.java[tag=the-components-of-codename-one-java-150,indent=0]
+----
 
 This will hide the toolbar for that given field.
 
@@ -451,9 +483,17 @@ iOS has a convention where an X can be placed after the text field to clear it. 
 
 You can wrap a `TextField` with a clearable wrapper to get this effect on all platforms. For example: replace this:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava151Snippet.java[tag=the-components-of-codename-one-java-151,indent=0]
+----
 
 With this:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava152Snippet.java[tag=the-components-of-codename-one-java-152,indent=0]
+----
 
 You can also specify the size of the clear icon if you wish. This is technically a `Container` with the text field style and a button to clear the text at the edge.
 
@@ -493,6 +533,10 @@ The validator class supports text component and it should "work." But the cool t
 
 If you add to the sample above a `Validator`:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava153Snippet.java[tag=the-components-of-codename-one-java-153,indent=0]
+----
 
 You would see something that looks like this on Android:
 
@@ -519,6 +563,10 @@ To keep the code common and generic you use the `InputComponent` abstract base c
 
 A picker can work with your existing sample using code like this:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava154Snippet.java[tag=the-components-of-codename-one-java-154,indent=0]
+----
 
 This produces the following which looks pretty standard:
 
@@ -641,6 +689,10 @@ The `CheckBox` can be added to a `Container` like any other `Component` but the 
 
 Notice in the sample below that you associate all the radio buttons with a group but don't do anything with the group as the radio buttons keep the reference internally. You also show the opposite side functionality and icon behavior:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava155Snippet.java[tag=the-components-of-codename-one-java-155,indent=0]
+----
 
 .RadioButton & CheckBox usage
 image::img/components-radiobutton-checkbox.png[RadioButton & CheckBox usage,scaledwidth=20%]
@@ -657,6 +709,10 @@ IMPORTANT: Invoking `setToggle(true)` implicitly converts the `UIID` to `ToggleB
 
 You can convert the sample above to use toggle buttons as such:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava156Snippet.java[tag=the-components-of-codename-one-java-156,indent=0]
+----
 
 .Toggle button converted sample
 image::img/components-toggle-buttons.png[Toggle button converted sample,scaledwidth=20%]
@@ -665,6 +721,10 @@ That's half the story though: to get the full effect of some cool toggle button 
 
 For example, to enclose the `CheckBox` components in a vertical `ComponentGroup` and the `RadioButton's` in a horizontal group, change the last line of the code above as such:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava157Snippet.java[tag=the-components-of-codename-one-java-157,indent=0]
+----
 
 .Toggle button converted sample wrapped in ComponentGroup
 image::img/components-toggle-buttons-component-group.png[Toggle button converted sample wrapped in ComponentGroup,scaledwidth=20%]
@@ -716,6 +776,10 @@ NOTE: The `MultiButton` was inspired by the aesthetics of the `UITableView` iOS 
 
 A common source of confusion in the `MultiButton` is the difference between the icon and the emblem, since both may have an icon image associated with them. The icon is an image representing the entry while the emblem is an optional visual representation of the action that will be undertaken when the element is pressed. Both may be used simultaneously or individually of one another:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava158Snippet.java[tag=the-components-of-codename-one-java-158,indent=0]
+----
 
 .Multiple usage scenarios for the MultiButton
 image::img/components-multibutton.png[Multiple usage scenarios for the MultiButton,scaledwidth=20%]
@@ -737,6 +801,10 @@ https://www.codenameone.com/javadoc/com/codename1/components/SpanButton.html[Spa
 
 Unlike the `MultiButton` it uses the `TextArea` internally to break lines seamlessly. The `SpanButton` is far simpler than the `MultiButton` and as a result isn't as configurable:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava159Snippet.java[tag=the-components-of-codename-one-java-159,indent=0]
+----
 
 .The SpanButton Component
 image::img/components-spanbutton.png[The SpanButton Component,scaledwidth=20%]
@@ -752,6 +820,10 @@ https://www.codenameone.com/javadoc/com/codename1/components/SpanLabel.html[Span
 
 One of the features of label that moved into `SpanLabel` to some extent is the ability to position the icon. For example, unlike a `Label` the icon position is determined by the layout manager of the composite so `setIconPosition` accepts a `BorderLayout` constraint:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava160Snippet.java[tag=the-components-of-codename-one-java-160,indent=0]
+----
 
 .The SpanLabel Component
 image::img/components-spanlabel.png[The SpanLabel Component,scaledwidth=20%]
@@ -789,6 +861,10 @@ constraints such as https://www.codenameone.com/javadoc/com/codename1/ui/validat
 
 This sample below continues from the place where the <<text-component-sample-code,TextField sample above>> stopped by adding validation to that code:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava161Snippet.java[tag=the-components-of-codename-one-java-161,indent=0]
+----
 
 .Validation & Regular Expressions
 image::img/validation-regex-masking-1.png[Validation and Regular Expressions,scaledwidth=20%]
@@ -809,6 +885,10 @@ TIP: This style of animation is often nicknamed "washing machine" as it spins en
 
 `InfiniteProgress` can be used in one of two ways either by embedding the component into the UI through something like this:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava162Snippet.java[tag=the-components-of-codename-one-java-162,indent=0]
+----
 
 `InfiniteProgress` can also appear over the entire screen, thus blocking all input. This tints the background while the infinite progress rotates:
 
@@ -841,6 +921,10 @@ image::img/components-infinitescrolladapter.png[InfiniteScrollAdapter demo code 
 
 The first step is creating the webservice call, you won't go into too much detail here as webservices & IO are discussed later in the guide:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava163Snippet.java[tag=the-components-of-codename-one-java-163,indent=0]
+----
 
 IMPORTANT: The demo code here doesn't do any error handling! This is a bad practice and it's taken here to keep the code short and readable. Proper error handling is used in the Property Cross demo.
 
@@ -848,6 +932,22 @@ The `fetchPropertyData` is a simplistic tool that fetches the next page of listi
 
 Now that you have a webservice lets proceed to create the UI. Check out the code annotations below:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava164Snippet.java[tag=the-components-of-codename-one-java-164,indent=0]
+----
+
+<1> Placeholder is essential for the https://www.codenameone.com/javadoc/com/codename1/ui/URLImage.html[URLImage] class which this guide covers at a different place.
+
+<2> The `InfiniteScrollAdapter` accepts a runnable which is invoked every time you reach the edge of the scrolling. You used a closure instead of the typical run() method override.
+
+<3> This is a blocking call, after the method completes you will have all the data you need. Notice that this method doesn't block the EDT illegally.
+
+<4> If there is no more data you call the `addMoreComponents` method with a false argument. This indicates that there is no more data to fetch.
+
+<5> Here you add the actual components to the end of the form. Notice that you *must not* invoke the `add`/`remove` method of `Container`. Those might conflict with the work of the `InfiniteScrollAdapter`.
+
+<6> You pass true to show that the data isn't "prefilled" so the method should be invoked when the `Form` is first shown
 
 IMPORTANT: Don't violate the EDT in the callback. It's invoked on the event dispatch thread and it's crucial
 
@@ -861,6 +961,10 @@ Converting the code above to an `InfiniteContainer` is pretty simple you moved a
 
 Unlike the `InfiniteScrollAdapter` you can't use the `ContentPane` directly so you've to use a `BorderLayout` and place the `InfiniteContainer` there:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava165Snippet.java[tag=the-components-of-codename-one-java-165,indent=0]
+----
 
 === List, MultiList, renderers & models
 
@@ -943,6 +1047,10 @@ When working with lists, you want the list to handle the scrolling (otherwise it
 
 It's also recommended to place the list in the `CENTER` location of a https://www.codenameone.com/javadoc/com/codename1/ui/layouts/BorderLayout.html[BorderLayout] to produce the most effective results. For example:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava166Snippet.java[tag=the-components-of-codename-one-java-166,indent=0]
+----
 
 ==== MultiList & DefaultListModel
 
@@ -954,6 +1062,10 @@ The full power of the `ListModel` is still available and allows you to create a 
 
 Here is a simple example of a `MultiList` containing a highly popular subject matter:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava167Snippet.java[tag=the-components-of-codename-one-java-167,indent=0]
+----
 
 .Basic usage of the MultiList & DefaultListModel]
 image::img/components-multilist.png[Basic usage of the MultiList and DefaultListModel,scaledwidth=20%]
@@ -985,9 +1097,17 @@ You will fake it a bit but notice that 1M components won't be created even if yo
 
 The https://www.codenameone.com/javadoc/com/codename1/ui/list/ListModel.html[ListModel] interface can be implemented by anyone in this case you did a stupid simple implementation:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava168Snippet.java[tag=the-components-of-codename-one-java-168,indent=0]
+----
 
 You can now replace the existing model by removing all the model related logic and changing the constructor call as such:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava169Snippet.java[tag=the-components-of-codename-one-java-169,indent=0]
+----
 
 .It took ages to scroll this far... This goes to a million...
 image::img/components-millionbooks.png[It took ages to scroll this far... This goes to a million...,scaledwidth=20%]
@@ -997,14 +1117,26 @@ image::img/components-millionbooks.png[It took ages to scroll this far... This g
 
 The Renderer is a simple interface with 2 methods:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava170Snippet.java[tag=the-components-of-codename-one-java-170,indent=0]
+----
 
 The most simple/naive implementation may choose to implement the renderer as follows:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava171Snippet.java[tag=the-components-of-codename-one-java-171,indent=0]
+----
 
 This will compile and work, but won't give you much, notice that you won't see the `List` selection move on the List, this is because the renderer returns a https://www.codenameone.com/javadoc/com/codename1/ui/Label.html[Label] with the same style regardless if it's selected or not.
 
 Now make it a bit more useful:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava172Snippet.java[tag=the-components-of-codename-one-java-172,indent=0]
+----
 
 In this renderer you set the `Label.setFocus(true)` if it's selected, calling to this method doesn't give the focus to the Label, it renders the label as selected.
 
@@ -1014,9 +1146,17 @@ That's still not efficient because you create a new `Label` each time the method
 
 To make the code tighter, keep a reference to the `Component` or extend it as https://www.codenameone.com/javadoc/com/codename1/ui/list/DefaultListCellRenderer.html[DefaultListCellRenderer] does:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava173Snippet.java[tag=the-components-of-codename-one-java-173,indent=0]
+----
 
 Now look at a more advanced Renderer:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava174Snippet.java[tag=the-components-of-codename-one-java-174,indent=0]
+----
 
 In this renderer you want to render a `Contact` object to the Screen, you build the `Component` in the constructor and in the getListCellRendererComponent you update the Labels' texts according to the `Contact` object.
 
@@ -1024,6 +1164,10 @@ Notice that in this renderer you return a focus `Label` with semi transparency, 
 
 For example, you can change the focus `Component` to have an icon:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava175Snippet.java[tag=the-components-of-codename-one-java-175,indent=0]
+----
 
 ==== Generic list cell renderer
 
@@ -1083,13 +1227,25 @@ This can be achieved with a custom renderer, but that's a pretty difficult task.
 
 Normally, to build the model for a renderer of this type, you use something like:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava176Snippet.java[tag=the-components-of-codename-one-java-176,indent=0]
+----
 
 What if you want componentName to be red? Just use:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava177Snippet.java[tag=the-components-of-codename-one-java-177,indent=0]
+----
 
 This will apply the UIID "red" to the component, which you can then style in the theme. Notice that once you start
 doing this, you need to define this entry for all entries, for example:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava178Snippet.java[tag=the-components-of-codename-one-java-178,indent=0]
+----
 
 Otherwise the component will stay red for the next entry (since the renderer acts like a rubber stamp).
 
@@ -1101,6 +1257,10 @@ As you might guess this triggers a performance penalty that's paid with every re
 
 `setRenderingPrototype` accepts a "fake" value that represents a reasonably large amount of data and it will be used to calculate the preferred size. For example: for a multiList that should render 2 lines of text with 20 characters and a 5mm square icon you can do something like this:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava179Snippet.java[tag=the-components-of-codename-one-java-179,indent=0]
+----
 
 ==== ComboBox
 
@@ -1133,6 +1293,10 @@ Since a `ComboBox` is a `List` you can use everything you learned about a `List`
 
 For example: the demo below uses the GRRM demo data from above to build a `ComboBox`:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava180Snippet.java[tag=the-components-of-codename-one-java-180,indent=0]
+----
 
 .GRRM ComboBox
 image::img/components-combobox.png[GRRM ComboBox,scaledwidth=25%]
@@ -1149,6 +1313,10 @@ The interesting part about the slider is that it has two separate style `UIID’
 
 `Slider` is highly customizable for example: a slider can be used to replicate a 5-star rating widget as such. Notice that this slider will work when its given its preferred size otherwise more stars will appear. That's why you place it within a `FlowLayout`:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava181Snippet.java[tag=the-components-of-codename-one-java-181,indent=0]
+----
 
 The slider itself is initialized in the code below. Notice that you can achieve almost the same result using a theme by setting the `Slider` & `SliderFull` UIID's (both in selected & unselected states).
 
@@ -1247,6 +1415,10 @@ Like the `Table` it works in consort with a model to construct its user interfac
 
 The data of the `Tree` arrives from a model for example: this:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava182Snippet.java[tag=the-components-of-codename-one-java-182,indent=0]
+----
 
 Will result in this:
 
@@ -1257,6 +1429,10 @@ NOTE: Since `Tree` is hierarchy based you can't have a simple model like you've 
 
 A more practical "real world" example would be working with XML data. You can use something like this to show an XML `Tree`:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava183Snippet.java[tag=the-components-of-codename-one-java-183,indent=0]
+----
 
 NOTE: The `try(Stream)` syntax is a try with resources clogic that implicitly closes the stream.
 
@@ -1265,6 +1441,10 @@ image::img/components-tree-xml.png[XML Tree,scaledwidth=20%]
 
 The model for the XML hierarchy is implemented as such:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava184Snippet.java[tag=the-components-of-codename-one-java-184,indent=0]
+----
 
 [[sharebutton-section]]
 === ShareButton
@@ -1310,6 +1490,10 @@ include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/g
 
 If you call `Display` directly instead of using `ShareButton`, pass the listener as the final argument to the new overload:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava185Snippet.java[tag=the-components-of-codename-one-java-185,indent=0]
+----
 
 When the share is dispatched through the non-native fallback dialog (platforms without `isNativeShareSupported`), the listener still fires: it reports `DISMISSED` when the user picks the Cancel button, and the underlying `ShareService` implementations report `SHARED_TO` once they call `ShareService.finish()`. Custom `ShareService` subclasses can call `deliverResult(ShareResult.failed("..."))` from inside `share(...)` to publish a failure explicitly; otherwise `finish()` falls back to a default `SHARED_TO(commandName)`.
 
@@ -1467,6 +1651,10 @@ IMPORTANT: The `ImageViewer` is a complex rich component designed for user inter
 
 You can use the `ImageViewer` as a tool to view a single image which allows you to zoom in/out to that image as such:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava187Snippet.java[tag=the-components-of-codename-one-java-187,indent=0]
+----
 
 TIP: You can simulate pinch to zoom on the simulator by dragging the right button away from the top left corner to zoom in and towards the top left corner to zoom out. On Mac touchpads you can drag two fingers to achieve that.
 
@@ -1491,6 +1679,10 @@ Notice that you use a https://www.codenameone.com/javadoc/com/codename1/ui/list/
 
 `ImageViewer` also supports optional side arrows (material font icons) and an optional thumbnail strip for direct image navigation:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava188Snippet.java[tag=the-components-of-codename-one-java-188,indent=0]
+----
 
 When arrows are enabled, tapping near the left/right edge will move to the previous/next image.
 When thumbnails are enabled, tapping a thumbnail jumps directly to that image.
@@ -1505,6 +1697,10 @@ TIP: `EncodedImage's` aren't always fully loaded and so when you swipe if the im
 
 You can dynamically download images directly into the `ImageViewer` with a custom list model like this:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava189Snippet.java[tag=the-components-of-codename-one-java-189,indent=0]
+----
 
 .Dynamically fetching an image URL from the internet footnote:[Image was fetched from http://awoiaf.westeros.org/index.php/Portal:Books]
 image::img/components-imageviewer-dynamic.png[Dynamically fetching an image URL from the internet,scaledwidth=20%]
@@ -1522,6 +1718,10 @@ You can use `ScaleImageLabel`/`ScaleImageButton` interchangeably. The major diff
 
 Here is a simple example that also shows the difference between the `scale to fill` and `scale to fit` modes:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava190Snippet.java[tag=the-components-of-codename-one-java-190,indent=0]
+----
 
 .ScaleImageLabel/Button, the top row includes scale to fit versions (the default) whereas the bottom row includes the scale to fill versions
 image::img/components-scaleimage.png[ScaleImageLabel/Button the top row includes scale to fit versions (the default) whereas the bottom row includes the scale to fill versions,scaledwidth=25%]
@@ -1551,6 +1751,10 @@ The basic functionality of the `Toolbar` includes the ability to add a command t
 
 The code below provides a brief overview of these options:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava191Snippet.java[tag=the-components-of-codename-one-java-191,indent=0]
+----
 
 .The Toolbar
 image::img/components-toolbar.png[The Toolbar,scaledwidth=25%]
@@ -1603,6 +1807,10 @@ You can customize the appearance of the search bar by using the UIID's: `Toolbar
 
 In the sample below you fetch all the contacts from the device and enable search through them, notice it expects and image called `duke.png` which is the default Codename One icon renamed and placed in the src folder:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava192Snippet.java[tag=the-components-of-codename-one-java-192,indent=0]
+----
 
 ==== South Component
 
@@ -1610,6 +1818,10 @@ A common feature in side menu bar is the ability to add a component to the "sout
 
 Notice that this feature works with the on-top and permanent versions of the side menu and not with the legacy versions:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava193Snippet.java[tag=the-components-of-codename-one-java-193,indent=0]
+----
 
 This places the component below the side menu bar. Notice that this component controls its entire UIID & is separate from the `SideNavigationPanel` UIID so if you set that component you might want to place it within a container that has the `SideNavigationPanel` UIID so it will blend with the rest of the UI.
 
@@ -1761,6 +1973,10 @@ Use the `BrowserComponent` API to interact with JavaScript. It replaces the depr
 
 The old API provided a synchronous wrapper around an inherently asynchronous process, and made extensive use of `invokeAndBlock()` underneath the covers. This resulted in a nice API with high-level abstractions that played with a synchronous programming model, but it came with a price-tag in performance, complexity, and predictability. Let’s take a simple example, getting a reference to the "window" object:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava194Snippet.java[tag=the-components-of-codename-one-java-194,indent=0]
+----
 
 This code looks harmless enough, but this is actually expensive. It issues a command to the `BrowserComponent`, and uses `invokeAndBlock()` to wait for the command to go through and send back a response. `invokeAndBlock()` is a magical tool that allows you to "block" without blocking the EDT, but it has its costs, and shouldn’t be overused. Most of the Codename One APIs that use `invokeAndBlock()` show this in their name. For example: `Component.animateLayoutAndWait()`. This provides you the expectation that this call could take some time, and helps to alert you to the underlying cost.
 
@@ -1772,6 +1988,10 @@ The new API fully embraces the asynchronous nature of JavaScript. It uses callba
 
 NOTE: In all the sample code below, you can assume that variables named `bc` represent an instance of https://www.codenameone.com/javadoc/com/codename1/ui/BrowserComponent.html[BrowserComponent]:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava195Snippet.java[tag=the-components-of-codename-one-java-195,indent=0]
+----
 
 This code should output "The result was 7" to the console. It's fully asynchronous, so you can include this code anywhere without worrying about it "bogging down" your code. The full signature of this form of the https://www.codenameone.com/javadoc/com/codename1/ui/BrowserComponent.html#execute(java.lang.String,com.codename1.util.SuccessCallback)[execute()] method is:
 
@@ -1788,6 +2008,10 @@ As mentioned before, the new API also provides an `executeAndWait()` wrapper for
 
 For example:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava196Snippet.java[tag=the-components-of-codename-one-java-196,indent=0]
+----
 
 Prints `The result was 7`.
 
@@ -1797,6 +2021,10 @@ IMPORTANT: When using the `andWait()` variant, it's critical that your JavaScrip
 
 The callbacks you pass to `execute()` and `executeAndWait()` are single-use callbacks. You can’t, for example, store the `callback` variable on the JavaScript side for later use (for example: to respond to a button click event). If you need a "multi-use" callback, you should use the `addJSCallback()` method instead. Its usage looks identical to `execute()`, the difference is that the callback will live on after its first use. For example: Consider the following code:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava197Snippet.java[tag=the-components-of-codename-one-java-197,indent=0]
+----
 
 The above example, assumes that jQuery is loaded in the webpage that you're interacting with, and you're adding a click handler to a button with ID "somebutton." The click handler calls your callback.
 
@@ -1804,6 +2032,10 @@ If you run this example, the first time the button is clicked, you’ll see "But
 
 You need to change this code to use the `addJSCallback()` method as follows:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava198Snippet.java[tag=the-components-of-codename-one-java-198,indent=0]
+----
 
 Now it will work no matter how many times the button is clicked.
 
@@ -1813,6 +2045,10 @@ Often, the JavaScript expressions that you execute will include parameters from 
 
 For example, suppose you want to pass a string with text to set in a textarea within the webpage. You can do something like:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava199Snippet.java[tag=the-components-of-codename-one-java-199,indent=0]
+----
 
 The gist is that you embed placeholders in the JavaScript expression that are replaced by the corresponding entry in an array of parameters. The `${0}` placeholder is replaced by the first item in the parameters array, the `${1}` placeholder is replaced by the 2nd, etc.
 
@@ -1822,18 +2058,38 @@ The new API also includes a https://www.codenameone.com/javadoc/com/codename1/ui
 
 For example: You might want to create a proxy for the https://developer.mozilla.org/en-You/docs/Web/API/Window/location[window.location] object so that you can access its properties more from Java:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava200Snippet.java[tag=the-components-of-codename-one-java-200,indent=0]
+----
 
 Then you can retrieve its properties using the `get()` method:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava201Snippet.java[tag=the-components-of-codename-one-java-201,indent=0]
+----
 
 Or synchronously:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava202Snippet.java[tag=the-components-of-codename-one-java-202,indent=0]
+----
 
 You can also set its properties:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava203Snippet.java[tag=the-components-of-codename-one-java-203,indent=0]
+----
 
 And call its methods:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava204Snippet.java[tag=the-components-of-codename-one-java-204,indent=0]
+----
 
 ===== Legacy JSObject support
 
@@ -1892,15 +2148,27 @@ NOTE: This conversion table is more verbose than necessary, since JavaScript fun
 
 You can access JavaScript variables from the context by using code like this:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava205Snippet.java[tag=the-components-of-codename-one-java-205,indent=0]
+----
 
 .The contents were copied from the DOM and placed in the south position of the form
 image::img/components-browsercomponent-context.png[The contents were copied from the DOM and placed in the south position of the form,scaledwidth=20%]
 
 Notice that when you work with numeric values or anything related to the types mentioned above your code must be aware of the typing. For example: in this case the type is `Double` and not `String`:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava206Snippet.java[tag=the-components-of-codename-one-java-206,indent=0]
+----
 
 You can also query the context for objects and change their value for example:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava207Snippet.java[tag=the-components-of-codename-one-java-207,indent=0]
+----
 
 This code effectively navigates to the Codename One home page by fetching the DOM's window object and setting its `location` property to https://www.codenameone.com/[https://www.codenameone.com/].
 
@@ -1947,6 +2215,10 @@ image::img/components-autocomplete.png[Autocomplete Text Field,scaledwidth=30%]
 
 For example, if you wish to query a database or a web service you will need to derive the class and perform more advanced filtering by overriding the `filter` method:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava208Snippet.java[tag=the-components-of-codename-one-java-208,indent=0]
+----
 
 .Autocomplete Text Field with a webservice
 image::img/dynamic-autocomplete.png[Autocomplete Text Field with a webservice,scaledwidth=20%]
@@ -2037,6 +2309,10 @@ A common use case is to format date values based on a specific appearance and `P
 
 When using lightweight picker mode (`setUseLightweightPopup(true)`), you can add custom quick-action buttons to the popup. This is useful for actions like setting the date to "Today" or "+7 Days" without scrolling the wheels manually:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava209Snippet.java[tag=the-components-of-codename-one-java-209,indent=0]
+----
 
 Button placement options are:
 
@@ -2051,9 +2327,22 @@ that can be exposed by swiping the component to the side.
 
 This swipe gesture is commonly used in touch interfaces to expose features such as delete, edit etc. It's trivial to use this component by determining the components placed on top and bottom (the revealed component):
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava210Snippet.java[tag=the-components-of-codename-one-java-210,indent=0]
+----
 
 You can combine some demos above including the <<slider-stars-demo,Slider stars demo>> to rank GRRM's books in an interactive way:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava211Snippet.java[tag=the-components-of-codename-one-java-211,indent=0]
+----
+
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava211Snippet.java[tag=the-components-of-codename-one-java-211-helper,indent=0]
+----
 
 .SwipableContainer showing a common use case of ranking on swipe
 image::img/components-swipablecontainer.png[SwipableContainer showing a common use case of ranking on swipe,scaledwidth=20%]
@@ -2087,6 +2376,10 @@ image::img/mapcomponent.png[Map Component,scaledwidth=30%]
 
 The screenshot above was produced using the following code:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava212Snippet.java[tag=the-components-of-codename-one-java-212,indent=0]
+----
 
 The example below shows how to integrate the https://www.codenameone.com/javadoc/com/codename1/maps/MapComponent.html[MapComponent] with the Google https://www.codenameone.com/javadoc/com/codename1/location/Location.html[Location] API.
 Make sure to get your secret API key from the Google https://www.codenameone.com/javadoc/com/codename1/location/Location.html[Location] data API at:
@@ -2181,6 +2474,10 @@ For example: the colors, fonts, styles, to use.
 You can check out the https://github.com/codenameone/codenameone-demos/tree/master/ChartsDemo[ChartsDemo]
 app for specific examples, but here is a high-level view of some code that creates a Pie Chart:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava213Snippet.java[tag=the-components-of-codename-one-java-213,indent=0]
+----
 
 === Calendar
 
@@ -2190,6 +2487,10 @@ NOTE: You recommend developers use the <<picker-section,Picker UI>> rather than 
 
 Simple usage of the `Calendar` class looks something like this:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava214Snippet.java[tag=the-components-of-codename-one-java-214,indent=0]
+----
 
 .The Calendar component
 image::img/components-calendar.png[The Calendar component,scaledwidth=20%]
@@ -2200,21 +2501,37 @@ The https://www.codenameone.com/javadoc/com/codename1/components/ToastBar.html[T
 
 Simple usage of the `ToastBar` class looks something like this:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava215Snippet.java[tag=the-components-of-codename-one-java-215,indent=0]
+----
 
 .ToastBar with message
 image::img/components-statusbar-message.png[ToastBar with message,scaledwidth=20%]
 
 You can show a progress indicator in the ToastBar like this:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava216Snippet.java[tag=the-components-of-codename-one-java-216,indent=0]
+----
 
 .Status Message with Progress Bar
 image::img/components-statusbar.png[Status Message with Progress Bar,scaledwidth=20%]
 
 You can automatically clear a status message/progress after a timeout using the `setExpires` method as such:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava217Snippet.java[tag=the-components-of-codename-one-java-217,indent=0]
+----
 
 You can also delay the showing of the status message using `showDelayed` as such:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava218Snippet.java[tag=the-components-of-codename-one-java-218,indent=0]
+----
 
 .ToastBar with a multiline message
 image::img/components-statusbar-multiline.png[ToastBar with a multiline message,scaledwidth=20%]
@@ -2319,6 +2636,10 @@ image::img/badge-floating-button.png[Badge floating button in action,scaledwidth
 
 The split pane component is a bit desktop specific but works reasonably well on devices. To get the image below you changed `SalesDemo.java` in the kitchen sink by changing this:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava219Snippet.java[tag=the-components-of-codename-one-java-219,indent=0]
+----
 
 To:
 

--- a/docs/developer-guide/The-Components-Of-Codename-One.asciidoc
+++ b/docs/developer-guide/The-Components-Of-Codename-One.asciidoc
@@ -288,6 +288,11 @@ You will need to define the following theme constants for the arrow to work:
 include::../demos/common/src/main/snippets/developer-guide/the-components-of-codename-one.properties[tag=the-components-of-codename-one-properties-001,indent=0]
 ----
 
+Each of the four image constants names an image in your theme resource, so add
+your own arrows under those names -- the values here are placeholders and there
+are no arrows built in. A constant naming an image the theme doesn't hold leaves
+the border with nothing to paint.
+
 Then style the `PopupDialog` UIID with the image for the `Dialog` itself.
 
 === InteractionDialog

--- a/docs/developer-guide/The-Components-Of-Codename-One.asciidoc
+++ b/docs/developer-guide/The-Components-Of-Codename-One.asciidoc
@@ -1812,6 +1812,14 @@ In the sample below you fetch all the contacts from the device and enable search
 include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava192Snippet.java[tag=the-components-of-codename-one-java-192,indent=0]
 ----
 
+The filter itself, shared by the search command and the load callback so a query
+typed while the contacts are still arriving is reapplied once they do:
+
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava192Snippet.java[tag=the-components-of-codename-one-java-192-filter,indent=0]
+----
+
 ==== South Component
 
 A common feature in side menu bar is the ability to add a component to the "south" part of the side menu.

--- a/scripts/developer-guide/check-guide-xrefs.py
+++ b/scripts/developer-guide/check-guide-xrefs.py
@@ -197,9 +197,11 @@ def main() -> int:
     anchor_total = 0
 
     for name, attributes in BACKENDS:
-        rendered = render(root, attributes)
-        ids = set(ID_RE.findall(rendered))
-        markup = without_listings(rendered)
+        # Strip listings before anything is collected. Ids are read from the same
+        # stripped markup as the links: a sample containing id="x" would otherwise
+        # register x as a real anchor and let a dangling <<x>> through.
+        markup = without_listings(render(root, attributes))
+        ids = set(ID_RE.findall(markup))
         anchor_total = max(anchor_total, len(ids))
         for target in HREF_RE.findall(markup):
             if target not in ids:

--- a/scripts/developer-guide/check-guide-xrefs.py
+++ b/scripts/developer-guide/check-guide-xrefs.py
@@ -58,6 +58,19 @@ ANCHOR_SOURCE_RE = re.compile(r"<<([^>,]+)")
 # legitimately test either, so the surrogate defines both. Missing the second one
 # meant ifdef::basebackend-pdf[] content vanished from the render that was meant
 # to be inspecting it.
+
+# A rendered listing is markup, not links. Rouge wraps each token in a span, so a
+# Java string literal such as "location.href=" reaches the HTML as text that ends
+# in `href="`, and scanning the whole page for hrefs then reports the rest of the
+# highlighted line as a relative URL. Strip listings before looking for links --
+# nothing inside one is a cross-reference, and no anchor id is emitted there.
+LISTING_RE = re.compile(r"<pre\b[^>]*>.*?</pre>", re.S)
+
+
+def without_listings(markup: str) -> str:
+    return LISTING_RE.sub("", markup)
+
+
 BACKENDS = (("html", ()), ("pdf", ("backend-pdf", "basebackend-pdf")))
 # The surrogate has one blind spot, and it cannot be closed from the command line.
 # Setting backend-pdf makes `ifndef::backend-pdf[]` content disappear and
@@ -184,8 +197,9 @@ def main() -> int:
     anchor_total = 0
 
     for name, attributes in BACKENDS:
-        markup = render(root, attributes)
-        ids = set(ID_RE.findall(markup))
+        rendered = render(root, attributes)
+        ids = set(ID_RE.findall(rendered))
+        markup = without_listings(rendered)
         anchor_total = max(anchor_total, len(ids))
         for target in HREF_RE.findall(markup):
             if target not in ids:

--- a/scripts/developer-guide/missing-code-blocks-baseline.txt
+++ b/scripts/developer-guide/missing-code-blocks-baseline.txt
@@ -159,85 +159,9 @@ Notifications-And-Background-Execution.asciidoc	before; the bean has been extend
 Notifications-And-Background-Execution.asciidoc	then reference it from a notification with `setChannelId(...)`:
 Printing.asciidoc	`Printer.printImage(image, listener)` prints a `com.codename1.ui.Image` directly. The image is encoded to a temporary PNG file behind the scenes and the file is deleted once the print flow finishes:
 SVG-Transcoder.asciidoc	the generated class directly:
-The-Components-Of-Codename-One.asciidoc	A common source of confusion in the `MultiButton` is the difference between the icon and the emblem, since both may have an icon image associated with them. The icon is an image representing the entry while the emblem is an optional visual representation of the action that will be undertaken when the element is pressed. Both may be used simultaneously or individually of one another:
-The-Components-Of-Codename-One.asciidoc	A form is a container with a title, a content area, and an optional menu or menu-bar area. When you call methods such as `add` or `remove` on a form, you're invoking something that maps to this:
-The-Components-Of-Codename-One.asciidoc	A more practical "real world" example would be working with XML data. You can use something like this to show an XML `Tree`:
-The-Components-Of-Codename-One.asciidoc	A picker can work with your existing sample using code like this:
-The-Components-Of-Codename-One.asciidoc	A popup dialog is a common mobile paradigm showing a `Dialog` that points at a specific component. It's a standard `Dialog` that's shown in a unique way:
-The-Components-Of-Codename-One.asciidoc	And call its methods:
 The-Components-Of-Codename-One.asciidoc	Call the builder from a Maven plugin, an Ant task or a one-shot `main`:
-The-Components-Of-Codename-One.asciidoc	For example, if you wish to query a database or a web service you will need to derive the class and perform more advanced filtering by overriding the `filter` method:
-The-Components-Of-Codename-One.asciidoc	For example, suppose you want to pass a string with text to set in a textarea within the webpage. You can do something like:
-The-Components-Of-Codename-One.asciidoc	For example, this behavior might not be desired so to block that you can do:
-The-Components-Of-Codename-One.asciidoc	For example, to enclose the `CheckBox` components in a vertical `ComponentGroup` and the `RadioButton's` in a horizontal group, change the last line of the code above as such:
-The-Components-Of-Codename-One.asciidoc	For example, you can change the focus `Component` to have an icon:
-The-Components-Of-Codename-One.asciidoc	For example:
-The-Components-Of-Codename-One.asciidoc	For example: You might want to create a proxy for the https://developer.mozilla.org/en-You/docs/Web/API/Window/location[window.location] object so that you can access its properties more from Java:
-The-Components-Of-Codename-One.asciidoc	For example: the demo below uses the GRRM demo data from above to build a `ComboBox`:
-The-Components-Of-Codename-One.asciidoc	Here is a simple example of a `MultiList` containing a highly popular subject matter:
-The-Components-Of-Codename-One.asciidoc	Here is a simple example that also shows the difference between the `scale to fill` and `scale to fit` modes:
-The-Components-Of-Codename-One.asciidoc	If you add to the sample above a `Validator`:
-The-Components-Of-Codename-One.asciidoc	If you call `Display` directly instead of using `ShareButton`, pass the listener as the final argument to the new overload:
-The-Components-Of-Codename-One.asciidoc	In the sample below you fetch all the contacts from the device and enable search through them, notice it expects and image called `duke.png` which is the default Codename One icon renamed and placed in the src folder:
-The-Components-Of-Codename-One.asciidoc	It's also recommended to place the list in the `CENTER` location of a https://www.codenameone.com/javadoc/com/codename1/ui/layouts/BorderLayout.html[BorderLayout] to produce the most effective results. For example:
 The-Components-Of-Codename-One.asciidoc	Let start by exploring how you can achieve this UI that fetches data from a webservice:
-The-Components-Of-Codename-One.asciidoc	Masking allows you to accept partial input in one field and implicitly move to the next, this can be used to all types of complex input thanks to the text component API. E.g with the code above you can mask the credit card input so the cursor jumps to the next field implicitly using this code:
-The-Components-Of-Codename-One.asciidoc	NOTE: In all the sample code below, you can assume that variables named `bc` represent an instance of https://www.codenameone.com/javadoc/com/codename1/ui/BrowserComponent.html[BrowserComponent]:
-The-Components-Of-Codename-One.asciidoc	Normally, to build the model for a renderer of this type, you use something like:
-The-Components-Of-Codename-One.asciidoc	Notice in the sample below that you associate all the radio buttons with a group but don't do anything with the group as the radio buttons keep the reference internally. You also show the opposite side functionality and icon behavior:
-The-Components-Of-Codename-One.asciidoc	Notice that this feature works with the on-top and permanent versions of the side menu and not with the legacy versions:
-The-Components-Of-Codename-One.asciidoc	Notice that when you work with numeric values or anything related to the types mentioned above your code must be aware of the typing. For example: in this case the type is `Double` and not `String`:
-The-Components-Of-Codename-One.asciidoc	Now look at a more advanced Renderer:
-The-Components-Of-Codename-One.asciidoc	Now make it a bit more useful:
-The-Components-Of-Codename-One.asciidoc	Now that you have a webservice lets proceed to create the UI. Check out the code annotations below:
-The-Components-Of-Codename-One.asciidoc	One of the features of label that moved into `SpanLabel` to some extent is the ability to position the icon. For example, unlike a `Label` the icon position is determined by the layout manager of the composite so `setIconPosition` accepts a `BorderLayout` constraint:
-The-Components-Of-Codename-One.asciidoc	Or synchronously:
-The-Components-Of-Codename-One.asciidoc	Simple usage of the `Calendar` class looks something like this:
-The-Components-Of-Codename-One.asciidoc	Simple usage of the `ToastBar` class looks something like this:
-The-Components-Of-Codename-One.asciidoc	The Renderer is a simple interface with 2 methods:
-The-Components-Of-Codename-One.asciidoc	The callbacks you pass to `execute()` and `executeAndWait()` are single-use callbacks. You can’t, for example, store the `callback` variable on the JavaScript side for later use (for example: to respond to a button click event). If you need a "multi-use" callback, you should use the `addJSCallback()` method instead. Its usage looks identical to `execute()`, the difference is that the callback will live on after its first use. For example: Consider the following code:
-The-Components-Of-Codename-One.asciidoc	The code below provides a brief overview of these options:
-The-Components-Of-Codename-One.asciidoc	The data of the `Tree` arrives from a model for example: this:
-The-Components-Of-Codename-One.asciidoc	The first step is creating the webservice call, you won't go into too much detail here as webservices & IO are discussed later in the guide:
-The-Components-Of-Codename-One.asciidoc	The https://www.codenameone.com/javadoc/com/codename1/ui/list/ListModel.html[ListModel] interface can be implemented by anyone in this case you did a stupid simple implementation:
-The-Components-Of-Codename-One.asciidoc	The model for the XML hierarchy is implemented as such:
-The-Components-Of-Codename-One.asciidoc	The most simple/naive implementation may choose to implement the renderer as follows:
-The-Components-Of-Codename-One.asciidoc	The old API provided a synchronous wrapper around an inherently asynchronous process, and made extensive use of `invokeAndBlock()` underneath the covers. This resulted in a nice API with high-level abstractions that played with a synchronous programming model, but it came with a price-tag in performance, complexity, and predictability. Let’s take a simple example, getting a reference to the "window" object:
-The-Components-Of-Codename-One.asciidoc	The screenshot above was produced using the following code:
-The-Components-Of-Codename-One.asciidoc	The split pane component is a bit desktop specific but works reasonably well on devices. To get the image below you changed `SalesDemo.java` in the kitchen sink by changing this:
-The-Components-Of-Codename-One.asciidoc	Then implement the method `automoveToNext` as:
-The-Components-Of-Codename-One.asciidoc	Then you can retrieve its properties using the `get()` method:
 The-Components-Of-Codename-One.asciidoc	This code should output "The result was 7" to the console. It's fully asynchronous, so you can include this code anywhere without worrying about it "bogging down" your code. The full signature of this form of the https://www.codenameone.com/javadoc/com/codename1/ui/BrowserComponent.html#execute(java.lang.String,com.codename1.util.SuccessCallback)[execute()] method is:
-The-Components-Of-Codename-One.asciidoc	This sample below continues from the place where the <<text-component-sample-code,TextField sample above>> stopped by adding validation to that code:
-The-Components-Of-Codename-One.asciidoc	This swipe gesture is commonly used in touch interfaces to expose features such as delete, edit etc. It's trivial to use this component by determining the components placed on top and bottom (the revealed component):
-The-Components-Of-Codename-One.asciidoc	To make the code tighter, keep a reference to the `Component` or extend it as https://www.codenameone.com/javadoc/com/codename1/ui/list/DefaultListCellRenderer.html[DefaultListCellRenderer] does:
-The-Components-Of-Codename-One.asciidoc	Unlike the `InfiniteScrollAdapter` you can't use the `ContentPane` directly so you've to use a `BorderLayout` and place the `InfiniteContainer` there:
-The-Components-Of-Codename-One.asciidoc	Unlike the `MultiButton` it uses the `TextArea` internally to break lines seamlessly. The `SpanButton` is far simpler than the `MultiButton` and as a result isn't as configurable:
-The-Components-Of-Codename-One.asciidoc	What if you want componentName to be red? Just use:
-The-Components-Of-Codename-One.asciidoc	When using lightweight picker mode (`setUseLightweightPopup(true)`), you can add custom quick-action buttons to the popup. This is useful for actions like setting the date to "Today" or "+7 Days" without scrolling the wheels manually:
-The-Components-Of-Codename-One.asciidoc	With this:
-The-Components-Of-Codename-One.asciidoc	You can access JavaScript variables from the context by using code like this:
-The-Components-Of-Codename-One.asciidoc	You can also delay the showing of the status message using `showDelayed` as such:
-The-Components-Of-Codename-One.asciidoc	You can also query the context for objects and change their value for example:
-The-Components-Of-Codename-One.asciidoc	You can also set its properties:
-The-Components-Of-Codename-One.asciidoc	You can automatically clear a status message/progress after a timeout using the `setExpires` method as such:
-The-Components-Of-Codename-One.asciidoc	You can combine some demos above including the <<slider-stars-demo,Slider stars demo>> to rank GRRM's books in an interactive way:
-The-Components-Of-Codename-One.asciidoc	You can convert the sample above to use toggle buttons as such:
-The-Components-Of-Codename-One.asciidoc	You can dynamically download images directly into the `ImageViewer` with a custom list model like this:
-The-Components-Of-Codename-One.asciidoc	You can now replace the existing model by removing all the model related logic and changing the constructor call as such:
-The-Components-Of-Codename-One.asciidoc	You can show a progress indicator in the ToastBar like this:
-The-Components-Of-Codename-One.asciidoc	You can use the `ImageViewer` as a tool to view a single image which allows you to zoom in/out to that image as such:
-The-Components-Of-Codename-One.asciidoc	You can wrap a `TextField` with a clearable wrapper to get this effect on all platforms. For example: replace this:
-The-Components-Of-Codename-One.asciidoc	You need to change this code to use the `addJSCallback()` method as follows:
-The-Components-Of-Codename-One.asciidoc	You will need to define the following theme constants for the arrow to work:
-The-Components-Of-Codename-One.asciidoc	`ImageViewer` also supports optional side arrows (material font icons) and an optional thumbnail strip for direct image navigation:
-The-Components-Of-Codename-One.asciidoc	`InfiniteProgress` can be used in one of two ways either by embedding the component into the UI through something like this:
-The-Components-Of-Codename-One.asciidoc	`Label` text can be positioned in one of 4 locations as such:
-The-Components-Of-Codename-One.asciidoc	`Slider` is highly customizable for example: a slider can be used to replicate a 5-star rating widget as such. Notice that this slider will work when its given its preferred size otherwise more stars will appear. That's why you place it within a `FlowLayout`:
-The-Components-Of-Codename-One.asciidoc	`setRenderingPrototype` accepts a "fake" value that represents a reasonably large amount of data and it will be used to calculate the preferred size. For example: for a multiList that should render 2 lines of text with 20 characters and a 5mm square icon you can do something like this:
-The-Components-Of-Codename-One.asciidoc	app for specific examples, but here is a high-level view of some code that creates a Pie Chart:
-The-Components-Of-Codename-One.asciidoc	doing this, you need to define this entry for all entries, for example:
-The-Components-Of-Codename-One.asciidoc	or a go icon using a hint such as this:
 The-EDT---Event-Dispatch-Thread.asciidoc	A simplistic approach is to do something like this:
 The-EDT---Event-Dispatch-Thread.asciidoc	For example, instead of using operation names lets use a more "real world" example:
 The-EDT---Event-Dispatch-Thread.asciidoc	However, `updateUIWithContentOfFile` should be executed on the EDT and not on a random thread. The right way to do this would therefore be something like this:


### PR DESCRIPTION
The Components chapter went from 140 Java listings to 58 in `bbdc6058f0`
("Extract developer guide snippets into demos"), the second-worst loss in the
guide after `io`. This restores 76 of the 79 holes, plus one block that was never
Java to begin with.

Each hole is matched to its original by the text of the introducing sentence, so
the mapping survives every edit the chapter has had since.

**Compiling the recovered code is what makes the restoration worth anything.**
These samples call APIs that do not exist:

* `Image.create(int, int)` -- the factory is `createImage`
* a static `fill(Image, int, int)`, where `fill` is an instance method on `Image`
* `JavascriptContext.get()` assigned straight to a `JSObject`, when it returns
  `Object`
* the custom `ListCellRenderer` example implements only one of the interface s two
  methods, so a reader copying it could not compile it -- and its class body
  carried one brace too many

The popup-dialog arrow constants were tagged `[source,java]` but are a properties
listing. They go into the chapter s snippets file under a `properties` block
rather than being forced into a Java class.

**Three holes are deliberately left.** Two never matched a pre-extraction
sentence. The third documents `IOSShareExtensionBuilder`, which lives in the Maven
plugin rather than the framework, so it cannot compile in the app-code module the
snippets build from.

I also applied the lesson from the `io` branch and checked for duplicate
insertions -- a sentence separated from an existing include by two blank lines
reads as a hole to the detector. Scanning for adjacent includes with no prose
between them finds only the deliberate two-part split in this chapter.

**`check-guide-xrefs.py` is fixed here too.** It scanned the whole rendered page
for `href` attributes, and two of these samples print `location.href`, so the Java
string literal reached the HTML as text ending in `href="` and the rest of the
highlighted line looked like a relative URL. Listings are stripped before the link
scan now -- nothing inside one is a cross-reference, and no anchor id is emitted
there. Verified still non-vacuous by planting a dangling xref, which it reports.

The missing-code-blocks ratchet drops from 407 to 331, with nothing added. All 136
of the chapter s snippets compile against core on JDK 17, and a `-bootclasspath`
probe against the `java-runtime` jar the compliance mojo uses confirms every API
they touch exists in the Codename One runtime.

Gates run locally: structure, xrefs, links, missing-code-blocks, snippets, unused
images (with CI s three `--allow-unused` flags), paragraph capitalization, control
characters, copyright headers over the branch range, Vale at suggestion level, and
LanguageTool over the whole assembled book -- all clean.