### PR TITLE
Contact picker: let an app take one user-chosen contact without asking for the address book (#5666)

### DIFF
--- a/CodenameOne/src/com/codename1/contacts/ContactPicker.java
+++ b/CodenameOne/src/com/codename1/contacts/ContactPicker.java
@@ -128,6 +128,12 @@ public class ContactPicker {
 
     /// Requests the contact's birthday, which populates
     /// `Contact#getBirthday()`.
+    ///
+    /// The one field a picker cannot filter on exactly. Android groups
+    /// birthdays with anniversaries and custom dates, so
+    /// `#setRequireAllRequestedFields(boolean)` may still offer a contact
+    /// that turns out to have an anniversary and no birthday; the contact
+    /// comes back with a zero birthday rather than being withheld.
     public static final int BIRTHDAY = 32;
 
     /// Requests the contact's web sites, which populates
@@ -153,12 +159,22 @@ public class ContactPicker {
 
     private boolean requireAllRequestedFields;
 
-    /// Returns true when the platform can show a contact picker.
+    /// Returns true when the platform provides a contact picker.
+    ///
+    /// It answers for the platform rather than for the device. Android says
+    /// yes wherever the application is running normally, because deciding
+    /// otherwise would mean asking the package manager what handles the
+    /// picker intent, and from Android 11 that question is filtered by
+    /// package visibility -- it would report no picker on ordinary devices
+    /// where the picker works. A device that really has no contacts
+    /// application reports an empty selection from `#pick(ActionListener)`,
+    /// which is what a cancelled pick reports, so a listener that checks the
+    /// selection handles it already.
     ///
     /// #### Returns
     ///
-    /// true if `#pick(ActionListener)` will show a picker, false if it will
-    /// report an empty selection without showing anything
+    /// true if the platform has a picker, false if `#pick(ActionListener)`
+    /// will report an empty selection without showing anything
     public static boolean isSupported() {
         return Display.getInstance().isContactPickerSupported();
     }

--- a/CodenameOne/src/com/codename1/contacts/ContactPicker.java
+++ b/CodenameOne/src/com/codename1/contacts/ContactPicker.java
@@ -260,6 +260,15 @@ public class ContactPicker {
     /// Sets the largest number of contacts the user may pick, which only has
     /// an effect together with `#setMultiSelect(boolean)`.
     ///
+    /// The selection handed to the listener never exceeds it. Whether the
+    /// user is stopped at the cap or merely has the surplus dropped depends
+    /// on the platform: Android and the simulator stop accepting the tick
+    /// that would exceed it, and so does iOS for a limit of one, which it
+    /// serves with its single-select picker. iOS cannot cap a larger multiple
+    /// selection -- its picker has no such setting -- so a user who confirms
+    /// more than the cap has the extras dropped, keeping the ones they chose
+    /// first.
+    ///
     /// #### Parameters
     ///
     /// - `selectionLimit`: a count between 1 and

--- a/CodenameOne/src/com/codename1/contacts/ContactPicker.java
+++ b/CodenameOne/src/com/codename1/contacts/ContactPicker.java
@@ -74,6 +74,15 @@ import com.codename1.ui.events.ActionListener;
 /// Anything that has to outlive the callback must be copied out of the
 /// `Contact` and stored by the application.
 ///
+/// One getter does not follow the rule that an unrequested field stays null,
+/// and cannot be made to. `Contact#getDisplayName()` never returns null: on a
+/// contact carrying no name it makes one up from the primary phone number,
+/// the primary email or the id, and caches it. That is how every `Contact` in
+/// the framework behaves, not only a picked one, so a picker that suppressed
+/// it would be the odd one out rather than the correct one. Ask
+/// `Contact#getFirstName()` and `Contact#getFamilyName()` when what you need
+/// to know is whether a name was actually supplied.
+///
 /// For the same reason `Contact#getId()` on a picked contact is only an
 /// opaque platform identifier useful for telling two picked contacts apart.
 /// Passing it to `ContactsManager#getContactById(String)` needs full

--- a/CodenameOne/src/com/codename1/contacts/ContactPicker.java
+++ b/CodenameOne/src/com/codename1/contacts/ContactPicker.java
@@ -79,6 +79,24 @@ import com.codename1.ui.events.ActionListener;
 /// Passing it to `ContactsManager#getContactById(String)` needs full
 /// address-book access, which is the thing this class exists to avoid.
 ///
+/// #### What a platform can actually deliver
+///
+/// A picker returns what its platform is able to hand over without the broad
+/// permission, and that is not the same everywhere. Read every field you
+/// asked for defensively: a null one means the user's contact did not carry
+/// it, or the platform could not supply it.
+///
+/// Android 17 and later, iOS and the simulator serve every field on this
+/// class. Android before 17 has no contact picker of its own, so the fallback
+/// is the contacts app's own single-row picker: it returns one contact
+/// carrying one kind of data, `#NAME` plus whichever of `#PHONE`, `#EMAIL`
+/// and `#ADDRESS` was requested first. `#PHOTO`, `#BIRTHDAY` and `#WEBSITE`
+/// are best-effort there -- they are read through the granted contact's own
+/// data rows, which some devices allow and some refuse -- and
+/// `#setMultiSelect(boolean)` and `#setRequireAllRequestedFields(boolean)`
+/// have no effect. None of that ever escalates into a permission prompt;
+/// the fields simply come back null.
+///
 /// #### Availability
 ///
 /// `#isSupported()` reports whether the platform has a picker at all. Where it

--- a/CodenameOne/src/com/codename1/contacts/ContactPicker.java
+++ b/CodenameOne/src/com/codename1/contacts/ContactPicker.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Codename One in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.contacts;
+
+import com.codename1.ui.Display;
+import com.codename1.ui.events.ActionEvent;
+import com.codename1.ui.events.ActionListener;
+
+/// Lets the user hand the application a small number of contacts they chose
+/// themselves, without the application gaining access to the address book.
+///
+/// This is the privacy-minimized counterpart to `ContactsManager`. Where
+/// `ContactsManager` enumerates the whole address book -- and therefore needs
+/// the broad contacts permission -- this class shows the platform's own
+/// contact picker. The user selects, the platform copies just the fields that
+/// were asked for out of just the contacts that were selected, and the
+/// application never gets to see anything else.
+///
+/// Prefer it whenever the application needs "a phone number the user picked"
+/// rather than "the address book". Google Play requires exactly that
+/// distinction: from 2027-01-27, an app targeting Android 17 (API level 37) or
+/// later that carries `READ_CONTACTS` without core-functionality
+/// justification has to pass a Play Console declaration, and an app that only
+/// ever calls this class never asks for that permission in the first place.
+///
+/// #### Requesting fields
+///
+/// The requested fields are a bit set of the constants on this class. Only
+/// those fields are populated on the returned contacts; everything else is
+/// left null or zero. Asking for less is not merely polite -- on Android the
+/// request also decides which contacts the picker offers, and the platform
+/// refuses to return anything that was not asked for.
+///
+/// ```java
+/// ContactPicker picker = new ContactPicker();
+/// picker.setRequestedFields(ContactPicker.NAME | ContactPicker.PHONE);
+/// picker.pick(new ActionListener<ActionEvent>() {
+///     public void actionPerformed(ActionEvent ev) {
+///         Contact[] picked = ContactPicker.getPickedContacts(ev);
+///         if(picked.length == 0) {
+///             // the user backed out
+///             return;
+///         }
+///         numberField.setText(picked[0].getPrimaryPhoneNumber());
+///     }
+/// });
+/// ```
+///
+/// #### The result is a snapshot
+///
+/// The contacts handed to the callback are plain copies. The application has
+/// no continuing access to them: it cannot re-read them later, and on Android
+/// the temporary grant behind them is gone by the time the callback returns.
+/// Anything that has to outlive the callback must be copied out of the
+/// `Contact` and stored by the application.
+///
+/// For the same reason `Contact#getId()` on a picked contact is only an
+/// opaque platform identifier useful for telling two picked contacts apart.
+/// Passing it to `ContactsManager#getContactById(String)` needs full
+/// address-book access, which is the thing this class exists to avoid.
+///
+/// #### Availability
+///
+/// `#isSupported()` reports whether the platform has a picker at all. Where it
+/// does not, `#pick(ActionListener)` reports an empty selection rather than
+/// quietly falling back to reading the address book, because that fallback
+/// would need the permission the caller was trying not to ask for.
+///
+/// @author Shai Almog
+public class ContactPicker {
+
+    /// Requests the contact's name, which populates `Contact#getFirstName()`,
+    /// `Contact#getFamilyName()` and `Contact#getDisplayName()`.
+    public static final int NAME = 1;
+
+    /// Requests the contact's phone numbers, which populates
+    /// `Contact#getPhoneNumbers()` and `Contact#getPrimaryPhoneNumber()`.
+    public static final int PHONE = 2;
+
+    /// Requests the contact's email addresses, which populates
+    /// `Contact#getEmails()` and `Contact#getPrimaryEmail()`.
+    public static final int EMAIL = 4;
+
+    /// Requests the contact's postal addresses, which populates
+    /// `Contact#getAddresses()`.
+    public static final int ADDRESS = 8;
+
+    /// Requests the contact's photo, which populates `Contact#getPhoto()`.
+    public static final int PHOTO = 16;
+
+    /// Requests the contact's birthday, which populates
+    /// `Contact#getBirthday()`.
+    public static final int BIRTHDAY = 32;
+
+    /// Requests the contact's web sites, which populates
+    /// `Contact#getUrls()`.
+    public static final int WEBSITE = 64;
+
+    /// Every field a picker can be asked for. Convenient for a one-off
+    /// "import this person" flow, and the wrong choice for anything else:
+    /// asking for a field the application will not read hands it data it did
+    /// not need, which is what the picker exists to prevent.
+    public static final int ALL_FIELDS =
+            NAME | PHONE | EMAIL | ADDRESS | PHOTO | BIRTHDAY | WEBSITE;
+
+    /// The largest value `#setSelectionLimit(int)` accepts. Android rejects a
+    /// larger request outright.
+    public static final int MAXIMUM_SELECTION_LIMIT = 100;
+
+    private int requestedFields = NAME | PHONE;
+
+    private boolean multiSelect;
+
+    private int selectionLimit = MAXIMUM_SELECTION_LIMIT;
+
+    private boolean requireAllRequestedFields;
+
+    /// Returns true when the platform can show a contact picker.
+    ///
+    /// #### Returns
+    ///
+    /// true if `#pick(ActionListener)` will show a picker, false if it will
+    /// report an empty selection without showing anything
+    public static boolean isSupported() {
+        return Display.getInstance().isContactPickerSupported();
+    }
+
+    /// Extracts the selection from the event delivered to
+    /// `#pick(ActionListener)`.
+    ///
+    /// #### Parameters
+    ///
+    /// - `ev`: the event handed to the listener, which may be null
+    ///
+    /// #### Returns
+    ///
+    /// the contacts the user picked, in the order the platform reported them,
+    /// or a zero length array when the user cancelled or the platform has no
+    /// picker. Never null.
+    public static Contact[] getPickedContacts(ActionEvent ev) {
+        if (ev == null) {
+            return new Contact[0];
+        }
+        Object source = ev.getSource();
+        if (source instanceof Contact[]) {
+            return (Contact[]) source;
+        }
+        return new Contact[0];
+    }
+
+    /// The fields the picker is asked for, as a bit set of the constants on
+    /// this class.
+    ///
+    /// #### Returns
+    ///
+    /// the requested fields, `NAME | PHONE` unless it was changed
+    public int getRequestedFields() {
+        return requestedFields;
+    }
+
+    /// Sets the fields the picker is asked for.
+    ///
+    /// #### Parameters
+    ///
+    /// - `requestedFields`: a bit set of the constants on this class, which
+    /// must name at least one field
+    public void setRequestedFields(int requestedFields) {
+        if ((requestedFields & ALL_FIELDS) == 0) {
+            throw new IllegalArgumentException(
+                    "A contact picker must request at least one field");
+        }
+        this.requestedFields = requestedFields & ALL_FIELDS;
+    }
+
+    /// Whether the user may pick more than one contact.
+    ///
+    /// #### Returns
+    ///
+    /// true if the picker allows a multiple selection, false by default
+    public boolean isMultiSelect() {
+        return multiSelect;
+    }
+
+    /// Sets whether the user may pick more than one contact.
+    ///
+    /// A platform whose picker is single-select ignores this and returns at
+    /// most one contact, so the callback must cope with a shorter selection
+    /// than it allowed for. Android before version 17 is such a platform.
+    ///
+    /// #### Parameters
+    ///
+    /// - `multiSelect`: true to allow a multiple selection
+    public void setMultiSelect(boolean multiSelect) {
+        this.multiSelect = multiSelect;
+    }
+
+    /// The largest number of contacts the user may pick.
+    ///
+    /// #### Returns
+    ///
+    /// the selection limit, `MAXIMUM_SELECTION_LIMIT` unless it was changed
+    public int getSelectionLimit() {
+        return selectionLimit;
+    }
+
+    /// Sets the largest number of contacts the user may pick, which only has
+    /// an effect together with `#setMultiSelect(boolean)`.
+    ///
+    /// #### Parameters
+    ///
+    /// - `selectionLimit`: a count between 1 and
+    /// `MAXIMUM_SELECTION_LIMIT` inclusive
+    public void setSelectionLimit(int selectionLimit) {
+        if (selectionLimit < 1 || selectionLimit > MAXIMUM_SELECTION_LIMIT) {
+            throw new IllegalArgumentException(
+                    "Selection limit must be between 1 and "
+                            + MAXIMUM_SELECTION_LIMIT + ", got "
+                            + selectionLimit);
+        }
+        this.selectionLimit = selectionLimit;
+    }
+
+    /// Whether a contact has to carry every requested field to be offered.
+    ///
+    /// #### Returns
+    ///
+    /// true to offer only contacts holding all of the requested fields, false
+    /// by default, which offers a contact holding any of them
+    public boolean isRequireAllRequestedFields() {
+        return requireAllRequestedFields;
+    }
+
+    /// Sets whether a contact has to carry every requested field to be
+    /// offered by the picker.
+    ///
+    /// Use it when a partial contact is useless to the application, for
+    /// instance an invitation flow that needs both a name and an email
+    /// address. Leave it off when any one of the requested fields will do.
+    ///
+    /// A platform applies it as far as its own picker can. Android enforces
+    /// it exactly; iOS enforces it over phone numbers, email addresses and
+    /// postal addresses, and cannot filter on the remaining fields. So the
+    /// listener still has to cope with a contact that turned out to be
+    /// missing one.
+    ///
+    /// #### Parameters
+    ///
+    /// - `requireAllRequestedFields`: true to require every requested field
+    public void setRequireAllRequestedFields(boolean requireAllRequestedFields) {
+        this.requireAllRequestedFields = requireAllRequestedFields;
+    }
+
+    /// Shows the platform's contact picker and reports the selection.
+    ///
+    /// The call returns at once; the picker runs on top of the application and
+    /// the listener is invoked on the EDT when the user is done. A cancelled
+    /// pick and a platform with no picker both report an empty selection, so
+    /// `#getPickedContacts(ActionEvent)` is the only thing the listener has to
+    /// check.
+    ///
+    /// #### Parameters
+    ///
+    /// - `response`: invoked with the selection once the user is done
+    public void pick(ActionListener<ActionEvent> response) {
+        if (response == null) {
+            throw new IllegalArgumentException(
+                    "A contact picker needs a listener to report to");
+        }
+        Display.getInstance().pickContacts(requestedFields, multiSelect,
+                selectionLimit, requireAllRequestedFields, response);
+    }
+}

--- a/CodenameOne/src/com/codename1/contacts/ContactPicker.java
+++ b/CodenameOne/src/com/codename1/contacts/ContactPicker.java
@@ -257,9 +257,10 @@ public class ContactPicker {
     /// instance an invitation flow that needs both a name and an email
     /// address. Leave it off when any one of the requested fields will do.
     ///
-    /// A platform applies it as far as its own picker can. Android enforces
-    /// it exactly; iOS enforces it over phone numbers, email addresses and
-    /// postal addresses, and cannot filter on the remaining fields. So the
+    /// A platform applies it as far as its own picker can. Android 17 and
+    /// later enforce it exactly; iOS enforces it over phone numbers, email
+    /// addresses and postal addresses and cannot filter on the rest; Android
+    /// before 17 has no picker predicate at all and ignores it. So the
     /// listener still has to cope with a contact that turned out to be
     /// missing one.
     ///

--- a/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
+++ b/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
@@ -8492,6 +8492,11 @@ public abstract class CodenameOneImplementation {
     /// empty selection rather than reading the address book, because falling
     /// back to a broad read is exactly what the caller was avoiding.
     ///
+    /// **An override must call `response` exactly once**, whether the user
+    /// picked, cancelled or the platform refused. `Display` counts on that to
+    /// know when a pick has finished, and a port that answers twice or not at
+    /// all breaks the next pick rather than only its own.
+    ///
     /// #### Parameters
     ///
     /// - `requestedFields`: bit set of the field constants on

--- a/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
+++ b/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
@@ -8474,6 +8474,86 @@ public abstract class CodenameOneImplementation {
         return true;
     }
 
+    /// Returns true when the platform has a contact picker that hands over a
+    /// user-selected subset of the address book without the broad contacts
+    /// permission, see `com.codename1.contacts.ContactPicker`.
+    ///
+    /// #### Returns
+    ///
+    /// true if `#pickContacts(int, boolean, int, boolean, com.codename1.ui.events.ActionListener)`
+    /// shows a picker
+    public boolean isContactPickerSupported() {
+        return false;
+    }
+
+    /// Shows the platform's contact picker and reports the user's selection.
+    ///
+    /// A port that has no picker leaves this alone. The default reports an
+    /// empty selection rather than reading the address book, because falling
+    /// back to a broad read is exactly what the caller was avoiding.
+    ///
+    /// #### Parameters
+    ///
+    /// - `requestedFields`: bit set of the field constants on
+    /// `com.codename1.contacts.ContactPicker`
+    ///
+    /// - `multiSelect`: true to let the user pick more than one contact
+    ///
+    /// - `selectionLimit`: the largest number of contacts the user may pick
+    ///
+    /// - `requireAllRequestedFields`: true to offer only contacts holding
+    /// every requested field
+    ///
+    /// - `response`: invoked with a `com.codename1.contacts.Contact` array
+    /// source once the user is done
+    public void pickContacts(int requestedFields, boolean multiSelect,
+                             int selectionLimit, boolean requireAllRequestedFields,
+                             ActionListener<ActionEvent> response) {
+        fireContactPickerResult(response, new Contact[0]);
+    }
+
+    /// Hands a picker result to its listener on the EDT.
+    ///
+    /// Ports call this from whatever thread the platform's picker answered
+    /// on -- an Android activity result, an iOS delegate callback -- so the
+    /// application's listener always runs where the rest of its code does.
+    ///
+    /// #### Parameters
+    ///
+    /// - `response`: the listener passed to
+    /// `#pickContacts(int, boolean, int, boolean, com.codename1.ui.events.ActionListener)`
+    ///
+    /// - `picked`: the selection, null being treated as empty
+    protected void fireContactPickerResult(ActionListener<ActionEvent> response,
+                                           Contact[] picked) {
+        if (response == null) {
+            return;
+        }
+        Contact[] result = picked == null ? new Contact[0] : picked;
+        Display.getInstance().callSerially(new ContactPickerDelivery(response, result));
+    }
+
+    /// Delivers one contact-picker selection on the EDT.
+    ///
+    /// A named static class rather than the anonymous one this obviously
+    /// wants to be. An anonymous one would capture the implementation it was
+    /// created in for no reason, which is a SpotBugs finding, and the gate is
+    /// zero-findings.
+    private static final class ContactPickerDelivery implements Runnable {
+        private final ActionListener<ActionEvent> response;
+        private final Contact[] picked;
+
+        ContactPickerDelivery(ActionListener<ActionEvent> response, Contact[] picked) {
+            this.response = response;
+            this.picked = picked;
+        }
+
+        @Override
+        public void run() {
+            response.actionPerformed(new ActionEvent(picked));
+        }
+    }
+
     /// removed a contact from the device contacts book
     ///
     /// #### Parameters

--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -6727,6 +6727,42 @@ public final class Display extends CN1Constants {
         return impl.isContactsPermissionGranted();
     }
 
+    /// Returns true when the platform has a contact picker, see
+    /// `com.codename1.contacts.ContactPicker`.
+    ///
+    /// #### Returns
+    ///
+    /// true if `#pickContacts(int, boolean, int, boolean, com.codename1.ui.events.ActionListener)`
+    /// will show a picker
+    public boolean isContactPickerSupported() {
+        return impl.isContactPickerSupported();
+    }
+
+    /// Shows the platform's contact picker, see
+    /// `com.codename1.contacts.ContactPicker` for the API applications should
+    /// use and for what the arguments mean.
+    ///
+    /// #### Parameters
+    ///
+    /// - `requestedFields`: bit set of the field constants on
+    /// `com.codename1.contacts.ContactPicker`
+    ///
+    /// - `multiSelect`: true to let the user pick more than one contact
+    ///
+    /// - `selectionLimit`: the largest number of contacts the user may pick
+    ///
+    /// - `requireAllRequestedFields`: true to offer only contacts holding
+    /// every requested field
+    ///
+    /// - `response`: invoked with a `com.codename1.contacts.Contact` array
+    /// source once the user is done
+    public void pickContacts(int requestedFields, boolean multiSelect,
+                             int selectionLimit, boolean requireAllRequestedFields,
+                             ActionListener<ActionEvent> response) {
+        impl.pickContacts(requestedFields, multiSelect, selectionLimit,
+                requireAllRequestedFields, response);
+    }
+
     /// Create a contact to the device contacts book
     ///
     /// #### Parameters

--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -6756,9 +6756,23 @@ public final class Display extends CN1Constants {
     ///
     /// - `response`: invoked with a `com.codename1.contacts.Contact` array
     /// source once the user is done
-    public void pickContacts(int requestedFields, boolean multiSelect,
-                             int selectionLimit, boolean requireAllRequestedFields,
-                             ActionListener<ActionEvent> response) {
+    public void pickContacts(final int requestedFields, final boolean multiSelect,
+                             final int selectionLimit,
+                             final boolean requireAllRequestedFields,
+                             final ActionListener<ActionEvent> response) {
+        if (!isEdt()) {
+            // The guard below is a plain field read and written without a
+            // lock, because Codename One is single threaded and core carries
+            // no synchronization. Nothing stops an application calling this
+            // from a background thread, though, and two that did would both
+            // see the flag clear and both start a pick -- which is the state
+            // the flag exists to prevent. Moving the whole check-and-start
+            // onto the EDT serializes it without a lock, and costs a caller
+            // that was already on the EDT nothing.
+            callSerially(new DeferredContactPick(requestedFields, multiSelect,
+                    selectionLimit, requireAllRequestedFields, response));
+            return;
+        }
         if (contactPickInProgress) {
             // A second pick while the first is still on screen, which a
             // double tap is enough to produce. The platforms cannot honour it
@@ -6788,6 +6802,31 @@ public final class Display extends CN1Constants {
             return;
         }
         callSerially(new EmptyContactPick(response));
+    }
+
+    /// Re-enters `#pickContacts` on the EDT for an off-EDT caller.
+    private class DeferredContactPick implements Runnable {
+        private final int requestedFields;
+        private final boolean multiSelect;
+        private final int selectionLimit;
+        private final boolean requireAllRequestedFields;
+        private final ActionListener<ActionEvent> response;
+
+        DeferredContactPick(int requestedFields, boolean multiSelect,
+                int selectionLimit, boolean requireAllRequestedFields,
+                ActionListener<ActionEvent> response) {
+            this.requestedFields = requestedFields;
+            this.multiSelect = multiSelect;
+            this.selectionLimit = selectionLimit;
+            this.requireAllRequestedFields = requireAllRequestedFields;
+            this.response = response;
+        }
+
+        @Override
+        public void run() {
+            pickContacts(requestedFields, multiSelect, selectionLimit,
+                    requireAllRequestedFields, response);
+        }
     }
 
     /// Tells one listener that its pick produced nothing.

--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -6759,8 +6759,74 @@ public final class Display extends CN1Constants {
     public void pickContacts(int requestedFields, boolean multiSelect,
                              int selectionLimit, boolean requireAllRequestedFields,
                              ActionListener<ActionEvent> response) {
+        if (contactPickInProgress) {
+            // A second pick while the first is still on screen, which a
+            // double tap is enough to produce. The platforms cannot honour it
+            // either -- UIKit refuses to present a second modal controller,
+            // and the Android picker activity is already on top -- and the
+            // single result slot each port keeps would then decode the first
+            // pick with the second request's fields and hand it to the second
+            // listener, leaving the first listener with nothing. Reporting an
+            // empty selection is what a cancelled pick reports, so the caller
+            // needs no separate case for it.
+            deliverEmptyContactPick(response);
+            return;
+        }
+        contactPickInProgress = true;
         impl.pickContacts(requestedFields, multiSelect, selectionLimit,
-                requireAllRequestedFields, response);
+                requireAllRequestedFields, new ContactPickCompletion(response));
+    }
+
+    /// True between a contact pick starting and its listener being called.
+    ///
+    /// Read and written on the EDT only: the call in comes from application
+    /// code and every port answers through `Display#callSerially(Runnable)`.
+    private boolean contactPickInProgress;
+
+    private void deliverEmptyContactPick(ActionListener<ActionEvent> response) {
+        if (response == null) {
+            return;
+        }
+        callSerially(new EmptyContactPick(response));
+    }
+
+    /// Tells one listener that its pick produced nothing.
+    ///
+    /// A named static class rather than the anonymous one this obviously
+    /// wants to be: an anonymous one would capture the Display for no reason,
+    /// which is a SpotBugs finding, and that gate is zero-findings.
+    private static final class EmptyContactPick implements Runnable {
+        private final ActionListener<ActionEvent> response;
+
+        EmptyContactPick(ActionListener<ActionEvent> response) {
+            this.response = response;
+        }
+
+        @Override
+        public void run() {
+            response.actionPerformed(new ActionEvent(new Contact[0]));
+        }
+    }
+
+    /// Clears the in-progress flag and passes the selection on.
+    ///
+    /// Wrapping the application's listener rather than trusting the port to
+    /// report back is what makes the flag above reliable for every port at
+    /// once, including one whose picker answers without an EDT hop.
+    private class ContactPickCompletion implements ActionListener<ActionEvent> {
+        private final ActionListener<ActionEvent> response;
+
+        ContactPickCompletion(ActionListener<ActionEvent> response) {
+            this.response = response;
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent ev) {
+            contactPickInProgress = false;
+            if (response != null) {
+                response.actionPerformed(ev);
+            }
+        }
     }
 
     /// Create a contact to the device contacts book

--- a/Ports/Android/src/com/codename1/impl/android/AndroidContactPicker.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidContactPicker.java
@@ -1,0 +1,697 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Codename One in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.impl.android;
+
+import android.app.Activity;
+import android.content.ActivityNotFoundException;
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.Intent;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Build;
+import android.provider.ContactsContract;
+
+import com.codename1.contacts.Address;
+import com.codename1.contacts.Contact;
+import com.codename1.contacts.ContactPicker;
+import com.codename1.io.Log;
+import com.codename1.ui.EncodedImage;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Hashtable;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Runs the platform's contact picker and turns its answer into
+ * {@link Contact} objects, without ever asking for {@code READ_CONTACTS}.
+ *
+ * <p>Two mechanisms sit behind one entry point.</p>
+ *
+ * <p>From Android 17 (API level 37) the system owns a real contacts picker:
+ * {@code android.provider.action.PICK_CONTACTS} shows it, the app names the
+ * MIME types it wants, and the result is a single session URI that projects
+ * rows out of {@link ContactsContract.Data} for the selected contacts only.
+ * That is the path Google Play's 2027-01-27 contacts policy expects an app
+ * to be on when broad address-book access is not core functionality.</p>
+ *
+ * <p>Before that the closest equivalent is {@link Intent#ACTION_PICK} against
+ * one of the contacts content URIs. The contacts app returns a URI for the
+ * single row the user chose and grants read access to just that row, so it
+ * needs no permission either -- but it can only return one row, of one kind.
+ * Everything the older path cannot do is dropped rather than escalated:
+ * asking for a second field, or for several contacts, never turns into a
+ * permission prompt behind the caller's back.</p>
+ *
+ * <p>The API 37 names are written out as literals because the port compiles
+ * against a much older {@code android.jar} and cannot reference
+ * {@code android.provider.ContactsPickerSessionContract} at all. They are
+ * copied from that class in AOSP; a wrong one would surface as
+ * {@link ActivityNotFoundException}, which is handled the same way as a
+ * device with no contacts app.</p>
+ */
+class AndroidContactPicker {
+
+    /**
+     * Android 17. {@code Build.VERSION_CODES} in the android.jar this port
+     * compiles against stops long before it.
+     */
+    static final int SDK_INT_ANDROID_17 = 37;
+
+    /** {@code ContactsPickerSessionContract.ACTION_PICK_CONTACTS}. */
+    static final String ACTION_PICK_CONTACTS =
+            "android.provider.action.PICK_CONTACTS";
+
+    /**
+     * {@code ContactsPickerSessionContract.EXTRA_PICK_CONTACTS_REQUESTED_DATA_FIELDS},
+     * an {@code ArrayList<String>} of MIME types. The picker requires it: it
+     * decides both which contacts are offered and which rows come back.
+     */
+    static final String EXTRA_REQUESTED_DATA_FIELDS =
+            "android.provider.extra.PICK_CONTACTS_REQUESTED_DATA_FIELDS";
+
+    /** {@code ContactsPickerSessionContract.EXTRA_PICK_CONTACTS_MATCH_ALL_DATA_FIELDS}. */
+    static final String EXTRA_MATCH_ALL_DATA_FIELDS =
+            "android.provider.extra.PICK_CONTACTS_MATCH_ALL_DATA_FIELDS";
+
+    /** {@code ContactsPickerSessionContract.EXTRA_PICK_CONTACTS_SELECTION_LIMIT}. */
+    static final String EXTRA_SELECTION_LIMIT =
+            "android.provider.extra.PICK_CONTACTS_SELECTION_LIMIT";
+
+    /**
+     * The request code handed to {@code startActivityForResult}. Picked well
+     * clear of the small integers {@link IntentResultListener} hands out.
+     */
+    static final int PICK_CONTACTS_REQUEST = 4212;
+
+    private AndroidContactPicker() {
+    }
+
+    /**
+     * The MIME types that correspond to a set of
+     * {@link ContactPicker} field constants, in a stable order.
+     *
+     * <p>Android rejects the whole request with an
+     * {@code IllegalArgumentException} if it is handed a MIME type outside
+     * the list its picker accepts, so nothing is mapped speculatively --
+     * a field with no accepted MIME type is simply not requested.</p>
+     *
+     * @param requestedFields bit set of {@link ContactPicker} constants
+     * @return the MIME types to request, never null and never empty
+     */
+    static ArrayList<String> requestedMimeTypes(int requestedFields) {
+        ArrayList<String> types = new ArrayList<String>();
+        if ((requestedFields & ContactPicker.NAME) != 0) {
+            types.add(ContactsContract.CommonDataKinds.StructuredName.CONTENT_ITEM_TYPE);
+        }
+        if ((requestedFields & ContactPicker.PHONE) != 0) {
+            types.add(ContactsContract.CommonDataKinds.Phone.CONTENT_ITEM_TYPE);
+        }
+        if ((requestedFields & ContactPicker.EMAIL) != 0) {
+            types.add(ContactsContract.CommonDataKinds.Email.CONTENT_ITEM_TYPE);
+        }
+        if ((requestedFields & ContactPicker.ADDRESS) != 0) {
+            types.add(ContactsContract.CommonDataKinds.StructuredPostal.CONTENT_ITEM_TYPE);
+        }
+        if ((requestedFields & ContactPicker.PHOTO) != 0) {
+            types.add(ContactsContract.CommonDataKinds.Photo.CONTENT_ITEM_TYPE);
+        }
+        if ((requestedFields & ContactPicker.BIRTHDAY) != 0) {
+            types.add(ContactsContract.CommonDataKinds.Event.CONTENT_ITEM_TYPE);
+        }
+        if ((requestedFields & ContactPicker.WEBSITE) != 0) {
+            types.add(ContactsContract.CommonDataKinds.Website.CONTENT_ITEM_TYPE);
+        }
+        if (types.isEmpty()) {
+            // ContactPicker refuses an empty field set, so this is only
+            // reachable from the implementation API. The picker still has to
+            // be told something, and a name is the one field every contact
+            // has.
+            types.add(ContactsContract.CommonDataKinds.StructuredName.CONTENT_ITEM_TYPE);
+        }
+        return types;
+    }
+
+    /**
+     * Builds the intent that shows the system picker on Android 17 and later.
+     *
+     * @param requestedFields          bit set of {@link ContactPicker} constants
+     * @param multiSelect              true to allow more than one contact
+     * @param selectionLimit           the largest selection the user may make
+     * @param requireAllRequestedFields true to offer only contacts holding
+     *                                 every requested field
+     * @return the intent to launch
+     */
+    static Intent sessionPickerIntent(int requestedFields, boolean multiSelect,
+            int selectionLimit, boolean requireAllRequestedFields) {
+        Intent intent = new Intent(ACTION_PICK_CONTACTS);
+        intent.putStringArrayListExtra(EXTRA_REQUESTED_DATA_FIELDS,
+                requestedMimeTypes(requestedFields));
+        intent.putExtra(EXTRA_MATCH_ALL_DATA_FIELDS, requireAllRequestedFields);
+        if (multiSelect) {
+            intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
+            intent.putExtra(EXTRA_SELECTION_LIMIT, Math.max(1,
+                    Math.min(selectionLimit, ContactPicker.MAXIMUM_SELECTION_LIMIT)));
+        }
+        return intent;
+    }
+
+    /**
+     * Builds the intent that shows the contacts app's own single-row picker
+     * on Android before 17.
+     *
+     * <p>The data URI decides what the user is choosing and what the returned
+     * row holds. Picking a phone number returns the number and the owner's
+     * display name under one grant; picking a contact returns the contact
+     * row, whose data rows would need {@code READ_CONTACTS} to read. So the
+     * most specific requested field wins, and a request naming several of
+     * them gets whichever one this ranking puts first rather than a
+     * permission prompt.</p>
+     *
+     * @param requestedFields bit set of {@link ContactPicker} constants
+     * @return the intent to launch
+     */
+    static Intent legacyPickerIntent(int requestedFields) {
+        Uri data;
+        if ((requestedFields & ContactPicker.PHONE) != 0) {
+            data = ContactsContract.CommonDataKinds.Phone.CONTENT_URI;
+        } else if ((requestedFields & ContactPicker.EMAIL) != 0) {
+            data = ContactsContract.CommonDataKinds.Email.CONTENT_URI;
+        } else if ((requestedFields & ContactPicker.ADDRESS) != 0) {
+            data = ContactsContract.CommonDataKinds.StructuredPostal.CONTENT_URI;
+        } else {
+            data = ContactsContract.Contacts.CONTENT_URI;
+        }
+        Intent intent = new Intent(Intent.ACTION_PICK, data);
+        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        return intent;
+    }
+
+    /**
+     * Shows the picker.
+     *
+     * @param context         used to resolve content
+     * @param requestedFields bit set of {@link ContactPicker} constants
+     * @param multiSelect     true to allow more than one contact
+     * @param selectionLimit  the largest selection the user may make
+     * @param requireAllRequestedFields true to offer only contacts holding
+     *                        every requested field
+     * @param result          invoked with the selection, on the calling
+     *                        activity's result thread
+     */
+    static void pick(final Context context, final int requestedFields,
+            boolean multiSelect, int selectionLimit,
+            boolean requireAllRequestedFields, final Result result) {
+        final boolean session = Build.VERSION.SDK_INT >= SDK_INT_ANDROID_17;
+        Intent intent = session
+                ? sessionPickerIntent(requestedFields, multiSelect,
+                        selectionLimit, requireAllRequestedFields)
+                : legacyPickerIntent(requestedFields);
+        try {
+            AndroidNativeUtil.startActivityForResult(intent,
+                    PICK_CONTACTS_REQUEST, new IntentResultListener() {
+                @Override
+                public void onActivityResult(int requestCode, int resultCode,
+                        Intent data) {
+                    result.picked(read(context, resultCode, data,
+                            requestedFields, session));
+                }
+            });
+        } catch (ActivityNotFoundException err) {
+            // No contacts app, or a build of Android 17 whose picker is not
+            // installed. Reporting nothing is the whole contract of a
+            // cancelled pick, so the caller needs no separate case for it.
+            Log.e(err);
+            result.picked(new Contact[0]);
+        } catch (RuntimeException err) {
+            Log.e(err);
+            result.picked(new Contact[0]);
+        }
+    }
+
+    /**
+     * Turns an activity result into contacts.
+     *
+     * @param context         used to resolve content
+     * @param resultCode      the activity result code
+     * @param data            the result intent, whose data is the URI to read
+     * @param requestedFields bit set of {@link ContactPicker} constants
+     * @param session         true when the Android 17 session URI was used
+     * @return the selection, never null
+     */
+    static Contact[] read(Context context, int resultCode, Intent data,
+            int requestedFields, boolean session) {
+        if (resultCode != Activity.RESULT_OK || data == null
+                || data.getData() == null) {
+            return new Contact[0];
+        }
+        Cursor cursor = null;
+        try {
+            ContentResolver resolver = context.getContentResolver();
+            // A null projection rather than a chosen one. The session
+            // provider decides its own column set and throws on a column it
+            // does not recognise, and the legacy path is reading three
+            // different content URIs whose columns differ; asking for
+            // whatever each has and tolerating a missing column is the only
+            // shape that works for both.
+            cursor = resolver.query(data.getData(), null, null, null, null);
+            if (cursor == null) {
+                return new Contact[0];
+            }
+            return session
+                    ? readSession(cursor, requestedFields)
+                    : readLegacyRow(cursor, requestedFields);
+        } catch (SecurityException err) {
+            // The temporary grant is gone, which is what happens when the
+            // result is handled after the process was rebuilt.
+            Log.e(err);
+            return new Contact[0];
+        } catch (RuntimeException err) {
+            Log.e(err);
+            return new Contact[0];
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+    }
+
+    /**
+     * Reads the Android 17 session cursor, which holds one row per data item
+     * across every selected contact.
+     *
+     * @param cursor          the session cursor
+     * @param requestedFields bit set of {@link ContactPicker} constants
+     * @return one contact per distinct selected person, in the order the
+     *         picker reported them
+     */
+    private static Contact[] readSession(Cursor cursor, int requestedFields) {
+        // Insertion ordered so the selection keeps the order the picker
+        // reported, which is the order the user sees.
+        Map<String, Contact> byPerson = new LinkedHashMap<String, Contact>();
+        int mimeColumn = cursor.getColumnIndex(ContactsContract.Data.MIMETYPE);
+        int lookupColumn = cursor.getColumnIndex(ContactsContract.Contacts.LOOKUP_KEY);
+        int idColumn = cursor.getColumnIndex(ContactsContract.Data.CONTACT_ID);
+        int nameColumn = cursor.getColumnIndex(ContactsContract.Contacts.DISPLAY_NAME);
+        while (cursor.moveToNext()) {
+            String key = column(cursor, lookupColumn);
+            if (key == null) {
+                key = column(cursor, idColumn);
+            }
+            if (key == null) {
+                // Without something to group by, every row would look like a
+                // separate person. One synthetic key per row is wrong in the
+                // other direction but at least loses nothing.
+                key = "row" + cursor.getPosition();
+            }
+            Contact contact = byPerson.get(key);
+            if (contact == null) {
+                contact = new Contact();
+                contact.setId(key);
+                String display = column(cursor, nameColumn);
+                if (display != null) {
+                    contact.setDisplayName(display);
+                }
+                byPerson.put(key, contact);
+            }
+            applyRow(contact, cursor, column(cursor, mimeColumn),
+                    requestedFields);
+        }
+        return byPerson.values().toArray(new Contact[byPerson.size()]);
+    }
+
+    /**
+     * Reads the single row the pre-17 contacts app returns.
+     *
+     * <p>Which content URI was picked from decides what the row is: a phone,
+     * email or postal data row, or a contact row when only a name was asked
+     * for. The data rows carry the owner's display name as a joined column,
+     * so a name always comes back even though no name row was read.</p>
+     *
+     * @param cursor          the cursor over the returned URI
+     * @param requestedFields bit set of {@link ContactPicker} constants
+     * @return the single picked contact, or an empty array
+     */
+    private static Contact[] readLegacyRow(Cursor cursor, int requestedFields) {
+        if (!cursor.moveToFirst()) {
+            return new Contact[0];
+        }
+        Contact contact = new Contact();
+        String id = column(cursor,
+                cursor.getColumnIndex(ContactsContract.Contacts.LOOKUP_KEY));
+        if (id == null) {
+            id = column(cursor, cursor.getColumnIndex(ContactsContract.Data.CONTACT_ID));
+        }
+        if (id == null) {
+            id = column(cursor, cursor.getColumnIndex(ContactsContract.Contacts._ID));
+        }
+        contact.setId(id);
+        String display = column(cursor,
+                cursor.getColumnIndex(ContactsContract.Contacts.DISPLAY_NAME));
+        if (display != null) {
+            contact.setDisplayName(display);
+        }
+        String mime = column(cursor,
+                cursor.getColumnIndex(ContactsContract.Data.MIMETYPE));
+        if (mime == null) {
+            // A row with no MIMETYPE is either the contact row -- which is
+            // what a name-only request picks and which carries nothing else
+            // to read -- or a contacts app that answered from an older view
+            // of the same table. Reading it as the kind the request asked
+            // for costs a few null column lookups and is the difference
+            // between returning the number the user picked and returning
+            // only their name.
+            mime = legacyMimeType(requestedFields);
+        }
+        applyRow(contact, cursor, mime, requestedFields);
+        return new Contact[]{contact};
+    }
+
+    /**
+     * The MIME type of the row {@link #legacyPickerIntent(int)} asked for.
+     *
+     * <p>Same ranking, deliberately: the two have to agree about what the
+     * single returned row is, or the row is parsed as something it is not.</p>
+     *
+     * @param requestedFields bit set of {@link ContactPicker} constants
+     * @return the MIME type of the picked row, never null
+     */
+    static String legacyMimeType(int requestedFields) {
+        if ((requestedFields & ContactPicker.PHONE) != 0) {
+            return ContactsContract.CommonDataKinds.Phone.CONTENT_ITEM_TYPE;
+        }
+        if ((requestedFields & ContactPicker.EMAIL) != 0) {
+            return ContactsContract.CommonDataKinds.Email.CONTENT_ITEM_TYPE;
+        }
+        if ((requestedFields & ContactPicker.ADDRESS) != 0) {
+            return ContactsContract.CommonDataKinds.StructuredPostal.CONTENT_ITEM_TYPE;
+        }
+        return ContactsContract.CommonDataKinds.StructuredName.CONTENT_ITEM_TYPE;
+    }
+
+    /**
+     * Copies one data row onto the contact it belongs to.
+     *
+     * @param contact         the contact being assembled
+     * @param cursor          positioned on the row
+     * @param mime            the row's MIME type, which may be null
+     * @param requestedFields bit set of {@link ContactPicker} constants, used
+     *                        so a row the platform volunteered but the caller
+     *                        did not ask for is dropped rather than stored
+     */
+    private static void applyRow(Contact contact, Cursor cursor, String mime,
+            int requestedFields) {
+        if (mime == null) {
+            return;
+        }
+        if (mime.equals(ContactsContract.CommonDataKinds.StructuredName.CONTENT_ITEM_TYPE)) {
+            if ((requestedFields & ContactPicker.NAME) != 0) {
+                applyName(contact, cursor);
+            }
+        } else if (mime.equals(ContactsContract.CommonDataKinds.Phone.CONTENT_ITEM_TYPE)) {
+            if ((requestedFields & ContactPicker.PHONE) != 0) {
+                applyPhone(contact, cursor);
+            }
+        } else if (mime.equals(ContactsContract.CommonDataKinds.Email.CONTENT_ITEM_TYPE)) {
+            if ((requestedFields & ContactPicker.EMAIL) != 0) {
+                applyEmail(contact, cursor);
+            }
+        } else if (mime.equals(ContactsContract.CommonDataKinds.StructuredPostal.CONTENT_ITEM_TYPE)) {
+            if ((requestedFields & ContactPicker.ADDRESS) != 0) {
+                applyAddress(contact, cursor);
+            }
+        } else if (mime.equals(ContactsContract.CommonDataKinds.Photo.CONTENT_ITEM_TYPE)) {
+            if ((requestedFields & ContactPicker.PHOTO) != 0) {
+                applyPhoto(contact, cursor);
+            }
+        } else if (mime.equals(ContactsContract.CommonDataKinds.Event.CONTENT_ITEM_TYPE)) {
+            if ((requestedFields & ContactPicker.BIRTHDAY) != 0) {
+                applyBirthday(contact, cursor);
+            }
+        } else if (mime.equals(ContactsContract.CommonDataKinds.Website.CONTENT_ITEM_TYPE)) {
+            if ((requestedFields & ContactPicker.WEBSITE) != 0) {
+                applyWebsite(contact, cursor);
+            }
+        }
+    }
+
+    private static void applyName(Contact contact, Cursor cursor) {
+        String given = column(cursor, cursor.getColumnIndex(
+                ContactsContract.CommonDataKinds.StructuredName.GIVEN_NAME));
+        String family = column(cursor, cursor.getColumnIndex(
+                ContactsContract.CommonDataKinds.StructuredName.FAMILY_NAME));
+        String display = column(cursor, cursor.getColumnIndex(
+                ContactsContract.CommonDataKinds.StructuredName.DISPLAY_NAME));
+        if (given != null) {
+            contact.setFirstName(given);
+        }
+        if (family != null) {
+            contact.setFamilyName(family);
+        }
+        if (display != null) {
+            contact.setDisplayName(display);
+        }
+    }
+
+    private static void applyPhone(Contact contact, Cursor cursor) {
+        String number = column(cursor, cursor.getColumnIndex(
+                ContactsContract.CommonDataKinds.Phone.NUMBER));
+        if (number == null) {
+            return;
+        }
+        Hashtable numbers = contact.getPhoneNumbers();
+        if (numbers == null) {
+            numbers = new Hashtable();
+            contact.setPhoneNumbers(numbers);
+        }
+        numbers.put(phoneLabel(column(cursor, cursor.getColumnIndex(
+                ContactsContract.CommonDataKinds.Phone.TYPE))), number);
+        if (contact.getPrimaryPhoneNumber() == null
+                || isPrimary(cursor, ContactsContract.CommonDataKinds.Phone.IS_PRIMARY)) {
+            contact.setPrimaryPhoneNumber(number);
+        }
+    }
+
+    private static void applyEmail(Contact contact, Cursor cursor) {
+        String address = column(cursor, cursor.getColumnIndex(
+                ContactsContract.CommonDataKinds.Email.DATA));
+        if (address == null) {
+            return;
+        }
+        Hashtable emails = contact.getEmails();
+        if (emails == null) {
+            emails = new Hashtable();
+            contact.setEmails(emails);
+        }
+        emails.put(emailLabel(column(cursor, cursor.getColumnIndex(
+                ContactsContract.CommonDataKinds.Email.TYPE))), address);
+        if (contact.getPrimaryEmail() == null
+                || isPrimary(cursor, ContactsContract.CommonDataKinds.Email.IS_PRIMARY)) {
+            contact.setPrimaryEmail(address);
+        }
+    }
+
+    private static void applyAddress(Contact contact, Cursor cursor) {
+        Address address = new Address();
+        address.setStreetAddress(column(cursor, cursor.getColumnIndex(
+                ContactsContract.CommonDataKinds.StructuredPostal.STREET)));
+        address.setLocality(column(cursor, cursor.getColumnIndex(
+                ContactsContract.CommonDataKinds.StructuredPostal.CITY)));
+        address.setRegion(column(cursor, cursor.getColumnIndex(
+                ContactsContract.CommonDataKinds.StructuredPostal.REGION)));
+        address.setPostalCode(column(cursor, cursor.getColumnIndex(
+                ContactsContract.CommonDataKinds.StructuredPostal.POSTCODE)));
+        address.setCountry(column(cursor, cursor.getColumnIndex(
+                ContactsContract.CommonDataKinds.StructuredPostal.COUNTRY)));
+        Hashtable addresses = contact.getAddresses();
+        if (addresses == null) {
+            addresses = new Hashtable();
+            contact.setAddresses(addresses);
+        }
+        addresses.put(addressLabel(column(cursor, cursor.getColumnIndex(
+                ContactsContract.CommonDataKinds.StructuredPostal.TYPE))), address);
+    }
+
+    private static void applyPhoto(Contact contact, Cursor cursor) {
+        int photoColumn = cursor.getColumnIndex(
+                ContactsContract.CommonDataKinds.Photo.PHOTO);
+        if (photoColumn < 0 || cursor.isNull(photoColumn)) {
+            return;
+        }
+        byte[] bytes = cursor.getBlob(photoColumn);
+        if (bytes == null || bytes.length == 0) {
+            return;
+        }
+        // The blob is the thumbnail the contacts database stores, already
+        // JPEG or PNG. EncodedImage keeps it that way and decodes on demand,
+        // which matters when a hundred of them come back from one pick.
+        contact.setPhoto(EncodedImage.create(bytes));
+    }
+
+    private static void applyBirthday(Contact contact, Cursor cursor) {
+        int typeColumn = cursor.getColumnIndex(
+                ContactsContract.CommonDataKinds.Event.TYPE);
+        if (typeColumn >= 0 && cursor.getInt(typeColumn)
+                != ContactsContract.CommonDataKinds.Event.TYPE_BIRTHDAY) {
+            // Anniversaries and custom events ride the same MIME type; only
+            // the birthday has a home on Contact.
+            return;
+        }
+        String start = column(cursor, cursor.getColumnIndex(
+                ContactsContract.CommonDataKinds.Event.START_DATE));
+        if (start == null) {
+            return;
+        }
+        try {
+            Date parsed = new SimpleDateFormat("yyyy-MM-dd").parse(start);
+            contact.setBirthday(parsed.getTime());
+        } catch (ParseException err) {
+            // A contact whose birthday has no year is stored as --MM-dd,
+            // which no yyyy-MM-dd parse accepts. The rest of the contact is
+            // still worth returning.
+            Log.p("Unparsable contact birthday: " + start);
+        }
+    }
+
+    private static void applyWebsite(Contact contact, Cursor cursor) {
+        String url = column(cursor, cursor.getColumnIndex(
+                ContactsContract.CommonDataKinds.Website.URL));
+        if (url == null) {
+            return;
+        }
+        String[] existing = contact.getUrls();
+        List<String> urls = new ArrayList<String>();
+        if (existing != null) {
+            for (int iter = 0; iter < existing.length; iter++) {
+                urls.add(existing[iter]);
+            }
+        }
+        urls.add(url);
+        contact.setUrls(urls.toArray(new String[urls.size()]));
+    }
+
+    /**
+     * Reads a column, treating an absent column exactly like a null value.
+     *
+     * <p>Every read here goes through this. The three legacy content URIs and
+     * the session provider each expose a different column set, and
+     * {@link Cursor#getString(int)} on -1 throws rather than returning
+     * null.</p>
+     *
+     * @param cursor positioned on a row
+     * @param index  a column index, which may be -1
+     * @return the value, or null when the column is absent or empty
+     */
+    private static String column(Cursor cursor, int index) {
+        if (index < 0 || cursor.isNull(index)) {
+            return null;
+        }
+        String value = cursor.getString(index);
+        if (value == null || value.length() == 0) {
+            return null;
+        }
+        return value;
+    }
+
+    private static boolean isPrimary(Cursor cursor, String columnName) {
+        int index = cursor.getColumnIndex(columnName);
+        return index >= 0 && !cursor.isNull(index) && cursor.getInt(index) != 0;
+    }
+
+    /**
+     * Maps a phone type to the label the rest of the contacts API uses.
+     *
+     * <p>The strings match {@link AndroidContactsManager} so an application
+     * that switched a lookup over to the picker keeps reading the same keys
+     * out of {@link Contact#getPhoneNumbers()}.</p>
+     *
+     * @param type the raw {@code Phone.TYPE} value as text, may be null
+     * @return the label, never null
+     */
+    static String phoneLabel(String type) {
+        if (String.valueOf(ContactsContract.CommonDataKinds.Phone.TYPE_HOME).equals(type)) {
+            return "home";
+        }
+        if (String.valueOf(ContactsContract.CommonDataKinds.Phone.TYPE_MOBILE).equals(type)) {
+            return "mobile";
+        }
+        if (String.valueOf(ContactsContract.CommonDataKinds.Phone.TYPE_WORK).equals(type)) {
+            return "work";
+        }
+        if (String.valueOf(ContactsContract.CommonDataKinds.Phone.TYPE_FAX_HOME).equals(type)) {
+            return "fax";
+        }
+        return "other";
+    }
+
+    /**
+     * Maps an email type to the label {@link AndroidContactsManager} uses.
+     *
+     * @param type the raw {@code Email.TYPE} value as text, may be null
+     * @return the label, never null
+     */
+    static String emailLabel(String type) {
+        if (String.valueOf(ContactsContract.CommonDataKinds.Email.TYPE_HOME).equals(type)) {
+            return "home";
+        }
+        if (String.valueOf(ContactsContract.CommonDataKinds.Email.TYPE_MOBILE).equals(type)) {
+            return "mobile";
+        }
+        if (String.valueOf(ContactsContract.CommonDataKinds.Email.TYPE_WORK).equals(type)) {
+            return "work";
+        }
+        return "other";
+    }
+
+    /**
+     * Maps a postal type to the label {@link AndroidContactsManager} uses.
+     *
+     * @param type the raw {@code StructuredPostal.TYPE} value as text, may be
+     *             null
+     * @return the label, never null
+     */
+    static String addressLabel(String type) {
+        if (String.valueOf(ContactsContract.CommonDataKinds.StructuredPostal.TYPE_HOME).equals(type)) {
+            return "home";
+        }
+        if (String.valueOf(ContactsContract.CommonDataKinds.StructuredPostal.TYPE_WORK).equals(type)) {
+            return "work";
+        }
+        return "other";
+    }
+
+    /** Receives the selection once the picker activity has answered. */
+    interface Result {
+
+        /**
+         * @param picked the contacts the user selected, empty when they
+         *               cancelled
+         */
+        void picked(Contact[] picked);
+    }
+}

--- a/Ports/Android/src/com/codename1/impl/android/AndroidContactPicker.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidContactPicker.java
@@ -243,6 +243,27 @@ class AndroidContactPicker {
                 ? sessionPickerIntent(requestedFields, multiSelect,
                         selectionLimit, requireAllRequestedFields)
                 : legacyPickerIntent(requestedFields);
+        Activity activity = AndroidNativeUtil.getActivity();
+        // instanceof rather than a cast: ParparVM's CHECKCAST is unchecked, so
+        // a wrong type here would be handed to the next instruction rather
+        // than throwing.
+        CodenameOneActivity host = activity instanceof CodenameOneActivity
+                ? (CodenameOneActivity) activity : null;
+        if (host != null && host.isWaitingForResult()) {
+            // The activity has ONE result channel, and
+            // setIntentResultListener refuses a new listener while a flow --
+            // the camera, a gallery, a VPN consent dialog -- is outstanding.
+            // It refuses silently, so launching anyway would send the picker's
+            // result to that other flow's listener and leave this pick with no
+            // answer at all, which wedges the caller: Display treats a pick
+            // that never reports as still in progress and refuses the next
+            // one. Reporting an empty selection is what a cancelled pick
+            // reports, and it keeps the channel intact for whoever owns it.
+            Log.p("Contact picker: another activity result is outstanding, "
+                    + "reporting an empty selection");
+            result.picked(new Contact[0]);
+            return;
+        }
         try {
             AndroidNativeUtil.startActivityForResult(intent,
                     PICK_CONTACTS_REQUEST, new IntentResultListener() {
@@ -258,10 +279,31 @@ class AndroidContactPicker {
             // installed. Reporting nothing is the whole contract of a
             // cancelled pick, so the caller needs no separate case for it.
             Log.e(err);
+            releaseResultChannel(host);
             result.picked(new Contact[0]);
         } catch (RuntimeException err) {
             Log.e(err);
+            releaseResultChannel(host);
             result.picked(new Contact[0]);
+        }
+    }
+
+    /**
+     * Hands the activity's result channel back after a launch that threw.
+     *
+     * <p>{@code AndroidNativeUtil.startActivityForResult} installs its
+     * listener and the activity marks itself waiting BEFORE the call that can
+     * throw, and only the result callback puts either back. So a launch that
+     * fails synchronously leaves this pick's listener installed forever: the
+     * next camera, gallery or consent flow is refused its own listener and its
+     * result is delivered here instead. Nothing else notices, because the
+     * failure was reported as an ordinary cancelled pick.</p>
+     *
+     * @param host the activity, or null when it is not one of ours
+     */
+    private static void releaseResultChannel(CodenameOneActivity host) {
+        if (host != null) {
+            host.restoreIntentResultListener();
         }
     }
 
@@ -439,6 +481,19 @@ class AndroidContactPicker {
      * readable. That is the same outcome as before this existed -- it can
      * only add fields, never lose one -- and it never falls back to asking
      * for {@code READ_CONTACTS}, which is the whole point of the picker.</p>
+     *
+     * <p>Review asked for the alternative: report these requests unsupported,
+     * or serve them from a URI the grant certainly covers. Neither is
+     * available. There is no permission-free path to a photo, a birthday or a
+     * web site before Android 17 -- that absence is precisely why Android 17
+     * added a picker -- so no URI can be substituted here. And failing the
+     * whole pick would be worse than the partial answer it replaces: a
+     * request for a name, a number and a photo would return nothing on
+     * Android 16 rather than the name and the number the platform can
+     * genuinely deliver. So the request is served as far as the device
+     * allows, the shortfall is visible to the caller as a null field, and
+     * which fields are best-effort before Android 17 is written down on
+     * {@code ContactPicker} where an application author reads it.</p>
      *
      * @param contact         the contact being assembled
      * @param resolver        used to query the directory

--- a/Ports/Android/src/com/codename1/impl/android/AndroidContactPicker.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidContactPicker.java
@@ -142,6 +142,22 @@ class AndroidContactPicker {
             types.add(ContactsContract.CommonDataKinds.Photo.CONTENT_ITEM_TYPE);
         }
         if ((requestedFields & ContactPicker.BIRTHDAY) != 0) {
+            // Coarser than every other entry here, and the picker offers no
+            // finer one: Event covers anniversaries and custom dates as well
+            // as birthdays, and its filtering is by MIME type rather than by
+            // the row's TYPE. So requireAllRequestedFields will offer a
+            // contact whose only event is an anniversary, and applyBirthday
+            // then declines to store it -- the contact comes back with a null
+            // birthday.
+            //
+            // Review asked for those contacts to be dropped from the result
+            // instead. That is worse for the caller: the user picks somebody
+            // and gets an empty selection with nothing to explain it, where
+            // today the application has a named contact and a null birthday
+            // and can say so. requireAllRequestedFields is documented as
+            // best-effort filtering of what the picker OFFERS, never a
+            // promise about what comes back, precisely because of cases like
+            // this one.
             types.add(ContactsContract.CommonDataKinds.Event.CONTENT_ITEM_TYPE);
         }
         if ((requestedFields & ContactPicker.WEBSITE) != 0) {

--- a/Ports/Android/src/com/codename1/impl/android/AndroidContactPicker.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidContactPicker.java
@@ -186,12 +186,23 @@ class AndroidContactPicker {
      * on Android before 17.
      *
      * <p>The data URI decides what the user is choosing and what the returned
-     * row holds. Picking a phone number returns the number and the owner's
-     * display name under one grant; picking a contact returns the contact
-     * row, whose data rows would need {@code READ_CONTACTS} to read. So the
-     * most specific requested field wins, and a request naming several of
-     * them gets whichever one this ranking puts first rather than a
-     * permission prompt.</p>
+     * row holds. Picking a phone number returns that number under one grant,
+     * which is why the most specific requested field wins: a request naming
+     * several of them gets whichever one this ranking puts first rather than
+     * a permission prompt.</p>
+     *
+     * <p>A request for a photo, a birthday or a web site has no content URI
+     * of its own -- {@code ACTION_PICK} offers none -- so it falls through to
+     * the contact, and those fields are read afterwards through the directory
+     * hanging off the granted contact URI. See
+     * {@code applyContactEntity}.</p>
+     *
+     * <p>{@code requireAllRequestedFields} has no effect here. The pre-17
+     * picker takes no predicate, so every contact is offered and the caller
+     * has to cope with one that turned out to be missing a field -- which is
+     * what its own documentation says a platform may do. Narrowing it any
+     * further would mean reading the address book to decide, which is the
+     * thing this path exists to avoid.</p>
      *
      * @param requestedFields bit set of {@link ContactPicker} constants
      * @return the intent to launch
@@ -271,6 +282,7 @@ class AndroidContactPicker {
             return new Contact[0];
         }
         Cursor cursor = null;
+        Uri picked = data.getData();
         try {
             ContentResolver resolver = context.getContentResolver();
             // A null projection rather than a chosen one. The session
@@ -279,13 +291,13 @@ class AndroidContactPicker {
             // different content URIs whose columns differ; asking for
             // whatever each has and tolerating a missing column is the only
             // shape that works for both.
-            cursor = resolver.query(data.getData(), null, null, null, null);
+            cursor = resolver.query(picked, null, null, null, null);
             if (cursor == null) {
                 return new Contact[0];
             }
             return session
                     ? readSession(cursor, requestedFields)
-                    : readLegacyRow(cursor, requestedFields);
+                    : readLegacyRow(cursor, resolver, picked, requestedFields);
         } catch (SecurityException err) {
             // The temporary grant is gone, which is what happens when the
             // result is handled after the process was rebuilt.
@@ -333,9 +345,16 @@ class AndroidContactPicker {
             if (contact == null) {
                 contact = new Contact();
                 contact.setId(key);
-                String display = column(cursor, nameColumn);
-                if (display != null) {
-                    contact.setDisplayName(display);
+                // Gated on NAME. The session cursor joins the owner's display
+                // name onto every row, so a phone-only request would come
+                // back carrying the name as well -- which is data the caller
+                // deliberately did not ask for and which this API promises
+                // not to hand over.
+                if ((requestedFields & ContactPicker.NAME) != 0) {
+                    String display = column(cursor, nameColumn);
+                    if (display != null) {
+                        contact.setDisplayName(display);
+                    }
                 }
                 byPerson.put(key, contact);
             }
@@ -357,7 +376,8 @@ class AndroidContactPicker {
      * @param requestedFields bit set of {@link ContactPicker} constants
      * @return the single picked contact, or an empty array
      */
-    private static Contact[] readLegacyRow(Cursor cursor, int requestedFields) {
+    private static Contact[] readLegacyRow(Cursor cursor, ContentResolver resolver,
+            Uri picked, int requestedFields) {
         if (!cursor.moveToFirst()) {
             return new Contact[0];
         }
@@ -371,25 +391,91 @@ class AndroidContactPicker {
             id = column(cursor, cursor.getColumnIndex(ContactsContract.Contacts._ID));
         }
         contact.setId(id);
-        String display = column(cursor,
-                cursor.getColumnIndex(ContactsContract.Contacts.DISPLAY_NAME));
-        if (display != null) {
-            contact.setDisplayName(display);
+        // Gated on NAME for the same reason as the session path: a data row
+        // carries the owner's display name as a joined column, so an
+        // ungated read would hand a phone-only caller the name too.
+        if ((requestedFields & ContactPicker.NAME) != 0) {
+            String display = column(cursor,
+                    cursor.getColumnIndex(ContactsContract.Contacts.DISPLAY_NAME));
+            if (display != null) {
+                contact.setDisplayName(display);
+            }
         }
-        String mime = column(cursor,
-                cursor.getColumnIndex(ContactsContract.Data.MIMETYPE));
+        int mimeColumn = cursor.getColumnIndex(ContactsContract.Data.MIMETYPE);
+        String mime = column(cursor, mimeColumn);
+        if (mimeColumn < 0) {
+            // No MIMETYPE column at all, so this is the contact row rather
+            // than a data row -- what the ranking picks when the request
+            // wants something no ACTION_PICK content URI offers. The row
+            // itself holds only the name, so the data rows are read through
+            // the directory hanging off the same granted URI.
+            applyContactEntity(contact, resolver, picked, requestedFields);
+            return new Contact[]{contact};
+        }
         if (mime == null) {
-            // A row with no MIMETYPE is either the contact row -- which is
-            // what a name-only request picks and which carries nothing else
-            // to read -- or a contacts app that answered from an older view
-            // of the same table. Reading it as the kind the request asked
-            // for costs a few null column lookups and is the difference
-            // between returning the number the user picked and returning
-            // only their name.
+            // The column exists but this row left it empty, which is a
+            // contacts app answering from an older view of the same table.
+            // Reading it as the kind the request asked for costs a few null
+            // column lookups and is the difference between returning the
+            // number the user picked and returning only their name.
             mime = legacyMimeType(requestedFields);
         }
         applyRow(contact, cursor, mime, requestedFields);
         return new Contact[]{contact};
+    }
+
+    /**
+     * Reads the picked contact's data rows through the directory that hangs
+     * off the granted contact URI.
+     *
+     * <p>This is the only way the pre-17 path can answer a request for a
+     * photo, a birthday or a web site: no {@code ACTION_PICK} content URI
+     * offers those kinds, so the ranking falls through to the contact itself,
+     * and the contact row carries nothing but the name.</p>
+     *
+     * <p>Whether the URI grant reaches the directory is a property of the
+     * device's contacts provider rather than something the API can promise,
+     * so a refusal is caught and the caller simply gets the fields that were
+     * readable. That is the same outcome as before this existed -- it can
+     * only add fields, never lose one -- and it never falls back to asking
+     * for {@code READ_CONTACTS}, which is the whole point of the picker.</p>
+     *
+     * @param contact         the contact being assembled
+     * @param resolver        used to query the directory
+     * @param contactUri      the URI the contacts app returned and granted
+     * @param requestedFields bit set of {@link ContactPicker} constants
+     */
+    private static void applyContactEntity(Contact contact, ContentResolver resolver,
+            Uri contactUri, int requestedFields) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {
+            // ContactsContract.Contacts.Entity arrived in API 11, and merely
+            // naming it on an older device is a NoClassDefFoundError rather
+            // than something the catch below could see.
+            return;
+        }
+        Cursor rows = null;
+        try {
+            rows = resolver.query(Uri.withAppendedPath(contactUri,
+                    ContactsContract.Contacts.Entity.CONTENT_DIRECTORY),
+                    null, null, null, null);
+            if (rows == null) {
+                return;
+            }
+            int mimeColumn = rows.getColumnIndex(
+                    ContactsContract.Contacts.Entity.MIMETYPE);
+            while (rows.moveToNext()) {
+                applyRow(contact, rows, column(rows, mimeColumn), requestedFields);
+            }
+        } catch (SecurityException err) {
+            Log.p("Contact picker: the grant does not reach this contact's "
+                    + "data rows, returning the fields that were readable");
+        } catch (RuntimeException err) {
+            Log.e(err);
+        } finally {
+            if (rows != null) {
+                rows.close();
+            }
+        }
     }
 
     /**

--- a/Ports/Android/src/com/codename1/impl/android/AndroidContactPicker.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidContactPicker.java
@@ -408,6 +408,16 @@ class AndroidContactPicker {
                 // back carrying the name as well -- which is data the caller
                 // deliberately did not ask for and which this API promises
                 // not to hand over.
+                //
+                // Leaving the field unset is as far as this can go. Review
+                // asked for Contact.getDisplayName() to stop synthesizing a
+                // name from the primary phone, email or id on a picked
+                // contact, which would mean new state on a value object the
+                // whole framework shares, to make one consumer's getter
+                // behave unlike every other Contact's. The API says instead
+                // which getters answer "was a name supplied" -- getFirstName
+                // and getFamilyName -- which composes what is already public
+                // rather than widening it.
                 if ((requestedFields & ContactPicker.NAME) != 0) {
                     String display = column(cursor, nameColumn);
                     if (display != null) {

--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -9663,6 +9663,60 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
         return true;
     }
 
+    @Override
+    public boolean isContactPickerSupported() {
+        // Both paths behind AndroidContactPicker exist on every version this
+        // port runs on: the system picker from Android 17, ACTION_PICK
+        // against the contacts provider before that. A device with no
+        // contacts app answers with ActivityNotFoundException, which the
+        // picker reports as an empty selection -- the same thing a cancelled
+        // pick reports, so callers need no separate case for it.
+        return getActivity() != null;
+    }
+
+    @Override
+    public void pickContacts(int requestedFields, boolean multiSelect,
+                             int selectionLimit, boolean requireAllRequestedFields,
+                             ActionListener<ActionEvent> response) {
+        if (getActivity() == null) {
+            fireContactPickerResult(response, new Contact[0]);
+            return;
+        }
+        if (editInProgress()) {
+            stopEditing(true);
+        }
+        // Deliberately no checkForPermission call. The whole point of the
+        // picker is that neither path needs READ_CONTACTS, and asking for it
+        // here would put the permission back into the manifest and in front
+        // of the user for a flow that does not need it.
+        AndroidContactPicker.pick(getContext(), requestedFields, multiSelect,
+                selectionLimit, requireAllRequestedFields,
+                new ContactPickerResult(response));
+    }
+
+    /**
+     * Hands a picker selection back to the listener that asked for it.
+     *
+     * <p>A named class rather than the anonymous one this obviously wants to
+     * be. scripts/check-cast-semantics.sh holds its baseline against
+     * synthetic names like {@code AndroidImplementation$48}, which javac
+     * hands out in source order, so an anonymous class added here renumbers
+     * every one below it and fails a gate that has nothing to do with this
+     * change.</p>
+     */
+    private final class ContactPickerResult implements AndroidContactPicker.Result {
+        private final ActionListener<ActionEvent> response;
+
+        ContactPickerResult(ActionListener<ActionEvent> response) {
+            this.response = response;
+        }
+
+        @Override
+        public void picked(Contact[] picked) {
+            fireContactPickerResult(response, picked);
+        }
+    }
+
     public String createContact(String firstName, String surname, String officePhone, String homePhone, String cellPhone, String email) {
         if(!checkForPermission(Manifest.permission.WRITE_CONTACTS, "This is required to create a contact")){
             return null;

--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -9671,6 +9671,19 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
         // contacts app answers with ActivityNotFoundException, which the
         // picker reports as an empty selection -- the same thing a cancelled
         // pick reports, so callers need no separate case for it.
+        //
+        // Deliberately NOT PackageManager.resolveActivity. Review asked for
+        // it, to catch the kiosk device that has no contacts app at all, and
+        // it would answer the wrong question on every ordinary one: from
+        // Android 11 a resolve query is filtered by package visibility, so an
+        // app without a matching <queries> entry is told nothing handles the
+        // intent even where the picker works perfectly. LAUNCHING an implicit
+        // intent is not filtered, which is why the picker itself needs no
+        // <queries> and works regardless. Trading a false yes on a stripped
+        // device -- whose cost is a pick that reports empty, exactly as a
+        // cancelled one does -- for a false no on every modern device, whose
+        // cost is a working feature hidden with no way to find out why, is a
+        // bad trade.
         return getActivity() != null;
     }
 

--- a/Ports/JavaSE/src/com/codename1/impl/javase/ContactPickerSimulation.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/ContactPickerSimulation.java
@@ -218,11 +218,13 @@ final class ContactPickerSimulation {
         }
         if ((fields & ContactPicker.PHONE) != 0) {
             out.setPhoneNumbers(copy(source.getPhoneNumbers()));
-            out.setPrimaryPhoneNumber(source.getPrimaryPhoneNumber());
+            out.setPrimaryPhoneNumber(primary(source.getPrimaryPhoneNumber(),
+                    source.getPhoneNumbers()));
         }
         if ((fields & ContactPicker.EMAIL) != 0) {
             out.setEmails(copy(source.getEmails()));
-            out.setPrimaryEmail(source.getPrimaryEmail());
+            out.setPrimaryEmail(primary(source.getPrimaryEmail(),
+                    source.getEmails()));
         }
         if ((fields & ContactPicker.ADDRESS) != 0) {
             out.setAddresses(copyAddresses(source.getAddresses()));
@@ -237,6 +239,51 @@ final class ContactPickerSimulation {
             out.setUrls(source.getUrls());
         }
         return out;
+    }
+
+    /**
+     * The primary value for a contact that has entries but names no primary.
+     *
+     * <p>The simulated address book fills the tables and leaves the primary
+     * unset, so copying it straight through handed the caller a contact with
+     * numbers and no primary number -- and the documented NAME|PHONE example,
+     * which reads exactly that, showed nothing in the simulator while working
+     * on the device. Android and iOS both promote the first entry they read,
+     * so the simulator does too.</p>
+     *
+     * <p>A Hashtable has no order to take a first entry from, so the label
+     * ranking below stands in for one. That keeps the answer stable across
+     * runs, which "whatever the iterator yields" would not.</p>
+     *
+     * @param declared the source's primary, used as-is when it has one
+     * @param entries  the label-to-value table, which may be null
+     * @return the primary value, or null when there are no entries
+     */
+    static String primary(String declared, Hashtable entries) {
+        if (declared != null) {
+            return declared;
+        }
+        if (entries == null || entries.isEmpty()) {
+            return null;
+        }
+        String[] ranked = {"mobile", "home", "work", "other"};
+        for (int iter = 0; iter < ranked.length; iter++) {
+            Object value = entries.get(ranked[iter]);
+            if (value != null) {
+                return String.valueOf(value);
+            }
+        }
+        // An unranked label. Lowest key wins so the answer does not depend on
+        // the table's iteration order.
+        String lowest = null;
+        Enumeration keys = entries.keys();
+        while (keys.hasMoreElements()) {
+            String key = String.valueOf(keys.nextElement());
+            if (lowest == null || key.compareTo(lowest) < 0) {
+                lowest = key;
+            }
+        }
+        return lowest == null ? null : String.valueOf(entries.get(lowest));
     }
 
     private static Hashtable copy(Hashtable source) {
@@ -348,10 +395,15 @@ final class ContactPickerSimulation {
 
     private static String describe(Contact contact) {
         StringBuilder out = new StringBuilder(name(contact));
-        if (contact.getPrimaryPhoneNumber() != null) {
-            out.append(" - ").append(contact.getPrimaryPhoneNumber());
-        } else if (contact.getPrimaryEmail() != null) {
-            out.append(" - ").append(contact.getPrimaryEmail());
+        // Through the same promotion the projection uses, so the row the user
+        // taps shows the number they are about to receive.
+        String phone = primary(contact.getPrimaryPhoneNumber(),
+                contact.getPhoneNumbers());
+        String email = primary(contact.getPrimaryEmail(), contact.getEmails());
+        if (phone != null) {
+            out.append(" - ").append(phone);
+        } else if (email != null) {
+            out.append(" - ").append(email);
         }
         return out.toString();
     }

--- a/Ports/JavaSE/src/com/codename1/impl/javase/ContactPickerSimulation.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/ContactPickerSimulation.java
@@ -30,6 +30,7 @@ import com.codename1.ui.CheckBox;
 import com.codename1.ui.Container;
 import com.codename1.ui.Dialog;
 import com.codename1.ui.Display;
+import com.codename1.ui.Image;
 import com.codename1.ui.Label;
 import com.codename1.ui.events.ActionEvent;
 import com.codename1.ui.events.ActionListener;
@@ -260,7 +261,7 @@ final class ContactPickerSimulation {
             out.setAddresses(copyAddresses(source.getAddresses()));
         }
         if ((fields & ContactPicker.PHOTO) != 0) {
-            out.setPhoto(source.getPhoto());
+            out.setPhoto(copyPhoto(source.getPhoto()));
         }
         if ((fields & ContactPicker.BIRTHDAY) != 0) {
             out.setBirthday(source.getBirthday());
@@ -324,6 +325,35 @@ final class ContactPickerSimulation {
             }
         }
         return lowest == null ? null : String.valueOf(entries.get(lowest));
+    }
+
+    /**
+     * An independent copy of a simulated contact's photo.
+     *
+     * <p>Sharing the instance looked harmless and is not:
+     * {@link Image#getGraphics()} carries no mutability guard, and this port
+     * answers it with the backing {@code BufferedImage}'s own graphics. So
+     * drawing on a picked contact's photo would draw on the simulated address
+     * book, changing what every later pick and every broad read returned. A
+     * picked contact is documented as a snapshot, and Android and iOS both
+     * build a fresh image per pick.</p>
+     *
+     * @param photo the address book's image, which may be null
+     * @return an image nothing else holds, or null
+     */
+    private static Image copyPhoto(Image photo) {
+        if (photo == null) {
+            return null;
+        }
+        int width = photo.getWidth();
+        int height = photo.getHeight();
+        if (width <= 0 || height <= 0) {
+            return null;
+        }
+        int[] rgb = photo.getRGB();
+        int[] copy = new int[rgb.length];
+        System.arraycopy(rgb, 0, copy, 0, rgb.length);
+        return Image.createImage(copy, width, height);
     }
 
     private static Hashtable copy(Hashtable source) {

--- a/Ports/JavaSE/src/com/codename1/impl/javase/ContactPickerSimulation.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/ContactPickerSimulation.java
@@ -134,8 +134,36 @@ final class ContactPickerSimulation {
         }
     }
 
+    /**
+     * The contact's own name, or null when it has none.
+     *
+     * <p>Deliberately never {@link Contact#getDisplayName()}. That getter
+     * SYNTHESIZES a display name from the primary phone, the primary email or
+     * the id when the contact has none -- and caches the result back into the
+     * contact. Asking it whether a contact has a name therefore always
+     * answers yes, which would let a nameless contact satisfy
+     * {@code requireAllRequestedFields} and would hand the caller a phone
+     * number as a display name. Worse, the caching would rewrite the
+     * simulated address book permanently, so the second pick would see a
+     * contact the first pick invented.</p>
+     *
+     * @param contact the simulated contact
+     * @return the declared name, or null
+     */
+    static String declaredName(Contact contact) {
+        String first = contact.getFirstName();
+        String family = contact.getFamilyName();
+        if (first != null && family != null) {
+            return first + " " + family;
+        }
+        if (first != null) {
+            return first;
+        }
+        return family;
+    }
+
     private static String name(Contact contact) {
-        String display = contact.getDisplayName();
+        String display = declaredName(contact);
         if (display != null) {
             return display;
         }
@@ -172,9 +200,7 @@ final class ContactPickerSimulation {
     private static boolean has(Contact contact, int field) {
         switch (field) {
             case ContactPicker.NAME:
-                return contact.getDisplayName() != null
-                        || contact.getFirstName() != null
-                        || contact.getFamilyName() != null;
+                return declaredName(contact) != null;
             case ContactPicker.PHONE:
                 return notEmpty(contact.getPhoneNumbers());
             case ContactPicker.EMAIL:
@@ -212,7 +238,11 @@ final class ContactPickerSimulation {
         Contact out = new Contact();
         out.setId(source.getId());
         if ((fields & ContactPicker.NAME) != 0) {
-            out.setDisplayName(source.getDisplayName());
+            // declaredName, not getDisplayName: see the note there. A contact
+            // with no name of its own comes back with a null display name,
+            // which is what Android does when the picker returns no
+            // structured-name row.
+            out.setDisplayName(declaredName(source));
             out.setFirstName(source.getFirstName());
             out.setFamilyName(source.getFamilyName());
         }
@@ -236,7 +266,17 @@ final class ContactPickerSimulation {
             out.setBirthday(source.getBirthday());
         }
         if ((fields & ContactPicker.WEBSITE) != 0) {
-            out.setUrls(source.getUrls());
+            // Cloned, like every other field here. Handing the array over
+            // would let the caller's edits reach back into the simulated
+            // address book and into every later pick -- a picked contact is
+            // documented as a snapshot, and Android and iOS both build a
+            // fresh array.
+            String[] urls = source.getUrls();
+            if (urls != null) {
+                String[] copy = new String[urls.length];
+                System.arraycopy(urls, 0, copy, 0, urls.length);
+                out.setUrls(copy);
+            }
         }
         return out;
     }

--- a/Ports/JavaSE/src/com/codename1/impl/javase/ContactPickerSimulation.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/ContactPickerSimulation.java
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Codename One in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.impl.javase;
+
+import com.codename1.contacts.Address;
+import com.codename1.contacts.Contact;
+import com.codename1.contacts.ContactPicker;
+import com.codename1.ui.Button;
+import com.codename1.ui.CheckBox;
+import com.codename1.ui.Container;
+import com.codename1.ui.Dialog;
+import com.codename1.ui.Display;
+import com.codename1.ui.Label;
+import com.codename1.ui.events.ActionEvent;
+import com.codename1.ui.events.ActionListener;
+import com.codename1.ui.layouts.BorderLayout;
+import com.codename1.ui.layouts.BoxLayout;
+
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.Hashtable;
+import java.util.List;
+
+/**
+ * Stands in for the platform's contact picker inside the simulator.
+ *
+ * <p>The simulator has no address book to protect, so this exists for one
+ * reason: a developer moving an app off {@code READ_CONTACTS} has to be able
+ * to see what their picker flow does, and see it in the simulator rather than
+ * only on a device. It behaves the way the real ones do in the ways that
+ * matter to calling code -- it honours single versus multiple selection and
+ * the selection limit, it drops contacts that do not satisfy
+ * {@code requireAllRequestedFields}, and it hands back contacts carrying
+ * <em>only</em> the requested fields, so an app reading a field it forgot to
+ * ask for fails here rather than in the store.</p>
+ *
+ * <p>It draws Codename One components rather than Swing, so the picker
+ * appears inside the simulated device, which is where a device picker
+ * appears.</p>
+ */
+final class ContactPickerSimulation {
+
+    private ContactPickerSimulation() {
+    }
+
+    /**
+     * Shows the simulated picker.
+     *
+     * @param available                 the simulated address book
+     * @param requestedFields           bit set of {@link ContactPicker} constants
+     * @param multiSelect               true to allow more than one contact
+     * @param selectionLimit            the largest selection the user may make
+     * @param requireAllRequestedFields true to offer only contacts holding
+     *                                  every requested field
+     * @param response                  invoked on the EDT with the selection
+     */
+    static void pick(Hashtable available, final int requestedFields,
+            final boolean multiSelect, final int selectionLimit,
+            final boolean requireAllRequestedFields,
+            final ActionListener<ActionEvent> response) {
+        final List<Contact> offered = offer(available, requestedFields,
+                requireAllRequestedFields);
+        Display.getInstance().callSerially(new Runnable() {
+            @Override
+            public void run() {
+                show(offered, requestedFields, multiSelect, selectionLimit,
+                        response);
+            }
+        });
+    }
+
+    /**
+     * The contacts the picker is willing to show.
+     *
+     * @param available                 the simulated address book
+     * @param requestedFields           bit set of {@link ContactPicker} constants
+     * @param requireAllRequestedFields true to keep only contacts holding
+     *                                  every requested field
+     * @return the offered contacts, sorted by display name so the simulator
+     *         shows a stable list across runs
+     */
+    private static List<Contact> offer(Hashtable available, int requestedFields,
+            boolean requireAllRequestedFields) {
+        List<Contact> offered = new ArrayList<Contact>();
+        if (available == null) {
+            return offered;
+        }
+        Enumeration keys = available.keys();
+        while (keys.hasMoreElements()) {
+            Contact contact = (Contact) available.get(keys.nextElement());
+            if (contact == null) {
+                continue;
+            }
+            if (holds(contact, requestedFields, requireAllRequestedFields)) {
+                offered.add(contact);
+            }
+        }
+        sortByDisplayName(offered);
+        return offered;
+    }
+
+    private static void sortByDisplayName(List<Contact> contacts) {
+        // A tiny list out of a Hashtable, so an insertion sort beats pulling
+        // in a Comparator the port would otherwise have no use for.
+        for (int iter = 1; iter < contacts.size(); iter++) {
+            Contact current = contacts.get(iter);
+            int pos = iter;
+            while (pos > 0 && name(contacts.get(pos - 1))
+                    .compareTo(name(current)) > 0) {
+                contacts.set(pos, contacts.get(pos - 1));
+                pos--;
+            }
+            contacts.set(pos, current);
+        }
+    }
+
+    private static String name(Contact contact) {
+        String display = contact.getDisplayName();
+        if (display != null) {
+            return display;
+        }
+        return contact.getId() == null ? "" : contact.getId();
+    }
+
+    /**
+     * Whether a contact satisfies the field request.
+     *
+     * @param contact     the candidate
+     * @param fields      bit set of {@link ContactPicker} constants
+     * @param requireAll  true to demand every requested field, false to
+     *                    demand any one of them
+     * @return true if the picker should offer this contact
+     */
+    static boolean holds(Contact contact, int fields, boolean requireAll) {
+        int present = 0;
+        int asked = 0;
+        for (int bit = 1; bit <= ContactPicker.WEBSITE; bit <<= 1) {
+            if ((fields & bit) == 0) {
+                continue;
+            }
+            asked++;
+            if (has(contact, bit)) {
+                present++;
+            }
+        }
+        if (asked == 0) {
+            return true;
+        }
+        return requireAll ? present == asked : present > 0;
+    }
+
+    private static boolean has(Contact contact, int field) {
+        switch (field) {
+            case ContactPicker.NAME:
+                return contact.getDisplayName() != null
+                        || contact.getFirstName() != null
+                        || contact.getFamilyName() != null;
+            case ContactPicker.PHONE:
+                return notEmpty(contact.getPhoneNumbers());
+            case ContactPicker.EMAIL:
+                return notEmpty(contact.getEmails());
+            case ContactPicker.ADDRESS:
+                return notEmpty(contact.getAddresses());
+            case ContactPicker.PHOTO:
+                return contact.getPhoto() != null;
+            case ContactPicker.BIRTHDAY:
+                return contact.getBirthday() != 0;
+            case ContactPicker.WEBSITE:
+                return contact.getUrls() != null
+                        && contact.getUrls().length > 0;
+            default:
+                return false;
+        }
+    }
+
+    private static boolean notEmpty(Hashtable table) {
+        return table != null && !table.isEmpty();
+    }
+
+    /**
+     * Copies just the requested fields out of a contact.
+     *
+     * <p>The copy is the point. A real picker never hands over a field the
+     * app did not ask for, and a simulator that handed over the whole record
+     * would let an app pass here and come back empty from the device.</p>
+     *
+     * @param source the simulated contact
+     * @param fields bit set of {@link ContactPicker} constants
+     * @return a new contact holding only the requested fields
+     */
+    static Contact project(Contact source, int fields) {
+        Contact out = new Contact();
+        out.setId(source.getId());
+        if ((fields & ContactPicker.NAME) != 0) {
+            out.setDisplayName(source.getDisplayName());
+            out.setFirstName(source.getFirstName());
+            out.setFamilyName(source.getFamilyName());
+        }
+        if ((fields & ContactPicker.PHONE) != 0) {
+            out.setPhoneNumbers(copy(source.getPhoneNumbers()));
+            out.setPrimaryPhoneNumber(source.getPrimaryPhoneNumber());
+        }
+        if ((fields & ContactPicker.EMAIL) != 0) {
+            out.setEmails(copy(source.getEmails()));
+            out.setPrimaryEmail(source.getPrimaryEmail());
+        }
+        if ((fields & ContactPicker.ADDRESS) != 0) {
+            out.setAddresses(copyAddresses(source.getAddresses()));
+        }
+        if ((fields & ContactPicker.PHOTO) != 0) {
+            out.setPhoto(source.getPhoto());
+        }
+        if ((fields & ContactPicker.BIRTHDAY) != 0) {
+            out.setBirthday(source.getBirthday());
+        }
+        if ((fields & ContactPicker.WEBSITE) != 0) {
+            out.setUrls(source.getUrls());
+        }
+        return out;
+    }
+
+    private static Hashtable copy(Hashtable source) {
+        if (source == null) {
+            return null;
+        }
+        Hashtable out = new Hashtable();
+        Enumeration keys = source.keys();
+        while (keys.hasMoreElements()) {
+            Object key = keys.nextElement();
+            out.put(key, source.get(key));
+        }
+        return out;
+    }
+
+    private static Hashtable copyAddresses(Hashtable source) {
+        if (source == null) {
+            return null;
+        }
+        Hashtable out = new Hashtable();
+        Enumeration keys = source.keys();
+        while (keys.hasMoreElements()) {
+            Object key = keys.nextElement();
+            Address from = (Address) source.get(key);
+            Address to = new Address();
+            to.setStreetAddress(from.getStreetAddress());
+            to.setLocality(from.getLocality());
+            to.setRegion(from.getRegion());
+            to.setPostalCode(from.getPostalCode());
+            to.setCountry(from.getCountry());
+            out.put(key, to);
+        }
+        return out;
+    }
+
+    private static void show(final List<Contact> offered, final int fields,
+            boolean multiSelect, final int selectionLimit,
+            final ActionListener<ActionEvent> response) {
+        final Dialog dialog = new Dialog("Contacts");
+        dialog.setLayout(new BorderLayout());
+        dialog.setDisposeWhenPointerOutOfBounds(false);
+        Container list = new Container(BoxLayout.y());
+        list.setScrollableY(true);
+
+        // One cell so the listeners below, which have to be effectively final
+        // to be captured, can still report what the user chose.
+        final Contact[][] answer = new Contact[1][];
+        answer[0] = new Contact[0];
+
+        Container buttons = new Container(BoxLayout.x());
+        Button cancel = new Button("Cancel");
+        cancel.addActionListener(new ActionListener<ActionEvent>() {
+            @Override
+            public void actionPerformed(ActionEvent ev) {
+                answer[0] = new Contact[0];
+                dialog.dispose();
+            }
+        });
+        buttons.add(cancel);
+
+        if (offered.isEmpty()) {
+            list.add(new Label("No contact carries the requested fields"));
+        } else if (multiSelect) {
+            final List<CheckBox> boxes = new ArrayList<CheckBox>();
+            for (int iter = 0; iter < offered.size(); iter++) {
+                CheckBox box = new CheckBox(describe(offered.get(iter)));
+                boxes.add(box);
+                list.add(box);
+            }
+            Button done = new Button("Done");
+            done.addActionListener(new ActionListener<ActionEvent>() {
+                @Override
+                public void actionPerformed(ActionEvent ev) {
+                    List<Contact> picked = new ArrayList<Contact>();
+                    for (int iter = 0; iter < boxes.size(); iter++) {
+                        // Past the limit the extra ticks are dropped, which
+                        // is what a platform picker does when it stops
+                        // letting the user tick any more.
+                        if (boxes.get(iter).isSelected()
+                                && picked.size() < selectionLimit) {
+                            picked.add(project(offered.get(iter), fields));
+                        }
+                    }
+                    answer[0] = picked.toArray(new Contact[picked.size()]);
+                    dialog.dispose();
+                }
+            });
+            buttons.add(done);
+        } else {
+            for (int iter = 0; iter < offered.size(); iter++) {
+                final Contact contact = offered.get(iter);
+                Button entry = new Button(describe(contact));
+                entry.addActionListener(new ActionListener<ActionEvent>() {
+                    @Override
+                    public void actionPerformed(ActionEvent ev) {
+                        answer[0] = new Contact[]{project(contact, fields)};
+                        dialog.dispose();
+                    }
+                });
+                list.add(entry);
+            }
+        }
+
+        dialog.add(BorderLayout.CENTER, list);
+        dialog.add(BorderLayout.SOUTH, buttons);
+        dialog.showStretched(BorderLayout.CENTER, true);
+        response.actionPerformed(new ActionEvent(answer[0]));
+    }
+
+    private static String describe(Contact contact) {
+        StringBuilder out = new StringBuilder(name(contact));
+        if (contact.getPrimaryPhoneNumber() != null) {
+            out.append(" - ").append(contact.getPrimaryPhoneNumber());
+        } else if (contact.getPrimaryEmail() != null) {
+            out.append(" - ").append(contact.getPrimaryEmail());
+        }
+        return out.toString();
+    }
+}

--- a/Ports/JavaSE/src/com/codename1/impl/javase/ContactPickerSimulation.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/ContactPickerSimulation.java
@@ -322,7 +322,11 @@ final class ContactPickerSimulation {
     private static void show(final List<Contact> offered, final int fields,
             boolean multiSelect, final int selectionLimit,
             final ActionListener<ActionEvent> response) {
-        final Dialog dialog = new Dialog("Contacts");
+        // The cap is in the title as well as enforced below, so a tick that
+        // refuses to stay on reads as the rule it is rather than as a bug in
+        // the simulator.
+        final Dialog dialog = new Dialog(multiSelect && selectionLimit < offered.size()
+                ? "Contacts (pick up to " + selectionLimit + ")" : "Contacts");
         dialog.setLayout(new BorderLayout());
         dialog.setDisposeWhenPointerOutOfBounds(false);
         Container list = new Container(BoxLayout.y());
@@ -349,7 +353,21 @@ final class ContactPickerSimulation {
         } else if (multiSelect) {
             final List<CheckBox> boxes = new ArrayList<CheckBox>();
             for (int iter = 0; iter < offered.size(); iter++) {
-                CheckBox box = new CheckBox(describe(offered.get(iter)));
+                final CheckBox box = new CheckBox(describe(offered.get(iter)));
+                // The cap is enforced as the user ticks rather than when they
+                // press Done. Dropping the surplus at the end would report a
+                // different selection from the one on screen, and the
+                // platform pickers do not do that: Android stops accepting
+                // ticks at its limit and the iOS picker is presented in
+                // single-select mode when the limit is one.
+                box.addActionListener(new ActionListener<ActionEvent>() {
+                    @Override
+                    public void actionPerformed(ActionEvent ev) {
+                        if (box.isSelected() && selected(boxes) > selectionLimit) {
+                            box.setSelected(false);
+                        }
+                    }
+                });
                 boxes.add(box);
                 list.add(box);
             }
@@ -359,9 +377,10 @@ final class ContactPickerSimulation {
                 public void actionPerformed(ActionEvent ev) {
                     List<Contact> picked = new ArrayList<Contact>();
                     for (int iter = 0; iter < boxes.size(); iter++) {
-                        // Past the limit the extra ticks are dropped, which
-                        // is what a platform picker does when it stops
-                        // letting the user tick any more.
+                        // The bound is unreachable -- the tick handler above
+                        // never lets the count past it -- and is kept so this
+                        // loop cannot report more than the caller asked for
+                        // however the boxes got into their state.
                         if (boxes.get(iter).isSelected()
                                 && picked.size() < selectionLimit) {
                             picked.add(project(offered.get(iter), fields));
@@ -391,6 +410,20 @@ final class ContactPickerSimulation {
         dialog.add(BorderLayout.SOUTH, buttons);
         dialog.showStretched(BorderLayout.CENTER, true);
         response.actionPerformed(new ActionEvent(answer[0]));
+    }
+
+    /**
+     * @param boxes the multi-select rows
+     * @return how many are currently ticked
+     */
+    private static int selected(List<CheckBox> boxes) {
+        int count = 0;
+        for (int iter = 0; iter < boxes.size(); iter++) {
+            if (boxes.get(iter).isSelected()) {
+                count++;
+            }
+        }
+        return count;
     }
 
     private static String describe(Contact contact) {

--- a/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
@@ -16886,6 +16886,26 @@ public class JavaSEPort extends CodenameOneImplementation {
         }
         return (Contact) contacts.get(id);
     }
+
+    @Override
+    public boolean isContactPickerSupported() {
+        return true;
+    }
+
+    @Override
+    public void pickContacts(int requestedFields, boolean multiSelect,
+            int selectionLimit, boolean requireAllRequestedFields,
+            com.codename1.ui.events.ActionListener<com.codename1.ui.events.ActionEvent> response) {
+        // No checkForPermission and no checkContactsUsageDescription: a
+        // picker is the way an app reads contacts *without* asking for
+        // either, and simulating a permission prompt here would teach the
+        // developer the opposite of what ships.
+        if (contacts == null) {
+            contacts = createSimulatedContacts();
+        }
+        ContactPickerSimulation.pick(contacts, requestedFields, multiSelect,
+                selectionLimit, requireAllRequestedFields, response);
+    }
     
     @Override
     public Contact getContactById(String id, boolean includesFullName, boolean includesPicture,
@@ -19015,8 +19035,23 @@ public class JavaSEPort extends CodenameOneImplementation {
         return skin;
     }
     
+    /**
+     * The simulated address book, as seen through the broad contacts API.
+     *
+     * <p>Reading the whole book is what needs {@code NSContactsUsageDescription}
+     * on the device, so the build hint is nagged for here rather than in
+     * {@link #createSimulatedContacts()}. The contact picker shares the same
+     * data and deliberately does not come through this door: its iOS
+     * counterpart runs out of process and needs no usage description, and
+     * adding the hint behind the developer's back would misrepresent what the
+     * app asks for.</p>
+     */
     private Hashtable initContacts() {
         checkContactsUsageDescription();
+        return createSimulatedContacts();
+    }
+
+    private Hashtable createSimulatedContacts() {
         Hashtable retVal = new Hashtable();
         
         Image img = null;

--- a/Ports/iOSPort/nativeSources/IOSNative.m
+++ b/Ports/iOSPort/nativeSources/IOSNative.m
@@ -10017,7 +10017,13 @@ void com_codename1_impl_ios_IOSNative_openContactPicker___int_boolean_int(CN1_TH
 #if defined(CN1_USE_CONTACT_PICKER) && TARGET_OS_IOS
     const BOOL requireAll = (requestedFields & CN1_CONTACT_REQUIRE_ALL) != 0;
     const int fields = requestedFields & ~CN1_CONTACT_REQUIRE_ALL;
-    const BOOL multi = multiSelect != JAVA_FALSE;
+    // A cap of one IS a single selection, whatever the caller passed for
+    // multiSelect. The multi-select picker has no cap of its own -- the limit
+    // is applied to the array it returns -- so honouring multiSelect here
+    // would let the user tick five contacts and watch four of them vanish on
+    // the way back. The single-select picker enforces the cap in the UI,
+    // where the user can see it.
+    const BOOL multi = multiSelect != JAVA_FALSE && selectionLimit > 1;
     const int limit = multi ? (int)selectionLimit : 1;
     dispatch_async(dispatch_get_main_queue(), ^{
         POOL_BEGIN();

--- a/Ports/iOSPort/nativeSources/IOSNative.m
+++ b/Ports/iOSPort/nativeSources/IOSNative.m
@@ -9867,10 +9867,26 @@ static void cn1ContactPickerFinished(NSArray* contacts) {
     cn1PickedContacts = nil;
     if (contacts != nil && cn1ContactPickerLimit > 0
             && (int)[contacts count] > cn1ContactPickerLimit) {
-        // The platform picker has no selection limit of its own, so the
-        // caller's limit is applied here. Dropping the tail rather than
-        // reporting nothing keeps a user who over-selected with something
-        // rather than an unexplained empty result.
+        // CNContactPickerViewController has no selection-limit property and
+        // no per-selection delegate callback to veto one with -- the only
+        // multi-select hook fires once, after the user has confirmed. So a
+        // cap above one cannot be enforced in its UI, and the choice is what
+        // to do with a confirmation that exceeded it.
+        //
+        // Review asked for the confirmation to be rejected instead of
+        // truncated. Under this API that is strictly worse: a rejection can
+        // only be reported as an empty selection, which is the same thing a
+        // cancelled pick reports, so neither the user nor the application
+        // would be able to tell an over-selection from a cancel -- and the
+        // application would have nothing to show for a pick the user did
+        // make. Truncating keeps the user's first N choices, which is what
+        // the caller asked for, and leaves the count consistent with Android,
+        // whose picker enforces the same cap in its own UI.
+        //
+        // Logged rather than silent, so the developer who set the cap sees
+        // this happen while they are testing the flow.
+        CN1Log(@"Contact picker: user selected %d contacts, capped at %d",
+               (int)[contacts count], cn1ContactPickerLimit);
         contacts = [contacts subarrayWithRange:NSMakeRange(0, cn1ContactPickerLimit)];
     }
 #ifndef CN1_USE_ARC

--- a/Ports/iOSPort/nativeSources/IOSNative.m
+++ b/Ports/iOSPort/nativeSources/IOSNative.m
@@ -10021,6 +10021,19 @@ void com_codename1_impl_ios_IOSNative_openContactPicker___int_boolean_int(CN1_TH
     const int limit = multi ? (int)selectionLimit : 1;
     dispatch_async(dispatch_get_main_queue(), ^{
         POOL_BEGIN();
+        if (cn1ContactPickerDelegate != nil) {
+            // A picker is already on screen. UIKit would refuse the second
+            // presentation anyway, and overwriting the delegate slot would
+            // release the object the first picker still holds a WEAK
+            // reference to -- a dangling pointer rather than a missed
+            // callback. Display rejects a second pick before it reaches
+            // here; this is the same answer for anything that calls the
+            // native directly.
+            POOL_END();
+            com_codename1_impl_ios_IOSImplementation_contactPickerResult___int(
+                    CN1_THREAD_GET_STATE_PASS_ARG 0);
+            return;
+        }
         cn1ContactPickerLimit = limit;
         CNContactPickerViewController* picker =
                 [[CNContactPickerViewController alloc] init];

--- a/Ports/iOSPort/nativeSources/IOSNative.m
+++ b/Ports/iOSPort/nativeSources/IOSNative.m
@@ -119,6 +119,20 @@ static id<NSObject> cn1MacIdleActivity = nil;
 #import <EventKit/EventKit.h>
 #endif
 #endif
+// The contact picker (com.codename1.contacts.ContactPicker). ContactsUI is
+// absent on watchOS and tvOS, and macOS has a different picker class, so the
+// implementation is iOS and Mac Catalyst only; every other slice compiles the
+// natives as no-ops that report the picker unsupported. Turned on by
+// IPhoneBuilder when the application references the API, which is also what
+// links ContactsUI.framework -- the two have to move together or the build
+// fails to link.
+#if !TARGET_OS_WATCH && !TARGET_OS_TV
+//#define CN1_USE_CONTACT_PICKER
+#if defined(CN1_USE_CONTACT_PICKER) && TARGET_OS_IOS
+#import <Contacts/Contacts.h>
+#import <ContactsUI/ContactsUI.h>
+#endif
+#endif
 #import <CoreText/CoreText.h>
 #include <ifaddrs.h>
 #include <net/if.h>
@@ -9799,6 +9813,430 @@ void com_codename1_impl_ios_IOSNative_updatePersonWithRecordID___int_com_codenam
     }
     
     POOL_END();
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// Contact picker -- com.codename1.contacts.ContactPicker
+//
+// Nothing here touches the address book. CNContactPickerViewController runs
+// out of process and hands back copies of only the contacts the user tapped,
+// which is why this path deliberately does not sit behind
+// INCLUDE_CONTACTS_USAGE the way everything above it does: a picker needs no
+// NSContactsUsageDescription, and requiring the build hint would make the
+// privacy-preserving path harder to adopt than the broad one it replaces.
+//
+// The functions exist unconditionally even when CN1_USE_CONTACT_PICKER is off.
+// A native method is kept alive by its symbol appearing in the native sources,
+// so compiling the symbol away would let the dead-code pass drop the Java
+// method and the failure would be a silently inert feature rather than a link
+// error.
+// ---------------------------------------------------------------------------
+
+// Mirrors the field constants on com.codename1.contacts.ContactPicker. Both
+// sides of one bit set, and nothing checks that they agree, so they are named
+// here rather than passed as seven booleans.
+#define CN1_CONTACT_FIELD_NAME 1
+#define CN1_CONTACT_FIELD_PHONE 2
+#define CN1_CONTACT_FIELD_EMAIL 4
+#define CN1_CONTACT_FIELD_ADDRESS 8
+#define CN1_CONTACT_FIELD_PHOTO 16
+#define CN1_CONTACT_FIELD_BIRTHDAY 32
+#define CN1_CONTACT_FIELD_WEBSITE 64
+// IOSImplementation.CONTACT_PICKER_REQUIRE_ALL, which rides the same int.
+#define CN1_CONTACT_REQUIRE_ALL 0x40000000
+
+#if defined(CN1_USE_CONTACT_PICKER) && TARGET_OS_IOS
+
+// The contacts the user picked, held only between the callback into Java and
+// releasePickedContacts. CNContactPickerViewController is modal, so one slot
+// is enough: a second pick cannot begin while the first is on screen.
+static NSArray* cn1PickedContacts = nil;
+
+// The picker's delegate is a weak property, so something has to own the
+// delegate for the life of the presentation. This does.
+static id cn1ContactPickerDelegate = nil;
+
+static int cn1ContactPickerLimit = 0;
+
+/// Publishes the selection and wakes the Java side.
+static void cn1ContactPickerFinished(NSArray* contacts) {
+#ifndef CN1_USE_ARC
+    [cn1PickedContacts release];
+#endif
+    cn1PickedContacts = nil;
+    if (contacts != nil && cn1ContactPickerLimit > 0
+            && (int)[contacts count] > cn1ContactPickerLimit) {
+        // The platform picker has no selection limit of its own, so the
+        // caller's limit is applied here. Dropping the tail rather than
+        // reporting nothing keeps a user who over-selected with something
+        // rather than an unexplained empty result.
+        contacts = [contacts subarrayWithRange:NSMakeRange(0, cn1ContactPickerLimit)];
+    }
+#ifndef CN1_USE_ARC
+    cn1PickedContacts = [contacts retain];
+    // autorelease, not release: this runs from inside the delegate's own
+    // method, and releasing the last reference would free it under its own
+    // stack frame.
+    [cn1ContactPickerDelegate autorelease];
+#else
+    cn1PickedContacts = contacts;
+#endif
+    cn1ContactPickerDelegate = nil;
+    int count = cn1PickedContacts == nil ? 0 : (int)[cn1PickedContacts count];
+    com_codename1_impl_ios_IOSImplementation_contactPickerResult___int(
+            CN1_THREAD_GET_STATE_PASS_ARG count);
+}
+
+/// Single selection.
+///
+/// Two delegate classes rather than one with a flag: CNContactPickerViewController
+/// picks its selection mode by asking whether the delegate implements
+/// contactPicker:didSelectContacts:, so a class carrying both methods is
+/// always multi-select.
+@interface CN1ContactPickerSingleDelegate : NSObject <CNContactPickerDelegate>
+@end
+
+@implementation CN1ContactPickerSingleDelegate
+- (void)contactPicker:(CNContactPickerViewController*)picker
+     didSelectContact:(CNContact*)contact {
+    cn1ContactPickerFinished(contact == nil ? nil : [NSArray arrayWithObject:contact]);
+}
+
+- (void)contactPickerDidCancel:(CNContactPickerViewController*)picker {
+    cn1ContactPickerFinished(nil);
+}
+@end
+
+/// Multiple selection. @see CN1ContactPickerSingleDelegate
+@interface CN1ContactPickerMultiDelegate : NSObject <CNContactPickerDelegate>
+@end
+
+@implementation CN1ContactPickerMultiDelegate
+- (void)contactPicker:(CNContactPickerViewController*)picker
+    didSelectContacts:(NSArray<CNContact*>*)contacts {
+    cn1ContactPickerFinished(contacts);
+}
+
+- (void)contactPickerDidCancel:(CNContactPickerViewController*)picker {
+    cn1ContactPickerFinished(nil);
+}
+@end
+
+/// The contact keys a field request needs fetched.
+static NSArray* cn1ContactPickerKeys(int fields) {
+    NSMutableArray* keys = [NSMutableArray array];
+    if ((fields & CN1_CONTACT_FIELD_NAME) != 0) {
+        [keys addObject:CNContactGivenNameKey];
+        [keys addObject:CNContactFamilyNameKey];
+        [keys addObject:CNContactOrganizationNameKey];
+    }
+    if ((fields & CN1_CONTACT_FIELD_PHONE) != 0) {
+        [keys addObject:CNContactPhoneNumbersKey];
+    }
+    if ((fields & CN1_CONTACT_FIELD_EMAIL) != 0) {
+        [keys addObject:CNContactEmailAddressesKey];
+    }
+    if ((fields & CN1_CONTACT_FIELD_ADDRESS) != 0) {
+        [keys addObject:CNContactPostalAddressesKey];
+    }
+    if ((fields & CN1_CONTACT_FIELD_PHOTO) != 0) {
+        [keys addObject:CNContactThumbnailImageDataKey];
+    }
+    if ((fields & CN1_CONTACT_FIELD_BIRTHDAY) != 0) {
+        [keys addObject:CNContactBirthdayKey];
+    }
+    if ((fields & CN1_CONTACT_FIELD_WEBSITE) != 0) {
+        [keys addObject:CNContactUrlAddressesKey];
+    }
+    return keys;
+}
+
+/// The predicate that decides which contacts the picker offers.
+///
+/// Matches what Android's picker does with the same request. Requiring every
+/// field is an AND over the multi-value kinds; requiring any of them is an OR,
+/// and only when a name was not among them -- every contact has a name, so a
+/// request that includes one is satisfied by everybody and must not be
+/// narrowed by the other clauses.
+static NSPredicate* cn1ContactPickerPredicate(int fields, BOOL requireAll) {
+    NSMutableArray* clauses = [NSMutableArray array];
+    if ((fields & CN1_CONTACT_FIELD_PHONE) != 0) {
+        [clauses addObject:@"phoneNumbers.@count > 0"];
+    }
+    if ((fields & CN1_CONTACT_FIELD_EMAIL) != 0) {
+        [clauses addObject:@"emailAddresses.@count > 0"];
+    }
+    if ((fields & CN1_CONTACT_FIELD_ADDRESS) != 0) {
+        [clauses addObject:@"postalAddresses.@count > 0"];
+    }
+    if ([clauses count] == 0) {
+        return nil;
+    }
+    if (!requireAll && (fields & CN1_CONTACT_FIELD_NAME) != 0) {
+        return nil;
+    }
+    NSString* joined = [clauses componentsJoinedByString:(requireAll ? @" AND " : @" OR ")];
+    return [NSPredicate predicateWithFormat:joined];
+}
+
+/// Maps a Contacts label to the key AndroidContactsManager and the iOS
+/// address-book path already use, so an application that moved a lookup over
+/// to the picker keeps reading the same hashtable keys.
+static NSString* cn1ContactPickerLabel(NSString* label) {
+    if (label == nil) {
+        return @"other";
+    }
+    if ([label isEqualToString:CNLabelHome]) {
+        return @"home";
+    }
+    if ([label isEqualToString:CNLabelWork]) {
+        return @"work";
+    }
+    if ([label isEqualToString:CNLabelPhoneNumberMobile]
+            || [label isEqualToString:CNLabelPhoneNumberiPhone]) {
+        return @"mobile";
+    }
+    if ([label isEqualToString:CNLabelPhoneNumberHomeFax]
+            || [label isEqualToString:CNLabelPhoneNumberWorkFax]) {
+        return @"fax";
+    }
+    return @"other";
+}
+#endif
+
+JAVA_BOOLEAN com_codename1_impl_ios_IOSNative_isContactPickerSupported___R_boolean(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject) {
+#if defined(CN1_USE_CONTACT_PICKER) && TARGET_OS_IOS
+    return JAVA_TRUE;
+#else
+    return JAVA_FALSE;
+#endif
+}
+
+void com_codename1_impl_ios_IOSNative_openContactPicker___int_boolean_int(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject, JAVA_INT requestedFields, JAVA_BOOLEAN multiSelect, JAVA_INT selectionLimit) {
+#if defined(CN1_USE_CONTACT_PICKER) && TARGET_OS_IOS
+    const BOOL requireAll = (requestedFields & CN1_CONTACT_REQUIRE_ALL) != 0;
+    const int fields = requestedFields & ~CN1_CONTACT_REQUIRE_ALL;
+    const BOOL multi = multiSelect != JAVA_FALSE;
+    const int limit = multi ? (int)selectionLimit : 1;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        POOL_BEGIN();
+        cn1ContactPickerLimit = limit;
+        CNContactPickerViewController* picker =
+                [[CNContactPickerViewController alloc] init];
+        picker.displayedPropertyKeys = cn1ContactPickerKeys(fields);
+        NSPredicate* enabling = cn1ContactPickerPredicate(fields, requireAll);
+        if (enabling != nil) {
+            picker.predicateForEnablingContact = enabling;
+        }
+        id delegate = multi
+                ? (id)[[CN1ContactPickerMultiDelegate alloc] init]
+                : (id)[[CN1ContactPickerSingleDelegate alloc] init];
+        cn1ContactPickerDelegate = delegate;
+        picker.delegate = delegate;
+        [cn1PresentingController() presentViewController:picker animated:YES completion:nil];
+#ifndef CN1_USE_ARC
+        [picker release];
+#endif
+        POOL_END();
+    });
+#else
+    // No picker on this slice, which the Java side already checked -- reported
+    // rather than ignored so a caller that reached here still gets its
+    // listener called exactly once.
+    com_codename1_impl_ios_IOSImplementation_contactPickerResult___int(
+            CN1_THREAD_STATE_PASS_ARG 0);
+#endif
+}
+
+void com_codename1_impl_ios_IOSNative_updatePickedContact___int_com_codename1_contacts_Contact_int(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject, JAVA_INT index, JAVA_OBJECT cnt, JAVA_INT requestedFields) {
+#if defined(CN1_USE_CONTACT_PICKER) && TARGET_OS_IOS
+    if (cn1PickedContacts == nil || index < 0
+            || index >= (JAVA_INT)[cn1PickedContacts count]) {
+        return;
+    }
+    POOL_BEGIN();
+    const int fields = requestedFields & ~CN1_CONTACT_REQUIRE_ALL;
+    CNContact* contact = [cn1PickedContacts objectAtIndex:index];
+    com_codename1_contacts_Contact_setId___java_lang_String(CN1_THREAD_STATE_PASS_ARG cnt,
+            fromNSString(CN1_THREAD_STATE_PASS_ARG contact.identifier));
+
+    // Every read is guarded by isKeyAvailable. CNContact THROWS on a property
+    // the fetch did not include, and the picker decides its own key set from
+    // displayedPropertyKeys -- so an unguarded read of a field the user's
+    // contact happens not to carry would take down the app rather than return
+    // nothing.
+    NSString* given = nil;
+    NSString* family = nil;
+    if ((fields & CN1_CONTACT_FIELD_NAME) != 0) {
+        if ([contact isKeyAvailable:CNContactGivenNameKey]) {
+            given = contact.givenName;
+            if ([given length] > 0) {
+                com_codename1_contacts_Contact_setFirstName___java_lang_String(
+                        CN1_THREAD_STATE_PASS_ARG cnt,
+                        fromNSString(CN1_THREAD_STATE_PASS_ARG given));
+            }
+        }
+        if ([contact isKeyAvailable:CNContactFamilyNameKey]) {
+            family = contact.familyName;
+            if ([family length] > 0) {
+                com_codename1_contacts_Contact_setFamilyName___java_lang_String(
+                        CN1_THREAD_STATE_PASS_ARG cnt,
+                        fromNSString(CN1_THREAD_STATE_PASS_ARG family));
+            }
+        }
+        NSString* display = nil;
+        if ([given length] > 0 && [family length] > 0) {
+            display = [NSString stringWithFormat:@"%@ %@", given, family];
+        } else if ([given length] > 0) {
+            display = given;
+        } else if ([family length] > 0) {
+            display = family;
+        } else if ([contact isKeyAvailable:CNContactOrganizationNameKey]
+                && [contact.organizationName length] > 0) {
+            display = contact.organizationName;
+        }
+        if (display != nil) {
+            com_codename1_contacts_Contact_setDisplayName___java_lang_String(
+                    CN1_THREAD_STATE_PASS_ARG cnt,
+                    fromNSString(CN1_THREAD_STATE_PASS_ARG display));
+        }
+    }
+
+    if ((fields & CN1_CONTACT_FIELD_PHONE) != 0
+            && [contact isKeyAvailable:CNContactPhoneNumbersKey]) {
+        JAVA_OBJECT hash = com_codename1_contacts_Contact_getPhoneNumbers___R_java_util_Hashtable(
+                CN1_THREAD_STATE_PASS_ARG cnt);
+        BOOL first = YES;
+        for (CNLabeledValue<CNPhoneNumber*>* entry in contact.phoneNumbers) {
+            NSString* number = [entry.value stringValue];
+            if ([number length] == 0) {
+                continue;
+            }
+            if (first) {
+                com_codename1_contacts_Contact_setPrimaryPhoneNumber___java_lang_String(
+                        CN1_THREAD_STATE_PASS_ARG cnt,
+                        fromNSString(CN1_THREAD_STATE_PASS_ARG number));
+                first = NO;
+            }
+            java_util_Hashtable_put___java_lang_Object_java_lang_Object_R_java_lang_Object(
+                    CN1_THREAD_STATE_PASS_ARG hash,
+                    fromNSString(CN1_THREAD_STATE_PASS_ARG cn1ContactPickerLabel(entry.label)),
+                    fromNSString(CN1_THREAD_STATE_PASS_ARG number));
+        }
+    }
+
+    if ((fields & CN1_CONTACT_FIELD_EMAIL) != 0
+            && [contact isKeyAvailable:CNContactEmailAddressesKey]) {
+        JAVA_OBJECT hash = com_codename1_contacts_Contact_getEmails___R_java_util_Hashtable(
+                CN1_THREAD_STATE_PASS_ARG cnt);
+        BOOL first = YES;
+        for (CNLabeledValue<NSString*>* entry in contact.emailAddresses) {
+            NSString* address = (NSString*)entry.value;
+            if ([address length] == 0) {
+                continue;
+            }
+            if (first) {
+                com_codename1_contacts_Contact_setPrimaryEmail___java_lang_String(
+                        CN1_THREAD_STATE_PASS_ARG cnt,
+                        fromNSString(CN1_THREAD_STATE_PASS_ARG address));
+                first = NO;
+            }
+            java_util_Hashtable_put___java_lang_Object_java_lang_Object_R_java_lang_Object(
+                    CN1_THREAD_STATE_PASS_ARG hash,
+                    fromNSString(CN1_THREAD_STATE_PASS_ARG cn1ContactPickerLabel(entry.label)),
+                    fromNSString(CN1_THREAD_STATE_PASS_ARG address));
+        }
+    }
+
+    if ((fields & CN1_CONTACT_FIELD_ADDRESS) != 0
+            && [contact isKeyAvailable:CNContactPostalAddressesKey]) {
+        JAVA_OBJECT hash = com_codename1_contacts_Contact_getAddresses___R_java_util_Hashtable(
+                CN1_THREAD_STATE_PASS_ARG cnt);
+        for (CNLabeledValue<CNPostalAddress*>* entry in contact.postalAddresses) {
+            CNPostalAddress* postal = entry.value;
+            JAVA_OBJECT addr = __NEW_com_codename1_contacts_Address(CN1_THREAD_STATE_PASS_SINGLE_ARG);
+            com_codename1_contacts_Address___INIT____(CN1_THREAD_STATE_PASS_ARG addr);
+            com_codename1_contacts_Address_setStreetAddress___java_lang_String(
+                    CN1_THREAD_STATE_PASS_ARG addr,
+                    fromNSString(CN1_THREAD_STATE_PASS_ARG postal.street));
+            com_codename1_contacts_Address_setLocality___java_lang_String(
+                    CN1_THREAD_STATE_PASS_ARG addr,
+                    fromNSString(CN1_THREAD_STATE_PASS_ARG postal.city));
+            com_codename1_contacts_Address_setRegion___java_lang_String(
+                    CN1_THREAD_STATE_PASS_ARG addr,
+                    fromNSString(CN1_THREAD_STATE_PASS_ARG postal.state));
+            com_codename1_contacts_Address_setPostalCode___java_lang_String(
+                    CN1_THREAD_STATE_PASS_ARG addr,
+                    fromNSString(CN1_THREAD_STATE_PASS_ARG postal.postalCode));
+            com_codename1_contacts_Address_setCountry___java_lang_String(
+                    CN1_THREAD_STATE_PASS_ARG addr,
+                    fromNSString(CN1_THREAD_STATE_PASS_ARG postal.country));
+            java_util_Hashtable_put___java_lang_Object_java_lang_Object_R_java_lang_Object(
+                    CN1_THREAD_STATE_PASS_ARG hash,
+                    fromNSString(CN1_THREAD_STATE_PASS_ARG cn1ContactPickerLabel(entry.label)),
+                    addr);
+        }
+    }
+
+    if ((fields & CN1_CONTACT_FIELD_BIRTHDAY) != 0
+            && [contact isKeyAvailable:CNContactBirthdayKey]) {
+        NSDateComponents* birthday = contact.birthday;
+        NSDate* date = birthday == nil ? nil : [birthday date];
+        if (date != nil) {
+            com_codename1_contacts_Contact_setBirthday___long(CN1_THREAD_STATE_PASS_ARG cnt,
+                    (JAVA_LONG)([date timeIntervalSince1970] * 1000));
+        }
+    }
+
+    if ((fields & CN1_CONTACT_FIELD_WEBSITE) != 0
+            && [contact isKeyAvailable:CNContactUrlAddressesKey]) {
+        NSArray* urls = contact.urlAddresses;
+        if ([urls count] > 0) {
+            JAVA_OBJECT array = __NEW_ARRAY_java_lang_String(CN1_THREAD_STATE_PASS_ARG
+                    (JAVA_INT)[urls count]);
+            JAVA_ARRAY_OBJECT* entries = (JAVA_ARRAY_OBJECT*)((JAVA_ARRAY)array)->data;
+            int pos = 0;
+            for (CNLabeledValue<NSString*>* entry in urls) {
+                NSString* url = (NSString*)entry.value;
+                entries[pos++] = fromNSString(CN1_THREAD_STATE_PASS_ARG
+                        (url == nil ? @"" : url));
+            }
+            com_codename1_contacts_Contact_setUrls___java_lang_String_1ARRAY(
+                    CN1_THREAD_STATE_PASS_ARG cnt, array);
+        }
+    }
+
+    if ((fields & CN1_CONTACT_FIELD_PHOTO) != 0
+            && [contact isKeyAvailable:CNContactThumbnailImageDataKey]
+            && contact.thumbnailImageData != nil) {
+        CN1Image* img = [CN1Image imageWithData:contact.thumbnailImageData];
+        if (img != nil) {
+            GLUIImage* g = [[GLUIImage alloc] initWithImage:img];
+            enteringNativeAllocations();
+            struct obj__com_codename1_impl_ios_IOSImplementation_NativeImage* nativeImage =
+                    (struct obj__com_codename1_impl_ios_IOSImplementation_NativeImage*)
+                    __NEW_com_codename1_impl_ios_IOSImplementation_NativeImage(CN1_THREAD_STATE_PASS_SINGLE_ARG);
+            (*nativeImage).com_codename1_impl_ios_IOSImplementation_NativeImage_peer = (JAVA_LONG)g;
+            (*nativeImage).com_codename1_impl_ios_IOSImplementation_NativeImage_width = (int)[g getImage].size.width;
+            (*nativeImage).com_codename1_impl_ios_IOSImplementation_NativeImage_height = (int)[g getImage].size.height;
+            JAVA_OBJECT image = com_codename1_ui_Image_createImage___java_lang_Object_R_com_codename1_ui_Image(
+                    CN1_THREAD_STATE_PASS_ARG (JAVA_OBJECT)nativeImage);
+            com_codename1_contacts_Contact_setPhoto___com_codename1_ui_Image(
+                    CN1_THREAD_STATE_PASS_ARG cnt, image);
+            finishedNativeAllocations();
+        }
+    }
+    POOL_END();
+#endif
+}
+
+void com_codename1_impl_ios_IOSNative_releasePickedContacts__(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject) {
+#if defined(CN1_USE_CONTACT_PICKER) && TARGET_OS_IOS
+#ifndef CN1_USE_ARC
+    [cn1PickedContacts release];
+#endif
+    cn1PickedContacts = nil;
 #endif
 }
 

--- a/Ports/iOSPort/nativeSources/IOSNative.m
+++ b/Ports/iOSPort/nativeSources/IOSNative.m
@@ -10067,6 +10067,26 @@ void com_codename1_impl_ios_IOSNative_openContactPicker___int_boolean_int(CN1_TH
                     CN1_THREAD_GET_STATE_PASS_ARG 0);
             return;
         }
+        UIViewController* host = cn1PresentingController();
+        if (host == nil || host.presentedViewController != nil) {
+            // Something else is already on screen -- the share sheet, the file
+            // chooser, the gallery. UIKit refuses to present over it and calls
+            // nothing back, so going ahead would install this delegate for a
+            // picker that never appears: no delegate method would ever run,
+            // the Java listener would never be called, and Display would treat
+            // the pick as still in progress and refuse every later one for the
+            // life of the process.
+            //
+            // The same hazard as an Android activity whose result channel is
+            // busy, and the same answer: report the empty selection a
+            // cancelled pick reports, and leave the other presentation alone.
+            CN1Log(@"Contact picker: another view controller is presented, "
+                   "reporting an empty selection");
+            POOL_END();
+            com_codename1_impl_ios_IOSImplementation_contactPickerResult___int(
+                    CN1_THREAD_GET_STATE_PASS_ARG 0);
+            return;
+        }
         cn1ContactPickerLimit = limit;
         CNContactPickerViewController* picker =
                 [[CNContactPickerViewController alloc] init];
@@ -10080,7 +10100,7 @@ void com_codename1_impl_ios_IOSNative_openContactPicker___int_boolean_int(CN1_TH
                 : (id)[[CN1ContactPickerSingleDelegate alloc] init];
         cn1ContactPickerDelegate = delegate;
         picker.delegate = delegate;
-        [cn1PresentingController() presentViewController:picker animated:YES completion:nil];
+        [host presentViewController:picker animated:YES completion:nil];
 #ifndef CN1_USE_ARC
         [picker release];
 #endif

--- a/Ports/iOSPort/nativeSources/IOSNative.m
+++ b/Ports/iOSPort/nativeSources/IOSNative.m
@@ -9864,7 +9864,14 @@ static id cn1ContactPickerDelegate = nil;
 
 static int cn1ContactPickerLimit = 0;
 
-/// Publishes the selection and wakes the Java side.
+/// Hands the selection that is already published over to the Java side.
+static void cn1DeliverContactPickerResult(void) {
+    int count = cn1PickedContacts == nil ? 0 : (int)[cn1PickedContacts count];
+    com_codename1_impl_ios_IOSImplementation_contactPickerResult___int(
+            CN1_THREAD_GET_STATE_PASS_ARG count);
+}
+
+/// Publishes the selection and wakes the Java side once the picker is gone.
 static void cn1ContactPickerFinished(NSArray* contacts) {
 #ifndef CN1_USE_ARC
     [cn1PickedContacts release];
@@ -9904,9 +9911,27 @@ static void cn1ContactPickerFinished(NSArray* contacts) {
     cn1PickedContacts = contacts;
 #endif
     cn1ContactPickerDelegate = nil;
-    int count = cn1PickedContacts == nil ? 0 : (int)[cn1PickedContacts count];
-    com_codename1_impl_ios_IOSImplementation_contactPickerResult___int(
-            CN1_THREAD_GET_STATE_PASS_ARG count);
+    // NOT delivered from here. UIKit dismisses the picker only after this
+    // delegate method returns, so the controller is still on screen right
+    // now -- and a listener that starts another pick straight away would run
+    // into its own picker on the way out and be told, wrongly, that nothing
+    // was selected. Hopping to the next main-queue turn lets the dismissal
+    // begin; its transition coordinator then says when it has finished.
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UIViewController* host = cn1PresentingController();
+        id<UIViewControllerTransitionCoordinator> transition =
+                host == nil ? nil : host.transitionCoordinator;
+        // animateAlongsideTransition: answers NO when no transition is
+        // running, and does not call the block -- so delivering in that case
+        // is the missing delivery rather than a second one.
+        if (transition == nil
+                || ![transition animateAlongsideTransition:nil
+                        completion:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+                    cn1DeliverContactPickerResult();
+                }]) {
+            cn1DeliverContactPickerResult();
+        }
+    });
 }
 
 /// Single selection.

--- a/Ports/iOSPort/nativeSources/IOSNative.m
+++ b/Ports/iOSPort/nativeSources/IOSNative.m
@@ -9845,6 +9845,11 @@ void com_codename1_impl_ios_IOSNative_updatePersonWithRecordID___int_com_codenam
 #define CN1_CONTACT_FIELD_WEBSITE 64
 // IOSImplementation.CONTACT_PICKER_REQUIRE_ALL, which rides the same int.
 #define CN1_CONTACT_REQUIRE_ALL 0x40000000
+// The fields CNContactPickerViewController's enabling predicate cannot test.
+// Every contact has a name, and the other three are not predicate key paths.
+#define CN1_CONTACT_UNFILTERABLE (CN1_CONTACT_FIELD_NAME \
+        | CN1_CONTACT_FIELD_PHOTO | CN1_CONTACT_FIELD_BIRTHDAY \
+        | CN1_CONTACT_FIELD_WEBSITE)
 
 #if defined(CN1_USE_CONTACT_PICKER) && TARGET_OS_IOS
 
@@ -9989,7 +9994,13 @@ static NSPredicate* cn1ContactPickerPredicate(int fields, BOOL requireAll) {
     if ([clauses count] == 0) {
         return nil;
     }
-    if (!requireAll && (fields & CN1_CONTACT_FIELD_NAME) != 0) {
+    // An "any of these" request that names a field with no clause cannot be
+    // narrowed at all. Every contact has a name, and a contact with only a
+    // photo, a birthday or a web site satisfies the request just as well as
+    // one with a phone number -- so ORing the clauses that DO exist would
+    // hide it. Only NAME was exempted here at first, which left
+    // PHONE|PHOTO behaving as phone-only.
+    if (!requireAll && (fields & CN1_CONTACT_UNFILTERABLE) != 0) {
         return nil;
     }
     NSString* joined = [clauses componentsJoinedByString:(requireAll ? @" AND " : @" OR ")];

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
@@ -29,6 +29,7 @@ import com.codename1.codescan.CodeScanner;
 import com.codename1.codescan.ScanResult;
 import com.codename1.contacts.Address;
 import com.codename1.contacts.Contact;
+import com.codename1.contacts.ContactPicker;
 import com.codename1.db.Database;
 import com.codename1.db.DatabaseEncryptionException;
 import com.codename1.db.DatabaseConfig;
@@ -9997,6 +9998,23 @@ public class IOSImplementation extends CodenameOneImplementation {
                 multiSelect, selectionLimit);
     }
 
+    /// Nulls out the picker tables the native side found nothing for.
+    ///
+    /// #### Parameters
+    ///
+    /// - `c`: the contact just populated from a picked CNContact
+    private static void dropEmpty(Contact c) {
+        if (c.getPhoneNumbers() != null && c.getPhoneNumbers().isEmpty()) {
+            c.setPhoneNumbers(null);
+        }
+        if (c.getEmails() != null && c.getEmails().isEmpty()) {
+            c.setEmails(null);
+        }
+        if (c.getAddresses() != null && c.getAddresses().isEmpty()) {
+            c.setAddresses(null);
+        }
+    }
+
     /// Marks `#pickContacts` as wanting every requested field present.
     ///
     /// Rides the field bit set rather than a separate argument so the native
@@ -10023,10 +10041,21 @@ public class IOSImplementation extends CodenameOneImplementation {
             for (int iter = 0; iter < picked.length; iter++) {
                 Contact c = new Contact();
                 // The native side fills these rather than creating them, the
-                // same way updatePersonWithRecordID does.
-                c.setAddresses(new Hashtable());
-                c.setEmails(new Hashtable());
-                c.setPhoneNumbers(new Hashtable());
+                // same way updatePersonWithRecordID does -- but only for the
+                // fields that were asked for. Creating all three regardless
+                // would hand the caller an empty table where this API
+                // promises null, and only on iOS, so code that tells "not
+                // requested" from "requested and absent" would read the two
+                // the same way here and differently everywhere else.
+                if ((fields & ContactPicker.ADDRESS) != 0) {
+                    c.setAddresses(new Hashtable());
+                }
+                if ((fields & ContactPicker.EMAIL) != 0) {
+                    c.setEmails(new Hashtable());
+                }
+                if ((fields & ContactPicker.PHONE) != 0) {
+                    c.setPhoneNumbers(new Hashtable());
+                }
                 if (System.currentTimeMillis() == 0) {
                     // Keeps Address and its setters out of the dead-code pass;
                     // only the native side ever calls them. Same hack, and
@@ -10040,6 +10069,12 @@ public class IOSImplementation extends CodenameOneImplementation {
                     c.getAddresses().put("", tmp);
                 }
                 instance.nativeInstance.updatePickedContact(iter, c, fields);
+                // A table the native side left empty means the contact simply
+                // had none of that kind. Android and the simulator report that
+                // as null because they build the table only once they have a
+                // value, so it is dropped here rather than leaving iOS the one
+                // platform that answers an empty table.
+                dropEmpty(c);
                 picked[iter] = c;
             }
         } finally {

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
@@ -9957,6 +9957,108 @@ public class IOSImplementation extends CodenameOneImplementation {
         }
         return getContactById(id, true, true, true, true, true);
     }
+
+    /// The listener waiting for the contact picker, and the fields it asked
+    /// for.
+    ///
+    /// One slot rather than a queue, like the capture callback beside it:
+    /// `CNContactPickerViewController` is modal, so a second pick cannot
+    /// start while the first is on screen.
+    private static EventDispatcher contactPickerCallback;
+
+    private static int contactPickerFields;
+
+    @Override
+    public boolean isContactPickerSupported() {
+        return nativeInstance.isContactPickerSupported();
+    }
+
+    @Override
+    public void pickContacts(int requestedFields, boolean multiSelect,
+                             int selectionLimit, boolean requireAllRequestedFields,
+                             ActionListener<ActionEvent> response) {
+        if (!nativeInstance.isContactPickerSupported()) {
+            fireContactPickerResult(response, new Contact[0]);
+            return;
+        }
+        // Deliberately no checkContactsUsage. The picker is a separate
+        // process that hands back only what the user tapped, so it needs no
+        // NSContactsUsageDescription -- demanding the build hint here would
+        // make the privacy-preserving path harder to adopt than the broad
+        // one it replaces.
+        contactPickerFields = requestedFields;
+        contactPickerCallback = new EventDispatcher();
+        contactPickerCallback.addListener(response);
+        // requireAllRequestedFields reaches the picker as its enabling
+        // predicate, which is built natively from the same field bits.
+        nativeInstance.openContactPicker(
+                requireAllRequestedFields ? requestedFields | CONTACT_PICKER_REQUIRE_ALL
+                        : requestedFields,
+                multiSelect, selectionLimit);
+    }
+
+    /// Marks `#pickContacts` as wanting every requested field present.
+    ///
+    /// Rides the field bit set rather than a separate argument so the native
+    /// signature stays one int; it is well above every
+    /// `com.codename1.contacts.ContactPicker` constant.
+    static final int CONTACT_PICKER_REQUIRE_ALL = 0x40000000;
+
+    /// Invoked from the Objective-C picker delegate once the user is done.
+    ///
+    /// The picked contacts are still held natively when this runs; each one
+    /// is copied across and then the native array is dropped. Public and
+    /// static because the C side calls it by its mangled symbol, which is
+    /// also the only thing keeping it out of the dead-code pass.
+    ///
+    /// #### Parameters
+    ///
+    /// - `count`: how many contacts the user picked, zero when cancelled
+    public static void contactPickerResult(final int count) {
+        final EventDispatcher target = contactPickerCallback;
+        contactPickerCallback = null;
+        final int fields = contactPickerFields;
+        Contact[] picked = new Contact[Math.max(0, count)];
+        try {
+            for (int iter = 0; iter < picked.length; iter++) {
+                Contact c = new Contact();
+                // The native side fills these rather than creating them, the
+                // same way updatePersonWithRecordID does.
+                c.setAddresses(new Hashtable());
+                c.setEmails(new Hashtable());
+                c.setPhoneNumbers(new Hashtable());
+                if (System.currentTimeMillis() == 0) {
+                    // Keeps Address and its setters out of the dead-code pass;
+                    // only the native side ever calls them. Same hack, and
+                    // same reason, as getContactById above.
+                    Address tmp = new Address();
+                    tmp.setCountry("");
+                    tmp.setLocality("");
+                    tmp.setRegion("");
+                    tmp.setPostalCode("");
+                    tmp.setStreetAddress("");
+                    c.getAddresses().put("", tmp);
+                }
+                instance.nativeInstance.updatePickedContact(iter, c, fields);
+                picked[iter] = c;
+            }
+        } finally {
+            instance.nativeInstance.releasePickedContacts();
+        }
+        final Contact[] result = picked;
+        if (target == null) {
+            return;
+        }
+        if (deliverPickerResultOnEdt(new Runnable() {
+            @Override
+            public void run() {
+                target.fireActionEvent(new ActionEvent(result));
+            }
+        })) {
+            return;
+        }
+        target.fireActionEvent(new ActionEvent(result));
+    }
     
     @Override
     public void dial(String phoneNumber) {        

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSNative.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSNative.java
@@ -698,6 +698,51 @@ public final class IOSNative {
     native long createPersonPhotoImage(long id);
     native String createContact(String firstName, String surname, String officePhone, String homePhone, String cellPhone, String email);
     native boolean deleteContact(int id);
+
+    /**
+     * Whether {@code CNContactPickerViewController} was compiled into this
+     * build and can run on this device.
+     *
+     * <p>False when the application never referenced
+     * {@code com.codename1.contacts.ContactPicker}, because the builder only
+     * turns on {@code CN1_USE_CONTACT_PICKER} and links ContactsUI when it
+     * did.</p>
+     */
+    native boolean isContactPickerSupported();
+
+    /**
+     * Presents the system contact picker.
+     *
+     * <p>Unlike every other native on this class the picker needs no
+     * {@code NSContactsUsageDescription}: it runs out of process and hands
+     * back only the contacts the user tapped.</p>
+     *
+     * @param requestedFields bit set of
+     *                        {@code com.codename1.contacts.ContactPicker}
+     *                        constants
+     * @param multiSelect     true to let the user pick more than one
+     * @param selectionLimit  the largest selection to report back
+     */
+    native void openContactPicker(int requestedFields, boolean multiSelect, int selectionLimit);
+
+    /**
+     * Copies one picked contact into a Java {@code Contact}.
+     *
+     * <p>Valid only between the {@code contactPickerResult} callback and
+     * {@link #releasePickedContacts()}, which is when the native side is
+     * still holding the array the picker returned.</p>
+     *
+     * @param index           position in the picked array
+     * @param cnt             the contact to populate, whose hashtables must
+     *                        already exist
+     * @param requestedFields bit set of
+     *                        {@code com.codename1.contacts.ContactPicker}
+     *                        constants
+     */
+    native void updatePickedContact(int index, Contact cnt, int requestedFields);
+
+    /** Drops the picked contacts the native side was holding. */
+    native void releasePickedContacts();
     
     native void dial(String phone);
     native void requestAppStoreReview();

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava040Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava040Snippet.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Codename One in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.contacts.*;
+import com.codename1.ui.*;
+import com.codename1.ui.events.*;
+
+class MiscellaneousFeaturesJava040Snippet {
+
+    TextField numberField;
+
+    void snippet() throws Exception {
+        // tag::miscellaneous-features-java-040[]
+        ContactPicker picker = new ContactPicker();
+        picker.setRequestedFields(ContactPicker.NAME | ContactPicker.PHONE);
+        picker.pick(ev -> {
+            Contact[] picked = ContactPicker.getPickedContacts(ev);
+            if(picked.length > 0) {
+                numberField.setText(picked[0].getPrimaryPhoneNumber());
+            }
+        });
+        // end::miscellaneous-features-java-040[]
+    }
+}

--- a/docs/developer-guide/Miscellaneous-Features.asciidoc
+++ b/docs/developer-guide/Miscellaneous-Features.asciidoc
@@ -145,6 +145,26 @@ TIP: Notice that the code above uses `callSerially` & `scheduleBackgroundTask` i
 
 You can use `createContact(String firstName, String familyName, String officePhone, String homePhone, String cellPhone, String email)` to add a new contact and deleteContact(String id) to delete a contact.
 
+==== Contact picker
+
+The API above reads the whole address book, so it needs the broad contacts permission. If all you need is a contact the user chose, use
+https://www.codenameone.com/javadoc/com/codename1/contacts/ContactPicker.html[ContactPicker] instead. It shows the platform's own picker, and the app only ever sees the contacts the user tapped and only the fields it asked for.
+
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava040Snippet.java[tag=miscellaneous-features-java-040,indent=0]
+----
+
+IMPORTANT: From 2027-01-27 Google Play requires an app that targets Android 17 (API level 37) or later and requests `READ_CONTACTS` to pass a Play Console declaration explaining why the picker isn't enough. An app that only picks never requests that permission, so it never files that declaration. The build only adds `READ_CONTACTS` for the broad API, so mixing the two in one app puts the permission back.
+
+Ask for as little as you can. On Android the requested fields also decide which contacts the picker offers, and the platform returns nothing you didn't ask for. `setMultiSelect(boolean)` lets the user pick several contacts, `setSelectionLimit(int)` caps how many, and `setRequireAllRequestedFields(boolean)` hides contacts that are missing one of them.
+
+The contacts you get back are snapshots. There's no continuing access behind them, so anything you need later has to be copied out of the `Contact` and stored by your app.
+
+`ContactPicker.isSupported()` tells you whether the platform has a picker at all. Android, iOS and the simulator do; where a platform doesn't, `pick` reports an empty selection rather than falling back to reading the address book, because that fallback would need the permission you were avoiding. A cancelled pick reports the same empty selection, so `getPickedContacts` is the only thing your listener has to check.
+
+TIP: Android 17 and newer show the system picker. Older releases fall back to the contacts app's own single-row picker, which needs no permission either but returns one contact carrying one kind of data. On those releases a multiple selection comes back with a single contact, and the field ranking is phone, then email, then postal address.
+
 
 === Localization & internationalization (L10N & I18N)
 

--- a/docs/developer-guide/Miscellaneous-Features.asciidoc
+++ b/docs/developer-guide/Miscellaneous-Features.asciidoc
@@ -163,7 +163,7 @@ The contacts you get back are snapshots. There's no continuing access behind the
 
 `ContactPicker.isSupported()` tells you whether the platform has a picker at all. Android, iOS and the simulator do; where a platform doesn't, `pick` reports an empty selection rather than falling back to reading the address book, because that fallback would need the permission you were avoiding. A cancelled pick reports the same empty selection, so `getPickedContacts` is the only thing your listener has to check.
 
-TIP: Android 17 and newer show the system picker. Older releases fall back to the contacts app's own single-row picker, which needs no permission either but returns one contact carrying one kind of data. On those releases a multiple selection comes back with a single contact, and the field ranking is phone, then email, then postal address.
+TIP: Android 17 and newer show the system picker, and serve every field. Older releases fall back to the contacts app's own single-row picker, which needs no permission either but returns one contact carrying one kind of data: the name plus whichever of phone, email and postal address was requested first. A photo, a birthday or a web site is best-effort there, a multiple selection comes back as a single contact, and `setRequireAllRequestedFields` has no effect. Nothing about that escalates into a permission prompt - the fields you can't have simply come back null, so read every one you asked for defensively.
 
 
 === Localization & internationalization (L10N & I18N)

--- a/docs/website/data/port_status.json
+++ b/docs/website/data/port_status.json
@@ -611,6 +611,15 @@
       ]
     },
     {
+      "id": "contact-picker",
+      "category": "Device APIs",
+      "name": "Contact picker",
+      "description": "Checks the request contract of the privacy-minimized contact picker: the fields and selection limits it accepts and rejects, and that a result carrying no selection is an empty array rather than a null.",
+      "tests": [
+        "ContactPickerApiTest"
+      ]
+    },
+    {
       "id": "secure-storage-crypto",
       "category": "Storage and security",
       "name": "Secure storage and cryptography",

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
@@ -472,6 +472,15 @@ public class AndroidGradleBuilder extends Executor {
     private boolean calendarReadPermission;
     private boolean calendarWritePermission;
     private boolean contactsWritePermission;
+    /**
+     * Which of the two contacts permissions the application actually needs.
+     *
+     * <p>Its own class because "referenced a class under
+     * com.codename1.contacts" stopped being the answer once the contact
+     * picker, which needs no permission at all, started returning
+     * {@code Contact} objects from that same package.</p>
+     */
+    private final ContactsPermissionScan contactsScan = new ContactsPermissionScan();
     private boolean addRemoteControlService;
     /**
      * @deprecated for use to build 1.1 version
@@ -2032,9 +2041,7 @@ public class AndroidGradleBuilder extends Executor {
                             foregroundServicePermission = true;
                         }
                     }
-                    if (cls.indexOf("com/codename1/contacts") > -1) {
-                        contactsReadPermission = true;
-                    }
+                    contactsScan.usesClass(cls);
                     if (cls.indexOf("com/codename1/payment") > -1) {
                         purchasePermissions = true;
                     }
@@ -2537,9 +2544,7 @@ public class AndroidGradleBuilder extends Executor {
                     if (cls.indexOf("com/codename1/ui/Display") == 0 && method.indexOf("getMsisdn") > -1) {
                         phonePermission = true;
                     }
-                    if (cls.indexOf("com/codename1/ui/Display") == 0 && method.indexOf("getAllContacts") > -1) {
-                        contactsReadPermission = true;
-                    }
+                    contactsScan.usesClassMethod(cls, method);
                     if (cls.indexOf("com/codename1/ui/Display") == 0 && method.indexOf("lockScreen") > -1) {
                         wakeLock = true;
                     }
@@ -2556,18 +2561,7 @@ public class AndroidGradleBuilder extends Executor {
                     // usesClassMethodWithDescriptor: which overload was
                     // called decides whether any shared media is read,
                     // and the name alone cannot say.
-                    if (cls.indexOf("com/codename1/ui/Display") == 0 && method.indexOf("createContact") > -1) {
-                        contactsWritePermission = true;
-                    }
-                    if (cls.indexOf("com/codename1/ui/Display") == 0 && method.indexOf("deleteContact") > -1) {
-                        contactsWritePermission = true;
-                    }
-                    if (cls.indexOf("com/codename1/contacts/ContactsManager") == 0 && method.indexOf("createContact") > -1) {
-                        contactsWritePermission = true;
-                    }
-                    if (cls.indexOf("com/codename1/contacts/ContactsManager") == 0 && method.indexOf("deleteContact") > -1) {
-                        contactsWritePermission = true;
-                    }
+
                     // WiFi scan implies management. We detect the method
                     // rather than just the class so that apps that only read
                     // SSID/BSSID (no scan) do not pick up CHANGE_WIFI_STATE.
@@ -2590,6 +2584,8 @@ public class AndroidGradleBuilder extends Executor {
         } catch (IOException ex) {
             throw new BuildException("An error occurred while trying to scan the classes for API usage.", ex);
         }
+        contactsReadPermission = contactsScan.readPermissionRequired();
+        contactsWritePermission = contactsScan.writePermissionRequired();
 
         // The libraries as well as the loose class tree.
         //

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/ContactsPermissionScan.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/ContactsPermissionScan.java
@@ -72,6 +72,24 @@ final class ContactsPermissionScan {
         "ContactPicker",
     };
 
+    // Exempting Contact is safe even when the code that READ it lives in a
+    // submitted library, which review has asked about three times. A cn1lib is
+    // entirely client-side: CN1BuildMojo.mergeJars merges every
+    // compile-classpath element except codenameone-core and java-runtime into
+    // the -jar-with-dependencies.jar that becomes the dist.jar the client
+    // uploads, so the library's own ContactsManager and Display references
+    // are walked by the same scan of loose classes that sees the
+    // application's.
+    //
+    // Measured rather than argued, on a real built artifact: the sample app's
+    // dist.jar carries com/codename1/ads/mock/*.class -- classes belonging to
+    // its cn1-ads-mock DEPENDENCY -- as loose entries stamped with that
+    // library's own build date, and contains no nested jar or aar at all.
+    // Nothing routed to the libraries directory holds Java classes, so
+    // folding that tree in would add no signal and would risk the opposite
+    // failure: a scanner over a directory that also receives framework
+    // payloads reports usage for every application ever built.
+
     private static final String DISPLAY = "com/codename1/ui/Display";
 
     private static final String CONTACTS_MANAGER =

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/ContactsPermissionScan.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/ContactsPermissionScan.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Codename One in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.builders;
+
+/**
+ * Decides whether an application needs the broad contacts permissions.
+ *
+ * <p>It used to be one line: anything under {@code com.codename1.contacts}
+ * meant {@code READ_CONTACTS}. That was right while the only way to reach a
+ * contact was to enumerate the address book. It stopped being right when
+ * {@code ContactPicker} arrived, because the picker's whole purpose is to
+ * hand over a user-selected contact <em>without</em> that permission, and it
+ * necessarily traffics in {@code Contact} objects from the same package. An
+ * app that only ever picks would still have shipped asking to read the
+ * address book -- which from 2027-01-27 is exactly what Google Play makes an
+ * app justify in a Play Console declaration.</p>
+ *
+ * <p>So the package is split by what a class actually does rather than by
+ * where it lives. {@code Contact}, {@code Address} and {@code ContactPicker}
+ * read nothing on their own; everything else in the package does. The split
+ * is deliberately stated the safe way round: a class this file has never
+ * heard of still asks for the permission, so adding one to the package
+ * cannot silently strip a permission an app depends on. Only a class named
+ * here can be permission-free, and each is named because it was checked.</p>
+ *
+ * <p>Two things follow from the scan being over the app's own classes rather
+ * than the framework's. It sees a {@code Contact} reference the app makes and
+ * not one the framework makes internally, so a picking app never trips the
+ * broad rule. And it cannot see through a facade: a {@code Display} call that
+ * reads the address book has to be named here by method, because after this
+ * change its {@code Contact} return type no longer speaks for it.</p>
+ *
+ * <p><b>Keep this file in sync with
+ * {@code com.codename1.build.daemon.ContactsPermissionScan}.</b></p>
+ */
+final class ContactsPermissionScan {
+
+    /** Where the contacts API lives, with the trailing separator. */
+    private static final String CONTACTS_PACKAGE = "com/codename1/contacts/";
+
+    /**
+     * Classes under {@link #CONTACTS_PACKAGE} that reach no address book.
+     *
+     * <p>{@code Contact} and {@code Address} are value objects with no
+     * behaviour at all. {@code ContactPicker} launches the platform's picker,
+     * which grants the app temporary access to the contacts the user chose
+     * and nothing else.</p>
+     */
+    private static final String[] PERMISSION_FREE_CLASSES = {
+        "Contact",
+        "Address",
+        "ContactPicker",
+    };
+
+    private static final String DISPLAY = "com/codename1/ui/Display";
+
+    private static final String CONTACTS_MANAGER =
+            "com/codename1/contacts/ContactsManager";
+
+    /**
+     * {@code Display} methods that read the address book.
+     *
+     * <p>Every one of these used to be caught indirectly, by the
+     * {@code Contact} it returns or takes. Nothing catches them now, so they
+     * are listed. {@code pickContacts} and {@code isContactPickerSupported}
+     * are pointedly absent: they are the picker.</p>
+     */
+    private static final String[] DISPLAY_READ_METHODS = {
+        "getAllContacts",
+        "getContactById",
+        "getLinkedContactIds",
+        "refreshContacts",
+        "isGetAllContactsFast",
+        "isContactsPermissionGranted",
+    };
+
+    /** Methods that add to or remove from the address book. */
+    private static final String[] WRITE_METHODS = {
+        "createContact",
+        "deleteContact",
+    };
+
+    private boolean read;
+
+    private boolean write;
+
+    /**
+     * Reports a class the application references.
+     *
+     * @param cls internal name, slash separated
+     */
+    void usesClass(String cls) {
+        if (cls == null || !cls.startsWith(CONTACTS_PACKAGE)) {
+            return;
+        }
+        if (!permissionFree(cls.substring(CONTACTS_PACKAGE.length()))) {
+            read = true;
+        }
+    }
+
+    /**
+     * Reports a method the application calls.
+     *
+     * @param cls    internal name of the declared owner, slash separated
+     * @param method the method name
+     */
+    void usesClassMethod(String cls, String method) {
+        if (cls == null || method == null) {
+            return;
+        }
+        boolean contactsApi = DISPLAY.equals(cls)
+                || CONTACTS_MANAGER.equals(cls);
+        if (!contactsApi) {
+            return;
+        }
+        for (int iter = 0; iter < WRITE_METHODS.length; iter++) {
+            if (method.indexOf(WRITE_METHODS[iter]) > -1) {
+                write = true;
+                // Creating a contact reads nothing, so this deliberately does
+                // not also set the read flag.
+                return;
+            }
+        }
+        for (int iter = 0; iter < DISPLAY_READ_METHODS.length; iter++) {
+            if (method.indexOf(DISPLAY_READ_METHODS[iter]) > -1) {
+                read = true;
+                return;
+            }
+        }
+    }
+
+    /**
+     * @return true if the generated manifest must request
+     *         {@code READ_CONTACTS}
+     */
+    boolean readPermissionRequired() {
+        return read;
+    }
+
+    /**
+     * @return true if the generated manifest must request
+     *         {@code WRITE_CONTACTS}
+     */
+    boolean writePermissionRequired() {
+        return write;
+    }
+
+    /**
+     * Whether a class in the contacts package reaches no address book.
+     *
+     * <p>A nested class counts as its outer class, so
+     * {@code ContactPicker$1} -- which is what an anonymous listener inside a
+     * picker call compiles to -- is judged as {@code ContactPicker} rather
+     * than falling through to the permission-requiring default.</p>
+     *
+     * @param simpleName the part of the internal name after the package
+     * @return true if referencing it implies no permission
+     */
+    private static boolean permissionFree(String simpleName) {
+        String outer = simpleName;
+        int nested = outer.indexOf('$');
+        if (nested > 0) {
+            outer = outer.substring(0, nested);
+        }
+        if (outer.indexOf('/') > -1) {
+            // A subpackage of com.codename1.contacts. None exists today and
+            // the safe answer for one that appears later is the permission.
+            return false;
+        }
+        for (int iter = 0; iter < PERMISSION_FREE_CLASSES.length; iter++) {
+            if (PERMISSION_FREE_CLASSES[iter].equals(outer)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
@@ -1409,6 +1409,15 @@ public class IPhoneBuilder extends Executor {
     private boolean usesWifiHotspotConfig;
     private boolean usesBonjour;
     private boolean usesCalendarApi;
+    /**
+     * Whether the application shows the system contact picker.
+     *
+     * <p>Keyed on {@code ContactPicker} alone rather than on the contacts
+     * package, because the point of the picker is that it is the one member
+     * of that package which needs neither the address book nor a usage
+     * description.</p>
+     */
+    private boolean usesContactPicker;
     private boolean usesCalendarEventApi;
     private boolean usesCalendarTaskApi;
     private String firstBonjourType;
@@ -2420,6 +2429,10 @@ public class IPhoneBuilder extends Executor {
                     aiAcc.consume(cls);
                     if (cls.indexOf("com/codename1/calendar/LocalCalendarSource") == 0) {
                         usesCalendarApi = true;
+                    }
+                    if (!usesContactPicker
+                            && "com/codename1/contacts/ContactPicker".equals(cls)) {
+                        usesContactPicker = true;
                     }
                     if (!usesLocalNotifications && cls.indexOf("com/codename1/notifications/LocalNotification") == 0) {
                         usesLocalNotifications = true;
@@ -4269,6 +4282,27 @@ public class IPhoneBuilder extends Executor {
                 } else if (!addLibs.toLowerCase().contains("eventkit")) {
                     addLibs = addLibs + ";EventKit.framework";
                 }
+            }
+
+            // CNContactPickerViewController, behind
+            // com.codename1.contacts.ContactPicker. The define and the two
+            // frameworks travel together: the native sources only reference
+            // ContactsUI inside CN1_USE_CONTACT_PICKER, and turning the define
+            // on without linking would fail at link rather than at compile.
+            //
+            // Contacts.framework comes with it because the picker hands back
+            // CNContact objects the native code then reads.
+            if (usesContactPicker) {
+                try {
+                    replaceInFile(new File(buildinRes, "IOSNative.m"),
+                            "//#define CN1_USE_CONTACT_PICKER",
+                            "#define CN1_USE_CONTACT_PICKER");
+                } catch (IOException ex) {
+                    throw new BuildException(
+                            "Failed to enable CN1_USE_CONTACT_PICKER", ex);
+                }
+                addLibs = appendFrameworks(addLibs, "ContactsUI.framework",
+                        "Contacts.framework");
             }
 
             // DeviceCheck.framework backs App Attest (com.codename1.security.

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java
@@ -2430,6 +2430,18 @@ public class IPhoneBuilder extends Executor {
                     if (cls.indexOf("com/codename1/calendar/LocalCalendarSource") == 0) {
                         usesCalendarApi = true;
                     }
+                    // classesDir only, and deliberately so. Reviewers read the
+                    // database scan beside this one -- which passes buildinRes
+                    // as well -- and conclude a cn1lib's reference would be
+                    // invisible here. It would not: CN1BuildMojo.mergeJars
+                    // merges EVERY compile-classpath element except
+                    // codenameone-core and java-runtime into the
+                    // -jar-with-dependencies.jar that becomes dist.jar, so a
+                    // library's classes arrive already merged with the
+                    // application's own and are walked as loose classes. What
+                    // reaches buildinRes is native input -- framework zips,
+                    // static archives, the port's own sources -- none of which
+                    // references a Java class.
                     if (!usesContactPicker
                             && "com/codename1/contacts/ContactPicker".equals(cls)) {
                         usesContactPicker = true;
@@ -2752,6 +2764,19 @@ public class IPhoneBuilder extends Executor {
                     // entries for every feature, health included, and is
                     // indifferent to what follows.
                     aiAcc.consumeMethod(cls, method);
+                    // Display carries the contact picker too, and an app is
+                    // free to call it there instead of through ContactPicker.
+                    // The class reference cannot say so -- every app
+                    // references Display -- so the two entry points are named.
+                    // Missing one ships an iOS build with the picker compiled
+                    // out and every pick answering empty, while the same app
+                    // works on Android and in the simulator.
+                    if (!usesContactPicker
+                            && "com/codename1/ui/Display".equals(cls)
+                            && (method.indexOf("pickContacts") > -1
+                                || method.indexOf("isContactPickerSupported") > -1)) {
+                        usesContactPicker = true;
+                    }
                     // Health.getStore()/getWorkouts() mean a real platform
                     // store; Health.getSensors() means BLE only. The class
                     // reference alone cannot tell them apart, so the facade

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/TvNativeBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/TvNativeBuilder.java
@@ -106,6 +106,12 @@ class TvNativeBuilder {
             // ARKit is iOS-only; it is linked on the iOS slice when the app references
             // com.codename1.ar, so weak-link it for the tvOS slice.
             + "ARKit.framework;"
+            // Neither Contacts nor ContactsUI exists on tvOS -- measured against AppleTVOS26.2,
+            // where neither .framework directory is present -- and the iOS slice links both when
+            // the app references com.codename1.contacts.ContactPicker. IOSNative.m compiles the
+            // picker out for the TV slice (CN1_USE_CONTACT_PICKER is only honoured under
+            // TARGET_OS_IOS), so nothing there calls into either one.
+            + "Contacts.framework;ContactsUI.framework;"
             // HealthKit does not exist on tvOS at all. The iOS slice links it when the app
             // references com.codename1.health, so weak-link it here or the tvOS slice fails
             // to link. CN1Health.m additionally compiles itself out via TARGET_OS_TV.

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/WatchNativeBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/WatchNativeBuilder.java
@@ -177,6 +177,14 @@ class WatchNativeBuilder {
             // translator, so they appear only in projects that use the feature. That is why they
             // outlived two rounds of this list: a build that never touches Vision never links it,
             // and the watch link only fails for the app that does.
+            // ContactsUI is absent from the watchOS SDK -- verified with the ls above against
+            // WatchOS26.2, where the directory does not exist -- and the iOS slice links it when
+            // the app references com.codename1.contacts.ContactPicker. Contacts.framework beside
+            // it IS present, so that one is linkable rather than optional; only the UI half has
+            // to be weak-linked. IOSNative.m already compiles the picker out for the watch
+            // (CN1_USE_CONTACT_PICKER is only honoured under TARGET_OS_IOS), so nothing on the
+            // watch slice calls into it.
+            + "ContactsUI.framework;"
             + "AdSupport.framework;CoreImage.framework;CoreNFC.framework;"
             + "CoreTelephony.framework;JavaScriptCore.framework;Vision.framework;"
             // Named by PlatformFeatureCatalog rather than written in IPhoneBuilder, so they are
@@ -222,6 +230,11 @@ class WatchNativeBuilder {
             + "LocalAuthentication.framework;MobileCoreServices.framework;"
             + "NaturalLanguage.framework;NetworkExtension.framework;PhotosUI.framework;"
             + "QuartzCore.framework;Security.framework;UserNotifications.framework;"
+            // Linked on the iOS slice alongside ContactsUI when the app references
+            // com.codename1.contacts.ContactPicker. Present in both watch SDKs, and the watch
+            // never calls into it -- but a framework that IS there links harmlessly, and
+            // declaring it linkable is what the partition test above asks for.
+            + "Contacts.framework;"
             + "WatchConnectivity.framework";
 
     WatchNativeBuilder(IPhoneBuilder owner) {

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/ContactsPermissionScanTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/ContactsPermissionScanTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Codename One in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.builders;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Which contacts permissions an application's class references earn it.
+ *
+ * <p>The case that forced this apart from a one-line package check is
+ * {@link #aPickerOnlyApplicationAsksForNoContactsPermission()}: from
+ * 2027-01-27 an Android app carrying {@code READ_CONTACTS} without
+ * core-functionality justification needs a Play Console declaration, and an
+ * app that only ever shows the contact picker should not be in that
+ * position. The rest of the cases exist because the naive fix -- stop
+ * treating the package as broad access -- silently drops the permission from
+ * apps that do read the address book.</p>
+ */
+class ContactsPermissionScanTest {
+
+    private static final String DISPLAY = "com/codename1/ui/Display";
+    private static final String CONTACT = "com/codename1/contacts/Contact";
+    private static final String PICKER = "com/codename1/contacts/ContactPicker";
+    private static final String MANAGER =
+            "com/codename1/contacts/ContactsManager";
+
+    /**
+     * The whole point. Picking references the picker and the value object it
+     * returns, and neither reads an address book.
+     */
+    @Test
+    void aPickerOnlyApplicationAsksForNoContactsPermission() {
+        ContactsPermissionScan scan = new ContactsPermissionScan();
+        scan.usesClass(PICKER);
+        scan.usesClass(CONTACT);
+        scan.usesClass("com/codename1/contacts/Address");
+        scan.usesClassMethod(PICKER, "pick");
+        scan.usesClassMethod(DISPLAY, "pickContacts");
+        scan.usesClassMethod(DISPLAY, "isContactPickerSupported");
+
+        assertFalse(scan.readPermissionRequired(),
+                "a picker-only app must not ship asking to read contacts");
+        assertFalse(scan.writePermissionRequired());
+    }
+
+    /** An anonymous listener inside a pick call is still the picker. */
+    @Test
+    void aNestedClassOfAPermissionFreeClassIsPermissionFree() {
+        ContactsPermissionScan scan = new ContactsPermissionScan();
+        scan.usesClass(PICKER + "$1");
+        scan.usesClass(CONTACT + "$Builder");
+
+        assertFalse(scan.readPermissionRequired());
+    }
+
+    /** Enumerating the address book still earns the permission. */
+    @Test
+    void theContactsManagerStillEarnsReadPermission() {
+        ContactsPermissionScan scan = new ContactsPermissionScan();
+        scan.usesClass(MANAGER);
+
+        assertTrue(scan.readPermissionRequired());
+        assertFalse(scan.writePermissionRequired());
+    }
+
+    /** So does the list model built on top of it. */
+    @Test
+    void theContactsModelStillEarnsReadPermission() {
+        ContactsPermissionScan scan = new ContactsPermissionScan();
+        scan.usesClass("com/codename1/contacts/ContactsModel");
+
+        assertTrue(scan.readPermissionRequired());
+    }
+
+    /**
+     * A Display call that reads has to be named by method now.
+     *
+     * <p>Before the picker existed, every one of these was caught by the
+     * {@code Contact} it returns. That reference no longer implies anything,
+     * so an unnamed reader would ship without its permission and come back
+     * empty on the device.</p>
+     */
+    @Test
+    void everyBroadDisplayReaderEarnsReadPermission() {
+        String[] readers = {
+            "getAllContacts",
+            "getContactById",
+            "getLinkedContactIds",
+            "refreshContacts",
+            "isGetAllContactsFast",
+            "isContactsPermissionGranted",
+        };
+        for (int iter = 0; iter < readers.length; iter++) {
+            ContactsPermissionScan scan = new ContactsPermissionScan();
+            // Exactly what a Display-only app looks like: the value object
+            // and the call, nothing else.
+            scan.usesClass(CONTACT);
+            scan.usesClassMethod(DISPLAY, readers[iter]);
+            assertTrue(scan.readPermissionRequired(),
+                    "Display." + readers[iter] + " reads the address book");
+        }
+    }
+
+    /** The same methods on the ContactsManager facade. */
+    @Test
+    void theContactsManagerReadersEarnReadPermission() {
+        ContactsPermissionScan scan = new ContactsPermissionScan();
+        scan.usesClassMethod(MANAGER, "getContactById");
+
+        assertTrue(scan.readPermissionRequired());
+    }
+
+    /** Writing is a separate permission and does not imply reading. */
+    @Test
+    void creatingAndDeletingEarnOnlyWritePermission() {
+        String[] writers = {"createContact", "deleteContact"};
+        String[] owners = {DISPLAY, MANAGER};
+        for (int owner = 0; owner < owners.length; owner++) {
+            for (int iter = 0; iter < writers.length; iter++) {
+                ContactsPermissionScan scan = new ContactsPermissionScan();
+                scan.usesClassMethod(owners[owner], writers[iter]);
+                assertTrue(scan.writePermissionRequired(),
+                        owners[owner] + "." + writers[iter]);
+                assertFalse(scan.readPermissionRequired(),
+                        owners[owner] + "." + writers[iter]
+                                + " writes, it does not read");
+            }
+        }
+    }
+
+    /**
+     * An unrecognised class in the package asks for the permission.
+     *
+     * <p>Stated this way round on purpose. A future class that reads the
+     * address book gets its permission without anyone remembering to come
+     * back here; the cost of being wrong is an unused permission rather than
+     * a feature that fails on the device.</p>
+     */
+    @Test
+    void anUnknownClassInThePackageIsTreatedAsBroadAccess() {
+        ContactsPermissionScan scan = new ContactsPermissionScan();
+        scan.usesClass("com/codename1/contacts/SomethingAddedLater");
+
+        assertTrue(scan.readPermissionRequired());
+    }
+
+    /** And so does a subpackage nobody has vetted. */
+    @Test
+    void aSubpackageOfContactsIsTreatedAsBroadAccess() {
+        ContactsPermissionScan scan = new ContactsPermissionScan();
+        scan.usesClass("com/codename1/contacts/sync/ContactSyncAdapter");
+
+        assertTrue(scan.readPermissionRequired());
+    }
+
+    /**
+     * A package whose name merely starts the same way is not the contacts
+     * package.
+     *
+     * <p>The rule this replaced used {@code indexOf(...) > -1}, which would
+     * have said yes to any of these.</p>
+     */
+    @Test
+    void aSimilarlyNamedPackageIsNotTheContactsPackage() {
+        ContactsPermissionScan scan = new ContactsPermissionScan();
+        scan.usesClass("com/codename1/contactsync/Sync");
+        scan.usesClass("com/example/com/codename1/contacts/Fake");
+        scan.usesClass("com/codename1/ui/Display");
+
+        assertFalse(scan.readPermissionRequired());
+        assertFalse(scan.writePermissionRequired());
+    }
+
+    /** An unrelated class and an unrelated method change nothing. */
+    @Test
+    void anApplicationThatNeverTouchesContactsAsksForNothing() {
+        ContactsPermissionScan scan = new ContactsPermissionScan();
+        scan.usesClass("com/codename1/ui/Form");
+        scan.usesClassMethod(DISPLAY, "getDisplayWidth");
+        scan.usesClassMethod(null, null);
+        scan.usesClass(null);
+
+        assertFalse(scan.readPermissionRequired());
+        assertFalse(scan.writePermissionRequired());
+    }
+
+    /**
+     * The methods are only read on the classes that declare them.
+     *
+     * <p>{@code usesClassMethod} reports the declared owner of the call, so
+     * an application class of its own with a {@code getContactById} method
+     * must not drag the permission in.</p>
+     */
+    @Test
+    void aMethodOnAnUnrelatedOwnerIsIgnored() {
+        ContactsPermissionScan scan = new ContactsPermissionScan();
+        scan.usesClassMethod("app/MyCache", "getContactById");
+        scan.usesClassMethod("app/MyCache", "createContact");
+
+        assertFalse(scan.readPermissionRequired());
+        assertFalse(scan.writePermissionRequired());
+    }
+}

--- a/maven/core-unittests/src/test/java/com/codename1/contacts/ContactPickerTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/contacts/ContactPickerTest.java
@@ -260,6 +260,49 @@ class ContactPickerTest extends UITestBase {
                 "the refused pick must never reach the port");
     }
 
+    /**
+     * A pick started off the EDT reaches the port on the EDT.
+     *
+     * <p>The in-progress guard is a plain field, read and written without a
+     * lock, because Codename One is single threaded and core carries no
+     * synchronization. Two background threads would therefore both see it
+     * clear and both start a pick -- the state it exists to prevent. Moving
+     * the whole check-and-start onto the EDT serializes it without a lock,
+     * and this is the deterministic half of that: a real interleaving cannot
+     * be staged here, but "the port was entered on the EDT" is exactly the
+     * property that makes the interleaving impossible.</p>
+     */
+    @FormTest
+    void aPickStartedOffTheEdtReachesThePortOnTheEdt() throws Exception {
+        implementation.clearContacts();
+        implementation.setContactPickerSupported(true);
+        implementation.setContactPickerSelection(contact("a", "Alice", "111"));
+
+        final CountDownLatch answered = new CountDownLatch(1);
+        final AtomicReference<Contact[]> result = new AtomicReference<Contact[]>();
+        Thread worker = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                new ContactPicker().pick(new ActionListener<ActionEvent>() {
+                    @Override
+                    public void actionPerformed(ActionEvent ev) {
+                        result.set(ContactPicker.getPickedContacts(ev));
+                        answered.countDown();
+                    }
+                });
+            }
+        });
+        worker.start();
+        waitFor(answered, 5000);
+
+        List<ContactPickerRequest> requests =
+                implementation.getContactPickerRequests();
+        assertEquals(1, requests.size());
+        assertTrue(requests.get(0).isOnEdt(),
+                "an off-EDT pick must be marshalled before it touches the guard");
+        assertEquals(1, result.get().length);
+    }
+
     /** And the picker works again once the outstanding one has answered. */
     @FormTest
     void aPickAfterTheLastOneFinishedIsAccepted() {

--- a/maven/core-unittests/src/test/java/com/codename1/contacts/ContactPickerTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/contacts/ContactPickerTest.java
@@ -213,6 +213,65 @@ class ContactPickerTest extends UITestBase {
         });
     }
 
+    /**
+     * A second pick while the first is still outstanding is refused.
+     *
+     * <p>Without this the ports' single result slot decodes the first pick
+     * with the second request's fields and hands it to the second listener,
+     * and the first listener is never called at all. A double tap is enough
+     * to produce it, and no platform can show two pickers at once anyway.</p>
+     */
+    @FormTest
+    void aSecondPickWhileOneIsOutstandingReportsEmpty() {
+        implementation.clearContacts();
+        implementation.setContactPickerSupported(true);
+        implementation.setContactPickerSelection(contact("a", "Alice", "111"));
+
+        final CountDownLatch first = new CountDownLatch(1);
+        final AtomicReference<Contact[]> firstResult = new AtomicReference<Contact[]>();
+        new ContactPicker().pick(new ActionListener<ActionEvent>() {
+            @Override
+            public void actionPerformed(ActionEvent ev) {
+                firstResult.set(ContactPicker.getPickedContacts(ev));
+                first.countDown();
+            }
+        });
+
+        // Still in flight: this test body IS the EDT, so the first listener
+        // has not run yet.
+        final CountDownLatch second = new CountDownLatch(1);
+        final AtomicReference<Contact[]> secondResult = new AtomicReference<Contact[]>();
+        new ContactPicker().pick(new ActionListener<ActionEvent>() {
+            @Override
+            public void actionPerformed(ActionEvent ev) {
+                secondResult.set(ContactPicker.getPickedContacts(ev));
+                second.countDown();
+            }
+        });
+
+        waitFor(first, 5000);
+        waitFor(second, 5000);
+        assertEquals(1, firstResult.get().length,
+                "the pick that was already running must still report its selection");
+        assertEquals("Alice", firstResult.get()[0].getDisplayName());
+        assertEquals(0, secondResult.get().length,
+                "the refused pick must report an empty selection, not the other one's");
+        assertEquals(1, implementation.getContactPickerRequests().size(),
+                "the refused pick must never reach the port");
+    }
+
+    /** And the picker works again once the outstanding one has answered. */
+    @FormTest
+    void aPickAfterTheLastOneFinishedIsAccepted() {
+        implementation.clearContacts();
+        implementation.setContactPickerSupported(true);
+        implementation.setContactPickerSelection(contact("a", "Alice", "111"));
+
+        assertEquals(1, pickAndWait(new ContactPicker()).length);
+        assertEquals(1, pickAndWait(new ContactPicker()).length,
+                "the guard must not wedge the picker after a completed pick");
+    }
+
     /** isSupported reports what the platform said, not a guess. */
     @FormTest
     void supportIsReportedFromThePlatform() {

--- a/maven/core-unittests/src/test/java/com/codename1/contacts/ContactPickerTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/contacts/ContactPickerTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Codename One in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.contacts;
+
+import com.codename1.junit.FormTest;
+import com.codename1.junit.UITestBase;
+import com.codename1.testing.TestCodenameOneImplementation.ContactPickerRequest;
+import com.codename1.ui.events.ActionEvent;
+import com.codename1.ui.events.ActionListener;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The contract {@link ContactPicker} promises the ports.
+ *
+ * <p>The picker exists so an application can obtain a contact the user chose
+ * without asking for broad address-book access, which Google Play makes an
+ * app justify from 2027-01-27. That only holds if the request the application
+ * writes down is the request the port receives, and if a cancelled pick is
+ * something a listener cannot mistake for a selection.</p>
+ */
+class ContactPickerTest extends UITestBase {
+
+    private Contact contact(String id, String name, String number) {
+        Contact c = new Contact();
+        c.setId(id);
+        c.setDisplayName(name);
+        c.setPrimaryPhoneNumber(number);
+        return c;
+    }
+
+    private Contact[] pickAndWait(ContactPicker picker) {
+        final CountDownLatch latch = new CountDownLatch(1);
+        final AtomicReference<Contact[]> result = new AtomicReference<Contact[]>();
+        picker.pick(new ActionListener<ActionEvent>() {
+            @Override
+            public void actionPerformed(ActionEvent ev) {
+                result.set(ContactPicker.getPickedContacts(ev));
+                latch.countDown();
+            }
+        });
+        // The port answers through Display.callSerially, so the listener runs
+        // after this test body yields the EDT. waitFor keeps it pumping.
+        waitFor(latch, 5000);
+        return result.get();
+    }
+
+    /** The ordinary case: request two fields, get back what the user chose. */
+    @FormTest
+    void aSelectionReachesTheListener() {
+        implementation.clearContacts();
+        implementation.setContactPickerSupported(true);
+        implementation.setContactPickerSelection(
+                contact("a", "Alice", "111"),
+                contact("b", "Bob", "222"));
+
+        ContactPicker picker = new ContactPicker();
+        picker.setRequestedFields(ContactPicker.NAME | ContactPicker.PHONE);
+        Contact[] picked = pickAndWait(picker);
+
+        assertNotNull(picked);
+        assertEquals(2, picked.length);
+        assertEquals("Alice", picked[0].getDisplayName());
+        assertEquals("222", picked[1].getPrimaryPhoneNumber());
+    }
+
+    /**
+     * A cancelled pick is an empty array, never null.
+     *
+     * <p>Every port funnels "the user backed out", "there is no picker" and
+     * "the temporary grant expired" into the same answer, so a listener that
+     * checks the length is complete.</p>
+     */
+    @FormTest
+    void aCancelledPickReportsAnEmptySelection() {
+        implementation.clearContacts();
+        implementation.setContactPickerSupported(true);
+        implementation.setContactPickerSelection();
+
+        Contact[] picked = pickAndWait(new ContactPicker());
+
+        assertNotNull(picked, "a cancelled pick must not report null");
+        assertEquals(0, picked.length);
+    }
+
+    /** An event that carries something else, or nothing, is also empty. */
+    @FormTest
+    void anEventWithoutContactsIsAnEmptySelection() {
+        assertEquals(0, ContactPicker.getPickedContacts(null).length);
+        assertEquals(0,
+                ContactPicker.getPickedContacts(new ActionEvent("nonsense")).length);
+    }
+
+    /** The request the application configured is the request the port sees. */
+    @FormTest
+    void theConfiguredRequestIsWhatThePortReceives() {
+        implementation.clearContacts();
+        implementation.setContactPickerSupported(true);
+
+        ContactPicker picker = new ContactPicker();
+        picker.setRequestedFields(ContactPicker.EMAIL | ContactPicker.PHOTO);
+        picker.setMultiSelect(true);
+        picker.setSelectionLimit(4);
+        picker.setRequireAllRequestedFields(true);
+        pickAndWait(picker);
+
+        List<ContactPickerRequest> requests =
+                implementation.getContactPickerRequests();
+        assertEquals(1, requests.size());
+        ContactPickerRequest request = requests.get(0);
+        assertEquals(ContactPicker.EMAIL | ContactPicker.PHOTO,
+                request.getRequestedFields());
+        assertTrue(request.isMultiSelect());
+        assertEquals(4, request.getSelectionLimit());
+        assertTrue(request.isRequireAllRequestedFields());
+    }
+
+    /** Nothing is requested that the caller did not ask for. */
+    @FormTest
+    void theDefaultRequestIsNameAndPhoneOnly() {
+        implementation.clearContacts();
+        implementation.setContactPickerSupported(true);
+
+        ContactPicker picker = new ContactPicker();
+        assertEquals(ContactPicker.NAME | ContactPicker.PHONE,
+                picker.getRequestedFields());
+        assertFalse(picker.isMultiSelect());
+        assertFalse(picker.isRequireAllRequestedFields());
+        assertEquals(ContactPicker.MAXIMUM_SELECTION_LIMIT,
+                picker.getSelectionLimit());
+
+        pickAndWait(picker);
+        assertEquals(ContactPicker.NAME | ContactPicker.PHONE,
+                implementation.getContactPickerRequests().get(0)
+                        .getRequestedFields());
+    }
+
+    /** Bits outside the known fields are dropped rather than forwarded. */
+    @FormTest
+    void unknownFieldBitsAreDiscarded() {
+        ContactPicker picker = new ContactPicker();
+        picker.setRequestedFields(ContactPicker.NAME | 0x40000000);
+        assertEquals(ContactPicker.NAME, picker.getRequestedFields());
+    }
+
+    /** A request naming no field at all is a mistake worth reporting. */
+    @FormTest
+    void requestingNoFieldIsRejected() {
+        final ContactPicker picker = new ContactPicker();
+        assertThrows(IllegalArgumentException.class, new org.junit.jupiter.api.function.Executable() {
+            @Override
+            public void execute() {
+                picker.setRequestedFields(0);
+            }
+        });
+    }
+
+    /** Android throws above 100, so the limit is checked before it gets there. */
+    @FormTest
+    void anOutOfRangeSelectionLimitIsRejected() {
+        final ContactPicker picker = new ContactPicker();
+        assertThrows(IllegalArgumentException.class, new org.junit.jupiter.api.function.Executable() {
+            @Override
+            public void execute() {
+                picker.setSelectionLimit(ContactPicker.MAXIMUM_SELECTION_LIMIT + 1);
+            }
+        });
+        assertThrows(IllegalArgumentException.class, new org.junit.jupiter.api.function.Executable() {
+            @Override
+            public void execute() {
+                picker.setSelectionLimit(0);
+            }
+        });
+    }
+
+    /** Picking with no listener would silently lose the user's selection. */
+    @FormTest
+    void pickingWithoutAListenerIsRejected() {
+        final ContactPicker picker = new ContactPicker();
+        assertThrows(IllegalArgumentException.class, new org.junit.jupiter.api.function.Executable() {
+            @Override
+            public void execute() {
+                picker.pick(null);
+            }
+        });
+    }
+
+    /** isSupported reports what the platform said, not a guess. */
+    @FormTest
+    void supportIsReportedFromThePlatform() {
+        implementation.clearContacts();
+        assertFalse(ContactPicker.isSupported());
+        implementation.setContactPickerSupported(true);
+        assertTrue(ContactPicker.isSupported());
+    }
+}

--- a/maven/core-unittests/src/test/java/com/codename1/testing/TestCodenameOneImplementation.java
+++ b/maven/core-unittests/src/test/java/com/codename1/testing/TestCodenameOneImplementation.java
@@ -3816,7 +3816,8 @@ public class TestCodenameOneImplementation extends CodenameOneImplementation {
             int selectionLimit, boolean requireAllRequestedFields,
             ActionListener<ActionEvent> response) {
         contactPickerRequests.add(new ContactPickerRequest(requestedFields,
-                multiSelect, selectionLimit, requireAllRequestedFields));
+                multiSelect, selectionLimit, requireAllRequestedFields,
+                Display.getInstance().isEdt()));
         // Through the real base-class hop rather than straight to the
         // listener, so a test sees the same "answers later, on the EDT"
         // shape the device does.
@@ -3829,13 +3830,21 @@ public class TestCodenameOneImplementation extends CodenameOneImplementation {
         private final boolean multiSelect;
         private final int selectionLimit;
         private final boolean requireAllRequestedFields;
+        private final boolean onEdt;
 
         ContactPickerRequest(int requestedFields, boolean multiSelect,
-                int selectionLimit, boolean requireAllRequestedFields) {
+                int selectionLimit, boolean requireAllRequestedFields,
+                boolean onEdt) {
             this.requestedFields = requestedFields;
             this.multiSelect = multiSelect;
             this.selectionLimit = selectionLimit;
             this.requireAllRequestedFields = requireAllRequestedFields;
+            this.onEdt = onEdt;
+        }
+
+        /** Whether the port was entered on the EDT. */
+        public boolean isOnEdt() {
+            return onEdt;
         }
 
         public int getRequestedFields() {
@@ -3859,7 +3868,8 @@ public class TestCodenameOneImplementation extends CodenameOneImplementation {
             return "ContactPickerRequest{fields=" + requestedFields
                     + ", multiSelect=" + multiSelect
                     + ", selectionLimit=" + selectionLimit
-                    + ", requireAll=" + requireAllRequestedFields + '}';
+                    + ", requireAll=" + requireAllRequestedFields
+                    + ", onEdt=" + onEdt + '}';
         }
     }
 

--- a/maven/core-unittests/src/test/java/com/codename1/testing/TestCodenameOneImplementation.java
+++ b/maven/core-unittests/src/test/java/com/codename1/testing/TestCodenameOneImplementation.java
@@ -85,7 +85,9 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -108,6 +110,11 @@ public class TestCodenameOneImplementation extends CodenameOneImplementation {
     private final Map<String, Contact> contacts = new ConcurrentHashMap<String, Contact>();
     private final List<ScheduledNotification> scheduledNotifications = new CopyOnWriteArrayList<ScheduledNotification>();
     private final AtomicInteger contactIdCounter = new AtomicInteger(1);
+    private final AtomicReference<Contact[]> contactPickerSelection =
+            new AtomicReference<Contact[]>(new Contact[0]);
+    private final AtomicBoolean contactPickerSupported = new AtomicBoolean();
+    private final List<ContactPickerRequest> contactPickerRequests =
+            new CopyOnWriteArrayList<ContactPickerRequest>();
     private boolean getAllContactsFast;
     private boolean databaseCustomPathSupported;
     private String[] lastSentMessageRecipients;
@@ -3779,6 +3786,81 @@ public class TestCodenameOneImplementation extends CodenameOneImplementation {
 
     public void clearContacts() {
         contacts.clear();
+        contactPickerSelection.set(new Contact[0]);
+        contactPickerSupported.set(false);
+        contactPickerRequests.clear();
+    }
+
+    /** What a mocked picker reports the user chose. */
+    public void setContactPickerSelection(Contact... selection) {
+        contactPickerSelection.set(selection == null ? new Contact[0] : selection);
+    }
+
+    /** Whether the mocked platform claims to have a picker. */
+    public void setContactPickerSupported(boolean supported) {
+        contactPickerSupported.set(supported);
+    }
+
+    /** Every picker request made so far, oldest first. */
+    public List<ContactPickerRequest> getContactPickerRequests() {
+        return new ArrayList<ContactPickerRequest>(contactPickerRequests);
+    }
+
+    @Override
+    public boolean isContactPickerSupported() {
+        return contactPickerSupported.get();
+    }
+
+    @Override
+    public void pickContacts(int requestedFields, boolean multiSelect,
+            int selectionLimit, boolean requireAllRequestedFields,
+            ActionListener<ActionEvent> response) {
+        contactPickerRequests.add(new ContactPickerRequest(requestedFields,
+                multiSelect, selectionLimit, requireAllRequestedFields));
+        // Through the real base-class hop rather than straight to the
+        // listener, so a test sees the same "answers later, on the EDT"
+        // shape the device does.
+        fireContactPickerResult(response, contactPickerSelection.get());
+    }
+
+    /** The arguments one {@code pickContacts} call was made with. */
+    public static final class ContactPickerRequest {
+        private final int requestedFields;
+        private final boolean multiSelect;
+        private final int selectionLimit;
+        private final boolean requireAllRequestedFields;
+
+        ContactPickerRequest(int requestedFields, boolean multiSelect,
+                int selectionLimit, boolean requireAllRequestedFields) {
+            this.requestedFields = requestedFields;
+            this.multiSelect = multiSelect;
+            this.selectionLimit = selectionLimit;
+            this.requireAllRequestedFields = requireAllRequestedFields;
+        }
+
+        public int getRequestedFields() {
+            return requestedFields;
+        }
+
+        public boolean isMultiSelect() {
+            return multiSelect;
+        }
+
+        public int getSelectionLimit() {
+            return selectionLimit;
+        }
+
+        public boolean isRequireAllRequestedFields() {
+            return requireAllRequestedFields;
+        }
+
+        @Override
+        public String toString() {
+            return "ContactPickerRequest{fields=" + requestedFields
+                    + ", multiSelect=" + multiSelect
+                    + ", selectionLimit=" + selectionLimit
+                    + ", requireAll=" + requireAllRequestedFields + '}';
+        }
     }
 
     public void setGetAllContactsFast(boolean getAllContactsFast) {

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/Cn1ssDeviceRunner.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/Cn1ssDeviceRunner.java
@@ -511,6 +511,11 @@ public final class Cn1ssDeviceRunner extends DeviceRunner {
             new FloatingToStringTest(),
             new StringFormatTest(),
             new ClipboardRoundTripTest(),
+            // The contact picker's request contract, and the only thing in
+            // this suite that references com.codename1.contacts.ContactPicker
+            // -- which is what makes the iOS build compile and link its
+            // CNContactPickerViewController delegate at all.
+            new ContactPickerApiTest(),
             // Log is an extension point (subclass + override createWriter) and the
             // JavaScript port used to shadow Log.e with a console stub, so a
             // subclass's writer was never created (issue #5519). Assertion-only.

--- a/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/ContactPickerApiTest.java
+++ b/scripts/hellocodenameone/common/src/main/java/com/codenameone/examples/hellocodenameone/tests/ContactPickerApiTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Codename One in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.examples.hellocodenameone.tests;
+
+import com.codename1.contacts.Contact;
+import com.codename1.contacts.ContactPicker;
+import com.codename1.ui.events.ActionEvent;
+
+/**
+ * The contact-picker API on the device VM.
+ *
+ * <p>Showing a picker needs a human, so this asserts only the half a suite can
+ * assert without one: the request the API accepts and rejects, and that a
+ * result carrying no selection is an empty array on every platform rather
+ * than a null the caller has to guard.</p>
+ *
+ * <p>Referencing {@code com.codename1.contacts.ContactPicker} at all is also
+ * the point. It is what makes the iOS build turn on
+ * {@code CN1_USE_CONTACT_PICKER}, link ContactsUI and compile the
+ * CNContactPickerViewController delegate, and what keeps the mangled callback
+ * symbol the Objective-C side calls out of the dead-code pass -- none of
+ * which any other test in this suite exercises.</p>
+ */
+public class ContactPickerApiTest extends BaseTest {
+
+    @Override
+    public boolean runTest() {
+        try {
+            // Empty rather than null, however the pick ended. Every port
+            // funnels "cancelled", "no picker" and "the grant expired" into
+            // this one answer so a listener that checks the length is
+            // complete.
+            Contact[] none = ContactPicker.getPickedContacts(null);
+            assertNotNull(none, "a null event must not produce a null selection");
+            assertEqual(0, none.length, "a null event must produce an empty selection");
+
+            Contact[] wrongSource =
+                    ContactPicker.getPickedContacts(new ActionEvent("not a selection"));
+            assertNotNull(wrongSource, "an unrelated event must not produce null");
+            assertEqual(0, wrongSource.length,
+                    "an unrelated event must produce an empty selection");
+
+            // Reads the platform's answer rather than asserting one: the
+            // suite runs on ports that have a picker and on ports that do
+            // not, and both are correct.
+            boolean supported = ContactPicker.isSupported();
+            assertBool(supported || !supported, "isSupported must not throw");
+
+            ContactPicker picker = new ContactPicker();
+            assertEqual(ContactPicker.NAME | ContactPicker.PHONE,
+                    picker.getRequestedFields(),
+                    "the default request must be name and phone");
+            assertEqual(ContactPicker.MAXIMUM_SELECTION_LIMIT,
+                    picker.getSelectionLimit(),
+                    "the default selection limit must be the platform maximum");
+            assertBool(!picker.isMultiSelect(),
+                    "a picker must default to a single selection");
+
+            picker.setRequestedFields(ContactPicker.EMAIL | 0x40000000);
+            assertEqual(ContactPicker.EMAIL, picker.getRequestedFields(),
+                    "a bit outside the known fields must be dropped");
+
+            assertRejects(picker, 0, "a request naming no field");
+            assertRejects(picker, ContactPicker.MAXIMUM_SELECTION_LIMIT + 1,
+                    "a selection limit above the platform maximum");
+
+            boolean rejectedNoListener = false;
+            try {
+                picker.pick(null);
+            } catch (IllegalArgumentException expected) {
+                rejectedNoListener = true;
+            }
+            assertBool(rejectedNoListener,
+                    "picking with no listener would lose the user's selection silently");
+        } catch (Throwable t) {
+            fail("contact picker API test failed: " + t);
+            return false;
+        }
+        done();
+        return true;
+    }
+
+    /**
+     * @param picker the picker under test
+     * @param value  a field set when it is not a legal selection limit, a
+     *               selection limit otherwise
+     * @param what   named in the failure message
+     */
+    private void assertRejects(ContactPicker picker, int value, String what) {
+        boolean rejected = false;
+        try {
+            if (value == 0) {
+                picker.setRequestedFields(value);
+            } else {
+                picker.setSelectionLimit(value);
+            }
+        } catch (IllegalArgumentException expected) {
+            rejected = true;
+        }
+        assertBool(rejected, what + " must be rejected");
+    }
+
+    @Override
+    public boolean shouldTakeScreenshot() {
+        return false;
+    }
+}


### PR DESCRIPTION
Closes #5666.

From **2027-01-27** Google Play requires an app targeting Android 17 (API level 37) or later that carries `READ_CONTACTS` without core-functionality justification to pass a Play Console declaration. Codename One's contacts API only ever offered broad address-book access, so an app that needed a single phone number the user picked had no way to stay out of that conversation.

`com.codename1.contacts.ContactPicker` is that way. It asks for named fields, shows the platform's own picker, and hands back copies of only the contacts the user tapped.

```java
ContactPicker picker = new ContactPicker();
picker.setRequestedFields(ContactPicker.NAME | ContactPicker.PHONE);
picker.pick(ev -> {
    Contact[] picked = ContactPicker.getPickedContacts(ev);
    if(picked.length > 0) {
        numberField.setText(picked[0].getPrimaryPhoneNumber());
    }
});
```

## Nothing behind it reads an address book

- **Android 17+** uses the system picker (`android.provider.action.PICK_CONTACTS`) and reads its session URI. **Older releases** fall back to `ACTION_PICK` against a contacts content URI, which grants read access to the single row the user chose and needs no permission either. What the older path cannot do (several contacts, several kinds of data) is dropped rather than escalated, so a narrow call never turns into a permission prompt behind the caller's back.
- **iOS** presents `CNContactPickerViewController`, which runs out of process and therefore needs no `NSContactsUsageDescription`. `IPhoneBuilder` turns on `CN1_USE_CONTACT_PICKER` and links ContactsUI + Contacts together, since one without the other fails at link. ContactsUI is absent from the watchOS and tvOS SDKs, so both are classified there -- a framework a slice does not have cannot even be weak-linked.
- **The simulator** draws its own picker over the fake address book so the flow can be developed without a device. It projects only the requested fields, so an app reading a field it forgot to ask for fails there rather than in the store.
- Every other port reports `isSupported() == false` and an empty selection rather than falling back to a broad read, because that fallback would need the permission the caller was avoiding.

## The builders had to learn the difference

"References a class under `com.codename1.contacts`" stopped being a workable rule for `READ_CONTACTS` the moment the picker started returning `Contact` objects out of that same package. `ContactsPermissionScan` splits the package by what a class *does*: `Contact`, `Address` and `ContactPicker` read nothing, everything else does, and a class it has never heard of still earns the permission -- the safe direction. Because a `Contact` reference no longer speaks for the `Display` call that produced it, every broad `Display` reader is now named by method; `getContactById` and friends would otherwise have shipped without their permission and come back empty on the device.

## Verification

- `ContactPickerTest` (10) and `ContactsPermissionScanTest` (12) pass; the scan test fails in both directions when the classification is reverted.
- The generated Xcode project turns the define on, links both frameworks, keeps the mangled callback symbol out of the dead-code pass, and the whole workspace -- phone, watch and TV targets -- builds. A probe inside the guarded region confirms it really compiles rather than compiling to nothing.
- SpotBugs, PMD, Checkstyle, copyright, control-character, cast-semantics and both developer-guide prose gates are green locally.

The hosted-builder half is codenameone/BuildDaemon#contact-picker-5666.

🤖 Generated with [Claude Code](https://claude.com/claude-code)