### PR TITLE
Developer guide: drop two ratchet entries that were never missing code

### DIFF
--- a/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
+++ b/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
@@ -1324,7 +1324,6 @@ When dragging on top of a child component of a drop target the code recursively 
 
 You can override these methods in the draggable components:
 
-
 * `getDragImage` - this generates an image preview of the component that will be dragged. This automatically generates a sensible default so you don't need to override it.
 
 * `drawDraggedImage` - this method will be invoked to draw the dragged image at a given location, it might be useful to override it if you want to display some drag related information such as an icon based on location etc. (for example: a move/copy icon).

--- a/docs/developer-guide/The-Components-Of-Codename-One.asciidoc
+++ b/docs/developer-guide/The-Components-Of-Codename-One.asciidoc
@@ -920,7 +920,6 @@ Infinite scroll fetches the next batch of data dynamically as you reach the end 
 
 Let start by exploring how you can achieve this UI that fetches data from a webservice:
 
-
 .InfiniteScrollAdapter demo code fetching property cross data
 image::img/components-infinitescrolladapter.png[InfiniteScrollAdapter demo code fetching property cross data,scaledwidth=20%]
 

--- a/scripts/developer-guide/missing-code-blocks-baseline.txt
+++ b/scripts/developer-guide/missing-code-blocks-baseline.txt
@@ -1,7 +1,6 @@
 # Prose that promises a code block where none follows.
 # A ratchet: entries may be removed as holes are filled, never added.
 # Regenerate with check-missing-code-blocks.py --write-baseline.
-Advanced-Topics-Under-The-Hood.asciidoc	You can override these methods in the draggable components:
 Advertising.asciidoc	identifier. The recommended order is to initialize, gather consent, then load:
 Advertising.asciidoc	method that registers its provider with `AdManager`:
 Annotation-JSON-XML-Mapping.asciidoc	Hand-write a `Mapper<T>` and register it at startup:
@@ -24,7 +23,6 @@ Monetization.asciidoc	The source for your ReceiptStore is as follows:
 Monetization.asciidoc	You are now ready to see the full magic of the `validateAndSaveReceipt()` method in all its glory:
 SVG-Transcoder.asciidoc	the generated class directly:
 The-Components-Of-Codename-One.asciidoc	Call the builder from a Maven plugin, an Ant task or a one-shot `main`:
-The-Components-Of-Codename-One.asciidoc	Let start by exploring how you can achieve this UI that fetches data from a webservice:
 The-Components-Of-Codename-One.asciidoc	This code should output "The result was 7" to the console. It's fully asynchronous, so you can include this code anywhere without worrying about it "bogging down" your code. The full signature of this form of the https://www.codenameone.com/javadoc/com/codename1/ui/BrowserComponent.html#execute(java.lang.String,com.codename1.util.SuccessCallback)[execute()] method is:
 appendix_goal_generate_graphql.adoc	The `@GraphQLClient` interface looks like:
 appendix_goal_generate_graphql.adoc	an `OnComplete<GraphQLResponse<T>>`:


### PR DESCRIPTION
`check-missing-code-blocks` looks for a sentence ending in a colon followed by **two** blank lines — the shape the snippet extraction left behind. Two baseline entries match that shape for an unrelated reason:

- `Advanced-Topics-Under-The-Hood` — the colon introduces a **bullet list** (`* getDragImage …`)
- `The-Components-Of-Codename-One` — the colon introduces a **figure** (`.InfiniteScrollAdapter demo code …`)

Each just happens to carry a stray second blank line.

**Verified rather than assumed.** `bbdc6058f0~1` has the same list and the same image in those exact places, with no code block before them, so nothing was ever dropped. That's the difference from the five entries whose next content is a `=====` heading (three in Monetization, two in io): I checked one of those against the original and it *does* hold a `[source,java]` block, so those holes are real and stay.

Removing the stray blank line fixes the asciidoc formatting and stops the false report. **Baseline 40 → 38**, regenerated from master's copy so both removals are provably entries the checker no longer produces — zero additions.

## What I looked at and did not do

- **`Introduction` ×4** are recoverable, but their content is obsolete: they document a hello-world class with hand-written `private Form current; private Resources theme;` and `init/start/stop/destroy` overrides. The archetype now generates `class X extends Lifecycle` overriding only `runApp()`, and **`runApp` appears nowhere in the guide**. Restoring them would add ~50 lines documenting a template that no longer exists. That needs a rewrite of the walkthrough, not a restore.
- **`appendix_goal_generate_{graphql,grpc,openapi}` ×6** reference code the annotation processors generate — `StarWarsApi.of(...)`, `GreeterGrpc`, `PetApi`. Compiling them means wiring those processors into the demos module, which is a build change rather than a snippet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)