### PR TITLE
Preserve Windows CI evidence and retry transient publication failures

### DIFF
--- a/.github/workflows/parparvm-tests-windows.yml
+++ b/.github/workflows/parparvm-tests-windows.yml
@@ -766,11 +766,14 @@ jobs:
           fi
           if [ "$fail" -ne 0 ]; then echo "Windows x64 screenshot gate failed."; exit 1; fi
 
-      - name: Upload Windows x64 port status
+      # windows-cross-build-run.yml owns the public windows-x64 report. Keep
+      # native-build diagnostics out of the publisher/backfill port-status-*
+      # selection so a green native run cannot hide a shipping-pipeline failure.
+      - name: Upload Windows native x64 diagnostics
         if: always()
         uses: ./.github/actions/upload-artifact-with-retry
         with:
-          name: port-status-windows-x64
+          name: windows-native-x64-diagnostics
           path: artifacts/windows-port/port-status-windows-x64.json
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/parparvm-tests-windows.yml
+++ b/.github/workflows/parparvm-tests-windows.yml
@@ -445,6 +445,8 @@ jobs:
           JDK_8_HOME: ${{ env.JDK_8_HOME }}
           CN1_SHOT_OUTPUT_DIR: ${{ github.workspace }}\artifacts\windows-port\raw
           CN1_PERFORMANCE_BINARY_OUT: ${{ github.workspace }}\artifacts\windows-port\raw\benchmark-app.exe
+          CN1_REQUIRE_SUITE: ${{ github.event_name != 'pull_request' }}
+          CN1_REQUIRE_PERFORMANCE: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         run: |
           # Both retried the way the clean-target job does. The package is a
           # download-and-build, so a blanket loop is safe; the test is restricted
@@ -542,7 +544,18 @@ jobs:
 
       # Temurin publishes Windows/aarch64 from JDK 21; that JDK drives the
       # translator harness and builds the JavaAPI. Core + port come pre-compiled.
+      # setup-java's archive extraction can crash PowerShell on ARM64.
+      # Retry only setup; the final attempt and every build/test stay blocking.
       - name: Set up JDK 21
+        id: jdk21
+        continue-on-error: true
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+      - name: Retry JDK 21 setup
+        if: steps.jdk21.outcome == 'failure'
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
@@ -670,7 +683,11 @@ jobs:
   windows-port-screenshot-comment-x64:
     name: screenshot-comment (x64)
     needs: windows-port-screenshot
-    if: github.event_name == 'pull_request'
+    if: >-
+      always() &&
+      needs.windows-port-screenshot.result != 'cancelled' &&
+      needs.windows-port-screenshot.result != 'skipped' &&
+      (github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -709,7 +726,8 @@ jobs:
               entries+=("$(basename "$f" .png)=$f")
             done
           fi
-          if [ ${#entries[@]} -eq 0 ]; then echo "No x64 screenshots; skipping comment."; exit 0; fi
+          # Empty captures must produce not-run evidence and fail the gate.
+          mkdir -p "$ART"
           echo "Posting ${#entries[@]} x64 screenshot(s)"
           mkdir -p "$ART/previews"
           cp -f "$ART"/raw/windows-benchmark-stats.txt "$ART/" 2>/dev/null || true
@@ -722,6 +740,14 @@ jobs:
           # through green CI (the picker case-conversion refresh was missed here).
           export CN1SS_FAIL_ON_MISMATCH=1
           export CN1SS_ALLOWED_MISSING=0
+          # PR capture may stop after the visual set; durable reports require the full suite.
+          if [ "${{ github.event_name }}" != "pull_request" ] || [ ${#entries[@]} -eq 0 ]; then
+            export CN1SS_FAIL_ON_TEST_PROBLEMS=1
+          fi
+          export CN1SS_PORT_ID=windows-x64
+          export CN1SS_BINARY_PATH="$ART/raw/benchmark-app.exe"
+          export CN1SS_SUITE_LOG="$ART/raw/app-output.log"
+          if [ "${{ github.event_name }}" != "pull_request" ]; then export CN1SS_SKIP_COMMENT=1; fi
           set +e
           cn1ss_process_and_report \
             "Native Windows port (x64)" \
@@ -739,6 +765,15 @@ jobs:
             echo "[windows-native-port x64] FATAL: $me screenshot(s) streamed with no stored golden (missing_expected) -- add them to $REF_DIR."; fail=1
           fi
           if [ "$fail" -ne 0 ]; then echo "Windows x64 screenshot gate failed."; exit 1; fi
+
+      - name: Upload Windows x64 port status
+        if: always()
+        uses: ./.github/actions/upload-artifact-with-retry
+        with:
+          name: port-status-windows-x64
+          path: artifacts/windows-port/port-status-windows-x64.json
+          if-no-files-found: error
+          retention-days: 14
 
   windows-port-screenshot-comment-arm64:
     name: screenshot-comment (arm64)
@@ -789,7 +824,8 @@ jobs:
               entries+=("$(basename "$f" .png)=$f")
             done
           fi
-          if [ ${#entries[@]} -eq 0 ]; then echo "No arm64 screenshots; skipping comment."; exit 0; fi
+          # Empty captures must produce not-run evidence and fail the gate.
+          mkdir -p "$ART"
           echo "Posting ${#entries[@]} arm64 screenshot(s)"
           mkdir -p "$ART/previews"
           cp -f "$ART"/raw/windows-benchmark-stats.txt "$ART/" 2>/dev/null || true
@@ -799,6 +835,10 @@ jobs:
           # Same blocking gate as the x64 leg.
           export CN1SS_FAIL_ON_MISMATCH=1
           export CN1SS_ALLOWED_MISSING=0
+          # PR capture may stop after the visual set; durable reports require the full suite.
+          if [ "${{ github.event_name }}" != "pull_request" ] || [ ${#entries[@]} -eq 0 ]; then
+            export CN1SS_FAIL_ON_TEST_PROBLEMS=1
+          fi
           export CN1SS_PORT_ID=windows-arm64
           export CN1SS_BINARY_PATH="$ART/raw/benchmark-app.exe"
           export CN1SS_SUITE_LOG="$ART/raw/app-output.log"
@@ -827,7 +867,7 @@ jobs:
         with:
           name: port-status-windows-arm64
           path: artifacts/windows-port/port-status-windows-arm64.json
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: 14
 
   # Widgets Board provider compile check: compiles the one nativeSources TU no

--- a/.github/workflows/port-status-contract.yml
+++ b/.github/workflows/port-status-contract.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - '.github/workflows/port-status-contract.yml'
       - '.github/workflows/port-status-publish.yml'
+      - '.github/workflows/parparvm-tests-windows.yml'
+      - 'scripts/lib/cn1ss.sh'
       - 'docs/website/data/port_status.json'
       - 'docs/website/data/port_status_supplement.json'
       - 'docs/website/data/port_status_support.json'
@@ -36,6 +38,8 @@ on:
     paths:
       - '.github/workflows/port-status-contract.yml'
       - '.github/workflows/port-status-publish.yml'
+      - '.github/workflows/parparvm-tests-windows.yml'
+      - 'scripts/lib/cn1ss.sh'
       - 'docs/website/data/port_status.json'
       - 'docs/website/data/port_status_supplement.json'
       - 'docs/website/data/port_status_support.json'
@@ -91,4 +95,4 @@ jobs:
           ./scripts/hellocodenameone/conformance/check_port_status_provenance.sh "${BASE_SHA:-HEAD^}"
       - name: Run normalizer tests
         working-directory: scripts/hellocodenameone/conformance
-        run: python3 -m unittest -v test_port_status.py
+        run: python3 -m unittest -v test_port_status.py test_publish_port_status.py test_ci_reporting.py

--- a/scripts/hellocodenameone/conformance/publish_port_status.py
+++ b/scripts/hellocodenameone/conformance/publish_port_status.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Publish an accepted report, retrying transport failures and CAS conflicts only."""
+import base64
+from datetime import datetime
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+import time
+
+
+class ApiError(RuntimeError):
+    def __init__(self, message, status=None):
+        super().__init__(message)
+        self.status = status
+
+
+def api(endpoint, method="GET", payload=None):
+    command = ["gh", "api", "--include", "--method", method, endpoint]
+    if payload is not None:
+        command += ["--input", "-"]
+    for attempt in range(3):
+        try:
+            result = subprocess.run(command, input=json.dumps(payload) if payload is not None else None,
+                                    text=True, capture_output=True, timeout=60)
+        except subprocess.TimeoutExpired:
+            result = subprocess.CompletedProcess(command, 1, "", "API request timed out after 60s")
+        # --include preserves the status even when GitHub returns a non-JSON body.
+        match = re.match(r"HTTP/\S+ (\d+)[^\n]*\n", result.stdout)
+        status = int(match[1]) if match else None
+        body = re.split(r"\r?\n\r?\n", result.stdout, maxsplit=1)
+        detail = result.stderr.strip() or f"HTTP {status}: invalid or empty API response"
+        if result.returncode == 0 and status is not None and 200 <= status < 300:
+            try:
+                value = json.loads(body[1])
+                if not isinstance(value, dict):
+                    raise ValueError("expected a JSON object")
+                return value
+            except (IndexError, ValueError):
+                detail = f"HTTP {status}: invalid or empty JSON response"
+                transient = True
+        else:
+            transient = status is None or status in (408, 429, 500, 502, 503, 504)
+        if not transient or attempt == 2:
+            raise ApiError(f"{method} {endpoint}: {detail}", status)
+        print(f"Transient API failure ({detail}); retrying {method} in {2 ** (attempt + 1)}s",
+              file=sys.stderr)
+        time.sleep(2 ** (attempt + 1))
+
+
+def stamp(value):
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("report timestamp must include a timezone")
+    return parsed
+
+
+def publish(report, repo):
+    branch = "port-status-data"
+    root = f"repos/{repo}"
+    ref = f"{root}/git/ref/heads/{branch}"
+    try:
+        api(ref)
+    except ApiError as error:
+        if error.status != 404:
+            raise
+        default = api(root)["default_branch"]
+        sha = api(f"{root}/git/ref/heads/{default}")["object"]["sha"]
+        try:
+            api(f"{root}/git/refs", "POST", {"ref": f"refs/heads/{branch}", "sha": sha})
+        except ApiError as conflict:
+            if conflict.status not in (409, 422):
+                raise
+            api(ref)  # A concurrent creator must actually have created the branch.
+
+    target = f"ports/{report['port']}.json"
+    endpoint = f"{root}/contents/{target}"
+    generated = stamp(report["generated_at"])
+    for attempt in range(3):
+        payload = {"message": f"Update {report['port']} compliance status", "branch": branch,
+                   "content": base64.b64encode(json.dumps(report).encode()).decode()}
+        try:
+            existing = api(f"{endpoint}?ref={branch}")
+        except ApiError as error:
+            if error.status != 404:
+                raise  # Never treat a failed read as an absent report.
+        else:
+            stored = json.loads(base64.b64decode(existing["content"]))
+            if stamp(stored["generated_at"]) >= generated:
+                print(f"Not publishing {target}: the branch already holds an equal or newer report.")
+                return
+            payload["sha"] = existing["sha"]
+        try:
+            api(endpoint, "PUT", payload)
+            print(f"Published {target} on {branch}.")
+            return
+        except ApiError as error:
+            if error.status not in (409, 422) or attempt == 2:
+                raise
+            # 422 can mean a concurrently created file now requires its SHA.
+            # Re-read both SHA and timestamp so a newer report cannot be replaced.
+            print(f"Report update conflict (HTTP {error.status}); re-reading {target}.", file=sys.stderr)
+            time.sleep(2 ** (attempt + 1))
+
+
+if __name__ == "__main__":
+    try:
+        publish(json.loads(Path(sys.argv[1]).read_text()), sys.argv[2])
+    except (ApiError, ValueError, KeyError, OSError) as error:
+        print(f"Port-status publication failed: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/scripts/hellocodenameone/conformance/publish_port_status.py
+++ b/scripts/hellocodenameone/conformance/publish_port_status.py
@@ -47,6 +47,7 @@ def api(endpoint, method="GET", payload=None):
         print(f"Transient API failure ({detail}); retrying {method} in {2 ** (attempt + 1)}s",
               file=sys.stderr)
         time.sleep(2 ** (attempt + 1))
+    raise ApiError(f"{method} {endpoint}: API retry loop exhausted")
 
 
 def stamp(value):

--- a/scripts/hellocodenameone/conformance/publish_port_status.sh
+++ b/scripts/hellocodenameone/conformance/publish_port_status.sh
@@ -16,7 +16,6 @@ if [ "${PORT_STATUS_PUBLISH:-}" != "1" ] && { [ "${GITHUB_ACTIONS:-}" != "true" 
   exit 0
 fi
 
-branch="port-status-data"
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 port="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["port"])' "$report")"
 
@@ -48,89 +47,6 @@ if [ "${accept_status}" -ne 0 ]; then
   exit "${accept_status}"
 fi
 
-for tool in gh jq python3; do
-  if ! command -v "${tool}" >/dev/null 2>&1; then
-    echo "${tool} is required to publish port status." >&2
-    exit 2
-  fi
-done
-
-repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
-target="ports/${port}.json"
-
-if ! gh api "repos/${repo}/git/ref/heads/${branch}" >/dev/null 2>&1; then
-  default_branch="$(gh api "repos/${repo}" --jq .default_branch)"
-  base_sha="$(gh api "repos/${repo}/git/ref/heads/${default_branch}" --jq .object.sha)"
-  gh api --method POST "repos/${repo}/git/refs" \
-    -f ref="refs/heads/${branch}" \
-    -f sha="$base_sha" >/dev/null 2>&1 || \
-    gh api "repos/${repo}/git/ref/heads/${branch}" >/dev/null
-fi
-
-content="$(base64 < "$report" | tr -d '\n')"
-generated="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1], encoding="utf-8")).get("generated_at", ""))' "$report")"
-
-# GNU spells it --decode, BSD -D.
-decode_base64() {
-  base64 --decode 2>/dev/null || base64 -D
-}
-
-# True when $1 is strictly later than $2; both ISO-8601 and timezone-aware, so
-# they are compared as instants rather than as text.
-newer_instant() {
-  python3 - "$1" "$2" <<'INSTANT'
-import sys
-from datetime import datetime
-
-def parse(value):
-    try:
-        stamp = datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except ValueError:
-        return None
-    return stamp if stamp.tzinfo is not None else None
-
-candidate = parse(sys.argv[1])
-current = parse(sys.argv[2])
-sys.exit(0 if candidate is not None and (current is None or candidate > current) else 1)
-INSTANT
-}
-
-for attempt in 1 2 3; do
-  # Read the sha AND the stored timestamp together, and re-read both on every
-  # retry. A scheduled producer's workflow_run publisher can land a newer report
-  # between the sweep deciding to publish and this PUT; retrying on the fresh sha
-  # alone would then overwrite it, and the sweep's own freshness check would still
-  # pass because the older report it wrote is inside the window. The sha is the
-  # compare-and-swap; this timestamp check is what makes the swap meaningful.
-  existing_json="$(gh api "repos/${repo}/contents/${target}?ref=${branch}" 2>/dev/null || true)"
-  existing_sha=""
-  existing_generated=""
-  if [ -n "${existing_json}" ]; then
-    existing_sha="$(printf '%s' "${existing_json}" | jq -r '.sha // empty' 2>/dev/null || true)"
-    existing_generated="$(printf '%s' "${existing_json}" | jq -r '.content // empty' 2>/dev/null \
-      | decode_base64 2>/dev/null | jq -r '.generated_at // empty' 2>/dev/null || true)"
-  fi
-  if [ -n "${existing_generated}" ] && [ -n "${generated}" ] \
-      && ! newer_instant "${generated}" "${existing_generated}"; then
-    echo "Not publishing ${target}: the branch already holds a report at ${existing_generated} (ours is ${generated})."
-    exit 0
-  fi
-  args=(
-    --method PUT
-    "repos/${repo}/contents/${target}"
-    -f message="Update ${port} compliance status"
-    -f content="$content"
-    -f branch="$branch"
-  )
-  if [ -n "$existing_sha" ]; then
-    args+=(-f sha="$existing_sha")
-  fi
-  if gh api "${args[@]}" >/dev/null; then
-    echo "Published ${target} on ${branch}."
-    exit 0
-  fi
-  echo "Port-status update raced another publisher; retrying (${attempt}/3)." >&2
-  sleep 2
-done
-echo "Failed to publish ${target} after three attempts." >&2
-exit 1
+# Authentication and malformed reports remain fatal; only the API transport
+# and compare-and-swap conflicts receive bounded retries.
+exec python3 "${script_dir}/publish_port_status.py" "$report" "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"

--- a/scripts/hellocodenameone/conformance/test_ci_reporting.py
+++ b/scripts/hellocodenameone/conformance/test_ci_reporting.py
@@ -1,16 +1,30 @@
 """Exercise the shell gate with real normalized evidence, without a native runner."""
 import json
+import fnmatch
 import os
 from pathlib import Path
 import subprocess
 import tempfile
 import unittest
+import re
 
 
 ROOT = Path(__file__).resolve().parents[3]
 
 
 class ReportingTests(unittest.TestCase):
+    def test_native_x64_artifacts_cannot_replace_shipping_evidence(self):
+        workflow = (ROOT / ".github/workflows/parparvm-tests-windows.yml").read_text()
+        x64 = workflow.split("  windows-port-screenshot-comment-x64:", 1)[1].split(
+            "  windows-port-screenshot-comment-arm64:", 1)[0]
+        artifacts = re.findall(r"uses: \./\.github/actions/upload-artifact-with-retry\s+with:\s+name: (\S+)", x64)
+        self.assertIn("windows-native-x64-diagnostics", artifacts)
+        self.assertFalse(any(fnmatch.fnmatch(name, "port-status-*") for name in artifacts))
+        self.assertNotIn("publish_port_status.sh", x64)
+        manifest = json.loads((ROOT / "docs/website/data/port_status.json").read_text())
+        port = next(port for port in manifest["ports"] if port["id"] == "windows-x64")
+        self.assertEqual("windows-cross-build-run.yml", port["workflow"])
+
     def run_gate(self, compare, artifacts, strict=True):
         env = dict(os.environ, CN1SS_PORT_ID="windows-x64",
                    CN1SS_FAIL_ON_TEST_PROBLEMS="1" if strict else "0")

--- a/scripts/hellocodenameone/conformance/test_ci_reporting.py
+++ b/scripts/hellocodenameone/conformance/test_ci_reporting.py
@@ -1,0 +1,56 @@
+"""Exercise the shell gate with real normalized evidence, without a native runner."""
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+class ReportingTests(unittest.TestCase):
+    def run_gate(self, compare, artifacts, strict=True):
+        env = dict(os.environ, CN1SS_PORT_ID="windows-x64",
+                   CN1SS_FAIL_ON_TEST_PROBLEMS="1" if strict else "0")
+        return subprocess.run(["bash", "-c",
+                               'source "$1/scripts/lib/cn1ss.sh"; cn1ss_generate_port_status "$2" "$3"',
+                               "gate", str(ROOT), str(compare), str(artifacts)],
+                              env=env, text=True, capture_output=True)
+
+    def test_empty_capture_writes_missing_test_evidence_and_fails(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory)
+            compare = path / "compare.json"
+            compare.write_text('{"results": []}')
+            result = self.run_gate(compare, path)
+            self.assertEqual(19, result.returncode, result.stdout + result.stderr)
+            report = json.loads((path / "port-status-windows-x64.json").read_text())
+            self.assertGreater(report["summary"]["not-run"], 0)
+            self.assertFalse(report["suite_finished"])
+            self.assertIn("Normalized report contains failing or missing tests", result.stdout + result.stderr)
+
+    def test_corrupt_comparison_is_a_generation_failure(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory)
+            compare = path / "compare.json"
+            compare.write_text('not json')
+            result = self.run_gate(compare, path)
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("Failed to generate normalized port status", result.stdout + result.stderr)
+            self.assertFalse((path / "port-status-windows-x64.json").exists())
+
+    def test_screenshot_defect_still_fails_and_is_preserved(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory)
+            compare = path / "compare.json"
+            compare.write_text(json.dumps({"results": [{"test": "VideoIODecodedFrames", "status": "different"}]}))
+            result = self.run_gate(compare, path)
+            self.assertNotEqual(0, result.returncode)
+            report = json.loads((path / "port-status-windows-x64.json").read_text())
+            self.assertEqual("fail", report["tests"]["VideoIODecodedFramesScreenshotTest"]["status"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/hellocodenameone/conformance/test_publish_port_status.py
+++ b/scripts/hellocodenameone/conformance/test_publish_port_status.py
@@ -1,0 +1,107 @@
+import base64
+import json
+import subprocess
+import unittest
+from unittest.mock import patch
+
+import publish_port_status as publisher
+
+
+def response(status, body, rc=0, stderr=""):
+    return subprocess.CompletedProcess([], rc, f"HTTP/2.0 {status} OK\nContent-Type: application/json\n\n{body}", stderr)
+
+
+class ApiTests(unittest.TestCase):
+    def test_transient_transport_and_empty_json_recover(self):
+        failures = [subprocess.CompletedProcess([], 1, "", "connection timed out"),
+                    response(200, ""), response(503, "unavailable", 1)]
+        for failure in failures:
+            with self.subTest(failure=failure), patch.object(publisher.subprocess, "run", side_effect=[failure, response(200, '{"ok":true}')]) as run, patch.object(publisher.time, "sleep"):
+                self.assertEqual({"ok": True}, publisher.api("endpoint"))
+                self.assertEqual(2, run.call_count)
+
+    def test_auth_and_validation_errors_are_not_transport_retries(self):
+        for status in (401, 403, 404, 409, 422):
+            with self.subTest(status=status), patch.object(publisher.subprocess, "run", return_value=response(status, '{}', 1, "denied")) as run:
+                with self.assertRaises(publisher.ApiError) as error:
+                    publisher.api("endpoint")
+                self.assertEqual(status, error.exception.status)
+                self.assertEqual(1, run.call_count)
+
+    def test_exhausted_transient_error_stays_fatal(self):
+        with patch.object(publisher.subprocess, "run", return_value=response(502, "", 1)) as run, patch.object(publisher.time, "sleep"):
+            with self.assertRaises(publisher.ApiError):
+                publisher.api("endpoint")
+            self.assertEqual(3, run.call_count)
+
+    def test_hung_request_has_a_bounded_retry(self):
+        with patch.object(publisher.subprocess, "run", side_effect=[subprocess.TimeoutExpired("gh", 60), response(200, '{}')]) as run, patch.object(publisher.time, "sleep"):
+            self.assertEqual({}, publisher.api("endpoint"))
+            self.assertEqual(60, run.call_args.kwargs["timeout"])
+
+
+class PublishTests(unittest.TestCase):
+    report = {"port": "windows-x64", "generated_at": "2026-09-06T07:00:00Z"}
+
+    def stored(self, timestamp, sha="old"):
+        return {"sha": sha, "content": base64.b64encode(json.dumps({"generated_at": timestamp}).encode()).decode()}
+
+    def test_failed_read_never_becomes_blind_write(self):
+        with patch.object(publisher, "api", side_effect=[{}, publisher.ApiError("unavailable", 503)]) as api:
+            with self.assertRaises(publisher.ApiError):
+                publisher.publish(self.report, "owner/repo")
+            self.assertEqual(2, api.call_count)
+
+    def test_conflict_rechecks_timestamp_and_preserves_newer_report(self):
+        with patch.object(publisher, "api", side_effect=[{}, self.stored("2026-09-06T06:00:00Z"), publisher.ApiError("conflict", 409), self.stored("2026-09-06T08:00:00Z")]) as api, patch.object(publisher.time, "sleep"):
+            publisher.publish(self.report, "owner/repo")
+            self.assertEqual(4, api.call_count)
+            self.assertEqual("old", api.call_args_list[2].args[2]["sha"])
+
+    def test_conflict_uses_fresh_sha_when_ours_is_still_newer(self):
+        with patch.object(publisher, "api", side_effect=[{}, self.stored("2026-09-06T05:00:00Z"), publisher.ApiError("conflict", 409), self.stored("2026-09-06T06:00:00Z", "fresh"), {}]) as api, patch.object(publisher.time, "sleep"):
+            publisher.publish(self.report, "owner/repo")
+            self.assertEqual("fresh", api.call_args.args[2]["sha"])
+
+    def test_only_404_allows_creating_a_report(self):
+        with patch.object(publisher, "api", side_effect=[{}, publisher.ApiError("missing", 404), {}]) as api:
+            publisher.publish(self.report, "owner/repo")
+            self.assertNotIn("sha", api.call_args.args[2])
+
+    def test_corrupt_existing_report_stays_fatal(self):
+        with patch.object(publisher, "api", side_effect=[{}, {"sha": "old", "content": ""}]) as api:
+            with self.assertRaises(ValueError):
+                publisher.publish(self.report, "owner/repo")
+            self.assertEqual(2, api.call_count)
+
+    def test_permission_failure_is_not_a_conflict(self):
+        with patch.object(publisher, "api", side_effect=[{}, self.stored("2026-09-06T06:00:00Z"), publisher.ApiError("denied", 403)]) as api:
+            with self.assertRaises(publisher.ApiError):
+                publisher.publish(self.report, "owner/repo")
+            self.assertEqual(3, api.call_count)
+
+    def test_repeated_conflicts_stay_fatal(self):
+        outcomes = [{}]
+        for _ in range(3):
+            outcomes += [self.stored("2026-09-06T06:00:00Z"), publisher.ApiError("conflict", 409)]
+        with patch.object(publisher, "api", side_effect=outcomes), patch.object(publisher.time, "sleep"):
+            with self.assertRaises(publisher.ApiError):
+                publisher.publish(self.report, "owner/repo")
+
+    def test_branch_creation_race_requires_a_real_branch(self):
+        outcomes = [publisher.ApiError("missing", 404), {"default_branch": "master"},
+                    {"object": {"sha": "base"}}, publisher.ApiError("already exists", 422),
+                    {}, self.stored("2026-09-06T08:00:00Z")]
+        with patch.object(publisher, "api", side_effect=outcomes) as api:
+            publisher.publish(self.report, "owner/repo")
+            self.assertEqual(6, api.call_count)
+
+    def test_branch_read_permission_failure_does_not_create_a_branch(self):
+        with patch.object(publisher, "api", side_effect=publisher.ApiError("denied", 403)) as api:
+            with self.assertRaises(publisher.ApiError):
+                publisher.publish(self.report, "owner/repo")
+            self.assertEqual(1, api.call_count)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/lib/cn1ss.sh
+++ b/scripts/lib/cn1ss.sh
@@ -492,8 +492,14 @@ cn1ss_generate_port_status() {
   if [ "${CN1SS_FAIL_ON_TEST_PROBLEMS:-0}" = "1" ]; then
     args+=(--fail-on-test-problems)
   fi
-  if ! "$python_bin" "${args[@]}"; then
-    cn1ss_log "FATAL: Failed to generate normalized port status for $CN1SS_PORT_ID"
+  local normalize_rc=0
+  "$python_bin" "${args[@]}" || normalize_rc=$?
+  if [ "$normalize_rc" -ne 0 ]; then
+    if [ "$normalize_rc" -eq 10 ]; then
+      cn1ss_log "FATAL: Normalized report contains failing or missing tests for $CN1SS_PORT_ID ($output)"
+    else
+      cn1ss_log "FATAL: Failed to generate normalized port status for $CN1SS_PORT_ID (rc=$normalize_rc)"
+    fi
     return 19
   fi
   cn1ss_log "Wrote normalized port status to $output"


### PR DESCRIPTION
The September 6 nightly failed because the Windows ARM64 runner crashed while installing JDK 21, and the successful native x64 capture had no diagnostic reporting job on master. Linux passed its tests but failed publication with an empty JSON response reported as a publisher race.

This change:

- Runs native Windows x64 diagnostic reporting on master and scheduled builds, independently of ARM64. Its artifact is excluded from the public publisher and nightly sweep, leaving windows-cross-build-run.yml authoritative for windows-x64. ARM64 keeps its public normalized report; both architectures retain evidence when capture fails. Empty captures produce failed/missing-test evidence instead of exiting green. Durable x64 runs require the full suite, with performance completion required on scheduled/manual runs as on ARM64.
- Retries ARM64 JDK setup once. The second attempt is blocking; no build or test retry behavior is relaxed.
- Keeps the existing report acceptance gate and moves GitHub transport into a tested Python helper. It retries transient transport/empty-JSON/5xx responses with bounded backoff, fails permission errors, and re-reads SHA and timestamp after update conflicts. Failed reads never become blind writes; equal or newer reports are preserved.
- Distinguishes a failed strict test gate from an actual report-generation error. Screenshot mismatches, missing tests, invalid reports, and exhausted infrastructure retries remain failures.

The existing JavaScript VideoIODecodedFrames tolerance fix is unchanged.

Validation: 100 focused normalizer, publisher, and shell-gate tests pass; port-status contract validation and workflow YAML/bash syntax checks pass. Executed both Windows reporting shell steps locally with empty captures: each wrote a report (135 failed, 56 not run) and exited nonzero. The API helper also passed read-only GitHub success/404 smoke checks. A regression test rejects the original colliding native artifact name. Windows JDK setup recovery and native execution require hosted CI.

Evidence: [nightly publisher](https://github.com/codenameone/CodenameOne/actions/runs/34018709527/job/101447187404), [Windows JDK setup crash](https://github.com/codenameone/CodenameOne/actions/runs/34012313754/job/101431985565), [Linux publication failure](https://github.com/codenameone/CodenameOne/actions/runs/34016688056).
