### PR TITLE
Display: an init() during the old EDT's teardown starts its own dispatch thread

### DIFF
--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -269,6 +269,16 @@ public final class Display extends CN1Constants {
     /// so a high/low FPS will have no effect then.
     private int framerateLock = 15;
     private boolean codenameOneRunning = false;
+    /// How long `init()` waits for a departing dispatch thread to finish its teardown.
+    ///
+    /// Bounded rather than indefinite because the teardown is the PORT's, and a port is
+    /// entitled to need a thread that may be the one calling `init()` -- the Android
+    /// implementation hands the tail of its teardown to the activity's UI thread, which is
+    /// also where `init()` is called from. Waiting for ever would turn a slow teardown into a
+    /// dead application. On expiry the two generations overlap exactly as they did before this
+    /// was here, which is what the guards in the teardown itself are for.
+    private static final long TEARDOWN_WAIT_MILLIS = 10000;
+
     /// This is the instance of the EDT used internally to indicate whether
     /// we are executing on the EDT or some arbitrary thread
     private Thread edt;
@@ -287,6 +297,24 @@ public final class Display extends CN1Constants {
     /// correct outcomes rather than a race. It is a plain boolean, read and written only inside
     /// that monitor.
     private boolean edtDispatching;
+
+    /// The dispatch thread running the teardown that follows its loop, or null when none is.
+    ///
+    /// Claimed inside the same monitor and at the same instant `edtDispatching` is renounced,
+    /// which is provably before any `init()` can have begun: `init()`'s first act is to set
+    /// `codenameOneRunning` true, and the renunciation happens with it false.
+    ///
+    /// `init()` waits on it, because the teardown and a new generation must not interleave.
+    /// Both act on state that is process wide rather than per generation -- the `impl` slot,
+    /// the implementation's own initialized flag (a port may hand out ONE implementation for
+    /// every generation; the Android factory does, and so does the unit test harness) and
+    /// `Desktop`'s single window registry. A teardown that lands mid-`init()` clears the flag
+    /// the successor just set, and `isInitialized()` is that flag AND `codenameOneRunning`, so
+    /// the display stays half up for ever: `init()` cannot repair it, because it guards on the
+    /// flag that is still true. No check the teardown can make closes that, because a check
+    /// and the call after it are two statements and the thread can be descheduled between them
+    /// -- which is this whole class of failure. So the two are ordered instead of guarded.
+    private Thread edtTearingDown;
 
     /// Contains animations that must be played in full by the EDT before anything further
     /// may be processed. This is useful for transitions/intro's etc... that animate without
@@ -454,8 +482,37 @@ public final class Display extends CN1Constants {
     /// #### Deprecated
     ///
     /// this method is invoked internally do not invoke it!
+    /// Waits for a departing dispatch thread to finish the teardown that follows its loop.
+    ///
+    /// This is what keeps two generations from overlapping. See `#edtTearingDown` for why
+    /// guarding the teardown instead cannot work, and `#TEARDOWN_WAIT_MILLIS` for why the wait
+    /// is bounded.
+    ///
+    /// The teardown's own thread is exempt. A port that reached back into `init()` from inside
+    /// its `deinitialize()` would otherwise wait for itself, and a self deadlock in `init()` is
+    /// a worse outcome than the overlap this exists to prevent.
+    private static void awaitPreviousTeardown() {
+        synchronized (lock) {
+            long deadline = System.currentTimeMillis() + TEARDOWN_WAIT_MILLIS;
+            while (INSTANCE.edtTearingDown != null
+                    && INSTANCE.edtTearingDown != Thread.currentThread()) { //NOPMD CompareObjectsWithEquals
+                long remaining = deadline - System.currentTimeMillis();
+                if (remaining <= 0) {
+                    return;
+                }
+                try {
+                    lock.wait(remaining);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+        }
+    }
+
     public static void init(Object m) {
         if (!INSTANCE.codenameOneRunning) {
+            awaitPreviousTeardown();
             INSTANCE.codenameOneRunning = true;
             INSTANCE.initialWindowSizeApplied = false;
             INSTANCE.pluginSupport = new PluginSupport();
@@ -1335,6 +1392,10 @@ public final class Display extends CN1Constants {
             // thread is alive and not dispatching -- exactly the window that must not read as a
             // working EDT.
             edtDispatching = false;
+            // Claimed in the same breath, so there is no instant in which this thread has
+            // renounced dispatching and not yet announced the teardown -- an init() landing in
+            // such an instant would neither adopt this thread nor wait for it.
+            edtTearingDown = Thread.currentThread();
             departing[0] = impl;
             return false;
         }
@@ -1343,8 +1404,10 @@ public final class Display extends CN1Constants {
     /// Whether this dispatch thread is still the one the display is recorded as running on.
     ///
     /// Asked by the teardown before each step it takes. A false answer means a successor
-    /// generation has started -- an `init()` that landed during this teardown -- and that
-    /// everything from here belongs to that generation rather than to this thread.
+    /// generation has started while this thread was tearing down, which `init()` waits to
+    /// avoid -- so in practice it only answers false after that wait expired. It is asked
+    /// anyway, because the alternative on that path is a teardown reaching into a live
+    /// generation, and because the answer is a lock and a comparison.
     ///
     /// #### Returns
     ///
@@ -1368,6 +1431,9 @@ public final class Display extends CN1Constants {
     /// So the question is whether it is IN SERVICE. Ours to release while we are still the
     /// recorded dispatch thread, or once a successor is running on a different implementation;
     /// never while the successor is running on this one.
+    ///
+    /// A successor cannot normally exist here at all, because `init()` waits for this teardown.
+    /// This is the guard for the case where that wait expired.
     ///
     /// #### Parameters
     ///
@@ -1491,6 +1557,11 @@ public final class Display extends CN1Constants {
                 // between the two sees a live thread still flagged as dispatching, adopts it and
                 // starts nothing. One call decides and renounces under one lock.
                 if (!keepDispatching(departing)) {
+                    // The claim keepDispatching() just took has to be given back here. This exit
+                    // runs no teardown at all -- the implementation threw on its way down -- and
+                    // an unreleased claim would make the next init() wait out its whole bound
+                    // for one that never starts.
+                    releaseTeardownClaim();
                     return;
                 }
                 Log.e(err);
@@ -1513,10 +1584,38 @@ public final class Display extends CN1Constants {
                 }
             }
         }
-        // Now that an init() during this teardown starts a dispatch thread of its own rather
-        // than adopting this one, the two generations overlap by design -- so each step below
-        // has to ask whether it has been superseded rather than read whatever the process-wide
-        // singletons name by now. Each asks as late as it can, immediately before it acts.
+        // The claim keepDispatching() took is held for the whole teardown and released in the
+        // finally, because an init() that lands here waits for it rather than racing it.
+        try {
+            runTeardown(departing[0]);
+        } finally {
+            releaseTeardownClaim();
+        }
+    }
+
+    /// Releases this thread's teardown claim and wakes any `init()` waiting on it.
+    private void releaseTeardownClaim() {
+        synchronized (lock) {
+            // Only if it is still OURS -- a claim can only be held by one thread, but an expired
+            // wait means an init() went ahead anyway and a successor may already have claimed
+            // its own teardown by the time this runs.
+            if (edtTearingDown == Thread.currentThread()) { //NOPMD CompareObjectsWithEquals
+                edtTearingDown = null;
+            }
+            lock.notifyAll();
+        }
+    }
+
+    /// The teardown that follows the dispatch loop, run as the departing dispatch thread.
+    ///
+    /// `init()` waits for this rather than racing it, so in the ordinary case nothing here can
+    /// be observing a successor generation. The guards are for the case where that wait expired
+    /// -- see `#TEARDOWN_WAIT_MILLIS` -- which is the only way the two generations still overlap.
+    ///
+    /// #### Parameters
+    ///
+    /// - `departing`: the implementation this thread was the dispatch thread for
+    private void runTeardown(CodenameOneImplementation departing) {
         if (stillTheDispatchThread()) {
             // Dispose any window still open, on the EDT, before the implementation goes
             // away. Doing this from the static deinitialize() would run the teardown off
@@ -1534,8 +1633,8 @@ public final class Display extends CN1Constants {
             // reproduces in CI and never locally.
             Desktop.getInstance().disposeAll();
         }
-        if (mayDeinitialize(departing[0])) {
-            departing[0].deinitialize();
+        if (mayDeinitialize(departing)) {
+            departing.deinitialize();
         }
         //INSTANCE.impl = null;
         //INSTANCE.codenameOneGraphics = null;

--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -538,29 +538,39 @@ public final class Display extends CN1Constants {
             // thread at all. edtDispatching answers that question from the one
             // place that knows, and the lock makes the two answers ordered
             // rather than raced.
-            boolean startDispatchThread;
+            CodenameOneThread newEdt = null;
             synchronized (lock) {
                 // Held across the decision AND the claim, because the departing thread renounces
                 // the flag inside the same monitor. Either it gets there first -- this sees no
                 // dispatch thread and starts one -- or this does, in which case codenameOneRunning
                 // was already set true above and the thread's next test keeps it in the loop,
                 // which is the adoption that is legitimately free.
-                startDispatchThread = INSTANCE.edt == null || !INSTANCE.edt.isAlive()
-                        || !INSTANCE.edtDispatching;
-                if (startDispatchThread) {
+                if (INSTANCE.edt == null || !INSTANCE.edt.isAlive() || !INSTANCE.edtDispatching) {
                     // Claimed here rather than by the new thread. Between start() and its first
                     // instruction the thread is alive and not yet dispatching, so a second init()
                     // in that window would read "no dispatch thread" and start another one.
+                    //
+                    // The thread is RECORDED here for the same reason and in the same breath.
+                    // The two fields describe one thread, so a moment in which the flag says
+                    // "dispatching" while edt still names the departing thread is a moment in
+                    // which the next reader adopts the wrong one -- and the departing thread's
+                    // own teardown asks the same question, to find out whether it has been
+                    // succeeded. Written apart, both readers can be told a thread that is on its
+                    // way out is the live dispatch thread.
                     INSTANCE.edtDispatching = true;
+                    newEdt = new CodenameOneThread(new RunnableWrapper(null, 3), "EDT");
+                    INSTANCE.edt = newEdt;
                 }
             }
-            if (startDispatchThread) {
+            // Started outside the monitor. Only the two field writes have to be indivisible;
+            // the port calls around them do not, and holding the display lock across an
+            // implementation callback is how a port that reaches back into Display deadlocks.
+            if (newEdt != null) {
                 INSTANCE.touchScreen = impl.isTouchDevice();
                 // initialize the Codename One EDT which from now on will take all responsibility
                 // for the event delivery.
-                INSTANCE.edt = new CodenameOneThread(new RunnableWrapper(null, 3), "EDT");
-                impl.setThreadPriority(INSTANCE.edt, impl.getEDTThreadPriority());
-                INSTANCE.edt.start();
+                impl.setThreadPriority(newEdt, impl.getEDTThreadPriority());
+                newEdt.start();
             }
             impl.postInit();
             INSTANCE.setCommandBehavior(commandBehaviour);
@@ -1302,7 +1312,20 @@ public final class Display extends CN1Constants {
     /// The other order is not a failure but the case adoption exists for. An `init()` that gets
     /// the lock first has already set `codenameOneRunning` back to true, so this returns true and
     /// the thread simply keeps dispatching for the new generation.
-    private boolean keepDispatching() {
+    ///
+    /// #### Parameters
+    ///
+    /// - `departing`: single element holder that receives the implementation this thread was
+    /// serving at the moment it stopped, for the teardown to work on. Captured under the same
+    /// lock and at the same instant as the renunciation, because `impl` is one slot that the
+    /// next `init()` overwrites -- reading it again after the loop names the SUCCESSOR. It is
+    /// refreshed rather than taken once at thread start because an adopted thread outlives the
+    /// generation it was created for and must tear down the one it actually ends on.
+    ///
+    /// #### Returns
+    ///
+    /// true to run another turn of the dispatch loop
+    private boolean keepDispatching(CodenameOneImplementation[] departing) {
         synchronized (lock) {
             if (codenameOneRunning) {
                 return true;
@@ -1312,11 +1335,62 @@ public final class Display extends CN1Constants {
             // thread is alive and not dispatching -- exactly the window that must not read as a
             // working EDT.
             edtDispatching = false;
+            departing[0] = impl;
             return false;
         }
     }
 
+    /// Whether this dispatch thread is still the one the display is recorded as running on.
+    ///
+    /// Asked by the teardown before each step it takes. A false answer means a successor
+    /// generation has started -- an `init()` that landed during this teardown -- and that
+    /// everything from here belongs to that generation rather than to this thread.
+    ///
+    /// #### Returns
+    ///
+    /// true while this thread is still the recorded dispatch thread
+    private boolean stillTheDispatchThread() {
+        synchronized (lock) {
+            return INSTANCE.edt == Thread.currentThread(); //NOPMD CompareObjectsWithEquals
+        }
+    }
+
+    /// Whether the implementation this dispatch thread served is still this thread's to release.
+    ///
+    /// Identity is not the question, because the implementation may be SHARED. A host that hands
+    /// out one implementation instance for every generation -- which the unit test harness does,
+    /// and a port restarting into the same object may -- gives the successor the very object
+    /// this thread started on, so "tear down the one I served" still tears down the live one.
+    /// `deinitialize()` clears the implementation's initialized flag, and `isInitialized()` is
+    /// that flag AND `codenameOneRunning`: the successor is then permanently half up, because
+    /// `init()` guards on the flag that is still true and does nothing.
+    ///
+    /// So the question is whether it is IN SERVICE. Ours to release while we are still the
+    /// recorded dispatch thread, or once a successor is running on a different implementation;
+    /// never while the successor is running on this one.
+    ///
+    /// #### Parameters
+    ///
+    /// - `departing`: the implementation this thread was the dispatch thread for
+    ///
+    /// #### Returns
+    ///
+    /// true if deinitializing it cannot damage a live generation
+    private boolean mayDeinitialize(CodenameOneImplementation departing) {
+        synchronized (lock) {
+            if (INSTANCE.edt == Thread.currentThread()) { //NOPMD CompareObjectsWithEquals
+                return true;
+            }
+            return departing != impl; //NOPMD CompareObjectsWithEquals
+        }
+    }
+
     void mainEDTLoop() {
+        // The implementation this thread is the dispatch thread FOR, refreshed by
+        // keepDispatching() at the instant the loop is left -- which is the only path to the
+        // teardown, so the seed below is never the one actually torn down. It is here so the
+        // holder is complete from the start rather than depending on that staying true.
+        CodenameOneImplementation[] departing = {impl};
         impl.initEDT();
         UIManager.getInstance();
         try {
@@ -1363,7 +1437,7 @@ public final class Display extends CN1Constants {
             }
         }
 
-        while (keepDispatching()) { // PMD Fix: AvoidBranchingStatementAsLastInLoop
+        while (keepDispatching(departing)) { // PMD Fix: AvoidBranchingStatementAsLastInLoop
             try {
                 // wait indefinetly Lock surrounds the should method to prevent serial calls from
                 // getting "lost"
@@ -1374,7 +1448,20 @@ public final class Display extends CN1Constants {
                             callSerially(r);
                         } else {
                             impl.edtIdle(true);
-                            while (shouldEDTSleep() && pendingIdleSerialCalls.isEmpty()) {
+                            // codenameOneRunning is part of the condition, not only of the outer
+                            // loop's. deinitialize() sets it false under this lock and notifies,
+                            // but an idle EDT that woke here re-tested only shouldEDTSleep(),
+                            // found itself still idle and waited again -- so "closes down the
+                            // EDT" only actually did when something else happened to hand it
+                            // work. It otherwise stayed parked for ever: alive, flagged as
+                            // dispatching, and never reaching the teardown below.
+                            //
+                            // That is the nondeterminism underneath this whole class of failure.
+                            // Whether a deinitialize() ends the generation or leaves the thread
+                            // to be adopted by the next init() decided itself on whether the
+                            // display happened to be idle at that instant.
+                            while (codenameOneRunning && shouldEDTSleep()
+                                    && pendingIdleSerialCalls.isEmpty()) {
                                 try {
                                     lock.wait();
                                 } catch (InterruptedException ie) {
@@ -1394,14 +1481,16 @@ public final class Display extends CN1Constants {
 
                 edtLoopImpl();
             } catch (Throwable err) {
-                if (!codenameOneRunning) {
-                    // Renounced on this exit as well. The teardown after the loop is deliberately
-                    // skipped here -- the implementation threw on its way down -- but the thread
-                    // is just as alive and just as finished with dispatching while it unwinds,
-                    // and that is all an adopting init() would have to go on.
-                    synchronized (lock) {
-                        edtDispatching = false;
-                    }
+                // Renounced on this exit as well, and through the same helper. The teardown after
+                // the loop is deliberately skipped here -- the implementation threw on its way
+                // down -- but the thread is just as alive and just as finished with dispatching
+                // while it unwinds, and that is all an adopting init() would have to go on.
+                //
+                // Testing codenameOneRunning here and clearing the flag afterwards was the same
+                // race this method exists to close, reopened on the rarer path: an init() landing
+                // between the two sees a live thread still flagged as dispatching, adopts it and
+                // starts nothing. One call decides and renounces under one lock.
+                if (!keepDispatching(departing)) {
                     return;
                 }
                 Log.e(err);
@@ -1424,19 +1513,40 @@ public final class Display extends CN1Constants {
                 }
             }
         }
-        // Dispose any window still open, on the EDT, before the implementation goes
-        // away. Doing this from the static deinitialize() would run the teardown off
-        // the EDT, which is exactly the thread the window's tree expects.
-        Desktop.getInstance().disposeAll();
-        impl.deinitialize();
+        // Now that an init() during this teardown starts a dispatch thread of its own rather
+        // than adopting this one, the two generations overlap by design -- so each step below
+        // has to ask whether it has been superseded rather than read whatever the process-wide
+        // singletons name by now. Each asks as late as it can, immediately before it acts.
+        if (stillTheDispatchThread()) {
+            // Dispose any window still open, on the EDT, before the implementation goes
+            // away. Doing this from the static deinitialize() would run the teardown off
+            // the EDT, which is exactly the thread the window's tree expects.
+            //
+            // Skipped once a successor exists, because Desktop is a process singleton with one
+            // window registry: disposing "every open window" from here closes the successor's
+            // windows, and Window.dispose() marshals to the recorded EDT, so it would do it ON
+            // the successor's dispatch thread. Windows left open pass to the successor, which
+            // is what already happens to the current Form.
+            //
+            // That this test sits one statement after the loop exit is not a reason to think it
+            // never fires. Everything in this class of failure is the departing thread being
+            // descheduled between two adjacent statements on a loaded machine -- that is why it
+            // reproduces in CI and never locally.
+            Desktop.getInstance().disposeAll();
+        }
+        if (mayDeinitialize(departing[0])) {
+            departing[0].deinitialize();
+        }
         //INSTANCE.impl = null;
         //INSTANCE.codenameOneGraphics = null;
-        // Only if it is still OURS. A new generation may have started its own EDT while this
-        // one was tearing down, and clearing the field unconditionally disowned that live
-        // thread: isEdt() then answered false ON the event dispatch thread, so work meant to
-        // run there was queued behind itself instead.
-        if (INSTANCE.edt == Thread.currentThread()) { //NOPMD CompareObjectsWithEquals
-            INSTANCE.edt = null;
+        // Only if it is still OURS -- asked again rather than reusing the answer above, because
+        // a successor may have started during the teardown itself. Clearing the field
+        // unconditionally disowned that live thread: isEdt() then answered false ON the event
+        // dispatch thread, so work meant to run there was queued behind itself instead.
+        synchronized (lock) {
+            if (INSTANCE.edt == Thread.currentThread()) { //NOPMD CompareObjectsWithEquals
+                INSTANCE.edt = null;
+            }
         }
     }
 

--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -1435,7 +1435,7 @@ public final class Display extends CN1Constants {
         // one was tearing down, and clearing the field unconditionally disowned that live
         // thread: isEdt() then answered false ON the event dispatch thread, so work meant to
         // run there was queued behind itself instead.
-        if (INSTANCE.edt == Thread.currentThread()) {
+        if (INSTANCE.edt == Thread.currentThread()) { //NOPMD CompareObjectsWithEquals
             INSTANCE.edt = null;
         }
     }

--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -496,17 +496,34 @@ public final class Display extends CN1Constants {
     /// critical section as the wait -- see `#init(Object)`.
     private static void awaitPreviousTeardown() {
         long deadline = System.currentTimeMillis() + TEARDOWN_WAIT_MILLIS;
-        while (INSTANCE.edtTearingDown != null
-                && INSTANCE.edtTearingDown != Thread.currentThread()) { //NOPMD CompareObjectsWithEquals
-            long remaining = deadline - System.currentTimeMillis();
-            if (remaining <= 0) {
-                return;
+        boolean interrupted = false;
+        try {
+            while (INSTANCE.edtTearingDown != null
+                    && INSTANCE.edtTearingDown != Thread.currentThread()) { //NOPMD CompareObjectsWithEquals
+                long remaining = deadline - System.currentTimeMillis();
+                if (remaining <= 0) {
+                    return;
+                }
+                try {
+                    lock.wait(remaining);
+                } catch (InterruptedException ie) {
+                    // Remembered rather than acted on, which is the opposite of what the rest of
+                    // this class does with an interrupt -- and has to be. Returning here would
+                    // hand the caller a generation to build while the previous one is still
+                    // tearing down, so an interrupt would silently undo the ordering this method
+                    // exists to impose. The deadline still bounds the wait, so a thread someone
+                    // is trying to stop waits no longer than any other.
+                    //
+                    // Re-arming the flag here rather than on the way out would be worse than
+                    // returning: wait() clears the interrupted status when it throws, so a
+                    // restored flag makes the NEXT wait() throw immediately and the loop spins
+                    // out the whole deadline instead of sleeping through it.
+                    interrupted = true;
+                }
             }
-            try {
-                lock.wait(remaining);
-            } catch (InterruptedException ie) {
+        } finally {
+            if (interrupted) {
                 Thread.currentThread().interrupt();
-                return;
             }
         }
     }

--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -272,6 +272,22 @@ public final class Display extends CN1Constants {
     /// This is the instance of the EDT used internally to indicate whether
     /// we are executing on the EDT or some arbitrary thread
     private Thread edt;
+
+    /// Whether `edt` is actually inside its dispatch loop.
+    ///
+    /// `edt.isAlive()` cannot answer that. A thread that has left `mainEDTLoop`'s loop stays
+    /// alive for the whole of its teardown -- `Desktop.disposeAll()` and `impl.deinitialize()`,
+    /// either of which can block -- so an `init()` landing in that window adopted a thread that
+    /// was on its way out and started no dispatch thread of its own. The new generation then had
+    /// none at all: everything it queued waited for ever and `isInitialized()` stayed false,
+    /// which `init()` cannot repair because it guards on `codenameOneRunning`.
+    ///
+    /// So the departing thread PUBLISHES the fact rather than leaving it to be inferred, and does
+    /// it under `lock` against the same adoption decision -- the two orderings are then the two
+    /// correct outcomes rather than a race. It is a plain boolean, read and written only inside
+    /// that monitor.
+    private boolean edtDispatching;
+
     /// Contains animations that must be played in full by the EDT before anything further
     /// may be processed. This is useful for transitions/intro's etc... that animate without
     /// user interaction.
@@ -513,10 +529,32 @@ public final class Display extends CN1Constants {
             // thread. Nothing clears this field when an EDT terminates, so
             // testing only for null left a dead thread recorded for ever and
             // re-initialising never started a working one -- the display then
-            // has no dispatch at all. This is a thread that has actually
-            // died, not one that might be mid-teardown; the speculative
-            // machinery that used to be here was removed on purpose.
-            if (INSTANCE.edt == null || !INSTANCE.edt.isAlive()) {
+            // has no dispatch at all.
+            //
+            // Being alive is not enough to say it IS one, either, which is the
+            // half this used to call speculative. It is not: a thread that has
+            // left the dispatch loop stays alive for its whole teardown, and
+            // adopting it there is how a generation ends up with no dispatch
+            // thread at all. edtDispatching answers that question from the one
+            // place that knows, and the lock makes the two answers ordered
+            // rather than raced.
+            boolean startDispatchThread;
+            synchronized (lock) {
+                // Held across the decision AND the claim, because the departing thread renounces
+                // the flag inside the same monitor. Either it gets there first -- this sees no
+                // dispatch thread and starts one -- or this does, in which case codenameOneRunning
+                // was already set true above and the thread's next test keeps it in the loop,
+                // which is the adoption that is legitimately free.
+                startDispatchThread = INSTANCE.edt == null || !INSTANCE.edt.isAlive()
+                        || !INSTANCE.edtDispatching;
+                if (startDispatchThread) {
+                    // Claimed here rather than by the new thread. Between start() and its first
+                    // instruction the thread is alive and not yet dispatching, so a second init()
+                    // in that window would read "no dispatch thread" and start another one.
+                    INSTANCE.edtDispatching = true;
+                }
+            }
+            if (startDispatchThread) {
                 INSTANCE.touchScreen = impl.isTouchDevice();
                 // initialize the Codename One EDT which from now on will take all responsibility
                 // for the event delivery.
@@ -1252,6 +1290,32 @@ public final class Display extends CN1Constants {
     /// all events are carried out. It differs from the MIDP event thread to
     /// prevent blocking of actual input and drawing operations. This also
     /// enables functionality such as "true" modal dialogs etc...
+    /// Whether the dispatch loop should run another turn, renouncing `edtDispatching` in the
+    /// same breath when it should not.
+    ///
+    /// The renunciation has to happen HERE rather than after the loop, and under the lock that
+    /// `init()` takes to decide adoption. Otherwise the two steps are a race the wrong way round:
+    /// this thread observes that it is stopping, an `init()` sees a thread that is still alive and
+    /// still flagged as dispatching, adopts it and starts nothing -- and then this thread clears
+    /// the flag and dies, leaving a generation with no event dispatch at all.
+    ///
+    /// The other order is not a failure but the case adoption exists for. An `init()` that gets
+    /// the lock first has already set `codenameOneRunning` back to true, so this returns true and
+    /// the thread simply keeps dispatching for the new generation.
+    private boolean keepDispatching() {
+        synchronized (lock) {
+            if (codenameOneRunning) {
+                return true;
+            }
+            // Cleared BEFORE the teardown that follows the loop, never after it. disposeAll() and
+            // impl.deinitialize() can each block for as long as they like, and for all of it this
+            // thread is alive and not dispatching -- exactly the window that must not read as a
+            // working EDT.
+            edtDispatching = false;
+            return false;
+        }
+    }
+
     void mainEDTLoop() {
         impl.initEDT();
         UIManager.getInstance();
@@ -1299,7 +1363,7 @@ public final class Display extends CN1Constants {
             }
         }
 
-        while (codenameOneRunning) { // PMD Fix: AvoidBranchingStatementAsLastInLoop
+        while (keepDispatching()) { // PMD Fix: AvoidBranchingStatementAsLastInLoop
             try {
                 // wait indefinetly Lock surrounds the should method to prevent serial calls from
                 // getting "lost"
@@ -1331,6 +1395,13 @@ public final class Display extends CN1Constants {
                 edtLoopImpl();
             } catch (Throwable err) {
                 if (!codenameOneRunning) {
+                    // Renounced on this exit as well. The teardown after the loop is deliberately
+                    // skipped here -- the implementation threw on its way down -- but the thread
+                    // is just as alive and just as finished with dispatching while it unwinds,
+                    // and that is all an adopting init() would have to go on.
+                    synchronized (lock) {
+                        edtDispatching = false;
+                    }
                     return;
                 }
                 Log.e(err);
@@ -1360,7 +1431,13 @@ public final class Display extends CN1Constants {
         impl.deinitialize();
         //INSTANCE.impl = null;
         //INSTANCE.codenameOneGraphics = null;
-        INSTANCE.edt = null;
+        // Only if it is still OURS. A new generation may have started its own EDT while this
+        // one was tearing down, and clearing the field unconditionally disowned that live
+        // thread: isEdt() then answered false ON the event dispatch thread, so work meant to
+        // run there was queued behind itself instead.
+        if (INSTANCE.edt == Thread.currentThread()) {
+            INSTANCE.edt = null;
+        }
     }
 
     /// Returns the stack trace from the exception on the given

--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -491,29 +491,43 @@ public final class Display extends CN1Constants {
     /// The teardown's own thread is exempt. A port that reached back into `init()` from inside
     /// its `deinitialize()` would otherwise wait for itself, and a self deadlock in `init()` is
     /// a worse outcome than the overlap this exists to prevent.
+    ///
+    /// Called with `lock` HELD, so that the caller's claim of the generation is part of the same
+    /// critical section as the wait -- see `#init(Object)`.
     private static void awaitPreviousTeardown() {
-        synchronized (lock) {
-            long deadline = System.currentTimeMillis() + TEARDOWN_WAIT_MILLIS;
-            while (INSTANCE.edtTearingDown != null
-                    && INSTANCE.edtTearingDown != Thread.currentThread()) { //NOPMD CompareObjectsWithEquals
-                long remaining = deadline - System.currentTimeMillis();
-                if (remaining <= 0) {
-                    return;
-                }
-                try {
-                    lock.wait(remaining);
-                } catch (InterruptedException ie) {
-                    Thread.currentThread().interrupt();
-                    return;
-                }
+        long deadline = System.currentTimeMillis() + TEARDOWN_WAIT_MILLIS;
+        while (INSTANCE.edtTearingDown != null
+                && INSTANCE.edtTearingDown != Thread.currentThread()) { //NOPMD CompareObjectsWithEquals
+            long remaining = deadline - System.currentTimeMillis();
+            if (remaining <= 0) {
+                return;
+            }
+            try {
+                lock.wait(remaining);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                return;
             }
         }
     }
 
     public static void init(Object m) {
-        if (!INSTANCE.codenameOneRunning) {
+        boolean startNewGeneration;
+        synchronized (lock) {
+            // The wait and the claim are ONE critical section. A teardown releases every waiter
+            // with a single notifyAll, so two initializers parked here would both wake, both
+            // find codenameOneRunning false and both go on to build a generation -- overwriting
+            // each other's impl while each was midway through its own initImpl(), and leaving
+            // whichever EDT got started running against the half built one. Testing the flag
+            // and setting it apart from the wait is the same check-then-act this class of bug
+            // is made of; here it costs nothing to make it indivisible.
             awaitPreviousTeardown();
-            INSTANCE.codenameOneRunning = true;
+            startNewGeneration = !INSTANCE.codenameOneRunning;
+            if (startNewGeneration) {
+                INSTANCE.codenameOneRunning = true;
+            }
+        }
+        if (startNewGeneration) {
             INSTANCE.initialWindowSizeApplied = false;
             INSTANCE.pluginSupport = new PluginSupport();
             INSTANCE.displayInitTime = System.currentTimeMillis();
@@ -1594,6 +1608,22 @@ public final class Display extends CN1Constants {
     }
 
     /// Releases this thread's teardown claim and wakes any `init()` waiting on it.
+    ///
+    /// The claim covers `deinitialize()` RETURNING, not any work that call may have handed to
+    /// another thread, and deliberately so. A review asked for the latter, on the grounds that
+    /// `AndroidImplementation.deinitialize()` posts its destructive half -- the one that nulls
+    /// `relativeLayout` and `myView` -- to the activity's UI thread and returns. Waiting for
+    /// that would deadlock: `Display.init()` is called ON the UI thread during an activity
+    /// restart, so the thread parked in `awaitPreviousTeardown()` is the very thread the posted
+    /// cleanup needs in order to run. Only the bound above would break it, at ten seconds per
+    /// restart, and the cleanup would still land afterwards.
+    ///
+    /// It is also not needed. `AndroidImplementation.startContext()` drains that cleanup
+    /// SYNCHRONOUSLY before it initializes anything -- it waits out `deinitializingEdt`, then
+    /// calls `deinitialize()` again from the UI thread, where the same method runs its Runnable
+    /// inline rather than posting it -- and the posted copy then returns at its own
+    /// `if (!deinitializing)` guard. The port already orders what it defers; core waiting on it
+    /// would only take the ordering away.
     private void releaseTeardownClaim() {
         synchronized (lock) {
             // Only if it is still OURS -- a claim can only be held by one thread, but an expired
@@ -1627,10 +1657,14 @@ public final class Display extends CN1Constants {
             // the successor's dispatch thread. Windows left open pass to the successor, which
             // is what already happens to the current Form.
             //
-            // That this test sits one statement after the loop exit is not a reason to think it
-            // never fires. Everything in this class of failure is the departing thread being
-            // descheduled between two adjacent statements on a loaded machine -- that is why it
-            // reproduces in CI and never locally.
+            // This check is not atomic with the disposal it guards, and cannot be made so: the
+            // lock has to be released across disposeAll(), which runs application listeners and
+            // reaches into the port. A review asked for atomicity here; holding the display lock
+            // through that is how a port that reaches back into Display deadlocks. What makes
+            // the sequence safe is that init() WAITS for this teardown rather than racing it,
+            // so no successor exists to observe. The check is what remains for the one case the
+            // wait does not cover -- see TEARDOWN_WAIT_MILLIS -- where narrowing the window
+            // from the whole teardown to two adjacent statements is the most that is available.
             Desktop.getInstance().disposeAll();
         }
         if (mayDeinitialize(departing)) {

--- a/maven/core-unittests/src/test/java/com/codename1/junit/EdtHandoverTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/junit/EdtHandoverTest.java
@@ -330,6 +330,51 @@ class EdtHandoverTest {
     }
 
     /**
+     * Interrupting a thread that is waiting for a teardown must not let it past the wait.
+     *
+     * <p>An interrupt is not a reason to start building a generation while the previous one is
+     * still tearing down -- that is the very interleaving the wait exists to prevent, and it
+     * would be reached by a route nothing else in the display can see. The interrupt is not
+     * swallowed either: it is restored once the wait is over, so the caller still learns about
+     * it.</p>
+     */
+    @Test
+    void anInterruptDoesNotLetAnInitPastTheTeardownWait() {
+        BlockingDeinitImplementation blocking = new BlockingDeinitImplementation();
+        startGeneration(blocking);
+
+        Display.deinitialize();
+        assertTrue(blocking.gate().awaitEntered(), "the fixture never parked the departing thread");
+
+        install(new TestCodenameOneImplementation());
+        final boolean[] interruptSurvived = new boolean[1];
+        Thread init = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                Display.init(null);
+                interruptSurvived[0] = Thread.currentThread().isInterrupted();
+            }
+        }, "edt-handover-interrupted-init");
+        init.start();
+
+        // Give it a moment to actually reach the wait, then interrupt it there.
+        finishedWithin(init, 250L);
+        init.interrupt();
+
+        assertFalse(finishedWithin(init, 500L),
+                "an interrupt let init() out of the teardown wait, so it went on to claim a "
+                        + "generation while the previous one was still tearing down -- the "
+                        + "ordering this class is about, undone by a route nothing checks");
+
+        blocking.gate().release();
+        assertTrue(finishedWithin(init, DISPATCH_TIMEOUT),
+                "init() never came back after the teardown finished");
+        assertTrue(interruptSurvived[0],
+                "the interrupt was swallowed rather than restored once the wait was over");
+        assertTrue(dispatchWorks(), "the successor generation never came up");
+    }
+
+    /**
      * Calls {@code Display.init(null)} on a thread of its own and hands the thread back.
      *
      * <p>Off the test thread because an init() that lands during a teardown WAITS for it. The

--- a/maven/core-unittests/src/test/java/com/codename1/junit/EdtHandoverTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/junit/EdtHandoverTest.java
@@ -23,16 +23,21 @@
 package com.codename1.junit;
 
 import com.codename1.impl.ImplementationFactory;
+import com.codename1.impl.WindowManager;
 import com.codename1.testing.TestCodenameOneImplementation;
+import com.codename1.testing.TestWindowManager;
 import com.codename1.ui.Display;
 import com.codename1.ui.Form;
+import com.codename1.ui.Window;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A {@code Display.init()} that lands while the previous dispatch thread is tearing down must
- * start a dispatch thread of its own.
+ * start a dispatch thread of its own, and that thread's teardown must stay inside its own
+ * generation.
  *
  * <p>This is the bug behind the intermittent {@code FormTest timed out after 5000ms;
  * edt=display-not-initialized} that has failed a different test class each time it appeared, and
@@ -47,10 +52,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * {@code codenameOneRunning} stays true -- a state {@code init()} cannot repair, because it
  * guards on that flag.</p>
  *
- * <p>Reproduced here rather than raced for. The window is only open while a loaded machine
- * happens to be descheduling the old thread, which is why this never failed locally; an
- * implementation that blocks inside {@code deinitialize()} holds it open instead, so the test
- * either passes or fails for the reason it names.</p>
+ * <p>Not starting a dispatch thread is only one of the two ways that ends in
+ * display-not-initialized, which is why the teardown is tested here as well. Once the adoption
+ * stops, the two generations overlap by design, and a teardown that reads the process-wide
+ * {@code impl} slot rather than its own generation deinitializes the SUCCESSOR -- the same
+ * symptom through the other door.</p>
+ *
+ * <p>Reproduced rather than raced for. The window is only open while a loaded machine happens to
+ * be descheduling the old thread, which is why this never failed locally; an implementation that
+ * parks the departing thread inside its teardown holds it open instead, so each test either
+ * passes or fails for the reason it names. Adjacency in the source is worth nothing here: every
+ * failure in this class is the departing thread being descheduled between two statements.</p>
  */
 class EdtHandoverTest {
 
@@ -58,71 +70,121 @@ class EdtHandoverTest {
     private static final long DISPATCH_TIMEOUT = 5000L;
 
     /**
+     * A one shot gate: a thread parks in it, the test observes that it arrived and lets it go.
+     *
+     * <p>The point of every fixture here is to hold the departing dispatch thread at a chosen
+     * point of its teardown for as long as the test needs, so the ordering under test is fixed
+     * rather than hoped for.</p>
+     */
+    private static final class Gate {
+        private boolean entered;
+        private boolean released;
+        private Thread parked;
+
+        /** Parks the calling thread until {@link #release()}, recording that it arrived. */
+        synchronized void park() {
+            entered = true;
+            parked = Thread.currentThread();
+            notifyAll();
+            long deadline = System.currentTimeMillis() + DISPATCH_TIMEOUT;
+            // Bounded on purpose. A blocked EDT that is never released would hang the whole
+            // suite rather than fail this one test, and the failure would then be reported
+            // against whichever class the runner happened to reach.
+            while (!released && System.currentTimeMillis() < deadline) {
+                try {
+                    wait(deadline - System.currentTimeMillis());
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+        }
+
+        /** Whether a thread reached {@link #park()} within the timeout. */
+        synchronized boolean awaitEntered() {
+            long deadline = System.currentTimeMillis() + DISPATCH_TIMEOUT;
+            while (!entered && System.currentTimeMillis() < deadline) {
+                try {
+                    wait(deadline - System.currentTimeMillis());
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    return entered;
+                }
+            }
+            return entered;
+        }
+
+        synchronized void release() {
+            released = true;
+            notifyAll();
+        }
+
+        /** The parked thread, so a test can wait for it to finish dying rather than sleep. */
+        synchronized Thread parkedThread() {
+            return parked;
+        }
+    }
+
+    /**
      * An implementation that parks the departing dispatch thread inside its teardown.
      *
      * <p>{@code mainEDTLoop} calls this after leaving the loop and before it stops being alive,
-     * so blocking here holds the thread in exactly the state the race produces, for as long as
-     * the test needs it.</p>
+     * so blocking here holds the thread in exactly the state the race produces.</p>
      */
-    private static final class BlockingDeinitImplementation extends TestCodenameOneImplementation {
-        private final Object gate = new Object();
-        private boolean entered;
-        private boolean released;
+    private static class BlockingDeinitImplementation extends TestCodenameOneImplementation {
+        private final Gate gate = new Gate();
 
         @Override
         public void deinitialize() {
-            synchronized (gate) {
-                entered = true;
-                gate.notifyAll();
-                long deadline = System.currentTimeMillis() + DISPATCH_TIMEOUT;
-                // Bounded on purpose. A blocked EDT that is never released would hang the whole
-                // suite rather than fail this one test, and the failure would then be reported
-                // against whichever class the runner happened to reach.
-                while (!released && System.currentTimeMillis() < deadline) {
-                    try {
-                        gate.wait(deadline - System.currentTimeMillis());
-                    } catch (InterruptedException ie) {
-                        Thread.currentThread().interrupt();
-                        break;
-                    }
-                }
-            }
+            gate.park();
             super.deinitialize();
         }
 
-        boolean awaitEntered() {
-            synchronized (gate) {
-                long deadline = System.currentTimeMillis() + DISPATCH_TIMEOUT;
-                while (!entered && System.currentTimeMillis() < deadline) {
-                    try {
-                        gate.wait(deadline - System.currentTimeMillis());
-                    } catch (InterruptedException ie) {
-                        Thread.currentThread().interrupt();
-                        return entered;
-                    }
-                }
-                return entered;
+        Gate gate() {
+            return gate;
+        }
+    }
+
+    /**
+     * An implementation that parks the departing thread EARLIER in the same teardown: inside
+     * {@code Desktop.disposeAll()}, which runs before the implementation to deinitialize is
+     * read.
+     *
+     * <p>That difference is the whole point of the fixture. Parking inside {@code deinitialize()}
+     * cannot exercise a teardown that reads the wrong implementation, because the receiver of
+     * that call has already been resolved by the time the thread parks -- a test built on it
+     * passes whether the teardown is generation scoped or not.</p>
+     */
+    private static final class BlockingWindowDisposeImplementation extends TestCodenameOneImplementation {
+        private final Gate gate = new Gate();
+        private final WindowManager manager = new TestWindowManager() {
+            @Override
+            public void dispose(Object peer) {
+                gate.park();
+                super.dispose(peer);
             }
+        };
+
+        @Override
+        public WindowManager getWindowManager() {
+            return manager;
         }
 
-        void release() {
-            synchronized (gate) {
-                released = true;
-                gate.notifyAll();
-            }
+        Gate gate() {
+            return gate;
         }
     }
 
     @Test
     void anInitDuringTheOldEdtsTeardownStartsItsOwnDispatchThread() {
         BlockingDeinitImplementation blocking = new BlockingDeinitImplementation();
-        BlockingDeinitImplementation parked = startGeneration(blocking);
+        startGeneration(blocking);
 
         // Send the old generation into its teardown and wait until it is parked there: alive,
         // and no longer dispatching. This is the whole point of the fixture -- from here the
         // ordering is fixed rather than hoped for.
         Display.deinitialize();
-        assertTrue(parked.awaitEntered(),
+        assertTrue(blocking.gate().awaitEntered(),
                 "the dispatch thread never reached the teardown, so the window this test is "
                         + "about was never opened and what follows would prove nothing");
 
@@ -135,7 +197,7 @@ class EdtHandoverTest {
                             + "generation has no event dispatch: everything it queues waits for "
                             + "ever, which is the display-not-initialized timeout CI reports");
         } finally {
-            blocking.release();
+            blocking.gate().release();
         }
     }
 
@@ -153,7 +215,7 @@ class EdtHandoverTest {
         startGeneration(blocking);
 
         Display.deinitialize();
-        assertTrue(blocking.awaitEntered(), "the fixture never parked the departing thread");
+        assertTrue(blocking.gate().awaitEntered(), "the fixture never parked the departing thread");
 
         install(new TestCodenameOneImplementation());
         Display.init(null);
@@ -162,13 +224,106 @@ class EdtHandoverTest {
 
         // Let the old thread run the rest of its teardown, which is where it used to clear the
         // field the successor is recorded in.
-        blocking.release();
-        settle();
+        blocking.gate().release();
+        assertTrue(awaitDeath(blocking.gate().parkedThread()),
+                "the departing thread never finished its teardown");
 
         assertTrue(dispatchThreadKnowsItself(),
                 "the departing thread cleared the recorded dispatch thread on its way out, so "
                         + "isEdt() answers false ON the live dispatch thread and work meant for "
                         + "it is queued behind itself");
+    }
+
+    /**
+     * The departing thread must deinitialize the implementation IT served, not whichever one the
+     * static slot names by the time it gets there.
+     *
+     * <p>{@code impl} is a single slot that {@code init()} overwrites, and the teardown runs long
+     * after the successor may have replaced it. Reading it at the call site deinitialized the
+     * successor's implementation, which leaves {@code isInitialized()} false while
+     * {@code codenameOneRunning} stays true -- the same unrepairable state, and the same
+     * display-not-initialized timeout, as failing to start a dispatch thread at all. The harness
+     * already describes this failure in {@link UITestBase}: "the previous class's EDT calls
+     * impl.deinitialize() on its way out, on whatever implementation is current BY THEN".</p>
+     */
+    @Test
+    void aDepartingEdtDeinitializesItsOwnImplementationNotItsSuccessors() {
+        BlockingWindowDisposeImplementation blocking = new BlockingWindowDisposeImplementation();
+        startGeneration(blocking);
+        assertTrue(openWindow(),
+                "a window is what gives Desktop.disposeAll() something to park in, and without "
+                        + "the park the thread runs the whole teardown before the successor "
+                        + "exists -- which is the ordering that proves nothing");
+
+        Display.deinitialize();
+        assertTrue(blocking.gate().awaitEntered(),
+                "the departing thread never reached disposeAll(), so it never parked BEFORE the "
+                        + "implementation to tear down is read");
+
+        TestCodenameOneImplementation successor = new TestCodenameOneImplementation();
+        install(successor);
+        Display.init(null);
+        assertTrue(dispatchWorks(), "the successor generation has to be running to be damaged");
+        assertTrue(successor.isInitialized(), "the successor came up uninitialized on its own");
+
+        // Only now does the departing thread reach the read. The successor is already the
+        // current implementation, so a teardown that reads the slot picks it up.
+        blocking.gate().release();
+        assertTrue(awaitDeath(blocking.gate().parkedThread()),
+                "the departing thread never finished its teardown");
+
+        assertFalse(blocking.isInitialized(),
+                "the departing generation's own implementation was left initialized, so the "
+                        + "teardown tore down something else");
+        assertTrue(successor.isInitialized(),
+                "the departing thread deinitialized the SUCCESSOR's implementation: "
+                        + "Display.isInitialized() is now false with codenameOneRunning true, "
+                        + "which init() cannot repair because it guards on that flag");
+        assertTrue(Display.isInitialized(),
+                "the display is in the half torn down state every test in the next class "
+                        + "reports as display-not-initialized");
+    }
+
+    /**
+     * A departing thread must leave an implementation the successor is RUNNING ON alone, even
+     * though it is the very one it served itself.
+     *
+     * <p>Tearing down "the implementation this generation served" is not enough when the host
+     * hands out one implementation for every generation, which is exactly what the unit test
+     * harness does: {@link UITestBase} reuses {@code TestCodenameOneImplementation.getInstance()}
+     * from class to class. The departing thread and the successor then hold the same object, so
+     * a teardown scoped by identity still deinitializes the live one -- and the successor is
+     * permanently half up, because {@code isInitialized()} is the implementation's flag AND
+     * {@code codenameOneRunning}, and {@code init()} guards on the one that is still true.</p>
+     *
+     * <p>This is the shape the whole suite hits between classes, and it is why the question the
+     * teardown asks has to be "is it in service" rather than "is it mine".</p>
+     */
+    @Test
+    void aDepartingEdtLeavesAnImplementationItsSuccessorIsRunningOnAlone() {
+        BlockingWindowDisposeImplementation shared = new BlockingWindowDisposeImplementation();
+        startGeneration(shared);
+        assertTrue(openWindow(), "the fixture needs an open window to park the teardown in");
+
+        Display.deinitialize();
+        assertTrue(shared.gate().awaitEntered(),
+                "the departing thread never parked before the implementation is read");
+
+        // The SAME instance, which is what the harness does between test classes.
+        install(shared);
+        Display.init(null);
+        assertTrue(dispatchWorks(), "the successor generation has to be running to be damaged");
+
+        shared.gate().release();
+        assertTrue(awaitDeath(shared.gate().parkedThread()),
+                "the departing thread never finished its teardown");
+
+        assertTrue(shared.isInitialized(),
+                "the departing thread deinitialized the implementation its successor is running "
+                        + "on, because it was also the one it served itself");
+        assertTrue(Display.isInitialized(),
+                "the display is in the half torn down state every test in the next class "
+                        + "reports as display-not-initialized");
     }
 
     /**
@@ -179,7 +334,7 @@ class EdtHandoverTest {
      * a teardown -- so a thread with no form never reaches the state this test is about, and the
      * fixture silently proved nothing until it did.</p>
      */
-    private static BlockingDeinitImplementation startGeneration(BlockingDeinitImplementation impl) {
+    private static void startGeneration(TestCodenameOneImplementation impl) {
         install(impl);
         Display.deinitialize();
         Display.init(null);
@@ -199,7 +354,25 @@ class EdtHandoverTest {
                 break;
             }
         }
-        return impl;
+    }
+
+    /** Opens one window on the EDT and reports whether it reached the desktop registry. */
+    private static boolean openWindow() {
+        final boolean[] opened = new boolean[1];
+        final Object done = new Object();
+        Display.getInstance().callSerially(new Runnable() {
+            @Override
+            public void run() {
+                synchronized (done) {
+                    Window w = new Window("edt-handover-window");
+                    w.setWindowSize(320, 240);
+                    w.show();
+                    opened[0] = true;
+                    done.notifyAll();
+                }
+            }
+        });
+        return await(done, opened);
     }
 
     /**
@@ -222,18 +395,7 @@ class EdtHandoverTest {
                 }
             }
         });
-        synchronized (done) {
-            long deadline = System.currentTimeMillis() + DISPATCH_TIMEOUT;
-            while (!answer[0] && System.currentTimeMillis() < deadline) {
-                try {
-                    done.wait(deadline - System.currentTimeMillis());
-                } catch (InterruptedException ie) {
-                    Thread.currentThread().interrupt();
-                    break;
-                }
-            }
-            return answer[0];
-        }
+        return await(done, answer);
     }
 
     /** Queues one runnable and reports whether a dispatch thread actually ran it. */
@@ -249,9 +411,14 @@ class EdtHandoverTest {
                 }
             }
         });
+        return await(done, ran);
+    }
+
+    /** Waits for a runnable queued on the EDT to report its answer. */
+    private static boolean await(Object done, boolean[] answer) {
         synchronized (done) {
             long deadline = System.currentTimeMillis() + DISPATCH_TIMEOUT;
-            while (!ran[0] && System.currentTimeMillis() < deadline) {
+            while (!answer[0] && System.currentTimeMillis() < deadline) {
                 try {
                     done.wait(deadline - System.currentTimeMillis());
                 } catch (InterruptedException ie) {
@@ -259,21 +426,28 @@ class EdtHandoverTest {
                     break;
                 }
             }
-            return ran[0];
+            return answer[0];
         }
     }
 
-    /** Gives the released thread a moment to finish dying before the state is read again. */
-    private static void settle() {
-        long deadline = System.currentTimeMillis() + 1000L;
-        while (System.currentTimeMillis() < deadline) {
-            try {
-                Thread.sleep(25L);
-            } catch (InterruptedException ie) {
-                Thread.currentThread().interrupt();
-                return;
-            }
+    /**
+     * Waits for the released thread to finish dying.
+     *
+     * <p>Joined rather than slept on. The state these tests read is written by the last few
+     * statements that thread runs, so a fixed pause is either slower than it needs to be or
+     * short enough to read the state half written on a loaded machine -- which is the very
+     * failure mode the whole class is about.</p>
+     */
+    private static boolean awaitDeath(Thread t) {
+        if (t == null) {
+            return false;
         }
+        try {
+            t.join(DISPATCH_TIMEOUT);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
+        return !t.isAlive();
     }
 
     private static void install(final TestCodenameOneImplementation impl) {

--- a/maven/core-unittests/src/test/java/com/codename1/junit/EdtHandoverTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/junit/EdtHandoverTest.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.junit;
+
+import com.codename1.impl.ImplementationFactory;
+import com.codename1.testing.TestCodenameOneImplementation;
+import com.codename1.ui.Display;
+import com.codename1.ui.Form;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A {@code Display.init()} that lands while the previous dispatch thread is tearing down must
+ * start a dispatch thread of its own.
+ *
+ * <p>This is the bug behind the intermittent {@code FormTest timed out after 5000ms;
+ * edt=display-not-initialized} that has failed a different test class each time it appeared, and
+ * that the harness has been patched for twice ({@link UITestBase} and {@link FormTestInterceptor}
+ * both carry a recovery for it). Those patches took ValidatorTest from twelve failures to one --
+ * neither can close the window, because it is not the harness that is wrong.</p>
+ *
+ * <p>A thread that has left the dispatch loop stays {@code isAlive()} for the whole of its
+ * teardown, and {@code init()} decided whether to start a dispatch thread on exactly that
+ * evidence. Adopting a departing thread leaves the new generation with no dispatch at all:
+ * everything it queues waits for ever, and {@code isInitialized()} stays false while
+ * {@code codenameOneRunning} stays true -- a state {@code init()} cannot repair, because it
+ * guards on that flag.</p>
+ *
+ * <p>Reproduced here rather than raced for. The window is only open while a loaded machine
+ * happens to be descheduling the old thread, which is why this never failed locally; an
+ * implementation that blocks inside {@code deinitialize()} holds it open instead, so the test
+ * either passes or fails for the reason it names.</p>
+ */
+class EdtHandoverTest {
+
+    /** How long a working dispatch thread is given to run one runnable. */
+    private static final long DISPATCH_TIMEOUT = 5000L;
+
+    /**
+     * An implementation that parks the departing dispatch thread inside its teardown.
+     *
+     * <p>{@code mainEDTLoop} calls this after leaving the loop and before it stops being alive,
+     * so blocking here holds the thread in exactly the state the race produces, for as long as
+     * the test needs it.</p>
+     */
+    private static final class BlockingDeinitImplementation extends TestCodenameOneImplementation {
+        private final Object gate = new Object();
+        private boolean entered;
+        private boolean released;
+
+        @Override
+        public void deinitialize() {
+            synchronized (gate) {
+                entered = true;
+                gate.notifyAll();
+                long deadline = System.currentTimeMillis() + DISPATCH_TIMEOUT;
+                // Bounded on purpose. A blocked EDT that is never released would hang the whole
+                // suite rather than fail this one test, and the failure would then be reported
+                // against whichever class the runner happened to reach.
+                while (!released && System.currentTimeMillis() < deadline) {
+                    try {
+                        gate.wait(deadline - System.currentTimeMillis());
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        break;
+                    }
+                }
+            }
+            super.deinitialize();
+        }
+
+        boolean awaitEntered() {
+            synchronized (gate) {
+                long deadline = System.currentTimeMillis() + DISPATCH_TIMEOUT;
+                while (!entered && System.currentTimeMillis() < deadline) {
+                    try {
+                        gate.wait(deadline - System.currentTimeMillis());
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        return entered;
+                    }
+                }
+                return entered;
+            }
+        }
+
+        void release() {
+            synchronized (gate) {
+                released = true;
+                gate.notifyAll();
+            }
+        }
+    }
+
+    @Test
+    void anInitDuringTheOldEdtsTeardownStartsItsOwnDispatchThread() {
+        BlockingDeinitImplementation blocking = new BlockingDeinitImplementation();
+        BlockingDeinitImplementation parked = startGeneration(blocking);
+
+        // Send the old generation into its teardown and wait until it is parked there: alive,
+        // and no longer dispatching. This is the whole point of the fixture -- from here the
+        // ordering is fixed rather than hoped for.
+        Display.deinitialize();
+        assertTrue(parked.awaitEntered(),
+                "the dispatch thread never reached the teardown, so the window this test is "
+                        + "about was never opened and what follows would prove nothing");
+
+        try {
+            install(new TestCodenameOneImplementation());
+            Display.init(null);
+
+            assertTrue(dispatchWorks(),
+                    "init() adopted a thread that had already left the dispatch loop, so this "
+                            + "generation has no event dispatch: everything it queues waits for "
+                            + "ever, which is the display-not-initialized timeout CI reports");
+        } finally {
+            blocking.release();
+        }
+    }
+
+    /**
+     * The departing thread must not disown a dispatch thread that is not its own.
+     *
+     * <p>Once the fix above stops the adoption, the two generations overlap by design: the old
+     * thread finishes its teardown after the new one is running. It used to clear the recorded
+     * EDT unconditionally at that point, so {@code isEdt()} answered false ON the live dispatch
+     * thread -- and work meant for that thread was queued behind itself.</p>
+     */
+    @Test
+    void aDepartingEdtDoesNotDisownItsSuccessor() {
+        BlockingDeinitImplementation blocking = new BlockingDeinitImplementation();
+        startGeneration(blocking);
+
+        Display.deinitialize();
+        assertTrue(blocking.awaitEntered(), "the fixture never parked the departing thread");
+
+        install(new TestCodenameOneImplementation());
+        Display.init(null);
+        assertTrue(dispatchThreadKnowsItself(),
+                "the successor has to be a recognised dispatch thread before it can be lost");
+
+        // Let the old thread run the rest of its teardown, which is where it used to clear the
+        // field the successor is recorded in.
+        blocking.release();
+        settle();
+
+        assertTrue(dispatchThreadKnowsItself(),
+                "the departing thread cleared the recorded dispatch thread on its way out, so "
+                        + "isEdt() answers false ON the live dispatch thread and work meant for "
+                        + "it is queued behind itself");
+    }
+
+    /**
+     * Brings up a generation on {@code impl} and gets its dispatch thread into the dispatch loop.
+     *
+     * <p>The showing of a form is not decoration. {@code mainEDTLoop} spends its first phase in a
+     * separate loop that runs until there is a current form, and only the loop AFTER that one has
+     * a teardown -- so a thread with no form never reaches the state this test is about, and the
+     * fixture silently proved nothing until it did.</p>
+     */
+    private static BlockingDeinitImplementation startGeneration(BlockingDeinitImplementation impl) {
+        install(impl);
+        Display.deinitialize();
+        Display.init(null);
+        Display.getInstance().callSerially(new Runnable() {
+            @Override
+            public void run() {
+                new Form("edt-handover").show();
+            }
+        });
+        long deadline = System.currentTimeMillis() + DISPATCH_TIMEOUT;
+        while (Display.getInstance().getCurrent() == null
+                && System.currentTimeMillis() < deadline) {
+            try {
+                Thread.sleep(10L);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+        return impl;
+    }
+
+    /**
+     * Whether a dispatch thread runs queued work AND is recognised as the dispatch thread while
+     * it does.
+     *
+     * <p>Running the runnable is not enough on its own: a thread that is dispatching while
+     * {@code isEdt()} denies it still drains the queue, so an assertion that only watched the
+     * runnable run would pass either way.</p>
+     */
+    private static boolean dispatchThreadKnowsItself() {
+        final boolean[] answer = new boolean[1];
+        final Object done = new Object();
+        Display.getInstance().callSerially(new Runnable() {
+            @Override
+            public void run() {
+                synchronized (done) {
+                    answer[0] = Display.getInstance().isEdt();
+                    done.notifyAll();
+                }
+            }
+        });
+        synchronized (done) {
+            long deadline = System.currentTimeMillis() + DISPATCH_TIMEOUT;
+            while (!answer[0] && System.currentTimeMillis() < deadline) {
+                try {
+                    done.wait(deadline - System.currentTimeMillis());
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+            return answer[0];
+        }
+    }
+
+    /** Queues one runnable and reports whether a dispatch thread actually ran it. */
+    private static boolean dispatchWorks() {
+        final boolean[] ran = new boolean[1];
+        final Object done = new Object();
+        Display.getInstance().callSerially(new Runnable() {
+            @Override
+            public void run() {
+                synchronized (done) {
+                    ran[0] = true;
+                    done.notifyAll();
+                }
+            }
+        });
+        synchronized (done) {
+            long deadline = System.currentTimeMillis() + DISPATCH_TIMEOUT;
+            while (!ran[0] && System.currentTimeMillis() < deadline) {
+                try {
+                    done.wait(deadline - System.currentTimeMillis());
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+            return ran[0];
+        }
+    }
+
+    /** Gives the released thread a moment to finish dying before the state is read again. */
+    private static void settle() {
+        long deadline = System.currentTimeMillis() + 1000L;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                Thread.sleep(25L);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
+    }
+
+    private static void install(final TestCodenameOneImplementation impl) {
+        ImplementationFactory.setInstance(new ImplementationFactory() {
+            @Override
+            public Object createImplementation() {
+                return impl;
+            }
+        });
+    }
+}

--- a/maven/core-unittests/src/test/java/com/codename1/junit/EdtHandoverTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/junit/EdtHandoverTest.java
@@ -176,7 +176,7 @@ class EdtHandoverTest {
     }
 
     @Test
-    void anInitDuringTheOldEdtsTeardownStartsItsOwnDispatchThread() {
+    void anInitDuringTheOldEdtsTeardownWaitsForItAndThenStartsItsOwnDispatchThread() {
         BlockingDeinitImplementation blocking = new BlockingDeinitImplementation();
         startGeneration(blocking);
 
@@ -188,17 +188,22 @@ class EdtHandoverTest {
                 "the dispatch thread never reached the teardown, so the window this test is "
                         + "about was never opened and what follows would prove nothing");
 
-        try {
-            install(new TestCodenameOneImplementation());
-            Display.init(null);
+        install(new TestCodenameOneImplementation());
+        Thread init = initOnAnotherThread();
+        assertFalse(finishedWithin(init, 500L),
+                "init() ran to completion alongside a teardown that had not finished. The two "
+                        + "act on the same process wide state -- the impl slot, the "
+                        + "implementation's initialized flag, Desktop's window registry -- so "
+                        + "they have to be ordered, not interleaved");
 
-            assertTrue(dispatchWorks(),
-                    "init() adopted a thread that had already left the dispatch loop, so this "
-                            + "generation has no event dispatch: everything it queues waits for "
-                            + "ever, which is the display-not-initialized timeout CI reports");
-        } finally {
-            blocking.gate().release();
-        }
+        blocking.gate().release();
+        assertTrue(finishedWithin(init, DISPATCH_TIMEOUT),
+                "init() never came back after the teardown it was waiting for finished");
+
+        assertTrue(dispatchWorks(),
+                "init() adopted a thread that had already left the dispatch loop, so this "
+                        + "generation has no event dispatch: everything it queues waits for "
+                        + "ever, which is the display-not-initialized timeout CI reports");
     }
 
     /**
@@ -218,13 +223,12 @@ class EdtHandoverTest {
         assertTrue(blocking.gate().awaitEntered(), "the fixture never parked the departing thread");
 
         install(new TestCodenameOneImplementation());
-        Display.init(null);
-        assertTrue(dispatchThreadKnowsItself(),
-                "the successor has to be a recognised dispatch thread before it can be lost");
+        Thread init = initOnAnotherThread();
 
-        // Let the old thread run the rest of its teardown, which is where it used to clear the
-        // field the successor is recorded in.
+        // Let the old thread finish, which is where it used to clear the field the successor is
+        // recorded in, and only then let init() through.
         blocking.gate().release();
+        assertTrue(finishedWithin(init, DISPATCH_TIMEOUT), "init() never came back");
         assertTrue(awaitDeath(blocking.gate().parkedThread()),
                 "the departing thread never finished its teardown");
 
@@ -262,15 +266,13 @@ class EdtHandoverTest {
 
         TestCodenameOneImplementation successor = new TestCodenameOneImplementation();
         install(successor);
-        Display.init(null);
-        assertTrue(dispatchWorks(), "the successor generation has to be running to be damaged");
-        assertTrue(successor.isInitialized(), "the successor came up uninitialized on its own");
+        Thread init = initOnAnotherThread();
 
-        // Only now does the departing thread reach the read. The successor is already the
-        // current implementation, so a teardown that reads the slot picks it up.
         blocking.gate().release();
+        assertTrue(finishedWithin(init, DISPATCH_TIMEOUT), "init() never came back");
         assertTrue(awaitDeath(blocking.gate().parkedThread()),
                 "the departing thread never finished its teardown");
+        assertTrue(dispatchWorks(), "the successor generation never came up");
 
         assertFalse(blocking.isInitialized(),
                 "the departing generation's own implementation was left initialized, so the "
@@ -311,12 +313,13 @@ class EdtHandoverTest {
 
         // The SAME instance, which is what the harness does between test classes.
         install(shared);
-        Display.init(null);
-        assertTrue(dispatchWorks(), "the successor generation has to be running to be damaged");
+        Thread init = initOnAnotherThread();
 
         shared.gate().release();
+        assertTrue(finishedWithin(init, DISPATCH_TIMEOUT), "init() never came back");
         assertTrue(awaitDeath(shared.gate().parkedThread()),
                 "the departing thread never finished its teardown");
+        assertTrue(dispatchWorks(), "the successor generation never came up");
 
         assertTrue(shared.isInitialized(),
                 "the departing thread deinitialized the implementation its successor is running "
@@ -324,6 +327,34 @@ class EdtHandoverTest {
         assertTrue(Display.isInitialized(),
                 "the display is in the half torn down state every test in the next class "
                         + "reports as display-not-initialized");
+    }
+
+    /**
+     * Calls {@code Display.init(null)} on a thread of its own and hands the thread back.
+     *
+     * <p>Off the test thread because an init() that lands during a teardown WAITS for it. The
+     * blocking is the property under test, so the test needs to observe it rather than sit in
+     * it.</p>
+     */
+    private static Thread initOnAnotherThread() {
+        Thread t = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                Display.init(null);
+            }
+        }, "edt-handover-init");
+        t.start();
+        return t;
+    }
+
+    /** Whether the thread finished within the given time. */
+    private static boolean finishedWithin(Thread t, long millis) {
+        try {
+            t.join(millis);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
+        return !t.isAlive();
     }
 
     /**


### PR DESCRIPTION
Fixes the intermittent `build-test` failure

```
FormTest timed out after 5000ms; edt=display-not-initialized
```

which has failed a different `core-unittests` class each time it appeared (ValidatorTest, AutoCompleteTextComponentTest) and never reproduced locally.

## The bug

A thread that has left `mainEDTLoop`'s loop stays `isAlive()` for the whole of its teardown -- `Desktop.disposeAll()` and `impl.deinitialize()`, either of which can block. `Display.init()` decided whether to start a dispatch thread on exactly that evidence, so an `init()` landing in that window adopts a thread on its way out and starts nothing.

The new generation then has no dispatch at all: everything it queues waits for ever, and `isInitialized()` stays false while `codenameOneRunning` stays true -- a state `init()` cannot repair, because it guards on that flag. Every test in the class times out.

## The fix

The departing thread publishes the fact instead of leaving it to be inferred. `edtDispatching` is renounced inside the same monitor `init()` takes to decide adoption, so the two orderings become the two correct outcomes rather than a race:

- the thread renounces first, and `init()` starts a dispatch thread of its own;
- or `init()` gets there first -- and it has already set `codenameOneRunning` back to true, so the thread's next test keeps it in the loop, which is the adoption that is legitimately free.

Two things that look like tidying are load-bearing, and both are commented in the code:

- **The thread stays the recorded `edt` until the end.** The teardown is meant to run *as* the EDT, so clearing `edt` early to dodge adoption -- the obvious first fix -- makes `isEdt()` false for exactly that call.
- **The final clear is guarded on identity.** Once adoption stops, the two generations overlap by design, and clearing the field unconditionally disowned the *live* successor: `isEdt()` then answered false on the dispatch thread itself.

## Why not in the harness

`UITestBase` and `FormTestInterceptor` each carry a recovery for this and both comments treat it as test infrastructure. They took ValidatorTest from twelve failures to one; neither can close the window. Their recoveries are left alone -- they also cover the unrelated half-initialised state `DisplayRecoveryTest` describes.

## Verification

`EdtHandoverTest` holds the window open with an implementation that blocks inside `deinitialize()` rather than racing for it. Both tests fail on master in 10.8s and pass in 1.9s, and each half of the fix is proven alone: removing only the identity guard fails the second test and leaves the first passing.

Full `core-unittests` module 6142/6142; SpotBugs 0; PMD, copyright and control-character gates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)