### PR TITLE
Developer guide: restore the commerce chapters' missing code samples

### DIFF
--- a/CodenameOne/src/com/codename1/ads/InterstitialAd.java
+++ b/CodenameOne/src/com/codename1/ads/InterstitialAd.java
@@ -28,11 +28,19 @@ package com.codename1.ads;
 /// ```java
 /// InterstitialAd ad = new InterstitialAd("ca-app-pub-xxx/yyy");
 /// ad.setAdListener(new AdListener() {
-///     public void onLoaded() { ad.show(); }
 ///     public void onDismissed() { ad.load(); } // preload the next one
 /// });
 /// ad.load();
+///
+/// // later, at a natural break such as the end of a level
+/// if (ad.isLoaded()) {
+///     ad.show();
+/// }
 /// ```
+///
+/// Show the ad at the break you chose rather than from `onLoaded()`. Because
+/// `onDismissed()` loads the next ad, a `show()` inside `onLoaded()` makes each
+/// dismissal open another ad and the user cannot get out of the sequence.
 ///
 /// All callbacks are delivered on the EDT. You can also let Codename One show an
 /// interstitial automatically on screen transitions with

--- a/CodenameOne/src/com/codename1/analytics/Analytics.java
+++ b/CodenameOne/src/com/codename1/analytics/Analytics.java
@@ -49,7 +49,7 @@ import java.util.Random;
 /// Analytics.setConsent(AnalyticsConsent.granted());
 ///
 /// Analytics.screen("Home", null);
-/// Analytics.event(AnalyticsEvent.create("purchase").param("value", 9.99).build());
+/// Analytics.event(AnalyticsEvent.create("tutorial_complete").param("seconds", 42).build());
 /// ```
 ///
 /// ### Consent and privacy

--- a/CodenameOne/src/com/codename1/analytics/AnalyticsEvent.java
+++ b/CodenameOne/src/com/codename1/analytics/AnalyticsEvent.java
@@ -30,12 +30,15 @@ import java.util.Map;
 /// an ordered set of parameters. Build one via {@link #create(String)}:
 ///
 /// ```java
-/// Analytics.event(AnalyticsEvent.create("purchase")
-///         .category("commerce")
-///         .param("sku", "abc-123")
-///         .param("value", 9.99)
+/// Analytics.event(AnalyticsEvent.create("tutorial_complete")
+///         .category("onboarding")
+///         .param("step", "checkout")
+///         .param("seconds", 42)
 ///         .build());
 /// ```
+///
+/// Name your own events. The `purchase` family is emitted for you when a
+/// receipt completes, so sending one by hand counts the transaction twice.
 public final class AnalyticsEvent {
     private final String name;
     private final String category;

--- a/CodenameOne/src/com/codename1/appreview/AppReview.java
+++ b/CodenameOne/src/com/codename1/appreview/AppReview.java
@@ -54,7 +54,7 @@ import com.codename1.util.SuccessCallback;
 ///
 /// ```java
 /// AppReview.getInstance()
-///         .setStoreUrl("https://apps.apple.com/app/id0000000000")
+///         .setStoreUrl(storeUrl)   // the listing for THIS platform's store
 ///         .setSupportEmail("support@example.com")
 ///         .registerSession();
 /// ```
@@ -141,6 +141,10 @@ public class AppReview {
     /// #### Returns
     ///
     /// this instance for chaining.
+    /// The fallback opens this URL when no native review prompt is available,
+    /// so it has to be the listing for the store the app was installed from.
+    /// There is one slot, so an app shipping to more than one store picks the
+    /// URL at runtime rather than hard-coding a single vendor's link.
     public AppReview setStoreUrl(String storeUrl) {
         this.storeUrl = storeUrl;
         return this;

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava003Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava003Snippet.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+
+
+class AdvertisingJava003Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::advertising-java-003[]
+        BannerAd banner = new BannerAd("ca-app-pub-xxx/yyy");
+        form.add(BorderLayout.SOUTH, banner);
+        banner.load();
+        // end::advertising-java-003[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava004Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava004Snippet.java
@@ -87,10 +87,18 @@ class AdvertisingJava004Snippet {
         // tag::advertising-java-004[]
         InterstitialAd ad = new InterstitialAd("ca-app-pub-xxx/yyy");
         ad.setAdListener(new AdListener() {
-            public void onLoaded() { ad.show(); }
+            // Do not show from onLoaded(): onDismissed() loads the next ad,
+            // which would then show itself the moment it arrives, and the user
+            // never escapes the sequence.
             public void onDismissed() { ad.load(); } // preload the next
         });
         ad.load();
+
+        // Show it where an ad belongs -- a natural break such as the end of a
+        // level -- and only if one is actually ready.
+        if (ad.isLoaded()) {
+            ad.show();
+        }
         // end::advertising-java-004[]
     }
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava004Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava004Snippet.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+
+
+class AdvertisingJava004Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::advertising-java-004[]
+        InterstitialAd ad = new InterstitialAd("ca-app-pub-xxx/yyy");
+        ad.setAdListener(new AdListener() {
+            public void onLoaded() { ad.show(); }
+            public void onDismissed() { ad.load(); } // preload the next
+        });
+        ad.load();
+        // end::advertising-java-004[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava004Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava004Snippet.java
@@ -78,6 +78,7 @@ class AdvertisingJava004Snippet {
     Container myForm;
     Component component;
     Button button;
+    Button levelComplete = new Button("Next level");
     MultiButton myMultiButton;
     Label label;
     BrowserComponent browserComponent;
@@ -95,10 +96,14 @@ class AdvertisingJava004Snippet {
         ad.load();
 
         // Show it where an ad belongs -- a natural break such as the end of a
-        // level -- and only if one is actually ready.
-        if (ad.isLoaded()) {
-            ad.show();
-        }
+        // level. Loading is asynchronous, so the readiness check belongs in the
+        // handler that runs at the break; straight after load() nothing is ready
+        // yet and the ad would never appear.
+        levelComplete.addActionListener(e -> {
+            if (ad.isLoaded()) {
+                ad.show();
+            }
+        });
         // end::advertising-java-004[]
     }
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava005Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava005Snippet.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+
+
+class AdvertisingJava005Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::advertising-java-005[]
+        AdManager.bindInterstitialOnTransition(new InterstitialAd("ca-app-pub-xxx/yyy"), 60000);
+        // end::advertising-java-005[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava006Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava006Snippet.java
@@ -89,20 +89,27 @@ class AdvertisingJava006Snippet {
         ad.setServerSideVerificationOptions(new ServerSideVerificationOptions(userId, "level=7"));
         ad.setAdListener(new AdListener() {
             public void onLoaded() {
-                // Server-side verification is configured above, so the network
-                // posts the reward to your server and that is what credits the
-                // user. This callback fires before any verification has
-                // happened, so it is for presentation only -- crediting here
-                // would pay the reward twice, and pay it unverified.
-                ad.show(reward -> showRewardPending(reward.getAmount()));
+                // A rewarded ad is an opt-in format, so loading only enables the
+                // offer. Showing it here would put a full screen ad in front of a
+                // user who never asked for one.
+                watchForCoins.setEnabled(true);
             }
         });
         ad.load();
+
+        watchForCoins.addActionListener(e -> ad.show(reward -> {
+            // Server-side verification is configured above, so the network posts
+            // the reward to your server and that is what credits the user. This
+            // callback runs before anything has verified it, so it is for
+            // presentation only -- crediting here too would pay the reward twice.
+            showRewardPending(reward.getAmount());
+        }));
         // end::advertising-java-006[]
     }
 
     void grantCoins(int coins) { }
     void showRewardPending(int coins) { }
+    Button watchForCoins = new Button("Watch for coins");
     String userId = "42";
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava006Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava006Snippet.java
@@ -108,6 +108,19 @@ class AdvertisingJava006Snippet {
                 // of a user who never asked for one.
                 watchForCoins.setEnabled(true);
             }
+
+            public void onDismissed() {
+                // A shown ad is spent and a session cannot be shown twice, so
+                // load the next one. Without this the offer is enabled once and
+                // never again.
+                ad.load();
+            }
+
+            public void onShowFailed(AdError error) {
+                // Nothing was consumed, so put the offer back rather than
+                // leaving it disabled for the rest of the screen.
+                ad.load();
+            }
         });
         ad.load();
         // end::advertising-java-006[]

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava006Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava006Snippet.java
@@ -125,17 +125,23 @@ class AdvertisingJava006Snippet {
             }
 
             public void onFailedToLoad(AdError error) {
-                // getCode() is provider specific -- adapters forward their own
-                // SDK's numbers -- so the only codes that mean the same thing
-                // everywhere are Codename One's own. Stop on those, since an
-                // unsupported platform or a bad ad unit id never becomes valid
-                // and retrying turns the graceful no-ads path into a permanent
-                // timer. Anything else may be transient, so retry it, but bound
-                // the attempts: an unrecognized permanent failure must not
-                // retry for the life of the screen either.
-                if (error.getCode() == AdError.CODE_UNSUPPORTED
-                        || error.getCode() == AdError.CODE_INVALID_REQUEST
-                        || ++loadFailures > 5) {
+                // getCode() is provider specific and getDomain() says whose it
+                // is: Codename One's own errors carry no domain, an adapter's
+                // carry the SDK's. The numbers collide -- AppLovin reports -1
+                // for an unspecified error and CODE_UNSUPPORTED is also -1 --
+                // so read the constants only for a framework error. Those two
+                // are genuinely permanent: an unsupported platform or a bad ad
+                // unit id never becomes valid, and retrying them turns the
+                // graceful no-ads path into a permanent timer.
+                if (error.getDomain() == null
+                        && (error.getCode() == AdError.CODE_UNSUPPORTED
+                            || error.getCode() == AdError.CODE_INVALID_REQUEST)) {
+                    return;
+                }
+                // A provider's code means nothing here, so treat it as possibly
+                // transient -- bounded, so an unrecognized permanent failure
+                // cannot retry for the life of the screen either.
+                if (++loadFailures > 5) {
                     return;
                 }
                 retryDelay = Math.min(retryDelay * 2, 60000);

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava006Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava006Snippet.java
@@ -104,6 +104,7 @@ class AdvertisingJava006Snippet {
         ad.setAdListener(new AdListener() {
             public void onLoaded() {
                 retryDelay = 1000;
+                loadFailures = 0;
                 // A rewarded ad is an opt-in format, so a loaded ad only enables
                 // the offer. Showing it here would put a full screen ad in front
                 // of a user who never asked for one.
@@ -124,12 +125,17 @@ class AdvertisingJava006Snippet {
             }
 
             public void onFailedToLoad(AdError error) {
-                // Retry only what can succeed later. A network error or an empty
-                // ad inventory is transient; an unsupported platform or a bad ad
-                // unit id never becomes valid, and retrying those turns the
-                // graceful "no ads here" path into a permanent timer.
-                if (error.getCode() != AdError.CODE_NETWORK_ERROR
-                        && error.getCode() != AdError.CODE_NO_FILL) {
+                // getCode() is provider specific -- adapters forward their own
+                // SDK's numbers -- so the only codes that mean the same thing
+                // everywhere are Codename One's own. Stop on those, since an
+                // unsupported platform or a bad ad unit id never becomes valid
+                // and retrying turns the graceful no-ads path into a permanent
+                // timer. Anything else may be transient, so retry it, but bound
+                // the attempts: an unrecognized permanent failure must not
+                // retry for the life of the screen either.
+                if (error.getCode() == AdError.CODE_UNSUPPORTED
+                        || error.getCode() == AdError.CODE_INVALID_REQUEST
+                        || ++loadFailures > 5) {
                     return;
                 }
                 retryDelay = Math.min(retryDelay * 2, 60000);
@@ -147,5 +153,6 @@ class AdvertisingJava006Snippet {
 
 
     int retryDelay = 1000;
+    int loadFailures;
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava006Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava006Snippet.java
@@ -124,9 +124,14 @@ class AdvertisingJava006Snippet {
             }
 
             public void onFailedToLoad(AdError error) {
-                // Transient provider and network errors are normal here. Without
-                // a retry the offer stays disabled for the life of the screen, so
-                // back off and try again rather than dropping it silently.
+                // Retry only what can succeed later. A network error or an empty
+                // ad inventory is transient; an unsupported platform or a bad ad
+                // unit id never becomes valid, and retrying those turns the
+                // graceful "no ads here" path into a permanent timer.
+                if (error.getCode() != AdError.CODE_NETWORK_ERROR
+                        && error.getCode() != AdError.CODE_NO_FILL) {
+                    return;
+                }
                 retryDelay = Math.min(retryDelay * 2, 60000);
                 UITimer.timer(retryDelay, false, form, () -> ad.load());
             }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava006Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava006Snippet.java
@@ -87,23 +87,29 @@ class AdvertisingJava006Snippet {
         // tag::advertising-java-006[]
         RewardedAd ad = new RewardedAd("ca-app-pub-xxx/yyy");
         ad.setServerSideVerificationOptions(new ServerSideVerificationOptions(userId, "level=7"));
+        // show() does nothing when no ad is loaded, so the offer starts disabled
+        // and goes back to disabled the moment it is spent.
+        watchForCoins.setEnabled(false);
+        watchForCoins.addActionListener(e -> {
+            watchForCoins.setEnabled(false);
+            ad.show(reward -> {
+                // Server-side verification is configured above, so the network
+                // posts the reward to your server and that is what credits the
+                // user. This callback runs before anything has verified it, so
+                // it is presentation only -- crediting here would pay twice.
+                showRewardPending(reward.getAmount());
+            });
+        });
+
         ad.setAdListener(new AdListener() {
             public void onLoaded() {
-                // A rewarded ad is an opt-in format, so loading only enables the
-                // offer. Showing it here would put a full screen ad in front of a
-                // user who never asked for one.
+                // A rewarded ad is an opt-in format, so a loaded ad only enables
+                // the offer. Showing it here would put a full screen ad in front
+                // of a user who never asked for one.
                 watchForCoins.setEnabled(true);
             }
         });
         ad.load();
-
-        watchForCoins.addActionListener(e -> ad.show(reward -> {
-            // Server-side verification is configured above, so the network posts
-            // the reward to your server and that is what credits the user. This
-            // callback runs before anything has verified it, so it is for
-            // presentation only -- crediting here too would pay the reward twice.
-            showRewardPending(reward.getAmount());
-        }));
         // end::advertising-java-006[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava006Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava006Snippet.java
@@ -103,6 +103,7 @@ class AdvertisingJava006Snippet {
 
         ad.setAdListener(new AdListener() {
             public void onLoaded() {
+                retryDelay = 1000;
                 // A rewarded ad is an opt-in format, so a loaded ad only enables
                 // the offer. Showing it here would put a full screen ad in front
                 // of a user who never asked for one.
@@ -121,6 +122,14 @@ class AdvertisingJava006Snippet {
                 // leaving it disabled for the rest of the screen.
                 ad.load();
             }
+
+            public void onFailedToLoad(AdError error) {
+                // Transient provider and network errors are normal here. Without
+                // a retry the offer stays disabled for the life of the screen, so
+                // back off and try again rather than dropping it silently.
+                retryDelay = Math.min(retryDelay * 2, 60000);
+                UITimer.timer(retryDelay, false, form, () -> ad.load());
+            }
         });
         ad.load();
         // end::advertising-java-006[]
@@ -130,5 +139,8 @@ class AdvertisingJava006Snippet {
     void showRewardPending(int coins) { }
     Button watchForCoins = new Button("Watch for coins");
     String userId = "42";
+
+
+    int retryDelay = 1000;
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava006Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava006Snippet.java
@@ -89,7 +89,12 @@ class AdvertisingJava006Snippet {
         ad.setServerSideVerificationOptions(new ServerSideVerificationOptions(userId, "level=7"));
         ad.setAdListener(new AdListener() {
             public void onLoaded() {
-                ad.show(reward -> grantCoins(reward.getAmount()));
+                // Server-side verification is configured above, so the network
+                // posts the reward to your server and that is what credits the
+                // user. This callback fires before any verification has
+                // happened, so it is for presentation only -- crediting here
+                // would pay the reward twice, and pay it unverified.
+                ad.show(reward -> showRewardPending(reward.getAmount()));
             }
         });
         ad.load();
@@ -97,6 +102,7 @@ class AdvertisingJava006Snippet {
     }
 
     void grantCoins(int coins) { }
+    void showRewardPending(int coins) { }
     String userId = "42";
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava006Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava006Snippet.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+
+
+class AdvertisingJava006Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::advertising-java-006[]
+        RewardedAd ad = new RewardedAd("ca-app-pub-xxx/yyy");
+        ad.setServerSideVerificationOptions(new ServerSideVerificationOptions(userId, "level=7"));
+        ad.setAdListener(new AdListener() {
+            public void onLoaded() {
+                ad.show(reward -> grantCoins(reward.getAmount()));
+            }
+        });
+        ad.load();
+        // end::advertising-java-006[]
+    }
+
+    void grantCoins(int coins) { }
+    String userId = "42";
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava007Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava007Snippet.java
@@ -85,7 +85,24 @@ class AdvertisingJava007Snippet {
     
     void snippet() throws Exception {
         // tag::advertising-java-007[]
-        AdManager.enableAppOpenAds(new AppOpenAd("ca-app-pub-xxx/yyy"));
+        AppOpenAd appOpen = new AppOpenAd("ca-app-pub-xxx/yyy");
+        AdManager.enableAppOpenAds(appOpen);
+
+        // enableAppOpenAds() loads the ad and asks the provider to show it when
+        // the app returns to the foreground. Whether that happens is up to the
+        // provider's adapter, so if yours does not implement the hook, drive it
+        // from the lifecycle instead -- start() runs on every foreground:
+        //
+        //     public void start() {
+        //         if (appOpen.isLoaded()) {
+        //             appOpen.show();
+        //         } else {
+        //             appOpen.load();
+        //         }
+        //     }
+        //
+        // Do one or the other, not both, or a provider that honours the hook
+        // shows two ads.
         // end::advertising-java-007[]
     }
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava007Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava007Snippet.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+
+
+class AdvertisingJava007Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::advertising-java-007[]
+        AdManager.enableAppOpenAds(new AppOpenAd("ca-app-pub-xxx/yyy"));
+        // end::advertising-java-007[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava008Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava008Snippet.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+
+
+class AdvertisingJava008Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::advertising-java-008[]
+        if (NativeAdLoader.isSupported()) {
+            new NativeAdLoader("ca-app-pub-xxx/yyy").load(null,
+                ad -> feed.addComponent(buildSponsoredRow(ad)),  // your own layout
+                err -> Log.p(err.toString()));
+        }
+        // end::advertising-java-008[]
+    }
+
+    Container feed = new Container();
+    Component buildSponsoredRow(NativeAd ad) { return new Label(); }
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnalyticsJava001Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnalyticsJava001Snippet.java
@@ -87,10 +87,14 @@ class AnalyticsJava001Snippet {
         // tag::analytics-java-001[]
         Analytics.screen("Home", null);
 
-        Analytics.event(AnalyticsEvent.create("purchase")
-                .category("commerce")
-                .param("sku", "abc-123")
-                .param("value", 9.99)
+        // Pick a name of your own. Do not send "purchase" yourself: Purchase
+        // emits that one for every completed receipt, so a manual copy counts
+        // the same transaction twice and skews the funnel. The automatic events
+        // are listed further down this chapter.
+        Analytics.event(AnalyticsEvent.create("tutorial_complete")
+                .category("onboarding")
+                .param("step", "checkout")
+                .param("seconds", 42)
                 .build());
 
         Analytics.setUserProperty("plan", "pro");

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnalyticsJava001Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnalyticsJava001Snippet.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+
+
+class AnalyticsJava001Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::analytics-java-001[]
+        Analytics.screen("Home", null);
+
+        Analytics.event(AnalyticsEvent.create("purchase")
+                .category("commerce")
+                .param("sku", "abc-123")
+                .param("value", 9.99)
+                .build());
+
+        Analytics.setUserProperty("plan", "pro");
+        Analytics.crash(throwable, "checkout failed", false);
+        // end::analytics-java-001[]
+    }
+
+    Throwable throwable;
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnalyticsJava002Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnalyticsJava002Snippet.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+
+
+class AnalyticsJava002Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::analytics-java-002[]
+        Analytics.setConsent(AnalyticsConsent.builder()
+                .analytics(true)
+                .crashReporting(true)
+                .personalization(false)
+                .build());
+        // end::analytics-java-002[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnalyticsJava003Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnalyticsJava003Snippet.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+
+
+class AnalyticsJava003Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::analytics-java-003[]
+        Analytics.setConsent(AnalyticsConsent.all());
+        // end::analytics-java-003[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnalyticsJava004Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnalyticsJava004Snippet.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+
+
+class AnalyticsJava004Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::analytics-java-004[]
+        Analytics.setConsent(AnalyticsConsent.builder().all().adStorage(false).build());
+        // end::analytics-java-004[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnalyticsJava005Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnalyticsJava005Snippet.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+
+
+class AnalyticsJava005Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::analytics-java-005[]
+        Analytics.setConsentMode(ConsentMode.OPT_OUT);
+        // end::analytics-java-005[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnalyticsJava006Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnalyticsJava006Snippet.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+
+
+class AnalyticsJava006Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::analytics-java-006[]
+        Analytics.resetClientId();
+        // end::analytics-java-006[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnalyticsJava007Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnalyticsJava007Snippet.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+
+
+class AnalyticsJava007Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::analytics-java-007[]
+        Analytics.addProvider(new GoogleAnalyticsProvider("G-XXXXXXXX", "API_SECRET"));
+        // end::analytics-java-007[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnalyticsJava008Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnalyticsJava008Snippet.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+
+
+class AnalyticsJava008Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::analytics-java-008[]
+        Analytics.addProvider(new MatomoAnalyticsProvider("https://matomo.example.com", 1));
+        // end::analytics-java-008[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnalyticsJava009Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnalyticsJava009Snippet.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+
+
+class AnalyticsJava009Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::analytics-java-009[]
+        Analytics.addProvider(new FirebaseAnalyticsProvider());
+        // end::analytics-java-009[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AppReviewJava001Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AppReviewJava001Snippet.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+
+
+class AppReviewJava001Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::app-review-java-001[]
+        AppReview.getInstance().requestReview();
+        // end::app-review-java-001[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AppReviewJava001Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AppReviewJava001Snippet.java
@@ -85,6 +85,11 @@ class AppReviewJava001Snippet {
     
     void snippet() throws Exception {
         // tag::app-review-java-001[]
+        // Configure the store URL and the feedback route first -- the next
+        // sample does that. Where no native review prompt exists this opens the
+        // fallback widget, and without them a high rating opens nothing while
+        // low-rating feedback goes nowhere. The flow still records itself as
+        // completed, so the user is never asked again.
         AppReview.getInstance().requestReview();
         // end::app-review-java-001[]
     }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AppReviewJava002Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AppReviewJava002Snippet.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+
+
+class AppReviewJava002Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::app-review-java-002[]
+        AppReview.getInstance()
+                .setMinimumLaunches(5)          // at least 5 launches
+                .setMinimumDaysInstalled(3)     // and installed at least 3 days
+                .setDaysBetweenPrompts(30)      // never nag more than monthly
+                .setStoreUrl("https://apps.apple.com/app/id0000000000")
+                .setSupportEmail("support@example.com")
+                .registerSession();
+        // end::app-review-java-002[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AppReviewJava002Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AppReviewJava002Snippet.java
@@ -85,11 +85,18 @@ class AppReviewJava002Snippet {
     
     void snippet() throws Exception {
         // tag::app-review-java-002[]
+        // When the native review prompt is unavailable the dialog falls back to
+        // opening this URL, so it has to be the listing for the store the app
+        // came from -- an Apple link sends Android users to the wrong place.
+        String storeUrl = "and".equals(CN.getPlatformName())
+                ? "https://play.google.com/store/apps/details?id=com.example.app"
+                : "https://apps.apple.com/app/id0000000000";
+
         AppReview.getInstance()
                 .setMinimumLaunches(5)          // at least 5 launches
                 .setMinimumDaysInstalled(3)     // and installed at least 3 days
                 .setDaysBetweenPrompts(30)      // never nag more than monthly
-                .setStoreUrl("https://apps.apple.com/app/id0000000000")
+                .setStoreUrl(storeUrl)
                 .setSupportEmail("support@example.com")
                 .registerSession();
         // end::app-review-java-002[]

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AppReviewJava002Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AppReviewJava002Snippet.java
@@ -109,7 +109,16 @@ class AppReviewJava002Snippet {
         // fallback dialog is a Sheet, which throws when no form is current. That
         // is exactly the state during init, so configure there and record the
         // session once a form is up.
-        form.addShowListener(e -> AppReview.getInstance().registerSession());
+        form.addShowListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                // Once per launch. registerSession() increments the launch
+                // counter, and a show listener fires again every time the user
+                // navigates back here -- which would reach the thresholds after
+                // a few screens rather than after the launches you configured.
+                form.removeShowListener(this);
+                AppReview.getInstance().registerSession();
+            }
+        });
         // end::app-review-java-002[]
     }
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AppReviewJava002Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AppReviewJava002Snippet.java
@@ -85,12 +85,18 @@ class AppReviewJava002Snippet {
     
     void snippet() throws Exception {
         // tag::app-review-java-002[]
-        // When the native review prompt is unavailable the dialog falls back to
-        // opening this URL, so it has to be the listing for the store the app
-        // came from -- an Apple link sends Android users to the wrong place.
-        String storeUrl = "and".equals(CN.getPlatformName())
-                ? "https://play.google.com/store/apps/details?id=com.example.app"
-                : "https://apps.apple.com/app/id0000000000";
+        // When no native review prompt is available the dialog falls back to
+        // opening this URL, and that happens on the simulator, the desktop and
+        // the web target as well as on a device, so every target needs an answer
+        // rather than everything-except-Android getting the Apple listing.
+        String storeUrl;
+        if ("ios".equals(CN.getPlatformName())) {
+            storeUrl = "https://apps.apple.com/app/id0000000000";
+        } else if ("and".equals(CN.getPlatformName())) {
+            storeUrl = "https://play.google.com/store/apps/details?id=com.example.app";
+        } else {
+            storeUrl = "https://example.com/app";   // no store listing to send them to
+        }
 
         AppReview.getInstance()
                 .setMinimumLaunches(5)          // at least 5 launches

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AppReviewJava002Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AppReviewJava002Snippet.java
@@ -103,8 +103,13 @@ class AppReviewJava002Snippet {
                 .setMinimumDaysInstalled(3)     // and installed at least 3 days
                 .setDaysBetweenPrompts(30)      // never nag more than monthly
                 .setStoreUrl(storeUrl)
-                .setSupportEmail("support@example.com")
-                .registerSession();
+                .setSupportEmail("support@example.com");
+
+        // registerSession() prompts as soon as the thresholds are met, and the
+        // fallback dialog is a Sheet, which throws when no form is current. That
+        // is exactly the state during init, so configure there and record the
+        // session once a form is up.
+        form.addShowListener(e -> AppReview.getInstance().registerSession());
         // end::app-review-java-002[]
     }
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AppReviewJava003Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AppReviewJava003Snippet.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+
+
+class AppReviewJava003Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::app-review-java-003[]
+        AppReview.getInstance().setFeedbackListener(new FeedbackListener() {
+            public boolean lowRating(int rating) {
+                // return true to present your own feedback UI and suppress the
+                // built-in e-mail composer
+                return false;
+            }
+
+            public void feedback(int rating, String text) {
+                // called with the free text the user typed in the built-in composer
+                myBackend.submitFeedback(rating, text);
+            }
+        });
+        // end::app-review-java-003[]
+    }
+
+    class Backend { void submitFeedback(int rating, String text) { } }
+    Backend myBackend = new Backend();
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava001Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava001Snippet.java
@@ -87,10 +87,13 @@ class CommerceJava001Snippet {
         // tag::commerce-java-001[]
         // With no cloud answer -- a build without commerce, an offline start, a
         // degraded account -- isEntitled falls back to asking the store for a
-        // subscription with this same id. Give at least one granting product a
-        // SKU equal to the entitlement id if that offline path has to unlock,
-        // because the cloud's entitlement-to-SKU mapping is not on the device.
-        if (CommerceManager.getInstance().isEntitled("pro")) {
+        // subscription named after the entitlement itself, because the cloud's
+        // entitlement-to-SKU mapping is not on the device. This chapter sells
+        // pro_monthly and grants pro, so that fallback has nothing to match and
+        // the SKUs have to be checked directly for the offline case.
+        boolean pro = CommerceManager.getInstance().isEntitled("pro")
+                || Purchase.getInAppPurchase().isSubscribed("pro_monthly");
+        if (pro) {
             // unlock pro features
         }
         // end::commerce-java-001[]

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava001Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava001Snippet.java
@@ -85,6 +85,11 @@ class CommerceJava001Snippet {
     
     void snippet() throws Exception {
         // tag::commerce-java-001[]
+        // With no cloud answer -- a build without commerce, an offline start, a
+        // degraded account -- isEntitled falls back to asking the store for a
+        // subscription with this same id. Give at least one granting product a
+        // SKU equal to the entitlement id if that offline path has to unlock,
+        // because the cloud's entitlement-to-SKU mapping is not on the device.
         if (CommerceManager.getInstance().isEntitled("pro")) {
             // unlock pro features
         }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava001Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava001Snippet.java
@@ -85,14 +85,20 @@ class CommerceJava001Snippet {
     
     void snippet() throws Exception {
         // tag::commerce-java-001[]
-        // With no cloud answer -- a build without commerce, an offline start, a
-        // degraded account -- isEntitled falls back to asking the store for a
-        // subscription named after the entitlement itself, because the cloud's
-        // entitlement-to-SKU mapping is not on the device. This chapter sells
-        // pro_monthly and grants pro, so that fallback has nothing to match and
-        // the SKUs have to be checked directly for the offline case.
-        boolean pro = CommerceManager.getInstance().isEntitled("pro")
-                || Purchase.getInAppPurchase().isSubscribed("pro_monthly");
+        CommerceManager cm = CommerceManager.getInstance();
+        boolean pro = cm.isEntitled("pro");
+
+        // The cloud maps entitlements to SKUs and the device does not, so
+        // isEntitled's own fallback looks for a subscription named after the
+        // entitlement -- and this chapter sells pro_monthly, which never
+        // matches. Ask the store for the granting SKU only where the cloud had
+        // nothing to say. Never OR it into a cloud answer: a refunded or
+        // revoked receipt still looks active on the device, and that would
+        // unlock the app after the server denied it.
+        if (!pro && (!cm.isCloudEnabled() || cm.isDegraded())) {
+            pro = Purchase.getInAppPurchase().isSubscribed("pro_monthly");
+        }
+
         if (pro) {
             // unlock pro features
         }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava001Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava001Snippet.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+
+
+class CommerceJava001Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::commerce-java-001[]
+        if (CommerceManager.getInstance().isEntitled("pro")) {
+            // unlock pro features
+        }
+        // end::commerce-java-001[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava001Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava001Snippet.java
@@ -85,21 +85,7 @@ class CommerceJava001Snippet {
     
     void snippet() throws Exception {
         // tag::commerce-java-001[]
-        CommerceManager cm = CommerceManager.getInstance();
-        boolean pro = cm.isEntitled("pro");
-
-        // The cloud maps entitlements to SKUs and the device does not, so
-        // isEntitled's own fallback looks for a subscription named after the
-        // entitlement -- and this chapter sells pro_monthly, which never
-        // matches. Ask the store for the granting SKU only where the cloud had
-        // nothing to say. Never OR it into a cloud answer: a refunded or
-        // revoked receipt still looks active on the device, and that would
-        // unlock the app after the server denied it.
-        if (!pro && (!cm.isCloudEnabled() || cm.isDegraded())) {
-            pro = Purchase.getInAppPurchase().isSubscribed("pro_monthly");
-        }
-
-        if (pro) {
+        if (CommerceManager.getInstance().isEntitled("pro")) {
             // unlock pro features
         }
         // end::commerce-java-001[]

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava002Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava002Snippet.java
@@ -87,9 +87,18 @@ class CommerceJava002Snippet {
         // tag::commerce-java-002[]
         CommerceManager cm = CommerceManager.getInstance();
         cm.setAppUserId(myAccountId);   // optional; a stable id for the signed-in user
+
+        // A receipt store is a prerequisite rather than an extra. Purchase only
+        // submits pending purchases and reloads its receipt list when one is
+        // installed, so without it refresh() finds nothing and no entitlement is
+        // ever granted. On iOS isSubscriptionSupported() is false outright,
+        // because it is defined as "a receipt store is installed". The
+        // Monetization chapter builds one.
+        Purchase.getInAppPurchase().setReceiptStore(myReceiptStore);
         // end::commerce-java-002[]
     }
 
     String myAccountId = "account-id";
+    ReceiptStore myReceiptStore;
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava002Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava002Snippet.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+
+
+class CommerceJava002Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::commerce-java-002[]
+        CommerceManager cm = CommerceManager.getInstance();
+        cm.setAppUserId(myAccountId);   // optional; a stable id for the signed-in user
+        // end::commerce-java-002[]
+    }
+
+    String myAccountId = "account-id";
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava003Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava003Snippet.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+
+
+class CommerceJava003Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::commerce-java-003[]
+        cm.subscribe("pro_monthly");
+        // or cm.purchase("remove_ads");
+        // end::commerce-java-003[]
+    }
+
+    CommerceManager cm = CommerceManager.getInstance();
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava004Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava004Snippet.java
@@ -85,17 +85,24 @@ class CommerceJava004Snippet {
     
     void snippet() throws Exception {
         // tag::commerce-java-004[]
-        new Thread(() -> {
-            cm.refresh();
-            // refresh() returns on the worker thread. Reading the entitlement
-            // and unlocking the UI has to hop back to the event dispatch
-            // thread, because Codename One UI calls are only legal there.
-            CN.callSerially(() -> {
-                if (cm.isEntitled("pro")) {
-                    // unlock the paid features here
-                }
-            });
-        }).start();
+        // Purchase submits a new receipt to the receipt store asynchronously,
+        // and refresh() only validates the receipts already stored. Called
+        // straight after a purchase it would not see the new one, and nothing
+        // retries it later, so chain it off the synchronization instead.
+        Purchase.getInAppPurchase().synchronizeReceipts(0, synced -> {
+            // This callback arrives on the EDT and refresh() blocks on the
+            // network, so it needs a thread of its own.
+            new Thread(() -> {
+                cm.refresh();
+                // Back to the EDT to read the entitlement and touch the UI:
+                // Codename One UI calls are only legal there.
+                CN.callSerially(() -> {
+                    if (cm.isEntitled("pro")) {
+                        // unlock the paid features here
+                    }
+                });
+            }).start();
+        });
         // end::commerce-java-004[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava004Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava004Snippet.java
@@ -90,6 +90,14 @@ class CommerceJava004Snippet {
         // straight after a purchase it would not see the new one, and nothing
         // retries it later, so chain it off the synchronization instead.
         Purchase.getInAppPurchase().synchronizeReceipts(0, synced -> {
+            if (!Boolean.TRUE.equals(synced)) {
+                // The receipt was not submitted or fetched, so it is still
+                // pending and the stored list is the old one. Refreshing from
+                // it would read a stale entitlement and leave a paying user
+                // locked out with no sign anything went wrong.
+                showPurchasePendingRetry();
+                return;
+            }
             // This callback arrives on the EDT and refresh() blocks on the
             // network, so it needs a thread of its own.
             new Thread(() -> {
@@ -107,5 +115,8 @@ class CommerceJava004Snippet {
     }
 
     CommerceManager cm = CommerceManager.getInstance();
+
+
+    void showPurchasePendingRetry() { }
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava004Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava004Snippet.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+
+
+class CommerceJava004Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::commerce-java-004[]
+        CN.callSerially(() -> {});                // (illustrative)
+        new Thread(() -> {
+            cm.refresh();
+            if (cm.isEntitled("pro")) { /* ... */ }
+        }).start();
+        // end::commerce-java-004[]
+    }
+
+    CommerceManager cm = CommerceManager.getInstance();
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava004Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava004Snippet.java
@@ -85,10 +85,16 @@ class CommerceJava004Snippet {
     
     void snippet() throws Exception {
         // tag::commerce-java-004[]
-        CN.callSerially(() -> {});                // (illustrative)
         new Thread(() -> {
             cm.refresh();
-            if (cm.isEntitled("pro")) { /* ... */ }
+            // refresh() returns on the worker thread. Reading the entitlement
+            // and unlocking the UI has to hop back to the event dispatch
+            // thread, because Codename One UI calls are only legal there.
+            CN.callSerially(() -> {
+                if (cm.isEntitled("pro")) {
+                    // unlock the paid features here
+                }
+            });
         }).start();
         // end::commerce-java-004[]
     }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava004Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava004Snippet.java
@@ -105,7 +105,14 @@ class CommerceJava004Snippet {
                 // Back to the EDT to read the entitlement and touch the UI:
                 // Codename One UI calls are only legal there.
                 CN.callSerially(() -> {
-                    if (cm.isEntitled("pro")) {
+                    // Same rule as the entitlement sample earlier in the chapter:
+                    // the store-direct check is for when the cloud had no answer,
+                    // not an override of one it gave.
+                    boolean pro = cm.isEntitled("pro");
+                    if (!pro && (!cm.isCloudEnabled() || cm.isDegraded())) {
+                        pro = Purchase.getInAppPurchase().isSubscribed("pro_monthly");
+                    }
+                    if (pro) {
                         // unlock the paid features here
                     }
                 });

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava029Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava029Snippet.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+
+
+class MonetizationJava029Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    // tag::monetization-java-029[]
+     public void start() {
+     if(current!= null){
+     current.show();
+     return;
+     }
+     Form hi = new Form("Hi World");
+     Button buyWorld = new Button("Buy World");
+     buyWorld.addActionListener(e->{
+     if (Purchase.getInAppPurchase().wasPurchased(SKU_WORLD)) {
+     Dialog.show("can't Buy It", "You already Own It", "OK", null);
+     } else {
+     Purchase.getInAppPurchase().purchase(SKU_WORLD);
+     }
+     });
+
+     hi.addComponent(buyWorld);
+     hi.show();
+     }
+    // end::monetization-java-029[]
+
+    static final String SKU_WORLD = "com.example.world";
+    Form current = new Form();
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava030Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava030Snippet.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+import java.util.List;
+
+
+class MonetizationJava030Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    abstract class Sample implements PurchaseCallback {
+    // tag::monetization-java-030[]
+     @Override
+     public void itemPurchased(String sku) {
+     ToastBar.showMessage("Thanks. You now own the world", FontImage.MATERIAL_THUMB_UP);
+     }
+
+     @Override
+     public void itemPurchaseError(String sku, String errorMessage) {
+     ToastBar.showErrorMessage("Failure occurred: "+errorMessage);
+     }
+    // end::monetization-java-030[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava031Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava031Snippet.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+
+
+class MonetizationJava031Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::monetization-java-031[]
+        buyWorld.addActionListener(e->{
+         if (Dialog.show("Confirm", "You own "+getNumWorlds()+
+         " worlds. Do you want to buy another one?", "Yes", "No")) {
+         Purchase.getInAppPurchase().purchase(SKU_WORLD);
+         }
+        });
+        // end::monetization-java-031[]
+    }
+
+    int getNumWorlds() { return 0; }
+    static final String SKU_WORLD = "com.example.world";
+    Button buyWorld = new Button("Buy");
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava032Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava032Snippet.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+import java.util.List;
+
+
+class MonetizationJava032Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    abstract class Sample implements PurchaseCallback {
+    // tag::monetization-java-032[]
+    @Override
+    public void itemPurchased(String sku) {
+     addWorld();
+     ToastBar.showMessage("Thanks. You now own "+getNumWorlds()+" worlds", FontImage.MATERIAL_THUMB_UP);
+    }
+    // end::monetization-java-032[]
+    }
+
+    void addWorld() { }
+    int getNumWorlds() { return 0; }
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava033Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava033Snippet.java
@@ -88,7 +88,10 @@ class MonetizationJava033Snippet {
         ApplePromotionalOffer offer = new ApplePromotionalOffer();
         offer.setOfferIdentifier("my-intro-offer");
         offer.setKeyIdentifier("A1B2C3D4");
-        offer.setNonce(UUID.randomUUID().toString());
+        // The nonce is one of the values your server signs, so it has to be
+        // the very one that produced the signature below. A fresh value
+        // generated here would never validate.
+        offer.setNonce(nonceFromYourServer);
         offer.setSignature(signatureFromYourServer);
         offer.setTimestamp(timestampFromYourServer);
 
@@ -100,5 +103,6 @@ class MonetizationJava033Snippet {
     long timestampFromYourServer;
     static final String SKU_WORLD_MONTHLY = "com.example.world.monthly";
     String signatureFromYourServer = "signature";
+    String nonceFromYourServer = "nonce";
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava033Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava033Snippet.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+
+
+class MonetizationJava033Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::monetization-java-033[]
+        ApplePromotionalOffer offer = new ApplePromotionalOffer();
+        offer.setOfferIdentifier("my-intro-offer");
+        offer.setKeyIdentifier("A1B2C3D4");
+        offer.setNonce(UUID.randomUUID().toString());
+        offer.setSignature(signatureFromYourServer);
+        offer.setTimestamp(timestampFromYourServer);
+
+        Purchase purchase = Purchase.getInAppPurchase();
+        purchase.subscribe(SKU_WORLD_MONTHLY, offer);
+        // end::monetization-java-033[]
+    }
+
+    long timestampFromYourServer;
+    static final String SKU_WORLD_MONTHLY = "com.example.world.monthly";
+    String signatureFromYourServer = "signature";
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava034Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava034Snippet.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+
+
+class MonetizationJava034Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    // tag::monetization-java-034[]
+    public void init(Object context) {
+    // ...
+
+     Purchase.getInAppPurchase().setReceiptStore(new ReceiptStore() {
+
+     @Override
+     public void fetchReceipts(SuccessCallback<Receipt[]> callback) {
+     // Fetch receipts from storage and pass them to the callback
+     }
+
+     @Override
+     public void submitReceipt(Receipt receipt, SuccessCallback<Boolean> callback) {
+     // Save a receipt to storage. Make sure to call callback when done.
+     }
+     });
+    }
+    // end::monetization-java-034[]
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava035Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava035Snippet.java
@@ -96,8 +96,14 @@ class MonetizationJava035Snippet {
      Storage s = Storage.getInstance();
      Receipt[] found;
      synchronized(RECEIPTS_KEY) {
-     if (s.exists(RECEIPTS_KEY)) {
-     List<Receipt> receipts = (List<Receipt>)s.readObject(RECEIPTS_KEY);
+     // readObject() answers null when the entry cannot be read or
+     // deserialized, and Purchase calls this from inside loadReceipts(),
+     // so throwing here would leave synchronization marked in progress for
+     // the rest of the session. Treat anything unreadable as "nothing
+     // stored" and always complete the callback.
+     Object stored = s.exists(RECEIPTS_KEY) ? s.readObject(RECEIPTS_KEY) : null;
+     if (stored instanceof List) {
+     List<Receipt> receipts = (List<Receipt>)stored;
      found = receipts.toArray(new Receipt[receipts.size()]);
      } else {
      found = new Receipt[0];

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava035Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava035Snippet.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+import java.util.List;
+
+
+class MonetizationJava035Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    abstract class Sample implements ReceiptStore {
+    // tag::monetization-java-035[]
+    // static declarations used by receipt store
+
+    // Storage key where list of receipts are stored
+    private static final String RECEIPTS_KEY = "RECEIPTS.dat";
+
+    @Override
+    public void fetchReceipts(SuccessCallback<Receipt[]> callback) {
+     Storage s = Storage.getInstance();
+     Receipt[] found;
+     synchronized(RECEIPTS_KEY) {
+     if (s.exists(RECEIPTS_KEY)) {
+     List<Receipt> receipts = (List<Receipt>)s.readObject(RECEIPTS_KEY);
+     found = receipts.toArray(new Receipt[receipts.size()]);
+     } else {
+     found = new Receipt[0];
+     }
+     }
+     // Make sure this is outside the synchronized block
+     callback.onSucess(found);
+    }
+    // end::monetization-java-035[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava035Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava035Snippet.java
@@ -106,8 +106,22 @@ class MonetizationJava035Snippet {
      boolean entryExists = s.exists(RECEIPTS_KEY);
      Object raw = entryExists ? s.readObject(RECEIPTS_KEY) : null;
      if (raw instanceof List) {
-     List<Receipt> receipts = (List<Receipt>)raw;
-     found = receipts.toArray(new Receipt[receipts.size()]);
+     // Checking the container is not checking its contents: a list holding
+     // anything else -- a key collision, an older schema, a partial write --
+     // makes toArray throw ArrayStoreException, which never reaches the
+     // callback and leaves synchronization stuck for the session. Copy
+     // element by element and fail the fetch if one does not belong.
+     List<?> stored = (List<?>) raw;
+     Receipt[] copy = new Receipt[stored.size()];
+     int i = 0;
+     for (Object o : stored) {
+     if (!(o instanceof Receipt)) {
+     copy = null;
+     break;
+     }
+     copy[i++] = (Receipt) o;
+     }
+     found = copy;
      } else if (entryExists) {
      found = null;
      } else {

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava035Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava035Snippet.java
@@ -97,14 +97,19 @@ class MonetizationJava035Snippet {
      Receipt[] found;
      synchronized(RECEIPTS_KEY) {
      // readObject() answers null when the entry cannot be read or
-     // deserialized, and Purchase calls this from inside loadReceipts(),
-     // so throwing here would leave synchronization marked in progress for
-     // the rest of the session. Treat anything unreadable as "nothing
-     // stored" and always complete the callback.
-     Object stored = s.exists(RECEIPTS_KEY) ? s.readObject(RECEIPTS_KEY) : null;
-     if (stored instanceof List) {
-     List<Receipt> receipts = (List<Receipt>)stored;
+     // deserialized, and Purchase calls this from inside loadReceipts(), so
+     // throwing would leave synchronization marked in progress for the rest of
+     // the session. Answering with an empty array is worse still: loadReceipts
+     // persists a non-null result, so it would overwrite the receipts already
+     // known and revoke a live subscription. null fails the fetch and leaves
+     // them untouched, and only a genuinely absent entry is empty.
+     boolean entryExists = s.exists(RECEIPTS_KEY);
+     Object raw = entryExists ? s.readObject(RECEIPTS_KEY) : null;
+     if (raw instanceof List) {
+     List<Receipt> receipts = (List<Receipt>)raw;
      found = receipts.toArray(new Receipt[receipts.size()]);
+     } else if (entryExists) {
+     found = null;
      } else {
      found = new Receipt[0];
      }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava036Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava036Snippet.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+import java.util.Calendar;
+import java.util.List;
+
+
+class MonetizationJava036Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    abstract class Sample implements ReceiptStore {
+    // tag::monetization-java-036[]
+    @Override
+    public void submitReceipt(Receipt receipt, SuccessCallback<Boolean> callback) {
+     Storage s = Storage.getInstance();
+     synchronized(RECEIPTS_KEY) {
+     List<Receipt> receipts;
+     if (s.exists(RECEIPTS_KEY)) {
+     receipts = (List<Receipt>)s.readObject(RECEIPTS_KEY);
+     } else {
+     receipts = new ArrayList<Receipt>();
+     }
+     // Check to see if this receipt already exists
+     // This probably won't ever happen (that you will be asked to submit an
+     // existing receipt, but better safe than sorry
+     for (Receipt r : receipts) {
+     if (r.getStoreCode().equals(receipt.getStoreCode()) &&
+     r.getTransactionId().equals(receipt.getTransactionId())) {
+     // If you've already got this receipt, you will this submission.
+     return;
+     }
+     }
+
+     // Now try to find the current expiry date
+     Date currExpiry = new Date();
+     List<String> lProducts = Arrays.asList(PRODUCTS);
+     for (Receipt r : receipts) {
+     if (!lProducts.contains(receipt.getSku())) {
+     continue;
+     }
+     if (r.getCancellationDate()!= null) {
+     continue;
+     }
+     if (r.getExpiryDate() == null) {
+     continue;
+     }
+     if (r.getExpiryDate().getTime() > currExpiry.getTime()) {
+     currExpiry = r.getExpiryDate();
+     }
+     }
+
+     // Now set the appropriate expiry date by adding time onto
+     // the end of the current expiry date
+     Calendar cal = Calendar.getInstance();
+     cal.setTime(currExpiry);
+     switch (receipt.getSku()) {
+     case SKU_WORLD_1_MONTH:
+     cal.add(Calendar.MONTH, 1);
+     break;
+     case SKU_WORLD_1_YEAR:
+     cal.add(Calendar.YEAR, 1);
+     }
+     Date newExpiry = cal.getTime();
+
+     receipt.setExpiryDate(newExpiry);
+     receipts.add(receipt);
+     s.writeObject(RECEIPTS_KEY, receipts);
+
+     }
+     // Make sure this is outside the synchronized block
+     callback.onSucess(Boolean.TRUE);
+    }
+    // end::monetization-java-036[]
+    }
+
+    static final String RECEIPTS_KEY = "RECEIPTS.dat";
+    String[] PRODUCTS = {"com.example.world"};
+    static final String SKU_WORLD_1_MONTH = "com.example.world.month";
+    static final String SKU_WORLD_1_YEAR = "com.example.world.year";
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava036Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava036Snippet.java
@@ -140,16 +140,22 @@ class MonetizationJava036Snippet {
      // the end of the current expiry date
      Calendar cal = Calendar.getInstance();
      cal.setTime(currExpiry);
-     switch (receipt.getSku()) {
-     case SKU_WORLD_1_MONTH:
+     Date newExpiry = null;
+     if (SKU_WORLD_1_MONTH.equals(receipt.getSku())) {
      cal.add(Calendar.MONTH, 1);
-     break;
-     case SKU_WORLD_1_YEAR:
+     newExpiry = cal.getTime();
+     } else if (SKU_WORLD_1_YEAR.equals(receipt.getSku())) {
      cal.add(Calendar.YEAR, 1);
+     newExpiry = cal.getTime();
      }
-     Date newExpiry = cal.getTime();
 
+     // Purchase submits every receipt to the store, including products outside
+     // this subscription group. Only the subscription SKUs get an expiry date:
+     // stamping a consumable or a one-off purchase with the subscription's
+     // expiry would make isSubscribed() report it as an active subscription.
+     if (newExpiry != null) {
      receipt.setExpiryDate(newExpiry);
+     }
      receipts.add(receipt);
      stored = s.writeObject(RECEIPTS_KEY, receipts);
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava036Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava036Snippet.java
@@ -105,9 +105,20 @@ class MonetizationJava036Snippet {
      callback.onSucess(Boolean.FALSE);
      return;
      }
-     List<Receipt> receipts = raw instanceof List
-     ? (List<Receipt>)raw
-     : new ArrayList<Receipt>();
+     // The container's type says nothing about its elements, and iterating a
+     // list holding something else throws before the callback runs, which
+     // leaves synchronization stuck for the session. Copy with a check, the
+     // same way fetchReceipts() does.
+     List<Receipt> receipts = new ArrayList<Receipt>();
+     if (raw instanceof List) {
+     for (Object o : (List<?>) raw) {
+     if (!(o instanceof Receipt)) {
+     callback.onSucess(Boolean.FALSE);
+     return;
+     }
+     receipts.add((Receipt) o);
+     }
+     }
      // Check to see if this receipt already exists. That should not happen,
      // but a store can resend one.
      for (Receipt r : receipts) {

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava036Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava036Snippet.java
@@ -97,13 +97,13 @@ class MonetizationJava036Snippet {
      } else {
      receipts = new ArrayList<Receipt>();
      }
-     // Check to see if this receipt already exists
-     // This probably won't ever happen (that you will be asked to submit an
-     // existing receipt, but better safe than sorry
+     // Check to see if this receipt already exists. That should not happen,
+     // but a store can resend one, and the transaction id may be null.
      for (Receipt r : receipts) {
-     if (r.getStoreCode().equals(receipt.getStoreCode()) &&
-     r.getTransactionId().equals(receipt.getTransactionId())) {
-     // If you've already got this receipt, you will this submission.
+     if (Objects.equals(r.getStoreCode(), receipt.getStoreCode()) &&
+     Objects.equals(r.getTransactionId(), receipt.getTransactionId())) {
+     // Already stored. Report success, or synchronizeReceipts() never finishes.
+     callback.onSucess(Boolean.TRUE);
      return;
      }
      }
@@ -112,7 +112,7 @@ class MonetizationJava036Snippet {
      Date currExpiry = new Date();
      List<String> lProducts = Arrays.asList(PRODUCTS);
      for (Receipt r : receipts) {
-     if (!lProducts.contains(receipt.getSku())) {
+     if (!lProducts.contains(r.getSku())) {
      continue;
      }
      if (r.getCancellationDate()!= null) {

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava036Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava036Snippet.java
@@ -98,10 +98,9 @@ class MonetizationJava036Snippet {
      receipts = new ArrayList<Receipt>();
      }
      // Check to see if this receipt already exists. That should not happen,
-     // but a store can resend one, and the transaction id may be null.
+     // but a store can resend one.
      for (Receipt r : receipts) {
-     if (Objects.equals(r.getStoreCode(), receipt.getStoreCode()) &&
-     Objects.equals(r.getTransactionId(), receipt.getTransactionId())) {
+     if (sameReceipt(r, receipt)) {
      // Already stored. Report success, or synchronizeReceipts() never finishes.
      callback.onSucess(Boolean.TRUE);
      return;
@@ -146,6 +145,26 @@ class MonetizationJava036Snippet {
      }
      // Make sure this is outside the synchronized block
      callback.onSucess(Boolean.TRUE);
+    }
+
+    // Two receipts are the same purchase when their transaction ids match. A
+    // null transaction id is not an identity, though: two distinct receipts
+    // can both carry one, so treating them as equal would silently drop the
+    // second purchase. Fall back to the fields that together identify a
+    // purchase -- the same comparison `Purchase.receiptsMatch()` makes.
+    private static boolean sameReceipt(Receipt a, Receipt b) {
+     String aTx = a.getTransactionId();
+     String bTx = b.getTransactionId();
+     if (aTx != null && bTx != null) {
+     return aTx.equals(bTx);
+     }
+     if (aTx != null || bTx != null) {
+     return false;
+     }
+     return Objects.equals(a.getSku(), b.getSku())
+     && Objects.equals(a.getStoreCode(), b.getStoreCode())
+     && Objects.equals(a.getPurchaseDate(), b.getPurchaseDate())
+     && Objects.equals(a.getOrderData(), b.getOrderData());
     }
     // end::monetization-java-036[]
     }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava036Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava036Snippet.java
@@ -92,17 +92,22 @@ class MonetizationJava036Snippet {
      Storage s = Storage.getInstance();
      boolean stored;
      synchronized(RECEIPTS_KEY) {
-     // Same guard as fetchReceipts(): readObject() answers null when the
-     // entry cannot be read or deserialized, and this runs inside
-     // synchronizeReceipts(), so throwing here would leave synchronization
-     // marked in progress for the rest of the session.
-     List<Receipt> receipts;
-     Object raw = s.exists(RECEIPTS_KEY) ? s.readObject(RECEIPTS_KEY) : null;
-     if (raw instanceof List) {
-     receipts = (List<Receipt>)raw;
-     } else {
-     receipts = new ArrayList<Receipt>();
+     // readObject() answers null when the entry cannot be read or
+     // deserialized, and this runs inside synchronizeReceipts(), so throwing
+     // would leave synchronization marked in progress for the rest of the
+     // session. An unreadable entry is not an empty one, though: carrying on
+     // as if it were would write this single receipt over every receipt the
+     // user has already paid for. Report failure and write nothing, and
+     // Purchase keeps the receipt pending and retries later.
+     boolean entryExists = s.exists(RECEIPTS_KEY);
+     Object raw = entryExists ? s.readObject(RECEIPTS_KEY) : null;
+     if (entryExists && !(raw instanceof List)) {
+     callback.onSucess(Boolean.FALSE);
+     return;
      }
+     List<Receipt> receipts = raw instanceof List
+     ? (List<Receipt>)raw
+     : new ArrayList<Receipt>();
      // Check to see if this receipt already exists. That should not happen,
      // but a store can resend one.
      for (Receipt r : receipts) {

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava036Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava036Snippet.java
@@ -92,9 +92,14 @@ class MonetizationJava036Snippet {
      Storage s = Storage.getInstance();
      boolean stored;
      synchronized(RECEIPTS_KEY) {
+     // Same guard as fetchReceipts(): readObject() answers null when the
+     // entry cannot be read or deserialized, and this runs inside
+     // synchronizeReceipts(), so throwing here would leave synchronization
+     // marked in progress for the rest of the session.
      List<Receipt> receipts;
-     if (s.exists(RECEIPTS_KEY)) {
-     receipts = (List<Receipt>)s.readObject(RECEIPTS_KEY);
+     Object raw = s.exists(RECEIPTS_KEY) ? s.readObject(RECEIPTS_KEY) : null;
+     if (raw instanceof List) {
+     receipts = (List<Receipt>)raw;
      } else {
      receipts = new ArrayList<Receipt>();
      }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava036Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava036Snippet.java
@@ -198,7 +198,7 @@ class MonetizationJava036Snippet {
     }
 
     static final String RECEIPTS_KEY = "RECEIPTS.dat";
-    String[] PRODUCTS = {"com.example.world"};
+    String[] PRODUCTS = {SKU_WORLD_1_MONTH, SKU_WORLD_1_YEAR};
     static final String SKU_WORLD_1_MONTH = "com.example.world.month";
     static final String SKU_WORLD_1_YEAR = "com.example.world.year";
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava036Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava036Snippet.java
@@ -90,6 +90,7 @@ class MonetizationJava036Snippet {
     @Override
     public void submitReceipt(Receipt receipt, SuccessCallback<Boolean> callback) {
      Storage s = Storage.getInstance();
+     boolean stored;
      synchronized(RECEIPTS_KEY) {
      List<Receipt> receipts;
      if (s.exists(RECEIPTS_KEY)) {
@@ -140,19 +141,31 @@ class MonetizationJava036Snippet {
 
      receipt.setExpiryDate(newExpiry);
      receipts.add(receipt);
-     s.writeObject(RECEIPTS_KEY, receipts);
+     stored = s.writeObject(RECEIPTS_KEY, receipts);
 
      }
-     // Make sure this is outside the synchronized block
-     callback.onSucess(Boolean.TRUE);
+     // Make sure this is outside the synchronized block. Report what the
+     // write actually did: on a failure Purchase would otherwise record the
+     // transaction as processed and drop it from the pending queue, losing a
+     // receipt the user paid for.
+     callback.onSucess(stored);
     }
 
-    // Two receipts are the same purchase when their transaction ids match. A
-    // null transaction id is not an identity, though: two distinct receipts
-    // can both carry one, so treating them as equal would silently drop the
-    // second purchase. Fall back to the fields that together identify a
-    // purchase -- the same comparison `Purchase.receiptsMatch()` makes.
+    // Two receipts are the same purchase when they come from the same store
+    // and carry the same transaction id. The store code is part of that
+    // identity because a transaction id is only unique within its own store,
+    // as Receipt#getTransactionId() says. A null transaction id is not an
+    // identity either: two distinct receipts can both carry one, so fall back
+    // to the fields that together identify a purchase.
+    //
+    // Purchase.receiptsMatch() compares one device's pending queue, where
+    // every receipt comes from the same store, so it can lean on the
+    // transaction id alone. A ReceiptStore holds receipts from every store
+    // and cannot.
     private static boolean sameReceipt(Receipt a, Receipt b) {
+     if (!Objects.equals(a.getStoreCode(), b.getStoreCode())) {
+     return false;
+     }
      String aTx = a.getTransactionId();
      String bTx = b.getTransactionId();
      if (aTx != null && bTx != null) {
@@ -162,7 +175,6 @@ class MonetizationJava036Snippet {
      return false;
      }
      return Objects.equals(a.getSku(), b.getSku())
-     && Objects.equals(a.getStoreCode(), b.getStoreCode())
      && Objects.equals(a.getPurchaseDate(), b.getPurchaseDate())
      && Objects.equals(a.getOrderData(), b.getOrderData());
     }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava037Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava037Snippet.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+
+
+class MonetizationJava037Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    // tag::monetization-java-037[]
+    public void start() {
+
+    // ...
+
+     // Now synchronize the receipts
+     iap.synchronizeReceipts(0, res->{
+     // Update the UI as necessary to reflect
+
+     });
+    }
+    // end::monetization-java-037[]
+
+    Purchase iap = Purchase.getInAppPurchase();
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava040Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava040Snippet.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+
+
+class MonetizationJava040Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::monetization-java-040[]
+        Purchase iap = Purchase.getInAppPurchase();
+        //...
+        Button rentWorld1M = new Button("Rent World 1 Month");
+        rentWorld1M.addActionListener(e->{
+         String msg = null;
+         if (iap.isSubscribed(PRODUCTS)) { // <1>
+         msg = "you're already renting the world until "
+         +iap.getExpiryDate(PRODUCTS) // <2>
+         +". Extend it for one more month?";
+         } else {
+         msg = "Rent the world for 1 month?";
+         }
+         if (Dialog.show("Confirm", msg, "Yes", "No")) {
+         Purchase.getInAppPurchase().purchase(SKU_WORLD_1_MONTH); // <3>
+         // Note: since this is a non-renewable subscription it's a regular
+         // product in the play store - therefore you use the purchase() method.
+         // If it were a "subscription" product in the play store, then you
+         // would use subscribe() instead.
+         }
+        });
+
+        Button rentWorld1Y = new Button("Rent World 1 Year");
+        rentWorld1Y.addActionListener(e->{
+         String msg = null;
+         if (iap.isSubscribed(PRODUCTS)) {
+         msg = "you're already renting the world until "+
+         iap.getExpiryDate(PRODUCTS)+
+         ". Extend it for one more year?";
+         } else {
+         msg = "Rent the world for 1 year?";
+         }
+         if (Dialog.show("Confirm", msg, "Yes", "No")) {
+         Purchase.getInAppPurchase().purchase(SKU_WORLD_1_YEAR);
+         // Note: since this is a non-renewable subscription it's a regular
+         // product in the play store - therefore you use the purchase() method.
+         // If it were a "subscription" product in the play store, then you
+         // would use subscribe() instead.
+         }
+        });
+        // end::monetization-java-040[]
+    }
+
+    static final String SKU_WORLD_1_YEAR = "com.example.world.year";
+    String[] PRODUCTS = {"com.example.world"};
+    static final String SKU_WORLD_1_MONTH = "com.example.world.month";
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava040Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava040Snippet.java
@@ -128,7 +128,7 @@ class MonetizationJava040Snippet {
     }
 
     static final String SKU_WORLD_1_YEAR = "com.example.world.year";
-    String[] PRODUCTS = {"com.example.world"};
+    String[] PRODUCTS = {SKU_WORLD_1_MONTH, SKU_WORLD_1_YEAR};
     static final String SKU_WORLD_1_MONTH = "com.example.world.month";
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava041Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava041Snippet.java
@@ -107,6 +107,8 @@ class MonetizationJava041Snippet {
     // end::monetization-java-041[]
     }
 
-    String[] PRODUCTS = {"com.example.world"};
+    String SKU_WORLD_1_MONTH = "com.example.world.month";
+    String SKU_WORLD_1_YEAR = "com.example.world.year";
+    String[] PRODUCTS = {SKU_WORLD_1_MONTH, SKU_WORLD_1_YEAR};
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava041Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava041Snippet.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.analytics.*;
+import com.codename1.appreview.*;
+import com.codename1.ads.*;
+import com.codename1.util.*;
+import java.util.*;
+
+
+class MonetizationJava041Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    abstract class Sample implements PurchaseCallback {
+    // tag::monetization-java-041[]
+    @Override
+    public void itemPurchased(String sku) {
+     Purchase iap = Purchase.getInAppPurchase();
+
+     // Force you to reload the receipts from the store.
+     iap.synchronizeReceiptsSync(0);
+     ToastBar.showMessage("Your subscription has been extended to "+iap.getExpiryDate(PRODUCTS), FontImage.MATERIAL_THUMB_UP);
+    }
+
+    @Override
+    public void itemPurchaseError(String sku, String errorMessage) {
+     ToastBar.showErrorMessage("Failure occurred: "+errorMessage);
+    }
+    // end::monetization-java-041[]
+    }
+
+    String[] PRODUCTS = {"com.example.world"};
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava041Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava041Snippet.java
@@ -89,8 +89,14 @@ class MonetizationJava041Snippet {
     public void itemPurchased(String sku) {
      Purchase iap = Purchase.getInAppPurchase();
 
-     // Force you to reload the receipts from the store.
-     iap.synchronizeReceiptsSync(0);
+     // Reload the receipts from the store. This answers false when the receipt
+     // could not be submitted or fetched, and the receipt then stays pending --
+     // so the expiry date below would be stale, or the epoch. Do not announce a
+     // success that did not happen.
+     if (!iap.synchronizeReceiptsSync(0)) {
+     ToastBar.showErrorMessage("Could not confirm the purchase yet -- it will retry.");
+     return;
+     }
      ToastBar.showMessage("Your subscription has been extended to "+iap.getExpiryDate(PRODUCTS), FontImage.MATERIAL_THUMB_UP);
     }
 

--- a/docs/developer-guide/Advertising.asciidoc
+++ b/docs/developer-guide/Advertising.asciidoc
@@ -106,6 +106,10 @@ unit ids while developing.
 `BannerAd` is a regular Codename One component. Add it to a form (typically
 anchored at the top or bottom) and call `load()`:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava003Snippet.java[tag=advertising-java-003,indent=0]
+----
 
 The default `SIZE_ADAPTIVE` requests an anchored adaptive banner sized to the
 available width, which is the recommended modern banner type.
@@ -115,16 +119,28 @@ available width, which is the recommended modern banner type.
 Interstitials are event driven - load, then show when loaded, and preload the
 next one when the current ad is dismissed:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava004Snippet.java[tag=advertising-java-004,indent=0]
+----
 
 You can also let Codename One show an interstitial automatically on screen
 transitions, no more often than a given interval:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava005Snippet.java[tag=advertising-java-005,indent=0]
+----
 
 === Rewarded and rewarded interstitial ads
 
 Register a reward listener and grant the reward when it fires. For valuable
 rewards, verify server side rather than trusting the client:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava006Snippet.java[tag=advertising-java-006,indent=0]
+----
 
 `RewardedInterstitialAd` has the same API but is shown on a transition rather
 than opt-in.
@@ -134,6 +150,10 @@ than opt-in.
 App open ads are shown while the app is brought to the foreground. Let the
 manager and provider handle the foreground hook and freshness window for you:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava007Snippet.java[tag=advertising-java-007,indent=0]
+----
 
 === Native ads
 
@@ -144,6 +164,10 @@ chat or a search results screen - where a banner feels bolted on but a row
 styled like the others fits in. The ad must still be clearly labelled
 (for example "Sponsored"):
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AdvertisingJava008Snippet.java[tag=advertising-java-008,indent=0]
+----
 
 `NativeAd` exposes the headline, body, call-to-action, advertiser and rating
 that you bind to your own components. Native ad support is an optional provider

--- a/docs/developer-guide/Advertising.asciidoc
+++ b/docs/developer-guide/Advertising.asciidoc
@@ -135,7 +135,11 @@ include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/g
 === Rewarded and rewarded interstitial ads
 
 Register a reward listener and grant the reward when it fires. For valuable
-rewards, verify server side rather than trusting the client:
+rewards, configure server-side verification. The network then posts the reward
+to your server, and that callback rather than the client one is what credits
+the user. The client listener still fires, before any verification has
+happened, so with verification configured it's for presentation only -- credit
+the user there as well and you'll pay the reward twice:
 
 [source,java]
 ----

--- a/docs/developer-guide/Analytics.asciidoc
+++ b/docs/developer-guide/Analytics.asciidoc
@@ -14,6 +14,10 @@ Register providers once, early in your app's lifecycle. Providers are plain obje
 
 Once at least one provider is registered, report usage from anywhere in your app:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnalyticsJava001Snippet.java[tag=analytics-java-001,indent=0]
+----
 
 `Analytics.crash` emits a lightweight exception event (for example GA4's `app_exception`) to whichever analytics backends you have registered, so exception counts appear next to your usage metrics. It's separate from Codename One Crash Protection (`com.codename1.crash.CrashProtection`), which is a dedicated pipeline that records full, symbolicated stack traces to the build cloud crash console for debugging. The two are independent: use Crash Protection to diagnose crashes, use `Analytics.crash` when you also want exception events in your analytics, and enable either or both.
 
@@ -27,6 +31,10 @@ The API is designed to help you comply with privacy regulations such as GDPR and
 
 Consent is broken down by category, so you can honor granular choices -- for example allowing crash reporting while declining behavioral analytics:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnalyticsJava002Snippet.java[tag=analytics-java-002,indent=0]
+----
 
 The consent choice is persisted, so it survives restarts. Screen views and events require the `analytics` category, crash reports require `crashReporting`, and `setUserId` requires `personalization`. Calls made without the matching consent are dropped.
 
@@ -34,12 +42,24 @@ The consent choice is persisted, so it survives restarts. Screen views and event
 
 If your application has already obtained consent through its own mechanism -- a custom prompt, a third-party consent-management platform, an enterprise device-management policy, or a jurisdiction where you have determined consent isn't required -- record it once at startup so reporting flows without a second prompt:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnalyticsJava003Snippet.java[tag=analytics-java-003,indent=0]
+----
 
 You can also seed every category and then revoke just one with the builder, for example to allow analytics but not ad storage:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnalyticsJava004Snippet.java[tag=analytics-java-004,indent=0]
+----
 
 If you would rather not gate at all, switch the default so collection is active unless the user withdraws it. This places the compliance responsibility on you as the integrator:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnalyticsJava005Snippet.java[tag=analytics-java-005,indent=0]
+----
 
 Note that the service records pseudonymous data rather than anonymous data. The client id described below is a persistent identifier stored on the device; it isn't tied to a real-world identity and the server discards full IP addresses, but storing and reading such an identifier for usage tracking is often treated as consent-requiring under GDPR and similar regimes. That's why opt-in is the safe default. Relax it only when you are confident the change fits your use.
 
@@ -47,6 +67,10 @@ Note that the service records pseudonymous data rather than anonymous data. The 
 
 Each device is identified by a pseudonymous client id. It's generated on first use and stored locally -- it isn't derived from any hardware identifier. To honor an erasure request ("right to be forgotten"), reset it:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnalyticsJava006Snippet.java[tag=analytics-java-006,indent=0]
+----
 
 For the first-party service this can be paired with a server-side deletion of the previous id's data.
 
@@ -89,6 +113,10 @@ The capabilities you actually get -- screen views, custom events, user propertie
 
 `GoogleAnalyticsProvider` uses the GA4 Measurement Protocol. Create it with a measurement id (`G-XXXXXXXX`) and a Measurement Protocol API secret from the GA4 admin console:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnalyticsJava007Snippet.java[tag=analytics-java-007,indent=0]
+----
 
 Screen views are sent as the GA4 `screen_view` event and crashes as `app_exception`.
 
@@ -96,11 +124,19 @@ Screen views are sent as the GA4 `screen_view` event and crashes as `app_excepti
 
 `MatomoAnalyticsProvider` targets Matomo (formerly Piwik) through its HTTP tracking API. Matomo can be self-hosted and supports IP anonymization, which makes it a good fit for privacy-sensitive deployments:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnalyticsJava008Snippet.java[tag=analytics-java-008,indent=0]
+----
 
 ==== Firebase
 
 `FirebaseAnalyticsProvider` forwards to the native Firebase Analytics SDK on Android and iOS. Register it like any other provider:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnalyticsJava009Snippet.java[tag=analytics-java-009,indent=0]
+----
 
 Firebase reports only from a native Android or iOS build, and only when two things are in place. Without both, `FirebaseAnalyticsProvider` does nothing -- which is why it's always safe to register, including in the Codename One simulator and the desktop build, where it's a no-op.
 

--- a/docs/developer-guide/App-Review.asciidoc
+++ b/docs/developer-guide/App-Review.asciidoc
@@ -17,7 +17,7 @@ include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/g
 
 === The engagement scheduler
 
-Rather than picking the moment yourself, you can let `AppReview` decide based on simple engagement heuristics: how many times the app was launched, how long ago it was installed, and how long since it last asked. Configure it once (for example in your app's `init` or `start` method) and call `registerSession()` on every launch:
+Rather than picking the moment yourself, you can let `AppReview` decide based on simple engagement heuristics: how many times the app was launched, how long ago it was installed, and how long since it last asked. Configure it once (for example in your app's `init` or `start` method) and call `registerSession()` on every launch -- but after a form is showing, not during `init`. It prompts as soon as the thresholds are met, and on a platform with no native prompt that dialog is a `Sheet`, which needs something to show on:
 
 [source,java]
 ----

--- a/docs/developer-guide/App-Review.asciidoc
+++ b/docs/developer-guide/App-Review.asciidoc
@@ -8,6 +8,10 @@ The native prompt is the store-sanctioned way to ask for a review, so prefer it 
 
 The simplest usage is a single call at a moment that makes sense in your app -- typically right after the user completed something rewarding (finished a level, saved a document, completed an order):
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AppReviewJava001Snippet.java[tag=app-review-java-001,indent=0]
+----
 
 `requestReview()` shows the native review sheet when the platform supports it. On platforms without a native prompt it shows the built-in rating widget instead. You decide the timing.
 
@@ -15,6 +19,10 @@ The simplest usage is a single call at a moment that makes sense in your app -- 
 
 Rather than picking the moment yourself, you can let `AppReview` decide based on simple engagement heuristics: how many times the app was launched, how long ago it was installed, and how long since it last asked. Configure it once (for example in your app's `init` or `start` method) and call `registerSession()` on every launch:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AppReviewJava002Snippet.java[tag=app-review-java-002,indent=0]
+----
 
 `registerSession()` records the launch and, once the thresholds are met and the user hasn't already rated or opted out, prompts. The bookkeeping (launch count, install date, last-prompt time and a completion flag) is stored in https://www.codenameone.com/javadoc/com/codename1/io/Preferences.html[Preferences] so it survives restarts. Once the user rates the app or chooses to stop, `AppReview` stops prompting. Call `reset()` to clear this state.
 
@@ -29,6 +37,10 @@ image::img/app-review-sheet.png[Fallback rating sheet,scaledwidth=30%]
 
 By default the low-rating feedback is collected through an e-mail to the address passed to `setSupportEmail(String)`. To deliver feedback through your own backend, register a `FeedbackListener`:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AppReviewJava003Snippet.java[tag=app-review-java-003,indent=0]
+----
 
 === How the platform decides
 

--- a/docs/developer-guide/Commerce.asciidoc
+++ b/docs/developer-guide/Commerce.asciidoc
@@ -8,6 +8,10 @@ Codename One doesn't process payments and never touches your money -- the stores
 
 The core idea is the *entitlement*: an abstract access right such as `pro` or `remove_ads`. You map one or more store products to an entitlement, and your code only ever checks the entitlement:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava001Snippet.java[tag=commerce-java-001,indent=0]
+----
 
 An entitlement is active when *any* of its granting products is active. This matters: a promotional grant and a paid subscription, or a sandbox and a production purchase, can both map to `pro` without one hiding the other. Access is decided by a single authoritative rule -- the latest expiry over the active grants, evaluated against a server timestamp -- so a tampered device clock can't extend it. Everything else (will-renew, billing stage, period type, family sharing) is advisory and never removes access on its own.
 
@@ -15,12 +19,24 @@ An entitlement is active when *any* of its granting products is active. This mat
 
 In your `Lifecycle.init` (or wherever you set up purchases):
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava002Snippet.java[tag=commerce-java-002,indent=0]
+----
 
 Drive purchases through the manager (these delegate to the `Purchase` API):
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava003Snippet.java[tag=commerce-java-003,indent=0]
+----
 
 After a purchase, or on app start, validate the device's receipts with the cloud and refresh the entitlement cache. `refresh()` makes a blocking network call, so run it off the EDT:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava004Snippet.java[tag=commerce-java-004,indent=0]
+----
 
 `isEntitled` returns the last cloud-validated answer when one is available, and otherwise falls back to the platform's own receipt (treating the entitlement id as a subscription SKU) so a paying user is never locked out while the network is down.
 

--- a/docs/developer-guide/Commerce.asciidoc
+++ b/docs/developer-guide/Commerce.asciidoc
@@ -13,6 +13,8 @@ The core idea is the *entitlement*: an abstract access right such as `pro` or `r
 include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava001Snippet.java[tag=commerce-java-001,indent=0]
 ----
 
+`isEntitled` reads the answer the cloud last cached, so it's only as fresh as your last `refresh()`: before one completes the cache is empty and a paying subscriber reads as unentitled. It falls back to asking the store for a subscription named after the entitlement, and since the entitlement-to-SKU mapping lives in the cloud rather than on the device, that only matches when a product happens to share the id. Where the cloud can't answer -- commerce not enabled in the build, an offline start, a degraded account -- check the granting SKU yourself, as the post-purchase example below does. Don't do it when the cloud answered no: a refunded or revoked receipt still looks active on the device, and treating that as a grant unlocks the app after the server denied it.
+
 An entitlement is active when *any* of its granting products is active. This matters: a promotional grant and a paid subscription, or a sandbox and a production purchase, can both map to `pro` without one hiding the other. Access is decided by a single authoritative rule -- the latest expiry over the active grants, evaluated against a server timestamp -- so a tampered device clock can't extend it. Everything else (will-renew, billing stage, period type, family sharing) is advisory and never removes access on its own.
 
 === Client usage

--- a/docs/developer-guide/Commerce.asciidoc
+++ b/docs/developer-guide/Commerce.asciidoc
@@ -31,7 +31,7 @@ Drive purchases through the manager (these delegate to the `Purchase` API):
 include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CommerceJava003Snippet.java[tag=commerce-java-003,indent=0]
 ----
 
-After a purchase, or on app start, validate the device's receipts with the cloud and refresh the entitlement cache. `refresh()` makes a blocking network call, so run it off the EDT:
+After a purchase, or on app start, validate the device's receipts with the cloud and refresh the entitlement cache. `refresh()` validates the receipts already stored rather than waiting for one in flight, so chain it off receipt synchronization after a purchase -- otherwise it runs before the new receipt has been submitted and nothing retries it. It's a blocking network call, so keep it off the EDT:
 
 [source,java]
 ----

--- a/docs/developer-guide/Commerce.asciidoc
+++ b/docs/developer-guide/Commerce.asciidoc
@@ -17,7 +17,7 @@ An entitlement is active when *any* of its granting products is active. This mat
 
 === Client usage
 
-In your `Lifecycle.init` (or wherever you set up purchases):
+In your `Lifecycle.init` (or wherever you set up purchases). Installing a receipt store is part of the setup, not an optional extra: `Purchase` submits pending purchases and reloads its receipt list only when one is installed, so without it `refresh()` finds no receipts and no entitlement is ever granted. On iOS `isSubscriptionSupported()` returns false until one is installed, so subscriptions don't start at all. <<Monetization,The monetization chapter>> builds a store you can use here.
 
 [source,java]
 ----

--- a/docs/developer-guide/Monetization.asciidoc
+++ b/docs/developer-guide/Monetization.asciidoc
@@ -42,9 +42,17 @@ Using these callbacks, the app receives notifications whenever a purchase change
 
 Now in the `start()` method, add a button that lets the user buy the world:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava029Snippet.java[tag=monetization-java-029,indent=0]
+----
 
 At this point, the app can track the sale of the world. To make it more useful, add `ToastBar` feedback for purchase completion:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava030Snippet.java[tag=monetization-java-030,indent=0]
+----
 
 NOTE: You can test out this code in the simulator without doing any more setup and it will work. If you want the code to work on Android and iOS, you'll need to set up the app and in-app purchase settings in the Google Play and iTunes stores respectively as explained below
 
@@ -76,9 +84,17 @@ include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/g
 
 Now you'll change your buy code as follows:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava031Snippet.java[tag=monetization-java-031,indent=0]
+----
 
 And your `itemPurchased()` callback will need to add a world:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava032Snippet.java[tag=monetization-java-032,indent=0]
+----
 
 NOTE: When you set up the products in the iTunes store you will need to mark the product as a consumable product or iTunes will prevent you from purchasing it more than once
 
@@ -104,6 +120,10 @@ Apple allows you to present discounted introductory pricing to existing subscrib
 
 To build the signed discount payload required by Apple you can use the `ApplePromotionalOffer` helper:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava033Snippet.java[tag=monetization-java-033,indent=0]
+----
 
 Apple generates the signature and timestamp from your App Store Connect server notifications endpoint; Codename One passes them to the native StoreKit APIs. For one-time products you can call `purchase(sku, offer)` instead of `subscribe(...)`.
 
@@ -174,11 +194,19 @@ A basic receipt store needs to implement just two methods:
 
 You'll register it in your app's init() method so that it's always available:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava034Snippet.java[tag=monetization-java-034,indent=0]
+----
 
 These methods are designed to be asynchronous since real-world apps will always be connecting to some sort of network service. Instead of returning a value, both of these methods are passed instances of the `SuccessCallback` class. It's important to make sure to call `callback.onSuccess()` *ALWAYS* when the methods have completed, even if there is an error, or the Buy class will just assume that you're taking a long time to complete the task, and will continue to wait for you to finish.
 
 Once implemented, your `fetchReceipts()` method will look like:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava035Snippet.java[tag=monetization-java-035,indent=0]
+----
 
 This is straight forward. You're checking to see if you already have a list of receipts stored. If so you return that list to the callback. If not you return an empty array of receipts.
 
@@ -186,6 +214,10 @@ NOTE: `Receipt` implements `Externalizable` so you are able to write instances d
 
 The `submitReceipt()` method is a little more complex, as it needs to calculate the new expiry date for your subscription:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava036Snippet.java[tag=monetization-java-036,indent=0]
+----
 
 The main logic of this method involves iterating through all the existing receipts to find the *latest* current expiry date, so that when the user purchases a subscription, it's added onto the end of the current subscription (if one exists) rather than going from today's date. This enables users to renew their subscription before the subscription has expired.
 
@@ -207,6 +239,10 @@ In your hello world app you synchronize the subscriptions in a few places.
 
 At the end of the `start()` method:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava037Snippet.java[tag=monetization-java-037,indent=0]
+----
 
 And you also provide a button to allow the user to manually synchronize the receipts:
 
@@ -230,6 +266,16 @@ You should now have all the background required to implement the Hello World Sub
 
 In the main form, you want two buttons to subscribe to the `World`, for one month and one year respectively. They look like:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava040Snippet.java[tag=monetization-java-040,indent=0]
+----
+
+<1> In the event handler you check if the user is subscribed by calling `isSubscribed(PRODUCTS)`.  Notice that you check it against the array of both the one month and one year subscription SKUs.
+
+<2> You are able to tell the user when the current expiry date is so that they can gauge whether to proceed.
+
+<3> Since this is a non-renewable subscription, you use the `Purchase.purchase()` method. See following note about `subscribe()` vs `purchase()`
 
 ==== Subscribe() vs purchase()
 
@@ -245,6 +291,10 @@ Which one you use depends on the type of product that's being purchased. If your
 
 The buy callbacks are like the ones implemented in the regular in-app purchase examples:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MonetizationJava041Snippet.java[tag=monetization-java-041,indent=0]
+----
 
 Notice that, in `itemPurchased()` you don't need to explicitly create any receipts or submit anything to the receipt store. This is handled for you automatically. You do make a call to `synchronizeReceiptsSync(0)` but this is just to ensure that your toast message has the new expiry date loaded already.
 

--- a/scripts/developer-guide/missing-code-blocks-baseline.txt
+++ b/scripts/developer-guide/missing-code-blocks-baseline.txt
@@ -6,14 +6,8 @@
 3D-Graphics.asciidoc	own material, so a textured model renders with no extra setup:
 Advanced-Topics-Under-The-Hood.asciidoc	For the release build, you will also need to inject some proguard configuration so that important classes don't get stripped out at build time. The FreshDesk SDK instructions state:
 Advanced-Topics-Under-The-Hood.asciidoc	You can override these methods in the draggable components:
-Advertising.asciidoc	(for example "Sponsored"):
-Advertising.asciidoc	anchored at the top or bottom) and call `load()`:
 Advertising.asciidoc	identifier. The recommended order is to initialize, gather consent, then load:
-Advertising.asciidoc	manager and provider handle the foreground hook and freshness window for you:
 Advertising.asciidoc	method that registers its provider with `AdManager`:
-Advertising.asciidoc	next one when the current ad is dismissed:
-Advertising.asciidoc	rewards, verify server side rather than trusting the client:
-Advertising.asciidoc	transitions, no more often than a given interval:
 Ai-And-Speech.asciidoc	`ChatMessage` values to JSON under a named key:
 Ai-And-Speech.asciidoc	`SecureStorage` overloads:
 Ai-And-Speech.asciidoc	`chatStream(...)` can mutate the view directly:
@@ -27,15 +21,6 @@ Ai-And-Speech.asciidoc	one user message:
 Ai-And-Speech.asciidoc	returns a string the runtime can hand to `JSONParser`:
 Ai-And-Speech.asciidoc	safe to log:
 Ai-And-Speech.asciidoc	you need a custom send pipeline:
-Analytics.asciidoc	Consent is broken down by category, so you can honor granular choices -- for example allowing crash reporting while declining behavioral analytics:
-Analytics.asciidoc	Each device is identified by a pseudonymous client id. It's generated on first use and stored locally -- it isn't derived from any hardware identifier. To honor an erasure request ("right to be forgotten"), reset it:
-Analytics.asciidoc	If you would rather not gate at all, switch the default so collection is active unless the user withdraws it. This places the compliance responsibility on you as the integrator:
-Analytics.asciidoc	If your application has already obtained consent through its own mechanism -- a custom prompt, a third-party consent-management platform, an enterprise device-management policy, or a jurisdiction where you have determined consent isn't required -- record it once at startup so reporting flows without a second prompt:
-Analytics.asciidoc	Once at least one provider is registered, report usage from anywhere in your app:
-Analytics.asciidoc	You can also seed every category and then revoke just one with the builder, for example to allow analytics but not ad storage:
-Analytics.asciidoc	`FirebaseAnalyticsProvider` forwards to the native Firebase Analytics SDK on Android and iOS. Register it like any other provider:
-Analytics.asciidoc	`GoogleAnalyticsProvider` uses the GA4 Measurement Protocol. Create it with a measurement id (`G-XXXXXXXX`) and a Measurement Protocol API secret from the GA4 admin console:
-Analytics.asciidoc	`MatomoAnalyticsProvider` targets Matomo (formerly Piwik) through its HTTP tracking API. Matomo can be self-hosted and supports IP anonymization, which makes it a good fit for privacy-sensitive deployments:
 Animations.asciidoc	That one command will enable swiping back from `currentForm`. https://www.codenameone.com/javadoc/com/codename1/util/LazyValue.html[LazyValue] allows you to pass a value lazily:
 Animations.asciidoc	builder:
 Annotation-Component-Binding.asciidoc	ASM and inserts the equivalent of:
@@ -43,15 +28,8 @@ Annotation-Component-Binding.asciidoc	After binding, drive validation through th
 Annotation-JSON-XML-Mapping.asciidoc	Hand-write a `Mapper<T>` and register it at startup:
 Annotation-JSON-XML-Mapping.asciidoc	mutation:
 Annotation-SQLite-ORM.asciidoc	dao surface isn't enough. Transactions:
-App-Review.asciidoc	By default the low-rating feedback is collected through an e-mail to the address passed to `setSupportEmail(String)`. To deliver feedback through your own backend, register a `FeedbackListener`:
-App-Review.asciidoc	Rather than picking the moment yourself, you can let `AppReview` decide based on simple engagement heuristics: how many times the app was launched, how long ago it was installed, and how long since it last asked. Configure it once (for example in your app's `init` or `start` method) and call `registerSession()` on every launch:
-App-Review.asciidoc	The simplest usage is a single call at a moment that makes sense in your app -- typically right after the user completed something rewarding (finished a level, saved a document, completed an order):
 Apple-Wallet-Extension.asciidoc	In Java, publish the user's cards whenever they change (typically after login) and keep a fresh token published so Wallet can skip the login screen:
 Authentication-And-Identity.asciidoc	Firebase Auth isn't an OIDC provider -- it issues Google-Identity-Toolkit-style tokens via REST endpoints. `com.codename1.social.FirebaseAuth` wraps those endpoints:
-Commerce.asciidoc	After a purchase, or on app start, validate the device's receipts with the cloud and refresh the entitlement cache. `refresh()` makes a blocking network call, so run it off the EDT:
-Commerce.asciidoc	Drive purchases through the manager (these delegate to the `Purchase` API):
-Commerce.asciidoc	In your `Lifecycle.init` (or wherever you set up purchases):
-Commerce.asciidoc	The core idea is the *entitlement*: an abstract access right such as `pro` or `remove_ads`. You map one or more store products to an entitlement, and your code only ever checks the entitlement:
 Crash-Protection.asciidoc	In your `Lifecycle.init`:
 Deep-Links-Routing.asciidoc	Or annotate a static factory method:
 Deep-Links-Routing.asciidoc	`AssetLinksBuilder` produces the payload:
@@ -119,23 +97,12 @@ Miscellaneous-Features.asciidoc	You can add more than one attachment by putting 
 Miscellaneous-Features.asciidoc	You can install the bundle using code like this:
 Miscellaneous-Features.asciidoc	You can send a task to the thread using:
 Monetization.asciidoc	And you also provide a button to allow the user to manually synchronize the receipts:
-Monetization.asciidoc	And your `itemPurchased()` callback will need to add a world:
-Monetization.asciidoc	At the end of the `start()` method:
-Monetization.asciidoc	At this point, the app can track the sale of the world. To make it more useful, add `ToastBar` feedback for purchase completion:
 Monetization.asciidoc	In the hello world app you'll use this information in a few different places. On your main form you'll include a label to show the current expiry date, and you allow the user to press a button to synchronize receipts manually if they think the value is out of date:
-Monetization.asciidoc	In the main form, you want two buttons to subscribe to the `World`, for one month and one year respectively. They look like:
-Monetization.asciidoc	Now in the `start()` method, add a button that lets the user buy the world:
-Monetization.asciidoc	Now you'll change your buy code as follows:
 Monetization.asciidoc	On the server-side, your REST controller is a standard JAX-RS REST interface. The Netbeans web service wizard generated it and then it was modified to suit the purposes here. The methods of the `ReceiptsFacadeREST` class for the REST API are shown here:
-Monetization.asciidoc	Once implemented, your `fetchReceipts()` method will look like:
 Monetization.asciidoc	The `createRESTClient()` method shown there creates a `RESTfulWebServiceClient` and configuring it to use basic authentication with a username and password. The idea is that your user would have logged into your app at some point, and you would have a username and password on hand to pass back to the web service with the receipt data so that you can connect the subscription to a user account. The source of that method is listed here:
-Monetization.asciidoc	The `submitReceipt()` method is a little more complex, as it needs to calculate the new expiry date for your subscription:
-Monetization.asciidoc	The buy callbacks are like the ones implemented in the regular in-app purchase examples:
 Monetization.asciidoc	The general usage is as follows:
 Monetization.asciidoc	The source for your ReceiptStore is as follows:
-Monetization.asciidoc	To build the signed discount payload required by Apple you can use the `ApplePromotionalOffer` helper:
 Monetization.asciidoc	You are now ready to see the full magic of the `validateAndSaveReceipt()` method in all its glory:
-Monetization.asciidoc	You'll register it in your app's init() method so that it's always available:
 Monetization.asciidoc	You'll set these in your constants:
 Motion-Sensors.asciidoc	Callbacks arrive on the EDT, so the listener can update the UI directly. Sampling is reference counted: the hardware sensor draws power only while at least one listener is registered. Remove the listener once the screen is no longer visible, typically from the form's `removeNotify`, so the sensor powers down:
 Motion-Sensors.asciidoc	Register a `GestureListener` for one of the `GestureEvent.TYPE_*` gestures. The accelerometer powers on for the duration that a gesture listener stays registered:


### PR DESCRIPTION
Monetization, Analytics, Advertising, Commerce and App-Review lost 43 listings to
`bbdc6058f0`. Three of those chapters had **no code at all** afterwards -- Commerce
documents a paid service and showed none. 33 are restored here, and the ratchet
drops from 213 to 180.

**Ten are deliberately left as holes**, because they are not app code and cannot
compile in the snippets module:

* seven Monetization blocks build a JavaEE receipt server (`@Stateless`, `@Path`,
  `AbstractFacade`, `getEntityManager`) or drive the **CN1-IAP-Validator** cn1lib,
  neither of which this repository contains;
* two Advertising blocks install an ad provider from **cn1-admob**, a separate
  library the demos do not depend on -- the listings say so in their own comments;
* one more configures that same validator library.

The recovered code needed the usual corrections:

* blocks implementing `PurchaseCallback` or `ReceiptStore` are wrapped in an
  abstract class, so their `@Override` annotations have something to override;
* SKU and secret constants are `static final`, because a `switch` case needs a
  compile-time constant;
* the originals use a bare `...` to elide code, which is not Java -- those are
  comments now.

All 36 snippets compile against core on JDK 17, and a `-bootclasspath` probe
against the `java-runtime` jar the compliance mojo uses confirms every API they
touch exists in the Codename One runtime. I compiled them one file at a time
rather than as a batch: a batch stops attributing after the first file with a
parse error, which reads as "everything else is fine" when nothing was checked.

Gates run locally: structure, xrefs, links, missing-code-blocks, snippets, unused
images (with CI s three `--allow-unused` flags), paragraph capitalization, control
characters, copyright headers over the branch range, Vale at suggestion level on
all five chapters, and LanguageTool over the whole assembled book -- all clean.