### PR TITLE
Developer guide: restore 12 more code examples, and record why four cannot be

### DIFF
--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnnotationComponentBindingJava001Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnnotationComponentBindingJava001Snippet.java
@@ -102,8 +102,10 @@ class AnnotationComponentBindingJava001Snippet {
               getter = "computeFullName",
               setter = "applyFullName")                                           // <3>
         private String fullName;
-        public String computeFullName()      { return fullName.toUpperCase(); }
-        public void   applyFullName(String f){ this.fullName = f.trim(); }
+        // both run during the initial bind, against a model that may still be
+        // empty, so neither can assume a value is present
+        public String computeFullName()      { return fullName == null ? "" : fullName.toUpperCase(); }
+        public void   applyFullName(String f){ this.fullName = f == null ? null : f.trim(); }
     }
     // end::annotation-component-binding-java-001[]
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnnotationComponentBindingJava001Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnnotationComponentBindingJava001Snippet.java
@@ -51,6 +51,7 @@ import com.codename1.security.*;
 import com.codename1.social.*;
 import com.codename1.ui.spinner.*;
 import java.io.*;
+import com.codename1.annotations.Required;
 import java.util.*;
 import com.codename1.annotations.*;
 import com.codename1.binding.BindAttr;
@@ -85,6 +86,7 @@ class AnnotationComponentBindingJava001Snippet {
     public class LoginModel {
 
         @Bind(name = "userField", attr = BindAttr.TEXT)
+        @Required
         private String user;
         public String getUser()              { return user; }
         public void   setUser(String u)      { this.user = u; }                  // <1>

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnnotationComponentBindingJava002Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnnotationComponentBindingJava002Snippet.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.binding.*;
+import java.util.*;
+import com.codename1.annotations.*;
+import com.codename1.binding.BindAttr;
+import com.codename1.properties.Property;
+
+class AnnotationComponentBindingJava002Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    // tag::annotation-component-binding-java-002[]
+    public void setName(String name) {
+        this.name = name;
+        com.codename1.binding.Binders.notifyChanged(this);   // injected
+    }
+    // end::annotation-component-binding-java-002[]
+
+    private String name;
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnnotationComponentBindingJava003Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnnotationComponentBindingJava003Snippet.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.ui.validation.Validator;
+import com.codename1.binding.*;
+import java.util.*;
+import com.codename1.annotations.*;
+import com.codename1.binding.BindAttr;
+import com.codename1.properties.Property;
+
+class AnnotationComponentBindingJava003Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::annotation-component-binding-java-003[]
+        LoginModel model = new LoginModel();
+        Binding b = Binders.bind(model, form);
+
+        // Auto-disable a submit button until everything is valid. Pass the
+        // button you built the form with: Container has no lookup by name.
+        b.getValidator().addSubmitButtons(submitButton);
+
+        // Live feedback as the user types (static toggle on the Validator
+        // class -- one switch flips the behaviour for every validator in the
+        // app):
+        Validator.setValidateOnEveryKey(true);
+
+        // Programmatic gate before saving:
+        if (b.getValidator().isValid()) {
+            repository.save(model);
+        }
+        // end::annotation-component-binding-java-003[]
+    }
+
+    static class LoginModel { }
+
+
+    Button submitButton = new Button("Submit");
+
+    static class Repository { void save(LoginModel m) { } }
+    Repository repository = new Repository();
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnnotationComponentBindingJava003Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnnotationComponentBindingJava003Snippet.java
@@ -86,17 +86,16 @@ class AnnotationComponentBindingJava003Snippet {
     
     void snippet() throws Exception {
         // tag::annotation-component-binding-java-003[]
+        // set this first: bind() attaches the constraints, and each one picks a
+        // data-change or an action listener from this flag as it attaches
+        Validator.setValidateOnEveryKey(true);
+
         LoginModel model = new LoginModel();
         Binding b = Binders.bind(model, form);
 
         // Auto-disable a submit button until everything is valid. Pass the
         // button you built the form with: Container has no lookup by name.
         b.getValidator().addSubmitButtons(submitButton);
-
-        // Live feedback as the user types (static toggle on the Validator
-        // class -- one switch flips the behaviour for every validator in the
-        // app):
-        Validator.setValidateOnEveryKey(true);
 
         // Programmatic gate before saving:
         if (b.getValidator().isValid()) {

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnnotationJsonXmlMappingJava002Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnnotationJsonXmlMappingJava002Snippet.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.mapping.*;
+import com.codename1.xml.*;
+import java.util.*;
+import com.codename1.annotations.*;
+import com.codename1.properties.*;
+
+class AnnotationJsonXmlMappingJava002Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    // tag::annotation-json-xml-mapping-java-002[]
+    @Mapped
+    public class Item implements PropertyBusinessObject {
+        public final Property<String, Item>  name = new Property<>("name");
+        public final Property<Integer, Item> qty  = new Property<>("qty");
+
+        private final PropertyIndex idx =
+                new PropertyIndex(this, "Item", name, qty);
+
+        public PropertyIndex getPropertyIndex() { return idx; }
+
+        public Item() { }
+    }
+    // end::annotation-json-xml-mapping-java-002[]
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CrashProtectionJava001Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CrashProtectionJava001Snippet.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.crash.*;
+import java.util.*;
+
+
+class CrashProtectionJava001Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    // tag::crash-protection-java-001[]
+    public void init(Object context) {
+        CrashProtection.install();
+        CrashProtection.setEnabled(true);  // default is false; user-controlled opt-in
+    }
+    // end::crash-protection-java-001[]
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CrashProtectionJava001Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CrashProtectionJava001Snippet.java
@@ -83,8 +83,16 @@ class CrashProtectionJava001Snippet {
     
     // tag::crash-protection-java-001[]
     public void init(Object context) {
+        // install() only registers the handler; nothing is sent while the
+        // service is disabled, and disabled is the default
         CrashProtection.install();
-        CrashProtection.setEnabled(true);  // default is false; user-controlled opt-in
+    }
+
+    /// Call this from the flow where the user agrees to send crash reports.
+    /// Doing it in init() would opt every user in on each launch, drain the
+    /// buffered reports, and undo an opt-out they had already made.
+    void onUserAcceptedCrashReporting() {
+        CrashProtection.setEnabled(true);
     }
     // end::crash-protection-java-001[]
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CrashProtectionJava001Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CrashProtectionJava001Snippet.java
@@ -55,7 +55,7 @@ import com.codename1.crash.*;
 import java.util.*;
 
 
-class CrashProtectionJava001Snippet {
+class CrashProtectionJava001Snippet extends com.codename1.system.Lifecycle {
 
 
     Object context;
@@ -83,6 +83,10 @@ class CrashProtectionJava001Snippet {
     
     // tag::crash-protection-java-001[]
     public void init(Object context) {
+        // Lifecycle.init sets the theme, the global Toolbar, the network thread
+        // count and the network error listener, so an override that skips it
+        // loses all of that
+        super.init(context);
         // install() only registers the handler; nothing is sent while the
         // service is disabled, and disabled is the default
         CrashProtection.install();

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NetworkConnectivityJava010Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NetworkConnectivityJava010Snippet.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.io.bonjour.*;
+import com.codename1.io.wifi.*;
+import java.util.*;
+import com.codename1.io.wifi.WiFi;
+
+class NetworkConnectivityJava010Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::network-connectivity-java-010[]
+        WiFi.connect("MyAccessPoint", "s3cret!", WiFiSecurity.WPA_PSK,
+                new WiFiConnectCallback() {
+            @Override
+            public void onConnectResult(boolean connected, Throwable error) {
+                if (!connected) {
+                    Log.e(error);
+                    return;
+                }
+                // ssid is now joined
+            }
+        });
+        // end::network-connectivity-java-010[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NetworkConnectivityJava011Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NetworkConnectivityJava011Snippet.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.io.bonjour.*;
+import com.codename1.io.wifi.*;
+import java.util.*;
+import com.codename1.io.wifi.WiFi;
+
+class NetworkConnectivityJava011Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::network-connectivity-java-011[]
+        BonjourPublisher pub = BonjourPublisher.publish(
+                "My Server", "_http._tcp.", 8080, null);
+
+        // later:
+        pub.unpublish();
+        // end::network-connectivity-java-011[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NotificationsAndBackgroundExecutionJava002Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NotificationsAndBackgroundExecutionJava002Snippet.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.background.*;
+import com.codename1.system.*;
+import com.codename1.share.*;
+import com.codename1.notifications.*;
+import java.util.*;
+import com.codename1.notifications.NotificationPermissionRequest;
+import com.codename1.notifications.NotificationPermissionResult.AuthorizationLevel;
+
+class NotificationsAndBackgroundExecutionJava002Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::notifications-and-background-execution-java-002[]
+        LocalNotification n = new LocalNotification()
+                .setChannelId("messages")                 // Android channel (see below)
+                .setGroup("chat-42")                       // bundle related notifications
+                .setProgress(100, 40)                      // determinate progress bar (Android)
+                .setTimeSensitive(true);                   // break through Focus / elevated importance
+        n.setId("msg-42");
+        n.setAlertTitle("New message");
+        n.setAlertBody("Tap to reply");
+        n.addAction("open", "Open");
+        n.addInputAction("reply", "Reply", "Type a message", "Send");  // inline quick reply
+        Display.getInstance().scheduleLocalNotification(n, System.currentTimeMillis() + 1000,
+                LocalNotification.REPEAT_NONE);
+        // end::notifications-and-background-execution-java-002[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NotificationsAndBackgroundExecutionJava003Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NotificationsAndBackgroundExecutionJava003Snippet.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.background.*;
+import com.codename1.system.*;
+import com.codename1.share.*;
+import com.codename1.notifications.*;
+import java.util.*;
+import com.codename1.notifications.NotificationPermissionRequest;
+import com.codename1.notifications.NotificationPermissionResult.AuthorizationLevel;
+
+class NotificationsAndBackgroundExecutionJava003Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::notifications-and-background-execution-java-003[]
+        new NotificationChannelBuilder("messages", "Messages")
+                .description("Incoming chat messages")
+                .importance(NotificationChannelBuilder.IMPORTANCE_HIGH)
+                .sound("/notification_sound_ping.mp3")
+                .enableVibration(true)
+                .lightColor(0xff0000)
+                .register();
+        // end::notifications-and-background-execution-java-003[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NotificationsAndBackgroundExecutionJava004Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NotificationsAndBackgroundExecutionJava004Snippet.java
@@ -96,16 +96,19 @@ class NotificationsAndBackgroundExecutionJava004Snippet {
             // was scheduled with, because no foreground state survives
             String account = inputData.get("account");
             boolean ok = account != null;
-            // TRUE for done, FALSE to ask the platform to retry later
+            // TRUE for done. FALSE asks for a retry on Android; the iOS port
+            // ignores the value, so do not rely on it to recover from failure
             onComplete.onSucess(Boolean.valueOf(ok));
         }
     }
 
     void scheduleSync() {
-        // on iOS the id has to be one of the permitted identifiers, so either
-        // use the default the build injects or declare your own with the
-        // ios.backgroundProcessingIds build hint
-        WorkRequest req = WorkRequest.builder("com.example.myapp.processing", SyncWorker.class)
+        // on iOS the id must appear in BGTaskSchedulerPermittedIdentifiers. The
+        // build injects <packageName>.processing by default, so deriving it
+        // from the package matches whatever this app is called; declare any
+        // other id with the ios.backgroundProcessingIds build hint
+        String taskId = Display.getInstance().getProperty("package_name", "") + ".processing";
+        WorkRequest req = WorkRequest.builder(taskId, SyncWorker.class)
                 .setRequiresNetwork(true)
                 .setRequiresCharging(true)
                 .setPeriodic(6 * 60 * 60 * 1000L)

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NotificationsAndBackgroundExecutionJava004Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NotificationsAndBackgroundExecutionJava004Snippet.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.background.*;
+import com.codename1.system.*;
+import com.codename1.share.*;
+import com.codename1.notifications.*;
+import java.util.*;
+import com.codename1.notifications.NotificationPermissionRequest;
+import com.codename1.notifications.NotificationPermissionResult.AuthorizationLevel;
+
+class NotificationsAndBackgroundExecutionJava004Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::notifications-and-background-execution-java-004[]
+        WorkRequest req = WorkRequest.builder("sync", SyncWorker.class)
+                .setRequiresNetwork(true)
+                .setRequiresCharging(true)
+                .setPeriodic(6 * 60 * 60 * 1000L)
+                .putInputData("account", "primary")
+                .build();
+        BackgroundWork.schedule(req);
+        // end::notifications-and-background-execution-java-004[]
+    }
+
+    static class SyncWorker implements com.codename1.background.BackgroundWorker {
+        public void performWork(String id, java.util.Map<String, String> inputData,
+                long deadline, com.codename1.util.Callback<Boolean> done) { }
+    }
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NotificationsAndBackgroundExecutionJava004Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NotificationsAndBackgroundExecutionJava004Snippet.java
@@ -103,10 +103,9 @@ class NotificationsAndBackgroundExecutionJava004Snippet {
     }
 
     void scheduleSync() {
-        // on iOS the id must appear in BGTaskSchedulerPermittedIdentifiers. The
-        // build injects <packageName>.processing by default, so deriving it
-        // from the package matches whatever this app is called; declare any
-        // other id with the ios.backgroundProcessingIds build hint
+        // on iOS the id must appear in BGTaskSchedulerPermittedIdentifiers, and
+        // it gets there only if you ask: ios.usesBackgroundProcessing=true
+        // declares <packageName>.processing, which is what this derives
         String taskId = Display.getInstance().getProperty("package_name", "") + ".processing";
         WorkRequest req = WorkRequest.builder(taskId, SyncWorker.class)
                 .setRequiresNetwork(true)

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NotificationsAndBackgroundExecutionJava004Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NotificationsAndBackgroundExecutionJava004Snippet.java
@@ -92,7 +92,10 @@ class NotificationsAndBackgroundExecutionJava004Snippet {
     public static class SyncWorker implements BackgroundWorker {
         public void performWork(String id, java.util.Map<String, String> inputData,
                 long deadline, com.codename1.util.Callback<Boolean> onComplete) {
-            boolean ok = sync(inputData.get("account"));
+            // the real work goes here; inputData carries whatever the request
+            // was scheduled with, because no foreground state survives
+            String account = inputData.get("account");
+            boolean ok = account != null;
             // TRUE for done, FALSE to ask the platform to retry later
             onComplete.onSucess(Boolean.valueOf(ok));
         }
@@ -110,7 +113,5 @@ class NotificationsAndBackgroundExecutionJava004Snippet {
     // end::notifications-and-background-execution-java-004[]
 
 
-
-    static boolean sync(String account) { return true; }
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NotificationsAndBackgroundExecutionJava004Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NotificationsAndBackgroundExecutionJava004Snippet.java
@@ -102,7 +102,10 @@ class NotificationsAndBackgroundExecutionJava004Snippet {
     }
 
     void scheduleSync() {
-        WorkRequest req = WorkRequest.builder("sync", SyncWorker.class)
+        // on iOS the id has to be one of the permitted identifiers, so either
+        // use the default the build injects or declare your own with the
+        // ios.backgroundProcessingIds build hint
+        WorkRequest req = WorkRequest.builder("com.example.myapp.processing", SyncWorker.class)
                 .setRequiresNetwork(true)
                 .setRequiresCharging(true)
                 .setPeriodic(6 * 60 * 60 * 1000L)

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NotificationsAndBackgroundExecutionJava004Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NotificationsAndBackgroundExecutionJava004Snippet.java
@@ -85,8 +85,20 @@ class NotificationsAndBackgroundExecutionJava004Snippet {
     BrowserComponent browserComponent;
     Resources theme;
     
-    void snippet() throws Exception {
-        // tag::notifications-and-background-execution-java-004[]
+    // tag::notifications-and-background-execution-java-004[]
+    /// The platform may rebuild this after the app process was killed, so it
+    /// needs a public no-argument constructor and can rely on nothing from the
+    /// foreground app -- state arrives through the input data.
+    public static class SyncWorker implements BackgroundWorker {
+        public void performWork(String id, java.util.Map<String, String> inputData,
+                long deadline, com.codename1.util.Callback<Boolean> onComplete) {
+            boolean ok = sync(inputData.get("account"));
+            // TRUE for done, FALSE to ask the platform to retry later
+            onComplete.onSucess(Boolean.valueOf(ok));
+        }
+    }
+
+    void scheduleSync() {
         WorkRequest req = WorkRequest.builder("sync", SyncWorker.class)
                 .setRequiresNetwork(true)
                 .setRequiresCharging(true)
@@ -94,12 +106,11 @@ class NotificationsAndBackgroundExecutionJava004Snippet {
                 .putInputData("account", "primary")
                 .build();
         BackgroundWork.schedule(req);
-        // end::notifications-and-background-execution-java-004[]
     }
+    // end::notifications-and-background-execution-java-004[]
 
-    static class SyncWorker implements com.codename1.background.BackgroundWorker {
-        public void performWork(String id, java.util.Map<String, String> inputData,
-                long deadline, com.codename1.util.Callback<Boolean> done) { }
-    }
+
+
+    static boolean sync(String account) { return true; }
 
 }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NotificationsAndBackgroundExecutionJava005Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NotificationsAndBackgroundExecutionJava005Snippet.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.background.*;
+import com.codename1.system.*;
+import com.codename1.share.*;
+import com.codename1.notifications.*;
+import java.util.*;
+import com.codename1.notifications.NotificationPermissionRequest;
+import com.codename1.notifications.NotificationPermissionResult.AuthorizationLevel;
+
+class NotificationsAndBackgroundExecutionJava005Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::notifications-and-background-execution-java-005[]
+        ForegroundService svc = ForegroundService.start("downloads", "Downloading", "Please wait",
+                null, service -> {
+                    for (int i = 0; i <= 100; i++) {
+                        service.updateNotification("Downloading", i + "%");
+                        // ... do a chunk of work ...
+                    }
+                });
+        // auto-stops when the task returns, or call svc.stop()
+        // end::notifications-and-background-execution-java-005[]
+    }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NotificationsAndBackgroundExecutionJava006Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NotificationsAndBackgroundExecutionJava006Snippet.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.background.*;
+import com.codename1.system.*;
+import com.codename1.share.*;
+import com.codename1.notifications.*;
+import java.util.*;
+import com.codename1.notifications.NotificationPermissionRequest;
+import com.codename1.notifications.NotificationPermissionResult.AuthorizationLevel;
+
+class NotificationsAndBackgroundExecutionJava006Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    // tag::notifications-and-background-execution-java-006[]
+    public class MyApp extends Lifecycle {
+        public void onReceivedSharedContent(SharedContent content) {
+            for (SharedContent.Item item : content.getItems()) {
+                if (item.getType() == SharedContent.TYPE_IMAGE) {
+                    importImage(item.getFilePath()); // a FileSystemStorage path
+                }
+            }
+        }
+    }
+    // end::notifications-and-background-execution-java-006[]
+
+    void importImage(String path) { }
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NotificationsAndBackgroundExecutionJava006Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NotificationsAndBackgroundExecutionJava006Snippet.java
@@ -90,7 +90,8 @@ class NotificationsAndBackgroundExecutionJava006Snippet {
         public void onReceivedSharedContent(SharedContent content) {
             for (SharedContent.Item item : content.getItems()) {
                 if (item.getType() == SharedContent.TYPE_IMAGE) {
-                    importImage(item.getFilePath()); // a FileSystemStorage path
+                    // your own import; the path is a FileSystemStorage path
+                    importImage(item.getFilePath());
                 }
             }
         }

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PrintingJava001Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PrintingJava001Snippet.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.printing.*;
+import java.util.*;
+
+
+class PrintingJava001Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    
+    void snippet() throws Exception {
+        // tag::printing-java-001[]
+        Image chart = renderChart();
+        Printer.printImage(chart, result -> {
+            if (result.isFailed()) {
+                ToastBar.showErrorMessage("Print failed: " + result.getError());
+            }
+        });
+        // end::printing-java-001[]
+    }
+
+    Image renderChart() { return null; }
+
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PrintingJava001Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PrintingJava001Snippet.java
@@ -83,7 +83,7 @@ class PrintingJava001Snippet {
     
     void snippet() throws Exception {
         // tag::printing-java-001[]
-        Image chart = renderChart();
+        Image chart = renderChart();   // your own drawing code
         Printer.printImage(chart, result -> {
             if (result.isFailed()) {
                 ToastBar.showErrorMessage("Print failed: " + result.getError());

--- a/docs/developer-guide/Annotation-Component-Binding.asciidoc
+++ b/docs/developer-guide/Annotation-Component-Binding.asciidoc
@@ -109,6 +109,10 @@ For every two-way `@Bind` field whose write accessor is a method
 `cn1:process-annotations` Mojo reads the original `.class` file with
 ASM and inserts the equivalent of:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnnotationComponentBindingJava002Snippet.java[tag=annotation-component-binding-java-002,indent=0]
+----
 
 The injection lands before every `return` point of the setter. The
 instrumented setter is written back to `target/classes`, replacing the
@@ -165,6 +169,10 @@ Multiple annotations on the same field are combined into a
 
 After binding, drive validation through the returned handle:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnnotationComponentBindingJava003Snippet.java[tag=annotation-component-binding-java-003,indent=0]
+----
 
 `Binding#getValidator()` never returns `null` -- when the model has no
 validation annotations the validator is empty and `isValid()` returns

--- a/docs/developer-guide/Annotation-JSON-XML-Mapping.asciidoc
+++ b/docs/developer-guide/Annotation-JSON-XML-Mapping.asciidoc
@@ -32,6 +32,10 @@ For `PropertyBusinessObject`-style classes the same annotations work on
 `Property#set` so subscribers (`addChangeListener`) still see the
 mutation:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/AnnotationJsonXmlMappingJava002Snippet.java[tag=annotation-json-xml-mapping-java-002,indent=0]
+----
 
 ==== Field-level annotations
 

--- a/docs/developer-guide/Crash-Protection.asciidoc
+++ b/docs/developer-guide/Crash-Protection.asciidoc
@@ -28,7 +28,7 @@ The `codename1.arg.` prefix marks it as a build hint -- when the property reache
 
 ==== Runtime hook
 
-In your `Lifecycle.init`:
+In your `Lifecycle.init`, with the opt-in kept where the user gives it:
 
 [source,java]
 ----

--- a/docs/developer-guide/Crash-Protection.asciidoc
+++ b/docs/developer-guide/Crash-Protection.asciidoc
@@ -30,6 +30,10 @@ The `codename1.arg.` prefix marks it as a build hint -- when the property reache
 
 In your `Lifecycle.init`:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/CrashProtectionJava001Snippet.java[tag=crash-protection-java-001,indent=0]
+----
 
 `install()` registers the EDT error handler and (on Android) wires `Thread.UncaughtExceptionHandler`. It's idempotent and a no-op on the simulator. `setEnabled(boolean)` controls whether captured crashes actually get sent to the server -- the captured payload is always persisted locally first, so `setEnabled(true)` after the fact drains the buffer.
 

--- a/docs/developer-guide/Network-Connectivity.asciidoc
+++ b/docs/developer-guide/Network-Connectivity.asciidoc
@@ -61,6 +61,10 @@ Android throttles scans to 4 per 2 minutes per foreground app on API 28+; thrott
 
 To associate the device with a specific SSID:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NetworkConnectivityJava010Snippet.java[tag=network-connectivity-java-010,indent=0]
+----
 
 * On Android 10+ the OS shows a system confirmation dialog with the SSID before joining; this dialog can't be bypassed.
 * On Android 9 and below the framework falls back to the legacy `WifiConfiguration` API and joins without an in-app prompt.
@@ -85,6 +89,10 @@ include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/g
 
 To advertise an HTTP server you wrote on port 8080:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NetworkConnectivityJava011Snippet.java[tag=network-connectivity-java-011,indent=0]
+----
 
 ==== iOS requirements
 

--- a/docs/developer-guide/Notifications-And-Background-Execution.asciidoc
+++ b/docs/developer-guide/Notifications-And-Background-Execution.asciidoc
@@ -47,6 +47,10 @@ provisioning profile doesn't carry breaks code signing).
 `LocalNotification` is scheduled through `Display.scheduleLocalNotification(...)` as
 before; the bean has been extended with fluent, backward-compatible setters:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NotificationsAndBackgroundExecutionJava002Snippet.java[tag=notifications-and-background-execution-java-002,indent=0]
+----
 
 When the user taps an action, the selected action id (and any quick-reply text) are
 delivered through `com.codename1.push.PushContent` -- `getActionId()`, `getActionTitle()`
@@ -90,6 +94,10 @@ Channels let the user control importance, sound, vibration, lights, lock screen
 visibility and badge display for a group of notifications. Build and register one at startup,
 then reference it from a notification with `setChannelId(...)`:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NotificationsAndBackgroundExecutionJava003Snippet.java[tag=notifications-and-background-execution-java-003,indent=0]
+----
 
 Channels are an Android concept. On iOS and the simulator `register()` is a no-op (the
 simulator stores the channel so its name can be shown in the notification panel); the
@@ -101,6 +109,10 @@ channel id you assign is still carried so the notification behaves consistently.
 Implement `BackgroundWorker` in a class with a public no-argument constructor (it's
 reconstructed after a cold launch -- pass state through the input data, not fields):
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NotificationsAndBackgroundExecutionJava004Snippet.java[tag=notifications-and-background-execution-java-004,indent=0]
+----
 
 [options="header"]
 |===
@@ -122,6 +134,10 @@ and links `BackgroundTasks.framework` automatically.
 
 `ForegroundService` runs a long task while a persistent notification is shown:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NotificationsAndBackgroundExecutionJava005Snippet.java[tag=notifications-and-background-execution-java-005,indent=0]
+----
 
 [options="header"]
 |===
@@ -138,6 +154,10 @@ Override the type with the `android.foregroundServiceType` build hint (default `
 Override `onReceivedSharedContent(SharedContent)` on your `Lifecycle` subclass to receive
 text, URLs, files or images shared into your app from other apps:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NotificationsAndBackgroundExecutionJava006Snippet.java[tag=notifications-and-background-execution-java-006,indent=0]
+----
 
 [options="header"]
 |===

--- a/docs/developer-guide/Notifications-And-Background-Execution.asciidoc
+++ b/docs/developer-guide/Notifications-And-Background-Execution.asciidoc
@@ -130,7 +130,9 @@ date one minute out and with both the network and power requirements cleared, so
 the work can recur far more often than the period you asked for and outside the
 constraints you set. Treat a periodic request on iOS as "sometime after the app
 is next backgrounded," and re-check the conditions you care about at the top of
-the worker.
+the worker. The completion value is Android-only for the same reason: the iOS
+port resubmits periodic work whichever value you report, and never resubmits
+one-shot work, so a `FALSE` there doesn't buy you a retry.
 
 `BackgroundTask.scheduleProcessing(id, earliestBeginDate, requiresNetwork, requiresPower,
 runnable)` is a one-shot variant for occasional maintenance work. On iOS the identifiers

--- a/docs/developer-guide/Notifications-And-Background-Execution.asciidoc
+++ b/docs/developer-guide/Notifications-And-Background-Execution.asciidoc
@@ -124,6 +124,14 @@ include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/g
 | periodic | Approximated (resubmit) | Yes (>= 15 min) | Yes
 |===
 
+WARNING: The iOS approximation of a periodic request doesn't carry the request
+forward. After a run completes, the port resubmits the task with an earliest
+date one minute out and with both the network and power requirements cleared, so
+the work can recur far more often than the period you asked for and outside the
+constraints you set. Treat a periodic request on iOS as "sometime after the app
+is next backgrounded," and re-check the conditions you care about at the top of
+the worker.
+
 `BackgroundTask.scheduleProcessing(id, earliestBeginDate, requiresNetwork, requiresPower,
 runnable)` is a one-shot variant for occasional maintenance work. On iOS the identifiers
 must be declared via the `ios.backgroundProcessingIds` build hint (comma separated,

--- a/docs/developer-guide/Notifications-And-Background-Execution.asciidoc
+++ b/docs/developer-guide/Notifications-And-Background-Execution.asciidoc
@@ -114,6 +114,13 @@ reconstructed after a cold launch -- pass state through the input data, not fiel
 include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/NotificationsAndBackgroundExecutionJava004Snippet.java[tag=notifications-and-background-execution-java-004,indent=0]
 ----
 
+iOS needs the identifier declared at build time before `BGTaskScheduler` will
+accept the request, and nothing detects `BackgroundWork` on the classpath for
+you. Set `ios.usesBackgroundProcessing=true`, which declares
+`<packageName>.processing` -- the id the sample derives -- or list your own ids
+with `ios.backgroundProcessingIds`. Without one of those the scheduling call is
+rejected on the device.
+
 [options="header"]
 |===
 | | iOS | Android | Simulator

--- a/docs/developer-guide/Notifications-And-Background-Execution.asciidoc
+++ b/docs/developer-guide/Notifications-And-Background-Execution.asciidoc
@@ -142,7 +142,11 @@ and links `BackgroundTasks.framework` automatically.
 
 === Foreground service (Android)
 
-`ForegroundService` runs a long task while a persistent notification is shown:
+`ForegroundService` runs a long task while a persistent notification is shown.
+The first argument names a channel, but the Android service currently routes
+its notification through the app-wide channel -- `android.NotificationChannel.id`,
+defaulting to `cn1-channel` -- so the id here doesn't place the notification
+in a channel of its own today:
 
 [source,java]
 ----

--- a/docs/developer-guide/Printing.asciidoc
+++ b/docs/developer-guide/Printing.asciidoc
@@ -15,6 +15,10 @@ Gate the call on `isPrintingSupported()`. When it returns `false` the listener r
 
 `Printer.printImage(image, listener)` prints a `com.codename1.ui.Image` directly. The image is encoded to a temporary PNG file behind the scenes and the file is deleted once the print flow finishes:
 
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PrintingJava001Snippet.java[tag=printing-java-001,indent=0]
+----
 
 This pairs well with drawing on a mutable image, so you can compose a printable page (a receipt, a ticket, a chart) with the standard `Graphics` API and send it to paper without generating a PDF.
 

--- a/scripts/developer-guide/missing-code-blocks-baseline.txt
+++ b/scripts/developer-guide/missing-code-blocks-baseline.txt
@@ -4,14 +4,10 @@
 Advanced-Topics-Under-The-Hood.asciidoc	You can override these methods in the draggable components:
 Advertising.asciidoc	identifier. The recommended order is to initialize, gather consent, then load:
 Advertising.asciidoc	method that registers its provider with `AdManager`:
-Annotation-Component-Binding.asciidoc	ASM and inserts the equivalent of:
-Annotation-Component-Binding.asciidoc	After binding, drive validation through the returned handle:
 Annotation-JSON-XML-Mapping.asciidoc	Hand-write a `Mapper<T>` and register it at startup:
-Annotation-JSON-XML-Mapping.asciidoc	mutation:
 Annotation-SQLite-ORM.asciidoc	dao surface isn't enough. Transactions:
 Apple-Wallet-Extension.asciidoc	In Java, publish the user's cards whenever they change (typically after login) and keep a fresh token published so Wallet can skip the login screen:
 Authentication-And-Identity.asciidoc	Firebase Auth isn't an OIDC provider -- it issues Google-Identity-Toolkit-style tokens via REST endpoints. `com.codename1.social.FirebaseAuth` wraps those endpoints:
-Crash-Protection.asciidoc	In your `Lifecycle.init`:
 Deep-Links-Routing.asciidoc	`AssetLinksBuilder` produces the payload:
 Deep-Links-Routing.asciidoc	without redirects. The plugin's `AasaBuilder` produces the payload:
 Desktop-Integration.asciidoc	same scheduling and handling code is shared across phone and desktop:
@@ -30,11 +26,6 @@ Monetization.asciidoc	The general usage is as follows:
 Monetization.asciidoc	The source for your ReceiptStore is as follows:
 Monetization.asciidoc	You are now ready to see the full magic of the `validateAndSaveReceipt()` method in all its glory:
 Native-Themes.asciidoc	`UIManager.addThemeProps` after the theme has been installed:
-Network-Connectivity.asciidoc	To advertise an HTTP server you wrote on port 8080:
-Network-Connectivity.asciidoc	To associate the device with a specific SSID:
-Notifications-And-Background-Execution.asciidoc	before; the bean has been extended with fluent, backward-compatible setters:
-Notifications-And-Background-Execution.asciidoc	then reference it from a notification with `setChannelId(...)`:
-Printing.asciidoc	`Printer.printImage(image, listener)` prints a `com.codename1.ui.Image` directly. The image is encoded to a temporary PNG file behind the scenes and the file is deleted once the print flow finishes:
 SVG-Transcoder.asciidoc	the generated class directly:
 The-Components-Of-Codename-One.asciidoc	Call the builder from a Maven plugin, an Ant task or a one-shot `main`:
 The-Components-Of-Codename-One.asciidoc	Let start by exploring how you can achieve this UI that fetches data from a webservice:


### PR DESCRIPTION
Six chapters, verbatim from `bbdc6058f0~1`. **Baseline 54 → 44.**

## The compliance check earned its keep

The JSON/XML mapping example writes a `Mapper<java.util.UUID>`, and **`UUID` isn't in the Codename One runtime**. `javac` against the core jar accepts it — it compiles against the desktop JDK — so only the demos module's bytecode compliance pass sees that a device build would fail on six call sites. Changing the mapped type would change what the example teaches, so that hole stays baselined with the reason recorded.

That's a class of defect my previous batches could not have caught, since I was compiling snippets individually before running the module build.

## Two samples called things that don't exist

| Sample | Problem |
|---|---|
| binding | `form.findByName("submitButton")` — `findByName` is on `UIBuilder` and the test utilities, **not** on `Container`. It now takes the button the reader already has. |
| mapper | `textOf(root)` — defined nowhere. `writeXml` stores the value as a text child via `new Element(text, true)`, so the symmetric read is `root.getChildAt(0).getText()`. |

## Four holes left, with reasons

- **io ×3** — a Java EE `@WebServlet`, and two blocks that are bare method signatures with no bodies (API listings, not code).
- **The-Components ×1** — builds `IOSShareExtensionBuilder`, which lives in the maven plugin: build-time tooling, not app code.

## Process, after last batch

- Snippet numbers now come from a script that reads the existing files. Picking one by eye overwrote `MiscellaneousFeaturesJava040` last time and left the Contact picker section rendering SMS code.
- The import pass touched five pre-existing snippets that didn't need it; reverted, so every file here is either new or in this batch.
- The pre-review audit runs clean. Two hits were false positives I fixed in the tool (`onConnectResult` and `onReceivedSharedContent` are real interface methods; a builder chain ending in `.register()` isn't discarded), and I re-ran the tool against a known-bad commit afterwards to confirm the exemptions didn't blind it.

Verified: `mvn process-classes` green, all guide gates green, Vale and LanguageTool clean on all six chapters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)