### PR TITLE
ParparVM collector: long-shift codegen fix, live-set heap goal, and an arm64 parallel-mark run

### DIFF
--- a/.github/workflows/parparvm-parallel-mark.yml
+++ b/.github/workflows/parparvm-parallel-mark.yml
@@ -1,0 +1,121 @@
+# Runs the collector's own tests against a PARALLEL marker on real arm64 Linux.
+#
+# gcMarkResolveThreadCount compiles the mark pool out by default, and the comment
+# there reads as a standing verdict: arm64 Linux corrupted the heap with the pool
+# on, and "a SECOND ordering hole remains somewhere in the branch-only
+# parallel-GC work". Read in isolation that says parallel marking is broken.
+#
+# The history says something narrower. Inside PR #5327 the sequence was:
+#
+#   Jul 3  30257f5234  acquire-load the mark word in parallel marking (arm64 corruption)
+#   Jul 3  3ad67971e9  default parallel marking to serial -- "arm64 isolation experiment"
+#   Jul 4  78752a21a2  gcMarkObject must reject freed BiBOP slots
+#   Jul 5  ff7a1f1947  SATB write barrier, closing the concurrent-mark cross-thread race
+#   Jul 5  017168581c  drain grace-object subtrees before sweep (swept-while-reachable)
+#   Jul 5  60ef4c7d85  belt pass: guarantee mark-drain completeness before sweep
+#   Jul 5  4888b66cd0  stop-the-world final mark, looped to a fixpoint
+#   Jul 6  c6144beb7a  object-bearing frameless OFF: "unsound under conservative GC on arm64"
+#   Jul 10 ff93b1c415  clazz-registry invariant (arm64 SIGSEGV in cn1GcRegisterClazz)
+#
+# The experiment that produced the comment ran on Jul 3. Every mechanism that
+# makes concurrent marking sound arrived after it -- the SATB barrier most of
+# all, which did not exist when the conclusion was drawn -- and at least one
+# other arm64 heap corruptor was found and disabled on Jul 6 that had nothing to
+# do with the mark pool. Parallel marking was never re-tested at any point after
+# Jul 3, and gcMarkDrainParallel, gcMarkObject, gcMarkFlushLocal and
+# gcMarkWorklistPush have all been reworked since.
+#
+# So the comment records what was believed on one day, before the fixes, and the
+# switch under it was never revisited. This workflow is how that gets settled
+# with evidence instead of archaeology.
+#
+# The cost of leaving it alone is measured. On the GcPause benchmark -- one
+# mutator, 20M short-lived objects, a 4096-node live set -- the worst mutator
+# pause is 2.2-3.3s with one marker and 0.3-0.9s with four, against Go's 20ms on
+# the identical loop. Median and p99 already match Go at 32ns/64ns, so the single
+# marker is a large part of why the tail loses.
+#
+# It could not be reproduced on an Apple-silicon podman guest: GcPause ran clean
+# with four markers, and a multi-threaded stress with graph rewiring and
+# cross-thread resurrection ran clean too -- but that second result proves
+# nothing, because the same stress passes with the SATB barrier compiled out
+# (-DCN1_DISABLE_SATB) and under -DCN1_GC_VERIFY at 6.6M references checked. A
+# four-CPU hypervisor guest is a weak generator of store interleavings. These
+# runners are native arm64 hardware, which is where the corruption was seen.
+#
+# NOTHING HERE CHANGES A DEFAULT. The pool is switched on for this workflow only,
+# through CN1_TEST_EXTRA_CFLAGS; every other build still compiles it out.
+name: ParparVM parallel mark (arm64 Linux)
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'vm/ByteCodeTranslator/src/cn1_globals.m'
+      - 'vm/ByteCodeTranslator/src/cn1_globals.h'
+      - 'vm/tests/src/test/java/com/codename1/tools/translator/Gc*.java'
+      - '.github/workflows/parparvm-parallel-mark.yml'
+
+concurrency:
+  group: parparvm-parallel-mark-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gc-suite:
+    name: GC suite (${{ matrix.markers }} marker(s), ${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # The control. A failure here is not the parallel path and the arm below
+          # cannot be read as evidence of anything until this one is green.
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            markers: 1
+            cflags: ''
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            markers: 4
+            cflags: '-DCN1_GC_MARK_THREADS=4'
+          # x64 as well, so a failure can be attributed to the architecture rather
+          # than to the pool itself.
+          - arch: x64
+            runner: ubuntu-latest
+            markers: 4
+            cflags: '-DCN1_GC_MARK_THREADS=4'
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '8'
+
+      - name: Install clang and cmake
+        run: bash scripts/ci/apt-get-install.sh clang cmake
+
+      - name: Build the translator
+        run: mvn -q -B -pl ByteCodeTranslator package -DskipTests
+        working-directory: vm
+
+      # The integration tests reload the translator from its packaged jar, so -am
+      # here would run them against classes that are not in it.
+      - name: GC suite
+        env:
+          CN1_TEST_EXTRA_CFLAGS: ${{ matrix.cflags }}
+        run: |
+          mvn -B -pl tests test \
+            -Dtest='GcHeapIntegrityIntegrationTest,GcOverflowSpiralIntegrationTest,GcUncooperativeThreadIntegrationTest,LargeArrayGcIntegrationTest,LowMemoryThrottleIntegrationTest,BibopPageFloorIntegrationTest'
+        working-directory: vm
+
+      - name: Surefire reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gc-suite-${{ matrix.arch }}-${{ matrix.markers }}marker
+          path: vm/tests/target/surefire-reports/
+          if-no-files-found: ignore

--- a/.github/workflows/parparvm-parallel-mark.yml
+++ b/.github/workflows/parparvm-parallel-mark.yml
@@ -123,6 +123,29 @@ jobs:
       - name: GC suite
         env:
           CN1_TEST_EXTRA_CFLAGS: ${{ matrix.cflags }}
+          # Page-release tracing, for BibopPageFloorIntegrationTest.
+          #
+          # That test fails here intermittently -- twice in six runs at the time
+          # of writing, on the 1-marker arm once and the 4-marker arm once, on
+          # arm64 only and never on x64 -- and the failure is bimodal rather than
+          # marginal: 6-7% of the dropped live set's pages handed back on a bad
+          # run against 91% on a good one. Bimodal is a major sweep happening or
+          # not happening, because cn1BibopTrimFreePool runs only at the end of
+          # one, so the question the next failure has to answer is whether any
+          # major sweep ran after the live set was dropped and how many pages it
+          # spliced. [MAJOR-SWEEP] and [PAGE-RELEASE] say exactly that.
+          #
+          # Two reasons this is safe to leave on. The tracer is read-only: it is
+          # gated behind getenv and only prints, so no collection decision
+          # changes. And it writes to STDERR, which runVm deliberately routes to
+          # the console rather than merging into stdout -- a merged tracer line
+          # can land in the middle of a phase marker and silently drop a row from
+          # the table the assertions read, which is a failure mode that file
+          # already carries a comment about. The parsed output is untouched.
+          #
+          # Costs one line per major sweep, which is cadence-limited, not one per
+          # page. Remove it once the flake is understood.
+          CN1_LOG_PAGE_RELEASE: 1
         run: |
           mvn -B test -pl tests -am \
             -Dsurefire.failIfNoSpecifiedTests=false \

--- a/.github/workflows/parparvm-parallel-mark.yml
+++ b/.github/workflows/parparvm-parallel-mark.yml
@@ -98,17 +98,22 @@ jobs:
       - name: Install clang and cmake
         run: bash scripts/ci/apt-get-install.sh clang cmake
 
-      - name: Build the translator
-        run: mvn -q -B -pl ByteCodeTranslator package -DskipTests
+      # Package first, then test with -am: the integration tests reload the
+      # translator from its PACKAGED jar, and the reactor is what resolves the
+      # dependency. Packaging alone without -am (and without install) leaves
+      # nothing for the tests module to resolve against, which is how the first
+      # revision of this workflow failed on all three arms including the control.
+      # This mirrors parparvm-tests.yml.
+      - name: Build JavaAPI and the translator
+        run: mvn -B clean package -pl JavaAPI -am -DskipTests
         working-directory: vm
 
-      # The integration tests reload the translator from its packaged jar, so -am
-      # here would run them against classes that are not in it.
       - name: GC suite
         env:
           CN1_TEST_EXTRA_CFLAGS: ${{ matrix.cflags }}
         run: |
-          mvn -B -pl tests test \
+          mvn -B test -pl tests -am \
+            -Dsurefire.failIfNoSpecifiedTests=false \
             -Dtest='GcHeapIntegrityIntegrationTest,GcOverflowSpiralIntegrationTest,GcUncooperativeThreadIntegrationTest,LargeArrayGcIntegrationTest,LowMemoryThrottleIntegrationTest,BibopPageFloorIntegrationTest'
         working-directory: vm
 

--- a/.github/workflows/parparvm-parallel-mark.yml
+++ b/.github/workflows/parparvm-parallel-mark.yml
@@ -123,29 +123,6 @@ jobs:
       - name: GC suite
         env:
           CN1_TEST_EXTRA_CFLAGS: ${{ matrix.cflags }}
-          # Page-release tracing, for BibopPageFloorIntegrationTest.
-          #
-          # That test fails here intermittently -- twice in six runs at the time
-          # of writing, on the 1-marker arm once and the 4-marker arm once, on
-          # arm64 only and never on x64 -- and the failure is bimodal rather than
-          # marginal: 6-7% of the dropped live set's pages handed back on a bad
-          # run against 91% on a good one. Bimodal is a major sweep happening or
-          # not happening, because cn1BibopTrimFreePool runs only at the end of
-          # one, so the question the next failure has to answer is whether any
-          # major sweep ran after the live set was dropped and how many pages it
-          # spliced. [MAJOR-SWEEP] and [PAGE-RELEASE] say exactly that.
-          #
-          # Two reasons this is safe to leave on. The tracer is read-only: it is
-          # gated behind getenv and only prints, so no collection decision
-          # changes. And it writes to STDERR, which runVm deliberately routes to
-          # the console rather than merging into stdout -- a merged tracer line
-          # can land in the middle of a phase marker and silently drop a row from
-          # the table the assertions read, which is a failure mode that file
-          # already carries a comment about. The parsed output is untouched.
-          #
-          # Costs one line per major sweep, which is cadence-limited, not one per
-          # page. Remove it once the flake is understood.
-          CN1_LOG_PAGE_RELEASE: 1
         run: |
           mvn -B test -pl tests -am \
             -Dsurefire.failIfNoSpecifiedTests=false \

--- a/.github/workflows/parparvm-parallel-mark.yml
+++ b/.github/workflows/parparvm-parallel-mark.yml
@@ -53,7 +53,19 @@ on:
     paths:
       - 'vm/ByteCodeTranslator/src/cn1_globals.m'
       - 'vm/ByteCodeTranslator/src/cn1_globals.h'
-      - 'vm/tests/src/test/java/com/codename1/tools/translator/Gc*.java'
+      # One entry per test the matrix below runs, plus the helper that injects
+      # CN1_TEST_EXTRA_CFLAGS. Keep this list and the -Dtest list in sync: a glob
+      # is what went wrong here, because Gc*.java matched three of the six tests
+      # and silently let the other three -- and every change to the flag plumbing
+      # every arm depends on to select its marker count -- land without the
+      # workflow that exercises them ever running.
+      - 'vm/tests/src/test/java/com/codename1/tools/translator/GcHeapIntegrityIntegrationTest.java'
+      - 'vm/tests/src/test/java/com/codename1/tools/translator/GcOverflowSpiralIntegrationTest.java'
+      - 'vm/tests/src/test/java/com/codename1/tools/translator/GcUncooperativeThreadIntegrationTest.java'
+      - 'vm/tests/src/test/java/com/codename1/tools/translator/LargeArrayGcIntegrationTest.java'
+      - 'vm/tests/src/test/java/com/codename1/tools/translator/LowMemoryThrottleIntegrationTest.java'
+      - 'vm/tests/src/test/java/com/codename1/tools/translator/BibopPageFloorIntegrationTest.java'
+      - 'vm/tests/src/test/java/com/codename1/tools/translator/CompilerHelper.java'
       - '.github/workflows/parparvm-parallel-mark.yml'
 
 concurrency:

--- a/vm/ByteCodeTranslator/src/cn1_globals.h
+++ b/vm/ByteCodeTranslator/src/cn1_globals.h
@@ -855,9 +855,19 @@ else if (IS_DOUBLE_WORD(-1)) SP=BC_DUP2_X2_DSS(SP);\
 
 #define BC_I2C() SP[-1].data.i = (SP[-1].data.i & 0xffff)
 
-#define BC_ISHL() SP--; SP[-1].data.i = (SP[-1].data.i << (0x1f & (*SP).data.i))
-#define BC_ISHL_EXPR(val1, val2) (val1 << (0x1f & val2))
-#define BC_LSHL() SP--; SP[-1].data.l = (SP[-1].data.l << (0x3f & (*SP).data.l))
+// Java defines << as two's-complement wraparound. C does not: shifting a signed
+// value left so that the result is not representable -- 1 << 31, or any negative
+// left operand -- is UNDEFINED, not merely implementation-defined, so the
+// optimizer is entitled to assume it never happens. Shifting through the
+// unsigned type of the same width gives Java's answer with no undefined step,
+// and the conversion back is the ordinary two's-complement reinterpretation.
+//
+// The signed RIGHT shifts below are left alone deliberately: a negative >> n is
+// implementation-defined rather than undefined, and every compiler this VM is
+// built with defines it as the arithmetic shift Java specifies.
+#define BC_ISHL() SP--; SP[-1].data.i = (JAVA_INT)(((unsigned int)SP[-1].data.i) << (0x1f & (*SP).data.i))
+#define BC_ISHL_EXPR(val1, val2) ((JAVA_INT)(((unsigned int)(JAVA_INT)(val1)) << (0x1f & (val2))))
+#define BC_LSHL() SP--; SP[-1].data.l = (JAVA_LONG)(((unsigned long long)SP[-1].data.l) << (0x3f & (*SP).data.l))
 /* val1 is CAST, and that cast is the whole point.
  *
  * The translator emits a long constant as a bare C literal, so LCONST_1 reaches
@@ -875,7 +885,10 @@ else if (IS_DOUBLE_WORD(-1)) SP=BC_DUP2_X2_DSS(SP);\
  *
  * BC_LUSHR_EXPR below already casts, so this class of bug was fixed once for the
  * unsigned shift and not carried across to its two siblings. */
-#define BC_LSHL_EXPR(val1, val2) (((JAVA_LONG)(val1)) << (0x3f & (val2)))
+// The inner JAVA_LONG cast is load-bearing and separate from the unsigned one:
+// the translator emits long constants as bare C literals, so without it LCONST_1
+// arrives as an int and 1L << 32 evaluates to 1. See the LongShift benchmark.
+#define BC_LSHL_EXPR(val1, val2) ((JAVA_LONG)(((unsigned long long)(JAVA_LONG)(val1)) << (0x3f & (val2))))
 
 #define BC_ISHR() SP--; SP[-1].data.i = (SP[-1].data.i >> (0x1f & (*SP).data.i))
 #define BC_ISHR_EXPR(val1, val2) (val1 >> (0x1f & val2))

--- a/vm/ByteCodeTranslator/src/cn1_globals.h
+++ b/vm/ByteCodeTranslator/src/cn1_globals.h
@@ -858,13 +858,32 @@ else if (IS_DOUBLE_WORD(-1)) SP=BC_DUP2_X2_DSS(SP);\
 #define BC_ISHL() SP--; SP[-1].data.i = (SP[-1].data.i << (0x1f & (*SP).data.i))
 #define BC_ISHL_EXPR(val1, val2) (val1 << (0x1f & val2))
 #define BC_LSHL() SP--; SP[-1].data.l = (SP[-1].data.l << (0x3f & (*SP).data.l))
-#define BC_LSHL_EXPR(val1, val2) (val1 << (0x3f & val2))
+/* val1 is CAST, and that cast is the whole point.
+ *
+ * The translator emits a long constant as a bare C literal, so LCONST_1 reaches
+ * here as `BC_LSHL_EXPR(1, n)` -- and in C `1` is an int, which makes this an
+ * int shift no matter what the 0x3f mask says. The result was silently wrong for
+ * every shift of a long CONSTANT by 31 or more:
+ *
+ *     1L << 31  gave -2147483648   (int overflow, then sign-extended)
+ *     1L << 32  gave 1             (int shift counts are masked to 5 bits)
+ *     1L << 33  gave 2
+ *
+ * `x << n` for a long VARIABLE was always right, which is why this survived: the
+ * variable carries JAVA_LONG into the macro and the constant does not. Found by a
+ * histogram whose bucket labels came out negative.
+ *
+ * BC_LUSHR_EXPR below already casts, so this class of bug was fixed once for the
+ * unsigned shift and not carried across to its two siblings. */
+#define BC_LSHL_EXPR(val1, val2) (((JAVA_LONG)(val1)) << (0x3f & (val2)))
 
 #define BC_ISHR() SP--; SP[-1].data.i = (SP[-1].data.i >> (0x1f & (*SP).data.i))
 #define BC_ISHR_EXPR(val1, val2) (val1 >> (0x1f & val2))
 
 #define BC_LSHR() SP--; SP[-1].data.l = (SP[-1].data.l >> (0x3f & (*SP).data.l))
-#define BC_LSHR_EXPR(val1, val2) (val1 >> (0x3f & val2))
+/* Cast for the same reason as BC_LSHL_EXPR above: a long constant arrives as an
+ * int literal and would otherwise be shifted 32 bits wide. */
+#define BC_LSHR_EXPR(val1, val2) (((JAVA_LONG)(val1)) >> (0x3f & (val2)))
 
 #define BC_IUSHL() SP--; SP[-1].data.i = (((unsigned int)SP[-1].data.i) << (0x1f & ((unsigned int)(*SP).data.i)))
 #define BC_IUSHL_EXPR(val1, val2) (((unsigned int)val1) << (0x1f & ((unsigned int)val2)))

--- a/vm/ByteCodeTranslator/src/cn1_globals.h
+++ b/vm/ByteCodeTranslator/src/cn1_globals.h
@@ -1797,6 +1797,22 @@ extern long long totalAllocations;
 #define CN1_BIBOP_FLUSH_BYTES(ts) do {} while(0)
 #endif
 
+#ifdef CN1_GC_CONFORM
+// Defined in cn1_globals.m. Declared here because the BiBOP fast paths are inline
+// in this header and are the route MOST small objects take -- profiling only
+// codenameOneGcMalloc would miss them and blame whatever little reaches it.
+//
+// There are FOUR entry points, and the profile is only honest if every one of
+// them records exactly once: codenameOneGcMalloc, cn1BibopFastAlloc (what
+// CN1_FAST_NEW calls), cn1BibopFastAllocNoZero, cn1AllocFused and
+// cn1FusedLatin1Begin. cn1BibopAlloc is deliberately NOT hooked -- it is an
+// internal callee of three of those and hooking it would double-count.
+// Each hook sits on the SUCCESS return rather than at function entry: a fast
+// path that returns 0 falls back to __NEW_X -> codenameOneGcMalloc, so an
+// entry-side hook counts that allocation twice.
+void cn1RecordAllocation(struct clazz* parent, int size);
+#endif
+
 // Inlined bump fast path. Returns 0 (slow path: page full / free-list present /
 // ineligible / oversized) -> caller falls back to __NEW_X / codenameOneGcMalloc.
 static inline JAVA_OBJECT cn1BibopFastAlloc(CODENAME_ONE_THREAD_STATE, int size, struct clazz* parent, int ci) {
@@ -1878,6 +1894,9 @@ static inline JAVA_OBJECT cn1BibopFastAlloc(CODENAME_ONE_THREAD_STATE, int size,
             // allocationsSinceLastGC / totalAllocations (the isHighFrequencyGC heuristic)
             // are now bumped in bulk by CN1_BIBOP_FLUSH_BYTES once per page-acquire, not
             // per object -- removing two global-counter stores from the hot path.
+#ifdef CN1_GC_CONFORM
+            cn1RecordAllocation(parent, size);
+#endif
             return o;
         }
     }
@@ -1902,6 +1921,7 @@ static inline JAVA_OBJECT cn1BibopFastAlloc(CODENAME_ONE_THREAD_STATE, int size,
 // memset" note in cn1BibopFastAlloc and OVERFLOW RESCAN in cn1_globals.m). The
 // header (parentCls / mark / heapPosition) is still initialized here; ONLY the
 // body zero is elided.
+
 static inline JAVA_OBJECT cn1BibopFastAllocNoZero(CODENAME_ONE_THREAD_STATE, int size, struct clazz* parent, int ci) {
     if(ci < 0) return (JAVA_OBJECT)0; // oversized: folded away for big types
     if(__builtin_expect(threadStateData->bibopBypassRemaining[ci] > 0, 0)) {
@@ -1956,6 +1976,9 @@ static inline JAVA_OBJECT cn1BibopFastAllocNoZero(CODENAME_ONE_THREAD_STATE, int
             __atomic_store_n(&p->gcAllocedSinceSweep, JAVA_TRUE, __ATOMIC_RELAXED);
 #endif
             CN1_BIBOP_ACCOUNT_BYTES(threadStateData, p->slotSize);
+#ifdef CN1_GC_CONFORM
+            cn1RecordAllocation(parent, size);
+#endif
             return o;
         }
     }

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -6491,9 +6491,27 @@ static void cn1BibopSweep(CODENAME_ONE_THREAD_STATE) {
         // bibopCycleAllocatedBytes alone would call it quiet and splice every
         // partial page in every sweep -- the O(all pages) regression issue 5425
         // fixed, reintroduced for exactly the workload that reported it.
+        //
+        // The cutoff is a QUARTER OF THE TRIGGER IN FORCE, not a fixed constant.
+        // "Quiet" is meant to describe a cycle that ran without the application
+        // allocating much, and what counts as much is relative to how much
+        // allocation it takes to start a cycle at all. A fixed cutoff derived
+        // from the 24MB default breaks as soon as the trigger is lower than it:
+        // a deployment that sets CN1_BIBOP_GC_MIN_TRIGGER_BYTES to 4MB collects
+        // every 4-6MB, every one of those ordinary allocation-driven cycles is
+        // below a 6MB cutoff, and every single collection then splices every
+        // partial pool -- the O(all pages) behaviour issue 5425 removed, handed
+        // straight back to the workload that reported it. Tracking the live
+        // trigger keeps the ratio the constant was chosen to express, at every
+        // trigger the policy can reach.
+        long quietCutoff = (long)(atomic_load_explicit(&bibopGcTriggerBytes,
+                                                       memory_order_relaxed) / 4);
+        if(quietCutoff > CN1_BIBOP_MAJOR_SWEEP_QUIET_BYTES) {
+            quietCutoff = CN1_BIBOP_MAJOR_SWEEP_QUIET_BYTES;
+        }
         JAVA_BOOLEAN quiet =
                 ((long long)bibopCycleAllocatedBytes + legacyCycleAllocatedBytes)
-                        < (long long)CN1_BIBOP_MAJOR_SWEEP_QUIET_BYTES;
+                        < (long long)quietCutoff;
         int major = atomic_load_explicit(&lowMemoryMode, memory_order_relaxed)
                 || quiet
                 || bibopCyclesSinceMajorSweep >= CN1_BIBOP_MAJOR_SWEEP_CYCLES;

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -6339,7 +6339,20 @@ static void cn1BibopAdaptAfterSweep(long occupiedBytes, long liveBytes,
         // reading to 16MB precisely to make the per-thread pending table fill, and
         // a live-set floor collects early enough that it never does -- the test
         // then fails itself as measuring nothing, which is exactly what it did.
-        if(oldTrigger != CN1_BIBOP_GC_TRIGGER_BYTES) {
+        // LOWER ONLY. This used to assign the constant, which on master could
+        // only ever bring the trigger down because nothing there put it below
+        // 24MB. Once a deployment can define CN1_BIBOP_GC_MIN_TRIGGER_BYTES lower
+        // -- the server sets 4MB -- the same assignment RAISES a trigger that the
+        // low-survival path had already shrunk, so an OS memory warning would
+        // postpone collection at the moment headroom is scarcest, and lift the
+        // pacing cap derived from it as well.
+        //
+        // Pinning to the constant from above is still the intent and is unchanged
+        // at the default: GcSteadyState pins the free-memory reading to 16MB to
+        // make the per-thread pending table fill, and it runs with the default
+        // minimum, so its trigger is at or above the constant and takes exactly
+        // the branch it always did.
+        if(oldTrigger > CN1_BIBOP_GC_TRIGGER_BYTES) {
             atomic_store_explicit(&bibopGcTriggerBytes,
                                   CN1_BIBOP_GC_TRIGGER_BYTES,
                                   memory_order_relaxed);

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -12307,7 +12307,11 @@ static long long cn1StallPercentileUs(int cause, double q) {
 #define CN1_ALLOC_PROFILE_SLOTS 65536
 static _Atomic long long cn1AllocProfBytes[CN1_ALLOC_PROFILE_SLOTS];
 static _Atomic long cn1AllocProfCount[CN1_ALLOC_PROFILE_SLOTS];
-static struct clazz* cn1AllocProfClass[CN1_ALLOC_PROFILE_SLOTS];
+// Atomic like the counters beside it. Several mutators allocating the same class
+// write this slot at once, and same-value concurrent writes are still a race in
+// C; the atexit report also reads it while allocation continues, so a torn read
+// would be dereferenced as a class pointer to print a name.
+static _Atomic(struct clazz*) cn1AllocProfClass[CN1_ALLOC_PROFILE_SLOTS];
 static _Atomic long long cn1AllocProfOutOfRangeBytes = 0;
 static _Atomic long cn1AllocProfOutOfRangeCount = 0;
 static _Atomic int cn1AllocProfMaxSeenId = 0;
@@ -12396,7 +12400,7 @@ void cn1RecordAllocation(struct clazz* parent, int size) {
         }
         return;
     }
-    cn1AllocProfClass[id] = parent;
+    atomic_store_explicit(&cn1AllocProfClass[id], parent, memory_order_relaxed);
     atomic_fetch_add_explicit(&cn1AllocProfBytes[id], (long long)size, memory_order_relaxed);
     atomic_fetch_add_explicit(&cn1AllocProfCount[id], 1, memory_order_relaxed);
 }
@@ -12479,9 +12483,11 @@ static void cn1ReportAllocProfile(void) {
         if(best < 0) {
             break;
         }
+        struct clazz* cn1AllocProfBest =
+                atomic_load_explicit(&cn1AllocProfClass[best], memory_order_relaxed);
         fprintf(stderr, "[ALLOCPROF] %-44s bytes=%-12lld count=%-10ld avg=%lld\n",
-                (cn1AllocProfClass[best] != 0 && cn1AllocProfClass[best]->clsName != 0)
-                        ? cn1AllocProfClass[best]->clsName : "?",
+                (cn1AllocProfBest != 0 && cn1AllocProfBest->clsName != 0)
+                        ? cn1AllocProfBest->clsName : "?",
                 bestBytes,
                 atomic_load_explicit(&cn1AllocProfCount[best], memory_order_relaxed),
                 cn1AllocProfAvg(bestBytes,

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -6449,6 +6449,7 @@ static long cn1BibopTriggerFloor(long liveBytes, int sampleCoversHeap) {
 
 static void cn1BibopAdaptAfterSweep(long occupiedBytes, long liveBytes,
                                     long reclaimedBytes, long excludedOccupiedBytes,
+                                    long excludedLiveBytes, int majorSweep,
                                     long* classSlots, long* classLive) {
     bibopLastCycleOccupiedBytes = occupiedBytes;
     bibopLastCycleLiveBytes = liveBytes;
@@ -6479,13 +6480,26 @@ static void cn1BibopAdaptAfterSweep(long occupiedBytes, long liveBytes,
         long oldTrigger = atomic_load_explicit(&bibopGcTriggerBytes,
                                                memory_order_relaxed);
         long newTrigger = oldTrigger;
-        // The sweep withheld excludedOccupiedBytes from the numbers above. If that
-        // is a small part of what it did measure, the objects it could not see
-        // cannot amount to much either and a low liveBytes really is a collapse.
-        // An eighth is deliberately strict: a wrong "yes" retraces a live heap
-        // every cycle, a wrong "no" only means the decay takes the old path.
-        int sampleCoversHeap = excludedOccupiedBytes <= (occupiedBytes >> 3);
-        long floorBytes = cn1BibopTriggerFloor(liveBytes, sampleCoversHeap);
+        // Only a MAJOR sweep can say anything about the size of the live set, and
+        // when it does it must be asked for the WHOLE of it.
+        //
+        // An ordinary sweep walks retired pages alone; every live object on a
+        // partial page is invisible to it, so its liveBytes is not a small live
+        // set, it is a small sample. A major sweep splices the partial pools in
+        // and walks them too -- but withholds their slots from the survival ratio,
+        // which is why liveBytes still understates even there. The complete figure
+        // is liveBytes plus what was withheld, and that number is already computed;
+        // it was simply being thrown away.
+        //
+        // An earlier revision of this gate tested the withheld BYTES instead, which
+        // is backwards in both directions: an ordinary sweep withholds nothing and
+        // was called complete precisely when it saw least, while a major sweep
+        // withholds exactly the pages it added and was called incomplete when it
+        // had in fact seen everything.
+        int sampleCoversHeap = majorSweep;
+        long completeLiveBytes = liveBytes + excludedLiveBytes;
+        long floorBytes = cn1BibopTriggerFloor(
+                sampleCoversHeap ? completeLiveBytes : liveBytes, sampleCoversHeap);
         if(survival >= CN1_BIBOP_BYPASS_SURVIVAL_PERCENT) {
             bibopTriggerHighSurvivalStreak++;
             if(bibopTriggerHighSurvivalStreak >= 2) {
@@ -6582,6 +6596,13 @@ static void cn1BibopAdaptAfterSweep(long occupiedBytes, long liveBytes,
 // pages it processes are off the SWEEP stack (owner==0), so no mutator is
 // allocating into them and no marking is in flight -> plain header access.
 static void cn1BibopSweep(CODENAME_ONE_THREAD_STATE) {
+    // Live bytes on pages this sweep excluded from the survival ratio, and whether
+    // it walked the partial pools at all. Only a MAJOR sweep does: an ordinary one
+    // sees retired pages alone, so its liveBytes omits every live object sitting
+    // on a partial page and is not a live-set measurement. Declared here because
+    // the major-sweep decision below is made before the accumulators.
+    long excludedLiveBytes = 0;
+    int majorSweep = 0;
 #ifdef CN1_GC_VERIFY
     extern int cn1GcFaultEarlyFree;
     { extern void cn1GcFaultInitPublic(void); cn1GcFaultInitPublic(); }
@@ -6628,6 +6649,7 @@ static void cn1BibopSweep(CODENAME_ONE_THREAD_STATE) {
                 || quiet
                 || bibopCyclesSinceMajorSweep >= CN1_BIBOP_MAJOR_SWEEP_CYCLES;
         if(major) {
+            majorSweep = 1;
             bibopCyclesSinceMajorSweep = 0;
             int spliced = 0;
             pthread_mutex_lock(&bibopMutex);
@@ -6916,6 +6938,7 @@ static void cn1BibopSweep(CODENAME_ONE_THREAD_STATE) {
         }
         if(statsExcluded) {
             excludedOccupiedBytes += (long)sampledSlots * page->slotSize;
+            excludedLiveBytes += (long)policySurvivors * page->slotSize;
         }
         if(!statsExcluded) {
             occupiedBytes += (long)sampledSlots * page->slotSize;
@@ -6949,7 +6972,8 @@ static void cn1BibopSweep(CODENAME_ONE_THREAD_STATE) {
         }
         pthread_mutex_unlock(&bibopMutex);
     }
-    cn1BibopAdaptAfterSweep(occupiedBytes, liveBytes, reclaimedBytes, excludedOccupiedBytes,
+    cn1BibopAdaptAfterSweep(occupiedBytes, liveBytes, reclaimedBytes,
+                            excludedOccupiedBytes, excludedLiveBytes, majorSweep,
                             classSlots, classLive);
     // Hand surplus empty pages back to the OS (issue 5537). Last, so it sees the
     // pool this sweep just refilled, and outside the per-page loop so the madvise
@@ -11140,19 +11164,27 @@ static void gcMarkWorkerDrainLoop() {
  *
  * Returns the number of entries marked, 0 if there was nothing to do.
  */
+// A/B switch for the assist, so it can be measured against the sleep it replaces
+// in one binary rather than two builds. Resolved through pthread_once because
+// this runs on every PACED MUTATOR: with more than one marker several of them
+// reach their first assist together, and a plain function-local static would be
+// read and written by all of them at once -- a data race in exactly the parallel
+// configuration the new workflow exists to exercise.
+static pthread_once_t cn1GcAssistOnce = PTHREAD_ONCE_INIT;
+static int cn1GcAssistEnabled = 1;
+
+static void cn1GcResolveAssistEnabled(void) {
+    const char* v = getenv("CN1_GC_NO_MUTATOR_ASSIST");
+    cn1GcAssistEnabled = (v != 0 && v[0] != '0') ? 0 : 1;
+}
+
 static int cn1GcMutatorAssist(CODENAME_ONE_THREAD_STATE) {
-    // A/B switch, so the assist can be measured against the sleep it replaces in
-    // one binary rather than two builds.
-    static int enabled = -1;
     struct gcMarkLocalBuffer localBuf;
     struct gcMarkWorklistEntry batch[CN1_GC_MARK_BATCH];
     int n;
     int i;
-    if(enabled < 0) {
-        const char* v = getenv("CN1_GC_NO_MUTATOR_ASSIST");
-        enabled = (v != 0 && v[0] != '0') ? 0 : 1;
-    }
-    if(!enabled || gcMarkLocalBuf != 0) {
+    pthread_once(&cn1GcAssistOnce, cn1GcResolveAssistEnabled);
+    if(!cn1GcAssistEnabled || gcMarkLocalBuf != 0) {
         return 0;
     }
     pthread_mutex_lock(&gcMarkWorklistMutex);

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -6361,9 +6361,15 @@ static void cn1BibopAdaptAfterSweep(long occupiedBytes, long liveBytes,
         long oldTrigger = atomic_load_explicit(&bibopGcTriggerBytes,
                                                memory_order_relaxed);
         bibopTriggerHighSurvivalStreak = 0;
-        long lowFloor = cn1BibopTriggerFloor(liveBytes);
-        if(oldTrigger != lowFloor) {
-            atomic_store_explicit(&bibopGcTriggerBytes, lowFloor,
+        // The live-set floor deliberately does NOT apply here. Low memory mode is
+        // about surviving pressure rather than about footprint, and it pins the
+        // trigger to the constant on purpose: GcSteadyState pins the free-memory
+        // reading to 16MB precisely to make the per-thread pending table fill, and
+        // a live-set floor collects early enough that it never does -- the test
+        // then fails itself as measuring nothing, which is exactly what it did.
+        if(oldTrigger != CN1_BIBOP_GC_TRIGGER_BYTES) {
+            atomic_store_explicit(&bibopGcTriggerBytes,
+                                  CN1_BIBOP_GC_TRIGGER_BYTES,
                                   memory_order_relaxed);
         }
     } else if(occupiedBytes >= (2 * 1024 * 1024)) {
@@ -6396,6 +6402,14 @@ static void cn1BibopAdaptAfterSweep(long occupiedBytes, long liveBytes,
                 if(newTrigger < floorBytes) {
                     newTrigger = floorBytes;
                 }
+            } else if(oldTrigger < floorBytes) {
+                // The floor is a bound in BOTH directions. Low survival on a big
+                // live set means the trigger should not stay under what that live
+                // set justifies: a 4MB trigger against 20MB live would retrace
+                // the whole live heap every 4MB of allocation. Raising it here is
+                // the only path that corrects a trigger which adapted down before
+                // the live set grew.
+                newTrigger = floorBytes;
             }
         }
         if(newTrigger != oldTrigger) {

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -1632,6 +1632,7 @@ static void gcMarkDrainWorklist(CODENAME_ONE_THREAD_STATE);
 // is configured. Defined further down (after gcMarkDrain). See the big comment block
 // at the worklist declarations for the design and the invariants it preserves.
 static void gcMarkDrainParallel(CODENAME_ONE_THREAD_STATE);
+static int cn1GcMutatorAssist(CODENAME_ONE_THREAD_STATE);
 
 #ifdef CN1_CONSERVATIVE_GC_ROOTS
 // PHASE 3b forward declarations (definitions live after the BiBOP block because the
@@ -4097,6 +4098,32 @@ BOOL isAppSuspended = 0;
 #ifndef CN1_BIBOP_GC_MAX_TRIGGER_BYTES
 #define CN1_BIBOP_GC_MAX_TRIGGER_BYTES (192*1024*1024)
 #endif
+// THE FLOOR IS PROPORTIONAL TO THE LIVE SET, not a constant.
+//
+// CN1_BIBOP_GC_TRIGGER_BYTES used to be the floor outright, so a process whose
+// live set was nearly nothing still let 24MB of garbage pile up before
+// collecting, and the page pool sized itself to that. Measured on the backend
+// (/plaintext, 64 connections), resident memory tracks the trigger almost
+// linearly and nothing else: 4MB -> 30MB RSS, 8MB -> 49MB, 16MB -> 68MB,
+// 24MB -> 98MB. Throughput and p99 across that same sweep were flat inside the
+// run-to-run noise, so the 24MB floor was buying footprint and no speed.
+//
+// Every modern collector sizes the next heap against the LIVE set rather than
+// against a constant -- Go's GOGC=100 means "collect when the heap reaches twice
+// what survived" -- which is why a Go server holding almost nothing live sits at
+// 6-17MB where we sat at 98MB. This is that rule: the floor is the live set plus
+// CN1_BIBOP_HEAP_GROWTH_PERCENT of it, never below CN1_BIBOP_GC_MIN_TRIGGER_BYTES.
+//
+// It is not merely smaller. An application with a real live set gets a LARGER
+// floor than the old constant (20MB live at 100% growth asks for 40MB, where the
+// constant gave 24MB), so this is more generous exactly where the old rule was
+// stingy and tighter only where it was wasteful.
+#ifndef CN1_BIBOP_GC_MIN_TRIGGER_BYTES
+#define CN1_BIBOP_GC_MIN_TRIGGER_BYTES (4*1024*1024)
+#endif
+#ifndef CN1_BIBOP_HEAP_GROWTH_PERCENT
+#define CN1_BIBOP_HEAP_GROWTH_PERCENT 100
+#endif
 #ifndef CN1_BIBOP_HIGH_THROUGHPUT_BYTES
 #define CN1_BIBOP_HIGH_THROUGHPUT_BYTES (8*1024*1024)
 #endif
@@ -5385,7 +5412,11 @@ static void cn1PacingPark(CODENAME_ONE_THREAD_STATE, int which, long long pendin
         }
         CN1_GC_PARK_CAPTURE(threadStateData);
         CN1_STALL_T0(__stallVol);
-        threadStateData->threadActive = JAVA_FALSE;
+        // NOT marked parked yet: the assist below runs Java mark functions on
+        // this thread's own stack, and advertising it as parked would let the
+        // collector scan that stack conservatively while it is moving. The flag
+        // is lowered only around the sleep, which is the one place this thread
+        // really is idle.
         int spins = 0;
         while(cn1PacingVolume(which) > (long long)cap &&
               get_static_java_lang_System_gcThreadInstance() != JAVA_NULL &&
@@ -5408,10 +5439,21 @@ static void cn1PacingPark(CODENAME_ONE_THREAD_STATE, int which, long long pendin
             // Yielding hands the host back. The virtual thread is RUNNABLE, not
             // waiting on its socket, so the scheduler must re-queue it rather
             // than hand it to the poller; see CN1_VT_YIELD_RUNNABLE.
+            // Help before sleeping: marking a batch shortens the very cycle this
+            // thread is waiting on, where sleeping only waits for someone else to
+            // finish it. This is Go's mutator assist in the one place we had a
+            // sleep-until-done park. See cn1GcMutatorAssist.
+            if(!threadStateData->threadBlockedByGC
+                    && cn1GcMutatorAssist(threadStateData) > 0) {
+                continue;
+            }
+            threadStateData->threadActive = JAVA_FALSE;
             if(!cn1VirtualThreadYieldIfVirtual()) {
                 usleep(50);
             }
+            threadStateData->threadActive = JAVA_TRUE;
         }
+        threadStateData->threadActive = JAVA_FALSE;
         while(threadStateData->threadBlockedByGC) {
             if(!cn1VirtualThreadYieldIfVirtual()) {
                 usleep((JAVA_INT)(500));
@@ -6237,6 +6279,31 @@ void cn1BibopNoteMonitorAttached(JAVA_OBJECT obj) {
 void cn1BibopNoteNativePeer(JAVA_OBJECT obj) { (void)obj; }
 #endif
 
+/**
+ * The smallest trigger this live set justifies: live + growth%, clamped to the
+ * absolute minimum. Answers in bytes.
+ */
+static long cn1BibopTriggerFloor(long liveBytes) {
+    long floor;
+    if(liveBytes < 0) {
+        liveBytes = 0;
+    }
+    // The multiply is done in long long so a large live set cannot wrap the
+    // percentage before the clamp sees it.
+    {
+        long long scaled = ((long long)liveBytes
+                * (long long)(100 + CN1_BIBOP_HEAP_GROWTH_PERCENT)) / 100;
+        if(scaled > (long long)CN1_BIBOP_GC_MAX_TRIGGER_BYTES) {
+            scaled = (long long)CN1_BIBOP_GC_MAX_TRIGGER_BYTES;
+        }
+        floor = (long)scaled;
+    }
+    if(floor < CN1_BIBOP_GC_MIN_TRIGGER_BYTES) {
+        floor = CN1_BIBOP_GC_MIN_TRIGGER_BYTES;
+    }
+    return floor;
+}
+
 static void cn1BibopAdaptAfterSweep(long occupiedBytes, long liveBytes,
                                     long reclaimedBytes,
                                     long* classSlots, long* classLive) {
@@ -6248,9 +6315,9 @@ static void cn1BibopAdaptAfterSweep(long occupiedBytes, long liveBytes,
         long oldTrigger = atomic_load_explicit(&bibopGcTriggerBytes,
                                                memory_order_relaxed);
         bibopTriggerHighSurvivalStreak = 0;
-        if(oldTrigger != CN1_BIBOP_GC_TRIGGER_BYTES) {
-            atomic_store_explicit(&bibopGcTriggerBytes,
-                                  CN1_BIBOP_GC_TRIGGER_BYTES,
+        long lowFloor = cn1BibopTriggerFloor(liveBytes);
+        if(oldTrigger != lowFloor) {
+            atomic_store_explicit(&bibopGcTriggerBytes, lowFloor,
                                   memory_order_relaxed);
         }
     } else if(occupiedBytes >= (2 * 1024 * 1024)) {
@@ -6265,8 +6332,8 @@ static void cn1BibopAdaptAfterSweep(long occupiedBytes, long liveBytes,
                 long freeMem = atomic_load_explicit(&cn1CachedFreeMem,
                                                     memory_order_relaxed);
                 if(freeMem > 0 && freeMem / 8 < ceiling) ceiling = freeMem / 8;
-                if(ceiling < CN1_BIBOP_GC_TRIGGER_BYTES) {
-                    ceiling = CN1_BIBOP_GC_TRIGGER_BYTES;
+                if(ceiling < cn1BibopTriggerFloor(liveBytes)) {
+                    ceiling = cn1BibopTriggerFloor(liveBytes);
                 }
                 newTrigger = oldTrigger * 2;
                 if(newTrigger > ceiling) newTrigger = ceiling;
@@ -6274,10 +6341,14 @@ static void cn1BibopAdaptAfterSweep(long occupiedBytes, long liveBytes,
             }
         } else if(survival <= 20) {
             bibopTriggerHighSurvivalStreak = 0;
-            if(oldTrigger > CN1_BIBOP_GC_TRIGGER_BYTES) {
+            // Shrink towards what the LIVE set justifies. This used to stop at
+            // the 24MB constant, which is why a server holding nothing live
+            // still held a 24MB trigger and ~98MB of resident memory.
+            long floorBytes = cn1BibopTriggerFloor(liveBytes);
+            if(oldTrigger > floorBytes) {
                 newTrigger = oldTrigger / 2;
-                if(newTrigger < CN1_BIBOP_GC_TRIGGER_BYTES) {
-                    newTrigger = CN1_BIBOP_GC_TRIGGER_BYTES;
+                if(newTrigger < floorBytes) {
+                    newTrigger = floorBytes;
                 }
             }
         }
@@ -10833,6 +10904,98 @@ static void gcMarkWorkerDrainLoop() {
 // Helper-thread entry point. Sleeps on the control condition until the GC thread bumps
 // the generation to dispatch a drain, participates, then reports completion. Lives for
 // the lifetime of the process (like the GC thread itself).
+/**
+ * MUTATOR ASSIST: a thread that has outrun the collector marks instead of sleeping.
+ *
+ * cn1PacingPark used to answer "you are too far ahead" with usleep(50) in a loop,
+ * so the thread contributed nothing while one collector thread did all the work,
+ * and the park therefore lasted as long as a whole collection. Measured on
+ * demo/gcpause (one thread, 20M short-lived objects, a 4096-node live set):
+ * 7 parks averaging 1.54s, worst 3.31s, against Go's 20ms worst pause on the
+ * identical loop -- and the heap reached 1.25GB to hold 128KB of live data,
+ * because nothing slowed the mutator until it crossed the 512MB floor.
+ *
+ * Go charges an allocating goroutine proportional marking work at allocation
+ * time, so the brake is proportional and the work SHORTENS the cycle. This is
+ * that: one batch of real marking per call, which both delays the allocator and
+ * helps the collection it is waiting for.
+ *
+ * Three things make it safe to join a mark already in progress:
+ *
+ *   - It REGISTERS in gcMarkActiveWorkers before releasing the lock. The
+ *     termination protocol is "last worker to find the list empty declares done",
+ *     so a thread holding a batch that is not counted would let mark finish early
+ *     and leave live objects unmarked. Registering makes this thread visible to
+ *     it, and the decrement below repeats the workers' own end condition.
+ *   - It only assists the PARALLEL mark. gcMarkDrainParallel falls back to the
+ *     serial gcMarkDrain when the pool is one thread, and that path touches the
+ *     worklist without the mutex, so joining it would be a data race.
+ *     gcMarkActiveWorkers > 0 is true only on the parallel path.
+ *   - It refuses to recurse: a thread already inside a mark has gcMarkLocalBuf
+ *     set, and pushing a second local buffer over it would strand the first.
+ *
+ * Returns the number of entries marked, 0 if there was nothing to do.
+ */
+static int cn1GcMutatorAssist(CODENAME_ONE_THREAD_STATE) {
+    // A/B switch, so the assist can be measured against the sleep it replaces in
+    // one binary rather than two builds.
+    static int enabled = -1;
+    struct gcMarkLocalBuffer localBuf;
+    struct gcMarkWorklistEntry batch[CN1_GC_MARK_BATCH];
+    int n;
+    int i;
+    if(enabled < 0) {
+        const char* v = getenv("CN1_GC_NO_MUTATOR_ASSIST");
+        enabled = (v != 0 && v[0] != '0') ? 0 : 1;
+    }
+    if(!enabled || gcMarkLocalBuf != 0) {
+        return 0;
+    }
+    pthread_mutex_lock(&gcMarkWorklistMutex);
+    if(gcMarkDone || gcMarkActiveWorkers <= 0 || gcMarkWorklistTop <= 0) {
+        pthread_mutex_unlock(&gcMarkWorklistMutex);
+        return 0;
+    }
+    n = gcMarkWorklistTop;
+    if(n > CN1_GC_MARK_BATCH) {
+        n = CN1_GC_MARK_BATCH;
+    }
+    gcMarkWorklistTop -= n;
+    memcpy(batch, &gcMarkWorklist[gcMarkWorklistTop],
+           n * sizeof(struct gcMarkWorklistEntry));
+    gcMarkActiveWorkers++;
+    pthread_mutex_unlock(&gcMarkWorklistMutex);
+
+    localBuf.count = 0;
+    gcMarkLocalBuf = &localBuf;
+    for(i = 0 ; i < n ; i++) {
+        JAVA_OBJECT obj = batch[i].obj;
+        gcMarkFunctionPointer fp = obj->__codenameOneParentClsReference->markFunction;
+        if(fp != 0) {
+#if CN1_ADOPT_POLICY != 0 && !defined(CN1_DISABLE_BIBOP)
+            JAVA_BOOLEAN __savedMaturing = gcCurrentlyMaturing;
+            gcCurrentlyMaturing = (obj->__heapPosition == CN1_BIBOP_ADOPTED)
+                    ? JAVA_TRUE : __savedMaturing;
+            fp(threadStateData, obj, batch[i].force);
+            gcCurrentlyMaturing = __savedMaturing;
+#else
+            fp(threadStateData, obj, batch[i].force);
+#endif
+        }
+    }
+    gcMarkFlushLocal(&localBuf);
+    gcMarkLocalBuf = 0;
+
+    pthread_mutex_lock(&gcMarkWorklistMutex);
+    gcMarkActiveWorkers--;
+    if(gcMarkActiveWorkers == 0) {
+        gcMarkDone = JAVA_TRUE;
+        pthread_cond_broadcast(&gcMarkWorklistCond);
+    }
+    pthread_mutex_unlock(&gcMarkWorklistMutex);
+    return n;
+}
+
 extern void cn1InstallThreadAltStack(void);
 static void* gcMarkWorkerMain(void* arg) {
     cn1InstallThreadAltStack();  // so a fault in the GC mark dumps a backtrace, not a silent die

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -11092,7 +11092,16 @@ static int cn1GcMutatorAssist(CODENAME_ONE_THREAD_STATE) {
 
     pthread_mutex_lock(&gcMarkWorklistMutex);
     gcMarkActiveWorkers--;
-    if(gcMarkActiveWorkers == 0) {
+    // BOTH conditions, and the worklist half is the one that matters here.
+    //
+    // gcMarkFlushLocal ran just above and may have pushed children this batch
+    // discovered. A worker only decrements after re-checking the list at the top
+    // of its loop, so it never declares done with work outstanding; this function
+    // decrements straight after flushing, so testing the worker count alone could
+    // end the mark with reachable subtrees unscanned and let the sweep reclaim
+    // them. The flush already broadcasts when it appends, so an idle worker wakes
+    // and picks the work up.
+    if(gcMarkActiveWorkers == 0 && gcMarkWorklistTop == 0) {
         gcMarkDone = JAVA_TRUE;
         pthread_cond_broadcast(&gcMarkWorklistCond);
     }
@@ -11219,7 +11228,11 @@ JAVA_OBJECT cn1AllocFused(CODENAME_ONE_THREAD_STATE, int totalSize, struct clazz
        && !threadStateData->nativeAllocationMode
 #endif
        ) {
-        return cn1BibopAlloc(threadStateData, totalSize, cls);
+        JAVA_OBJECT fused = cn1BibopAlloc(threadStateData, totalSize, cls);
+#ifdef CN1_GC_CONFORM
+        if(fused != JAVA_NULL) { cn1RecordAllocation(cls, totalSize); }
+#endif
+        return fused;
     }
 #endif
     return JAVA_NULL;
@@ -11621,6 +11634,14 @@ JAVA_OBJECT cn1FusedLatin1Begin(CODENAME_ONE_THREAD_STATE, int len, JAVA_ARRAY_B
                 JAVA_OBJECT arr = cn1FusedInstallPrimArray(so, off, &class_array1__JAVA_BYTE, sizeof(JAVA_ARRAY_BYTE), len);
                 ((struct obj__java_lang_String*)so)->java_lang_String_value = arr; // count stays 0 until End
                 *dst = (JAVA_ARRAY_BYTE*)((JAVA_ARRAY)arr)->data;
+#ifdef CN1_GC_CONFORM
+                // Attribute the two halves separately: the fused block is one
+                // allocation but the profile is read to find out WHAT is being
+                // allocated, and "String" alone would hide the byte[] payload
+                // that dominates the block for long strings.
+                cn1RecordAllocation(&class__java_lang_String, off);
+                cn1RecordAllocation(&class_array1__JAVA_BYTE, total - off);
+#endif
                 return so;
             }
         }
@@ -12190,6 +12211,13 @@ void cn1RecordAllocation(struct clazz* parent, int size) {
     atomic_fetch_add_explicit(&cn1AllocProfCount[id], 1, memory_order_relaxed);
 }
 
+// count|1 was meant to guard a divide by zero and silently changed the divisor
+// instead: two allocations reported bytes/3. Selecting on bytes>0 already implies
+// a nonzero count, so the guard only has to be honest about the degenerate case.
+static long long cn1AllocProfAvg(long long bytes, long count) {
+    return count > 0 ? bytes / count : 0;
+}
+
 static void cn1ReportAllocProfile(void) {
     long long total = 0;
     int i;
@@ -12218,7 +12246,8 @@ static void cn1ReportAllocProfile(void) {
                         ? cn1AllocProfClass[best]->clsName : "?",
                 bestBytes,
                 atomic_load_explicit(&cn1AllocProfCount[best], memory_order_relaxed),
-                bestBytes / (atomic_load_explicit(&cn1AllocProfCount[best], memory_order_relaxed) | 1));
+                cn1AllocProfAvg(bestBytes,
+                        atomic_load_explicit(&cn1AllocProfCount[best], memory_order_relaxed)));
         atomic_store_explicit(&cn1AllocProfBytes[best], 0, memory_order_relaxed);
         printed++;
     }

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -4112,45 +4112,27 @@ BOOL isAppSuspended = 0;
 // 24MB -> 98MB. Throughput and p99 across that same sweep were flat inside the
 // run-to-run noise, so the 24MB floor was buying footprint and no speed.
 //
-// Every modern collector sizes the next heap against the LIVE set rather than
-// against a constant -- Go's GOGC=100 means "collect when the heap reaches twice
-// what survived" -- which is why a Go server holding almost nothing live sits at
-// 6-17MB where we sat at 98MB. This is that rule: the floor is the live set plus
-// CN1_BIBOP_HEAP_GROWTH_PERCENT of it, never below CN1_BIBOP_GC_MIN_TRIGGER_BYTES.
+// So this is a floor a deployment CHOOSES, not one the collector infers. It
+// defaults to the old constant, which is why a stock build collects exactly
+// where it always did, and an application that knows its live set is small sets
+// it lower -- the backend uses 4MB and its resident memory fell from 98MB to
+// 38MB.
 //
-// It is not merely smaller. An application with a real live set gets a LARGER
-// floor than the old constant (20MB live at 100% growth asks for 40MB, where the
-// constant gave 24MB), so this is more generous exactly where the old rule was
-// stingy and tighter only where it was wasteful.
-// The floor never drops BELOW the old constant by default, and that default is
-// the conservative one on purpose.
-//
-// Sizing the floor from the live set is right in principle, but liveBytes is a
-// per-sweep sample that systematically understates: the sweep walks the retired
-// list, and pages the major sweep splices out of a partial pool are withheld
-// from policy statistics (see statsExcluded). A decaying high-water delays the
-// consequence rather than removing it -- roughly twenty low-survival cycles and
-// a stable 20MB live set is estimated at the minimum, after which the collector
-// retraces that heap every few megabytes.
-//
-// Measured rather than argued: with the minimum at 4MB,
-// GcSteadyStateIntegrationTest fails itself in CI with "pinning the free-memory
-// reading to 16MB did not make the per-thread pending table fill, so this
-// scenario and its twin measure nothing" -- cyclesOnDemand=5598 and 22331 volume
-// parks, which is the collector running continuously because the trigger sat at
-// the floor. ProcessBudgetPacingIntegrationTest's 72MB static cap floor
-// (3 x 24MB) is derived from this constant too.
-//
-// So the proportional rule now only ever RAISES the floor: an application with a
-// real live set gets more headroom than the constant gave it, and nothing gets
-// less. A deployment that knows its live set is tiny -- the backend, whose
-// resident memory fell from 98MB to 38MB on this -- opts in by defining
-// CN1_BIBOP_GC_MIN_TRIGGER_BYTES lower at build time.
+// It is deliberately not sized from the live set. Every modern collector does
+// size the next heap against what survived -- Go's GOGC=100 collects when the
+// heap reaches twice the live set -- and this collector tried that and could not
+// make it sound, because it cannot measure a live set. What a sweep reports is
+// what that sweep SAMPLED: an ordinary sweep walks retired pages only and never
+// sees a live object on a partial page, a major sweep splices the partial pools
+// in but withholds their slots from the policy numbers, mutator-owned current
+// pages are never swept at all, and the legacy heap above CN1_BIBOP_MAX_OBJECT
+// is not in BiBOP pages and reaches none of these counters. Three attempts to
+// build a proportional floor on that number each failed differently, the first
+// of them by latching a departed live set high enough to starve the sweeps that
+// return pages to the OS. A constant a deployment sets from what it knows about
+// its own workload needs no such measurement to be correct.
 #ifndef CN1_BIBOP_GC_MIN_TRIGGER_BYTES
 #define CN1_BIBOP_GC_MIN_TRIGGER_BYTES CN1_BIBOP_GC_TRIGGER_BYTES
-#endif
-#ifndef CN1_BIBOP_HEAP_GROWTH_PERCENT
-#define CN1_BIBOP_HEAP_GROWTH_PERCENT 100
 #endif
 #ifndef CN1_BIBOP_HIGH_THROUGHPUT_BYTES
 #define CN1_BIBOP_HIGH_THROUGHPUT_BYTES (8*1024*1024)
@@ -5503,6 +5485,26 @@ static void cn1PacingPark(CODENAME_ONE_THREAD_STATE, int which, long long pendin
             }
         }
         threadStateData->threadActive = JAVA_TRUE;
+        // This is CN1_RESUME_THREAD's handshake, deliberately, and NOT a stronger
+        // one. A review asked for an atomic block-check-and-reactivate here on the
+        // grounds that the collector can set threadBlockedByGC after this loop's
+        // last read but before the store above, observe threadActive already
+        // false, and scan a stack that is about to start moving. The window is
+        // real and the description is accurate.
+        //
+        // It is also not this function's window. CN1_RESUME_THREAD is exactly
+        // `while(threadBlockedByGC) wait; threadActive = TRUE;`, the collector
+        // stops threads by setting the flag and then waiting for threadActive to
+        // clear with no re-validation afterwards, and that pair is the protocol at
+        // every native boundary in the VM. Making this one site atomic would close
+        // nothing -- the same window stays open at thousands of others -- while
+        // leaving one function speaking a different protocol from the collector it
+        // has to agree with, which is how the last few defects here happened.
+        //
+        // So it is left matching the protocol on purpose. If the window is worth
+        // closing it needs a collector-side acknowledgement applied to every
+        // resume site at once, which is a change to the VM's thread protocol and
+        // not something to smuggle in through a pacing fix.
         CN1_STALL_ADD(__stallVol, CN1_STALL_PACING_VOLUME, threadStateData);
         return;
     }
@@ -12334,31 +12336,52 @@ static long long cn1AllocProfAvg(long long bytes, long count) {
     return count > 0 ? bytes / count : 0;
 }
 
+// Report-local copies. atexit handlers do not stop the other threads, so a
+// mutator can still be allocating while this runs: ranking the live counters
+// destructively meant a class could be printed, keep allocating, and be selected
+// again for a second row, while its bytes and count were read at different
+// instants and need not describe the same set of allocations. Everything is
+// copied once here and the ranking then consumes the copy, so the report is a
+// snapshot of one moment and the live counters are left alone.
+static long long cn1AllocProfSnapBytes[CN1_ALLOC_PROFILE_SLOTS];
+static long cn1AllocProfSnapCount[CN1_ALLOC_PROFILE_SLOTS];
+static struct clazz* cn1AllocProfSnapClass[CN1_ALLOC_PROFILE_SLOTS];
+
 static void cn1ReportAllocProfile(void) {
     long long total = 0;
     int i;
     int printed = 0;
     for(i = 0 ; i < CN1_ALLOC_PROFILE_SLOTS ; i++) {
-        total += atomic_load_explicit(&cn1AllocProfBytes[i], memory_order_relaxed);
+        cn1AllocProfSnapBytes[i] =
+                atomic_load_explicit(&cn1AllocProfBytes[i], memory_order_relaxed);
+        cn1AllocProfSnapCount[i] =
+                atomic_load_explicit(&cn1AllocProfCount[i], memory_order_relaxed);
+        cn1AllocProfSnapClass[i] =
+                atomic_load_explicit(&cn1AllocProfClass[i], memory_order_relaxed);
+        total += cn1AllocProfSnapBytes[i];
     }
     if(cn1AllocSizeClassName != 0) {
         int i;
-        // Descending by count, selection-style: the table is 48 entries and this
-        // runs once at exit, so the quadratic scan costs nothing and keeps the
-        // hot recorder free of any ordering work.
+        // Snapshot first, for the same reason as the per-class table above; 48
+        // entries fit on the stack. Descending by count, selection-style: this
+        // runs once at exit, so the quadratic scan costs nothing and keeps the hot
+        // recorder free of any ordering work.
+        long long snapCount[CN1_ALLOC_SIZE_BUCKETS];
+        int snapKey[CN1_ALLOC_SIZE_BUCKETS];
+        for(i = 0 ; i < CN1_ALLOC_SIZE_BUCKETS ; i++) {
+            snapCount[i] = atomic_load_explicit(&cn1AllocSizeCount[i], memory_order_relaxed);
+            snapKey[i] = atomic_load_explicit(&cn1AllocSizeKey[i], memory_order_relaxed);
+        }
         for(;;) {
             int bestIdx = -1;
             long long bestCount = 0;
             for(i = 0 ; i < CN1_ALLOC_SIZE_BUCKETS ; i++) {
-                long long c = atomic_load_explicit(&cn1AllocSizeCount[i], memory_order_relaxed);
-                if(c > bestCount) { bestCount = c; bestIdx = i; }
+                if(snapCount[i] > bestCount) { bestCount = snapCount[i]; bestIdx = i; }
             }
             if(bestIdx < 0) { break; }
             fprintf(stderr, "[ALLOCSIZE] %-28s bytes=%-8d count=%lld\n",
-                    cn1AllocSizeClassName,
-                    atomic_load_explicit(&cn1AllocSizeKey[bestIdx], memory_order_relaxed),
-                    bestCount);
-            atomic_store_explicit(&cn1AllocSizeCount[bestIdx], 0, memory_order_relaxed);
+                    cn1AllocSizeClassName, snapKey[bestIdx], bestCount);
+            snapCount[bestIdx] = 0;
         }
         fprintf(stderr, "[ALLOCSIZE] %-28s overflow=%lld\n", cn1AllocSizeClassName,
                 atomic_load_explicit(&cn1AllocSizeOverflow, memory_order_relaxed));
@@ -12385,25 +12408,22 @@ static void cn1ReportAllocProfile(void) {
         int best = -1;
         long long bestBytes = 0;
         for(i = 0 ; i < CN1_ALLOC_PROFILE_SLOTS ; i++) {
-            long long b = atomic_load_explicit(&cn1AllocProfBytes[i], memory_order_relaxed);
-            if(b > bestBytes) {
-                bestBytes = b;
+            if(cn1AllocProfSnapBytes[i] > bestBytes) {
+                bestBytes = cn1AllocProfSnapBytes[i];
                 best = i;
             }
         }
         if(best < 0) {
             break;
         }
-        struct clazz* cn1AllocProfBest =
-                atomic_load_explicit(&cn1AllocProfClass[best], memory_order_relaxed);
-        fprintf(stderr, "[ALLOCPROF] %-44s bytes=%-12lld count=%-10ld avg=%lld\n",
-                (cn1AllocProfBest != 0 && cn1AllocProfBest->clsName != 0)
-                        ? cn1AllocProfBest->clsName : "?",
-                bestBytes,
-                atomic_load_explicit(&cn1AllocProfCount[best], memory_order_relaxed),
-                cn1AllocProfAvg(bestBytes,
-                        atomic_load_explicit(&cn1AllocProfCount[best], memory_order_relaxed)));
-        atomic_store_explicit(&cn1AllocProfBytes[best], 0, memory_order_relaxed);
+        {
+            struct clazz* cls = cn1AllocProfSnapClass[best];
+            long count = cn1AllocProfSnapCount[best];
+            fprintf(stderr, "[ALLOCPROF] %-44s bytes=%-12lld count=%-10ld avg=%lld\n",
+                    (cls != 0 && cls->clsName != 0) ? cls->clsName : "?",
+                    bestBytes, count, cn1AllocProfAvg(bestBytes, count));
+        }
+        cn1AllocProfSnapBytes[best] = 0;   // consume the COPY, not the counter
         printed++;
     }
     fflush(stderr);

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -642,6 +642,10 @@ static JAVA_BOOLEAN cn1GcPageIndexStale = JAVA_FALSE;
 // peak footprint. Tracer-gated, like the counters above.
 static _Atomic long long cn1GcAllocatedTotal = 0;
 static _Atomic int cn1GcOverflowTrace = -1;
+#ifdef CN1_GC_CONFORM
+void cn1RecordAllocation(struct clazz* parent, int size);
+#endif
+
 static int cn1GcOverflowTraceOn(void) {
     int on = atomic_load_explicit(&cn1GcOverflowTrace, memory_order_relaxed);
     if(on < 0) {
@@ -4118,8 +4122,32 @@ BOOL isAppSuspended = 0;
 // floor than the old constant (20MB live at 100% growth asks for 40MB, where the
 // constant gave 24MB), so this is more generous exactly where the old rule was
 // stingy and tighter only where it was wasteful.
+// The floor never drops BELOW the old constant by default, and that default is
+// the conservative one on purpose.
+//
+// Sizing the floor from the live set is right in principle, but liveBytes is a
+// per-sweep sample that systematically understates: the sweep walks the retired
+// list, and pages the major sweep splices out of a partial pool are withheld
+// from policy statistics (see statsExcluded). A decaying high-water delays the
+// consequence rather than removing it -- roughly twenty low-survival cycles and
+// a stable 20MB live set is estimated at the minimum, after which the collector
+// retraces that heap every few megabytes.
+//
+// Measured rather than argued: with the minimum at 4MB,
+// GcSteadyStateIntegrationTest fails itself in CI with "pinning the free-memory
+// reading to 16MB did not make the per-thread pending table fill, so this
+// scenario and its twin measure nothing" -- cyclesOnDemand=5598 and 22331 volume
+// parks, which is the collector running continuously because the trigger sat at
+// the floor. ProcessBudgetPacingIntegrationTest's 72MB static cap floor
+// (3 x 24MB) is derived from this constant too.
+//
+// So the proportional rule now only ever RAISES the floor: an application with a
+// real live set gets more headroom than the constant gave it, and nothing gets
+// less. A deployment that knows its live set is tiny -- the backend, whose
+// resident memory fell from 98MB to 38MB on this -- opts in by defining
+// CN1_BIBOP_GC_MIN_TRIGGER_BYTES lower at build time.
 #ifndef CN1_BIBOP_GC_MIN_TRIGGER_BYTES
-#define CN1_BIBOP_GC_MIN_TRIGGER_BYTES (4*1024*1024)
+#define CN1_BIBOP_GC_MIN_TRIGGER_BYTES CN1_BIBOP_GC_TRIGGER_BYTES
 #endif
 #ifndef CN1_BIBOP_HEAP_GROWTH_PERCENT
 #define CN1_BIBOP_HEAP_GROWTH_PERCENT 100
@@ -9091,6 +9119,9 @@ static void cn1GcSelfCheckThreadStack(struct ThreadLocalData* t, int stackSize) 
 #endif /* CN1_CONSERVATIVE_GC_ROOTS */
 
 JAVA_OBJECT codenameOneGcMalloc(CODENAME_ONE_THREAD_STATE, int size, struct clazz* parent) {
+#ifdef CN1_GC_CONFORM
+    cn1RecordAllocation(parent, size);
+#endif
 cn1GcMallocRetry:
     CN1_CLAZZ_REGISTER(parent); // first-alloc-per-class: exact clazz registry for the GC guard
     if(isAppSuspended) {
@@ -12129,6 +12160,72 @@ static long long cn1StallPercentileUs(int cause, double q) {
 
 // The whole-run table. Printed at exit so a run that ends in a kill still leaves the
 // 1Hz series behind, and a run that ends cleanly leaves the distribution too.
+#ifdef CN1_GC_CONFORM
+// PER-CLASS ALLOCATION PROFILE.
+//
+// Four attempts to cut allocation on the backend's hot path were aimed by
+// reading code, and all four missed: a per-request buffer copy that turned out
+// to be per-connection, a header materialisation the load generator never
+// triggers. 662 bytes per request on /plaintext is a fact; WHERE they come from
+// was guesswork. This counts every allocation by class so the answer is a table
+// rather than an argument.
+//
+// CONFORM-only, two relaxed atomics on the allocation path, printed at exit.
+#define CN1_ALLOC_PROFILE_SLOTS 8192
+static _Atomic long long cn1AllocProfBytes[CN1_ALLOC_PROFILE_SLOTS];
+static _Atomic long cn1AllocProfCount[CN1_ALLOC_PROFILE_SLOTS];
+static struct clazz* cn1AllocProfClass[CN1_ALLOC_PROFILE_SLOTS];
+
+void cn1RecordAllocation(struct clazz* parent, int size) {
+    int id;
+    if(parent == 0) {
+        return;
+    }
+    id = parent->classId;
+    if(id < 0 || id >= CN1_ALLOC_PROFILE_SLOTS) {
+        return;
+    }
+    cn1AllocProfClass[id] = parent;
+    atomic_fetch_add_explicit(&cn1AllocProfBytes[id], (long long)size, memory_order_relaxed);
+    atomic_fetch_add_explicit(&cn1AllocProfCount[id], 1, memory_order_relaxed);
+}
+
+static void cn1ReportAllocProfile(void) {
+    long long total = 0;
+    int i;
+    int printed = 0;
+    for(i = 0 ; i < CN1_ALLOC_PROFILE_SLOTS ; i++) {
+        total += atomic_load_explicit(&cn1AllocProfBytes[i], memory_order_relaxed);
+    }
+    fprintf(stderr, "[ALLOCPROF] totalBytes=%lld\n", total);
+    // Top twenty by bytes, selected by repeated max rather than a sort: this runs
+    // once at exit and the table is small.
+    while(printed < 20) {
+        int best = -1;
+        long long bestBytes = 0;
+        for(i = 0 ; i < CN1_ALLOC_PROFILE_SLOTS ; i++) {
+            long long b = atomic_load_explicit(&cn1AllocProfBytes[i], memory_order_relaxed);
+            if(b > bestBytes) {
+                bestBytes = b;
+                best = i;
+            }
+        }
+        if(best < 0) {
+            break;
+        }
+        fprintf(stderr, "[ALLOCPROF] %-44s bytes=%-12lld count=%-10ld avg=%lld\n",
+                (cn1AllocProfClass[best] != 0 && cn1AllocProfClass[best]->clsName != 0)
+                        ? cn1AllocProfClass[best]->clsName : "?",
+                bestBytes,
+                atomic_load_explicit(&cn1AllocProfCount[best], memory_order_relaxed),
+                bestBytes / (atomic_load_explicit(&cn1AllocProfCount[best], memory_order_relaxed) | 1));
+        atomic_store_explicit(&cn1AllocProfBytes[best], 0, memory_order_relaxed);
+        printed++;
+    }
+    fflush(stderr);
+}
+#endif
+
 static void cn1ReportStalls(void) {
     long long wallMs = cn1GcProbeElapsedMs();
     // Mutator-only, to match the thread count it is divided by; the per-cause table below
@@ -12441,6 +12538,9 @@ void initConstantPool() {
     cn1StartSimulatedMemoryWarnings();
 #ifdef CN1_GC_CONFORM
     atexit(cn1ReportStalls);
+#ifdef CN1_GC_CONFORM
+    atexit(cn1ReportAllocProfile);
+#endif
 #ifdef CN1_CONSERVATIVE_GC_ROOTS
     // The self test sorts the conservative extent table, which only exists on
     // this arm. Calling it under CN1_GC_CONFORM alone does not compile, so

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -6405,6 +6405,7 @@ static void cn1BibopAdaptAfterSweep(long occupiedBytes, long liveBytes,
         long oldTrigger = atomic_load_explicit(&bibopGcTriggerBytes,
                                                memory_order_relaxed);
         long newTrigger = oldTrigger;
+        long floorBytes = cn1BibopTriggerFloor(liveBytes);
         if(survival >= CN1_BIBOP_BYPASS_SURVIVAL_PERCENT) {
             bibopTriggerHighSurvivalStreak++;
             if(bibopTriggerHighSurvivalStreak >= 2) {
@@ -6412,8 +6413,8 @@ static void cn1BibopAdaptAfterSweep(long occupiedBytes, long liveBytes,
                 long freeMem = atomic_load_explicit(&cn1CachedFreeMem,
                                                     memory_order_relaxed);
                 if(freeMem > 0 && freeMem / 8 < ceiling) ceiling = freeMem / 8;
-                if(ceiling < cn1BibopTriggerFloor(liveBytes)) {
-                    ceiling = cn1BibopTriggerFloor(liveBytes);
+                if(ceiling < floorBytes) {
+                    ceiling = floorBytes;
                 }
                 newTrigger = oldTrigger * 2;
                 if(newTrigger > ceiling) newTrigger = ceiling;
@@ -6424,7 +6425,6 @@ static void cn1BibopAdaptAfterSweep(long occupiedBytes, long liveBytes,
             // Shrink towards what the LIVE set justifies. This used to stop at
             // the 24MB constant, which is why a server holding nothing live
             // still held a 24MB trigger and ~98MB of resident memory.
-            long floorBytes = cn1BibopTriggerFloor(liveBytes);
             if(oldTrigger > floorBytes) {
                 newTrigger = oldTrigger / 2;
                 if(newTrigger < floorBytes) {
@@ -6439,6 +6439,17 @@ static void cn1BibopAdaptAfterSweep(long occupiedBytes, long liveBytes,
                 // the live set grew.
                 newTrigger = floorBytes;
             }
+        }
+        // The floor is a property of the live set, not of the survival rate, so
+        // it is enforced outside the branches that react to survival. Those cover
+        // >= 25% and <= 20% and nothing between: a trigger that adapted down
+        // before the live set grew sat in that dead band uncorrected for as long
+        // as survival stayed at 21-24%, retracing a live heap it no longer had
+        // the headroom for. Raising is the only direction taken here, and the
+        // <= 20% branch already does exactly this, so the dead band gets the
+        // behaviour the branches either side of it already had.
+        if(newTrigger < floorBytes) {
+            newTrigger = floorBytes;
         }
         if(newTrigger != oldTrigger) {
             atomic_store_explicit(&bibopGcTriggerBytes, newTrigger,
@@ -12192,10 +12203,25 @@ static long long cn1StallPercentileUs(int cause, double q) {
 // rather than an argument.
 //
 // CONFORM-only, two relaxed atomics on the allocation path, printed at exit.
-#define CN1_ALLOC_PROFILE_SLOTS 8192
+// Class ids are numbered scalar classes first and array classes after them
+// (cn1_array_start_offset), one contiguous range, so the bound has to cover
+// BOTH -- an app well under the limit in scalar classes can still put its array
+// classes past it. The table is CONFORM-only and costs 24 bytes an entry, so it
+// is sized past any plausible translated app rather than tuned.
+//
+// Whatever still lands outside is counted and REPORTED rather than dropped. A
+// profile that silently omits the hottest class reads exactly like a profile
+// that found nothing there, and this file already has one instrument that lied
+// by omission (see the entry-point note on cn1RecordAllocation). The overflow
+// row is how a reader learns the bound was reached instead of trusting a total
+// that quietly excludes it.
+#define CN1_ALLOC_PROFILE_SLOTS 65536
 static _Atomic long long cn1AllocProfBytes[CN1_ALLOC_PROFILE_SLOTS];
 static _Atomic long cn1AllocProfCount[CN1_ALLOC_PROFILE_SLOTS];
 static struct clazz* cn1AllocProfClass[CN1_ALLOC_PROFILE_SLOTS];
+static _Atomic long long cn1AllocProfOutOfRangeBytes = 0;
+static _Atomic long cn1AllocProfOutOfRangeCount = 0;
+static _Atomic int cn1AllocProfMaxSeenId = 0;
 
 void cn1RecordAllocation(struct clazz* parent, int size) {
     int id;
@@ -12204,6 +12230,12 @@ void cn1RecordAllocation(struct clazz* parent, int size) {
     }
     id = parent->classId;
     if(id < 0 || id >= CN1_ALLOC_PROFILE_SLOTS) {
+        atomic_fetch_add_explicit(&cn1AllocProfOutOfRangeBytes, (long long)size,
+                                  memory_order_relaxed);
+        atomic_fetch_add_explicit(&cn1AllocProfOutOfRangeCount, 1, memory_order_relaxed);
+        if(id > atomic_load_explicit(&cn1AllocProfMaxSeenId, memory_order_relaxed)) {
+            atomic_store_explicit(&cn1AllocProfMaxSeenId, id, memory_order_relaxed);
+        }
         return;
     }
     cn1AllocProfClass[id] = parent;
@@ -12236,7 +12268,22 @@ static void cn1ReportAllocProfile(void) {
     for(i = 0 ; i < CN1_ALLOC_PROFILE_SLOTS ; i++) {
         total += atomic_load_explicit(&cn1AllocProfBytes[i], memory_order_relaxed);
     }
-    fprintf(stderr, "[ALLOCPROF] totalBytes=%lld\n", total);
+    {
+        // Counted into the total so the headline figure stays the truth about the
+        // run, and printed separately so a non-zero row names the bound to raise.
+        long long oor = atomic_load_explicit(&cn1AllocProfOutOfRangeBytes,
+                                             memory_order_relaxed);
+        total += oor;
+        fprintf(stderr, "[ALLOCPROF] totalBytes=%lld\n", total);
+        if(oor > 0) {
+            fprintf(stderr, "[ALLOCPROF] %-44s bytes=%-12lld count=%-10ld "
+                            "(classId past %d, highest seen %d -- RAISE THE BOUND)\n",
+                    "<unattributed: classId out of range>", oor,
+                    atomic_load_explicit(&cn1AllocProfOutOfRangeCount, memory_order_relaxed),
+                    CN1_ALLOC_PROFILE_SLOTS - 1,
+                    atomic_load_explicit(&cn1AllocProfMaxSeenId, memory_order_relaxed));
+        }
+    }
     // Top twenty by bytes, selected by repeated max rather than a sort: this runs
     // once at exit and the table is small.
     while(printed < 20) {

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -5451,6 +5451,21 @@ static void cn1PacingPark(CODENAME_ONE_THREAD_STATE, int which, long long pendin
             if(!cn1VirtualThreadYieldIfVirtual()) {
                 usleep(50);
             }
+            // Do NOT go active again while the collector has this thread blocked.
+            //
+            // threadActive is what tells the collector it may scan this thread's
+            // roots without stopping it. If threadBlockedByGC went up during the
+            // sleep, the collector saw threadActive == false and may already be
+            // walking this stack conservatively; raising the flag here would let
+            // the mutator run -- moving that stack, and the assist above running
+            // mark functions on it -- underneath a scan in progress, which loses
+            // reachable objects. Wait the block out first, exactly as the tail of
+            // this function does.
+            while(threadStateData->threadBlockedByGC) {
+                if(!cn1VirtualThreadYieldIfVirtual()) {
+                    usleep((JAVA_INT)(500));
+                }
+            }
             threadStateData->threadActive = JAVA_TRUE;
         }
         threadStateData->threadActive = JAVA_FALSE;
@@ -6283,11 +6298,37 @@ void cn1BibopNoteNativePeer(JAVA_OBJECT obj) { (void)obj; }
  * The smallest trigger this live set justifies: live + growth%, clamped to the
  * absolute minimum. Answers in bytes.
  */
+// Recent live-set high-water, in bytes, decayed once per adapt.
+//
+// liveBytes as handed to cn1BibopAdaptAfterSweep is NOT the whole live set: the
+// sweep walks the retired-page list, and a page the major sweep splices out of a
+// partial pool is deliberately withheld from policy statistics (see
+// statsExcluded). Sizing the floor from one such sample lets it collapse toward
+// the minimum while a large live heap sits on pages this cycle never looked at,
+// and the collector would then retrace that heap every few megabytes.
+//
+// A decaying high-water is the cheap defence: any recent cycle that DID see a
+// large live set holds the floor up, and a genuinely small live set walks it
+// down within a few cycles. It costs one long and no extra walking, where an
+// exact answer needs a live count over every registered page and there is no
+// such figure today.
+static long bibopLiveHighWater = 0;
+
+// 1/8 per adapt: a real drop in the live set reaches the floor in a handful of
+// cycles, while a single unrepresentative sample cannot move it far.
+#ifndef CN1_BIBOP_LIVE_DECAY_SHIFT
+#define CN1_BIBOP_LIVE_DECAY_SHIFT 3
+#endif
+
 static long cn1BibopTriggerFloor(long liveBytes) {
     long floor;
     if(liveBytes < 0) {
         liveBytes = 0;
     }
+    if(liveBytes > bibopLiveHighWater) {
+        bibopLiveHighWater = liveBytes;
+    }
+    liveBytes = bibopLiveHighWater;
     // The multiply is done in long long so a large live set cannot wrap the
     // percentage before the clamp sees it.
     {
@@ -6310,6 +6351,11 @@ static void cn1BibopAdaptAfterSweep(long occupiedBytes, long liveBytes,
     bibopLastCycleOccupiedBytes = occupiedBytes;
     bibopLastCycleLiveBytes = liveBytes;
     bibopLastCycleReclaimedBytes = reclaimedBytes;
+
+    // Decay before this cycle's sample is folded in by cn1BibopTriggerFloor, so a
+    // live set that really has shrunk walks the floor down instead of pinning it
+    // at the largest value ever seen.
+    bibopLiveHighWater -= bibopLiveHighWater >> CN1_BIBOP_LIVE_DECAY_SHIFT;
 
     if(lowMemoryMode) {
         long oldTrigger = atomic_load_explicit(&bibopGcTriggerBytes,

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -10807,6 +10807,19 @@ static int gcMarkResolveThreadCount() {
 #ifdef CN1_GC_MARK_THREADS
     int n = CN1_GC_MARK_THREADS;
 #elif 1
+    // NOTE (later): this verdict predates the fixes. The isolation experiment
+    // below ran on 2026-07-03. The SATB write barrier that closes the
+    // concurrent-mark cross-thread race landed 2026-07-05, as did the freed-slot
+    // rejection in gcMarkObject, the grace-subtree drain before sweep, the belt
+    // pass for mark-drain completeness and the looped stop-the-world final mark;
+    // and on 2026-07-06 object-bearing frameless was defaulted off as "unsound
+    // under conservative GC on arm64", which is an arm64 heap corruptor that has
+    // nothing to do with this pool. Parallel marking was never re-tested after
+    // the experiment, and gcMarkDrainParallel/gcMarkObject/gcMarkFlushLocal/
+    // gcMarkWorklistPush have all been reworked since. Treat the text below as a
+    // record of what was believed that day, not as a current finding -- see
+    // .github/workflows/parparvm-parallel-mark.yml, which re-tests it on arm64.
+    //
     // ISOLATION EXPERIMENT (git-A/B): default to SERIAL marking. The acquire-load
     // fix removed the parallel mark-worker crash, but arm64 Linux still corrupts the
     // heap (crash moved to a frameless method reading a smashed threadStateData), so

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -6353,10 +6353,41 @@ static long cn1BibopTriggerFloor(long liveBytes) {
     if(liveBytes < 0) {
         liveBytes = 0;
     }
-    if(liveBytes > bibopLiveHighWater) {
-        bibopLiveHighWater = liveBytes;
+    // The high-water smooths the floor UPWARD and must not hold it up on the way
+    // down. Substituting it for the sample unconditionally latches: the floor is
+    // derived from a live set that is already gone, the raised trigger means the
+    // next sweep is far away, and the decay above only runs per sweep -- so a high
+    // floor buys itself the very scarcity of cycles that keeps it high.
+    //
+    // That is not hypothetical. cn1BibopTrimFreePool, which hands surplus pages
+    // back to the OS, runs ONLY at the end of a sweep. With the latch in place
+    // BibopPageFloorIntegrationTest dropped a 196MB live set and got 6% of its
+    // pages back instead of the 91% the same commit returned on a luckier run,
+    // because after the drop the trigger was raised toward the floor the departed
+    // live set justified and no further sweep arrived to trim anything. On master,
+    // which has no floor at all, low survival simply halves the trigger and the
+    // pages come back.
+    //
+    // So the two directions are treated differently, which is the asymmetry that
+    // was missing rather than a new policy: growth is damped through the
+    // high-water, and a collapse is believed immediately. A steady live set has
+    // sample and high-water in the same place and is unaffected either way.
+    {
+        long sampleFloor;
+        if(liveBytes > bibopLiveHighWater) {
+            bibopLiveHighWater = liveBytes;
+        }
+        sampleFloor = liveBytes;
+        liveBytes = bibopLiveHighWater;
+        if(sampleFloor < liveBytes) {
+            // Believe the smaller CURRENT reading, with one MIN of slack so a
+            // sample that merely dipped does not slam the floor to the minimum.
+            long relaxed = sampleFloor + CN1_BIBOP_GC_MIN_TRIGGER_BYTES;
+            if(relaxed < liveBytes) {
+                liveBytes = relaxed;
+            }
+        }
     }
-    liveBytes = bibopLiveHighWater;
     // The multiply is done in long long so a large live set cannot wrap the
     // percentage before the clamp sees it.
     {

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -12223,11 +12223,56 @@ static _Atomic long long cn1AllocProfOutOfRangeBytes = 0;
 static _Atomic long cn1AllocProfOutOfRangeCount = 0;
 static _Atomic int cn1AllocProfMaxSeenId = 0;
 
+// A per-class total answers "what is being allocated" but not "which line
+// allocates it": byte[] is one class and a dozen unrelated call sites. Sizes
+// separate them, because the sites differ in what they allocate -- a 13-byte
+// body, a 48-byte empty array and a 120-byte header block are three distinct
+// buckets even though the profile calls all of them byte[]. Set
+// CN1_ALLOC_SIZE_CLASS to a class name to get its size histogram alongside the
+// totals; the table is tiny and linear-probed because a handful of distinct
+// sizes is the expected case, and a site with a genuinely variable size shows up
+// as the overflow row rather than crowding out the fixed ones.
+#define CN1_ALLOC_SIZE_BUCKETS 48
+static const char* cn1AllocSizeClassName = 0;
+static int cn1AllocSizeClassResolved = 0;
+static _Atomic int cn1AllocSizeKey[CN1_ALLOC_SIZE_BUCKETS];
+static _Atomic long long cn1AllocSizeCount[CN1_ALLOC_SIZE_BUCKETS];
+static _Atomic long long cn1AllocSizeOverflow = 0;
+
+static void cn1RecordAllocationSize(struct clazz* parent, int size) {
+    int i;
+    if(!cn1AllocSizeClassResolved) {
+        cn1AllocSizeClassName = getenv("CN1_ALLOC_SIZE_CLASS");
+        cn1AllocSizeClassResolved = 1;
+    }
+    if(cn1AllocSizeClassName == 0 || parent->clsName == 0 ||
+       strcmp(parent->clsName, cn1AllocSizeClassName) != 0) {
+        return;
+    }
+    for(i = 0 ; i < CN1_ALLOC_SIZE_BUCKETS ; i++) {
+        int k = atomic_load_explicit(&cn1AllocSizeKey[i], memory_order_relaxed);
+        if(k == size) {
+            atomic_fetch_add_explicit(&cn1AllocSizeCount[i], 1, memory_order_relaxed);
+            return;
+        }
+        if(k == 0) {
+            atomic_store_explicit(&cn1AllocSizeKey[i], size, memory_order_relaxed);
+            atomic_fetch_add_explicit(&cn1AllocSizeCount[i], 1, memory_order_relaxed);
+            return;
+        }
+    }
+    atomic_fetch_add_explicit(&cn1AllocSizeOverflow, 1, memory_order_relaxed);
+}
+
 void cn1RecordAllocation(struct clazz* parent, int size) {
     int id;
     if(parent == 0) {
         return;
     }
+    // Before the id range check, so a class past the table still contributes its
+    // sizes -- the out-of-range row says a class is missing, this says what size
+    // it was.
+    cn1RecordAllocationSize(parent, size);
     id = parent->classId;
     if(id < 0 || id >= CN1_ALLOC_PROFILE_SLOTS) {
         atomic_fetch_add_explicit(&cn1AllocProfOutOfRangeBytes, (long long)size,
@@ -12267,6 +12312,28 @@ static void cn1ReportAllocProfile(void) {
     int printed = 0;
     for(i = 0 ; i < CN1_ALLOC_PROFILE_SLOTS ; i++) {
         total += atomic_load_explicit(&cn1AllocProfBytes[i], memory_order_relaxed);
+    }
+    if(cn1AllocSizeClassName != 0) {
+        int i;
+        // Descending by count, selection-style: the table is 48 entries and this
+        // runs once at exit, so the quadratic scan costs nothing and keeps the
+        // hot recorder free of any ordering work.
+        for(;;) {
+            int bestIdx = -1;
+            long long bestCount = 0;
+            for(i = 0 ; i < CN1_ALLOC_SIZE_BUCKETS ; i++) {
+                long long c = atomic_load_explicit(&cn1AllocSizeCount[i], memory_order_relaxed);
+                if(c > bestCount) { bestCount = c; bestIdx = i; }
+            }
+            if(bestIdx < 0) { break; }
+            fprintf(stderr, "[ALLOCSIZE] %-28s bytes=%-8d count=%lld\n",
+                    cn1AllocSizeClassName,
+                    atomic_load_explicit(&cn1AllocSizeKey[bestIdx], memory_order_relaxed),
+                    bestCount);
+            atomic_store_explicit(&cn1AllocSizeCount[bestIdx], 0, memory_order_relaxed);
+        }
+        fprintf(stderr, "[ALLOCSIZE] %-28s overflow=%lld\n", cn1AllocSizeClassName,
+                atomic_load_explicit(&cn1AllocSizeOverflow, memory_order_relaxed));
     }
     {
         // Counted into the total so the headline figure stays the truth about the

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -6322,143 +6322,12 @@ void cn1BibopNoteMonitorAttached(JAVA_OBJECT obj) {
 void cn1BibopNoteNativePeer(JAVA_OBJECT obj) { (void)obj; }
 #endif
 
-/**
- * The smallest trigger this live set justifies: live + growth%, clamped to the
- * absolute minimum. Answers in bytes.
- */
-// Recent live-set high-water, in bytes, decayed once per adapt.
-//
-// liveBytes as handed to cn1BibopAdaptAfterSweep is NOT the whole live set: the
-// sweep walks the retired-page list, and a page the major sweep splices out of a
-// partial pool is deliberately withheld from policy statistics (see
-// statsExcluded). Sizing the floor from one such sample lets it collapse toward
-// the minimum while a large live heap sits on pages this cycle never looked at,
-// and the collector would then retrace that heap every few megabytes.
-//
-// A decaying high-water is the cheap defence: any recent cycle that DID see a
-// large live set holds the floor up, and a genuinely small live set walks it
-// down within a few cycles. It costs one long and no extra walking, where an
-// exact answer needs a live count over every registered page and there is no
-// such figure today.
-static long bibopLiveHighWater = 0;
-
-// 1/8 per adapt: a real drop in the live set reaches the floor in a handful of
-// cycles, while a single unrepresentative sample cannot move it far.
-#ifndef CN1_BIBOP_LIVE_DECAY_SHIFT
-#define CN1_BIBOP_LIVE_DECAY_SHIFT 3
-#endif
-
-static long cn1BibopTriggerFloor(long liveBytes, int sampleCoversHeap) {
-    long floor;
-    if(liveBytes < 0) {
-        liveBytes = 0;
-    }
-    // The high-water smooths the floor UPWARD and must not hold it up on the way
-    // down. Substituting it for the sample unconditionally latches: the floor is
-    // derived from a live set that is already gone, the raised trigger means the
-    // next sweep is far away, and the decay above only runs per sweep -- so a high
-    // floor buys itself the very scarcity of cycles that keeps it high.
-    //
-    // That is not hypothetical. cn1BibopTrimFreePool, which hands surplus pages
-    // back to the OS, runs ONLY at the end of a sweep. With the latch in place
-    // BibopPageFloorIntegrationTest dropped a 196MB live set and got 6% of its
-    // pages back instead of the 91% the same commit returned on a luckier run,
-    // because after the drop the trigger was raised toward the floor the departed
-    // live set justified and no further sweep arrived to trim anything. On master,
-    // which has no floor at all, low survival simply halves the trigger and the
-    // pages come back.
-    //
-    // So the two directions are treated differently, which is the asymmetry that
-    // was missing rather than a new policy: growth is damped through the
-    // high-water, and a collapse is believed immediately. A steady live set has
-    // sample and high-water in the same place and is unaffected either way.
-    {
-        long sampleFloor;
-        if(liveBytes > bibopLiveHighWater) {
-            bibopLiveHighWater = liveBytes;
-        }
-        sampleFloor = liveBytes;
-        liveBytes = bibopLiveHighWater;
-        if(sampleCoversHeap && sampleFloor < liveBytes) {
-            // Believe the smaller CURRENT reading, with one MIN of slack so a
-            // sample that merely dipped does not slam the floor to the minimum.
-            //
-            // Only when the sweep actually LOOKED at the heap. liveBytes is not a
-            // live-set measurement, it is the part of the live set this sweep
-            // sampled: pages the major sweep splices out of a partial pool are
-            // withheld from the policy numbers, so a near-zero reading can equally
-            // mean "the objects are all on pages that were excluded". Believing
-            // that as a collapse would halve the trigger against a heap that never
-            // shrank and retrace it every cycle -- the exact cost the floor exists
-            // to avoid, and worse than the latch it replaces, because the latch at
-            // least erred toward collecting less. The caller decides coverage from
-            // how much the sweep withheld; when it withheld too much the
-            // high-water stands and the decay walks it down as before.
-            long relaxed = sampleFloor + CN1_BIBOP_GC_MIN_TRIGGER_BYTES;
-            if(relaxed < liveBytes) {
-                liveBytes = relaxed;
-            }
-        }
-    }
-    // The multiply is done in long long so a large live set cannot wrap the
-    // percentage before the clamp sees it.
-    {
-        long long scaled = ((long long)liveBytes
-                * (long long)(100 + CN1_BIBOP_HEAP_GROWTH_PERCENT)) / 100;
-        if(scaled > (long long)CN1_BIBOP_GC_MAX_TRIGGER_BYTES) {
-            scaled = (long long)CN1_BIBOP_GC_MAX_TRIGGER_BYTES;
-        }
-        floor = (long)scaled;
-    }
-    // Memory pressure bounds the live-set floor, because the floor is an argument
-    // about how OFTEN to retrace a live heap and says nothing about whether the
-    // heap it justifies will fit. Without this a 100MB live set asks for 192MB
-    // (growth is 100%, clamped by the max) no matter how little is left, and the
-    // high-survival branch below then RAISES its own free-memory ceiling to meet
-    // it -- deferring collection past the remaining headroom.
-    //
-    // lowMemoryMode does not cover this. It is set by iOS didReceiveMemoryWarning
-    // and by the CI simulation hook, and by nothing else -- so on Linux, which is
-    // where the server runs and where this floor was introduced to cut resident
-    // memory, it is never set at all and there is otherwise no memory bound here.
-    //
-    // The cap floors at the old constant rather than at freeMem/8 directly, and
-    // that is the load-bearing half: GcSteadyState pins the free-memory reading to
-    // 16MB, and a bare eighth of that is 2MB. A 2MB trigger is the collector
-    // running continuously, which is the failure this constant already caused
-    // twice. Bounded this way the pinned-memory case lands exactly on the value
-    // the trigger had before any of this, so the floor can be lowered by pressure
-    // but never below what was always safe.
-    {
-        long freeMem = atomic_load_explicit(&cn1CachedFreeMem, memory_order_relaxed);
-        if(freeMem > 0) {
-            long memCap = freeMem / 8;
-            if(memCap < CN1_BIBOP_GC_MIN_TRIGGER_BYTES) {
-                memCap = CN1_BIBOP_GC_MIN_TRIGGER_BYTES;
-            }
-            if(floor > memCap) {
-                floor = memCap;
-            }
-        }
-    }
-    if(floor < CN1_BIBOP_GC_MIN_TRIGGER_BYTES) {
-        floor = CN1_BIBOP_GC_MIN_TRIGGER_BYTES;
-    }
-    return floor;
-}
-
 static void cn1BibopAdaptAfterSweep(long occupiedBytes, long liveBytes,
-                                    long reclaimedBytes, long excludedOccupiedBytes,
-                                    long excludedLiveBytes, int majorSweep,
+                                    long reclaimedBytes,
                                     long* classSlots, long* classLive) {
     bibopLastCycleOccupiedBytes = occupiedBytes;
     bibopLastCycleLiveBytes = liveBytes;
     bibopLastCycleReclaimedBytes = reclaimedBytes;
-
-    // Decay before this cycle's sample is folded in by cn1BibopTriggerFloor, so a
-    // live set that really has shrunk walks the floor down instead of pinning it
-    // at the largest value ever seen.
-    bibopLiveHighWater -= bibopLiveHighWater >> CN1_BIBOP_LIVE_DECAY_SHIFT;
 
     if(lowMemoryMode) {
         long oldTrigger = atomic_load_explicit(&bibopGcTriggerBytes,
@@ -6480,26 +6349,30 @@ static void cn1BibopAdaptAfterSweep(long occupiedBytes, long liveBytes,
         long oldTrigger = atomic_load_explicit(&bibopGcTriggerBytes,
                                                memory_order_relaxed);
         long newTrigger = oldTrigger;
-        // Only a MAJOR sweep can say anything about the size of the live set, and
-        // when it does it must be asked for the WHOLE of it.
+        // NO LIVE-SET FLOOR. The trigger is not sized from the live set here,
+        // because this collector cannot measure the live set and a policy built on
+        // a number it cannot measure kept being wrong in a new way.
         //
-        // An ordinary sweep walks retired pages alone; every live object on a
-        // partial page is invisible to it, so its liveBytes is not a small live
-        // set, it is a small sample. A major sweep splices the partial pools in
-        // and walks them too -- but withholds their slots from the survival ratio,
-        // which is why liveBytes still understates even there. The complete figure
-        // is liveBytes plus what was withheld, and that number is already computed;
-        // it was simply being thrown away.
+        // liveBytes is what a sweep SAMPLED. An ordinary sweep walks retired pages
+        // only, so every live object on a partial page is invisible to it. A major
+        // sweep splices the partial pools in, but mutator-owned current pages are
+        // never swept at all -- that is an invariant, not an omission -- and the
+        // legacy heap above CN1_BIBOP_MAX_OBJECT is not in BiBOP pages and never
+        // reaches these counters. Three successive attempts to derive a floor from
+        // this number were each unsound in a different direction: it latched a
+        // dropped live set at 192MB and stopped the sweeps that return pages to
+        // the OS (BibopPageFloorIntegrationTest, 6% of pages returned against 91%
+        // on a luckier run of the same commit); then it believed a partial sample
+        // as a collapse; then it called an ordinary sweep complete precisely when
+        // it saw least.
         //
-        // An earlier revision of this gate tested the withheld BYTES instead, which
-        // is backwards in both directions: an ordinary sweep withholds nothing and
-        // was called complete precisely when it saw least, while a major sweep
-        // withholds exactly the pages it added and was called incomplete when it
-        // had in fact seen everything.
-        int sampleCoversHeap = majorSweep;
-        long completeLiveBytes = liveBytes + excludedLiveBytes;
-        long floorBytes = cn1BibopTriggerFloor(
-                sampleCoversHeap ? completeLiveBytes : liveBytes, sampleCoversHeap);
+        // What actually delivered the footprint win is the MINIMUM, which is a
+        // build-time constant and not an estimate: a deployment that knows its
+        // live set is small defines CN1_BIBOP_GC_MIN_TRIGGER_BYTES lower and the
+        // shrink path below walks the trigger down to it. That is the whole of the
+        // 98MB-to-38MB result, and it needs no live-set measurement to be correct.
+        // So the shrink target is that minimum rather than the fixed 24MB constant
+        // master uses, and nothing else about this policy differs from master.
         if(survival >= CN1_BIBOP_BYPASS_SURVIVAL_PERCENT) {
             bibopTriggerHighSurvivalStreak++;
             if(bibopTriggerHighSurvivalStreak >= 2) {
@@ -6507,8 +6380,8 @@ static void cn1BibopAdaptAfterSweep(long occupiedBytes, long liveBytes,
                 long freeMem = atomic_load_explicit(&cn1CachedFreeMem,
                                                     memory_order_relaxed);
                 if(freeMem > 0 && freeMem / 8 < ceiling) ceiling = freeMem / 8;
-                if(ceiling < floorBytes) {
-                    ceiling = floorBytes;
+                if(ceiling < CN1_BIBOP_GC_MIN_TRIGGER_BYTES) {
+                    ceiling = CN1_BIBOP_GC_MIN_TRIGGER_BYTES;
                 }
                 newTrigger = oldTrigger * 2;
                 if(newTrigger > ceiling) newTrigger = ceiling;
@@ -6516,34 +6389,12 @@ static void cn1BibopAdaptAfterSweep(long occupiedBytes, long liveBytes,
             }
         } else if(survival <= 20) {
             bibopTriggerHighSurvivalStreak = 0;
-            // Shrink towards what the LIVE set justifies. This used to stop at
-            // the 24MB constant, which is why a server holding nothing live
-            // still held a 24MB trigger and ~98MB of resident memory.
-            if(oldTrigger > floorBytes) {
+            if(oldTrigger > CN1_BIBOP_GC_MIN_TRIGGER_BYTES) {
                 newTrigger = oldTrigger / 2;
-                if(newTrigger < floorBytes) {
-                    newTrigger = floorBytes;
+                if(newTrigger < CN1_BIBOP_GC_MIN_TRIGGER_BYTES) {
+                    newTrigger = CN1_BIBOP_GC_MIN_TRIGGER_BYTES;
                 }
-            } else if(oldTrigger < floorBytes) {
-                // The floor is a bound in BOTH directions. Low survival on a big
-                // live set means the trigger should not stay under what that live
-                // set justifies: a 4MB trigger against 20MB live would retrace
-                // the whole live heap every 4MB of allocation. Raising it here is
-                // the only path that corrects a trigger which adapted down before
-                // the live set grew.
-                newTrigger = floorBytes;
             }
-        }
-        // The floor is a property of the live set, not of the survival rate, so
-        // it is enforced outside the branches that react to survival. Those cover
-        // >= 25% and <= 20% and nothing between: a trigger that adapted down
-        // before the live set grew sat in that dead band uncorrected for as long
-        // as survival stayed at 21-24%, retracing a live heap it no longer had
-        // the headroom for. Raising is the only direction taken here, and the
-        // <= 20% branch already does exactly this, so the dead band gets the
-        // behaviour the branches either side of it already had.
-        if(newTrigger < floorBytes) {
-            newTrigger = floorBytes;
         }
         if(newTrigger != oldTrigger) {
             atomic_store_explicit(&bibopGcTriggerBytes, newTrigger,
@@ -6601,8 +6452,6 @@ static void cn1BibopSweep(CODENAME_ONE_THREAD_STATE) {
     // sees retired pages alone, so its liveBytes omits every live object sitting
     // on a partial page and is not a live-set measurement. Declared here because
     // the major-sweep decision below is made before the accumulators.
-    long excludedLiveBytes = 0;
-    int majorSweep = 0;
 #ifdef CN1_GC_VERIFY
     extern int cn1GcFaultEarlyFree;
     { extern void cn1GcFaultInitPublic(void); cn1GcFaultInitPublic(); }
@@ -6649,7 +6498,6 @@ static void cn1BibopSweep(CODENAME_ONE_THREAD_STATE) {
                 || quiet
                 || bibopCyclesSinceMajorSweep >= CN1_BIBOP_MAJOR_SWEEP_CYCLES;
         if(major) {
-            majorSweep = 1;
             bibopCyclesSinceMajorSweep = 0;
             int spliced = 0;
             pthread_mutex_lock(&bibopMutex);
@@ -6679,12 +6527,6 @@ static void cn1BibopSweep(CODENAME_ONE_THREAD_STATE) {
     long occupiedBytes = 0;
     long liveBytes = 0;
     long reclaimedBytes = 0;
-    // Bytes on pages the major sweep spliced out of a partial pool, which are
-    // deliberately withheld from the policy numbers above. Kept so the policy can
-    // tell "the live set shrank" from "this sweep only looked at part of it" --
-    // the ratio is unaffected by the exclusion (both halves skip the same pages)
-    // but the ABSOLUTE liveBytes understates by exactly this much.
-    long excludedOccupiedBytes = 0;
     long classSlots[CN1_BIBOP_NUM_CLASSES] = {0};
     long classLive[CN1_BIBOP_NUM_CLASSES] = {0};
 #ifndef CN1_BIBOP_NO_FASTSWEEP
@@ -6936,10 +6778,6 @@ static void cn1BibopSweep(CODENAME_ONE_THREAD_STATE) {
         if(policySurvivors < 0) {
             policySurvivors = 0;
         }
-        if(statsExcluded) {
-            excludedOccupiedBytes += (long)sampledSlots * page->slotSize;
-            excludedLiveBytes += (long)policySurvivors * page->slotSize;
-        }
         if(!statsExcluded) {
             occupiedBytes += (long)sampledSlots * page->slotSize;
             liveBytes += (long)policySurvivors * page->slotSize;
@@ -6973,7 +6811,6 @@ static void cn1BibopSweep(CODENAME_ONE_THREAD_STATE) {
         pthread_mutex_unlock(&bibopMutex);
     }
     cn1BibopAdaptAfterSweep(occupiedBytes, liveBytes, reclaimedBytes,
-                            excludedOccupiedBytes, excludedLiveBytes, majorSweep,
                             classSlots, classLive);
     // Hand surplus empty pages back to the OS (issue 5537). Last, so it sees the
     // pool this sweep just refilled, and outside the per-page loop so the madvise

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -12282,12 +12282,29 @@ static void cn1RecordAllocationSize(struct clazz* parent, int size) {
     }
     for(i = 0 ; i < CN1_ALLOC_SIZE_BUCKETS ; i++) {
         int k = atomic_load_explicit(&cn1AllocSizeKey[i], memory_order_relaxed);
-        if(k == size) {
-            atomic_fetch_add_explicit(&cn1AllocSizeCount[i], 1, memory_order_relaxed);
-            return;
-        }
         if(k == 0) {
-            atomic_store_explicit(&cn1AllocSizeKey[i], size, memory_order_relaxed);
+            // Claim the empty bucket with a compare-exchange rather than a store.
+            // The allocation path is genuinely concurrent -- that is why the counts
+            // beside this are atomics -- so two threads allocating the profiled
+            // class at DIFFERENT sizes could both read this zero, both store, and
+            // then both add into whichever size was written last: one size's row
+            // vanishes and the other's count is overstated by exactly the same
+            // amount. The value of this table is that a reading like "7073173 of
+            // 7073834 allocations were exactly 97 bytes" can be trusted to mean one
+            // site, so a silent merge would attack the one thing it is for. On
+            // losing the race the winner's key is adopted and compared, which lands
+            // the allocation in that bucket if the sizes agree and moves to the next
+            // bucket if they do not.
+            int expected = 0;
+            if(atomic_compare_exchange_strong_explicit(&cn1AllocSizeKey[i], &expected,
+                                                       size, memory_order_relaxed,
+                                                       memory_order_relaxed)) {
+                k = size;
+            } else {
+                k = expected;
+            }
+        }
+        if(k == size) {
             atomic_fetch_add_explicit(&cn1AllocSizeCount[i], 1, memory_order_relaxed);
             return;
         }

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -12395,8 +12395,19 @@ void cn1RecordAllocation(struct clazz* parent, int size) {
         atomic_fetch_add_explicit(&cn1AllocProfOutOfRangeBytes, (long long)size,
                                   memory_order_relaxed);
         atomic_fetch_add_explicit(&cn1AllocProfOutOfRangeCount, 1, memory_order_relaxed);
-        if(id > atomic_load_explicit(&cn1AllocProfMaxSeenId, memory_order_relaxed)) {
-            atomic_store_explicit(&cn1AllocProfMaxSeenId, id, memory_order_relaxed);
+        // Compare-exchange rather than load-then-store: that pair is a
+        // read-modify-write, so two threads reporting out-of-range classes can
+        // both pass the comparison and the smaller id can land last. This number
+        // exists to tell a reader how far the table has to grow, and understating
+        // it sends the next run back with a bound that is still too small.
+        {
+            int seen = atomic_load_explicit(&cn1AllocProfMaxSeenId, memory_order_relaxed);
+            while(id > seen &&
+                  !atomic_compare_exchange_weak_explicit(&cn1AllocProfMaxSeenId, &seen, id,
+                                                         memory_order_relaxed,
+                                                         memory_order_relaxed)) {
+                /* seen was reloaded by the failed exchange; retry while we are still larger */
+            }
         }
         return;
     }

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -6367,6 +6367,37 @@ static long cn1BibopTriggerFloor(long liveBytes) {
         }
         floor = (long)scaled;
     }
+    // Memory pressure bounds the live-set floor, because the floor is an argument
+    // about how OFTEN to retrace a live heap and says nothing about whether the
+    // heap it justifies will fit. Without this a 100MB live set asks for 192MB
+    // (growth is 100%, clamped by the max) no matter how little is left, and the
+    // high-survival branch below then RAISES its own free-memory ceiling to meet
+    // it -- deferring collection past the remaining headroom.
+    //
+    // lowMemoryMode does not cover this. It is set by iOS didReceiveMemoryWarning
+    // and by the CI simulation hook, and by nothing else -- so on Linux, which is
+    // where the server runs and where this floor was introduced to cut resident
+    // memory, it is never set at all and there is otherwise no memory bound here.
+    //
+    // The cap floors at the old constant rather than at freeMem/8 directly, and
+    // that is the load-bearing half: GcSteadyState pins the free-memory reading to
+    // 16MB, and a bare eighth of that is 2MB. A 2MB trigger is the collector
+    // running continuously, which is the failure this constant already caused
+    // twice. Bounded this way the pinned-memory case lands exactly on the value
+    // the trigger had before any of this, so the floor can be lowered by pressure
+    // but never below what was always safe.
+    {
+        long freeMem = atomic_load_explicit(&cn1CachedFreeMem, memory_order_relaxed);
+        if(freeMem > 0) {
+            long memCap = freeMem / 8;
+            if(memCap < CN1_BIBOP_GC_MIN_TRIGGER_BYTES) {
+                memCap = CN1_BIBOP_GC_MIN_TRIGGER_BYTES;
+            }
+            if(floor > memCap) {
+                floor = memCap;
+            }
+        }
+    }
     if(floor < CN1_BIBOP_GC_MIN_TRIGGER_BYTES) {
         floor = CN1_BIBOP_GC_MIN_TRIGGER_BYTES;
     }

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -6348,7 +6348,7 @@ static long bibopLiveHighWater = 0;
 #define CN1_BIBOP_LIVE_DECAY_SHIFT 3
 #endif
 
-static long cn1BibopTriggerFloor(long liveBytes) {
+static long cn1BibopTriggerFloor(long liveBytes, int sampleCoversHeap) {
     long floor;
     if(liveBytes < 0) {
         liveBytes = 0;
@@ -6379,9 +6379,21 @@ static long cn1BibopTriggerFloor(long liveBytes) {
         }
         sampleFloor = liveBytes;
         liveBytes = bibopLiveHighWater;
-        if(sampleFloor < liveBytes) {
+        if(sampleCoversHeap && sampleFloor < liveBytes) {
             // Believe the smaller CURRENT reading, with one MIN of slack so a
             // sample that merely dipped does not slam the floor to the minimum.
+            //
+            // Only when the sweep actually LOOKED at the heap. liveBytes is not a
+            // live-set measurement, it is the part of the live set this sweep
+            // sampled: pages the major sweep splices out of a partial pool are
+            // withheld from the policy numbers, so a near-zero reading can equally
+            // mean "the objects are all on pages that were excluded". Believing
+            // that as a collapse would halve the trigger against a heap that never
+            // shrank and retrace it every cycle -- the exact cost the floor exists
+            // to avoid, and worse than the latch it replaces, because the latch at
+            // least erred toward collecting less. The caller decides coverage from
+            // how much the sweep withheld; when it withheld too much the
+            // high-water stands and the decay walks it down as before.
             long relaxed = sampleFloor + CN1_BIBOP_GC_MIN_TRIGGER_BYTES;
             if(relaxed < liveBytes) {
                 liveBytes = relaxed;
@@ -6436,7 +6448,7 @@ static long cn1BibopTriggerFloor(long liveBytes) {
 }
 
 static void cn1BibopAdaptAfterSweep(long occupiedBytes, long liveBytes,
-                                    long reclaimedBytes,
+                                    long reclaimedBytes, long excludedOccupiedBytes,
                                     long* classSlots, long* classLive) {
     bibopLastCycleOccupiedBytes = occupiedBytes;
     bibopLastCycleLiveBytes = liveBytes;
@@ -6467,7 +6479,13 @@ static void cn1BibopAdaptAfterSweep(long occupiedBytes, long liveBytes,
         long oldTrigger = atomic_load_explicit(&bibopGcTriggerBytes,
                                                memory_order_relaxed);
         long newTrigger = oldTrigger;
-        long floorBytes = cn1BibopTriggerFloor(liveBytes);
+        // The sweep withheld excludedOccupiedBytes from the numbers above. If that
+        // is a small part of what it did measure, the objects it could not see
+        // cannot amount to much either and a low liveBytes really is a collapse.
+        // An eighth is deliberately strict: a wrong "yes" retraces a live heap
+        // every cycle, a wrong "no" only means the decay takes the old path.
+        int sampleCoversHeap = excludedOccupiedBytes <= (occupiedBytes >> 3);
+        long floorBytes = cn1BibopTriggerFloor(liveBytes, sampleCoversHeap);
         if(survival >= CN1_BIBOP_BYPASS_SURVIVAL_PERCENT) {
             bibopTriggerHighSurvivalStreak++;
             if(bibopTriggerHighSurvivalStreak >= 2) {
@@ -6639,6 +6657,12 @@ static void cn1BibopSweep(CODENAME_ONE_THREAD_STATE) {
     long occupiedBytes = 0;
     long liveBytes = 0;
     long reclaimedBytes = 0;
+    // Bytes on pages the major sweep spliced out of a partial pool, which are
+    // deliberately withheld from the policy numbers above. Kept so the policy can
+    // tell "the live set shrank" from "this sweep only looked at part of it" --
+    // the ratio is unaffected by the exclusion (both halves skip the same pages)
+    // but the ABSOLUTE liveBytes understates by exactly this much.
+    long excludedOccupiedBytes = 0;
     long classSlots[CN1_BIBOP_NUM_CLASSES] = {0};
     long classLive[CN1_BIBOP_NUM_CLASSES] = {0};
 #ifndef CN1_BIBOP_NO_FASTSWEEP
@@ -6890,6 +6914,9 @@ static void cn1BibopSweep(CODENAME_ONE_THREAD_STATE) {
         if(policySurvivors < 0) {
             policySurvivors = 0;
         }
+        if(statsExcluded) {
+            excludedOccupiedBytes += (long)sampledSlots * page->slotSize;
+        }
         if(!statsExcluded) {
             occupiedBytes += (long)sampledSlots * page->slotSize;
             liveBytes += (long)policySurvivors * page->slotSize;
@@ -6922,7 +6949,7 @@ static void cn1BibopSweep(CODENAME_ONE_THREAD_STATE) {
         }
         pthread_mutex_unlock(&bibopMutex);
     }
-    cn1BibopAdaptAfterSweep(occupiedBytes, liveBytes, reclaimedBytes,
+    cn1BibopAdaptAfterSweep(occupiedBytes, liveBytes, reclaimedBytes, excludedOccupiedBytes,
                             classSlots, classLive);
     // Hand surplus empty pages back to the OS (issue 5537). Last, so it sees the
     // pool this sweep just refilled, and outside the per-page loop so the madvise
@@ -12295,18 +12322,25 @@ static _Atomic int cn1AllocProfMaxSeenId = 0;
 // sizes is the expected case, and a site with a genuinely variable size shows up
 // as the overflow row rather than crowding out the fixed ones.
 #define CN1_ALLOC_SIZE_BUCKETS 48
+// pthread_once rather than a flag plus a pointer. Read and written by every
+// mutator's first allocation, those two are a data race in the C sense, and its
+// visible form is the wrong one for an instrument: a thread that sees the flag
+// set before the pointer is published reads a null name and silently drops its
+// early samples, so the histogram quietly loses exactly the allocations a
+// start-up question is about. Once-initialisation publishes both or neither.
+static pthread_once_t cn1AllocSizeClassOnce = PTHREAD_ONCE_INIT;
 static const char* cn1AllocSizeClassName = 0;
-static int cn1AllocSizeClassResolved = 0;
+
+static void cn1ResolveAllocSizeClass(void) {
+    cn1AllocSizeClassName = getenv("CN1_ALLOC_SIZE_CLASS");
+}
 static _Atomic int cn1AllocSizeKey[CN1_ALLOC_SIZE_BUCKETS];
 static _Atomic long long cn1AllocSizeCount[CN1_ALLOC_SIZE_BUCKETS];
 static _Atomic long long cn1AllocSizeOverflow = 0;
 
 static void cn1RecordAllocationSize(struct clazz* parent, int size) {
     int i;
-    if(!cn1AllocSizeClassResolved) {
-        cn1AllocSizeClassName = getenv("CN1_ALLOC_SIZE_CLASS");
-        cn1AllocSizeClassResolved = 1;
-    }
+    pthread_once(&cn1AllocSizeClassOnce, cn1ResolveAllocSizeClass);
     if(cn1AllocSizeClassName == 0 || parent->clsName == 0 ||
        strcmp(parent->clsName, cn1AllocSizeClassName) != 0) {
         return;

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -12211,6 +12211,17 @@ void cn1RecordAllocation(struct clazz* parent, int size) {
     atomic_fetch_add_explicit(&cn1AllocProfCount[id], 1, memory_order_relaxed);
 }
 
+// NOT comparable with the allocatedKb figure CN1_LOG_GC_OVERFLOW prints, and a
+// close agreement between the two is not evidence either is right. This profile
+// counts REQUESTED bytes at the moment of allocation; allocatedKb accumulates
+// BiBOP SLOT bytes (rounded up to the size class) and only at GC cycle
+// boundaries, so everything allocated after the last cycle is missing from it.
+// The two therefore differ by the rounding gap in one direction and the tail of
+// the run in the other. An earlier version of this profile double-counted every
+// fast-path allocation that fell back to codenameOneGcMalloc and still landed
+// within 2% of allocatedKb, because those errors happened to cancel -- which is
+// exactly how a broken instrument reads as a verified one.
+//
 // count|1 was meant to guard a divide by zero and silently changed the divisor
 // instead: two allocations reported bytes/3. Selecting on bytes>0 already implies
 // a nonzero count, so the guard only has to be honest about the degenerate case.

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -12197,8 +12197,19 @@ static long long cn1StallPercentileUs(int cause, double q) {
 // Class ids are numbered scalar classes first and array classes after them
 // (cn1_array_start_offset), one contiguous range, so the bound has to cover
 // BOTH -- an app well under the limit in scalar classes can still put its array
-// classes past it. The table is CONFORM-only and costs 24 bytes an entry, so it
-// is sized past any plausible translated app rather than tuned.
+// classes past it.
+//
+// 8192, and DO NOT RAISE IT. Sizing this "past any plausible app" was tried at
+// 65536 and broke the profile outright: four tables of that many 8-byte entries
+// is 2MB of BSS, and in the static musl binary the report then faulted partway
+// through its first scan, with the VM's SEGV handler swallowing it so the
+// handler returned having printed NOTHING. Measured by bisection -- 8192 prints,
+// 65536 prints nothing, everything else held equal.
+//
+// The bound is not what makes this safe anyway. The overflow row below is: it
+// counts what fell outside, adds it to the total and names the highest id seen,
+// so a table that is too small SAYS SO instead of quietly omitting the hottest
+// class. Raise this only together with evidence that the larger BSS still runs.
 //
 // Whatever still lands outside is counted and REPORTED rather than dropped. A
 // profile that silently omits the hottest class reads exactly like a profile
@@ -12206,7 +12217,7 @@ static long long cn1StallPercentileUs(int cause, double q) {
 // by omission (see the entry-point note on cn1RecordAllocation). The overflow
 // row is how a reader learns the bound was reached instead of trusting a total
 // that quietly excludes it.
-#define CN1_ALLOC_PROFILE_SLOTS 65536
+#define CN1_ALLOC_PROFILE_SLOTS 8192
 static _Atomic long long cn1AllocProfBytes[CN1_ALLOC_PROFILE_SLOTS];
 static _Atomic long cn1AllocProfCount[CN1_ALLOC_PROFILE_SLOTS];
 // Atomic like the counters beside it. Several mutators allocating the same class
@@ -12336,29 +12347,26 @@ static long long cn1AllocProfAvg(long long bytes, long count) {
     return count > 0 ? bytes / count : 0;
 }
 
-// Report-local copies. atexit handlers do not stop the other threads, so a
-// mutator can still be allocating while this runs: ranking the live counters
-// destructively meant a class could be printed, keep allocating, and be selected
-// again for a second row, while its bytes and count were read at different
-// instants and need not describe the same set of allocations. Everything is
-// copied once here and the ranking then consumes the copy, so the report is a
-// snapshot of one moment and the live counters are left alone.
-static long long cn1AllocProfSnapBytes[CN1_ALLOC_PROFILE_SLOTS];
-static long cn1AllocProfSnapCount[CN1_ALLOC_PROFILE_SLOTS];
-static struct clazz* cn1AllocProfSnapClass[CN1_ALLOC_PROFILE_SLOTS];
-
 static void cn1ReportAllocProfile(void) {
     long long total = 0;
     int i;
     int printed = 0;
+    // KNOWN AND ACCEPTED: a mutator still allocating while this runs can have its
+    // bytes and count read at different instants, and a class that keeps
+    // allocating can take a second row. A review asked for a consistent snapshot
+    // and the attempt is worth recording, because it was strictly worse: copying
+    // the tables aside meant three more arrays of CN1_ALLOC_PROFILE_SLOTS -- 3MB
+    // of BSS all told -- and the copy loop then faulted partway, with ParparVM's
+    // SEGV handler swallowing it so the report simply returned having printed
+    // NOTHING. Quiescing the recorders first needed a usleep in an atexit handler,
+    // which is not async-signal-safe and blocked the handler outright on the
+    // SIGTERM path this is always reached by.
+    //
+    // A report that is a few allocations stale is a working instrument. A report
+    // that is exactly consistent and silent is not one, and this profile is what
+    // localised the keep-alive buffer copy. So the skew stays, documented.
     for(i = 0 ; i < CN1_ALLOC_PROFILE_SLOTS ; i++) {
-        cn1AllocProfSnapBytes[i] =
-                atomic_load_explicit(&cn1AllocProfBytes[i], memory_order_relaxed);
-        cn1AllocProfSnapCount[i] =
-                atomic_load_explicit(&cn1AllocProfCount[i], memory_order_relaxed);
-        cn1AllocProfSnapClass[i] =
-                atomic_load_explicit(&cn1AllocProfClass[i], memory_order_relaxed);
-        total += cn1AllocProfSnapBytes[i];
+        total += atomic_load_explicit(&cn1AllocProfBytes[i], memory_order_relaxed);
     }
     if(cn1AllocSizeClassName != 0) {
         int i;
@@ -12408,8 +12416,9 @@ static void cn1ReportAllocProfile(void) {
         int best = -1;
         long long bestBytes = 0;
         for(i = 0 ; i < CN1_ALLOC_PROFILE_SLOTS ; i++) {
-            if(cn1AllocProfSnapBytes[i] > bestBytes) {
-                bestBytes = cn1AllocProfSnapBytes[i];
+            long long b = atomic_load_explicit(&cn1AllocProfBytes[i], memory_order_relaxed);
+            if(b > bestBytes) {
+                bestBytes = b;
                 best = i;
             }
         }
@@ -12417,13 +12426,14 @@ static void cn1ReportAllocProfile(void) {
             break;
         }
         {
-            struct clazz* cls = cn1AllocProfSnapClass[best];
-            long count = cn1AllocProfSnapCount[best];
+            struct clazz* cls =
+                    atomic_load_explicit(&cn1AllocProfClass[best], memory_order_relaxed);
+            long count = atomic_load_explicit(&cn1AllocProfCount[best], memory_order_relaxed);
             fprintf(stderr, "[ALLOCPROF] %-44s bytes=%-12lld count=%-10ld avg=%lld\n",
                     (cls != 0 && cls->clsName != 0) ? cls->clsName : "?",
                     bestBytes, count, cn1AllocProfAvg(bestBytes, count));
         }
-        cn1AllocProfSnapBytes[best] = 0;   // consume the COPY, not the counter
+        atomic_store_explicit(&cn1AllocProfBytes[best], 0, memory_order_relaxed);
         printed++;
     }
     fflush(stderr);

--- a/vm/benchmarks/src/com/bench/GcPause.java
+++ b/vm/benchmarks/src/com/bench/GcPause.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.bench;
+
+/**
+ * The narrowest test of the thing the server benchmark kept pointing at: how
+ * long does a mutator stop when the collector runs?
+ *
+ * No sockets, no HTTP, no scheduler -- one thread allocating short-lived objects
+ * against a fixed live set, timing EVERY iteration. Steady work per iteration
+ * means every large gap is the collector and nothing else, so the distribution's
+ * tail IS the pause distribution. The Go twin (gcpause.go) is the same loop with
+ * the same live-set size and iteration count.
+ *
+ * Reported as a log2 histogram rather than a mean: a mean over millions of fast
+ * iterations hides exactly the rare multi-millisecond stall this exists to find.
+ */
+public class GcPause {
+    static final class Node {
+        int v;
+        Node next;
+        Node(int v, Node next) { this.v = v; this.next = next; }
+    }
+
+    static int envInt(String name, int def) {
+        String v = System.getenv(name);
+        if(v == null || v.length() == 0) {
+            return def;
+        }
+        try {
+            return Integer.parseInt(v);
+        } catch (NumberFormatException err) {
+            return def;
+        }
+    }
+
+    public static void main(String[] args) {
+        int iterations = envInt("ITERS", 20000000);
+        int liveSize = envInt("LIVE", 4096);      // power of two, for the mask
+        Node[] live = new Node[liveSize];
+        long[] buckets = new long[48];
+        long worst = 0;
+        long checksum = 0;
+
+        // Untimed warm-up so first-touch page faults and the first collection are
+        // not charged to the measurement.
+        for(int i = 0 ; i < 1000000 ; i++) {
+            live[i & (liveSize - 1)] = new Node(i, null);
+        }
+
+        long prev = System.nanoTime();
+        for(int i = 0 ; i < iterations ; i++) {
+            // Each new node points at an older live one, so the collector has a
+            // real graph to trace rather than a field of isolated leaves.
+            Node n = new Node(i, live[(i * 7) & (liveSize - 1)]);
+            live[i & (liveSize - 1)] = n;
+            checksum += n.v;
+            long now = System.nanoTime();
+            long d = now - prev;
+            prev = now;
+            int b = 0;
+            long x = d;
+            while(x > 0 && b < 47) {
+                x >>= 1;
+                b++;
+            }
+            buckets[b]++;
+            if(d > worst) {
+                worst = d;
+            }
+        }
+        report(buckets, worst, checksum, iterations);
+    }
+
+    static void report(long[] buckets, long worst, long checksum, long iterations) {
+        System.out.println("GCPAUSE iterations=" + iterations + " checksum=" + checksum);
+        System.out.println("GCPAUSE maxNs=" + worst);
+        long total = 0;
+        for(int b = 0 ; b < buckets.length ; b++) {
+            total += buckets[b];
+        }
+        printPercentile("p50", buckets, total, 0.50);
+        printPercentile("p99", buckets, total, 0.99);
+        printPercentile("p999", buckets, total, 0.999);
+        printPercentile("p9999", buckets, total, 0.9999);
+        // Everything at or above 64us: with steady per-iteration work nothing but
+        // a collection reaches that, so this counts pauses directly.
+        long stalls = 0;
+        for(int b = 17 ; b < buckets.length ; b++) {
+            stalls += buckets[b];
+        }
+        System.out.println("GCPAUSE stallsOver64us=" + stalls);
+        for(int b = 17 ; b < buckets.length ; b++) {
+            if(buckets[b] != 0) {
+                System.out.println("GCPAUSE bucket=" + (1L << (b - 1)) + "ns count=" + buckets[b]);
+            }
+        }
+    }
+
+    static void printPercentile(String name, long[] buckets, long total, double q) {
+        long want = (long)(q * (double)total);
+        long seen = 0;
+        for(int b = 0 ; b < buckets.length ; b++) {
+            seen += buckets[b];
+            if(seen > want) {
+                System.out.println("GCPAUSE " + name + "Ns=" + (b == 0 ? 0L : (1L << (b - 1))));
+                return;
+            }
+        }
+    }
+}

--- a/vm/benchmarks/src/com/bench/LongShift.java
+++ b/vm/benchmarks/src/com/bench/LongShift.java
@@ -1,0 +1,24 @@
+package com.bench;
+
+/** Does `1L << n` keep long semantics for n >= 31 on the clean target? */
+public class LongShift {
+    public static void main(String[] args) {
+        for(int b = 29 ; b <= 34 ; b++) {
+            long viaLiteral = 1L << b;
+            long one = 1L;
+            long viaVariable = one << b;
+            System.out.println("SHIFT b=" + b
+                    + " literal=" + viaLiteral
+                    + " variable=" + viaVariable
+                    + " expected=" + expected(b));
+        }
+    }
+    /** Built by doubling, so it cannot share a shift bug with what it checks. */
+    static long expected(int b) {
+        long v = 1;
+        for(int i = 0 ; i < b ; i++) {
+            v = v + v;
+        }
+        return v;
+    }
+}

--- a/vm/benchmarks/src/com/bench/LongShift.java
+++ b/vm/benchmarks/src/com/bench/LongShift.java
@@ -23,10 +23,19 @@
 
 package com.bench;
 
-/** Does `1L << n` keep long semantics for n >= 31 on the clean target? */
+/**
+ * Does `1L << n` keep long semantics for n >= 31 on the clean target?
+ *
+ * Runs to 63 rather than stopping short of the sign bit. The interesting shifts
+ * are exactly the ones that overflow into it: in C a signed left shift whose
+ * result is not representable is undefined, so 1L << 63 and any negative left
+ * operand are where a compiler is free to produce something other than Java's
+ * wraparound. Stopping at 34 exercised the translator's int-literal bug and
+ * nothing about the shift itself.
+ */
 public class LongShift {
     public static void main(String[] args) {
-        for(int b = 29 ; b <= 34 ; b++) {
+        for(int b = 29 ; b <= 63 ; b++) {
             long viaLiteral = 1L << b;
             long one = 1L;
             long viaVariable = one << b;
@@ -35,10 +44,39 @@ public class LongShift {
                     + " variable=" + viaVariable
                     + " expected=" + expected(b));
         }
+        // Negative left operands: the other half of what C leaves undefined.
+        for(int b = 60 ; b <= 63 ; b++) {
+            long minusOne = -1L;
+            long minusFive = -5L;
+            System.out.println("NEGSHIFT b=" + b
+                    + " minusOne=" + (minusOne << b)
+                    + " minusFive=" + (minusFive << b)
+                    + " expectedMinusOne=" + negExpected(-1L, b)
+                    + " expectedMinusFive=" + negExpected(-5L, b));
+        }
+        for(int b = 29 ; b <= 31 ; b++) {
+            int oneInt = 1;
+            int minusOneInt = -1;
+            System.out.println("INTSHIFT b=" + b
+                    + " one=" + (oneInt << b)
+                    + " minusOne=" + (minusOneInt << b)
+                    + " expectedOne=" + (int) negExpected(1L, b)
+                    + " expectedMinusOne=" + (int) negExpected(-1L, b));
+        }
     }
+
     /** Built by doubling, so it cannot share a shift bug with what it checks. */
     static long expected(int b) {
         long v = 1;
+        for(int i = 0 ; i < b ; i++) {
+            v = v + v;
+        }
+        return v;
+    }
+
+    /** Same doubling reference, for an arbitrary (including negative) start. */
+    static long negExpected(long start, int b) {
+        long v = start;
         for(int i = 0 ; i < b ; i++) {
             v = v + v;
         }

--- a/vm/benchmarks/src/com/bench/LongShift.java
+++ b/vm/benchmarks/src/com/bench/LongShift.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
 package com.bench;
 
 /** Does `1L << n` keep long semantics for n >= 31 on the clean target? */

--- a/vm/tests/src/test/java/com/codename1/tools/translator/BibopPageFloorIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/BibopPageFloorIntegrationTest.java
@@ -221,6 +221,9 @@ class BibopPageFloorIntegrationTest {
             // arm64 269552KB -> 90656KB, x86_64 263813KB -> 263821KB.
             cmakeArgs.add("-DCMAKE_OSX_ARCHITECTURES=arm64");
         }
+        // Injected flags (CN1_TEST_EXTRA_CFLAGS) appended last, so they survive the
+        // hardcoded compiler settings above; empty unless the variable is set.
+        cmakeArgs.addAll(CompilerHelper.extraCFlagArgs());
         CleanTargetIntegrationTest.runCommand(cmakeArgs, distDir);
         CleanTargetIntegrationTest.runCommand(Arrays.asList("cmake", "--build", buildDir.toString()), distDir);
 

--- a/vm/tests/src/test/java/com/codename1/tools/translator/BibopPageFloorIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/BibopPageFloorIntegrationTest.java
@@ -394,8 +394,21 @@ class BibopPageFloorIntegrationTest {
         // stderr, and a merged write can land in the middle of a marker line --
         // observed as a phase silently missing from the table because its marker
         // had a tracer line spliced through it. The footprint columns are the
-        // evidence here; set CN1_LOG_PAGE_RELEASE=1 by hand when you want the
-        // per-sweep page counts alongside them.
+        // evidence here, and the per-sweep page counts go beside them.
+        //
+        // The tracer is turned on HERE rather than in the workflow, because the
+        // workflow's env reaches every test in the suite and these are timing
+        // sensitive: an extra stderr write per major sweep is not free in a
+        // verifier run, and scoping it to the one test that needs it keeps the
+        // others exactly as they were. It is read-only in any case -- gated on
+        // getenv, and it only prints -- so it changes no collection decision.
+        //
+        // Why it is on at all: this test fails intermittently on arm64 Linux, and
+        // bimodally (6-7% of a dropped live set's pages handed back against 91%
+        // on a good run) rather than marginally. Bimodal is a major sweep running
+        // or not, since cn1BibopTrimFreePool runs only at the end of one, so a
+        // failing run has to say whether one ran and what it spliced.
+        builder.environment().put("CN1_LOG_PAGE_RELEASE", "1");
         builder.redirectError(ProcessBuilder.Redirect.INHERIT);
         Process process = builder.start();
         String output;

--- a/vm/tests/src/test/java/com/codename1/tools/translator/CompilerHelper.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/CompilerHelper.java
@@ -159,13 +159,77 @@ public class CompilerHelper {
      * {@code LANGUAGES C CXX} project (its COM layer is C++), so cmake needs a
      * CXX compiler even when the particular app contributes no .cpp itself.
      */
-    public static List<String> cmakeToolchainArgs() {
-        if (isWindows()) {
-            return Arrays.asList("-G", "Ninja",
-                    "-DCMAKE_C_COMPILER=clang-cl", "-DCMAKE_CXX_COMPILER=clang-cl");
+    /**
+     * Extra C flags for the generated project, from {@code CN1_TEST_EXTRA_CFLAGS}.
+     *
+     * Padded on BOTH sides. CMAKE_C_FLAGS is a command-line fragment whose options
+     * must be space separated, and a caller appending its own flag to this would
+     * otherwise produce {@code -DCN1_GC_MARK_THREADS=4-DCN1_GC_NO_FORCE_STOP} --
+     * one undeclared macro instead of two, which clang accepts and which silently
+     * builds the wrong thing.
+     *
+     * Empty unless the variable is set, so every build is byte-identical to before
+     * by default.
+     */
+    public static String extraCFlags() {
+        String v = System.getenv("CN1_TEST_EXTRA_CFLAGS");
+        if (v == null || v.trim().isEmpty()) {
+            return "";
         }
-        return Arrays.asList("-DCMAKE_C_COMPILER=clang", "-DCMAKE_CXX_COMPILER=clang++",
-                "-DCMAKE_OBJC_COMPILER=clang");
+        return " " + v.trim() + " ";
+    }
+
+    /** {@code -DCMAKE_C_FLAGS=} with the test's own flags and the injected ones merged. */
+    public static String cFlagsArg(String own) {
+        return "-DCMAKE_C_FLAGS=" + (own == null ? "" : own) + extraCFlags();
+    }
+
+    /** {@code -DCMAKE_OBJC_FLAGS=} with the test's own flags and the injected ones merged. */
+    public static String objcFlagsArg(String own) {
+        return "-DCMAKE_OBJC_FLAGS=" + (own == null ? "" : own) + extraCFlags();
+    }
+
+    /**
+     * The injected flags as cmake arguments, empty when nothing is injected.
+     *
+     * Several GC tests build their cmake command inline with hardcoded compilers
+     * rather than going through cmakeToolchainArgs, so the hook has to be
+     * available in list form for them too. Only two of the six tests in the
+     * parallel-mark matrix call cmakeToolchainArgs; adding it there alone left
+     * three still compiling the default collector, which an invalid-flag probe
+     * caught (the build should have failed and did not).
+     */
+    public static List<String> extraCFlagArgs() {
+        if (extraCFlags().isEmpty()) {
+            return java.util.Collections.emptyList();
+        }
+        return Arrays.asList(cFlagsArg(""), objcFlagsArg(""));
+    }
+
+    /**
+     * Toolchain arguments every integration test passes.
+     *
+     * The injected flags are added HERE rather than per test, because most GC tests
+     * pass no CMAKE_C_FLAGS of their own: hooking only the ones that do left four of
+     * the six tests in the parallel-mark matrix compiling the default single-marker
+     * collector, so a green matrix would not have validated what it claimed.
+     * A test that passes its own flags must use cFlagsArg/objcFlagsArg, since a
+     * later -DCMAKE_C_FLAGS on the command line overrides this one.
+     */
+    public static List<String> cmakeToolchainArgs() {
+        List<String> args = new ArrayList<>();
+        if (isWindows()) {
+            args.addAll(Arrays.asList("-G", "Ninja",
+                    "-DCMAKE_C_COMPILER=clang-cl", "-DCMAKE_CXX_COMPILER=clang-cl"));
+        } else {
+            args.addAll(Arrays.asList("-DCMAKE_C_COMPILER=clang", "-DCMAKE_CXX_COMPILER=clang++",
+                    "-DCMAKE_OBJC_COMPILER=clang"));
+        }
+        if (!extraCFlags().isEmpty()) {
+            args.add(cFlagsArg(""));
+            args.add(objcFlagsArg(""));
+        }
+        return args;
     }
 
     public static List<CompilerConfig> getAvailableCompilers(String targetVersion) {

--- a/vm/tests/src/test/java/com/codename1/tools/translator/CompilerHelper.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/CompilerHelper.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
 package com.codename1.tools.translator;
 
 import java.io.ByteArrayOutputStream;

--- a/vm/tests/src/test/java/com/codename1/tools/translator/GcHeapIntegrityIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/GcHeapIntegrityIntegrationTest.java
@@ -152,8 +152,8 @@ class GcHeapIntegrityIntegrationTest {
                 "-DCMAKE_BUILD_TYPE=Release",
                 "-DCMAKE_C_COMPILER=clang",
                 "-DCMAKE_OBJC_COMPILER=clang",
-                "-DCMAKE_C_FLAGS=-DCN1_GC_VERIFY" + extraCFlags(),
-                "-DCMAKE_OBJC_FLAGS=-DCN1_GC_VERIFY" + extraCFlags()
+                CompilerHelper.cFlagsArg("-DCN1_GC_VERIFY"),
+                CompilerHelper.objcFlagsArg("-DCN1_GC_VERIFY")
         ), distDir);
         CleanTargetIntegrationTest.runCommand(Arrays.asList("cmake", "--build", buildDir.toString()), distDir);
 
@@ -347,20 +347,5 @@ class GcHeapIntegrityIntegrationTest {
         }
     }
 
-    /**
-     * Extra compile flags for the C build, from the {@code CN1_TEST_EXTRA_CFLAGS}
-     * environment variable, appended to whatever this test already passes.
-     *
-     * The parallel mark pool is compiled out by default (see
-     * gcMarkResolveThreadCount) because arm64 Linux corrupted the heap with it on
-     * and the second ordering hole was never located. Reproducing that needs the
-     * existing GC tests run against a parallel marker on real arm64 hardware,
-     * which this hook allows without changing any default: unset, every test
-     * compiles exactly as before.
-     */
-    static String extraCFlags() {
-        String v = System.getenv("CN1_TEST_EXTRA_CFLAGS");
-        return v == null ? "" : (" " + v);
-    }
 
 }

--- a/vm/tests/src/test/java/com/codename1/tools/translator/GcHeapIntegrityIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/GcHeapIntegrityIntegrationTest.java
@@ -152,8 +152,8 @@ class GcHeapIntegrityIntegrationTest {
                 "-DCMAKE_BUILD_TYPE=Release",
                 "-DCMAKE_C_COMPILER=clang",
                 "-DCMAKE_OBJC_COMPILER=clang",
-                "-DCMAKE_C_FLAGS=-DCN1_GC_VERIFY",
-                "-DCMAKE_OBJC_FLAGS=-DCN1_GC_VERIFY"
+                "-DCMAKE_C_FLAGS=-DCN1_GC_VERIFY" + extraCFlags(),
+                "-DCMAKE_OBJC_FLAGS=-DCN1_GC_VERIFY" + extraCFlags()
         ), distDir);
         CleanTargetIntegrationTest.runCommand(Arrays.asList("cmake", "--build", buildDir.toString()), distDir);
 
@@ -346,4 +346,21 @@ class GcHeapIntegrityIntegrationTest {
                     + root + " (first failure: " + firstFailure[0] + ")");
         }
     }
+
+    /**
+     * Extra compile flags for the C build, from the {@code CN1_TEST_EXTRA_CFLAGS}
+     * environment variable, appended to whatever this test already passes.
+     *
+     * The parallel mark pool is compiled out by default (see
+     * gcMarkResolveThreadCount) because arm64 Linux corrupted the heap with it on
+     * and the second ordering hole was never located. Reproducing that needs the
+     * existing GC tests run against a parallel marker on real arm64 hardware,
+     * which this hook allows without changing any default: unset, every test
+     * compiles exactly as before.
+     */
+    static String extraCFlags() {
+        String v = System.getenv("CN1_TEST_EXTRA_CFLAGS");
+        return v == null ? "" : (" " + v);
+    }
+
 }

--- a/vm/tests/src/test/java/com/codename1/tools/translator/GcSteadyStateIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/GcSteadyStateIntegrationTest.java
@@ -885,7 +885,7 @@ class GcSteadyStateIntegrationTest {
         cmake.addAll(CompilerHelper.cmakeToolchainArgs());
         // CMAKE_C_FLAGS composes with the target's own options, so the mandatory
         // -fwrapv / -fno-strict-aliasing the generated project adds are kept.
-        cmake.add("-DCMAKE_C_FLAGS=" + cFlags);
+        cmake.add("-DCMAKE_C_FLAGS=" + extraCFlags() + cFlags);
         CleanTargetIntegrationTest.runCommand(cmake, distDir);
         CleanTargetIntegrationTest.runCommand(
                 Arrays.asList("cmake", "--build", buildDir.toString()), distDir);
@@ -1181,4 +1181,21 @@ class GcSteadyStateIntegrationTest {
             // best effort
         }
     }
+
+    /**
+     * Extra compile flags for the C build, from the {@code CN1_TEST_EXTRA_CFLAGS}
+     * environment variable, appended to whatever this test already passes.
+     *
+     * The parallel mark pool is compiled out by default (see
+     * gcMarkResolveThreadCount) because arm64 Linux corrupted the heap with it on
+     * and the second ordering hole was never located. Reproducing that needs the
+     * existing GC tests run against a parallel marker on real arm64 hardware,
+     * which this hook allows without changing any default: unset, every test
+     * compiles exactly as before.
+     */
+    static String extraCFlags() {
+        String v = System.getenv("CN1_TEST_EXTRA_CFLAGS");
+        return v == null ? "" : (" " + v);
+    }
+
 }

--- a/vm/tests/src/test/java/com/codename1/tools/translator/GcSteadyStateIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/GcSteadyStateIntegrationTest.java
@@ -885,7 +885,7 @@ class GcSteadyStateIntegrationTest {
         cmake.addAll(CompilerHelper.cmakeToolchainArgs());
         // CMAKE_C_FLAGS composes with the target's own options, so the mandatory
         // -fwrapv / -fno-strict-aliasing the generated project adds are kept.
-        cmake.add("-DCMAKE_C_FLAGS=" + extraCFlags() + cFlags);
+        cmake.add(CompilerHelper.cFlagsArg("") + cFlags);
         CleanTargetIntegrationTest.runCommand(cmake, distDir);
         CleanTargetIntegrationTest.runCommand(
                 Arrays.asList("cmake", "--build", buildDir.toString()), distDir);
@@ -1182,20 +1182,5 @@ class GcSteadyStateIntegrationTest {
         }
     }
 
-    /**
-     * Extra compile flags for the C build, from the {@code CN1_TEST_EXTRA_CFLAGS}
-     * environment variable, appended to whatever this test already passes.
-     *
-     * The parallel mark pool is compiled out by default (see
-     * gcMarkResolveThreadCount) because arm64 Linux corrupted the heap with it on
-     * and the second ordering hole was never located. Reproducing that needs the
-     * existing GC tests run against a parallel marker on real arm64 hardware,
-     * which this hook allows without changing any default: unset, every test
-     * compiles exactly as before.
-     */
-    static String extraCFlags() {
-        String v = System.getenv("CN1_TEST_EXTRA_CFLAGS");
-        return v == null ? "" : (" " + v);
-    }
 
 }

--- a/vm/tests/src/test/java/com/codename1/tools/translator/GcUncooperativeThreadIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/GcUncooperativeThreadIntegrationTest.java
@@ -274,7 +274,7 @@ class GcUncooperativeThreadIntegrationTest {
         cmake.addAll(CompilerHelper.cmakeToolchainArgs());
         // CMAKE_C_FLAGS composes with the target's own options, so the mandatory
         // -fwrapv / -fno-strict-aliasing the generated project adds are kept.
-        cmake.add("-DCMAKE_C_FLAGS=" + cFlags);
+        cmake.add("-DCMAKE_C_FLAGS=" + extraCFlags() + cFlags);
         CleanTargetIntegrationTest.runCommand(cmake, distDir);
         CleanTargetIntegrationTest.runCommand(
                 Arrays.asList("cmake", "--build", buildDir.toString()), distDir);
@@ -412,4 +412,21 @@ class GcUncooperativeThreadIntegrationTest {
             // best effort
         }
     }
+
+    /**
+     * Extra compile flags for the C build, from the {@code CN1_TEST_EXTRA_CFLAGS}
+     * environment variable, appended to whatever this test already passes.
+     *
+     * The parallel mark pool is compiled out by default (see
+     * gcMarkResolveThreadCount) because arm64 Linux corrupted the heap with it on
+     * and the second ordering hole was never located. Reproducing that needs the
+     * existing GC tests run against a parallel marker on real arm64 hardware,
+     * which this hook allows without changing any default: unset, every test
+     * compiles exactly as before.
+     */
+    static String extraCFlags() {
+        String v = System.getenv("CN1_TEST_EXTRA_CFLAGS");
+        return v == null ? "" : (" " + v);
+    }
+
 }

--- a/vm/tests/src/test/java/com/codename1/tools/translator/GcUncooperativeThreadIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/GcUncooperativeThreadIntegrationTest.java
@@ -274,7 +274,7 @@ class GcUncooperativeThreadIntegrationTest {
         cmake.addAll(CompilerHelper.cmakeToolchainArgs());
         // CMAKE_C_FLAGS composes with the target's own options, so the mandatory
         // -fwrapv / -fno-strict-aliasing the generated project adds are kept.
-        cmake.add("-DCMAKE_C_FLAGS=" + extraCFlags() + cFlags);
+        cmake.add(CompilerHelper.cFlagsArg(cFlags));
         CleanTargetIntegrationTest.runCommand(cmake, distDir);
         CleanTargetIntegrationTest.runCommand(
                 Arrays.asList("cmake", "--build", buildDir.toString()), distDir);
@@ -413,20 +413,5 @@ class GcUncooperativeThreadIntegrationTest {
         }
     }
 
-    /**
-     * Extra compile flags for the C build, from the {@code CN1_TEST_EXTRA_CFLAGS}
-     * environment variable, appended to whatever this test already passes.
-     *
-     * The parallel mark pool is compiled out by default (see
-     * gcMarkResolveThreadCount) because arm64 Linux corrupted the heap with it on
-     * and the second ordering hole was never located. Reproducing that needs the
-     * existing GC tests run against a parallel marker on real arm64 hardware,
-     * which this hook allows without changing any default: unset, every test
-     * compiles exactly as before.
-     */
-    static String extraCFlags() {
-        String v = System.getenv("CN1_TEST_EXTRA_CFLAGS");
-        return v == null ? "" : (" " + v);
-    }
 
 }

--- a/vm/tests/src/test/java/com/codename1/tools/translator/LargeArrayGcIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/LargeArrayGcIntegrationTest.java
@@ -145,14 +145,18 @@ class LargeArrayGcIntegrationTest {
         Path buildDir = distDir.resolve("build");
         Files.createDirectories(buildDir);
 
-        CleanTargetIntegrationTest.runCommand(Arrays.asList(
+        List<String> cmakeArgs = new ArrayList<>(Arrays.asList(
                 "cmake",
                 "-S", distDir.toString(),
                 "-B", buildDir.toString(),
                 "-DCMAKE_BUILD_TYPE=Release",
                 "-DCMAKE_C_COMPILER=clang",
                 "-DCMAKE_OBJC_COMPILER=clang"
-        ), distDir);
+        ));
+        // Injected flags (CN1_TEST_EXTRA_CFLAGS) appended last, so they survive the
+        // hardcoded compiler settings above; empty unless the variable is set.
+        cmakeArgs.addAll(CompilerHelper.extraCFlagArgs());
+        CleanTargetIntegrationTest.runCommand(cmakeArgs, distDir);
 
         CleanTargetIntegrationTest.runCommand(Arrays.asList("cmake", "--build", buildDir.toString()), distDir);
 

--- a/vm/tests/src/test/java/com/codename1/tools/translator/LowMemoryThrottleIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/LowMemoryThrottleIntegrationTest.java
@@ -163,14 +163,18 @@ class LowMemoryThrottleIntegrationTest {
 
         Path buildDir = distDir.resolve("build");
         Files.createDirectories(buildDir);
-        CleanTargetIntegrationTest.runCommand(Arrays.asList(
+        List<String> cmakeArgs = new ArrayList<>(Arrays.asList(
                 "cmake",
                 "-S", distDir.toString(),
                 "-B", buildDir.toString(),
                 "-DCMAKE_BUILD_TYPE=Release",
                 "-DCMAKE_C_COMPILER=clang",
                 "-DCMAKE_OBJC_COMPILER=clang"
-        ), distDir);
+        ));
+        // Injected flags (CN1_TEST_EXTRA_CFLAGS) appended last, so they survive the
+        // hardcoded compiler settings above; empty unless the variable is set.
+        cmakeArgs.addAll(CompilerHelper.extraCFlagArgs());
+        CleanTargetIntegrationTest.runCommand(cmakeArgs, distDir);
         CleanTargetIntegrationTest.runCommand(Arrays.asList("cmake", "--build", buildDir.toString()), distDir);
 
         Path executable = buildDir.resolve("LowMemoryThrottleApp");


### PR DESCRIPTION
Three separable changes, each with its rationale in the code rather than here.

## 1. `1L << n` was computed as a 32-bit shift

`BC_LSHL_EXPR` / `BC_LSHR_EXPR` masked the shift count to 6 bits but left the left
operand alone, and the translator emits a long constant as a bare C literal. So
`LCONST_1` arrived as an `int`:

    1L << 31  ->  -2147483648      1L << 32  ->  1      1L << 33  ->  2

Shifting a long *variable* was always correct, which is how it survived.
`BC_LUSHR_EXPR` already cast, so this was fixed once for the unsigned shift and
not carried to its siblings. `LongShift` checks all three forms against a
reference built by repeated doubling.

## 2. Heap goal sized against the live set, not a constant

`CN1_BIBOP_GC_TRIGGER_BYTES` was the floor outright, so a process holding almost
nothing live still accumulated 24MB of garbage before collecting. Resident memory
tracked the trigger and nothing else (backend, `/plaintext`, 64 connections):

| trigger | 4MB | 8MB | 16MB | 24MB | 48MB |
|---|---|---|---|---|---|
| loaded RSS | 30MB | 49MB | 68MB | 98MB | 102MB |

Throughput and p99 across that sweep were flat inside noise, so the floor bought
footprint and no speed. The floor is now live-set + growth%, clamped to a 4MB
minimum, at all three clamp sites. An app with a real live set gets a *larger*
floor than the old constant. Measured after: **98MB -> 38MB** loaded RSS, with
throughput and p50 improving.

Also adds `cn1GcMutatorAssist` (a thread parked on the run-ahead cap marks a
batch instead of sleeping). It registers in `gcMarkActiveWorkers` before
releasing the worklist mutex so mark termination cannot fire while it holds a
batch, and assists only the parallel path. It is **inert** until the mark pool is
enabled.

## 3. Re-test parallel marking on arm64

`gcMarkResolveThreadCount` forces one marker behind `#elif 1`. The comment reads
as a standing verdict that arm64 corrupts the heap with the pool on. The history
is narrower - inside #5327:

    Jul 3   default parallel marking to serial ("isolation experiment")  <- the comment
    Jul 4   gcMarkObject must reject freed BiBOP slots
    Jul 5   SATB write barrier, closing the concurrent-mark cross-thread race
    Jul 5   grace-subtree drain before sweep; belt pass; looped final mark
    Jul 6   object-bearing frameless OFF - "unsound under conservative GC on arm64"
    Jul 10  clazz-registry invariant (arm64 SIGSEGV)

The conclusion was drawn before every mechanism that makes concurrent marking
sound, the SATB barrier included. A different arm64 heap corruptor was found on
Jul 6. Parallel marking was never re-tested afterwards, and
`gcMarkDrainParallel` / `gcMarkObject` / `gcMarkFlushLocal` /
`gcMarkWorklistPush` have all been reworked since.

Cost of leaving it: on `GcPause` (one mutator, 20M short-lived objects, 4096-node
live set) the worst pause is **2.2-3.3s with one marker, 0.3-0.9s with four**,
against Go's 20ms on the identical loop. Median and p99 already match Go.

Not reproduced locally: `GcPause` ran clean with four markers on an aarch64
guest, and a multi-threaded stress ran clean too - but that stress also passes
with the SATB barrier compiled out, so it is not a valid detector and is
deliberately not included here.

**No defaults change.** The pool is enabled for the new workflow only, via the
`CN1_TEST_EXTRA_CFLAGS` hook. Matrix: 1 marker arm64 (control), 4 markers arm64
(the question), 4 markers x64 (attribution).

## Verification

GC suite (`GcHeapIntegrity`, `GcOverflowSpiral`, `GcUncooperativeThread`,
`LargeArrayGc`, `LowMemoryThrottle`, `BibopPageFloor`) 6/6 locally on this
branch. Copyright and control-character gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)