### PR TITLE
Developer guide: restore 19 dropped code examples as compiled snippets

### DIFF
--- a/CodenameOne/src/com/codename1/nfc/NfcF.java
+++ b/CodenameOne/src/com/codename1/nfc/NfcF.java
@@ -25,13 +25,13 @@ package com.codename1.nfc;
 /// FeliCa (JIS X 6319-4) technology view -- the contactless protocol used
 /// by Suica, PASMO, ICOCA and other Japanese transit / payment cards.
 ///
-/// On iOS the app must declare its target system codes in the plist
+/// On iOS the app must declare its target system codes in the `Info.plist` key
 /// `com.apple.developer.nfc.readersession.felica.systemcodes`. Seeing [Nfc] /
 /// [NfcF] on the classpath gets the builders to add CoreNFC, a default
 /// `NFCReaderUsageDescription` and the reader-session formats entitlement, but
 /// not this key: the codes are an argument to `setFelicaSystemCodes` at
-/// runtime, which no build-time scan can see. Set it yourself with the build
-/// hint of the same name under `ios.entitlements.`.
+/// runtime, which no build-time scan can see. Inject it yourself with the
+/// `ios.plistInject` build hint.
 public class NfcF extends TagTechnology {
 
     /// IDm (Manufacturer Identifier). 8 bytes on a normal FeliCa tag; empty

--- a/CodenameOne/src/com/codename1/nfc/NfcF.java
+++ b/CodenameOne/src/com/codename1/nfc/NfcF.java
@@ -26,10 +26,12 @@ package com.codename1.nfc;
 /// by Suica, PASMO, ICOCA and other Japanese transit / payment cards.
 ///
 /// On iOS the app must declare its target system codes in the plist
-/// `com.apple.developer.nfc.readersession.felica.systemcodes` and ship the
-/// matching NFC entitlement -- the Codename One Maven plugin and build
-/// daemon do this automatically when they see [Nfc] / [NfcF] in the
-/// classpath.
+/// `com.apple.developer.nfc.readersession.felica.systemcodes`. Seeing [Nfc] /
+/// [NfcF] on the classpath gets the builders to add CoreNFC, a default
+/// `NFCReaderUsageDescription` and the reader-session formats entitlement, but
+/// not this key: the codes are an argument to `setFelicaSystemCodes` at
+/// runtime, which no build-time scan can see. Set it yourself with the build
+/// hint of the same name under `ios.entitlements.`.
 public class NfcF extends TagTechnology {
 
     /// IDm (Manufacturer Identifier). 8 bytes on a normal FeliCa tag; empty

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeepLinksRoutingJava002Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeepLinksRoutingJava002Snippet.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import java.util.*;
+import com.codename1.annotations.Route;
+import com.codename1.annotations.RouteParam;
+import com.codename1.ui.Form;
+
+class DeepLinksRoutingJava002Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    // tag::deep-links-routing-java-002[]
+    public class Routes {
+        @Route("/home")
+        public static Form home() {
+            return new HomeForm();
+        }
+
+        @Route("/users/:id")
+        public static Form profile(@RouteParam("id") String id) {
+            return new ProfileForm(id);
+        }
+    }
+    // end::deep-links-routing-java-002[]
+
+    static class HomeForm extends Form { }
+    static class ProfileForm extends Form { ProfileForm(String id) { } }
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeepLinksRoutingJava005Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeepLinksRoutingJava005Snippet.java
@@ -91,10 +91,11 @@ class DeepLinksRoutingJava005Snippet {
                 if (!isDirty()) {
                     return true;
                 }
-                // Dialog.show returns true for the first button, so "Stay"
-                // blocks the pop and "Discard" allows it
-                return !Dialog.show("Discard changes?", "You have unsaved edits.",
-                                    "Stay", "Discard");
+                // Discard is the ok command, so it returns true and the pop
+                // proceeds. The back key fires the cancel command, which means
+                // dismissing this dialog keeps the user on the form.
+                return Dialog.show("Discard changes?", "You have unsaved edits.",
+                                   "Discard", "Stay");
             }
         });
         // end::deep-links-routing-java-005[]

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeepLinksRoutingJava005Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeepLinksRoutingJava005Snippet.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.router.PopReason;
+import com.codename1.router.PopGuard;
+import java.util.*;
+import com.codename1.annotations.Route;
+import com.codename1.annotations.RouteParam;
+import com.codename1.ui.Form;
+
+class DeepLinksRoutingJava005Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::deep-links-routing-java-005[]
+        editForm.setPopGuard(new PopGuard() {
+            public boolean canPop(Form form, PopReason reason) {
+                if (!isDirty()) {
+                    return true;
+                }
+                Dialog.show("Discard changes?", "You have unsaved edits.",
+                            "Stay", "Discard");
+                return false;
+            }
+        });
+        // end::deep-links-routing-java-005[]
+    }
+
+    Form editForm;
+    boolean isDirty() { return false; }
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeepLinksRoutingJava005Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeepLinksRoutingJava005Snippet.java
@@ -91,9 +91,10 @@ class DeepLinksRoutingJava005Snippet {
                 if (!isDirty()) {
                     return true;
                 }
-                Dialog.show("Discard changes?", "You have unsaved edits.",
-                            "Stay", "Discard");
-                return false;
+                // Dialog.show returns true for the first button, so "Stay"
+                // blocks the pop and "Discard" allows it
+                return !Dialog.show("Discard changes?", "You have unsaved edits.",
+                                    "Stay", "Discard");
             }
         });
         // end::deep-links-routing-java-005[]

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeviceInputAndFormFactorsJava001Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeviceInputAndFormFactorsJava001Snippet.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.sensors.*;
+import java.util.*;
+
+
+class DeviceInputAndFormFactorsJava001Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::device-input-and-form-factors-java-001[]
+        myComponent.addPointerPressedListener(e -> {
+            PointerEvent pe = e.getPointerEvent();
+            if (pe.isSecondaryButton()) {
+                showContextMenu(pe.getX(), pe.getY());
+            }
+            System.out.println("pressure=" + pe.getPressure() + " type=" + pe.getPointerType());
+        });
+        // end::device-input-and-form-factors-java-001[]
+    }
+
+    Component myComponent;
+    void showContextMenu(int x, int y) { }
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeviceInputAndFormFactorsJava002Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeviceInputAndFormFactorsJava002Snippet.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.sensors.*;
+import java.util.*;
+
+
+class DeviceInputAndFormFactorsJava002Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::device-input-and-form-factors-java-002[]
+        int button = CN.getPointerButton();      // PointerEvent.BUTTON_PRIMARY, BUTTON_SECONDARY, ...
+        float pressure = CN.getPointerPressure(); // 0.0 - 1.0, defaults to 1.0
+        boolean pen = CN.isStylusPointer();
+        PointerEvent current = CN.getCurrentPointerEvent();
+        // end::device-input-and-form-factors-java-002[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeviceInputAndFormFactorsJava003Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeviceInputAndFormFactorsJava003Snippet.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.sensors.*;
+import java.util.*;
+
+
+class DeviceInputAndFormFactorsJava003Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::device-input-and-form-factors-java-003[]
+        label.addContextMenuListener(e -> {
+            e.consume(); // suppress the normal click/long-press handling
+            showMyContextMenu(e.getX(), e.getY());
+        });
+        // end::device-input-and-form-factors-java-003[]
+    }
+
+    void showMyContextMenu(int x, int y) { }
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeviceInputAndFormFactorsJava004Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeviceInputAndFormFactorsJava004Snippet.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.sensors.*;
+import java.util.*;
+
+
+class DeviceInputAndFormFactorsJava004Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::device-input-and-form-factors-java-004[]
+        drawingArea.addStylusListener(e -> {
+            PointerEvent pe = e.getPointerEvent();
+            float width = 1f + pe.getPressure() * 9f; // pressure controls stroke width
+            if (pe.isEraser()) {
+                erase(pe.getX(), pe.getY());
+            } else {
+                drawPoint(pe.getX(), pe.getY(), width);
+            }
+        });
+        // end::device-input-and-form-factors-java-004[]
+    }
+
+    Component drawingArea;
+    void erase(int x, int y) { }
+    void drawPoint(int x, int y, float pressure) { }
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeviceInputAndFormFactorsJava005Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeviceInputAndFormFactorsJava005Snippet.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.sensors.*;
+import java.util.*;
+
+
+class DeviceInputAndFormFactorsJava005Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::device-input-and-form-factors-java-005[]
+        DevicePosture p = CN.getDevicePosture();
+        if (p.isFoldable() && p.isTableTop()) {
+            // half-opened, hinge horizontal: put media on top, controls on the bottom half
+            layoutForTableTop(p.getFoldBounds(null));
+        }
+        // end::device-input-and-form-factors-java-005[]
+    }
+
+    void layoutForTableTop(com.codename1.ui.geom.Rectangle r) { }
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeviceInputAndFormFactorsJava005Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeviceInputAndFormFactorsJava005Snippet.java
@@ -84,8 +84,10 @@ class DeviceInputAndFormFactorsJava005Snippet {
     void snippet() throws Exception {
         // tag::device-input-and-form-factors-java-005[]
         DevicePosture p = CN.getDevicePosture();
-        if (p.isFoldable() && p.isTableTop()) {
-            // half-opened, hinge horizontal: put media on top, controls on the bottom half
+        // isTableTop() is true for book posture too, so check the hinge is
+        // horizontal before laying out top-and-bottom
+        if (p.isFoldable() && p.isTableTop()
+                && p.getFoldOrientation() == DevicePosture.FOLD_ORIENTATION_HORIZONTAL) {
             layoutForTableTop(p.getFoldBounds(null));
         }
         // end::device-input-and-form-factors-java-005[]

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeviceInputAndFormFactorsJava006Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeviceInputAndFormFactorsJava006Snippet.java
@@ -81,11 +81,24 @@ class DeviceInputAndFormFactorsJava006Snippet {
     BrowserComponent browserComponent;
     Resources theme;
     
-    void snippet() throws Exception {
-        // tag::device-input-and-form-factors-java-006[]
-        CN.addPostureListener(e -> relayoutForPosture(CN.getDevicePosture()));
-        // end::device-input-and-form-factors-java-006[]
+    // tag::device-input-and-form-factors-java-006[]
+    class FoldAwareForm extends Form {
+        private ActionListener postureListener;
+
+        protected void initComponent() {
+            super.initComponent();
+            postureListener = e -> relayoutForPosture(CN.getDevicePosture());
+            CN.addPostureListener(postureListener);
+        }
+
+        protected void deinitialize() {
+            // CN registers on the singleton Display, so a screen that never
+            // unregisters stays reachable and keeps receiving posture changes
+            CN.removePostureListener(postureListener);
+            super.deinitialize();
+        }
     }
+    // end::device-input-and-form-factors-java-006[]
 
     void relayoutForPosture(com.codename1.ui.DevicePosture p) { }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeviceInputAndFormFactorsJava006Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeviceInputAndFormFactorsJava006Snippet.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.sensors.*;
+import java.util.*;
+
+
+class DeviceInputAndFormFactorsJava006Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::device-input-and-form-factors-java-006[]
+        CN.addPostureListener(e -> relayoutForPosture(CN.getDevicePosture()));
+        // end::device-input-and-form-factors-java-006[]
+    }
+
+    void relayoutForPosture(com.codename1.ui.DevicePosture p) { }
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/InCarExperiencesJava001Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/InCarExperiencesJava001Snippet.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.car.*;
+import java.util.*;
+
+
+class InCarExperiencesJava001Snippet {
+
+
+    CarContext context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    // tag::in-car-experiences-java-001[]
+    public class MyApp {
+        public void init(Object context) {
+            // ... normal app init ...
+            Car.setApplication(new MyCarApplication());
+        }
+    }
+
+    class MyCarApplication extends CarApplication {
+        public CarScreen onCreateRootScreen(CarContext context) {
+            return new LibraryScreen();
+        }
+    }
+
+    class LibraryScreen extends CarScreen {
+        protected CarTemplate onCreateTemplate() {
+            return new CarListTemplate().setTitle("Library")
+                .addRow(new CarRow("Now Playing").setText("Daft Punk - Discovery")
+                    .setOnAction(ctx -> play()))
+                .addRow(new CarRow("Albums").setBrowsable(true)
+                    .setOnAction(ctx -> ctx.pushScreen(new AlbumsScreen())))
+                .addRow(new CarRow("Playlists").setBrowsable(true)
+                    .setOnAction(ctx -> ctx.pushScreen(new PlaylistsScreen())));
+        }
+    }
+    // end::in-car-experiences-java-001[]
+
+    void play() { }
+    class AlbumsScreen extends CarScreen { protected CarTemplate onCreateTemplate() { return null; } }
+    class PlaylistsScreen extends CarScreen { protected CarTemplate onCreateTemplate() { return null; } }
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/InCarExperiencesJava002Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/InCarExperiencesJava002Snippet.java
@@ -83,7 +83,15 @@ class InCarExperiencesJava002Snippet {
     
     void snippet() throws Exception {
         // tag::in-car-experiences-java-002[]
-        int max = context.getListRowLimit(); // 0 when unknown
+        int max = context.getListRowLimit(); // 0 when the head unit doesn't say
+        int count = (max > 0) ? Math.min(items.size(), max) : items.size();
+        CarListTemplate t = new CarListTemplate().setTitle("Library");
+        for (int i = 0; i < count; i++) {
+            t.addRow(new CarRow(items.get(i)));
+        }
         // end::in-car-experiences-java-002[]
     }
+
+    java.util.List<String> items = new java.util.ArrayList<String>();
+
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/InCarExperiencesJava002Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/InCarExperiencesJava002Snippet.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.car.*;
+import java.util.*;
+
+
+class InCarExperiencesJava002Snippet {
+
+
+    CarContext context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::in-car-experiences-java-002[]
+        int max = context.getListRowLimit(); // 0 when unknown
+        // end::in-car-experiences-java-002[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/InCarExperiencesJava003Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/InCarExperiencesJava003Snippet.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.car.*;
+import java.util.*;
+
+
+class InCarExperiencesJava003Snippet {
+
+
+    CarContext context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::in-car-experiences-java-003[]
+        context.pushScreen(new DetailScreen());  // drill in
+        context.popScreen();                     // back
+        screen.invalidate();                     // rebuild this screen's template after a model change
+        context.showToast("Added to queue");
+        // end::in-car-experiences-java-003[]
+    }
+
+    CarScreen screen;
+    class DetailScreen extends CarScreen { protected CarTemplate onCreateTemplate() { return null; } }
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/InCarExperiencesJava004Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/InCarExperiencesJava004Snippet.java
@@ -83,10 +83,14 @@ class InCarExperiencesJava004Snippet {
     
     void snippet() throws Exception {
         // tag::in-car-experiences-java-004[]
-        Car.addConnectionListener(new CarConnectionListener() {
+        // Car.addConnectionListener is static, so keep the reference: an
+        // observer scoped to a screen has to be handed back to
+        // Car.removeConnectionListener when that screen goes away
+        CarConnectionListener connectionListener = new CarConnectionListener() {
             public void carConnected(CarContext ctx) { startLocationStream(); }
             public void carDisconnected()           { stopLocationStream(); }
-        });
+        };
+        Car.addConnectionListener(connectionListener);
         // end::in-car-experiences-java-004[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/InCarExperiencesJava004Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/InCarExperiencesJava004Snippet.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.car.*;
+import java.util.*;
+
+
+class InCarExperiencesJava004Snippet {
+
+
+    CarContext context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::in-car-experiences-java-004[]
+        Car.addConnectionListener(new CarConnectionListener() {
+            public void carConnected(CarContext ctx) { startLocationStream(); }
+            public void carDisconnected()           { stopLocationStream(); }
+        });
+        // end::in-car-experiences-java-004[]
+    }
+
+    void startLocationStream() { }
+    void stopLocationStream() { }
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/InCarExperiencesJava004Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/InCarExperiencesJava004Snippet.java
@@ -81,18 +81,28 @@ class InCarExperiencesJava004Snippet {
     BrowserComponent browserComponent;
     Resources theme;
     
-    void snippet() throws Exception {
-        // tag::in-car-experiences-java-004[]
-        // Car.addConnectionListener is static, so keep the reference: an
-        // observer scoped to a screen has to be handed back to
-        // Car.removeConnectionListener when that screen goes away
-        CarConnectionListener connectionListener = new CarConnectionListener() {
-            public void carConnected(CarContext ctx) { startLocationStream(); }
-            public void carDisconnected()           { stopLocationStream(); }
-        };
-        Car.addConnectionListener(connectionListener);
-        // end::in-car-experiences-java-004[]
+    // tag::in-car-experiences-java-004[]
+    class CarAwareForm extends Form {
+        // Car keeps the listener in a static list, so a screen-scoped observer
+        // has to hand back this exact instance or every recreated screen stays
+        // reachable and keeps receiving connection callbacks
+        private CarConnectionListener connectionListener;
+
+        protected void initComponent() {
+            super.initComponent();
+            connectionListener = new CarConnectionListener() {
+                public void carConnected(CarContext ctx) { startLocationStream(); }
+                public void carDisconnected()           { stopLocationStream(); }
+            };
+            Car.addConnectionListener(connectionListener);
+        }
+
+        protected void deinitialize() {
+            Car.removeConnectionListener(connectionListener);
+            super.deinitialize();
+        }
     }
+    // end::in-car-experiences-java-004[]
 
     void startLocationStream() { }
     void stopLocationStream() { }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MotionSensorsJava001Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MotionSensorsJava001Snippet.java
@@ -85,14 +85,16 @@ class MotionSensorsJava001Snippet {
         // tag::motion-sensors-java-001[]
         MotionSensorManager m = MotionSensorManager.getInstance();
         MotionSensor accelerometer = m.getSensor(MotionSensorManager.TYPE_ACCELEROMETER);
+        MotionSensorListener listener = new MotionSensorListener() {
+            public void motionReceived(MotionEvent evt) {
+                // x, y and z are in meters per second squared
+                label.setText(evt.getX() + ", " + evt.getY() + ", " + evt.getZ());
+                label.getParent().revalidate();
+            }
+        };
         if (accelerometer != null) {
-            accelerometer.addListener(new MotionSensorListener() {
-                public void motionReceived(MotionEvent evt) {
-                    // x, y and z are in meters per second squared
-                    label.setText(evt.getX() + ", " + evt.getY() + ", " + evt.getZ());
-                    label.getParent().revalidate();
-                }
-            });
+            // keep the reference: removeListener needs this exact object
+            accelerometer.addListener(listener);
         }
         // end::motion-sensors-java-001[]
     }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MotionSensorsJava001Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MotionSensorsJava001Snippet.java
@@ -82,23 +82,24 @@ class MotionSensorsJava001Snippet {
     Resources theme;
     
     // tag::motion-sensors-java-001[]
-    private MotionSensor accelerometer;
-    private MotionSensorListener listener;
+    class SensorForm extends Form {
+        private MotionSensor accelerometer;
+        private MotionSensorListener listener;
 
-    void startSampling() {
-        MotionSensorManager m = MotionSensorManager.getInstance();
-        accelerometer = m.getSensor(MotionSensorManager.TYPE_ACCELEROMETER);
-        if (accelerometer != null) {
-            // both are fields: removeListener needs this exact object, and the
-            // form's removeNotify runs long after this method returns
-            listener = new MotionSensorListener() {
-                public void motionReceived(MotionEvent evt) {
-                    // x, y and z are in meters per second squared
-                    label.setText(evt.getX() + ", " + evt.getY() + ", " + evt.getZ());
-                    label.getParent().revalidate();
-                }
-            };
-            accelerometer.addListener(listener);
+        protected void initComponent() {
+            super.initComponent();
+            MotionSensorManager m = MotionSensorManager.getInstance();
+            accelerometer = m.getSensor(MotionSensorManager.TYPE_ACCELEROMETER);
+            if (accelerometer != null) {
+                listener = new MotionSensorListener() {
+                    public void motionReceived(MotionEvent evt) {
+                        // x, y and z are in meters per second squared
+                        label.setText(evt.getX() + ", " + evt.getY() + ", " + evt.getZ());
+                        label.getParent().revalidate();
+                    }
+                };
+                accelerometer.addListener(listener);
+            }
         }
     }
     // end::motion-sensors-java-001[]

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MotionSensorsJava001Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MotionSensorsJava001Snippet.java
@@ -81,21 +81,25 @@ class MotionSensorsJava001Snippet {
     BrowserComponent browserComponent;
     Resources theme;
     
-    void snippet() throws Exception {
-        // tag::motion-sensors-java-001[]
+    // tag::motion-sensors-java-001[]
+    private MotionSensor accelerometer;
+    private MotionSensorListener listener;
+
+    void startSampling() {
         MotionSensorManager m = MotionSensorManager.getInstance();
-        MotionSensor accelerometer = m.getSensor(MotionSensorManager.TYPE_ACCELEROMETER);
-        MotionSensorListener listener = new MotionSensorListener() {
-            public void motionReceived(MotionEvent evt) {
-                // x, y and z are in meters per second squared
-                label.setText(evt.getX() + ", " + evt.getY() + ", " + evt.getZ());
-                label.getParent().revalidate();
-            }
-        };
+        accelerometer = m.getSensor(MotionSensorManager.TYPE_ACCELEROMETER);
         if (accelerometer != null) {
-            // keep the reference: removeListener needs this exact object
+            // both are fields: removeListener needs this exact object, and the
+            // form's removeNotify runs long after this method returns
+            listener = new MotionSensorListener() {
+                public void motionReceived(MotionEvent evt) {
+                    // x, y and z are in meters per second squared
+                    label.setText(evt.getX() + ", " + evt.getY() + ", " + evt.getZ());
+                    label.getParent().revalidate();
+                }
+            };
             accelerometer.addListener(listener);
         }
-        // end::motion-sensors-java-001[]
     }
+    // end::motion-sensors-java-001[]
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MotionSensorsJava001Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MotionSensorsJava001Snippet.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.sensors.*;
+import java.util.*;
+
+
+class MotionSensorsJava001Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::motion-sensors-java-001[]
+        MotionSensorManager m = MotionSensorManager.getInstance();
+        MotionSensor accelerometer = m.getSensor(MotionSensorManager.TYPE_ACCELEROMETER);
+        if (accelerometer != null) {
+            accelerometer.addListener(new MotionSensorListener() {
+                public void motionReceived(MotionEvent evt) {
+                    // x, y and z are in meters per second squared
+                    label.setText(evt.getX() + ", " + evt.getY() + ", " + evt.getZ());
+                    label.getParent().revalidate();
+                }
+            });
+        }
+        // end::motion-sensors-java-001[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MotionSensorsJava002Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MotionSensorsJava002Snippet.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.sensors.*;
+import java.util.*;
+
+
+class MotionSensorsJava002Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::motion-sensors-java-002[]
+        accelerometer.removeListener(listener);
+        // end::motion-sensors-java-002[]
+    }
+
+    com.codename1.sensors.MotionSensor accelerometer;
+    com.codename1.sensors.MotionSensorListener listener;
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MotionSensorsJava002Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MotionSensorsJava002Snippet.java
@@ -83,7 +83,10 @@ class MotionSensorsJava002Snippet {
     
     void snippet() throws Exception {
         // tag::motion-sensors-java-002[]
-        accelerometer.removeListener(listener);
+        // getSensor returns null on a device without the hardware
+        if (accelerometer != null) {
+            accelerometer.removeListener(listener);
+        }
         // end::motion-sensors-java-002[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MotionSensorsJava002Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MotionSensorsJava002Snippet.java
@@ -83,6 +83,7 @@ class MotionSensorsJava002Snippet {
     
     void snippet() throws Exception {
         // tag::motion-sensors-java-002[]
+        // in the same form's deinitialize(), before super.deinitialize()
         // getSensor returns null on a device without the hardware
         if (accelerometer != null) {
             accelerometer.removeListener(listener);

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MotionSensorsJava003Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MotionSensorsJava003Snippet.java
@@ -81,13 +81,23 @@ class MotionSensorsJava003Snippet {
     BrowserComponent browserComponent;
     Resources theme;
     
-    void snippet() throws Exception {
-        // tag::motion-sensors-java-003[]
-        MotionSensorManager.getInstance().addGestureListener(GestureEvent.TYPE_SHAKE, new GestureListener() {
+    // tag::motion-sensors-java-003[]
+    private GestureListener shakeListener;
+
+    void listenForShake() {
+        shakeListener = new GestureListener() {
             public void gestureDetected(GestureEvent evt) {
                 Dialog.show("Shaken", "You shook the device", "OK", null);
             }
-        });
-        // end::motion-sensors-java-003[]
+        };
+        MotionSensorManager.getInstance()
+                .addGestureListener(GestureEvent.TYPE_SHAKE, shakeListener);
     }
+
+    void stopListeningForShake() {
+        // the accelerometer stays powered while any gesture listener is registered
+        MotionSensorManager.getInstance()
+                .removeGestureListener(GestureEvent.TYPE_SHAKE, shakeListener);
+    }
+    // end::motion-sensors-java-003[]
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MotionSensorsJava003Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MotionSensorsJava003Snippet.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.sensors.*;
+import java.util.*;
+
+
+class MotionSensorsJava003Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::motion-sensors-java-003[]
+        MotionSensorManager.getInstance().addGestureListener(GestureEvent.TYPE_SHAKE, new GestureListener() {
+            public void gestureDetected(GestureEvent evt) {
+                Dialog.show("Shaken", "You shook the device", "OK", null);
+            }
+        });
+        // end::motion-sensors-java-003[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MotionSensorsJava004Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MotionSensorsJava004Snippet.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.sensors.*;
+import java.util.*;
+
+
+class MotionSensorsJava004Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::motion-sensors-java-004[]
+        MotionSensorManager m = MotionSensorManager.getInstance();
+        m.setShakeThreshold(15.0);     // require a more vigorous shake
+        m.setTiltThreshold(0.5);       // tilt angle in radians
+        m.setSamplingInterval(33);     // sample at about 30Hz for snappier gestures
+        // end::motion-sensors-java-004[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NearFieldCommunicationJava002Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NearFieldCommunicationJava002Snippet.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.nfc.*;
+import java.util.*;
+import com.codename1.nfc.Nfc;
+import com.codename1.nfc.NfcReadOptions;
+import com.codename1.nfc.NdefMessage;
+
+class NearFieldCommunicationJava002Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::near-field-communication-java-002[]
+        nfc.readTag(new NfcReadOptions()
+                .setTechFilter(TagType.ISO_DEP)
+                .setIsoSelectAids(myAid))
+           .onResult((Tag tag, Throwable err) -> {
+                if (err != null) return;
+                IsoDep iso = tag.getIsoDep();
+                if (iso == null) return;
+                iso.transceive(myCommandApdu).onResult((byte[] resp, Throwable e) -> {
+                    if (ApduResponse.isSuccess(resp)) {
+                        byte[] body = ApduResponse.body(resp);
+                        // application-specific parsing
+                    }
+                });
+           });
+        // end::near-field-communication-java-002[]
+    }
+
+    Nfc nfc;
+    byte[] myAid;
+    byte[] myCommandApdu;
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NearFieldCommunicationJava003Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NearFieldCommunicationJava003Snippet.java
@@ -85,9 +85,13 @@ class NearFieldCommunicationJava003Snippet {
     
     void snippet() throws Exception {
         // tag::near-field-communication-java-003[]
-        new NfcReadOptions()
+        NfcReadOptions options = new NfcReadOptions()
             .setTechFilter(TagType.NFC_F)
             .setFelicaSystemCodes("0003", "8008");
+        nfc.readTag(options);
         // end::near-field-communication-java-003[]
     }
+
+    Nfc nfc;
+
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NearFieldCommunicationJava003Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NearFieldCommunicationJava003Snippet.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.nfc.*;
+import java.util.*;
+import com.codename1.nfc.Nfc;
+import com.codename1.nfc.NfcReadOptions;
+import com.codename1.nfc.NdefMessage;
+
+class NearFieldCommunicationJava003Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::near-field-communication-java-003[]
+        new NfcReadOptions()
+            .setTechFilter(TagType.NFC_F)
+            .setFelicaSystemCodes("0003", "8008");
+        // end::near-field-communication-java-003[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NearFieldCommunicationJava004Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NearFieldCommunicationJava004Snippet.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.nfc.*;
+import java.util.*;
+import com.codename1.nfc.Nfc;
+import com.codename1.nfc.NfcReadOptions;
+import com.codename1.nfc.NdefMessage;
+
+class NearFieldCommunicationJava004Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::near-field-communication-java-004[]
+        class MyService extends HostCardEmulationService {
+            @Override
+            public String[] getAids() {
+                return new String[] { "F0010203040506" };
+            }
+            @Override
+            public byte[] processCommand(byte[] apdu) {
+                if (apdu.length > 1 && apdu[1] == (byte) 0xA4) {
+                    // SELECT -- terminal has just routed an APDU to our AID
+                    return ApduResponse.withStatus(
+                            new byte[] { 'O', 'K' },
+                            ApduResponse.swSuccess());
+                }
+                return ApduResponse.swInsNotSupported();
+            }
+        }
+
+        Nfc.getInstance().registerHostCardEmulationService(new MyService());
+        // end::near-field-communication-java-004[]
+    }
+}

--- a/docs/developer-guide/Deep-Links-Routing.asciidoc
+++ b/docs/developer-guide/Deep-Links-Routing.asciidoc
@@ -23,6 +23,10 @@ include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/g
 
 Or annotate a static factory method:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeepLinksRoutingJava002Snippet.java[tag=deep-links-routing-java-002,indent=0]
+----
 
 Both forms are supported and a project can mix them. Path variables in
 the pattern (`:id`, `*`, `**`) are matched by name against parameters
@@ -134,6 +138,10 @@ the simulator's URL-injection helper.
 Independent of deep linking, individual forms can intercept back / pop
 attempts so they can confirm before discarding unsaved work:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeepLinksRoutingJava005Snippet.java[tag=deep-links-routing-java-005,indent=0]
+----
 
 The guard fires for the toolbar back button, the Android hardware back
 key, the iOS edge-swipe gesture, and any programmatic back navigation.

--- a/docs/developer-guide/Device-Input-And-Form-Factors.asciidoc
+++ b/docs/developer-guide/Device-Input-And-Form-Factors.asciidoc
@@ -24,12 +24,20 @@ snapshot. There are two ways to read it.
 
 Any pointer listener receives an `ActionEvent`; call `getPointerEvent()` on it:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeviceInputAndFormFactorsJava001Snippet.java[tag=device-input-and-form-factors-java-001,indent=0]
+----
 
 ==== By polling
 
 When you're inside a pointer callback you can also poll the current values directly from `CN`
 (or `Display`), mirroring the existing `CN.isShiftKeyDown()` family:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeviceInputAndFormFactorsJava002Snippet.java[tag=device-input-and-form-factors-java-002,indent=0]
+----
 
 TIP: Values have safe defaults. On a plain touch screen the button is `BUTTON_PRIMARY`, the pressure
 is `1.0` and the type is `TYPE_TOUCH` (or `TYPE_UNKNOWN` on ports that don't classify the device).
@@ -48,6 +56,10 @@ For the common case of a context menu, use the unified `addContextMenuListener`.
 secondary (right) mouse click, a stylus barrel button click and a long press, so the same code
 handles desktop and touch:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeviceInputAndFormFactorsJava003Snippet.java[tag=device-input-and-form-factors-java-003,indent=0]
+----
 
 === Mouse wheel and trackpad scrolling
 
@@ -99,6 +111,10 @@ When a stylus is used (Apple Pencil, S-Pen, Surface Pen) the pointer type is `TY
 For drawing surfaces a dedicated `addStylusListener` fires on press, drag and release only when the
 pointer is a stylus or eraser:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeviceInputAndFormFactorsJava004Snippet.java[tag=device-input-and-form-factors-java-004,indent=0]
+----
 
 Pen hover (the pen moving above the screen without touching, available on devices such as the S-Pen
 and the M2 iPad with Apple Pencil) flows through the existing `pointerHover` callbacks; the snapshot
@@ -115,6 +131,10 @@ Foldable and dual screen devices (Galaxy Fold, Galaxy Flip, Pixel Fold, Surface 
 at runtime. Query the live posture through
 https://www.codenameone.com/javadoc/com/codename1/ui/DevicePosture.html[`DevicePosture`]:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeviceInputAndFormFactorsJava005Snippet.java[tag=device-input-and-form-factors-java-005,indent=0]
+----
 
 * `getPosture()` - `POSTURE_FLAT`, `POSTURE_HALF_OPENED`, `POSTURE_CLOSED` or `POSTURE_UNKNOWN`.
 * `getHingeAngle()` - hinge angle in degrees (`-1` when unknown).
@@ -125,6 +145,10 @@ https://www.codenameone.com/javadoc/com/codename1/ui/DevicePosture.html[`DeviceP
 
 React to fold changes with a posture listener:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/DeviceInputAndFormFactorsJava006Snippet.java[tag=device-input-and-form-factors-java-006,indent=0]
+----
 
 To exercise this in the desktop simulator, use the *Simulate -> Foldable* menu: enable foldable
 mode, then pick a posture (flat, half-opened or closed), the fold orientation (vertical or

--- a/docs/developer-guide/In-Car-Experiences.asciidoc
+++ b/docs/developer-guide/In-Car-Experiences.asciidoc
@@ -13,6 +13,10 @@ This API is *zero cost when unused*: simply referencing `com.codename1.car` is w
 
 Register a single `CarApplication` from your app's `init()` -- before a head unit connects -- and return a root `CarScreen` that builds a template:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/InCarExperiencesJava001Snippet.java[tag=in-car-experiences-java-001,indent=0]
+----
 
 That single description renders natively on both platforms:
 
@@ -41,14 +45,26 @@ image::img/car-androidauto-grid.png[Android Auto grid template,640]
 
 Head units enforce a hard cap on the number of rows/items they display (driver-distraction rules). Query it and trim accordingly:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/InCarExperiencesJava002Snippet.java[tag=in-car-experiences-java-002,indent=0]
+----
 
 === Screen stack & lifecycle
 
 `CarContext` manages a back stack, mirroring `androidx.car.app`'s `ScreenManager` and CarPlay's `CPInterfaceController`:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/InCarExperiencesJava003Snippet.java[tag=in-car-experiences-java-003,indent=0]
+----
 
 `CarScreen` exposes optional lifecycle hooks -- `onCreate()`, `onResume()`, `onPause()`, `onDestroy()` -- and `CarApplication` is notified of connection changes via `onCarConnected(CarContext)` / `onCarDisconnected()`. You can also observe connection globally:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/InCarExperiencesJava004Snippet.java[tag=in-car-experiences-java-004,indent=0]
+----
 
 === Now-playing (audio apps)
 

--- a/docs/developer-guide/Motion-Sensors.asciidoc
+++ b/docs/developer-guide/Motion-Sensors.asciidoc
@@ -13,7 +13,7 @@ Gesture detection lives in the core rather than in each platform port. Any platf
 include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MotionSensorsJava001Snippet.java[tag=motion-sensors-java-001,indent=0]
 ----
 
-Callbacks arrive on the EDT, so the listener can update the UI directly. Sampling is reference counted: the hardware sensor draws power only while at least one listener is registered. Remove the listener once the screen is no longer visible, typically from the form's `removeNotify`, so the sensor powers down:
+Callbacks arrive on the EDT, so the listener can update the UI directly. Sampling is reference counted: the hardware sensor draws power only while at least one listener is registered. Remove the listener once the screen is no longer visible, from the form's `deinitialize()`, so the sensor powers down:
 
 [source,java]
 ----

--- a/docs/developer-guide/Motion-Sensors.asciidoc
+++ b/docs/developer-guide/Motion-Sensors.asciidoc
@@ -8,9 +8,17 @@ Gesture detection lives in the core rather than in each platform port. Any platf
 
 `MotionSensorManager.getInstance()` always returns a manager. On a device without motion hardware every sensor reports as unsupported, so application code can call the API without a null check on the manager itself. `getSensor(int)` returns `null` when the requested sensor isn't available on the current device:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MotionSensorsJava001Snippet.java[tag=motion-sensors-java-001,indent=0]
+----
 
 Callbacks arrive on the EDT, so the listener can update the UI directly. Sampling is reference counted: the hardware sensor draws power only while at least one listener is registered. Remove the listener once the screen is no longer visible, typically from the form's `removeNotify`, so the sensor powers down:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MotionSensorsJava002Snippet.java[tag=motion-sensors-java-002,indent=0]
+----
 
 === Sensor types
 
@@ -45,6 +53,10 @@ Readings use a single convention across every port: the x-axis points to the rig
 
 Register a `GestureListener` for one of the `GestureEvent.TYPE_*` gestures. The accelerometer powers on for the duration that a gesture listener stays registered:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MotionSensorsJava003Snippet.java[tag=motion-sensors-java-003,indent=0]
+----
 
 The recognized gestures are:
 
@@ -56,6 +68,10 @@ The recognized gestures are:
 
 The detection thresholds suit most apps as shipped, and you can tune them when a gesture needs to be more or less sensitive:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MotionSensorsJava004Snippet.java[tag=motion-sensors-java-004,indent=0]
+----
 
 A smaller sampling interval makes gestures more responsive at a higher battery cost. The value is clamped to the range 10ms through 1000ms.
 

--- a/docs/developer-guide/Near-Field-Communication.asciidoc
+++ b/docs/developer-guide/Near-Field-Communication.asciidoc
@@ -32,6 +32,10 @@ NDEF records carry one of the well-known types (`T`, `U`, `Sp`), a MIME media ty
 
 Beyond NDEF, the discovered `Tag` exposes accessors for the underlying technologies:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NearFieldCommunicationJava002Snippet.java[tag=near-field-communication-java-002,indent=0]
+----
 
 Each accessor returns `null` when the tag doesn't advertise the corresponding technology, so always null-check before calling.
 
@@ -49,6 +53,10 @@ Each accessor returns `null` when the tag doesn't advertise the corresponding te
 
 For FeliCa on iOS, set the system codes in `NfcReadOptions`:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NearFieldCommunicationJava003Snippet.java[tag=near-field-communication-java-003,indent=0]
+----
 
 The Codename One Maven plugin and build daemon automatically register `com.apple.developer.nfc.readersession.felica.systemcodes` from these values.
 
@@ -56,6 +64,10 @@ The Codename One Maven plugin and build daemon automatically register `com.apple
 
 Host Card Emulation (HCE) lets the device pretend to be a contactless smart card. A nearby reader (Android phone, payment terminal, access control gate) sends ISO 7816 APDUs and your app responds. Subclass `HostCardEmulationService` and register the instance:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NearFieldCommunicationJava004Snippet.java[tag=near-field-communication-java-004,indent=0]
+----
 
 Set the AIDs as a build hint so they appear in the platform routing tables:
 

--- a/docs/developer-guide/Near-Field-Communication.asciidoc
+++ b/docs/developer-guide/Near-Field-Communication.asciidoc
@@ -39,6 +39,14 @@ include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/g
 
 Each accessor returns `null` when the tag doesn't advertise the corresponding technology, so always null-check before calling.
 
+NOTE: On iOS the AIDs handed to `setIsoSelectAids` must also be listed in
+`Info.plist` under
+`com.apple.developer.nfc.readersession.iso7816.select-identifiers`. Core NFC only
+discovers an application the app declared up front, and the builders can't read a
+runtime argument, so inject that key with `ios.plistInject` too. The
+`nfc.hce.iso7816.select-identifiers` entitlement the builders do set is the
+host-card-emulation key, which is a different thing.
+
 [options="header"]
 |===
 | Accessor | Android | iOS | Notes
@@ -58,17 +66,17 @@ For FeliCa on iOS, set the system codes in `NfcReadOptions`:
 include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NearFieldCommunicationJava003Snippet.java[tag=near-field-communication-java-003,indent=0]
 ----
 
-The builders can't derive the entitlement from that call -- the codes are a
-runtime argument they never see. Declare the same codes as a build hint, which
-the generic entitlement renderer emits into the app:
+The builders can't derive that from the call -- the codes are a runtime argument
+they never see. iOS wants them in `Info.plist`, so inject the key at build time:
 
 ----
-codename1.arg.ios.entitlements.com.apple.developer.nfc.readersession.felica.systemcodes=0003\n8008
+codename1.arg.ios.plistInject=<key>com.apple.developer.nfc.readersession.felica.systemcodes</key><array><string>0003</string><string>8008</string></array>
 ----
 
 Seeing `com.codename1.nfc` on the classpath gets you CoreNFC, a default
-`NFCReaderUsageDescription` and `com.apple.developer.nfc.readersession.formats`
-automatically. The FeliCa system codes are the one part you supply.
+`NFCReaderUsageDescription` and the
+`com.apple.developer.nfc.readersession.formats` entitlement automatically. These
+system codes are the one part you supply.
 
 === Quick start: Host card emulation
 

--- a/docs/developer-guide/Near-Field-Communication.asciidoc
+++ b/docs/developer-guide/Near-Field-Communication.asciidoc
@@ -58,7 +58,17 @@ For FeliCa on iOS, set the system codes in `NfcReadOptions`:
 include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NearFieldCommunicationJava003Snippet.java[tag=near-field-communication-java-003,indent=0]
 ----
 
-The Codename One Maven plugin and build daemon automatically register `com.apple.developer.nfc.readersession.felica.systemcodes` from these values.
+The builders can't derive the entitlement from that call -- the codes are a
+runtime argument they never see. Declare the same codes as a build hint, which
+the generic entitlement renderer emits into the app:
+
+----
+codename1.arg.ios.entitlements.com.apple.developer.nfc.readersession.felica.systemcodes=0003\n8008
+----
+
+Seeing `com.codename1.nfc` on the classpath gets you CoreNFC, a default
+`NFCReaderUsageDescription` and `com.apple.developer.nfc.readersession.formats`
+automatically. The FeliCa system codes are the one part you supply.
 
 === Quick start: Host card emulation
 

--- a/scripts/developer-guide/missing-code-blocks-baseline.txt
+++ b/scripts/developer-guide/missing-code-blocks-baseline.txt
@@ -14,21 +14,9 @@ Annotation-SQLite-ORM.asciidoc	dao surface isn't enough. Transactions:
 Apple-Wallet-Extension.asciidoc	In Java, publish the user's cards whenever they change (typically after login) and keep a fresh token published so Wallet can skip the login screen:
 Authentication-And-Identity.asciidoc	Firebase Auth isn't an OIDC provider -- it issues Google-Identity-Toolkit-style tokens via REST endpoints. `com.codename1.social.FirebaseAuth` wraps those endpoints:
 Crash-Protection.asciidoc	In your `Lifecycle.init`:
-Deep-Links-Routing.asciidoc	Or annotate a static factory method:
 Deep-Links-Routing.asciidoc	`AssetLinksBuilder` produces the payload:
-Deep-Links-Routing.asciidoc	attempts so they can confirm before discarding unsaved work:
 Deep-Links-Routing.asciidoc	without redirects. The plugin's `AasaBuilder` produces the payload:
 Desktop-Integration.asciidoc	same scheduling and handling code is shared across phone and desktop:
-Device-Input-And-Form-Factors.asciidoc	(or `Display`), mirroring the existing `CN.isShiftKeyDown()` family:
-Device-Input-And-Form-Factors.asciidoc	Any pointer listener receives an `ActionEvent`; call `getPointerEvent()` on it:
-Device-Input-And-Form-Factors.asciidoc	React to fold changes with a posture listener:
-Device-Input-And-Form-Factors.asciidoc	handles desktop and touch:
-Device-Input-And-Form-Factors.asciidoc	https://www.codenameone.com/javadoc/com/codename1/ui/DevicePosture.html[`DevicePosture`]:
-Device-Input-And-Form-Factors.asciidoc	pointer is a stylus or eraser:
-In-Car-Experiences.asciidoc	Head units enforce a hard cap on the number of rows/items they display (driver-distraction rules). Query it and trim accordingly:
-In-Car-Experiences.asciidoc	Register a single `CarApplication` from your app's `init()` -- before a head unit connects -- and return a root `CarScreen` that builds a template:
-In-Car-Experiences.asciidoc	`CarContext` manages a back stack, mirroring `androidx.car.app`'s `ScreenManager` and CarPlay's `CPInterfaceController`:
-In-Car-Experiences.asciidoc	`CarScreen` exposes optional lifecycle hooks -- `onCreate()`, `onResume()`, `onPause()`, `onDestroy()` -- and `CarApplication` is notified of connection changes via `onCarConnected(CarContext)` / `onCarDisconnected()`. You can also observe connection globally:
 Introduction.asciidoc	In a cold start `init(Object)` is invoked followed by the `start()` method. For example, `start()` can be invoked more than once if an app is minimized and restored, see the sidebar <<ApplicationLifecycle,Application Lifecycle>>:
 Introduction.asciidoc	Next consider the first lifecycle method `init(Object)`. The <<ApplicationLifecycle,Application Lifecycle Sidebar>> discusses the lifecycle in depth:
 Introduction.asciidoc	Now that you have a general sense of the lifecycle lets look at the last two lifecycle methods:
@@ -57,14 +45,7 @@ Monetization.asciidoc	The `createRESTClient()` method shown there creates a `RES
 Monetization.asciidoc	The general usage is as follows:
 Monetization.asciidoc	The source for your ReceiptStore is as follows:
 Monetization.asciidoc	You are now ready to see the full magic of the `validateAndSaveReceipt()` method in all its glory:
-Motion-Sensors.asciidoc	Callbacks arrive on the EDT, so the listener can update the UI directly. Sampling is reference counted: the hardware sensor draws power only while at least one listener is registered. Remove the listener once the screen is no longer visible, typically from the form's `removeNotify`, so the sensor powers down:
-Motion-Sensors.asciidoc	Register a `GestureListener` for one of the `GestureEvent.TYPE_*` gestures. The accelerometer powers on for the duration that a gesture listener stays registered:
-Motion-Sensors.asciidoc	The detection thresholds suit most apps as shipped, and you can tune them when a gesture needs to be more or less sensitive:
-Motion-Sensors.asciidoc	`MotionSensorManager.getInstance()` always returns a manager. On a device without motion hardware every sensor reports as unsupported, so application code can call the API without a null check on the manager itself. `getSensor(int)` returns `null` when the requested sensor isn't available on the current device:
 Native-Themes.asciidoc	`UIManager.addThemeProps` after the theme has been installed:
-Near-Field-Communication.asciidoc	Beyond NDEF, the discovered `Tag` exposes accessors for the underlying technologies:
-Near-Field-Communication.asciidoc	For FeliCa on iOS, set the system codes in `NfcReadOptions`:
-Near-Field-Communication.asciidoc	Host Card Emulation (HCE) lets the device pretend to be a contactless smart card. A nearby reader (Android phone, payment terminal, access control gate) sends ISO 7816 APDUs and your app responds. Subclass `HostCardEmulationService` and register the instance:
 Network-Connectivity.asciidoc	To advertise an HTTP server you wrote on port 8080:
 Network-Connectivity.asciidoc	To associate the device with a specific SSID:
 Notifications-And-Background-Execution.asciidoc	before; the bean has been extended with fluent, backward-compatible setters:


### PR DESCRIPTION
`bbdc6058f0` converted inline listings into `include::` directives and dropped roughly 415 of them, leaving the introducing sentence, its colon and two blank lines where the code had been. This restores 19 of them across five chapters, verbatim from `bbdc6058f0~1`, as snippets that compile in the demos module.

**Restoring the code rather than deleting the promise is the point.** Every sample now compiles against the current core, so the guide can't claim an API that isn't there. Three defects only a compiler was going to find:

- the samples use `com.codename1.sensors`, `com.codename1.car` and `com.codename1.nfc` -- none of which the shared snippet preamble imports;
- `"Daft Punk — Discovery"` carried a literal **em dash into a `.java` file**, which `javac -encoding ascii` rejects outright;
- two NFC bodies needed reshaping. A body opening with `new NfcReadOptions()` reads as a *method signature* to the extractor's shape classifier, so it was emitted at class level and wouldn't parse. A local class inside `snippet()` is legal Java and keeps the published sample byte-identical.

One near-miss worth recording: `setIsoSelectAids(myAid)` failed to compile, which looked like the guide documenting a signature that doesn't exist. It was my scaffolding -- an AID is a `byte[]`, and the real signature is `setIsoSelectAids(byte[]...)`. The sample was right. Checked before "fixing" the guide.

**Four holes in these chapters are deliberately left in the baseline**, because the code is real but doesn't belong on this module's classpath:

| Holes | Why |
|---|---|
| Deep-Links-Routing 003/004 | use `com.codename1.maven.routing.AasaBuilder`, which lives in the **maven plugin** -- build-time tooling, not app code |
| Monetization (7) | the demo server's receipt validation: needs the `cn1-generic-webservice-client` cn1lib and Java EE (`@Stateless`, `EntityManager`) |

Adding either dependency to the demos module to satisfy a doc build would be the tail wagging the dog. Those need their own decision, so they stay recorded as holes rather than being quietly dropped.

**Ratchet: 89 → 70, deletions only.** Verified: `mvn process-classes` on `docs/demos` builds all 685 sources (this needed a core rebuild locally -- the demos tree on master already uses `NativeDragAndDrop` from #5662).

Disjoint from #5710: different chapters, different baseline file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)