### PR TITLE
getLayeredPane() before show() left the first text field focused (issue #2710)

### DIFF
--- a/CodenameOne/src/com/codename1/ui/Container.java
+++ b/CodenameOne/src/com/codename1/ui/Container.java
@@ -296,7 +296,18 @@ public class Container extends Component implements Iterable<Component> {
                     parentLayout.addLayoutComponent(constraint, newParent, oldParent);
                 }
 
-                newParent.initComponentImpl();
+                // Only when we are splicing the wrapper into a hierarchy that is already
+                // live. initComponentImpl() recurses into every child, and doing that to a
+                // form that has not been shown runs initComponent() far too early: it binds
+                // the laf, registers animations, shows native overlays and - the way this
+                // surfaced in issue #2710 - makes InputComponent build its editor. The
+                // editor then exists when show() picks the initial focus, so merely asking
+                // a form for its layered pane before showing it left the first text field
+                // focused with a blinking caret. An uninitialized wrapper is initialized
+                // with the rest of the form when it is finally shown.
+                if (isInitialized()) {
+                    newParent.initComponentImpl();
+                }
                 if (oldParent != null) {
                     int cmpIndex = -1;
                     for (int i = 0; i < oldParent.getComponentCount(); i++) {

--- a/maven/core-unittests/src/test/java/com/codename1/components/InteractionDialogTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/components/InteractionDialogTest.java
@@ -187,10 +187,16 @@ class InteractionDialogTest extends UITestBase {
         dialog.dispose();
     }
 
-    @Test
+    /// The listeners go in from `initComponent()`, so the form has to be shown: naming it to
+    /// the implementation as the current one is not enough, because a form that was never
+    /// shown is not initialized and nothing added to it is either. That used to pass on a
+    /// bare `setCurrentForm` only because reaching for the layered pane initialized the
+    /// wrapper it splices in whether or not the form was live, which is the fault behind
+    /// issue #2710.
+    @FormTest
     void pointerOutOfBoundsListenersInstalledWhenEnabled() throws Exception {
         Form form = new Form(new BorderLayout());
-        implementation.setCurrentForm(form);
+        form.show();
         InteractionDialog dialog = new InteractionDialog();
         dialog.setDisposeWhenPointerOutOfBounds(true);
         dialog.setAnimateShow(false);

--- a/maven/core-unittests/src/test/java/com/codename1/ui/LayeredPaneInitialFocusTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/LayeredPaneInitialFocusTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.ui;
+
+import com.codename1.junit.FormTest;
+import com.codename1.junit.UITestBase;
+import com.codename1.ui.layouts.TextModeLayout;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Asking a form for its layered pane before showing it used to leave the first text field
+ * focused and blinking a caret, while asking after showing it did not (issue #2710).
+ *
+ * <p>{@code wrapInLayeredPane()} initialized the wrapper it splices around the content pane
+ * unconditionally, so on a form that had never been shown it ran {@code initComponent()} over
+ * the whole tree - which is what makes an {@link InputComponent} build its editor. The editor
+ * then existed when {@code show()} chose the initial focus, and the field the user had never
+ * touched came up focused and blinking.</p>
+ */
+class LayeredPaneInitialFocusTest extends UITestBase {
+
+    private static TextComponent addField(Form f) {
+        TextComponent tc = new TextComponent().label("TestField");
+        f.add(tc);
+        return tc;
+    }
+
+    @FormTest
+    void askingForTheLayeredPaneBeforeShowingDoesNotInitializeTheForm() {
+        Form f = new Form("Test", new TextModeLayout(1, 1));
+        TextComponent tc = addField(f);
+
+        f.getLayeredPane();
+
+        assertFalse(f.getContentPane().isInitialized(),
+                "a form that was never shown must not be initialized by getLayeredPane()");
+        assertEquals(0, tc.getComponentCount(),
+                "the input component must not build its editor before the form is shown");
+    }
+
+    @FormTest
+    void theLayeredPaneStillWorksAndIsInitializedOnceTheFormIsShown() {
+        Form f = new Form("Test", new TextModeLayout(1, 1));
+        addField(f);
+        Container pane = f.getLayeredPane();
+        Label marker = new Label("marker");
+        pane.add(marker);
+
+        f.show();
+
+        assertTrue(f.getContentPane().isInitialized(), "showing the form initializes the content pane");
+        assertTrue(pane.isInitialized(), "and the layered pane that was created before it");
+        assertTrue(marker.isInitialized(), "along with everything already inside the layered pane");
+        assertSame(pane, f.getLayeredPane(), "the pane created before the show is the one still in use");
+    }
+
+    @FormTest
+    void gettingTheLayeredPaneBeforeShowingLeavesTheFieldUnfocused() {
+        Form f = new Form("Test", new TextModeLayout(1, 1));
+        TextComponent tc = addField(f);
+        f.getLayeredPane();
+        f.show();
+
+        assertNull(f.getFocused(), "no component asked for the focus, so nothing may hold it");
+        assertFalse(tc.getField().hasFocus(), "the text field must not be focused");
+    }
+
+    @FormTest
+    void gettingTheLayeredPaneAfterShowingBehavesTheSameWay() {
+        Form f = new Form("Test", new TextModeLayout(1, 1));
+        TextComponent tc = addField(f);
+        f.show();
+        f.getLayeredPane();
+
+        assertNull(f.getFocused(), "the order of the two calls must not change the focus");
+        assertFalse(tc.getField().hasFocus(), "the text field must not be focused");
+    }
+
+}


### PR DESCRIPTION
Fixes #2710.

## What was happening

`Container.wrapInLayeredPane()` splices a `LayeredLayout` wrapper around the content pane and then initialized it unconditionally. `initComponentImpl()` recurses into every child, so on a form that had never been shown that ran `initComponent()` over the whole tree: it bound the look and feel, registered animations, showed native overlays, and - the part that was reported - made `InputComponent` build its editor.

`show()` picks the initial focus before `Display` initializes the form, so which component it finds depends on what has been constructed by then. With the editor already built the form handed it the focus, and the field the user had never touched came up with a blinking caret; without the pre-show `getLayeredPane()` call there was nothing focusable to find and the same form came up clean. That is the whole of the difference the report describes between calling `getLayeredPane()` before and after `show()`.

A probe confirmed it directly - across the `getLayeredPane()` call on an unshown form, `contentPane.isInitialized()` went `false -> true` and the `TextComponent`'s child count went `0 -> 3`.

## The fix

Initialize the wrapper only when it is being spliced into a hierarchy that is already live, which is what every other insertion in `Container` does - `insertComponentAtImpl` guards on `isInitialized()` the same way. A wrapper created before the show is initialized with the rest of the form when the form is finally shown, so the layered pane still works exactly as before once the form is up.

`Display.setCurrent` initializes the new form before any transition is set up, so the paths that reach for a layered pane during a transition (`MorphTransition`) or from `Toolbar` are unaffected.

## Tests

`LayeredPaneInitialFocusTest` covers both orderings from the report, that the form is not initialized early, and that a pane created before the show still works and is initialized once the form is up. Reverting the production change fails two of them.

`InteractionDialogTest.pointerOutOfBoundsListenersInstalledWhenEnabled` installs its listeners from `initComponent()` while only naming the form current on the implementation rather than showing it, so it passed only because of this fault. It now shows the form.

Verified locally: full `core-unittests` suite green (6546 tests, 0 failures) on this branch rebased onto master, SpotBugs 0 findings, and the copyright / ASCII / control-character / since-tag gates clean.

## Not in this PR

There is a second, separate fault behind the same symptom: `TextField` paints a caret whenever it merely has the focus, including on platforms where editing is native, focus opens no keyboard and `keyPressed` does not reach the field. So a form shown a second time - when its editor already exists - still blinks an untouched field. Diffing the two Android screenshots in the issue, that caret is the only pixel difference between them.

Fixing it changes every stored screenshot that contains a focused field (`TextFieldTheme_light.png` visibly has one today), across the iOS, Android, macOS, Mac Catalyst, Linux, Windows and JavaScript suites, all of which run with `CN1SS_FAIL_ON_MISMATCH=1`. It needs its own change with the baselines reseeded from CI rather than being bundled here.
