### PR TITLE
Developer guide: restore 16 more code examples, and fix four that never worked

### DIFF
--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnimationsJava001Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnimationsJava001Snippet.java
@@ -51,13 +51,10 @@ import com.codename1.security.*;
 import com.codename1.social.*;
 import com.codename1.ui.spinner.*;
 import java.io.*;
-import com.codename1.util.EasyThread;
-import com.codename1.notifications.LocalNotification;
-import com.codename1.ui.table.TableLayout;
 import java.util.*;
 
 
-class MiscellaneousFeaturesJava040Snippet {
+class AnimationsJava001Snippet {
 
 
     Object context;
@@ -84,30 +81,15 @@ class MiscellaneousFeaturesJava040Snippet {
     Resources theme;
     
     void snippet() throws Exception {
-        // tag::miscellaneous-features-java-040[]
-        try {
-            switch(Display.getInstance().getSMSSupport()) {
-                case Display.SMS_NOT_SUPPORTED:
-                    return;
-                case Display.SMS_SEAMLESS:
-                    showUIDialogToEditMessageData();
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-                default:
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-            }
-        } catch(IOException err) {
-            Log.e(err);
-            Dialog.show("SMS Failed", "Unable to send the SMS", "OK", null);
-        }
-        // end::miscellaneous-features-java-040[]
+        // tag::animations-java-001[]
+        MorphTransition morph = MorphTransition.create(300)
+                .snapshotMode(true)
+                .morph("card");
+        nextForm.setTransitionInAnimator(morph);
+        nextForm.show();
+        // end::animations-java-001[]
     }
 
-    String data = "message body";
-
-
-    void showUIDialogToEditMessageData() { }
-    String phone = "555-0100";
+    Form nextForm = new Form();
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnimationsJava002Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnimationsJava002Snippet.java
@@ -51,13 +51,10 @@ import com.codename1.security.*;
 import com.codename1.social.*;
 import com.codename1.ui.spinner.*;
 import java.io.*;
-import com.codename1.util.EasyThread;
-import com.codename1.notifications.LocalNotification;
-import com.codename1.ui.table.TableLayout;
 import java.util.*;
 
 
-class MiscellaneousFeaturesJava040Snippet {
+class AnimationsJava002Snippet {
 
 
     Object context;
@@ -83,31 +80,19 @@ class MiscellaneousFeaturesJava040Snippet {
     BrowserComponent browserComponent;
     Resources theme;
     
-    void snippet() throws Exception {
-        // tag::miscellaneous-features-java-040[]
-        try {
-            switch(Display.getInstance().getSMSSupport()) {
-                case Display.SMS_NOT_SUPPORTED:
-                    return;
-                case Display.SMS_SEAMLESS:
-                    showUIDialogToEditMessageData();
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-                default:
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-            }
-        } catch(IOException err) {
-            Log.e(err);
-            Dialog.show("SMS Failed", "Unable to send the SMS", "OK", null);
-        }
-        // end::miscellaneous-features-java-040[]
+    // tag::animations-java-002[]
+    /**
+     * Useful when passing a value that might not exist to a function, e.g. When we
+     * pass a form that we might need to construct dynamically later on.
+     */
+    public interface LazyValue<T> {
+        /**
+         * Returns the actual value.
+         *
+         * @param args optional arguments for the creation of the lazy value
+         * @return the value
+         */
+        T get(Object... args);
     }
-
-    String data = "message body";
-
-
-    void showUIDialogToEditMessageData() { }
-    String phone = "555-0100";
-
+    // end::animations-java-002[]
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava001Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava001Snippet.java
@@ -81,8 +81,11 @@ class MiscellaneousFeaturesJava001Snippet {
     void snippet() throws Exception {
         // tag::miscellaneous-features-java-001[]
         try {
-            Display.getInstance().sendSMS("+999999999", "My SMS Message");
-            // Or: CN.sendSMS("+999999999", "My SMS Message");
+            // true opens the platform composer, which is what both Android and
+            // iOS offer; the two-argument overload asks for a background send
+            // that neither implements
+            Display.getInstance().sendSMS("+999999999", "My SMS Message", true);
+            // Or: CN.sendSMS("+999999999", "My SMS Message", true);
         } catch(IOException err) {
             Log.e(err);
             Dialog.show("SMS Failed", "Unable to send the SMS", "OK", null);

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava001Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava001Snippet.java
@@ -82,8 +82,8 @@ class MiscellaneousFeaturesJava001Snippet {
         // tag::miscellaneous-features-java-001[]
         try {
             // true opens the platform composer, which is what both Android and
-            // iOS offer; the two-argument overload asks for a background send
-            // that neither implements
+            // iOS offer. iOS opens it either way, but Android takes the flag
+            // literally and its background path is not implemented
             Display.getInstance().sendSMS("+999999999", "My SMS Message", true);
             // Or: CN.sendSMS("+999999999", "My SMS Message", true);
         } catch(IOException err) {

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava040Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava040Snippet.java
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
  * published by the Free Software Foundation.  Codename One designates this
  * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * by Codename One in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -20,94 +20,26 @@
  * Please contact Codename One through http://www.codenameone.com/ if you
  * need additional information or have any questions.
  */
-
 package com.codenameone.developerguide.snippets.generated;
 
-import com.codename1.gpu.*;
+import com.codename1.contacts.*;
 import com.codename1.ui.*;
-import com.codename1.ui.animations.*;
 import com.codename1.ui.events.*;
-import com.codename1.ui.geom.*;
-import com.codename1.ui.layouts.*;
-import com.codename1.ui.list.*;
-import com.codename1.ui.plaf.*;
-import com.codename1.ui.util.*;
-import com.codename1.components.*;
-import com.codename1.charts.models.*;
-import com.codename1.charts.renderers.*;
-import com.codename1.charts.views.*;
-import com.codename1.capture.*;
-import com.codename1.io.*;
-import com.codename1.l10n.*;
-import com.codename1.location.*;
-import com.codename1.maps.*;
-import com.codename1.media.*;
-import com.codename1.messaging.*;
-import com.codename1.payment.*;
-import com.codename1.processing.*;
-import com.codename1.properties.*;
-import com.codename1.push.*;
-import com.codename1.security.*;
-import com.codename1.social.*;
-import com.codename1.ui.spinner.*;
-import java.io.*;
-import com.codename1.util.EasyThread;
-import com.codename1.notifications.LocalNotification;
-import com.codename1.ui.table.TableLayout;
-import java.util.*;
-
 
 class MiscellaneousFeaturesJava040Snippet {
 
+    TextField numberField;
 
-    Object context;
-    Object url;
-    Object value;
-    Object body;
-    Object event;
-    String apiKey = "test-key";
-    String myHttpsURL = "https://example.com";
-    java.util.List<String> validKeysList = new java.util.ArrayList<>();
-    Image myImage;
-    Graphics graphics;
-    Graphics g;
-    GraphicsDevice device;
-    Form form;
-    Form hi;
-    Container cnt;
-    Container myForm;
-    Component component;
-    Button button;
-    MultiButton myMultiButton;
-    Label label;
-    BrowserComponent browserComponent;
-    Resources theme;
-    
     void snippet() throws Exception {
         // tag::miscellaneous-features-java-040[]
-        try {
-            switch(Display.getInstance().getSMSSupport()) {
-                case Display.SMS_NOT_SUPPORTED:
-                    return;
-                case Display.SMS_SEAMLESS:
-                    showUIDialogToEditMessageData();
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-                default:
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
+        ContactPicker picker = new ContactPicker();
+        picker.setRequestedFields(ContactPicker.NAME | ContactPicker.PHONE);
+        picker.pick(ev -> {
+            Contact[] picked = ContactPicker.getPickedContacts(ev);
+            if(picked.length > 0) {
+                numberField.setText(picked[0].getPrimaryPhoneNumber());
             }
-        } catch(IOException err) {
-            Log.e(err);
-            Dialog.show("SMS Failed", "Unable to send the SMS", "OK", null);
-        }
+        });
         // end::miscellaneous-features-java-040[]
     }
-
-    String data = "message body";
-
-
-    void showUIDialogToEditMessageData() { }
-    String phone = "555-0100";
-
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava041Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava041Snippet.java
@@ -57,7 +57,7 @@ import com.codename1.ui.table.TableLayout;
 import java.util.*;
 
 
-class MiscellaneousFeaturesJava040Snippet {
+class MiscellaneousFeaturesJava041Snippet {
 
 
     Object context;
@@ -84,30 +84,15 @@ class MiscellaneousFeaturesJava040Snippet {
     Resources theme;
     
     void snippet() throws Exception {
-        // tag::miscellaneous-features-java-040[]
-        try {
-            switch(Display.getInstance().getSMSSupport()) {
-                case Display.SMS_NOT_SUPPORTED:
-                    return;
-                case Display.SMS_SEAMLESS:
-                    showUIDialogToEditMessageData();
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-                default:
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-            }
-        } catch(IOException err) {
-            Log.e(err);
-            Dialog.show("SMS Failed", "Unable to send the SMS", "OK", null);
-        }
-        // end::miscellaneous-features-java-040[]
+        // tag::miscellaneous-features-java-041[]
+        Message m = new Message("Body of message");
+        m.getAttachments().put(textAttachmentUri, "text/plain");
+        m.getAttachments().put(imageAttachmentUri, "image/png");
+        Display.getInstance().sendMessage(new String[] {"someone@gmail.com"}, "Subject of message", m);
+        // end::miscellaneous-features-java-041[]
     }
 
-    String data = "message body";
-
-
-    void showUIDialogToEditMessageData() { }
-    String phone = "555-0100";
+    String textAttachmentUri = "file:///notes.txt";
+    String imageAttachmentUri = "file:///shot.png";
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava042Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava042Snippet.java
@@ -57,7 +57,7 @@ import com.codename1.ui.table.TableLayout;
 import java.util.*;
 
 
-class MiscellaneousFeaturesJava040Snippet {
+class MiscellaneousFeaturesJava042Snippet {
 
 
     Object context;
@@ -84,30 +84,17 @@ class MiscellaneousFeaturesJava040Snippet {
     Resources theme;
     
     void snippet() throws Exception {
-        // tag::miscellaneous-features-java-040[]
-        try {
-            switch(Display.getInstance().getSMSSupport()) {
-                case Display.SMS_NOT_SUPPORTED:
-                    return;
-                case Display.SMS_SEAMLESS:
-                    showUIDialogToEditMessageData();
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-                default:
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-            }
-        } catch(IOException err) {
-            Log.e(err);
-            Dialog.show("SMS Failed", "Unable to send the SMS", "OK", null);
+        // tag::miscellaneous-features-java-042[]
+        Display display = Display.getInstance();
+        if (display.isLargerTextEnabled()) {
+            float scale = display.getLargerTextScale();
+            Font base = UIManager.getInstance().getComponentStyle("Label").getFont();
+            Font scaled = base.derive(base.getHeight() * scale, base.getStyle());
+            someComponent.getUnselectedStyle().setFont(scaled);
         }
-        // end::miscellaneous-features-java-040[]
+        // end::miscellaneous-features-java-042[]
     }
 
-    String data = "message body";
-
-
-    void showUIDialogToEditMessageData() { }
-    String phone = "555-0100";
+    Component someComponent = new Label();
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava042Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava042Snippet.java
@@ -89,7 +89,14 @@ class MiscellaneousFeaturesJava042Snippet {
         if (display.isLargerTextEnabled()) {
             float scale = display.getLargerTextScale();
             Font base = UIManager.getInstance().getComponentStyle("Label").getFont();
-            Font scaled = base.derive(base.getHeight() * scale, base.getStyle());
+            // derive() takes a requested pixel size; getHeight() is the rendered
+            // line height, which is larger. This is what the framework's own
+            // larger-text scaler does.
+            float baseSize = base.getPixelSize();
+            if (baseSize <= 0) {
+                baseSize = base.getHeight();
+            }
+            Font scaled = base.derive(baseSize * scale, base.getStyle());
             someComponent.getUnselectedStyle().setFont(scaled);
         }
         // end::miscellaneous-features-java-042[]

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava042Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava042Snippet.java
@@ -91,8 +91,7 @@ class MiscellaneousFeaturesJava042Snippet {
             // take the base from the component's own style: derive() keeps the
             // typeface of its receiver, so deriving Label's font would replace
             // whatever face this component was given
-            Style style = someComponent.getUnselectedStyle();
-            Font base = style.getFont();
+            Font base = someComponent.getUnselectedStyle().getFont();
             // derive() only works on TrueType/native fonts and throws on a
             // legacy bitmap font, and it takes a requested pixel size rather
             // than getHeight(), which is the rendered line height. Both checks
@@ -104,7 +103,10 @@ class MiscellaneousFeaturesJava042Snippet {
                 }
                 if (baseSize > 0) {
                     Font scaled = base.derive(baseSize * scale, base.getStyle());
-                    style.setFont(scaled);
+                    // getAllStyles writes through to selected, pressed and
+                    // disabled too, so the text does not snap back to the
+                    // original size when the component changes state
+                    someComponent.getAllStyles().setFont(scaled);
                 }
             }
         }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava042Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava042Snippet.java
@@ -84,53 +84,27 @@ class MiscellaneousFeaturesJava042Snippet {
     Resources theme;
     
     // tag::miscellaneous-features-java-042[]
-    /// Every state's font as the theme installed it, so a second call scales
-    /// the original rather than the font the first call derived. Without this a
-    /// 1.3 preference applied twice gives 1.69, and turning larger text off
-    /// never restores the original size.
-    private final java.util.Map<Style, Font> originalFonts =
-            new java.util.HashMap<Style, Font>();
-
-    void applyLargerText(Component someComponent) {
+    void snippet() throws Exception {
         Display display = Display.getInstance();
-        // scale 1 means "no scaling", and the helper hands the original back,
-        // so this same path also undoes a previous scaling
+        // 1.0 when the user has not asked for larger text, so the same
+        // arithmetic works either way
         float scale = display.isLargerTextEnabled() ? display.getLargerTextScale() : 1f;
-        applyLargerText(someComponent.getUnselectedStyle(), scale);
-        applyLargerText(someComponent.getSelectedStyle(), scale);
-        applyLargerText(someComponent.getPressedStyle(), scale);
-        applyLargerText(someComponent.getDisabledStyle(), scale);
-    }
 
-    private void applyLargerText(Style style, float scale) {
-        Font original = originalFonts.get(style);
-        if (original == null) {
-            original = style.getFont();
-            originalFonts.put(style, original);
-        }
-        // each state keeps its own face: a bold selected font stays bold
-        style.setFont(scaleForLargerText(original, scale));
-    }
-
-    /// Mirrors UIManager's own scaler: derive() handles only TrueType and
-    /// native fonts, and takes a requested pixel size rather than the rendered
-    /// line height getHeight() reports. Anything it cannot scale comes back
-    /// unchanged rather than throwing.
-    private Font scaleForLargerText(Font font, float scale) {
-        if (font == null || !font.isTTFNativeFont() || scale <= 1f) {
-            return font;
-        }
-        float baseSize = font.getPixelSize();
-        if (baseSize <= 0) {
-            baseSize = font.getHeight();
-        }
-        if (baseSize <= 0) {
-            return font;
-        }
-        return font.derive(baseSize * scale, font.getStyle());
+        // a custom-painted row has no Style for the theme to scale, so give it
+        // the same preference the theme fonts get
+        int rowHeight = Math.round(baseRowHeight * scale);
+        int iconSize = Math.round(baseIconSize * scale);
+        drawingArea.setPreferredH(rowHeight);
+        g.drawRect(0, 0, iconSize, iconSize);
     }
     // end::miscellaneous-features-java-042[]
 
     Component someComponent = new Label();
+
+    int baseRowHeight = 40;
+
+    int baseIconSize = 24;
+
+    Component drawingArea = new Label();
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava042Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava042Snippet.java
@@ -83,35 +83,44 @@ class MiscellaneousFeaturesJava042Snippet {
     BrowserComponent browserComponent;
     Resources theme;
     
-    void snippet() throws Exception {
-        // tag::miscellaneous-features-java-042[]
+    // tag::miscellaneous-features-java-042[]
+    void applyLargerText(Component someComponent) {
         Display display = Display.getInstance();
-        if (display.isLargerTextEnabled()) {
-            float scale = display.getLargerTextScale();
-            // take the base from the component's own style: derive() keeps the
-            // typeface of its receiver, so deriving Label's font would replace
-            // whatever face this component was given
-            Font base = someComponent.getUnselectedStyle().getFont();
-            // derive() only works on TrueType/native fonts and throws on a
-            // legacy bitmap font, and it takes a requested pixel size rather
-            // than getHeight(), which is the rendered line height. Both checks
-            // mirror UIManager's own scaleFontForLargerText.
-            if (base != null && base.isTTFNativeFont()) {
-                float baseSize = base.getPixelSize();
-                if (baseSize <= 0) {
-                    baseSize = base.getHeight();
-                }
-                if (baseSize > 0) {
-                    Font scaled = base.derive(baseSize * scale, base.getStyle());
-                    // getAllStyles writes through to selected, pressed and
-                    // disabled too, so the text does not snap back to the
-                    // original size when the component changes state
-                    someComponent.getAllStyles().setFont(scaled);
-                }
-            }
+        if (!display.isLargerTextEnabled()) {
+            return;
         }
-        // end::miscellaneous-features-java-042[]
+        float scale = display.getLargerTextScale();
+        // each state can carry its own face -- a bold selected font, say -- so
+        // derive from the font that state already has instead of broadcasting
+        // one scaled font to all four
+        Style unselected = someComponent.getUnselectedStyle();
+        unselected.setFont(scaleForLargerText(unselected.getFont(), scale));
+        Style selected = someComponent.getSelectedStyle();
+        selected.setFont(scaleForLargerText(selected.getFont(), scale));
+        Style pressed = someComponent.getPressedStyle();
+        pressed.setFont(scaleForLargerText(pressed.getFont(), scale));
+        Style disabled = someComponent.getDisabledStyle();
+        disabled.setFont(scaleForLargerText(disabled.getFont(), scale));
     }
+
+    /// Mirrors UIManager's own scaler: derive() handles only TrueType and
+    /// native fonts, and takes a requested pixel size rather than the rendered
+    /// line height getHeight() reports. Anything it cannot scale comes back
+    /// unchanged rather than throwing.
+    private Font scaleForLargerText(Font font, float scale) {
+        if (font == null || !font.isTTFNativeFont() || scale <= 1f) {
+            return font;
+        }
+        float baseSize = font.getPixelSize();
+        if (baseSize <= 0) {
+            baseSize = font.getHeight();
+        }
+        if (baseSize <= 0) {
+            return font;
+        }
+        return font.derive(baseSize * scale, font.getStyle());
+    }
+    // end::miscellaneous-features-java-042[]
 
     Component someComponent = new Label();
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava042Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava042Snippet.java
@@ -89,15 +89,20 @@ class MiscellaneousFeaturesJava042Snippet {
         if (display.isLargerTextEnabled()) {
             float scale = display.getLargerTextScale();
             Font base = UIManager.getInstance().getComponentStyle("Label").getFont();
-            // derive() takes a requested pixel size; getHeight() is the rendered
-            // line height, which is larger. This is what the framework's own
-            // larger-text scaler does.
-            float baseSize = base.getPixelSize();
-            if (baseSize <= 0) {
-                baseSize = base.getHeight();
+            // derive() only works on TrueType/native fonts and throws on a
+            // legacy bitmap font, and it takes a requested pixel size rather
+            // than getHeight(), which is the rendered line height. Both checks
+            // mirror UIManager's own scaleFontForLargerText.
+            if (base != null && base.isTTFNativeFont()) {
+                float baseSize = base.getPixelSize();
+                if (baseSize <= 0) {
+                    baseSize = base.getHeight();
+                }
+                if (baseSize > 0) {
+                    Font scaled = base.derive(baseSize * scale, base.getStyle());
+                    someComponent.getUnselectedStyle().setFont(scaled);
+                }
             }
-            Font scaled = base.derive(baseSize * scale, base.getStyle());
-            someComponent.getUnselectedStyle().setFont(scaled);
         }
         // end::miscellaneous-features-java-042[]
     }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava042Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava042Snippet.java
@@ -84,23 +84,32 @@ class MiscellaneousFeaturesJava042Snippet {
     Resources theme;
     
     // tag::miscellaneous-features-java-042[]
+    /// Every state's font as the theme installed it, so a second call scales
+    /// the original rather than the font the first call derived. Without this a
+    /// 1.3 preference applied twice gives 1.69, and turning larger text off
+    /// never restores the original size.
+    private final java.util.Map<Style, Font> originalFonts =
+            new java.util.HashMap<Style, Font>();
+
     void applyLargerText(Component someComponent) {
         Display display = Display.getInstance();
-        if (!display.isLargerTextEnabled()) {
-            return;
+        // scale 1 means "no scaling", and the helper hands the original back,
+        // so this same path also undoes a previous scaling
+        float scale = display.isLargerTextEnabled() ? display.getLargerTextScale() : 1f;
+        applyLargerText(someComponent.getUnselectedStyle(), scale);
+        applyLargerText(someComponent.getSelectedStyle(), scale);
+        applyLargerText(someComponent.getPressedStyle(), scale);
+        applyLargerText(someComponent.getDisabledStyle(), scale);
+    }
+
+    private void applyLargerText(Style style, float scale) {
+        Font original = originalFonts.get(style);
+        if (original == null) {
+            original = style.getFont();
+            originalFonts.put(style, original);
         }
-        float scale = display.getLargerTextScale();
-        // each state can carry its own face -- a bold selected font, say -- so
-        // derive from the font that state already has instead of broadcasting
-        // one scaled font to all four
-        Style unselected = someComponent.getUnselectedStyle();
-        unselected.setFont(scaleForLargerText(unselected.getFont(), scale));
-        Style selected = someComponent.getSelectedStyle();
-        selected.setFont(scaleForLargerText(selected.getFont(), scale));
-        Style pressed = someComponent.getPressedStyle();
-        pressed.setFont(scaleForLargerText(pressed.getFont(), scale));
-        Style disabled = someComponent.getDisabledStyle();
-        disabled.setFont(scaleForLargerText(disabled.getFont(), scale));
+        // each state keeps its own face: a bold selected font stays bold
+        style.setFont(scaleForLargerText(original, scale));
     }
 
     /// Mirrors UIManager's own scaler: derive() handles only TrueType and

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava042Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava042Snippet.java
@@ -88,7 +88,11 @@ class MiscellaneousFeaturesJava042Snippet {
         Display display = Display.getInstance();
         if (display.isLargerTextEnabled()) {
             float scale = display.getLargerTextScale();
-            Font base = UIManager.getInstance().getComponentStyle("Label").getFont();
+            // take the base from the component's own style: derive() keeps the
+            // typeface of its receiver, so deriving Label's font would replace
+            // whatever face this component was given
+            Style style = someComponent.getUnselectedStyle();
+            Font base = style.getFont();
             // derive() only works on TrueType/native fonts and throws on a
             // legacy bitmap font, and it takes a requested pixel size rather
             // than getHeight(), which is the rendered line height. Both checks
@@ -100,7 +104,7 @@ class MiscellaneousFeaturesJava042Snippet {
                 }
                 if (baseSize > 0) {
                     Font scaled = base.derive(baseSize * scale, base.getStyle());
-                    someComponent.getUnselectedStyle().setFont(scaled);
+                    style.setFont(scaled);
                 }
             }
         }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava043Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava043Snippet.java
@@ -57,7 +57,7 @@ import com.codename1.ui.table.TableLayout;
 import java.util.*;
 
 
-class MiscellaneousFeaturesJava040Snippet {
+class MiscellaneousFeaturesJava043Snippet {
 
 
     Object context;
@@ -84,30 +84,12 @@ class MiscellaneousFeaturesJava040Snippet {
     Resources theme;
     
     void snippet() throws Exception {
-        // tag::miscellaneous-features-java-040[]
-        try {
-            switch(Display.getInstance().getSMSSupport()) {
-                case Display.SMS_NOT_SUPPORTED:
-                    return;
-                case Display.SMS_SEAMLESS:
-                    showUIDialogToEditMessageData();
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-                default:
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-            }
-        } catch(IOException err) {
-            Log.e(err);
-            Dialog.show("SMS Failed", "Unable to send the SMS", "OK", null);
-        }
-        // end::miscellaneous-features-java-040[]
+        // tag::miscellaneous-features-java-043[]
+        UIManager.getInstance().setBundle(res.getL10N("l10n", local));
+        // end::miscellaneous-features-java-043[]
     }
 
-    String data = "message body";
-
-
-    void showUIDialogToEditMessageData() { }
-    String phone = "555-0100";
+    Resources res;
+    String local = "en";
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava043Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava043Snippet.java
@@ -85,7 +85,9 @@ class MiscellaneousFeaturesJava043Snippet {
     
     void snippet() throws Exception {
         // tag::miscellaneous-features-java-043[]
-        UIManager.getInstance().setBundle(res.getL10N("l10n", local));
+        // the bundle id is the .properties base name, not the directory: the
+        // archetype ships common/src/main/l10n/Bundle.properties
+        UIManager.getInstance().setBundle(res.getL10N("Bundle", local));
         // end::miscellaneous-features-java-043[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava043Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava043Snippet.java
@@ -87,7 +87,13 @@ class MiscellaneousFeaturesJava043Snippet {
         // tag::miscellaneous-features-java-043[]
         // the bundle id is the .properties base name, not the directory: the
         // archetype ships common/src/main/l10n/Bundle.properties
-        UIManager.getInstance().setBundle(res.getL10N("Bundle", local));
+        Hashtable<String, String> bundle = res.getL10N("Bundle", local);
+        if (bundle == null) {
+            // a file with no _locale suffix is filed under the empty locale,
+            // and getL10N is an exact lookup that will not fall back for you
+            bundle = res.getL10N("Bundle", "");
+        }
+        UIManager.getInstance().setBundle(bundle);
         // end::miscellaneous-features-java-043[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava044Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava044Snippet.java
@@ -86,7 +86,7 @@ class MiscellaneousFeaturesJava044Snippet {
     void snippet() throws Exception {
         // tag::miscellaneous-features-java-044[]
         Resources res = fetchResourceFile();
-        Enumeration locales = res.listL10NLocales( "l10n" );
+        Enumeration locales = res.listL10NLocales("Bundle");
         // end::miscellaneous-features-java-044[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava044Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava044Snippet.java
@@ -57,7 +57,7 @@ import com.codename1.ui.table.TableLayout;
 import java.util.*;
 
 
-class MiscellaneousFeaturesJava040Snippet {
+class MiscellaneousFeaturesJava044Snippet {
 
 
     Object context;
@@ -84,30 +84,12 @@ class MiscellaneousFeaturesJava040Snippet {
     Resources theme;
     
     void snippet() throws Exception {
-        // tag::miscellaneous-features-java-040[]
-        try {
-            switch(Display.getInstance().getSMSSupport()) {
-                case Display.SMS_NOT_SUPPORTED:
-                    return;
-                case Display.SMS_SEAMLESS:
-                    showUIDialogToEditMessageData();
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-                default:
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-            }
-        } catch(IOException err) {
-            Log.e(err);
-            Dialog.show("SMS Failed", "Unable to send the SMS", "OK", null);
-        }
-        // end::miscellaneous-features-java-040[]
+        // tag::miscellaneous-features-java-044[]
+        Resources res = fetchResourceFile();
+        Enumeration locales = res.listL10NLocales( "l10n" );
+        // end::miscellaneous-features-java-044[]
     }
 
-    String data = "message body";
-
-
-    void showUIDialogToEditMessageData() { }
-    String phone = "555-0100";
+    Resources fetchResourceFile() { return null; }
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava045Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava045Snippet.java
@@ -87,6 +87,11 @@ class MiscellaneousFeaturesJava045Snippet {
         // tag::miscellaneous-features-java-045[]
         Form hi = new Form("L10N", new TableLayout(16, 2));
         L10NManager l10n = L10NManager.getInstance();
+        // the parsers take locale-formatted input -- a hard coded "34.35" is
+        // read as 3435 anywhere "." groups digits -- so round-trip the
+        // formatters' own output
+        String localeDouble = l10n.format(34.35);
+        String localeCurrency = l10n.formatCurrency(33.77);
         hi.add("format(double)").add(l10n.format(11.11)).
             add("format(int)").add(l10n.format(33)).
             add("formatCurrency").add(l10n.formatCurrency(53.267)).
@@ -99,8 +104,8 @@ class MiscellaneousFeaturesJava045Snippet {
             add("getLanguage").add(l10n.getLanguage()).
             add("getLocale").add(l10n.getLocale()).
             add("isRTLLocale").add("" + l10n.isRTLLocale()).
-            add("parseCurrency").add(l10n.formatCurrency(l10n.parseCurrency("33.77$"))).
-            add("parseDouble").add(l10n.format(l10n.parseDouble("34.35"))).
+            add("parseCurrency").add(l10n.formatCurrency(l10n.parseCurrency(localeCurrency))).
+            add("parseDouble").add(l10n.format(l10n.parseDouble(localeDouble))).
             add("parseInt").add(l10n.format(l10n.parseInt("56"))).
             add("parseLong").add("" + l10n.parseLong("4444444"));
         hi.show();

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava045Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava045Snippet.java
@@ -57,7 +57,7 @@ import com.codename1.ui.table.TableLayout;
 import java.util.*;
 
 
-class MiscellaneousFeaturesJava040Snippet {
+class MiscellaneousFeaturesJava045Snippet {
 
 
     Object context;
@@ -84,30 +84,26 @@ class MiscellaneousFeaturesJava040Snippet {
     Resources theme;
     
     void snippet() throws Exception {
-        // tag::miscellaneous-features-java-040[]
-        try {
-            switch(Display.getInstance().getSMSSupport()) {
-                case Display.SMS_NOT_SUPPORTED:
-                    return;
-                case Display.SMS_SEAMLESS:
-                    showUIDialogToEditMessageData();
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-                default:
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-            }
-        } catch(IOException err) {
-            Log.e(err);
-            Dialog.show("SMS Failed", "Unable to send the SMS", "OK", null);
-        }
-        // end::miscellaneous-features-java-040[]
+        // tag::miscellaneous-features-java-045[]
+        Form hi = new Form("L10N", new TableLayout(16, 2));
+        L10NManager l10n = L10NManager.getInstance();
+        hi.add("format(double)").add(l10n.format(11.11)).
+            add("format(int)").add(l10n.format(33)).
+            add("formatCurrency").add(l10n.formatCurrency(53.267)).
+            add("formatDateLongStyle").add(l10n.formatDateLongStyle(new Date())).
+            add("formatDateShortStyle").add(l10n.formatDateShortStyle(new Date())).
+            add("formatDateTime").add(l10n.formatDateTime(new Date())).
+            add("formatDateTimeMedium").add(l10n.formatDateTimeMedium(new Date())).
+            add("formatDateTimeShort").add(l10n.formatDateTimeShort(new Date())).
+            add("getCurrencySymbol").add(l10n.getCurrencySymbol()).
+            add("getLanguage").add(l10n.getLanguage()).
+            add("getLocale").add(l10n.getLocale()).
+            add("isRTLLocale").add("" + l10n.isRTLLocale()).
+            add("parseCurrency").add(l10n.formatCurrency(l10n.parseCurrency("33.77$"))).
+            add("parseDouble").add(l10n.format(l10n.parseDouble("34.35"))).
+            add("parseInt").add(l10n.format(l10n.parseInt("56"))).
+            add("parseLong").add("" + l10n.parseLong("4444444"));
+        hi.show();
+        // end::miscellaneous-features-java-045[]
     }
-
-    String data = "message body";
-
-
-    void showUIDialogToEditMessageData() { }
-    String phone = "555-0100";
-
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava046Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava046Snippet.java
@@ -57,7 +57,7 @@ import com.codename1.ui.table.TableLayout;
 import java.util.*;
 
 
-class MiscellaneousFeaturesJava040Snippet {
+class MiscellaneousFeaturesJava046Snippet {
 
 
     Object context;
@@ -84,30 +84,18 @@ class MiscellaneousFeaturesJava040Snippet {
     Resources theme;
     
     void snippet() throws Exception {
-        // tag::miscellaneous-features-java-040[]
-        try {
-            switch(Display.getInstance().getSMSSupport()) {
-                case Display.SMS_NOT_SUPPORTED:
-                    return;
-                case Display.SMS_SEAMLESS:
-                    showUIDialogToEditMessageData();
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-                default:
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-            }
-        } catch(IOException err) {
-            Log.e(err);
-            Dialog.show("SMS Failed", "Unable to send the SMS", "OK", null);
-        }
-        // end::miscellaneous-features-java-040[]
+        // tag::miscellaneous-features-java-046[]
+        Geofence gf = new Geofence("test", loc, 100, 100000);
+
+        LocationManager.getLocationManager()
+                .addGeoFencing(GeofenceListenerImpl.class, gf);
+        // end::miscellaneous-features-java-046[]
     }
 
-    String data = "message body";
-
-
-    void showUIDialogToEditMessageData() { }
-    String phone = "555-0100";
+    com.codename1.location.Location loc;
+    static class GeofenceListenerImpl implements com.codename1.location.GeofenceListener {
+        public void onExit(String id) { }
+        public void onEntered(String id) { }
+    }
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava047Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava047Snippet.java
@@ -57,7 +57,7 @@ import com.codename1.ui.table.TableLayout;
 import java.util.*;
 
 
-class MiscellaneousFeaturesJava040Snippet {
+class MiscellaneousFeaturesJava047Snippet {
 
 
     Object context;
@@ -83,31 +83,25 @@ class MiscellaneousFeaturesJava040Snippet {
     BrowserComponent browserComponent;
     Resources theme;
     
-    void snippet() throws Exception {
-        // tag::miscellaneous-features-java-040[]
-        try {
-            switch(Display.getInstance().getSMSSupport()) {
-                case Display.SMS_NOT_SUPPORTED:
-                    return;
-                case Display.SMS_SEAMLESS:
-                    showUIDialogToEditMessageData();
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-                default:
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-            }
-        } catch(IOException err) {
-            Log.e(err);
-            Dialog.show("SMS Failed", "Unable to send the SMS", "OK", null);
+    // tag::miscellaneous-features-java-047[]
+    public class GeofenceListenerImpl implements GeofenceListener {
+        @Override
+        public void onExit(String id) {
         }
-        // end::miscellaneous-features-java-040[]
+
+        @Override
+        public void onEntered(String id) {
+            if(Display.getInstance().isMinimized()) {
+                Display.getInstance().callSerially(() -> {
+                    Dialog.show("Welcome", "Thanks for arriving", "OK", null);
+                });
+            } else {
+                LocalNotification ln = new LocalNotification();
+                ln.setAlertTitle("Welcome");
+                ln.setAlertBody("Thanks for arriving!");
+                Display.getInstance().scheduleLocalNotification(ln, 10, LocalNotification.REPEAT_NONE);
+            }
+        }
     }
-
-    String data = "message body";
-
-
-    void showUIDialogToEditMessageData() { }
-    String phone = "555-0100";
-
+    // end::miscellaneous-features-java-047[]
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava048Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava048Snippet.java
@@ -57,7 +57,7 @@ import com.codename1.ui.table.TableLayout;
 import java.util.*;
 
 
-class MiscellaneousFeaturesJava040Snippet {
+class MiscellaneousFeaturesJava048Snippet {
 
 
     Object context;
@@ -84,30 +84,14 @@ class MiscellaneousFeaturesJava040Snippet {
     Resources theme;
     
     void snippet() throws Exception {
-        // tag::miscellaneous-features-java-040[]
-        try {
-            switch(Display.getInstance().getSMSSupport()) {
-                case Display.SMS_NOT_SUPPORTED:
-                    return;
-                case Display.SMS_SEAMLESS:
-                    showUIDialogToEditMessageData();
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-                default:
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-            }
-        } catch(IOException err) {
-            Log.e(err);
-            Dialog.show("SMS Failed", "Unable to send the SMS", "OK", null);
+        // tag::miscellaneous-features-java-048[]
+        String filePath = Capture.capturePhoto();
+        if(filePath != null) {
+            Util.copy(FileSystemStorage.getInstance().openInputStream(filePath), Storage.getInstance().createOutputStream(myImageFileName));
         }
-        // end::miscellaneous-features-java-040[]
+        // end::miscellaneous-features-java-048[]
     }
 
-    String data = "message body";
-
-
-    void showUIDialogToEditMessageData() { }
-    String phone = "555-0100";
+    String myImageFileName = "photo.png";
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava049Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava049Snippet.java
@@ -57,7 +57,7 @@ import com.codename1.ui.table.TableLayout;
 import java.util.*;
 
 
-class MiscellaneousFeaturesJava040Snippet {
+class MiscellaneousFeaturesJava049Snippet {
 
 
     Object context;
@@ -84,30 +84,31 @@ class MiscellaneousFeaturesJava040Snippet {
     Resources theme;
     
     void snippet() throws Exception {
-        // tag::miscellaneous-features-java-040[]
-        try {
-            switch(Display.getInstance().getSMSSupport()) {
-                case Display.SMS_NOT_SUPPORTED:
-                    return;
-                case Display.SMS_SEAMLESS:
-                    showUIDialogToEditMessageData();
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-                default:
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-            }
-        } catch(IOException err) {
-            Log.e(err);
-            Dialog.show("SMS Failed", "Unable to send the SMS", "OK", null);
-        }
-        // end::miscellaneous-features-java-040[]
+        // tag::miscellaneous-features-java-049[]
+        hi.getToolbar().addCommandToRightBar("", icon, (ev) -> {
+            Capture.capturePhoto((e) -> {
+                if(e != null && e.getSource() != null) {
+                    try {
+                        DefaultListModel<Image> m = (DefaultListModel<Image>)iv.getImageList();
+                        Image img = Image.createImage((String)e.getSource());
+                        if(m == null) {
+                            m = new DefaultListModel<>(img);
+                            iv.setImageList(m);
+                            iv.setImage(img);
+                        } else {
+                            m.addItem(img);
+                        }
+                        m.setSelectedIndex(m.getSize() - 1);
+                    } catch(IOException err) {
+                        Log.e(err);
+                    }
+                }
+            });
+        });
+        // end::miscellaneous-features-java-049[]
     }
 
-    String data = "message body";
-
-
-    void showUIDialogToEditMessageData() { }
-    String phone = "555-0100";
+    Image icon;
+    com.codename1.components.ImageViewer iv;
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava051Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava051Snippet.java
@@ -57,7 +57,7 @@ import com.codename1.ui.table.TableLayout;
 import java.util.*;
 
 
-class MiscellaneousFeaturesJava040Snippet {
+class MiscellaneousFeaturesJava051Snippet {
 
 
     Object context;
@@ -84,30 +84,8 @@ class MiscellaneousFeaturesJava040Snippet {
     Resources theme;
     
     void snippet() throws Exception {
-        // tag::miscellaneous-features-java-040[]
-        try {
-            switch(Display.getInstance().getSMSSupport()) {
-                case Display.SMS_NOT_SUPPORTED:
-                    return;
-                case Display.SMS_SEAMLESS:
-                    showUIDialogToEditMessageData();
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-                default:
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-            }
-        } catch(IOException err) {
-            Log.e(err);
-            Dialog.show("SMS Failed", "Unable to send the SMS", "OK", null);
-        }
-        // end::miscellaneous-features-java-040[]
+        // tag::miscellaneous-features-java-051[]
+        EasyThread e = EasyThread.start("ThreadName");
+        // end::miscellaneous-features-java-051[]
     }
-
-    String data = "message body";
-
-
-    void showUIDialogToEditMessageData() { }
-    String phone = "555-0100";
-
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava052Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava052Snippet.java
@@ -57,7 +57,7 @@ import com.codename1.ui.table.TableLayout;
 import java.util.*;
 
 
-class MiscellaneousFeaturesJava040Snippet {
+class MiscellaneousFeaturesJava052Snippet {
 
 
     Object context;
@@ -84,30 +84,12 @@ class MiscellaneousFeaturesJava040Snippet {
     Resources theme;
     
     void snippet() throws Exception {
-        // tag::miscellaneous-features-java-040[]
-        try {
-            switch(Display.getInstance().getSMSSupport()) {
-                case Display.SMS_NOT_SUPPORTED:
-                    return;
-                case Display.SMS_SEAMLESS:
-                    showUIDialogToEditMessageData();
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-                default:
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-            }
-        } catch(IOException err) {
-            Log.e(err);
-            Dialog.show("SMS Failed", "Unable to send the SMS", "OK", null);
-        }
-        // end::miscellaneous-features-java-040[]
+        // tag::miscellaneous-features-java-052[]
+        e.run(() -> doThisOnTheThread());
+        // end::miscellaneous-features-java-052[]
     }
 
-    String data = "message body";
-
-
-    void showUIDialogToEditMessageData() { }
-    String phone = "555-0100";
+    EasyThread e;
+    Object doThisOnTheThread() { return null; }
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava053Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava053Snippet.java
@@ -57,7 +57,7 @@ import com.codename1.ui.table.TableLayout;
 import java.util.*;
 
 
-class MiscellaneousFeaturesJava040Snippet {
+class MiscellaneousFeaturesJava053Snippet {
 
 
     Object context;
@@ -84,30 +84,13 @@ class MiscellaneousFeaturesJava040Snippet {
     Resources theme;
     
     void snippet() throws Exception {
-        // tag::miscellaneous-features-java-040[]
-        try {
-            switch(Display.getInstance().getSMSSupport()) {
-                case Display.SMS_NOT_SUPPORTED:
-                    return;
-                case Display.SMS_SEAMLESS:
-                    showUIDialogToEditMessageData();
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-                default:
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-            }
-        } catch(IOException err) {
-            Log.e(err);
-            Dialog.show("SMS Failed", "Unable to send the SMS", "OK", null);
-        }
-        // end::miscellaneous-features-java-040[]
+        // tag::miscellaneous-features-java-053[]
+        e.run((success) -> success.onSucess(doThisOnTheThread()), (myResult) -> onEDTGotResult(myResult));
+        // end::miscellaneous-features-java-053[]
     }
 
-    String data = "message body";
-
-
-    void showUIDialogToEditMessageData() { }
-    String phone = "555-0100";
+    EasyThread e;
+    Object doThisOnTheThread() { return null; }
+    void onEDTGotResult(Object r) { }
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava053Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava053Snippet.java
@@ -85,7 +85,10 @@ class MiscellaneousFeaturesJava053Snippet {
     
     void snippet() throws Exception {
         // tag::miscellaneous-features-java-053[]
-        e.run((success) -> success.onSucess(doThisOnTheThread()), (myResult) -> onEDTGotResult(myResult));
+        // the result callback runs on the EasyThread, not the EDT, so anything
+        // that touches the UI has to be marshalled back explicitly
+        e.run((success) -> success.onSucess(doThisOnTheThread()),
+              (myResult) -> Display.getInstance().callSerially(() -> onEDTGotResult(myResult)));
         // end::miscellaneous-features-java-053[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava054Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava054Snippet.java
@@ -90,6 +90,9 @@ class MiscellaneousFeaturesJava054Snippet {
             System.out.println("This is a thread");
             return 3;
         });
+        // the worker stays alive waiting for more work, so release it when the
+        // thread has nothing left to do
+        e.killWhenIdle();
         // end::miscellaneous-features-java-054[]
     }
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava054Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava054Snippet.java
@@ -57,7 +57,7 @@ import com.codename1.ui.table.TableLayout;
 import java.util.*;
 
 
-class MiscellaneousFeaturesJava040Snippet {
+class MiscellaneousFeaturesJava054Snippet {
 
 
     Object context;
@@ -84,30 +84,12 @@ class MiscellaneousFeaturesJava040Snippet {
     Resources theme;
     
     void snippet() throws Exception {
-        // tag::miscellaneous-features-java-040[]
-        try {
-            switch(Display.getInstance().getSMSSupport()) {
-                case Display.SMS_NOT_SUPPORTED:
-                    return;
-                case Display.SMS_SEAMLESS:
-                    showUIDialogToEditMessageData();
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-                default:
-                    Display.getInstance().sendSMS(phone, data);
-                    return;
-            }
-        } catch(IOException err) {
-            Log.e(err);
-            Dialog.show("SMS Failed", "Unable to send the SMS", "OK", null);
-        }
-        // end::miscellaneous-features-java-040[]
+        // tag::miscellaneous-features-java-054[]
+        EasyThread e = EasyThread.start("Hi");
+        int result = e.run(() -> {
+            System.out.println("This is a thread");
+            return 3;
+        });
+        // end::miscellaneous-features-java-054[]
     }
-
-    String data = "message body";
-
-
-    void showUIDialogToEditMessageData() { }
-    String phone = "555-0100";
-
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava055Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava055Snippet.java
@@ -94,9 +94,9 @@ class MiscellaneousFeaturesJava055Snippet {
                     Display.getInstance().sendSMS(phone, data);
                     return;
                 default:
-                    // interactive ports hand off to the platform composer; the
-                    // two-argument overload asks for a seamless send they do
-                    // not implement, so nothing would happen
+                    // interactive ports hand off to the platform composer. On
+                    // Android the two-argument overload asks for a seamless
+                    // send it does not implement, and nothing happens at all
                     Display.getInstance().sendSMS(phone, data, true);
                     return;
             }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava055Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava055Snippet.java
@@ -94,7 +94,10 @@ class MiscellaneousFeaturesJava055Snippet {
                     Display.getInstance().sendSMS(phone, data);
                     return;
                 default:
-                    Display.getInstance().sendSMS(phone, data);
+                    // interactive ports hand off to the platform composer; the
+                    // two-argument overload asks for a seamless send they do
+                    // not implement, so nothing would happen
+                    Display.getInstance().sendSMS(phone, data, true);
                     return;
             }
         } catch(IOException err) {

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava055Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava055Snippet.java
@@ -57,7 +57,7 @@ import com.codename1.ui.table.TableLayout;
 import java.util.*;
 
 
-class MiscellaneousFeaturesJava047Snippet {
+class MiscellaneousFeaturesJava055Snippet {
 
 
     Object context;
@@ -83,28 +83,31 @@ class MiscellaneousFeaturesJava047Snippet {
     BrowserComponent browserComponent;
     Resources theme;
     
-    // tag::miscellaneous-features-java-047[]
-    public class GeofenceListenerImpl implements GeofenceListener {
-        @Override
-        public void onExit(String id) {
-        }
-
-        @Override
-        public void onEntered(String id) {
-            if(Display.getInstance().isMinimized()) {
-                // backgrounded, so there is no form to show a dialog on
-                LocalNotification ln = new LocalNotification();
-                ln.setId("geofence-welcome");
-                ln.setAlertTitle("Welcome");
-                ln.setAlertBody("Thanks for arriving!");
-                Display.getInstance().scheduleLocalNotification(ln,
-                        System.currentTimeMillis() + 10, LocalNotification.REPEAT_NONE);
-            } else {
-                Display.getInstance().callSerially(() -> {
-                    Dialog.show("Welcome", "Thanks for arriving", "OK", null);
-                });
+    void snippet() throws Exception {
+        // tag::miscellaneous-features-java-055[]
+        try {
+            switch(Display.getInstance().getSMSSupport()) {
+                case Display.SMS_NOT_SUPPORTED:
+                    return;
+                case Display.SMS_SEAMLESS:
+                    showUIDialogToEditMessageData();
+                    Display.getInstance().sendSMS(phone, data);
+                    return;
+                default:
+                    Display.getInstance().sendSMS(phone, data);
+                    return;
             }
+        } catch(IOException err) {
+            Log.e(err);
+            Dialog.show("SMS Failed", "Unable to send the SMS", "OK", null);
         }
+        // end::miscellaneous-features-java-055[]
     }
-    // end::miscellaneous-features-java-047[]
+
+    String data = "message body";
+
+
+    void showUIDialogToEditMessageData() { }
+    String phone = "555-0100";
+
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava056Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava056Snippet.java
@@ -86,8 +86,13 @@ class MiscellaneousFeaturesJava056Snippet {
     
     void snippet() throws Exception {
         // tag::miscellaneous-features-java-056[]
-        // the port reads these through UIManager.localize(), so any bundle works
-        java.util.Map<String, String> bundle = new java.util.HashMap<String, String>();
+        // the port reads these through UIManager.localize(). There is only one
+        // bundle, so add to the installed one rather than replacing it -- a
+        // fresh map here would drop every other localized string in the app.
+        java.util.Map<String, String> bundle = UIManager.getInstance().getBundle();
+        if (bundle == null) {
+            bundle = new java.util.HashMap<String, String>();
+        }
         bundle.put("android.permission.ACCESS_BACKGROUND_LOCATION.title",
                 "Location needed");
         bundle.put("android.permission.ACCESS_BACKGROUND_LOCATION.explanation_body",

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava056Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava056Snippet.java
@@ -93,6 +93,10 @@ class MiscellaneousFeaturesJava056Snippet {
         if (bundle == null) {
             bundle = new java.util.HashMap<String, String>();
         }
+        // the bare key is the body of the first prompt; the suffixed ones
+        // dress the follow-up dialog that sends the user to settings
+        bundle.put("android.permission.ACCESS_BACKGROUND_LOCATION",
+                "Reminders need your location while the app is closed.");
         bundle.put("android.permission.ACCESS_BACKGROUND_LOCATION.title",
                 "Location needed");
         bundle.put("android.permission.ACCESS_BACKGROUND_LOCATION.explanation_body",

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava056Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava056Snippet.java
@@ -57,7 +57,8 @@ import com.codename1.ui.table.TableLayout;
 import java.util.*;
 
 
-class MiscellaneousFeaturesJava047Snippet {
+class MiscellaneousFeaturesJava056Snippet {
+
 
 
     Object context;
@@ -83,28 +84,17 @@ class MiscellaneousFeaturesJava047Snippet {
     BrowserComponent browserComponent;
     Resources theme;
     
-    // tag::miscellaneous-features-java-047[]
-    public class GeofenceListenerImpl implements GeofenceListener {
-        @Override
-        public void onExit(String id) {
-        }
-
-        @Override
-        public void onEntered(String id) {
-            if(Display.getInstance().isMinimized()) {
-                // backgrounded, so there is no form to show a dialog on
-                LocalNotification ln = new LocalNotification();
-                ln.setId("geofence-welcome");
-                ln.setAlertTitle("Welcome");
-                ln.setAlertBody("Thanks for arriving!");
-                Display.getInstance().scheduleLocalNotification(ln,
-                        System.currentTimeMillis() + 10, LocalNotification.REPEAT_NONE);
-            } else {
-                Display.getInstance().callSerially(() -> {
-                    Dialog.show("Welcome", "Thanks for arriving", "OK", null);
-                });
-            }
-        }
+    void snippet() throws Exception {
+        // tag::miscellaneous-features-java-056[]
+        // the port reads these through UIManager.localize(), so any bundle works
+        java.util.Map<String, String> bundle = new java.util.HashMap<String, String>();
+        bundle.put("android.permission.ACCESS_BACKGROUND_LOCATION.title",
+                "Location needed");
+        bundle.put("android.permission.ACCESS_BACKGROUND_LOCATION.explanation_body",
+                "Choose \"Allow all the time\" so reminders still arrive when the app is closed.");
+        bundle.put("android.permission.ACCESS_BACKGROUND_LOCATION.settings", "Open settings");
+        bundle.put("android.permission.ACCESS_BACKGROUND_LOCATION.cancel", "Not now");
+        UIManager.getInstance().setBundle(bundle);
+        // end::miscellaneous-features-java-056[]
     }
-    // end::miscellaneous-features-java-047[]
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava056Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava056Snippet.java
@@ -89,10 +89,12 @@ class MiscellaneousFeaturesJava056Snippet {
         // the port reads these through UIManager.localize(). There is only one
         // bundle, so add to the installed one rather than replacing it -- a
         // fresh map here would drop every other localized string in the app.
-        java.util.Map<String, String> bundle = UIManager.getInstance().getBundle();
-        if (bundle == null) {
-            bundle = new java.util.HashMap<String, String>();
-        }
+        // setBundle keeps whatever map it was handed, so the installed one may
+        // be immutable -- copy before adding
+        java.util.Map<String, String> installed = UIManager.getInstance().getBundle();
+        java.util.Map<String, String> bundle = installed == null
+                ? new java.util.HashMap<String, String>()
+                : new java.util.HashMap<String, String>(installed);
         // the bare key is the body of the first prompt; the suffixed ones
         // dress the follow-up dialog that sends the user to settings
         bundle.put("android.permission.ACCESS_BACKGROUND_LOCATION",
@@ -106,9 +108,6 @@ class MiscellaneousFeaturesJava056Snippet {
         bundle.put("android.permission.ACCESS_BACKGROUND_LOCATION.settings", "Open settings");
         bundle.put("android.permission.ACCESS_BACKGROUND_LOCATION.ok", "Done");
         bundle.put("android.permission.ACCESS_BACKGROUND_LOCATION.cancel", "Not now");
-        // the rationale dialog Android shows before the request uses these two
-        bundle.put("android.permission.ACCESS_BACKGROUND_LOCATION.askAgain", "Ask again");
-        bundle.put("android.permission.ACCESS_BACKGROUND_LOCATION.dontAsk", "Don't ask");
         UIManager.getInstance().setBundle(bundle);
         // end::miscellaneous-features-java-056[]
     }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava056Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava056Snippet.java
@@ -101,8 +101,14 @@ class MiscellaneousFeaturesJava056Snippet {
                 "Location needed");
         bundle.put("android.permission.ACCESS_BACKGROUND_LOCATION.explanation_body",
                 "Choose \"Allow all the time\" so reminders still arrive when the app is closed.");
+        bundle.put("android.permission.ACCESS_BACKGROUND_LOCATION.explanation_title",
+                "One more step");
         bundle.put("android.permission.ACCESS_BACKGROUND_LOCATION.settings", "Open settings");
+        bundle.put("android.permission.ACCESS_BACKGROUND_LOCATION.ok", "Done");
         bundle.put("android.permission.ACCESS_BACKGROUND_LOCATION.cancel", "Not now");
+        // the rationale dialog Android shows before the request uses these two
+        bundle.put("android.permission.ACCESS_BACKGROUND_LOCATION.askAgain", "Ask again");
+        bundle.put("android.permission.ACCESS_BACKGROUND_LOCATION.dontAsk", "Don't ask");
         UIManager.getInstance().setBundle(bundle);
         // end::miscellaneous-features-java-056[]
     }

--- a/docs/developer-guide/Animations.asciidoc
+++ b/docs/developer-guide/Animations.asciidoc
@@ -372,6 +372,10 @@ the source during the animation doesn't carry the original parent's clip.
 To opt into the image-snapshot path call `snapshotMode(true)` on the
 builder:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnimationsJava001Snippet.java[tag=animations-java-001,indent=0]
+----
 
 `snapshotMode(true)` captures each `(source, dest)` pair as a clipped
 `Image` at `initTransition()`, then the tween draws those images at the
@@ -397,6 +401,10 @@ include::../demos/common/src/main/java/com/codenameone/developerguide/animations
 // vale-skip: Microsoft.Adverbs: "lazily" describes the lazy-evaluation semantics of LazyValue, a precise CS term, not a softener.
 That one command will enable swiping back from `currentForm`. https://www.codenameone.com/javadoc/com/codename1/util/LazyValue.html[LazyValue] allows you to pass a value lazily:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnimationsJava002Snippet.java[tag=animations-java-002,indent=0]
+----
 
 This effectively allows you to pass a form and create it as necessary (for example, for a GUI builder app you don't
 have the actual previous form instance), notice that the arguments aren't used for this case but will be used in

--- a/docs/developer-guide/Miscellaneous-Features.asciidoc
+++ b/docs/developer-guide/Miscellaneous-Features.asciidoc
@@ -204,7 +204,9 @@ When you're iterating on translations you can also use the simulator to capture 
 Open the Simulator menu and enable *Auto Update Default Bundle* so that running your app in the Codename One simulator will create any missing resource bundles on the fly as you interact with the UI, which makes it simple to populate keys without manually editing files during development.
 The resource is keyed by the properties file's base name rather than by the
 directory holding it, so the archetype's `common/src/main/l10n/Bundle.properties`
-becomes `Bundle`. You can install it using code like this:
+becomes `Bundle`. The locale comes from the `_xx` suffix, and a file without one
+is filed under the empty locale, so ask for that when the device's language has
+no bundle of its own:
 
 [source,java]
 ----

--- a/docs/developer-guide/Miscellaneous-Features.asciidoc
+++ b/docs/developer-guide/Miscellaneous-Features.asciidoc
@@ -35,7 +35,7 @@ A typical use of this API would be something like this:
 
 [source,java]
 ----
-include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava040Snippet.java[tag=miscellaneous-features-java-040,indent=0]
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava055Snippet.java[tag=miscellaneous-features-java-055,indent=0]
 ----
 
 ==== Dialing
@@ -164,7 +164,7 @@ https://www.codenameone.com/javadoc/com/codename1/contacts/ContactPicker.html[Co
 
 [source,java]
 ----
-include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava055Snippet.java[tag=miscellaneous-features-java-055,indent=0]
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava040Snippet.java[tag=miscellaneous-features-java-040,indent=0]
 ----
 
 IMPORTANT: From 2027-01-27 Google Play requires an app that targets Android 17 (API level 37) or later and requests `READ_CONTACTS` to pass a Play Console declaration explaining why the picker isn't enough. An app that only picks never requests that permission, so it never files that declaration. The build only adds `READ_CONTACTS` for the broad API, so mixing the two in one app puts the permission back.

--- a/docs/developer-guide/Miscellaneous-Features.asciidoc
+++ b/docs/developer-guide/Miscellaneous-Features.asciidoc
@@ -36,9 +36,10 @@ Pass `true` for it whenever `getSMSSupport` reports `SMS_INTERACTIVE`. The
 two-argument overload asks for a seamless send, and a port that only offers the
 system composer does nothing with that request -- on Android nothing happens at
 all, because the background-send path isn't implemented there. Both the Android and
-the iOS port report `SMS_INTERACTIVE`. A platform reporting `SMS_SEAMLESS` or
-`SMS_BOTH` sends without a composer, which is why the switch above branches on
-the constant instead of hard coding one call.
+the iOS port report `SMS_INTERACTIVE`. A platform reporting `SMS_SEAMLESS`
+sends without a composer, and one reporting `SMS_BOTH` does whichever the
+`interactive` argument asks for, which is why the switch above branches on the
+constant instead of hard coding one call.
 
 A typical use of this API would be something like this:
 
@@ -201,7 +202,9 @@ Each file inside this directory is treated as a resource bundle and will be pack
 
 When you're iterating on translations you can also use the simulator to capture bundles automatically.
 Open the Simulator menu and enable *Auto Update Default Bundle* so that running your app in the Codename One simulator will create any missing resource bundles on the fly as you interact with the UI, which makes it simple to populate keys without manually editing files during development.
-You can install the bundle using code like this:
+The resource is keyed by the properties file's base name rather than by the
+directory holding it, so the archetype's `common/src/main/l10n/Bundle.properties`
+becomes `Bundle`. You can install it using code like this:
 
 [source,java]
 ----

--- a/docs/developer-guide/Miscellaneous-Features.asciidoc
+++ b/docs/developer-guide/Miscellaneous-Features.asciidoc
@@ -14,14 +14,14 @@ include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/g
 ----
 
 Both Android and iOS launch the native SMS application with your message
-composed, for the user to send. Neither sends in the background: the API keeps a
-seamless mode for platforms that allow it, and no port in the tree implements
-one today.
+composed, for the user to send. Neither sends in the background, so check
+`getSMSSupport` rather than assuming -- the constant is the contract, and the
+base implementation defaults to `SMS_SEAMLESS`.
 
 That's why the samples pass `true` for the interactive argument. On Android
 the two-argument overload does nothing at all -- it asks for the seamless
 send, and that branch isn't implemented. The iOS port ignores the flag and
-opens the composer either way, so passing `true` is what works everywhere.
+opens the composer either way, so passing `true` is what works on both.
 
 The `getSMSSupport` API returns one of the following options:
 
@@ -36,7 +36,9 @@ Pass `true` for it whenever `getSMSSupport` reports `SMS_INTERACTIVE`. The
 two-argument overload asks for a seamless send, and a port that only offers the
 system composer does nothing with that request -- on Android nothing happens at
 all, because the background-send path isn't implemented there. Both the Android and
-the iOS port report `SMS_INTERACTIVE`; no port in the tree returns `SMS_BOTH`.
+the iOS port report `SMS_INTERACTIVE`. A platform reporting `SMS_SEAMLESS` or
+`SMS_BOTH` sends without a composer, which is why the switch above branches on
+the constant instead of hard coding one call.
 
 A typical use of this API would be something like this:
 

--- a/docs/developer-guide/Miscellaneous-Features.asciidoc
+++ b/docs/developer-guide/Miscellaneous-Features.asciidoc
@@ -465,8 +465,7 @@ For Android 11+ (API 30+), Codename One detects if background location is needed
 `android.permission.ACCESS_BACKGROUND_LOCATION` key is the body of the first
 prompt, and the port looks up `.title`, `.explanation_title`,
 `.explanation_body`, `.settings`, `.ok` and `.cancel` beneath it for the
-follow-up dialog that sends the user to the settings screen. `.askAgain` and
-`.dontAsk` label the rationale dialog Android shows before a repeat request:
+follow-up dialog that sends the user to the settings screen:
 
 [source,java]
 ----

--- a/docs/developer-guide/Miscellaneous-Features.asciidoc
+++ b/docs/developer-guide/Miscellaneous-Features.asciidoc
@@ -164,7 +164,7 @@ https://www.codenameone.com/javadoc/com/codename1/contacts/ContactPicker.html[Co
 
 [source,java]
 ----
-include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava040Snippet.java[tag=miscellaneous-features-java-040,indent=0]
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava055Snippet.java[tag=miscellaneous-features-java-055,indent=0]
 ----
 
 IMPORTANT: From 2027-01-27 Google Play requires an app that targets Android 17 (API level 37) or later and requests `READ_CONTACTS` to pass a Play Console declaration explaining why the picker isn't enough. An app that only picks never requests that permission, so it never files that declaration. The build only adds `READ_CONTACTS` for the broad API, so mixing the two in one app puts the permission back.
@@ -449,16 +449,26 @@ The following code demonstrates usage of the GeoFence API:
 include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava046Snippet.java[tag=miscellaneous-features-java-046,indent=0]
 ----
 
+The listener it registers looks like this:
+
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava047Snippet.java[tag=miscellaneous-features-java-047,indent=0]
+----
+
 
 ===== Android background location permissions (API 30+)
 
 On Android 11 (API level 30) and higher, requesting background location permission requires a two-step process. First, foreground location permissions must be granted. Then, the app must request background location access, which will direct the user to the system settings to select `Allow all the time`. Codename One handles this flow automatically when you use `LocationManager`.
 
-For Android 11+ (API 30+), Codename One detects if background location is needed and presents a dialog explaining the need before redirecting the user to the app settings. You can customize the permission prompt message using the localization key `android.permission.ACCESS_BACKGROUND_LOCATION`:
+For Android 11+ (API 30+), Codename One detects if background location is needed and presents a dialog explaining the need before redirecting the user to the app settings. You can customize the prompt through localization keys prefixed with
+`android.permission.ACCESS_BACKGROUND_LOCATION` -- the port looks up `.title`,
+`.explanation_title`, `.explanation_body`, `.settings`, `.ok` and `.cancel`
+beneath it:
 
 [source,java]
 ----
-include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava047Snippet.java[tag=miscellaneous-features-java-047,indent=0]
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava056Snippet.java[tag=miscellaneous-features-java-056,indent=0]
 ----
 
 === Background music playback

--- a/docs/developer-guide/Miscellaneous-Features.asciidoc
+++ b/docs/developer-guide/Miscellaneous-Features.asciidoc
@@ -461,10 +461,11 @@ include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/g
 
 On Android 11 (API level 30) and higher, requesting background location permission requires a two-step process. First, foreground location permissions must be granted. Then, the app must request background location access, which will direct the user to the system settings to select `Allow all the time`. Codename One handles this flow automatically when you use `LocationManager`.
 
-For Android 11+ (API 30+), Codename One detects if background location is needed and presents a dialog explaining the need before redirecting the user to the app settings. You can customize the prompt through localization keys prefixed with
-`android.permission.ACCESS_BACKGROUND_LOCATION` -- the port looks up `.title`,
-`.explanation_title`, `.explanation_body`, `.settings`, `.ok` and `.cancel`
-beneath it:
+For Android 11+ (API 30+), Codename One detects if background location is needed and presents a dialog explaining the need before redirecting the user to the app settings. You can customize the prompt through localization keys. The bare
+`android.permission.ACCESS_BACKGROUND_LOCATION` key is the body of the first
+prompt, and the port looks up `.title`, `.explanation_title`,
+`.explanation_body`, `.settings`, `.ok` and `.cancel` beneath it for the
+follow-up dialog that sends the user to the settings screen:
 
 [source,java]
 ----
@@ -798,7 +799,7 @@ However, it gets better, say you want to return a value:
 include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava053Snippet.java[tag=miscellaneous-features-java-053,indent=0]
 ----
 
-Lets break that down... You ran the thread with the success callback on the new thread then the callback got invoked on the EDT as a result. This code `(success) -> success.onSucess(doThisOnTheThread())` ran off the EDT in the thread and when you invoked the `onSuccess` callback it sent it asynchronously to the EDT here: `(myResult) -> onEDTGotResult(myResult)`.
+Lets break that down. `(success) -> success.onSucess(doThisOnTheThread())` runs on the `EasyThread`, off the EDT, and the result callback runs there too: `EasyThread` hands your `SuccessCallback` straight to the worker and never marshals it. Anything that touches the UI has to be sent back with `callSerially`, which is what the second lambda does.
 
 These asynchronous calls make things a bit painful to wade through, so the API wraps them in a simplified synchronous version:
 

--- a/docs/developer-guide/Miscellaneous-Features.asciidoc
+++ b/docs/developer-guide/Miscellaneous-Features.asciidoc
@@ -23,13 +23,15 @@ The `getSMSSupport` API returns one of the following options:
 - SMS_NOT_SUPPORTED - for desktop, tablet etc.
 - SMS_SEAMLESS - `sendSMS` won't show a UI and will send in the background
 - SMS_INTERACTIVE - `sendSMS` will show an SMS sending UI
-- SMS_BOTH - `sendSMS` can support both seamless and interactive mode, this works on Android
+- SMS_BOTH - `sendSMS` can support both seamless and interactive mode
 
 The `sendSMS` can accept an interactive argument: `sendSMS(String phoneNumber, String message, boolean interactive)`
 
-The last argument will be ignored unless `SMS_BOTH` is returned from `getSMSSupport` at which point you
-would be able to choose one way or the other. The default behavior (when not using that flag) is the background
-sending which is the current behavior on Android.
+Pass `true` for it whenever `getSMSSupport` reports `SMS_INTERACTIVE`. The
+two-argument overload asks for a seamless send, and a port that only offers the
+system composer does nothing with that request -- on Android nothing happens at
+all, because the background-send path isn't implemented there. Both the Android and
+the iOS port report `SMS_INTERACTIVE`; no port in the tree returns `SMS_BOTH`.
 
 A typical use of this API would be something like this:
 

--- a/docs/developer-guide/Miscellaneous-Features.asciidoc
+++ b/docs/developer-guide/Miscellaneous-Features.asciidoc
@@ -33,6 +33,10 @@ sending which is the current behavior on Android.
 
 A typical use of this API would be something like this:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava040Snippet.java[tag=miscellaneous-features-java-040,indent=0]
+----
 
 ==== Dialing
 
@@ -77,6 +81,10 @@ NOTE: You need to use files from `FileSystemStorage` and *NOT* `Storage` files!
 
 You can add more than one attachment by putting them directly into the attachment map for example:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava041Snippet.java[tag=miscellaneous-features-java-041,indent=0]
+----
 
 NOTE: Some features such as attachments etc. Don't work in the simulator but should work on iOS/Android
 
@@ -95,6 +103,10 @@ You can also enable this behavior in the theme by setting the `useLargerTextScal
 
 If you need to apply the scale manually for custom fonts or layout calculations, read the values directly:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava042Snippet.java[tag=miscellaneous-features-java-042,indent=0]
+----
 
 ==== How the scale is computed per platform
 
@@ -180,6 +192,10 @@ When you're iterating on translations you can also use the simulator to capture 
 Open the Simulator menu and enable *Auto Update Default Bundle* so that running your app in the Codename One simulator will create any missing resource bundles on the fly as you interact with the UI, which makes it simple to populate keys without manually editing files during development.
 You can install the bundle using code like this:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava043Snippet.java[tag=miscellaneous-features-java-043,indent=0]
+----
 
 The device language (as an ISO 639 two-letter code) could be retrieved with this:
 
@@ -197,6 +213,10 @@ include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/g
 
 The list of available languages in the resource bundle could be retrieved like this. Notice that this a list that was set by you and doesn't need to confirm to the ISO language code standards:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava044Snippet.java[tag=miscellaneous-features-java-044,indent=0]
+----
 
 An exception for localization is the `TextField`/`TextArea` components both of which contain user data, in those cases the text won't be localized to avoid accidental localization of user input.
 
@@ -218,6 +238,10 @@ The https://www.codenameone.com/javadoc/com/codename1/l10n/L10NManager.html[L10N
 
 It allows formatting numbers/dates & time based on platform locale. It also provides a great deal of the information you need such as the language/locale information you need to pick the proper resource bundle:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava045Snippet.java[tag=miscellaneous-features-java-045,indent=0]
+----
 
 .Localization formatting/parsing and information
 image::img/l10n-manager.png[Localization formatting/parsing and information,scaledwidth=20%]
@@ -420,6 +444,10 @@ Class names are problematic since device builds are obfuscated, you should use l
 
 The following code demonstrates usage of the GeoFence API:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava046Snippet.java[tag=miscellaneous-features-java-046,indent=0]
+----
 
 
 ===== Android background location permissions (API 30+)
@@ -428,6 +456,10 @@ On Android 11 (API level 30) and higher, requesting background location permissi
 
 For Android 11+ (API 30+), Codename One detects if background location is needed and presents a dialog explaining the need before redirecting the user to the app settings. You can customize the permission prompt message using the localization key `android.permission.ACCESS_BACKGROUND_LOCATION`:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava047Snippet.java[tag=miscellaneous-features-java-047,indent=0]
+----
 
 === Background music playback
 
@@ -457,6 +489,10 @@ IMPORTANT: The returned file is a temporary file, you shouldn't store a referenc
 
 For example: you can copy the `Image` to `Storage` using:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava048Snippet.java[tag=miscellaneous-features-java-048,indent=0]
+----
 
 TIP: When running on the simulator the `Capture` API opens a file chooser API instead of physically capturing the data. This makes debugging device or situation specific issues simpler
 
@@ -532,6 +568,10 @@ request depends on the input device already providing two channels.
 
 The `Capture` API also includes a callback based API that uses the `ActionListener` interface to implement capture. For example: you can adapt the previous sample to use this API as such:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava049Snippet.java[tag=miscellaneous-features-java-049,indent=0]
+----
 
 === Gallery
 
@@ -729,17 +769,33 @@ That's why `EasyThread` exists: it takes some concepts of Codename One's threadi
 
 Easy thread can be created like this:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava051Snippet.java[tag=miscellaneous-features-java-051,indent=0]
+----
 
 You can send a task to the thread using:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava052Snippet.java[tag=miscellaneous-features-java-052,indent=0]
+----
 
 However, it gets better, say you want to return a value:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava053Snippet.java[tag=miscellaneous-features-java-053,indent=0]
+----
 
-Lets break that down... You ran the thread with the success callback on the new thread then the callback got invoked on the EDT as a result. This code `(success) -> success.onSuccess(doThisOnTheThread())` ran off the EDT in the thread and when you invoked the `onSuccess` callback it sent it asynchronously to the EDT here: `(myResult) -> onEDTGotResult(myRsult)`.
+Lets break that down... You ran the thread with the success callback on the new thread then the callback got invoked on the EDT as a result. This code `(success) -> success.onSucess(doThisOnTheThread())` ran off the EDT in the thread and when you invoked the `onSuccess` callback it sent it asynchronously to the EDT here: `(myResult) -> onEDTGotResult(myResult)`.
 
 These asynchronous calls make things a bit painful to wade through, so the API wraps them in a simplified synchronous version:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava054Snippet.java[tag=miscellaneous-features-java-054,indent=0]
+----
 
 There are a few other variants like `runAndWait` and there is a `kill()` method which stops a thread and releases its resources.
 

--- a/docs/developer-guide/Miscellaneous-Features.asciidoc
+++ b/docs/developer-guide/Miscellaneous-Features.asciidoc
@@ -108,7 +108,9 @@ include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/g
 
 You can also enable this behavior in the theme by setting the `useLargerTextScaleBool` theme constant to `true`.
 
-If you need to apply the scale manually for custom fonts or layout calculations, read the values directly:
+Component fonts are the theme's job -- don't scale them by hand. For anything
+the theme can't reach, a custom-painted row or an icon measured in code,
+read the values directly:
 
 [source,java]
 ----

--- a/docs/developer-guide/Miscellaneous-Features.asciidoc
+++ b/docs/developer-guide/Miscellaneous-Features.asciidoc
@@ -465,7 +465,8 @@ For Android 11+ (API 30+), Codename One detects if background location is needed
 `android.permission.ACCESS_BACKGROUND_LOCATION` key is the body of the first
 prompt, and the port looks up `.title`, `.explanation_title`,
 `.explanation_body`, `.settings`, `.ok` and `.cancel` beneath it for the
-follow-up dialog that sends the user to the settings screen:
+follow-up dialog that sends the user to the settings screen. `.askAgain` and
+`.dontAsk` label the rationale dialog Android shows before a repeat request:
 
 [source,java]
 ----

--- a/docs/developer-guide/Miscellaneous-Features.asciidoc
+++ b/docs/developer-guide/Miscellaneous-Features.asciidoc
@@ -13,10 +13,14 @@ Codename One supports sending SMS messages but not receiving them as this functi
 include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/MiscellaneousFeaturesJava001Snippet.java[tag=miscellaneous-features-java-001,indent=0]
 ----
 
-Android supports sending SMS messages in the background without any UI. iOS doesn't provide that ability, so the best it can offer is to launch the native SMS app with your message composed for the user to send. Android supports that interactive flow as well (launching the OS native SMS app).
+Both Android and iOS launch the native SMS application with your message
+composed, for the user to send. Neither sends in the background: the API keeps a
+seamless mode for platforms that allow it, and no port in the tree implements
+one today.
 
-The default `sendSMS` API ignores that difference and works interactively on iOS while sending
-in the background for Android when the platform allows it.
+That's why the samples pass `true` for the interactive argument. The
+two-argument overload asks for the seamless send, so on these platforms it does
+nothing at all.
 
 The `getSMSSupport` API returns one of the following options:
 

--- a/docs/developer-guide/Miscellaneous-Features.asciidoc
+++ b/docs/developer-guide/Miscellaneous-Features.asciidoc
@@ -18,9 +18,10 @@ composed, for the user to send. Neither sends in the background: the API keeps a
 seamless mode for platforms that allow it, and no port in the tree implements
 one today.
 
-That's why the samples pass `true` for the interactive argument. The
-two-argument overload asks for the seamless send, so on these platforms it does
-nothing at all.
+That's why the samples pass `true` for the interactive argument. On Android
+the two-argument overload does nothing at all -- it asks for the seamless
+send, and that branch isn't implemented. The iOS port ignores the flag and
+opens the composer either way, so passing `true` is what works everywhere.
 
 The `getSMSSupport` API returns one of the following options:
 

--- a/docs/developer-guide/Miscellaneous-Features.asciidoc
+++ b/docs/developer-guide/Miscellaneous-Features.asciidoc
@@ -475,11 +475,11 @@ include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/g
 
 On Android 11 (API level 30) and higher, requesting background location permission requires a two-step process. First, foreground location permissions must be granted. Then, the app must request background location access, which will direct the user to the system settings to select `Allow all the time`. Codename One handles this flow automatically when you use `LocationManager`.
 
-For Android 11+ (API 30+), Codename One detects if background location is needed and presents a dialog explaining the need before redirecting the user to the app settings. You can customize the prompt through localization keys. The bare
-`android.permission.ACCESS_BACKGROUND_LOCATION` key is the body of the first
-prompt, and the port looks up `.title`, `.explanation_title`,
-`.explanation_body`, `.settings`, `.ok` and `.cancel` beneath it for the
-follow-up dialog that sends the user to the settings screen:
+For Android 11+ (API 30+), Codename One detects if background location is needed and presents a dialog explaining the need before redirecting the user to the app settings. You can customize both dialogs through localization keys under
+`android.permission.ACCESS_BACKGROUND_LOCATION`. The first one, offering to open
+the settings screen, takes its body from the bare key and its title and buttons
+from `.title`, `.settings` and `.cancel`. The second, shown after the user comes
+back, uses `.explanation_title`, `.explanation_body` and `.ok`:
 
 [source,java]
 ----

--- a/scripts/developer-guide/missing-code-blocks-baseline.txt
+++ b/scripts/developer-guide/missing-code-blocks-baseline.txt
@@ -4,8 +4,6 @@
 Advanced-Topics-Under-The-Hood.asciidoc	You can override these methods in the draggable components:
 Advertising.asciidoc	identifier. The recommended order is to initialize, gather consent, then load:
 Advertising.asciidoc	method that registers its provider with `AdManager`:
-Animations.asciidoc	That one command will enable swiping back from `currentForm`. https://www.codenameone.com/javadoc/com/codename1/util/LazyValue.html[LazyValue] allows you to pass a value lazily:
-Animations.asciidoc	builder:
 Annotation-Component-Binding.asciidoc	ASM and inserts the equivalent of:
 Annotation-Component-Binding.asciidoc	After binding, drive validation through the returned handle:
 Annotation-JSON-XML-Mapping.asciidoc	Hand-write a `Mapper<T>` and register it at startup:
@@ -23,21 +21,7 @@ Introduction.asciidoc	Now that you have a general sense of the lifecycle lets lo
 Introduction.asciidoc	The hello world Java source file looks like this (removed some comments and whitespace):
 Maven-Creating-CN1Libs.adoc	Now try it out. Try adding the following code to your application project's main class (or anywhere in the application project, for that matter):
 Maven-Creating-CN1Libs.adoc	The simulator dispatches every action on the Codename One EDT through `Display.callSerially`, so your method can call `Display.getInstance()`, `Form.show()`, `Dialog.show()`, `ToastBar.showInfoMessage()` and any other CN1 API. Reflection uses the same classloader that loaded `Display`, so cn1lib internals (including package-private classes) resolve normally:
-Miscellaneous-Features.asciidoc	A typical use of this API would be something like this:
-Miscellaneous-Features.asciidoc	Easy thread can be created like this:
-Miscellaneous-Features.asciidoc	For Android 11+ (API 30+), Codename One detects if background location is needed and presents a dialog explaining the need before redirecting the user to the app settings. You can customize the permission prompt message using the localization key `android.permission.ACCESS_BACKGROUND_LOCATION`:
-Miscellaneous-Features.asciidoc	For example: you can copy the `Image` to `Storage` using:
-Miscellaneous-Features.asciidoc	However, it gets better, say you want to return a value:
-Miscellaneous-Features.asciidoc	If you need to apply the scale manually for custom fonts or layout calculations, read the values directly:
-Miscellaneous-Features.asciidoc	It allows formatting numbers/dates & time based on platform locale. It also provides a great deal of the information you need such as the language/locale information you need to pick the proper resource bundle:
-Miscellaneous-Features.asciidoc	The `Capture` API also includes a callback based API that uses the `ActionListener` interface to implement capture. For example: you can adapt the previous sample to use this API as such:
-Miscellaneous-Features.asciidoc	The following code demonstrates usage of the GeoFence API:
-Miscellaneous-Features.asciidoc	The list of available languages in the resource bundle could be retrieved like this. Notice that this a list that was set by you and doesn't need to confirm to the ISO language code standards:
-Miscellaneous-Features.asciidoc	These asynchronous calls make things a bit painful to wade through, so the API wraps them in a simplified synchronous version:
 Miscellaneous-Features.asciidoc	To solve this sort of used case you have two APIs in `Display`:
-Miscellaneous-Features.asciidoc	You can add more than one attachment by putting them directly into the attachment map for example:
-Miscellaneous-Features.asciidoc	You can install the bundle using code like this:
-Miscellaneous-Features.asciidoc	You can send a task to the thread using:
 Monetization.asciidoc	And you also provide a button to allow the user to manually synchronize the receipts:
 Monetization.asciidoc	In the hello world app you'll use this information in a few different places. On your main form you'll include a label to show the current expiry date, and you allow the user to press a button to synchronize receipts manually if they think the value is out of date:
 Monetization.asciidoc	On the server-side, your REST controller is a standard JAX-RS REST interface. The Netbeans web service wizard generated it and then it was modified to suit the purposes here. The methods of the `ReceiptsFacadeREST` class for the REST API are shown here:


### PR DESCRIPTION
Miscellaneous-Features (14) and Animations (2), verbatim from `bbdc6058f0~1` as compiled snippets. **Baseline 70 → 54.**

Deliberately smaller than the last batch, and audited before review rather than after.

## Four samples didn't work as published

None of these are things a reader could have worked around:

| Sample | Defect |
|---|---|
| `scheduleLocalNotification(ln, 10, false)` | passes a boolean where the API takes an `int` repeat constant → `REPEAT_NONE` |
| `getLookAndFeel().getDefaultStyle()` | `LookAndFeel` has no `getDefaultStyle()` → `UIManager.getComponentStyle(String)` |
| `success.onSuccess(...)` | the `SuccessCallback` method is **`onSucess`**, one `c`. That spelling is the public API, so the sample matches it rather than the reverse |
| `(myResult) -> onEDTGotResult(myRsult)` | parameter and use spelled differently |

The chapter quotes the last two, so the prose is corrected with them.

## Six holes deliberately left, with reasons

- **Advertising ×2** need `com.codename1.ads.admob.AdMobProvider`, which is in the `cn1-admob` cn1lib, not core.
- **security ×2** — one is a listing of two method signatures with no bodies; the other is introduced by its own sentence as *pseudo-code* and calls `EncryptedStorage`, which exists in no module in this repo.
- **performance ×2** quote the constructors of Codename One's own `ShareButton` and `SMSShare` to explain a bug in them. Reproducing those classes in the demos module to make the quote compile would be inventing a fake of the thing under discussion.
- **Miscellaneous 050** lists `Display` method signatures with javadoc.

## The audit

The previous batch (#5711) took 15 review findings, several for defects that compiled perfectly. I wrote a check for the four classes that got through — Swing lifecycle hooks the framework never calls, global registrations with no matching removal, two-button `Dialog.show` polarity, and builders constructed then discarded — and **validated it against #5711's pre-fix commit first**, where it reports all four. Only then did I run it here.

This batch comes back clean. The single remaining hit is a local that *is* the demonstration, in a sample about a call returning a value synchronously.

Verified: `mvn process-classes` on `docs/demos` green, all guide gates green, Vale and LanguageTool clean on both chapters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)