### PR TITLE
Developer guide: fix every insecure or dead link and close the links ratchet

### DIFF
--- a/docs/developer-guide/About-This-Guide.asciidoc
+++ b/docs/developer-guide/About-This-Guide.asciidoc
@@ -26,8 +26,8 @@ This document includes content from the following contributors and from earlier 
 - https://github.com/shai-almog[Shai Almog]
 - https://github.com/Isborg[Ismael Baum]
 - https://twitter.com/ericcoolmandev[Eric Coolman]
-- http://github.com/chen-fishbein/[Chen Fishbein]
-- http://github.com/shannah/[Steve Hannah]
+- https://github.com/chen-fishbein/[Chen Fishbein]
+- https://github.com/shannah/[Steve Hannah]
 - https://github.com/kheops37[Matt]
 
 <<<

--- a/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
+++ b/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
@@ -1479,7 +1479,7 @@ On Android you need to define an intent filter which you can do using the `andro
 include::../demos/common/src/main/snippets/developer-guide/advanced-topics-under-the-hood.xml[tag=advanced-topics-under-the-hood-xml-007,indent=0]
 ----
 
-You can read more about it in link:http://stackoverflow.com/questions/11421048/android-ios-custom-uri-protocol-handling[this stack overflow question].
+You can read more about it in link:https://stackoverflow.com/questions/11421048/android-ios-custom-uri-protocol-handling[this stack overflow question].
 
 To bind the `myapp://` URL to your application. As a result typing `myapp://x` into the Android browser will launch the application.
 

--- a/docs/developer-guide/Introduction.asciidoc
+++ b/docs/developer-guide/Introduction.asciidoc
@@ -87,7 +87,7 @@ Lightweight components date back to Smalltalk frameworks, this notion was popula
 
 ===== Why ParparVM
 
-On iOS, Codename One uses https://github.com/codenameone/CodenameOne/tree/master/vm[ParparVM] which translates Java bytecode to C code and boasts a non-blocking GC. This VM is fully open source in the https://github.com/codenameone/CodenameOne/[Codename One git repository]. In the past Codename One used http://www.xmlvm.org/[XMLVM] to generate native code similarly, but the XMLVM solution was too generic for the needs of Codename One. https://github.com/codenameone/CodenameOne/tree/master/vm[ParparVM] boasts a unique architecture of translating code to C (similarly to XMLVM), because of that Codename One is the only solution of its kind that can **guarantee** future iOS compatibility since the officially supported iOS toolchain is always used instead of undocumented behaviors.
+On iOS, Codename One uses https://github.com/codenameone/CodenameOne/tree/master/vm[ParparVM] which translates Java bytecode to C code and boasts a non-blocking GC. This VM is fully open source in the https://github.com/codenameone/CodenameOne/[Codename One git repository]. In the past Codename One used XMLVM to generate native code similarly, but the XMLVM solution was too generic for the needs of Codename One. https://github.com/codenameone/CodenameOne/tree/master/vm[ParparVM] boasts a unique architecture of translating code to C (similarly to XMLVM), because of that Codename One is the only solution of its kind that can **guarantee** future iOS compatibility since the officially supported iOS toolchain is always used instead of undocumented behaviors.
 
 NOTE: XMLVM could guarantee that as well, but it's no longer maintained and lacked the API layer support
 

--- a/docs/developer-guide/Miscellaneous-Features.asciidoc
+++ b/docs/developer-guide/Miscellaneous-Features.asciidoc
@@ -678,8 +678,10 @@ invoked at the same moment; only the visual rendering differs.
 
 The https://www.codenameone.com/javadoc/com/codename1/ui/Display.html[Display] class's `execute` method allows you to invoke a URL which is bound to a particular application.
 
-This works rather well assuming the application is installed. For example: link:http://wiki.akosma.com/IPhone_URL_Schemes[this list]
-contains a set of valid URLs that can be used on iOS to run common applications and use built-in functionality.
+This works rather well assuming the application is installed. Apple's
+https://developer.apple.com/library/archive/featuredarticles/iPhoneURLScheme_Reference/Introduction/Introduction.html[URL scheme reference]
+lists the schemes iOS handles itself, for common applications and built-in
+functionality.
 
 Some URLs might not be supported if an app isn't installed, on Android there isn't much that can be done but iOS has a `canOpenURL` method for Objective-C.
 

--- a/docs/developer-guide/The-Components-Of-Codename-One.asciidoc
+++ b/docs/developer-guide/The-Components-Of-Codename-One.asciidoc
@@ -1096,7 +1096,7 @@ TIP: Since the `MultiList` uses the `GenericListCellRenderer` internally you can
 
 ===== Going further with the ListModel
 
-Suppose that http://www.georgerrmartin.com/[GRRM] was prolific and wrote 1 million books. The default list model won't make much sense in that case but you would still be able to render everything in a list model.
+Suppose that https://georgerrmartin.com/[GRRM] was prolific and wrote 1 million books. The default list model won't make much sense in that case but you would still be able to render everything in a list model.
 
 You will fake it a bit but notice that 1M components won't be created even if you somehow scroll all the way down...
 
@@ -1707,7 +1707,7 @@ You can dynamically download images directly into the `ImageViewer` with a custo
 include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/TheComponentsOfCodenameOneJava189Snippet.java[tag=the-components-of-codename-one-java-189,indent=0]
 ----
 
-.Dynamically fetching an image URL from the internet footnote:[Image was fetched from http://awoiaf.westeros.org/index.php/Portal:Books]
+.Dynamically fetching an image URL from the internet footnote:[Image was fetched from https://awoiaf.westeros.org/index.php/Portal:Books]
 image::img/components-imageviewer-dynamic.png[Dynamically fetching an image URL from the internet,scaledwidth=20%]
 
 This fetches the images in the URL asynchronously and fires a data change event when the data arrives to automatically refresh the `ImageViewer` when that happens.
@@ -1844,7 +1844,7 @@ This places the component below the side menu bar. Notice that this component co
 
 Modern UI's often animate the title upon scrolling to balance the highly functional smaller title advantage with the gorgeous large image based title. This is pretty easy to do with the Toolbar API through the Title animation API.
 
-The code below shows off an attractive title based on a book by GRRM on top of text footnote:[The text below is from A Wiki of Ice & Fire: http://awoiaf.westeros.org/index.php/A_Game_of_Thrones] that's scrollable. As the text is scrolled the title fades out:
+The code below shows off an attractive title based on a book by GRRM on top of text footnote:[The text below is from A Wiki of Ice & Fire: https://awoiaf.westeros.org/index.php/A_Game_of_Thrones] that's scrollable. As the text is scrolled the title fades out:
 
 [source,java]
 ----

--- a/docs/developer-guide/The-EDT---Event-Dispatch-Thread.asciidoc
+++ b/docs/developer-guide/The-EDT---Event-Dispatch-Thread.asciidoc
@@ -110,7 +110,7 @@ Full output will include stack traces to the area in the code that's suspected i
 [[invoke-And-Block-section]]
 === Invoke And Block
 
-Invoke and block is the exact opposite of `callSeriallyAndWait()`, it blocks the EDT and opens a separate thread for the runnable call. This functionality is inspired by the http://foxtrot.sourceforge.net/[Foxtrot] API, which is
+Invoke and block is the exact opposite of `callSeriallyAndWait()`, it blocks the EDT and opens a separate thread for the runnable call. This functionality is inspired by the https://foxtrot.sourceforge.net/[Foxtrot] API, which is
 a remarkably powerful tool most Swing developers don't know about.
 
 This is best explained by an example. Typical Java code reads as a single sequence as such:

--- a/docs/developer-guide/basics.asciidoc
+++ b/docs/developer-guide/basics.asciidoc
@@ -203,7 +203,7 @@ include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/g
 
 <1> Most layouts have a version of enclose to encapsulate components within (((Encapsulate)))
 
-<2> `FlowLayout` has variants that support aligning the components on various axis
+<2> `FlowLayout` has variants that support aligning the components on various axes
 
 To sum this up, you can use layout managers and nesting to create elaborate UI's that implicitly adapt to different screen sizes and device orientation.
 
@@ -708,7 +708,7 @@ https://www.codenameone.com/javadoc/com/codename1/ui/layouts/mig/MigLayout.html[
 WARNING: MiG is still considered experimental so proceed with caution! +
 The API was deprecated to serve as a warning of its experimental status.
 
-The best reference for MiG would probably be its http://www.miglayout.com/QuickStart.pdf[quick start guide (PDF link)]. The sample below is one of that guide's examples, ported to Codename One:
+The best reference for MiG would probably be its https://www.miglayout.com/QuickStart.pdf[quick start guide (PDF link)]. The sample below is one of that guide's examples, ported to Codename One:
 
 [source,java]
 ----
@@ -837,7 +837,8 @@ include::../demos/common/src/main/snippets/developer-guide/basics.sh[tag=basics-
 
 Projects generated from the archetype also carry a ready-made shortcut for this: a *CN1 GUI Builder* run configuration in IntelliJ IDEA, an *Open in GUI Builder* action in NetBeans, a *GUI Builder* launch configuration in Eclipse, and a *Tools > GUI Builder* entry in the Visual Studio Code Maven favorites. They all run the same goal.
 
-The full goal reference, including every parameter, lives in <<create-gui-form>> and <<guibuilder>> in the Maven goals appendix.
+The full goal reference, including every parameter, lives in <<create-gui-form,the `cn1:create-gui-form` goal>> and
+<<guibuilder,the `cn1:guibuilder` goal>> in the Maven goals appendix.
 
 TIP: The GUI builder is a Java 8 artifact, so it runs on whichever JDK already builds your project.
 

--- a/docs/developer-guide/graphics.asciidoc
+++ b/docs/developer-guide/graphics.asciidoc
@@ -793,7 +793,7 @@ The 9-image borders use multi images by default to keep their appearance more re
 
 https://www.codenameone.com/javadoc/com/codename1/ui/FontImage.html[FontImage] allows using an icon font as if it was an image. You can specify the character, color and size and then treat the `FontImage` as if its a regular image. The huge benefits are that the font image can adapt to platform conventions in color and scale to adapt to DPI.
 
-You can generate icon fonts using free tools on the internet such as http://fontello.com/[this]. Icon fonts are a simple and powerful technique to create a small, modern applications.
+You can generate icon fonts using free tools on the internet such as https://fontello.com/[this]. Icon fonts are a simple and powerful technique to create a small, modern applications.
 
 Icon fonts can be created in 2 basic ways the first is explicitly by defining all the elements within the font:
 

--- a/docs/developer-guide/io.asciidoc
+++ b/docs/developer-guide/io.asciidoc
@@ -522,11 +522,11 @@ run reports both for every platform it covers.
 
 === Network manager & connection request
 
-One of the more common problems in Network programming is spawning a new thread to handle the network operations. In Codename One this is done seamlessly and becomes unessential thanks to the http://www.codenameone.com/javadoc/com/codename1/io/NetworkManager.html[NetworkManager].
+One of the more common problems in Network programming is spawning a new thread to handle the network operations. In Codename One this is done seamlessly and becomes unessential thanks to the https://www.codenameone.com/javadoc/com/codename1/io/NetworkManager.html[NetworkManager].
 
 `NetworkManager` effectively alleviates the need for managing network threads by managing the complexity of network threading. The connection request class can be used to ease web service requests when coupled with the JSON/XML parsing capabilities.
 
-To open a connection one needs to use a http://www.codenameone.com/javadoc/com/codename1/io/ConnectionRequest.html[ConnectionRequest]
+To open a connection one needs to use a https://www.codenameone.com/javadoc/com/codename1/io/ConnectionRequest.html[ConnectionRequest]
 object, which has some similarities to the networking mechanism in JavaScript but is obviously somewhat more elaborate.
 
 You can send a get request to a URL using something like:
@@ -799,7 +799,7 @@ include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/g
 
 The response is a `Map` containing a nested hierarchy of `Collection` (`java.util.List`), Strings and numbers to represent the content of the submitted JSON. To extract the data from a specific path iterate the `Map` keys and recurs into it.
 
-The sample below uses results from https://anapioficeandfire.com/[an API of ice and fire] that queries structured data about the "Song Of Ice & Fire" book series. Here is a sample result returned from the API for the query http://www.anapioficeandfire.com/api/characters?page=5&pageSize=3 :
+The sample below uses results from https://anapioficeandfire.com/[an API of ice and fire] that queries structured data about the "Song Of Ice & Fire" book series. Here is a sample result returned from the API for the query https://www.anapioficeandfire.com/api/characters?page=5&pageSize=3 :
 
 [source,JavaScript]
 ----
@@ -1170,7 +1170,7 @@ The code in the kitchen sink webservice sample was updated to use this API. The 
 
 The best way to explain the usage of this API is through a concrete "real world" example. Twilio provides many great telephony-oriented webservices to developers. One of those is an SMS sending webservice which can be useful for things such as "device activation."
 
-To get started you would need to sign up to http://twillo.com/[Twilio] and have the following 3 variable values:
+To get started you would need to sign up to https://www.twilio.com/[Twilio] and have the following 3 variable values:
 
 [source,java]
 ----

--- a/docs/developer-guide/performance.asciidoc
+++ b/docs/developer-guide/performance.asciidoc
@@ -27,7 +27,7 @@ If you have a large image that's opaque you might want to consider converting it
 .Convert a MultiImage to use JPEGs instead of PNGs
 image::img/performance-image-to-jpen.png[Convert a MultiImage to use JPEGs instead of PNGs]
 
-You can use the excellent http://optipng.sourceforge.net/[OptiPng] tool to optimize image files right from the Codename One designer. To use this feature you need to install OptiPng then select #Images# -> #Launch OptiPng# from the menu. Once you do that the tool will automatically optimize all your PNG's.
+You can use the excellent https://optipng.sourceforge.net/[OptiPng] tool to optimize image files right from the Codename One designer. To use this feature you need to install OptiPng then select #Images# -> #Launch OptiPng# from the menu. Once you do that the tool will automatically optimize all your PNG's.
 
 When faced with size issues make sure to check the size of your res file, if your JAR file is large open it with a tool such as 7-zip and sort elements by size. Start reviewing which element justifies the size overhead.
 

--- a/docs/developer-guide/signing.asciidoc
+++ b/docs/developer-guide/signing.asciidoc
@@ -34,7 +34,7 @@ The UDID is the Universal Device Identifier. It identifies mobile devices unique
 You need the iOS device UDID value during development to add the device into the list of allowed devices.
 
 IMPORTANT: Don't use an app to get the UDID! +
-Most return the wrong value. Use the Finder device summary (macOS), Apple Configurator, or a trusted service such as http://get.udid.io/ which seems to work rather well
+Most return the wrong value. Use the Finder device summary on macOS, or Apple Configurator.
 
 ==== Should you reuse the same certificate for all apps
 
@@ -186,7 +186,7 @@ The same decision need to be made twice: Once for the development certificate, a
 TIP: Each Apple Developer account can have three active iOS Development certificates and three active iOS Distribution certificates at a time. Reuse existing certificates whenever possible to avoid hitting this limit.
 
 TIP: You can revoke a certificate when you have an application in the store shipping with said certificate! +
-This won't affect the shipping app see http://stackoverflow.com/questions/6320255/if-i-revoke-an-existing-distribution-certificate-will-it-mess-up-anything-with[this].
+This won't affect the shipping app see https://stackoverflow.com/questions/6320255/if-i-revoke-an-existing-distribution-certificate-will-it-mess-up-anything-with[this].
 
 .Why Two Certificates?
 ****
@@ -252,7 +252,7 @@ You need two versions of each file (4 total files) one pair is for development a
 
 IMPORTANT: You need to use a Mac to create a certificate file for iOS
 
-The first step you need to do is signing up as a developer to http://developer.apple.com/[Apple's iOS development program], even for testing on a device this is required! +
+The first step you need to do is signing up as a developer to https://developer.apple.com/[Apple's iOS development program], even for testing on a device this is required! +
 This step requires that you pay Apple on an annual basis.
 
 The Apple website will guide you through the process of applying for a certificate at the end of this process you should have a distribution and development certificate pair. After that point you can log in to the https://developer.apple.com/ios/manage/overview/index.action[iOS provisioning portal] where there are plenty of videos and tutorials to guide you through the process. Within the iOS provisioning portal you need to create an application ID and register your development devices.
@@ -371,4 +371,4 @@ Password: [password] (we expect both passwords to be identical)
 
 Executing the command produces a `Keystore.ks` file in that directory. Keep it safe: if you lose it, you can no longer publish upgrades signed with the same identity. Enter its path, alias, and passwords in `common/codenameone_settings.properties`, or use the *Android* page in the standalone Certificate Wizard (`mvn cn1:certificatewizard`) to generate and install a keystore.
 
-For more details see http://developer.android.com/guide/publishing/app-signing.html
+For more details see https://developer.android.com/studio/publish/app-signing

--- a/scripts/developer-guide/guide-links-baseline.txt
+++ b/scripts/developer-guide/guide-links-baseline.txt
@@ -3,23 +3,3 @@
 # two lines, because that is two things to fix.
 # A ratchet: entries may be removed as links are fixed, never added.
 # Regenerate with check-guide-links.py --write-baseline.
-About-This-Guide.asciidoc	http://github.com/chen-fishbein/
-About-This-Guide.asciidoc	http://github.com/shannah/
-Advanced-Topics-Under-The-Hood.asciidoc	http://stackoverflow.com/questions/11421048/android-ios-custom-uri-protocol-handling
-Introduction.asciidoc	http://www.xmlvm.org/
-Miscellaneous-Features.asciidoc	http://wiki.akosma.com/IPhone_URL_Schemes
-The-Components-Of-Codename-One.asciidoc	http://awoiaf.westeros.org/index.php/A_Game_of_Thrones
-The-Components-Of-Codename-One.asciidoc	http://awoiaf.westeros.org/index.php/Portal:Books
-The-Components-Of-Codename-One.asciidoc	http://www.georgerrmartin.com/
-The-EDT---Event-Dispatch-Thread.asciidoc	http://foxtrot.sourceforge.net/
-basics.asciidoc	http://www.miglayout.com/QuickStart.pdf
-graphics.asciidoc	http://fontello.com/
-io.asciidoc	http://twillo.com/
-io.asciidoc	http://www.anapioficeandfire.com/api/characters?page=5&pageSize=3
-io.asciidoc	http://www.codenameone.com/javadoc/com/codename1/io/ConnectionRequest.html
-io.asciidoc	http://www.codenameone.com/javadoc/com/codename1/io/NetworkManager.html
-performance.asciidoc	http://optipng.sourceforge.net/
-signing.asciidoc	http://developer.android.com/guide/publishing/app-signing.html
-signing.asciidoc	http://developer.apple.com/
-signing.asciidoc	http://get.udid.io/
-signing.asciidoc	http://stackoverflow.com/questions/6320255/if-i-revoke-an-existing-distribution-certificate-will-it-mess-up-anything-with


### PR DESCRIPTION
All 20 entries in `guide-links-baseline.txt` were bare `http://`. Every target was fetched to confirm it answers on `https` and serves the page the surrounding text claims. Most are a scheme upgrade and nothing else. Five needed more:

| Link | Problem | Fix |
|---|---|---|
| `twillo.com` | typo for `twilio.com` -- never worked | `https://www.twilio.com/` |
| `developer.android.com/guide/publishing/app-signing.html` | redirects | point at `studio/publish/app-signing` directly |
| `xmlvm.org` | does not resolve; project discontinued | keep the name, drop the link -- the next paragraph already says it's unmaintained |
| `wiki.akosma.com/IPhone_URL_Schemes` | does not resolve | Apple's own URL scheme reference, which covers the same ground |
| `get.udid.io` | redirects to `udid.tech`, a **different operator** | drop it |

The UDID one is worth spelling out. That sentence called it "a trusted service such as…", and these services work by installing a provisioning profile on the device. The guide shouldn't extend that endorsement to whoever now sits behind a redirect it never followed. It already named the Finder device summary and Apple Configurator; it now names only those.

**A 403 from curl is not a dead link.** Stack Overflow, `westeros.org` and SourceForge all bot-block, and `miglayout.com/QuickStart.pdf` answers 200 with browser headers. Those were checked rather than assumed dead — deleting a live reference would have been the easy mistake here.

**The baseline is now empty**, so any new insecure or dead link fails the build outright rather than being absorbed. That's one of the two ratchets in the plan closed; missing-code-blocks remains at 89.

Two pre-existing LanguageTool errors in `basics.asciidoc` are fixed in the same change, because that gate is per-changed-file and would otherwise fail this PR for them: "various axis" (should be axes) and `<<guibuilder>>` rendering as a bare anchor name mid-sentence. Both xrefs now carry display text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)