### PR TITLE
ParparVM collections: fix an O(n) HashMap miss, and compact Hashtable

### DIFF
--- a/scripts/copyright-header-exclusions.txt
+++ b/scripts/copyright-header-exclusions.txt
@@ -30,3 +30,6 @@ Ports/JavaScriptPort/src/main/webapp/js/sqlite3mc.js | SQLite3 Multiple Ciphers 
 Ports/JavaScriptPort/src/main/webapp/js/sqlite3-opfs-async-proxy.js | SQLite3 Multiple Ciphers OPFS proxy worker, MIT over public-domain SQLite
 vm/JavaAPI/src/java/util/LinkedHashMap.java | Apache Harmony source retaining its original Apache-2.0 notice
 vm/JavaAPI/src/java/util/Collections.java | Apache Harmony source retaining its original Apache-2.0 notice
+vm/JavaAPI/src/java/util/HashMap.java | Apache Harmony source retaining its original Apache-2.0 notice
+vm/JavaAPI/src/java/util/Hashtable.java | Apache Harmony source retaining its original Apache-2.0 notice
+vm/JavaAPI/src/java/util/IdentityHashMap.java | Apache Harmony source retaining its original Apache-2.0 notice

--- a/vm/ByteCodeTranslator/src/javascript/parparvm_runtime.js
+++ b/vm/ByteCodeTranslator/src/javascript/parparvm_runtime.js
@@ -39,9 +39,6 @@ const CN1_DATEFORMAT_DATE_STYLE = "cn1_java_text_DateFormat_dateStyle";
 const CN1_DATEFORMAT_TIME_STYLE = "cn1_java_text_DateFormat_timeStyle";
 const CN1_STRINGBUFFER_INTERNAL = "cn1_java_lang_StringBuffer_internal";
 const CN1_ENUM_NAME = "cn1_java_lang_Enum_name";
-const CN1_HASHMAP_ELEMENT_DATA = "cn1_java_util_HashMap_elementData";
-const CN1_HASHMAP_ENTRY_NEXT = "cn1_java_util_HashMap_Entry_next";
-const CN1_HASHMAP_ENTRY_KEY = "cn1_java_util_MapEntry_key";
 // Shared dispatch id for ``Object.clone()`` post the dispatch-id refactor.
 // The mangler rewrites the literal in lockstep with every call site so
 // equality against ``methodId`` keeps matching after mangling — the

--- a/vm/ByteCodeTranslator/src/nativeMethods.m
+++ b/vm/ByteCodeTranslator/src/nativeMethods.m
@@ -3418,7 +3418,9 @@ JAVA_BOOLEAN java_util_HashMap_areEqualKeys___java_lang_Object_java_lang_Object_
 }
 
 // the occupied-slot marker: mixed hash with the sign bit forced on (must match
-// HashMap.cn1Marker exactly)
+// HashMap.cn1Marker exactly). The spread is deliberately weak so Integer keys
+// stay at slot == value and a dense range keeps its sequential-store locality;
+// what makes that safe is the probe sequence below, not the spread.
 static inline JAVA_INT cn1HmMarker(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT key) {
     if(key == JAVA_NULL) {
         return (JAVA_INT)0x80000000;
@@ -3426,6 +3428,19 @@ static inline JAVA_INT cn1HmMarker(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT key) {
     JAVA_INT h = virtual_java_lang_Object_hashCode___R_int(threadStateData, key);
     h ^= (JAVA_INT)(((uint32_t)h) >> 16);
     return h | (JAVA_INT)0x80000000;
+}
+
+// The next slot on a probe path -- CPython's dict recurrence, and the C twin of
+// HashMap.cn1NextSlot. NOT i + 1: linear probing walks a run of occupied slots
+// end to end, and the weak spread above puts every dense Integer key range in
+// exactly one such run, so a MISS inside it was O(n) -- 2547 probes at 20k
+// keys, 222721 at 1M. The first probe is still marker & mask, so sequential
+// placement and its locality are untouched; every probe after it jumps
+// pseudo-randomly and leaves the run at once. perturb decays to 0 within seven
+// steps, after which 5 * i + 1 is a full-period permutation of a power-of-two
+// table, so the walk always reaches the terminating empty slot.
+static inline int cn1HmNextSlot(int i, uint32_t perturb, int mask) {
+    return (int)((((uint32_t)i << 2) + (uint32_t)i + 1u + perturb) & (uint32_t)mask);
 }
 
 // probe; >=0 found slot, else -(insertionPoint+1) (first tombstone on the path
@@ -3436,6 +3451,7 @@ static JAVA_INT cn1HmFindSlot(CODENAME_ONE_THREAD_STATE, struct obj__java_util_H
     JAVA_ARRAY_OBJECT* keys = (JAVA_ARRAY_OBJECT*)((JAVA_ARRAY)t->java_util_HashMap_cn1Keys)->data;
     int mask = metaArr->length - 1;
     int i = marker & mask;
+    uint32_t perturb = (uint32_t)marker;
     int firstTomb = -1;
     while(1) {
         JAVA_INT m = meta[i];
@@ -3451,7 +3467,8 @@ static JAVA_INT cn1HmFindSlot(CODENAME_ONE_THREAD_STATE, struct obj__java_util_H
         } else if(m == 1 && firstTomb < 0) { // META_TOMB
             firstTomb = i;
         }
-        i = (i + 1) & mask;
+        perturb >>= 5;
+        i = cn1HmNextSlot(i, perturb, mask);
     }
 }
 

--- a/vm/CLAUDE.md
+++ b/vm/CLAUDE.md
@@ -1,5 +1,93 @@
 # vm/ (ParparVM)
 
+## The compact HashMap: benchmark the MISS, not the hit
+
+`java.util.HashMap` here is open-addressed over three parallel arrays with linear probing
+and native C hot paths (`vm/JavaAPI/src/java/util/HashMap.java`,
+`vm/ByteCodeTranslator/src/nativeMethods.m`). Open addressing has a failure mode chaining
+does not, and it is invisible to any benchmark that only looks up keys that are present.
+
+`cn1Marker` spreads the hash with the JDK's `h ^= h >>> 16`, which was designed for a
+**chained** map, where colliding keys share a bucket and clustering costs nothing.
+`Integer.hashCode()` is the value itself, so under that spread a dense key range -- ids from
+zero, epoch seconds, counters, indices -- lands at `slot == value`, one contiguous run of
+occupied slots with no gap. Linear probing then walks that run end to end for any probe that
+enters it and does not find its key. Measured average probe length for a MISS:
+
+| entries | miss probes, `i + 1` | miss probes, perturbed |
+|---|---|---|
+| 20,000 | 2,547 | 1.39 |
+| 100,000 | 16,742 | 1.53 |
+| 1,000,000 | 222,721 | 1.98 |
+
+That is **O(n) per unsuccessful lookup**, and it reaches `get` returning null, `containsKey`
+returning false, and `put` of a key not adjacent to the run. In wall time on this Mac, 3M
+`containsKey` calls against a 100k-entry map took **32.7 seconds**, against 49.9ms on
+HotSpot -- 655x. A remove/insert churn shape took 7.8 seconds against 12.5ms.
+
+**Hits stayed at exactly one probe the whole time.** `hashMapChurn` in `CommonWorkloads` is
+get+put on keys that are present, so it reported a healthy 1.12x throughout. That is the
+lesson worth keeping: for an open-addressed table, a hit-only benchmark cannot see the
+defect that matters, and neither can a checksum.
+
+The fix is the probe SEQUENCE, not the spread (`cn1NextSlot` / `cn1HmNextSlot`, CPython's
+dict recurrence). Scrambling the hash instead was tried first and is the wrong trade: it
+fixes the miss but destroys the sequential placement, and dense-key **build** and **scan**
+shapes regressed 1.8x-2.2x, because inserting keys 0..n in ascending slot order is a
+sequential memory walk and HotSpot's `HashMap` gets the same benefit from the same weak
+spread. Keeping the first probe at `marker & mask` and perturbing only the steps after it
+keeps that locality and still leaves the run immediately.
+
+Residual cost, measured interleaved best-of-N: `largeTable` (1M-entry map, random hits) 1.26x
+and `hashMapChurn` 1.07x, against 728x and 471x the other way; `vm/benchmarks` geomean moved
+1.005, i.e. not at all. `MapTorture` stays bit-identical.
+
+`vm/benchmarks/src/com/bench/MapBench.java` is the suite that found this -- miss-heavy,
+String-keyed, large-table, tombstone-heavy, grow-dominated and identity-keyed shapes. It is
+deliberately NOT in `CommonWorkloads`, because
+`scripts/hellocodenameone/conformance/port_status.py` requires exactly ten benchmark ids
+there.
+
+### The neighbours
+
+`java.util.Hashtable` has since been given the same compact layout (open addressed, no
+`Entry` per mapping, the same perturbed probe). Build got 1.74x faster. **Lookup only got
+1.09x**, and the reason is worth knowing: with identical probe code, `Hashtable` is still 3x
+`HashMap` on the same workload, and the difference is `synchronized`. ParparVM keeps monitors
+in an address-keyed side table (`CN1MonitorEntry`, 4096 buckets in `cn1_globals.m`) rather
+than an object header word, so an uncontended `synchronized` accessor costs roughly 23ns --
+which is more than the entire lookup. Do not look for more in the map; look at the monitor.
+
+`java.util.IdentityHashMap` also got fixed, and it is the cautionary tale of the group.
+**Do not port HotSpot's hash function to this VM.** Its `identityHashCode` is a scrambled
+per-object value; ours is a truncated object ADDRESS, measured 32-byte aligned (five always-zero
+low bits). `java.util.IdentityHashMap` indexes with `(h << 1) - (h << 8)`, i.e. `h * -254` --
+an EVEN multiplier, which preserves those zeros and adds a sixth. Copying it reached 2045
+distinct home slots out of 65536 and 12.73 probes per lookup, and made the class measurably
+SLOWER than the unscrambled modulo it replaced. What works is folding the high half down
+first (`h ^= h >>> 16`), which reached 50000/65536 home slots and 1.00 probes. An extra
+multiply on top made it worse again (2.36 probes): sequentially allocated objects have
+sequentially increasing addresses, so one fold is already near a perfect hash and scrambling
+it re-randomizes near-perfect placement into collisions. Net 2.65x on both lookup and build.
+`vm/benchmarks/src/com/bench/IdmProbe.java` is the diagnostic that settled this; it must run
+ON the target, because the input distribution is a property of the allocator.
+
+`LinkedHashMap` inherits the compact layout but overrides `get`/`put`/`remove`/`clear` in
+Java rather than native (the natives are deliberately base-class-only), which measures 1.21x
+over `HashMap` on the same shape. Still open. Note #5658 already fixed a different
+`LinkedHashMap` cost -- the `CompactEntry` allocated per insertion to feed `removeEldestEntry`
+-- so do not confuse the two.
+
+### A trap in the benchmark target itself
+
+A null receiver is a hard SIGSEGV on the `clean` target these benchmarks and tortures run on,
+not a `NullPointerException`. On iOS it IS an NPE, but only because the port installs a
+SIGSEGV handler (`installSignalHandlers` in `CodenameOne_GLAppDelegate.m`); the clean and
+desktop targets install nothing, as `cn1ThrowNullPointerOrDie`'s comment in `cn1_globals.h`
+says. So `Hashtable.get(null)` -- which reaches `key.hashCode()` -- crashes the harness with
+no output and exit 139. A torture cannot assert on null-receiver NPEs; only on the explicit
+`throw new NullPointerException()` paths.
+
 ## GC memory: measure the steady state, not the peak
 
 Every GC workload in `vm/tests` measures a **peak under load**, and a peak cannot express

--- a/vm/CLAUDE.md
+++ b/vm/CLAUDE.md
@@ -48,6 +48,24 @@ deliberately NOT in `CommonWorkloads`, because
 `scripts/hellocodenameone/conformance/port_status.py` requires exactly ten benchmark ids
 there.
 
+### The growth rule assumed a load factor it never checked
+
+All three compact maps decided whether to double or to rebuild-in-place with
+`elementCount * 2 >= capacity`. That is a capacity test standing in for a threshold
+test, and it silently assumes a load factor of 0.5 or more. Below that the threshold is
+reached while the table is still less than half full, so the rebuild keeps the same
+capacity, the rebuilt table is immediately at its threshold again, and **every
+subsequent put rebuilds the whole table**. Inserting 20000 entries at a load factor of
+0.25 cost 19999 rebuilds and 200 million rehashed entries -- **22.3 seconds against
+16.4ms once fixed, 1362x**. The two-argument constructors accept any positive load
+factor, so `new HashMap<>(16, 0.25f)` reached it from ordinary code.
+
+The rule is `elementCount >= threshold` -- grow when the LIVE count has reached the
+threshold, and rebuild at the same size only when the threshold was reached because of
+tombstones. At 0.75 and 0.5 the two rules agree rebuild for rebuild, which is why no
+existing benchmark or torture moved, and why none of them could have caught it:
+`MapBench.lowLoadFactorBuild` and `HtTorture`'s `sparse` case exist for this alone.
+
 ### The neighbours
 
 `java.util.Hashtable` has since been given the same compact layout (open addressed, no

--- a/vm/JavaAPI/src/java/util/HashMap.java
+++ b/vm/JavaAPI/src/java/util/HashMap.java
@@ -152,6 +152,13 @@ public class HashMap<K, V> extends AbstractMap<K, V> implements Map<K, V> {
      * The occupied-slot marker for a key: its mixed hash with the sign bit
      * forced on -- strictly negative, so it can never collide with META_EMPTY
      * or META_TOMB, and slot occupancy tests are a single sign check.
+     *
+     * <p>The spread is deliberately the JDK's and deliberately weak: it leaves
+     * {@code Integer} keys placed at {@code slot == value}, so a dense key
+     * range is stored in ascending slot order and building or scanning one
+     * walks memory sequentially. That locality is worth keeping -- what makes
+     * it safe here is that the probe SEQUENCE no longer walks neighbours.
+     * See {@link #cn1NextSlot}.
      */
     static int cn1Marker(Object key) {
         if (key == null) {
@@ -160,6 +167,41 @@ public class HashMap<K, V> extends AbstractMap<K, V> implements Map<K, V> {
         int h = computeHashCode(key);
         h ^= (h >>> 16);
         return h | 0x80000000;
+    }
+
+    /**
+     * The next slot on a key's probe path.
+     *
+     * <p><b>Not {@code i + 1}.</b> Linear probing puts colliding keys in
+     * NEIGHBOURING slots, so a run of occupied slots is walked end to end by
+     * any probe that enters it and does not find its key. With the weak
+     * spread above, {@code Integer} keys from a dense range form exactly one
+     * such run -- 100k sequential keys occupy slots [0, 99999] with no gap --
+     * and every lookup that MISSES inside it walked the whole thing. Measured
+     * average probe length for a miss, before this: 2547 slots at 20k keys,
+     * 16742 at 100k, 222721 at 1M. That is O(n) per unsuccessful lookup, and
+     * it reached {@code get} returning null, {@code containsKey} returning
+     * false, and {@code put} of a key that is not adjacent to the run.
+     *
+     * <p>Hits stayed at exactly one probe throughout, which is why a hit-only
+     * churn benchmark never saw it.
+     *
+     * <p>This is CPython's dict recurrence. The first probe is still
+     * {@code marker & mask}, so the sequential-key locality above survives
+     * untouched; every probe after it jumps pseudo-randomly, so a miss leaves
+     * the run immediately instead of walking it (1.4 to 2.0 probes at the
+     * sizes above). {@code perturb} decays to zero within seven steps, after
+     * which {@code 5 * i + 1} is a full-period permutation of a power-of-two
+     * table (Hull-Dobell: 1 is coprime to 2^k and 4 divides 5 - 1), so the
+     * walk always reaches the empty slot that terminates it.
+     *
+     * @param i the current slot
+     * @param perturb the decaying perturbation, seeded with the marker and
+     *        shifted down by the caller on every step
+     * @param mask {@code capacity - 1}
+     */
+    static int cn1NextSlot(int i, int perturb, int mask) {
+        return ((i << 2) + i + 1 + perturb) & mask;
     }
 
     /**
@@ -172,6 +214,7 @@ public class HashMap<K, V> extends AbstractMap<K, V> implements Map<K, V> {
         int[] meta = cn1Meta;
         int mask = meta.length - 1;
         int i = marker & mask;
+        int perturb = marker;
         int firstTomb = -1;
         while (true) {
             int m = meta[i];
@@ -187,7 +230,8 @@ public class HashMap<K, V> extends AbstractMap<K, V> implements Map<K, V> {
             } else if (m == META_TOMB && firstTomb < 0) {
                 firstTomb = i;
             }
-            i = (i + 1) & mask;
+            perturb >>>= 5;
+            i = cn1NextSlot(i, perturb, mask);
         }
     }
 
@@ -259,8 +303,10 @@ public class HashMap<K, V> extends AbstractMap<K, V> implements Map<K, V> {
         int[] meta = cn1Meta;
         int mask = meta.length - 1;
         int i = marker & mask;
+        int perturb = marker;
         while (meta[i] != META_EMPTY) {
-            i = (i + 1) & mask;
+            perturb >>>= 5;
+            i = cn1NextSlot(i, perturb, mask);
         }
         meta[i] = marker;
         cn1Keys[i] = key;

--- a/vm/JavaAPI/src/java/util/HashMap.java
+++ b/vm/JavaAPI/src/java/util/HashMap.java
@@ -282,7 +282,19 @@ public class HashMap<K, V> extends AbstractMap<K, V> implements Map<K, V> {
      */
     void cn1Grow() {
         int cap = cn1Meta.length;
-        int newCap = (elementCount * 2 >= cap) ? cap << 1 : cap;
+        // Grow when the LIVE count has reached the threshold; rebuild at the
+        // same size only when the threshold was reached because of TOMBSTONES.
+        //
+        // Testing capacity directly (elementCount * 2 >= cap) silently assumed
+        // a load factor of 0.5 or more. Below that the threshold is reached
+        // while the table is still less than half full, so the rebuild kept the
+        // same capacity, the rebuilt table was immediately at its threshold
+        // again, and every subsequent put rebuilt the whole table: inserting
+        // 20000 entries at a load factor of 0.25 did 19999 rebuilds and
+        // rehashed 200 million entries. The two-argument constructor accepts
+        // any positive load factor, so this was reachable from ordinary code.
+        // At 0.75 and 0.5 the two rules agree exactly, rebuild for rebuild.
+        int newCap = (elementCount >= threshold) ? cap << 1 : cap;
         Object[] oldK = cn1Keys;
         Object[] oldV = cn1Vals;
         int[] oldM = cn1Meta;

--- a/vm/JavaAPI/src/java/util/Hashtable.java
+++ b/vm/JavaAPI/src/java/util/Hashtable.java
@@ -33,17 +33,25 @@ package java.util;
  */
 
 public class Hashtable<K, V> extends Dictionary<K, V> implements Map<K, V> {
+    /** slot metadata: empty slot. */
+    static final int META_EMPTY = 0;
+    /** slot metadata: tombstone (previously occupied). */
+    static final int META_TOMB = 1;
+
+    /** parallel storage; length is always a power of two. */
+    transient Object[] cn1Keys;
+    transient Object[] cn1Vals;
+    transient int[] cn1Meta;
+
+    /** live mappings. */
     transient int elementCount;
 
-    transient Entry<K, V>[] elementData;
+    /** live + tombstones (drives resizing). */
+    transient int cn1Occupied;
 
     private float loadFactor;
 
     private int threshold;
-
-    transient int firstSlot;
-
-    transient int lastSlot = -1;
 
     transient int modCount;
 
@@ -72,18 +80,25 @@ public class Hashtable<K, V> extends Dictionary<K, V> implements Map<K, V> {
         }
     };
 
-    private static <K, V> Entry<K, V> newEntry(K key, V value, int hash) {
-        return new Entry<K, V>(key, value);
-    }
-
+    /**
+     * A view of one occupied slot.
+     *
+     * <p>There are no node objects in this representation, so unlike the
+     * chained layout this replaced -- where the Entry WAS the storage and cost
+     * an allocation per mapping -- an Entry is built only when an iterator
+     * hands one out, and only for {@code entrySet()}. It keeps the table and
+     * slot so {@link #setValue} still writes through.
+     */
     private static class Entry<K, V> extends MapEntry<K, V> {
-        Entry<K, V> next;
+        private final Hashtable<K, V> table;
 
-        final int hashcode;
+        private final int index;
 
-        Entry(K theKey, V theValue) {
-            super(theKey, theValue);
-            hashcode = theKey.hashCode();
+        @SuppressWarnings("unchecked")
+        Entry(Hashtable<K, V> table, int index) {
+            super((K) table.cn1Keys[index], (V) table.cn1Vals[index]);
+            this.table = table;
+            this.index = index;
         }
 
         @Override
@@ -93,15 +108,8 @@ public class Hashtable<K, V> extends Dictionary<K, V> implements Map<K, V> {
             }
             V result = value;
             value = object;
+            table.cn1Vals[index] = object;
             return result;
-        }
-
-        public int getKeyHash() {
-            return key.hashCode();
-        }
-
-        public boolean equalsKey(Object aKey, int hash) {
-            return hashcode == aKey.hashCode() && key.equals(aKey);
         }
 
         @Override
@@ -110,100 +118,163 @@ public class Hashtable<K, V> extends Dictionary<K, V> implements Map<K, V> {
         }
     }
 
+    /**
+     * The occupied-slot marker for a key: its spread hash with the sign bit
+     * forced on -- strictly negative, so it can never collide with META_EMPTY
+     * or META_TOMB and an occupancy test is a single sign check.
+     *
+     * <p>Null keys are rejected by {@code put}, and every read path reaches
+     * {@code key.hashCode()} here, so a null key still faults exactly where it
+     * did before rather than being silently accepted.
+     */
+    static int cn1Marker(Object key) {
+        int h = key.hashCode();
+        h ^= (h >>> 16);
+        return h | 0x80000000;
+    }
+
+    /**
+     * The next slot on a key's probe path -- the same recurrence
+     * {@link HashMap#cn1NextSlot} uses, and for the same reason: linear
+     * probing walks a run of occupied slots end to end, which turns a dense
+     * key range into an O(n) miss. See the rationale there.
+     */
+    static int cn1NextSlot(int i, int perturb, int mask) {
+        return ((i << 2) + i + 1 + perturb) & mask;
+    }
+
+    /** Round up to a power of two, at least 8. */
+    static int cn1Capacity(int requested) {
+        int cap = 8;
+        while (cap < requested && cap < (1 << 30)) {
+            cap <<= 1;
+        }
+        return cap;
+    }
+
+    final void cn1Alloc(int capacity) {
+        cn1Keys = new Object[capacity];
+        cn1Vals = new Object[capacity];
+        cn1Meta = new int[capacity];
+        elementCount = 0;
+        cn1Occupied = 0;
+        computeMaxSize();
+    }
+
+    /**
+     * Probe for a key. Returns the slot index (>= 0) when found; otherwise
+     * {@code -(insertionPoint + 1)}, where insertionPoint is the first
+     * tombstone on the path (reuse) or the terminating empty slot.
+     */
+    final int cn1FindSlot(Object key) {
+        int marker = cn1Marker(key);
+        int[] meta = cn1Meta;
+        int mask = meta.length - 1;
+        int i = marker & mask;
+        int perturb = marker;
+        int firstTomb = -1;
+        while (true) {
+            int m = meta[i];
+            if (m == META_EMPTY) {
+                return -((firstTomb >= 0 ? firstTomb : i) + 1);
+            }
+            if (m == marker) {
+                Object k = cn1Keys[i];
+                if (key == k || key.equals(k)) {
+                    return i;
+                }
+            } else if (m == META_TOMB && firstTomb < 0) {
+                firstTomb = i;
+            }
+            perturb >>>= 5;
+            i = cn1NextSlot(i, perturb, mask);
+        }
+    }
+
+    /** raw insert into a table known not to contain the key (rebuild path). */
+    final void cn1Insert(Object key, Object value, int marker) {
+        int[] meta = cn1Meta;
+        int mask = meta.length - 1;
+        int i = marker & mask;
+        int perturb = marker;
+        while (meta[i] != META_EMPTY) {
+            perturb >>>= 5;
+            i = cn1NextSlot(i, perturb, mask);
+        }
+        meta[i] = marker;
+        cn1Keys[i] = key;
+        cn1Vals[i] = value;
+    }
+
+    /** Tombstone a found slot. The single mutation point for removals. */
+    final void cn1RemoveAtIndex(int idx) {
+        cn1Meta[idx] = META_TOMB;
+        cn1Keys[idx] = null;
+        cn1Vals[idx] = null;
+        elementCount--;
+        modCount++;
+    }
+
     private class HashIterator<E> implements Iterator<E> {
-        int position, expectedModCount;
+        /** next slot to examine. */
+        int position;
+
+        /** slot of the entry last returned, or -1. */
+        int lastPosition = -1;
+
+        int expectedModCount;
 
         final MapEntry.Type<E, K, V> type;
-
-        Entry<K, V> lastEntry;
-
-        int lastPosition;
 
         boolean canRemove = false;
 
         HashIterator(MapEntry.Type<E, K, V> value) {
             type = value;
-            position = lastSlot;
+            position = 0;
             expectedModCount = modCount;
         }
 
-        public boolean hasNext() {
-            if (lastEntry != null && lastEntry.next != null) {
-                return true;
-            }
-            while (position >= firstSlot) {
-                if (elementData[position] == null) {
-                    position--;
-                } else {
+        /** Advance past empty and tombstoned slots. */
+        final boolean advance() {
+            int[] meta = cn1Meta;
+            while (position < meta.length) {
+                if (meta[position] < 0) {
                     return true;
                 }
+                position++;
             }
             return false;
         }
 
+        public boolean hasNext() {
+            return advance();
+        }
+
         public E next() {
-            if (expectedModCount == modCount) {
-                if (lastEntry != null) {
-                    lastEntry = lastEntry.next;
-                }
-                if (lastEntry == null) {
-                    while (position >= firstSlot
-                            && (lastEntry = elementData[position]) == null) {
-                        position--;
-                    }
-                    if (lastEntry != null) {
-                        lastPosition = position;
-                        // decrement the position so we don't find the same slot
-                        // next time
-                        position--;
-                    }
-                }
-                if (lastEntry != null) {
-                    canRemove = true;
-                    return type.get(lastEntry);
-                }
+            if (expectedModCount != modCount) {
+                throw new ConcurrentModificationException();
+            }
+            if (!advance()) {
                 throw new NoSuchElementException();
             }
-            throw new ConcurrentModificationException();
+            lastPosition = position;
+            position++;
+            canRemove = true;
+            return type.get(new Entry<K, V>(Hashtable.this, lastPosition));
         }
 
         public void remove() {
-            if (expectedModCount == modCount) {
-                if (canRemove) {
-                    canRemove = false;
-                    synchronized (Hashtable.this) {
-                        boolean removed = false;
-                        Entry<K, V> entry = elementData[lastPosition];
-                        if (entry == lastEntry) {
-                            elementData[lastPosition] = entry.next;
-                            removed = true;
-                        } else {
-                            while (entry != null && entry.next != lastEntry) {
-                                entry = entry.next;
-                            }
-                            if (entry != null) {
-                                entry.next = lastEntry.next;
-                                removed = true;
-                            }
-                        }
-                        if (removed) {
-                            modCount++;
-                            elementCount--;
-                            expectedModCount++;
-                            return;
-                        }
-                        // the entry must have been (re)moved outside of the
-                        // iterator
-                        // but this condition wasn't caught by the modCount
-                        // check
-                        // throw ConcurrentModificationException() outside of
-                        // synchronized block
-                    }
-                } else {
-                    throw new IllegalStateException();
-                }
+            if (expectedModCount != modCount) {
+                throw new ConcurrentModificationException();
             }
-            throw new ConcurrentModificationException();
+            if (!canRemove) {
+                throw new IllegalStateException();
+            }
+            canRemove = false;
+            synchronized (Hashtable.this) {
+                cn1RemoveAtIndex(lastPosition);
+                expectedModCount++;
+            }
         }
     }
 
@@ -224,11 +295,8 @@ public class Hashtable<K, V> extends Dictionary<K, V> implements Map<K, V> {
      */
     public Hashtable(int capacity) {
         if (capacity >= 0) {
-            elementCount = 0;
-            elementData = newElementArray(capacity == 0 ? 1 : capacity);
-            firstSlot = elementData.length;
             loadFactor = 0.75f;
-            computeMaxSize();
+            cn1Alloc(cn1Capacity(capacity));
         } else {
             throw new IllegalArgumentException();
         }
@@ -245,11 +313,8 @@ public class Hashtable<K, V> extends Dictionary<K, V> implements Map<K, V> {
      */
     public Hashtable(int capacity, float loadFactor) {
         if (capacity >= 0 && loadFactor > 0) {
-            elementCount = 0;
-            firstSlot = capacity;
-            elementData = newElementArray(capacity == 0 ? 1 : capacity);
             this.loadFactor = loadFactor;
-            computeMaxSize();
+            cn1Alloc(cn1Capacity(capacity));
         } else {
             throw new IllegalArgumentException();
         }
@@ -267,11 +332,6 @@ public class Hashtable<K, V> extends Dictionary<K, V> implements Map<K, V> {
         putAll(map);
     }
 
-    @SuppressWarnings("unchecked")
-    private Entry<K, V>[] newElementArray(int size) {
-        return new Entry[size];
-    }
-
     /**
      * Removes all key/value pairs from this {@code Hashtable}, leaving the
      * size zero and the capacity unchanged.
@@ -280,14 +340,32 @@ public class Hashtable<K, V> extends Dictionary<K, V> implements Map<K, V> {
      * @see #size
      */
     public synchronized void clear() {
-        elementCount = 0;
-        Arrays.fill(elementData, null);
-        modCount++;
+        if (elementCount > 0 || cn1Occupied > 0) {
+            Arrays.fill(cn1Keys, null);
+            Arrays.fill(cn1Vals, null);
+            Arrays.fill(cn1Meta, META_EMPTY);
+            elementCount = 0;
+            cn1Occupied = 0;
+            modCount++;
+        }
     }
 
 
+    /**
+     * The occupancy at which the table is rebuilt.
+     *
+     * <p>Clamped below the capacity, which chaining did not have to do: an open
+     * addressed probe terminates on an empty slot, so a completely full table
+     * would loop forever. A load factor of 1 or more is legal to ASK for -- the
+     * two-argument constructor accepts any positive float -- so the clamp is
+     * load-bearing rather than defensive.
+     */
     private void computeMaxSize() {
-        threshold = (int) (elementData.length * loadFactor);
+        int capacity = cn1Meta.length;
+        threshold = (int) (capacity * loadFactor);
+        if (threshold >= capacity) {
+            threshold = capacity - 1;
+        }
     }
 
     /**
@@ -306,13 +384,10 @@ public class Hashtable<K, V> extends Dictionary<K, V> implements Map<K, V> {
             throw new NullPointerException();
         }
 
-        for (int i = elementData.length; --i >= 0;) {
-            Entry<K, V> entry = elementData[i];
-            while (entry != null) {
-                if (entry.value.equals(value)) {
-                    return true;
-                }
-                entry = entry.next;
+        int[] meta = cn1Meta;
+        for (int i = 0; i < meta.length; i++) {
+            if (meta[i] < 0 && value.equals(cn1Vals[i])) {
+                return true;
             }
         }
         return false;
@@ -467,30 +542,15 @@ public class Hashtable<K, V> extends Dictionary<K, V> implements Map<K, V> {
      * @see #put
      */
     @Override
+    @SuppressWarnings("unchecked")
     public synchronized V get(Object key) {
-        int hash = key.hashCode();
-        int index = (hash & 0x7FFFFFFF) % elementData.length;
-        Entry<K, V> entry = elementData[index];
-        while (entry != null) {
-            if (entry.equalsKey(key, hash)) {
-                return entry.value;
-            }
-            entry = entry.next;
-        }
-        return null;
+        int idx = cn1FindSlot(key);
+        return idx < 0 ? null : (V) cn1Vals[idx];
     }
 
     Entry<K, V> getEntry(Object key) {
-        int hash = key.hashCode();
-        int index = (hash & 0x7FFFFFFF) % elementData.length;
-        Entry<K, V> entry = elementData[index];
-        while (entry != null) {
-            if (entry.equalsKey(key, hash)) {
-                return entry;
-            }
-            entry = entry.next;
-        }
-        return null;
+        int idx = cn1FindSlot(key);
+        return idx < 0 ? null : new Entry<K, V>(this, idx);
     }
 
     @Override
@@ -600,10 +660,6 @@ public class Hashtable<K, V> extends Dictionary<K, V> implements Map<K, V> {
 
         private boolean isEnumeration = false;
 
-        int start;
-
-        Entry<K, V> entry;
-
         HashEnumIterator(MapEntry.Type<E, K, V> value) {
             super(value);
         }
@@ -611,31 +667,16 @@ public class Hashtable<K, V> extends Dictionary<K, V> implements Map<K, V> {
         HashEnumIterator(MapEntry.Type<E, K, V> value, boolean isEnumeration) {
             super(value);
             this.isEnumeration = isEnumeration;
-            start = lastSlot + 1;
         }
 
         public boolean hasMoreElements() {
-            if (isEnumeration) {
-                if (entry != null) {
-                    return true;
-                }
-                while (start > firstSlot) {
-                    if (elementData[--start] != null) {
-                        entry = elementData[start];
-                        return true;
-                    }
-                }
-                return false;
-            }
-            // iterator
-            return super.hasNext();
+            return advance();
         }
 
         public boolean hasNext() {
             if (isEnumeration) {
                 return hasMoreElements();
             }
-            // iterator
             return super.hasNext();
         }
 
@@ -643,34 +684,35 @@ public class Hashtable<K, V> extends Dictionary<K, V> implements Map<K, V> {
             if (isEnumeration) {
                 if (expectedModCount == modCount) {
                     return nextElement();
-                } else {
-                    throw new ConcurrentModificationException();
                 }
+                throw new ConcurrentModificationException();
             }
-            // iterator
             return super.next();
         }
 
-        @SuppressWarnings("unchecked")
+        /**
+         * An Enumeration is deliberately NOT fail-fast -- the class docs say
+         * its results "may be affected if the contents are modified" -- so this
+         * does not consult modCount, matching the chained implementation it
+         * replaces. {@link #next} still does.
+         */
         public E nextElement() {
             if (isEnumeration) {
-                if (hasMoreElements()) {
-                    Object result = type.get(entry);
-                    entry = entry.next;
-                    return (E) result;
+                if (!advance()) {
+                    throw new NoSuchElementException();
                 }
-                throw new NoSuchElementException();
+                int idx = position;
+                position++;
+                return type.get(new Entry<K, V>(Hashtable.this, idx));
             }
-            // iterator
             return super.next();
         }
 
         public void remove() {
             if (isEnumeration) {
                 throw new UnsupportedOperationException();
-            } else {
-                super.remove();
             }
+            super.remove();
         }
     }
 
@@ -693,32 +735,27 @@ public class Hashtable<K, V> extends Dictionary<K, V> implements Map<K, V> {
     @Override
     public synchronized V put(K key, V value) {
         if (key != null && value != null) {
-            int hash = key.hashCode();
-            int index = (hash & 0x7FFFFFFF) % elementData.length;
-            Entry<K, V> entry = elementData[index];
-            while (entry != null && !entry.equalsKey(key, hash)) {
-                entry = entry.next;
+            int idx = cn1FindSlot(key);
+            if (idx >= 0) {
+                @SuppressWarnings("unchecked")
+                V result = (V) cn1Vals[idx];
+                cn1Vals[idx] = value;
+                return result;
             }
-            if (entry == null) {
-                modCount++;
-                if (++elementCount > threshold) {
-                    rehash();
-                    index = (hash & 0x7FFFFFFF) % elementData.length;
-                }
-                if (index < firstSlot) {
-                    firstSlot = index;
-                }
-                if (index > lastSlot) {
-                    lastSlot = index;
-                }
-                entry = newEntry(key, value, hash);
-                entry.next = elementData[index];
-                elementData[index] = entry;
-                return null;
+            int ins = -idx - 1;
+            boolean wasEmpty = cn1Meta[ins] == META_EMPTY;
+            cn1Meta[ins] = cn1Marker(key);
+            cn1Keys[ins] = key;
+            cn1Vals[ins] = value;
+            elementCount++;
+            if (wasEmpty) {
+                cn1Occupied++;
             }
-            V result = entry.value;
-            entry.value = value;
-            return result;
+            modCount++;
+            if (cn1Occupied >= threshold) {
+                rehash();
+            }
+            return null;
         }
         throw new NullPointerException();
     }
@@ -742,33 +779,28 @@ public class Hashtable<K, V> extends Dictionary<K, V> implements Map<K, V> {
      * when the size of this {@code Hashtable} exceeds the load factor.
      */
     protected void rehash() {
-        int length = (elementData.length << 1) + 1;
-        if (length == 0) {
-            length = 1;
+        int capacity = cn1Meta.length;
+        // Double only when genuinely full; a table that is merely
+        // tombstone-heavy is rebuilt at the same size, which purges them.
+        int newCapacity = (elementCount * 2 >= capacity) ? capacity << 1 : capacity;
+        if (newCapacity <= 0) {
+            newCapacity = capacity;
         }
-        int newFirst = length;
-        int newLast = -1;
-        Entry<K, V>[] newData = newElementArray(length);
-        for (int i = lastSlot + 1; --i >= firstSlot;) {
-            Entry<K, V> entry = elementData[i];
-            while (entry != null) {
-                int index = (entry.getKeyHash() & 0x7FFFFFFF) % length;
-                if (index < newFirst) {
-                    newFirst = index;
-                }
-                if (index > newLast) {
-                    newLast = index;
-                }
-                Entry<K, V> next = entry.next;
-                entry.next = newData[index];
-                newData[index] = entry;
-                entry = next;
+        Object[] oldKeys = cn1Keys;
+        Object[] oldVals = cn1Vals;
+        int[] oldMeta = cn1Meta;
+        cn1Alloc(newCapacity);
+        int count = 0;
+        for (int i = 0; i < oldMeta.length; i++) {
+            if (oldMeta[i] < 0) {
+                // The stored marker is reused, so a rebuild makes no
+                // hashCode() calls at all.
+                cn1Insert(oldKeys[i], oldVals[i], oldMeta[i]);
+                count++;
             }
         }
-        firstSlot = newFirst;
-        lastSlot = newLast;
-        elementData = newData;
-        computeMaxSize();
+        elementCount = count;
+        cn1Occupied = count;
     }
 
     /**
@@ -783,28 +815,15 @@ public class Hashtable<K, V> extends Dictionary<K, V> implements Map<K, V> {
      * @see #put
      */
     @Override
+    @SuppressWarnings("unchecked")
     public synchronized V remove(Object key) {
-        int hash = key.hashCode();
-        int index = (hash & 0x7FFFFFFF) % elementData.length;
-        Entry<K, V> last = null;
-        Entry<K, V> entry = elementData[index];
-        while (entry != null && !entry.equalsKey(key, hash)) {
-            last = entry;
-            entry = entry.next;
+        int idx = cn1FindSlot(key);
+        if (idx < 0) {
+            return null;
         }
-        if (entry != null) {
-            modCount++;
-            if (last == null) {
-                elementData[index] = entry.next;
-            } else {
-                last.next = entry.next;
-            }
-            elementCount--;
-            V result = entry.value;
-            entry.value = null;
-            return result;
-        }
-        return null;
+        V result = (V) cn1Vals[idx];
+        cn1RemoveAtIndex(idx);
+        return result;
     }
 
     /**
@@ -832,24 +851,25 @@ public class Hashtable<K, V> extends Dictionary<K, V> implements Map<K, V> {
 
         StringBuffer buffer = new StringBuffer(size() * 28);
         buffer.append('{');
-        for (int i = lastSlot; i >= firstSlot; i--) {
-            Entry<K, V> entry = elementData[i];
-            while (entry != null) {
-                if (entry.key != this) {
-                    buffer.append(entry.key);
+        int[] meta = cn1Meta;
+        for (int i = 0; i < meta.length; i++) {
+            if (meta[i] < 0) {
+                Object k = cn1Keys[i];
+                Object v = cn1Vals[i];
+                if (k != this) {
+                    buffer.append(k);
                 } else {
                     // luni.04=this Map
                     buffer.append("(this)"); //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$
                 }
                 buffer.append('=');
-                if (entry.value != this) {
-                    buffer.append(entry.value);
+                if (v != this) {
+                    buffer.append(v);
                 } else {
                     // luni.04=this Map
                     buffer.append("(this)"); //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$
                 }
                 buffer.append(", "); //$NON-NLS-1$
-                entry = entry.next;
             }
         }
         // Remove the last ", "

--- a/vm/JavaAPI/src/java/util/Hashtable.java
+++ b/vm/JavaAPI/src/java/util/Hashtable.java
@@ -405,7 +405,12 @@ public class Hashtable<K, V> extends Dictionary<K, V> implements Map<K, V> {
      * @see java.lang.Object#equals
      */
     public synchronized boolean containsKey(Object key) {
-        return getEntry(key) != null;
+        // Deliberately NOT getEntry(key) != null: that builds an Entry purely
+        // to compare it against null, so every successful membership test
+        // would allocate. The chained representation this replaced handed back
+        // the entry it already had; the compact probe can answer from the
+        // index alone. keySet().contains() routes here, so it is a hot path.
+        return cn1FindSlot(key) >= 0;
     }
 
     /**
@@ -780,9 +785,19 @@ public class Hashtable<K, V> extends Dictionary<K, V> implements Map<K, V> {
      */
     protected void rehash() {
         int capacity = cn1Meta.length;
-        // Double only when genuinely full; a table that is merely
-        // tombstone-heavy is rebuilt at the same size, which purges them.
-        int newCapacity = (elementCount * 2 >= capacity) ? capacity << 1 : capacity;
+        // Grow when the LIVE count has reached the threshold; rebuild at the
+        // same size only when the threshold was reached because of TOMBSTONES.
+        //
+        // Testing capacity directly (elementCount * 2 >= cap) silently assumed
+        // a load factor of 0.5 or more. Below that the threshold is reached
+        // while the table is still less than half full, so the rebuild kept the
+        // same capacity, the rebuilt table was immediately at its threshold
+        // again, and every subsequent put rebuilt the whole table: inserting
+        // 20000 entries at a load factor of 0.25 did 19999 rebuilds and
+        // rehashed 200 million entries. The two-argument constructor accepts
+        // any positive load factor, so this was reachable from ordinary code.
+        // At 0.75 and 0.5 the two rules agree exactly, rebuild for rebuild.
+        int newCapacity = (elementCount >= threshold) ? capacity << 1 : capacity;
         if (newCapacity <= 0) {
             newCapacity = capacity;
         }

--- a/vm/JavaAPI/src/java/util/IdentityHashMap.java
+++ b/vm/JavaAPI/src/java/util/IdentityHashMap.java
@@ -63,6 +63,15 @@ public class IdentityHashMap<K, V> extends AbstractMap<K, V> implements
     private static final int loadFactor = 7500;
 
     /*
+     * Bounds on the backing array length, which is always a power of two. The
+     * minimum is 8 cells (4 slots): findIndex needs at least one empty slot to
+     * terminate on, and remove() reads index + 1.
+     */
+    private static final int MINIMUM_ARRAY_SIZE = 8;
+
+    private static final int MAXIMUM_ARRAY_SIZE = 1 << 30;
+
+    /*
      * modification count, to keep track of structural modifications between the
      * IdentityHashMap and the iterator
      */
@@ -254,11 +263,31 @@ public class IdentityHashMap<K, V> extends AbstractMap<K, V> implements
         return maxSize > 3 ? maxSize : 3;
     }
 
+    /**
+     * The backing array length, always a POWER OF TWO and at least
+     * {@link #MINIMUM_ARRAY_SIZE}.
+     *
+     * <p>It did not used to be, and that cost an integer division on every
+     * probe: {@link #findIndex} and {@link #remove} wrapped with {@code %} and
+     * {@link #getModuloHash} took {@code % (length / 2)}. A power of two lets
+     * all three be a mask instead. The array holds keys and values in
+     * alternating cells, so the length is twice the slot count and the low bit
+     * of an index is always 0.
+     */
     private int computeElementArraySize() {
-        int arraySize = (int) (((long) threshold * 10000) / loadFactor) * 2;
-        // ensure arraySize is positive, the above cast from long to int type
-        // leads to overflow and negative arraySize if threshold is too big
-        return arraySize < 0 ? -arraySize : arraySize;
+        long slots = ((long) threshold * 10000) / loadFactor;
+        long arraySize = slots * 2;
+        if (arraySize < MINIMUM_ARRAY_SIZE) {
+            arraySize = MINIMUM_ARRAY_SIZE;
+        }
+        if (arraySize >= MAXIMUM_ARRAY_SIZE) {
+            return MAXIMUM_ARRAY_SIZE;
+        }
+        int pow2 = MINIMUM_ARRAY_SIZE;
+        while (pow2 < arraySize) {
+            pow2 <<= 1;
+        }
+        return pow2;
     }
 
     /**
@@ -404,8 +433,9 @@ public class IdentityHashMap<K, V> extends AbstractMap<K, V> implements
      */
     private int findIndex(Object key, Object[] array) {
         int length = array.length;
+        int mask = length - 1;
         int index = getModuloHash(key, length);
-        int last = (index + length - 2) % length;
+        int last = (index + length - 2) & mask;
         while (index != last) {
             if (array[index] == key || (array[index] == null)) {
                 /*
@@ -414,13 +444,46 @@ public class IdentityHashMap<K, V> extends AbstractMap<K, V> implements
                  */
                 break;
             }
-            index = (index + 2) % length;
+            index = (index + 2) & mask;
         }
         return index;
     }
 
+    /**
+     * The home index for a key: always even, always in {@code [0, length)}.
+     *
+     * <p>Here {@code System.identityHashCode} is a truncated object ADDRESS, not
+     * a scrambled per-object value the way HotSpot's is, and that changes what a
+     * correct index function looks like. Measured over 50,000 freshly allocated
+     * objects on the translated target, addresses are 32-byte aligned -- the low
+     * FIVE bits are always zero -- so any index that reads the low bits of the
+     * hash directly can only reach a fraction of the table.
+     *
+     * <p>That rules out the obvious thing to copy. {@code java.util.IdentityHashMap}
+     * uses {@code (h << 1) - (h << 8)}, i.e. {@code h * -254}; the multiplier is
+     * EVEN, so it preserves those five zeros and adds a sixth. Measured on a
+     * 65536-slot table it reached 2045 distinct home slots and averaged 12.73
+     * probes per lookup. Using the hash unscrambled reached 4090 and averaged
+     * 6.61. Both are far worse than the {@code % (length / 2)} this replaced,
+     * which survived only because a non-power-of-two modulus folds the high bits
+     * back in as a side effect.
+     *
+     * <p>Folding explicitly is what actually works: {@code h ^= h >>> 16} moves
+     * the high half -- where an address's real entropy lives -- down over the
+     * aligned zeros. That reached 50000 home slots out of 65536 and averaged
+     * 1.00 probes, better than the modulo it replaces and without the divide.
+     * Adding a multiply on top made it worse, not better (2.36 probes):
+     * sequentially allocated objects have sequentially increasing addresses, so
+     * one fold is already very close to a perfect hash, and scrambling that
+     * turns near-perfect placement back into random collisions.
+     *
+     * <p>{@code & ~1} keeps the index even, since the array holds keys and
+     * values in alternating cells.
+     */
     private int getModuloHash(Object key, int length) {
-        return ((System.identityHashCode(key) & 0x7FFFFFFF) % (length / 2)) * 2;
+        int h = System.identityHashCode(key);
+        h ^= (h >>> 16);
+        return h & (length - 1) & ~1;
     }
 
     /**
@@ -483,9 +546,17 @@ public class IdentityHashMap<K, V> extends AbstractMap<K, V> implements
     }
 
     private void rehash() {
+        // Doubling keeps the length a power of two, which findIndex and remove
+        // rely on. The old guard turned an overflowed length into 1 -- an ODD
+        // array length, which would have split every key from its value; the
+        // real bound is MAXIMUM_ARRAY_SIZE, above which there is nowhere to
+        // grow and the load factor simply rises.
         int newlength = elementData.length << 1;
-        if (newlength == 0) {
-            newlength = 1;
+        if (newlength <= 0 || newlength > MAXIMUM_ARRAY_SIZE) {
+            if (elementData.length >= MAXIMUM_ARRAY_SIZE) {
+                return;
+            }
+            newlength = MAXIMUM_ARRAY_SIZE;
         }
         Object[] newData = newElementArray(newlength);
         for (int i = 0; i < elementData.length; i = i + 2) {
@@ -534,8 +605,9 @@ public class IdentityHashMap<K, V> extends AbstractMap<K, V> implements
         // shift the following elements up if needed
         // until we reach an empty spot
         int length = elementData.length;
+        int mask = length - 1;
         while (true) {
-            next = (next + 2) % length;
+            next = (next + 2) & mask;
             object = elementData[next];
             if (object == null) {
                 break;

--- a/vm/JavaAPI/src/java/util/LinkedHashMap.java
+++ b/vm/JavaAPI/src/java/util/LinkedHashMap.java
@@ -188,7 +188,19 @@ public class LinkedHashMap<K, V> extends HashMap<K, V> implements Map<K, V> {
             c++;
         }
         int cap = cn1Meta.length;
-        int newCap = (n * 2 >= cap) ? cap << 1 : cap;
+        // Grow when the LIVE count has reached the threshold; rebuild at the
+        // same size only when the threshold was reached because of TOMBSTONES.
+        //
+        // Testing capacity directly (elementCount * 2 >= cap) silently assumed
+        // a load factor of 0.5 or more. Below that the threshold is reached
+        // while the table is still less than half full, so the rebuild kept the
+        // same capacity, the rebuilt table was immediately at its threshold
+        // again, and every subsequent put rebuilt the whole table: inserting
+        // 20000 entries at a load factor of 0.25 did 19999 rebuilds and
+        // rehashed 200 million entries. The two-argument constructor accepts
+        // any positive load factor, so this was reachable from ordinary code.
+        // At 0.75 and 0.5 the two rules agree exactly, rebuild for rebuild.
+        int newCap = (n >= threshold) ? cap << 1 : cap;
         cn1Alloc(newCap);
         cn1InitLinks();
         for (int i = 0; i < c; i++) {

--- a/vm/benchmarks/README.md
+++ b/vm/benchmarks/README.md
@@ -52,11 +52,60 @@ measurement runner (`BENCH <name> rep <n> ns=<t> checksum=<c>` lines):
 | recursion | call-overhead (fib) — a JIT-inlining shape, accepted above 1x |
 | quicksort | mixed array scan/swap + recursion |
 
+## Map shapes (`MapBench`, run on its own)
+
+`hashMapChurn` above is get+put on keys that are PRESENT. An open-addressed table's
+failure mode is the miss, so that benchmark cannot see it -- and did not: a probe
+sequence that walked 222,721 slots per unsuccessful lookup at 1M entries sat behind a
+healthy-looking 1.12x for as long as it existed. `MapBench` is the suite that covers
+the rest of the surface.
+
+```bash
+./translate-and-build.sh MapBench target/mapbench && ./target/mapbench
+```
+
+| bench | shape |
+|---|---|
+| missHeavy | `containsKey` at a 10% hit rate -- the unsuccessful-probe case |
+| stringKeys | small long-lived String-keyed map read repeatedly (the `UIManager` theme shape) |
+| largeTable | 1M entries, ~20MB of table, random hits -- every probe a cache miss |
+| tombstones | remove/insert churn at a flat live count, so slots fill with tombstones |
+| growBuild | build from an empty default-capacity map, so `cn1Grow` dominates |
+| identityKeys | `Object` keys, i.e. hashes that are truncated size-class-aligned pointers |
+| linkedStringKeys | as stringKeys on `LinkedHashMap`, whose accessors are Java, not native |
+| hashtableStringKeys / hashtableBuild | as above on `Hashtable`, which is still chained |
+
+`IdmProbe` is a diagnostic beside it, not a benchmark: it harvests the REAL
+`System.identityHashCode` values of freshly allocated objects and replays several
+indexing schemes over them, reporting how much of the table each can even reach.
+It has to run on the target -- the input distribution is a property of the
+allocator (object addresses, 32-byte aligned), so a host-side simulation answers
+a different question.
+
+```bash
+./translate-and-build.sh IdmProbe target/bin/IdmProbe && ./target/bin/IdmProbe
+```
+
+`MapBench` is deliberately NOT part of `CommonWorkloads`:
+`scripts/hellocodenameone/conformance/port_status.py` requires exactly ten unique
+benchmark ids there, and that set is what every generated port application runs.
+
+Two rules the workloads follow, and any addition must:
+
+- **No checksum may depend on iteration order or on hash VALUES.** This map and
+  HotSpot's enumerate differently and identity hash codes differ by construction, so a
+  checksum is a sum or a count over lookups the workload chose.
+- **Pre-box the keys.** `Integer.valueOf` allocates above 127 on HotSpot and never
+  allocates here (tagged immediates), so boxing inside the timed loop measures the
+  allocator instead of the probe.
+
 ## The tortures (run by `run-gauntlet.sh`)
 
 | test | guards |
 |---|---|
 | MapTorture | compact HashMap/LinkedHashMap: growth, tombstones, null keys, views, 200k PRNG op mix, insertion/access order |
+| HtTorture | Hashtable: null rejection, Dictionary keys/elements Enumerations, rehash growth, remove churn, all four views incl. setValue write-through, equals/hashCode, 80k PRNG op mix replayed against an array model |
+| IdmTorture | IdentityHashMap: equal-but-distinct keys, null key/value, rehash growth, the backward-shift relocation on remove, views, 60k PRNG op mix replayed against an array model |
 | SbTorture | StringBuilder: every append overload, toString independence under later mutation, editing ops, surrogates, 100k PRNG mix |
 | StrCmp | String equals/compareTo/sort incl. unicode + surrogates; charAt logical-length bounds |
 | FusedTest | @Fused layout: param/computed sizes, oversize fallback, ctor guard paths, survivors across GC — **also the canary for setjmp/longjmp bugs (deliberate caught exception)** |

--- a/vm/benchmarks/README.md
+++ b/vm/benchmarks/README.md
@@ -72,6 +72,7 @@ the rest of the surface.
 | tombstones | remove/insert churn at a flat live count, so slots fill with tombstones |
 | growBuild | build from an empty default-capacity map, so `cn1Grow` dominates |
 | identityKeys | `Object` keys, i.e. hashes that are truncated size-class-aligned pointers |
+| lowLoadFactorBuild | build at a load factor of 0.25 -- the growth rule regression guard (22.3s before the fix, 16.4ms after) |
 | linkedStringKeys | as stringKeys on `LinkedHashMap`, whose accessors are Java, not native |
 | hashtableStringKeys / hashtableBuild | as above on `Hashtable`, which is still chained |
 

--- a/vm/benchmarks/run-gauntlet.sh
+++ b/vm/benchmarks/run-gauntlet.sh
@@ -15,7 +15,7 @@ J8="${JDK_8_HOME:?set JDK_8_HOME}"
 # TaggedSync guards Java monitor semantics on tagged boxed Integers (mutual
 # exclusion + wait/notify) -- regression test for the tagged monitorEnter/Exit
 # no-op bug a review caught.
-TORTURES="MapTorture SbTorture StrCmp FusedTest IbpTest ExcTest ThreadChurn SoeTest TaggedSync"
+TORTURES="MapTorture IdmTorture HtTorture SbTorture StrCmp FusedTest IbpTest ExcTest ThreadChurn SoeTest TaggedSync"
 mkdir -p target/host-classes target/bin
 # FusedTest uses @com.codename1.annotations.Fused -- supply the annotation
 # source for the host compile (ParparVM's JavaAPI carries its own copy)

--- a/vm/benchmarks/src/com/bench/HtTorture.java
+++ b/vm/benchmarks/src/com/bench/HtTorture.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.bench;
+
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.Hashtable;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Semantic torture for {@link Hashtable}, comparable byte-for-byte against
+ * HotSpot.
+ *
+ * <p>Written as a SAFETY NET before the representation changed, and it passed
+ * against the chained-Entry implementation first -- a torture that only ever ran
+ * against the new code proves nothing about the change.
+ *
+ * <p>Iteration order is unspecified and differs between implementations, so
+ * every aggregation here is ORDER-INDEPENDENT (separate {@code +} and {@code ^}
+ * accumulators, each of which commutes). {@code toString} is deliberately NOT
+ * compared for the same reason -- only that it round-trips through
+ * {@code length}.
+ *
+ * <p>Covers: the Dictionary half (keys/elements Enumerations, size, isEmpty),
+ * the Map half (get/put/remove/containsKey/containsValue/contains/clear/putAll/
+ * equals/hashCode), null rejection on both key and value, growth across several
+ * rehashes, remove churn, all four views including removal through each and
+ * entrySet setValue write-through, and a PRNG op mix replayed against a plain
+ * array model.
+ */
+public class HtTorture {
+    static int seed = 0x1234567;
+
+    static int rnd(int bound) {
+        seed = seed * 1103515245 + 12345;
+        return (seed >>> 16) % bound;
+    }
+
+    /** order-independent digest: separate + and ^ accumulators. */
+    static long digest(Map<Integer, Integer> m) {
+        long sum = 0;
+        long xor = 0;
+        Iterator<Map.Entry<Integer, Integer>> it = m.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<Integer, Integer> e = it.next();
+            long k = e.getKey().intValue();
+            long v = e.getValue().intValue();
+            long mix = (k * 0x9E3779B97F4A7C15L) ^ (v * 0xC2B2AE3D27D4EB4FL);
+            sum += mix;
+            xor ^= mix * 31 + 17;
+        }
+        return sum * 31 + xor + m.size();
+    }
+
+    static void emit(String label, long value) {
+        System.out.println(label + "=" + value);
+    }
+
+    public static void main(String[] args) {
+        // ---- null rejection --------------------------------------------------
+        Hashtable<Integer, Integer> t = new Hashtable<Integer, Integer>();
+        int npes = 0;
+        try {
+            t.put(null, Integer.valueOf(1));
+        } catch (NullPointerException e) {
+            npes++;
+        }
+        try {
+            t.put(Integer.valueOf(1), null);
+        } catch (NullPointerException e) {
+            npes++;
+        }
+        // NOTE: get(null)/containsKey(null) are deliberately NOT exercised.
+        // They reach key.hashCode() on a null receiver, and a null receiver is
+        // only a NullPointerException on this VM by way of the iOS port's
+        // SIGSEGV handler (installSignalHandlers in
+        // CodenameOne_GLAppDelegate.m). The clean target this torture runs on
+        // installs no handler, so the same call is a hard SIGSEGV here -- see
+        // the comment on cn1ThrowNullPointerOrDie in cn1_globals.h. Only the
+        // EXPLICIT throws in put() are portable enough to compare.
+        emit("nullRejection.npes", npes);
+        emit("nullRejection.size", t.size());
+
+        // ---- basic put/get/replace ------------------------------------------
+        emit("basic.putFresh", t.put(Integer.valueOf(7), Integer.valueOf(70)) == null ? 1 : 0);
+        emit("basic.putReplace", t.put(Integer.valueOf(7), Integer.valueOf(71)).intValue());
+        emit("basic.get", t.get(Integer.valueOf(7)).intValue());
+        emit("basic.size", t.size());
+        emit("basic.containsKey", t.containsKey(Integer.valueOf(7)) ? 1 : 0);
+        emit("basic.containsMissing", t.containsKey(Integer.valueOf(8)) ? 1 : 0);
+        emit("basic.contains", t.contains(Integer.valueOf(71)) ? 1 : 0);
+        emit("basic.containsValue", t.containsValue(Integer.valueOf(71)) ? 1 : 0);
+        emit("basic.getMissing", t.get(Integer.valueOf(8)) == null ? 1 : 0);
+        emit("basic.removeMissing", t.remove(Integer.valueOf(8)) == null ? 1 : 0);
+        emit("basic.remove", t.remove(Integer.valueOf(7)).intValue());
+        emit("basic.afterRemove.size", t.size());
+        emit("basic.isEmpty", t.isEmpty() ? 1 : 0);
+
+        // ---- growth across several rehashes ---------------------------------
+        int n = 5000;
+        Hashtable<Integer, Integer> grow = new Hashtable<Integer, Integer>();
+        for (int i = 0; i < n; i++) {
+            grow.put(Integer.valueOf(i), Integer.valueOf(i * 3));
+        }
+        emit("grow.size", grow.size());
+        emit("grow.digest", digest(grow));
+        emit("grow.hashCode", grow.hashCode());
+        long found = 0;
+        for (int i = 0; i < n; i++) {
+            Integer v = grow.get(Integer.valueOf(i));
+            if (v != null && v.intValue() == i * 3) {
+                found++;
+            }
+        }
+        emit("grow.allFound", found);
+
+        // small capacity + a large load factor, so the table rehashes often
+        Hashtable<Integer, Integer> tight = new Hashtable<Integer, Integer>(3, 0.9f);
+        for (int i = 0; i < 2000; i++) {
+            tight.put(Integer.valueOf(i * 17), Integer.valueOf(i));
+        }
+        emit("tight.size", tight.size());
+        emit("tight.digest", digest(tight));
+
+        // ---- Enumerations (the Dictionary half) -----------------------------
+        long keySum = 0;
+        long keyXor = 0;
+        Enumeration<Integer> ke = grow.keys();
+        while (ke.hasMoreElements()) {
+            long k = ke.nextElement().intValue();
+            keySum += k;
+            keyXor ^= k * 31 + 7;
+        }
+        emit("keys.sum", keySum);
+        emit("keys.xor", keyXor);
+        long valSum = 0;
+        long valXor = 0;
+        Enumeration<Integer> ve = grow.elements();
+        while (ve.hasMoreElements()) {
+            long v = ve.nextElement().intValue();
+            valSum += v;
+            valXor ^= v * 31 + 7;
+        }
+        emit("elements.sum", valSum);
+        emit("elements.xor", valXor);
+
+        // ---- remove churn ----------------------------------------------------
+        long survivors = 0;
+        for (int pass = 0; pass < 3; pass++) {
+            for (int i = pass; i < n; i += 3) {
+                grow.remove(Integer.valueOf(i));
+            }
+            for (int i = 0; i < n; i++) {
+                if (grow.containsKey(Integer.valueOf(i))) {
+                    survivors++;
+                }
+            }
+            emit("removeChurn.pass" + pass + ".size", grow.size());
+            emit("removeChurn.pass" + pass + ".digest", digest(grow));
+        }
+        emit("removeChurn.survivors", survivors);
+
+        // ---- interleaved remove/put -----------------------------------------
+        Hashtable<Integer, Integer> churn = new Hashtable<Integer, Integer>();
+        int live = 800;
+        for (int i = 0; i < live; i++) {
+            churn.put(Integer.valueOf(i), Integer.valueOf(i));
+        }
+        for (int i = 0; i < live * 3; i++) {
+            churn.put(Integer.valueOf(i + live), Integer.valueOf(i));
+            churn.remove(Integer.valueOf(i));
+        }
+        emit("interleaved.size", churn.size());
+        emit("interleaved.digest", digest(churn));
+
+        // ---- views -----------------------------------------------------------
+        Hashtable<Integer, Integer> views = new Hashtable<Integer, Integer>();
+        for (int i = 0; i < 300; i++) {
+            views.put(Integer.valueOf(i), Integer.valueOf(i * 2));
+        }
+        Set<Integer> ks = views.keySet();
+        Collection<Integer> vs = views.values();
+        Set<Map.Entry<Integer, Integer>> es = views.entrySet();
+        emit("views.keySet.size", ks.size());
+        emit("views.values.size", vs.size());
+        emit("views.entrySet.size", es.size());
+        emit("views.keySet.contains", ks.contains(Integer.valueOf(5)) ? 1 : 0);
+        emit("views.values.contains", vs.contains(Integer.valueOf(10)) ? 1 : 0);
+
+        long ksum = 0;
+        Iterator<Integer> ki = ks.iterator();
+        while (ki.hasNext()) {
+            ksum += ki.next().intValue();
+        }
+        emit("views.keySet.sum", ksum);
+
+        // setValue write-through
+        Iterator<Map.Entry<Integer, Integer>> ei = es.iterator();
+        while (ei.hasNext()) {
+            Map.Entry<Integer, Integer> e = ei.next();
+            if (e.getKey().intValue() % 5 == 0) {
+                e.setValue(Integer.valueOf(-e.getKey().intValue()));
+            }
+        }
+        emit("views.afterSetValue.digest", digest(views));
+        emit("views.setValueVisible", views.get(Integer.valueOf(10)).intValue());
+
+        // removal through the entrySet iterator
+        ei = es.iterator();
+        while (ei.hasNext()) {
+            if ((ei.next().getKey().intValue() & 1) == 0) {
+                ei.remove();
+            }
+        }
+        emit("views.afterIteratorRemove.size", views.size());
+        emit("views.afterIteratorRemove.digest", digest(views));
+
+        // removal through keySet
+        views.keySet().remove(Integer.valueOf(3));
+        emit("views.afterKeySetRemove.size", views.size());
+        emit("views.containsRemoved", views.containsKey(Integer.valueOf(3)) ? 1 : 0);
+
+        // ---- putAll, copy ctor, equals --------------------------------------
+        Hashtable<Integer, Integer> src = new Hashtable<Integer, Integer>();
+        for (int i = 0; i < 400; i++) {
+            src.put(Integer.valueOf(i * 7), Integer.valueOf(i));
+        }
+        Hashtable<Integer, Integer> dst = new Hashtable<Integer, Integer>();
+        dst.putAll(src);
+        emit("putAll.size", dst.size());
+        emit("putAll.digest", digest(dst));
+        emit("putAll.equalsSrc", dst.equals(src) ? 1 : 0);
+        emit("putAll.hashCodeMatches", dst.hashCode() == src.hashCode() ? 1 : 0);
+        Hashtable<Integer, Integer> copy = new Hashtable<Integer, Integer>(src);
+        emit("copyCtor.digest", digest(copy));
+        emit("copyCtor.equals", copy.equals(src) ? 1 : 0);
+        copy.remove(Integer.valueOf(0));
+        emit("copyCtor.notEqualAfterRemove", copy.equals(src) ? 1 : 0);
+
+        // toString is order-dependent, so only its shape is comparable
+        emit("toString.startsWithBrace", src.toString().charAt(0) == '{' ? 1 : 0);
+        emit("toString.endsWithBrace",
+                src.toString().charAt(src.toString().length() - 1) == '}' ? 1 : 0);
+
+        // ---- PRNG op mix vs a plain array model -----------------------------
+        int universe = 2000;
+        Integer[] model = new Integer[universe];
+        boolean[] present = new boolean[universe];
+        Hashtable<Integer, Integer> mix = new Hashtable<Integer, Integer>();
+        long mismatches = 0;
+        long modelSize = 0;
+        for (int op = 0; op < 80000; op++) {
+            int slot = rnd(universe);
+            Integer key = Integer.valueOf(slot);
+            int kind = rnd(10);
+            if (kind < 5) {
+                Integer v = Integer.valueOf(op + 1);
+                Integer prev = mix.put(key, v);
+                Integer modelPrev = present[slot] ? model[slot] : null;
+                if ((prev == null) != (modelPrev == null)
+                        || (prev != null && !prev.equals(modelPrev))) {
+                    mismatches++;
+                }
+                if (!present[slot]) {
+                    modelSize++;
+                }
+                present[slot] = true;
+                model[slot] = v;
+            } else if (kind < 7) {
+                Integer got = mix.get(key);
+                Integer want = present[slot] ? model[slot] : null;
+                if ((got == null) != (want == null)
+                        || (got != null && !got.equals(want))) {
+                    mismatches++;
+                }
+            } else if (kind < 8) {
+                if (mix.containsKey(key) != present[slot]) {
+                    mismatches++;
+                }
+            } else {
+                Integer removed = mix.remove(key);
+                Integer want = present[slot] ? model[slot] : null;
+                if ((removed == null) != (want == null)
+                        || (removed != null && !removed.equals(want))) {
+                    mismatches++;
+                }
+                if (present[slot]) {
+                    modelSize--;
+                }
+                present[slot] = false;
+                model[slot] = null;
+            }
+            if (mix.size() != modelSize) {
+                mismatches++;
+            }
+        }
+        emit("opMix.mismatches", mismatches);
+        emit("opMix.size", mix.size());
+        emit("opMix.digest", digest(mix));
+        long reachable = 0;
+        for (int i = 0; i < universe; i++) {
+            if (present[i] && model[i].equals(mix.get(Integer.valueOf(i)))) {
+                reachable++;
+            }
+        }
+        emit("opMix.reachable", reachable);
+
+        // ---- clear -----------------------------------------------------------
+        mix.clear();
+        emit("clear.size", mix.size());
+        emit("clear.isEmpty", mix.isEmpty() ? 1 : 0);
+        emit("clear.keysEmpty", mix.keys().hasMoreElements() ? 1 : 0);
+        emit("clear.getAfter", mix.get(Integer.valueOf(0)) == null ? 1 : 0);
+        mix.put(Integer.valueOf(0), Integer.valueOf(77));
+        emit("clear.reusable", mix.get(Integer.valueOf(0)).intValue());
+
+        // ---- String keys, since that is how CN1 actually uses this -----------
+        Hashtable<String, String> strs = new Hashtable<String, String>();
+        for (int i = 0; i < 1000; i++) {
+            strs.put("Component.style.uiid." + i, "value" + i);
+        }
+        long strSum = 0;
+        long strXor = 0;
+        Iterator<Map.Entry<String, String>> si = strs.entrySet().iterator();
+        while (si.hasNext()) {
+            Map.Entry<String, String> e = si.next();
+            long mixv = e.getKey().hashCode() * 31L + e.getValue().hashCode();
+            strSum += mixv;
+            strXor ^= mixv * 17 + 3;
+        }
+        emit("strings.size", strs.size());
+        emit("strings.sum", strSum);
+        emit("strings.xor", strXor);
+        emit("strings.get", strs.get("Component.style.uiid.500").equals("value500") ? 1 : 0);
+        emit("strings.removeAll", strs.remove("Component.style.uiid.0") != null ? 1 : 0);
+    }
+}

--- a/vm/benchmarks/src/com/bench/HtTorture.java
+++ b/vm/benchmarks/src/com/bench/HtTorture.java
@@ -145,6 +145,25 @@ public class HtTorture {
         emit("tight.size", tight.size());
         emit("tight.digest", digest(tight));
 
+        // A load factor BELOW 0.5. The growth rule used to test capacity
+        // directly, which assumed 0.5 or more and rebuilt the table at the same
+        // size forever below that; nothing with a default load factor can see
+        // it, which is why this case is here explicitly.
+        Hashtable<Integer, Integer> sparse = new Hashtable<Integer, Integer>(4, 0.25f);
+        for (int i = 0; i < 3000; i++) {
+            sparse.put(Integer.valueOf(i * 3), Integer.valueOf(i));
+        }
+        emit("sparse.size", sparse.size());
+        emit("sparse.digest", digest(sparse));
+        long sparseFound = 0;
+        for (int i = 0; i < 3000; i++) {
+            Integer v = sparse.get(Integer.valueOf(i * 3));
+            if (v != null && v.intValue() == i) {
+                sparseFound++;
+            }
+        }
+        emit("sparse.allFound", sparseFound);
+
         // ---- Enumerations (the Dictionary half) -----------------------------
         long keySum = 0;
         long keyXor = 0;

--- a/vm/benchmarks/src/com/bench/IdmProbe.java
+++ b/vm/benchmarks/src/com/bench/IdmProbe.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.bench;
+
+/**
+ * Diagnostic, not a benchmark: reports what IdentityHashMap's indexing actually
+ * does to REAL identity hash codes on whichever VM runs it.
+ *
+ * <p>A host-side simulation cannot answer this. ParparVM's
+ * {@code System.identityHashCode} is a truncated object address, so the input
+ * distribution is a property of the allocator -- BiBOP slot size, page layout,
+ * allocation order -- and exists only on the target. This allocates the keys the
+ * same way the workload does, harvests their real hashes, and replays several
+ * indexing schemes over them.
+ *
+ * <p>Prints, per scheme: the fraction of distinct home slots (how much of the
+ * table the hash can even reach), and the average probe length for a build and
+ * for a random successful lookup.
+ */
+public final class IdmProbe {
+
+    /** the shipped-before-2026 scheme: modulo a non-power-of-two, no scramble. */
+    static int oldIndex(int h, int len) {
+        return ((h & 0x7FFFFFFF) % (len / 2)) * 2;
+    }
+
+    /** power-of-two mask, JDK scramble (h * -254). */
+    static int newIndex(int h, int len) {
+        return ((h << 1) - (h << 8)) & (len - 1);
+    }
+
+    /** power-of-two mask, NO scramble -- isolates what the multiply is worth. */
+    static int rawIndex(int h, int len) {
+        return (h & 0x7FFFFFFF) & (len - 1) & ~1;
+    }
+
+    /** fold the high half down, then mask. */
+    static int foldIndex(int h, int len) {
+        h ^= (h >>> 16);
+        return h & (len - 1) & ~1;
+    }
+
+    /** fold, then Fibonacci multiply, then fold again. */
+    static int mixIndex(int h, int len) {
+        h ^= (h >>> 16);
+        h *= 0x9E3779B1;
+        h ^= (h >>> 16);
+        return h & (len - 1) & ~1;
+    }
+
+    /** Fibonacci multiply then fold (one fold). */
+    static int fibIndex(int h, int len) {
+        h *= 0x9E3779B1;
+        h ^= (h >>> 16);
+        return h & (len - 1) & ~1;
+    }
+
+    static int index(int h, int len, int scheme) {
+        switch (scheme) {
+            case 0: return oldIndex(h, len);
+            case 1: return newIndex(h, len);
+            case 2: return rawIndex(h, len);
+            case 3: return foldIndex(h, len);
+            case 4: return mixIndex(h, len);
+            default: return fibIndex(h, len);
+        }
+    }
+
+    /** Fills a table with the hashes; returns {buildProbes, distinctHomeSlots}. */
+    static long[] build(int[] hashes, int len, int scheme, int[] table) {
+        for (int i = 0; i < len; i++) {
+            table[i] = 0;
+        }
+        boolean[] home = new boolean[len];
+        long probes = 0;
+        int mask = len - 1;
+        for (int k = 0; k < hashes.length; k++) {
+            int h = hashes[k];
+            int start = index(h, len, scheme);
+            home[start] = true;
+            int i = start;
+            int n = 1;
+            while (table[i] != 0) {
+                i = scheme == 0 ? (i + 2) % len : (i + 2) & mask;
+                n++;
+            }
+            table[i] = h == 0 ? 1 : h;
+            probes += n;
+        }
+        long distinct = 0;
+        for (int i = 0; i < len; i++) {
+            if (home[i]) {
+                distinct++;
+            }
+        }
+        return new long[] { probes, distinct };
+    }
+
+    static long lookupProbes(int[] hashes, int len, int scheme, int[] table) {
+        long probes = 0;
+        int mask = len - 1;
+        int r = 7;
+        for (int t = 0; t < 200000; t++) {
+            r ^= r << 13;
+            r ^= r >>> 17;
+            r ^= r << 5;
+            int h = hashes[(r >>> 1) % hashes.length];
+            int want = h == 0 ? 1 : h;
+            int i = index(h, len, scheme);
+            int n = 1;
+            while (table[i] != want && table[i] != 0) {
+                i = scheme == 0 ? (i + 2) % len : (i + 2) & mask;
+                n++;
+            }
+            probes += n;
+        }
+        return probes;
+    }
+
+    static void report(String name, int[] hashes, int len, int scheme) {
+        int[] table = new int[len];
+        long[] b = build(hashes, len, scheme, table);
+        long look = lookupProbes(hashes, len, scheme, table);
+        System.out.println(name
+                + " len=" + len
+                + " homeSlots=" + b[1] + "/" + (len / 2)
+                + " buildProbes/key=" + (b[0] * 100 / hashes.length) / 100.0
+                + " lookupProbes/key=" + (look * 100 / 200000) / 100.0);
+    }
+
+    public static void main(String[] args) {
+        int n = 50000;
+        Object[] keys = new Object[n];
+        int[] hashes = new int[n];
+        for (int i = 0; i < n; i++) {
+            keys[i] = new Object();
+        }
+        for (int i = 0; i < n; i++) {
+            hashes[i] = System.identityHashCode(keys[i]);
+        }
+
+        // What do the raw hashes even look like?
+        int orAll = 0;
+        int andAll = -1;
+        for (int i = 0; i < n; i++) {
+            orAll |= hashes[i];
+            andAll &= hashes[i];
+        }
+        int alignZeros = 0;
+        while (alignZeros < 31 && (orAll & (1 << alignZeros)) == 0) {
+            alignZeros++;
+        }
+        System.out.println("identityHashCode: alwaysZeroLowBits=" + alignZeros
+                + " (i.e. addresses are " + (1 << alignZeros) + "-byte aligned)");
+
+        // Old sizing was (threshold*10000/7500)*2 with no rounding; new sizing
+        // rounds that up to a power of two.
+        int oldLen = (int) (((long) n * 10000) / 7500) * 2;
+        int newLen = 8;
+        while (newLen < oldLen) {
+            newLen <<= 1;
+        }
+        int tightLen = newLen >> 1;
+
+        System.out.println("-- at the OLD array size (" + oldLen + " cells) --");
+        report("old   modulo, no scramble   ", hashes, oldLen, 0);
+        System.out.println("-- at a power-of-two size matched to the old one (" + tightLen + " cells) --");
+        report("jdk   h*-254                ", hashes, tightLen, 1);
+        report("raw   no scramble           ", hashes, tightLen, 2);
+        report("fold  h^=h>>>16             ", hashes, tightLen, 3);
+        report("mix   fold,*phi,fold        ", hashes, tightLen, 4);
+        report("fib   *phi,fold             ", hashes, tightLen, 5);
+        System.out.println("-- at the next power of two up (" + newLen + " cells) --");
+        report("fold  h^=h>>>16             ", hashes, newLen, 3);
+        report("mix   fold,*phi,fold        ", hashes, newLen, 4);
+    }
+
+    private IdmProbe() {
+    }
+}

--- a/vm/benchmarks/src/com/bench/IdmTorture.java
+++ b/vm/benchmarks/src/com/bench/IdmTorture.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.bench;
+
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Semantic torture for {@link IdentityHashMap}, comparable byte-for-byte
+ * against HotSpot.
+ *
+ * <p>Two things make this map awkward to compare across VMs, and both are
+ * designed around here:
+ *
+ * <ul>
+ * <li><b>Identity hash codes differ by construction</b> (ParparVM's is a
+ * truncated object address), so iteration order differs and every aggregation
+ * below is ORDER-INDEPENDENT -- separate {@code +} and {@code ^} accumulators,
+ * each of which commutes.
+ * <li><b>The keys cannot be bare Objects</b>, because a digest then has nothing
+ * stable to hash. {@link K} carries an {@code id} the digest can use, and is
+ * deliberately given {@code equals}/{@code hashCode} by id so that two distinct
+ * {@code K(5)} instances are EQUAL yet must remain SEPARATE keys -- the defining
+ * property of this map, and the one a String- or Integer-keyed test cannot
+ * check.
+ * </ul>
+ *
+ * <p>Covers: put/get/remove/containsKey/containsValue/clear/size, null key and
+ * null value, equal-but-distinct keys, growth across several rehashes, the
+ * backward-shift relocation on remove (which is what a wrong probe index
+ * corrupts most quietly), keySet/values/entrySet iteration and removal through
+ * views, putAll, and a PRNG op mix replayed against a plain array model.
+ */
+public class IdmTorture {
+    static int seed = 0x1234567;
+
+    static int rnd(int bound) {
+        seed = seed * 1103515245 + 12345;
+        return (seed >>> 16) % bound;
+    }
+
+    /** A key with a stable payload, equal by id but distinct by identity. */
+    static final class K {
+        final int id;
+
+        K(int id) {
+            this.id = id;
+        }
+
+        public boolean equals(Object o) {
+            return (o instanceof K) && ((K) o).id == id;
+        }
+
+        public int hashCode() {
+            return id;
+        }
+    }
+
+    /** order-independent digest over (key id, value) pairs. */
+    static long digest(Map<K, Integer> m) {
+        long sum = 0;
+        long xor = 0;
+        Iterator<Map.Entry<K, Integer>> it = m.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<K, Integer> e = it.next();
+            long k = e.getKey() == null ? -7 : e.getKey().id;
+            long v = e.getValue() == null ? -13 : e.getValue().intValue();
+            long mix = (k * 0x9E3779B97F4A7C15L) ^ (v * 0xC2B2AE3D27D4EB4FL);
+            sum += mix;
+            xor ^= mix * 31 + 17;
+        }
+        return sum * 31 + xor + m.size();
+    }
+
+    static void emit(String label, long value) {
+        System.out.println(label + "=" + value);
+    }
+
+    public static void main(String[] args) {
+        // ---- equal-but-distinct keys stay separate --------------------------
+        IdentityHashMap<K, Integer> id = new IdentityHashMap<K, Integer>();
+        K a = new K(5);
+        K b = new K(5);
+        id.put(a, Integer.valueOf(1));
+        id.put(b, Integer.valueOf(2));
+        emit("distinctEqualKeys.size", id.size());
+        emit("distinctEqualKeys.a", id.get(a).intValue());
+        emit("distinctEqualKeys.b", id.get(b).intValue());
+        emit("distinctEqualKeys.containsA", id.containsKey(a) ? 1 : 0);
+        emit("distinctEqualKeys.containsFresh", id.containsKey(new K(5)) ? 1 : 0);
+        // replacing through the SAME reference must overwrite, not add
+        id.put(a, Integer.valueOf(9));
+        emit("distinctEqualKeys.afterReplace.size", id.size());
+        emit("distinctEqualKeys.afterReplace.a", id.get(a).intValue());
+
+        // ---- null key and null value ---------------------------------------
+        IdentityHashMap<K, Integer> nulls = new IdentityHashMap<K, Integer>();
+        nulls.put(null, Integer.valueOf(42));
+        nulls.put(new K(1), null);
+        emit("nulls.size", nulls.size());
+        emit("nulls.nullKey", nulls.get(null).intValue());
+        emit("nulls.containsNullKey", nulls.containsKey(null) ? 1 : 0);
+        emit("nulls.containsNullValue", nulls.containsValue(null) ? 1 : 0);
+        emit("nulls.removeNullKey", nulls.remove(null).intValue());
+        emit("nulls.afterRemove.size", nulls.size());
+
+        // ---- growth across several rehashes --------------------------------
+        int n = 4000;
+        K[] keys = new K[n];
+        IdentityHashMap<K, Integer> grow = new IdentityHashMap<K, Integer>();
+        for (int i = 0; i < n; i++) {
+            keys[i] = new K(i);
+            grow.put(keys[i], Integer.valueOf(i * 3));
+        }
+        emit("grow.size", grow.size());
+        emit("grow.digest", digest(grow));
+        long found = 0;
+        for (int i = 0; i < n; i++) {
+            Integer v = grow.get(keys[i]);
+            if (v != null && v.intValue() == i * 3) {
+                found++;
+            }
+        }
+        emit("grow.allFound", found);
+
+        // ---- remove churn: the backward-shift relocation --------------------
+        // Every removal shifts a following entry back over the hole when that
+        // entry probed past it. Get the index arithmetic wrong and a key that
+        // is still present becomes unreachable -- silently, and only for some
+        // keys, which is why this re-checks EVERY survivor after every pass.
+        long survivors = 0;
+        for (int pass = 0; pass < 3; pass++) {
+            for (int i = pass; i < n; i += 3) {
+                grow.remove(keys[i]);
+            }
+            for (int i = 0; i < n; i++) {
+                if (grow.containsKey(keys[i])) {
+                    survivors++;
+                }
+            }
+            emit("removeChurn.pass" + pass + ".size", grow.size());
+            emit("removeChurn.pass" + pass + ".digest", digest(grow));
+        }
+        emit("removeChurn.survivors", survivors);
+
+        // ---- interleaved remove/put (relocation under reuse) ----------------
+        IdentityHashMap<K, Integer> churn = new IdentityHashMap<K, Integer>();
+        int live = 600;
+        K[] ck = new K[live * 3];
+        for (int i = 0; i < ck.length; i++) {
+            ck[i] = new K(i);
+        }
+        for (int i = 0; i < live; i++) {
+            churn.put(ck[i], Integer.valueOf(i));
+        }
+        for (int i = 0; i < live * 2; i++) {
+            churn.put(ck[(i + live) % ck.length], Integer.valueOf(i));
+            churn.remove(ck[i % ck.length]);
+        }
+        emit("interleaved.size", churn.size());
+        emit("interleaved.digest", digest(churn));
+
+        // ---- views ----------------------------------------------------------
+        IdentityHashMap<K, Integer> views = new IdentityHashMap<K, Integer>();
+        K[] vk = new K[200];
+        for (int i = 0; i < vk.length; i++) {
+            vk[i] = new K(i);
+            views.put(vk[i], Integer.valueOf(i));
+        }
+        long keySum = 0;
+        Iterator<K> ki = views.keySet().iterator();
+        while (ki.hasNext()) {
+            keySum += ki.next().id;
+        }
+        emit("views.keySum", keySum);
+        long valSum = 0;
+        Iterator<Integer> vi = views.values().iterator();
+        while (vi.hasNext()) {
+            valSum += vi.next().intValue();
+        }
+        emit("views.valSum", valSum);
+        // removal through the entrySet iterator
+        Iterator<Map.Entry<K, Integer>> ei = views.entrySet().iterator();
+        while (ei.hasNext()) {
+            if ((ei.next().getKey().id & 1) == 0) {
+                ei.remove();
+            }
+        }
+        emit("views.afterIteratorRemove.size", views.size());
+        emit("views.afterIteratorRemove.digest", digest(views));
+        // removal through keySet
+        views.keySet().remove(vk[3]);
+        emit("views.afterKeySetRemove.size", views.size());
+        emit("views.containsRemoved", views.containsKey(vk[3]) ? 1 : 0);
+
+        // ---- putAll ---------------------------------------------------------
+        IdentityHashMap<K, Integer> src = new IdentityHashMap<K, Integer>();
+        K[] pk = new K[500];
+        for (int i = 0; i < pk.length; i++) {
+            pk[i] = new K(i * 7);
+            src.put(pk[i], Integer.valueOf(i));
+        }
+        IdentityHashMap<K, Integer> dst = new IdentityHashMap<K, Integer>();
+        dst.putAll(src);
+        emit("putAll.size", dst.size());
+        emit("putAll.digest", digest(dst));
+        emit("putAll.copyCtor.digest", digest(new IdentityHashMap<K, Integer>(src)));
+
+        // ---- PRNG op mix, replayed against a plain array model --------------
+        // The model is deliberately dumb -- linear scan over parallel arrays,
+        // compared with == -- so it shares no code or assumption with the map.
+        int universe = 1500;
+        K[] uk = new K[universe];
+        for (int i = 0; i < universe; i++) {
+            uk[i] = new K(i);
+        }
+        Integer[] model = new Integer[universe];
+        boolean[] present = new boolean[universe];
+        IdentityHashMap<K, Integer> mix = new IdentityHashMap<K, Integer>();
+        long mismatches = 0;
+        long modelSize = 0;
+        for (int op = 0; op < 60000; op++) {
+            int slot = rnd(universe);
+            int kind = rnd(10);
+            if (kind < 5) {
+                Integer v = Integer.valueOf(op);
+                Integer prev = mix.put(uk[slot], v);
+                Integer modelPrev = present[slot] ? model[slot] : null;
+                if (prev != modelPrev) {
+                    mismatches++;
+                }
+                if (!present[slot]) {
+                    modelSize++;
+                }
+                present[slot] = true;
+                model[slot] = v;
+            } else if (kind < 7) {
+                Integer got = mix.get(uk[slot]);
+                Integer want = present[slot] ? model[slot] : null;
+                if (got != want) {
+                    mismatches++;
+                }
+            } else if (kind < 8) {
+                if (mix.containsKey(uk[slot]) != present[slot]) {
+                    mismatches++;
+                }
+            } else {
+                Integer removed = mix.remove(uk[slot]);
+                Integer want = present[slot] ? model[slot] : null;
+                if (removed != want) {
+                    mismatches++;
+                }
+                if (present[slot]) {
+                    modelSize--;
+                }
+                present[slot] = false;
+                model[slot] = null;
+            }
+            if (mix.size() != modelSize) {
+                mismatches++;
+            }
+        }
+        emit("opMix.mismatches", mismatches);
+        emit("opMix.size", mix.size());
+        emit("opMix.digest", digest(mix));
+
+        // every surviving key must still be reachable
+        long reachable = 0;
+        for (int i = 0; i < universe; i++) {
+            if (present[i] && mix.get(uk[i]) == model[i]) {
+                reachable++;
+            }
+        }
+        emit("opMix.reachable", reachable);
+
+        // ---- clear ----------------------------------------------------------
+        mix.clear();
+        emit("clear.size", mix.size());
+        emit("clear.isEmpty", mix.isEmpty() ? 1 : 0);
+        emit("clear.getAfter", mix.get(uk[0]) == null ? 1 : 0);
+        mix.put(uk[0], Integer.valueOf(77));
+        emit("clear.reusable", mix.get(uk[0]).intValue());
+    }
+}

--- a/vm/benchmarks/src/com/bench/MapBench.java
+++ b/vm/benchmarks/src/com/bench/MapBench.java
@@ -327,6 +327,29 @@ public final class MapBench {
         return checksum;
     }
 
+    // ---- 11. low load factor build ---------------------------------------
+    // The regression guard for the growth rule. A table asked for a load factor
+    // below 0.5 used to reach its threshold while still less than half full,
+    // rebuild at the SAME capacity, and so rebuild again on the very next put:
+    // 20000 inserts cost 19999 full rebuilds and 200 million rehashed entries.
+    // Nothing at a default load factor can see that, so it needs its own shape.
+    public static long lowLoadFactorBuild() {
+        int perRound = 20000;
+        Integer[] keys = new Integer[perRound];
+        for (int i = 0; i < perRound; i++) {
+            keys[i] = Integer.valueOf(i);
+        }
+        long checksum = 0;
+        for (int round = 0; round < 20; round++) {
+            HashMap<Integer, Integer> map = new HashMap<Integer, Integer>(16, 0.25f);
+            for (int i = 0; i < perRound; i++) {
+                map.put(keys[i], keys[i]);
+            }
+            checksum += map.size();
+        }
+        return checksum;
+    }
+
     private static final int WARMUP = 3;
     private static final int MEASURE = 5;
 
@@ -380,6 +403,9 @@ public final class MapBench {
         });
         runBench("identityMapBuild", new BenchFn() {
             public long run() { return identityMapBuild(); }
+        });
+        runBench("lowLoadFactorBuild", new BenchFn() {
+            public long run() { return lowLoadFactorBuild(); }
         });
         System.out.println("DONE");
     }

--- a/vm/benchmarks/src/com/bench/MapBench.java
+++ b/vm/benchmarks/src/com/bench/MapBench.java
@@ -1,0 +1,389 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.bench;
+
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Map-shaped workloads that {@code CommonWorkloads.hashMapChurn} does not reach.
+ *
+ * <p>These live OUTSIDE {@code CommonWorkloads} on purpose: that class is the
+ * ten-benchmark set every generated port application runs, and
+ * {@code scripts/hellocodenameone/conformance/port_status.py} enforces exactly
+ * ten unique ids. This class is driven only by {@code vm/benchmarks}.
+ *
+ * <p>Two rules govern every workload here:
+ * <ul>
+ * <li><b>Checksums must not depend on iteration order or on hash VALUES.</b>
+ * ParparVM's open-addressed map and HotSpot's chained map enumerate in
+ * different orders, and identity hash codes differ by construction, so a
+ * checksum is only ever a sum or a count over lookups the workload chose.
+ * <li><b>Keys are pre-boxed into arrays.</b> {@code Integer.valueOf} allocates
+ * above 127 on HotSpot and never allocates on ParparVM (tagged immediates), so
+ * boxing inside the timed loop would measure the allocator rather than the
+ * probe. Every shape below hoists that out.
+ * </ul>
+ */
+public final class MapBench {
+
+    /** xorshift32; identical on both VMs, and cheap enough not to dominate. */
+    private static int rnd(int x) {
+        x ^= x << 13;
+        x ^= x >>> 17;
+        x ^= x << 5;
+        return x;
+    }
+
+    // ---- 1. miss-heavy containsKey ----------------------------------------
+    // The case linear probing is worst at: an unsuccessful probe walks to the
+    // terminating empty slot, ~8.5 slots at a 0.75 load factor against ~2.5 for
+    // a hit. If SIMD group probing is worth anything, it is worth it here.
+    public static long missHeavy() {
+        int present = 100000;
+        HashMap<Integer, Integer> map = new HashMap<Integer, Integer>();
+        Integer[] keys = new Integer[present * 10];
+        for (int i = 0; i < keys.length; i++) {
+            keys[i] = Integer.valueOf(i);
+        }
+        for (int i = 0; i < present; i++) {
+            map.put(keys[i], keys[i]);
+        }
+        long hits = 0;
+        int r = 12345;
+        for (int i = 0; i < 3000000; i++) {
+            r = rnd(r);
+            if (map.containsKey(keys[(r >>> 1) % keys.length])) {
+                hits++;
+            }
+        }
+        return hits;
+    }
+
+    // ---- 2. String-keyed lookup (the UIManager theme shape) ---------------
+    // A small, long-lived, string-keyed map read over and over. String caches
+    // its hash in a field, so this isolates probe + equals, not hashing --
+    // except that cn1HmMarker still reaches String.hashCode through an
+    // indirect virtual_ call, which is what makes this the lever-D shape.
+    public static long stringKeys() {
+        int distinct = 2000;
+        HashMap<String, Integer> map = new HashMap<String, Integer>();
+        String[] keys = new String[distinct];
+        for (int i = 0; i < distinct; i++) {
+            keys[i] = "Component.style.uiid." + i;
+            map.put(keys[i], Integer.valueOf(i));
+        }
+        long checksum = 0;
+        int r = 987654321;
+        for (int i = 0; i < 3000000; i++) {
+            r = rnd(r);
+            Integer v = map.get(keys[(r >>> 1) % distinct]);
+            if (v != null) {
+                checksum += v.intValue();
+            }
+        }
+        return checksum;
+    }
+
+    // ---- 3. large table, random hits -------------------------------------
+    // 1M entries: keys 8MB + values 8MB + meta 4MB, well past any L2. Every
+    // probe is a cache miss, which is where a 1-byte control word (4x less
+    // metadata traffic) would pay for itself if it ever does.
+    public static long largeTable() {
+        int n = 1000000;
+        HashMap<Integer, Integer> map = new HashMap<Integer, Integer>(n * 2);
+        Integer[] keys = new Integer[n];
+        for (int i = 0; i < n; i++) {
+            keys[i] = Integer.valueOf(i);
+            map.put(keys[i], keys[i]);
+        }
+        long checksum = 0;
+        int r = 24680;
+        for (int i = 0; i < 2000000; i++) {
+            r = rnd(r);
+            Integer v = map.get(keys[(r >>> 1) % n]);
+            if (v != null) {
+                checksum += v.intValue();
+            }
+        }
+        return checksum;
+    }
+
+    // ---- 4. tombstone-heavy remove/insert --------------------------------
+    // Keeps live count flat while churning slots, so the table fills with
+    // tombstones between rebuilds. Linear probing degrades on tombstones (they
+    // do not terminate a probe); a swiss table can convert a tombstone back to
+    // empty when its group has a free slot, which this shape would show.
+    public static long tombstones() {
+        int live = 50000;
+        HashMap<Integer, Integer> map = new HashMap<Integer, Integer>();
+        Integer[] keys = new Integer[live * 4];
+        for (int i = 0; i < keys.length; i++) {
+            keys[i] = Integer.valueOf(i);
+        }
+        for (int i = 0; i < live; i++) {
+            map.put(keys[i], keys[i]);
+        }
+        long checksum = 0;
+        for (int i = 0; i < 1500000; i++) {
+            Integer add = keys[(i + live) % keys.length];
+            Integer drop = keys[i % keys.length];
+            map.put(add, add);
+            Integer removed = map.remove(drop);
+            if (removed != null) {
+                checksum += removed.intValue();
+            }
+        }
+        return checksum + map.size();
+    }
+
+    // ---- 5. grow-dominated build ------------------------------------------
+    // Builds from an empty default-capacity map every round, so the run is
+    // dominated by cn1Grow. This is the shape that PRICES a swiss layout: the
+    // current int[] meta rehashes by reusing the stored marker and makes zero
+    // hashCode() calls on resize, while a 7-bit control byte forces one virtual
+    // hashCode() per live key per grow.
+    public static long growBuild() {
+        int perRound = 20000;
+        Integer[] keys = new Integer[perRound];
+        for (int i = 0; i < perRound; i++) {
+            keys[i] = Integer.valueOf(i);
+        }
+        long checksum = 0;
+        for (int round = 0; round < 120; round++) {
+            HashMap<Integer, Integer> map = new HashMap<Integer, Integer>();
+            for (int i = 0; i < perRound; i++) {
+                map.put(keys[i], keys[i]);
+            }
+            checksum += map.size();
+        }
+        return checksum;
+    }
+
+    // ---- 6. identity-keyed lookup ----------------------------------------
+    // Object.hashCode is a truncated raw pointer with no header cache, and
+    // BiBOP slots are size-class aligned, so the low bits are structurally
+    // non-random. Any h2 derivation that narrows the hash has to survive THIS
+    // shape, not just Integer and String keys.
+    //
+    // The checksum is a HIT COUNT, never a sum of hashes -- identity hash codes
+    // legitimately differ between the two VMs.
+    public static long identityKeys() {
+        int n = 50000;
+        Object[] keys = new Object[n];
+        HashMap<Object, Integer> map = new HashMap<Object, Integer>();
+        for (int i = 0; i < n; i++) {
+            keys[i] = new Object();
+            map.put(keys[i], Integer.valueOf(i));
+        }
+        long hits = 0;
+        int r = 1357911;
+        for (int i = 0; i < 2000000; i++) {
+            r = rnd(r);
+            if (map.get(keys[(r >>> 1) % n]) != null) {
+                hits++;
+            }
+        }
+        return hits;
+    }
+
+    // ---- 7. LinkedHashMap lookup (lever E) --------------------------------
+    // Same shape as stringKeys, but LinkedHashMap overrides get/put/remove in
+    // JAVA -- the native HashMap functions are deliberately base-class-only.
+    // The ratio between this and stringKeys is the cost of that gap.
+    public static long linkedStringKeys() {
+        int distinct = 2000;
+        LinkedHashMap<String, Integer> map = new LinkedHashMap<String, Integer>();
+        String[] keys = new String[distinct];
+        for (int i = 0; i < distinct; i++) {
+            keys[i] = "Component.style.uiid." + i;
+            map.put(keys[i], Integer.valueOf(i));
+        }
+        long checksum = 0;
+        int r = 987654321;
+        for (int i = 0; i < 3000000; i++) {
+            r = rnd(r);
+            Integer v = map.get(keys[(r >>> 1) % distinct]);
+            if (v != null) {
+                checksum += v.intValue();
+            }
+        }
+        return checksum;
+    }
+
+    // ---- 8. Hashtable lookup (lever C) ------------------------------------
+    // Same shape again. Hashtable never got the compact layout: one Entry
+    // object per mapping, chain walking, synchronized accessors, and a bucket
+    // index computed with % (integer division) rather than a mask.
+    public static long hashtableStringKeys() {
+        int distinct = 2000;
+        Hashtable<String, Integer> map = new Hashtable<String, Integer>();
+        String[] keys = new String[distinct];
+        for (int i = 0; i < distinct; i++) {
+            keys[i] = "Component.style.uiid." + i;
+            map.put(keys[i], Integer.valueOf(i));
+        }
+        long checksum = 0;
+        int r = 987654321;
+        for (int i = 0; i < 3000000; i++) {
+            r = rnd(r);
+            Integer v = map.get(keys[(r >>> 1) % distinct]);
+            if (v != null) {
+                checksum += v.intValue();
+            }
+        }
+        return checksum;
+    }
+
+    // ---- 9. Hashtable build (lever C, allocation half) --------------------
+    // One Entry allocation per mapping is the other half of Hashtable's cost;
+    // this shape is what JSONParser's map-per-object-node actually looks like.
+    public static long hashtableBuild() {
+        int perRound = 20000;
+        Integer[] keys = new Integer[perRound];
+        for (int i = 0; i < perRound; i++) {
+            keys[i] = Integer.valueOf(i);
+        }
+        long checksum = 0;
+        for (int round = 0; round < 120; round++) {
+            Map<Integer, Integer> map = new Hashtable<Integer, Integer>();
+            for (int i = 0; i < perRound; i++) {
+                map.put(keys[i], keys[i]);
+            }
+            checksum += map.size();
+        }
+        return checksum;
+    }
+
+    // ---- 10. IdentityHashMap ---------------------------------------------
+    // Its own open-addressed table, and its own hazard: getModuloHash feeds
+    // System.identityHashCode straight into a modulo with no scramble, and an
+    // identity hash here is a truncated pointer whose low bits carry the
+    // allocator's slot alignment rather than entropy. Probing is linear
+    // (index + 2), so any home-slot bias turns into a cluster walk.
+    //
+    // The checksum is a HIT COUNT: identity hashes, and therefore this map's
+    // iteration order, legitimately differ between the two VMs.
+    public static long identityMapLookup() {
+        int n = 50000;
+        Object[] keys = new Object[n];
+        java.util.IdentityHashMap<Object, Integer> map =
+                new java.util.IdentityHashMap<Object, Integer>(n);
+        for (int i = 0; i < n; i++) {
+            keys[i] = new Object();
+            map.put(keys[i], Integer.valueOf(i));
+        }
+        long hits = 0;
+        int r = 24681357;
+        for (int i = 0; i < 500000; i++) {
+            r = rnd(r);
+            if (map.get(keys[(r >>> 1) % n]) != null) {
+                hits++;
+            }
+        }
+        return hits;
+    }
+
+    // Build-dominated: grows from the default capacity, so every rehash
+    // re-probes every live key.
+    public static long identityMapBuild() {
+        int n = 20000;
+        Object[] keys = new Object[n];
+        for (int i = 0; i < n; i++) {
+            keys[i] = new Object();
+        }
+        long checksum = 0;
+        for (int round = 0; round < 20; round++) {
+            java.util.IdentityHashMap<Object, Integer> map =
+                    new java.util.IdentityHashMap<Object, Integer>();
+            for (int i = 0; i < n; i++) {
+                map.put(keys[i], Integer.valueOf(i));
+            }
+            checksum += map.size();
+        }
+        return checksum;
+    }
+
+    private static final int WARMUP = 3;
+    private static final int MEASURE = 5;
+
+    private interface BenchFn {
+        long run();
+    }
+
+    private static void runBench(String name, BenchFn fn) {
+        for (int warmup = 0; warmup < WARMUP; warmup++) {
+            fn.run();
+        }
+        for (int repetition = 0; repetition < MEASURE; repetition++) {
+            long started = System.nanoTime();
+            long checksum = fn.run();
+            long elapsed = System.nanoTime() - started;
+            System.out.println("BENCH " + name + " rep " + repetition
+                    + " ns=" + elapsed + " checksum=" + checksum);
+        }
+    }
+
+    public static void main(String[] args) {
+        runBench("missHeavy", new BenchFn() {
+            public long run() { return missHeavy(); }
+        });
+        runBench("stringKeys", new BenchFn() {
+            public long run() { return stringKeys(); }
+        });
+        runBench("largeTable", new BenchFn() {
+            public long run() { return largeTable(); }
+        });
+        runBench("tombstones", new BenchFn() {
+            public long run() { return tombstones(); }
+        });
+        runBench("growBuild", new BenchFn() {
+            public long run() { return growBuild(); }
+        });
+        runBench("identityKeys", new BenchFn() {
+            public long run() { return identityKeys(); }
+        });
+        runBench("linkedStringKeys", new BenchFn() {
+            public long run() { return linkedStringKeys(); }
+        });
+        runBench("hashtableStringKeys", new BenchFn() {
+            public long run() { return hashtableStringKeys(); }
+        });
+        runBench("hashtableBuild", new BenchFn() {
+            public long run() { return hashtableBuild(); }
+        });
+        runBench("identityMapLookup", new BenchFn() {
+            public long run() { return identityMapLookup(); }
+        });
+        runBench("identityMapBuild", new BenchFn() {
+            public long run() { return identityMapBuild(); }
+        });
+        System.out.println("DONE");
+    }
+
+    private MapBench() {
+    }
+}


### PR DESCRIPTION
Rationale lives in the code comments and in `vm/CLAUDE.md`; this is the summary.

## The bug

`java.util.HashMap` on ParparVM is open addressed with linear probing, and `cn1Marker` spreads the hash with the JDK's `h ^= h >>> 16` -- a spread designed for a **chained** map, where colliding keys share a bucket and clustering costs nothing. `Integer.hashCode()` is the value itself, so a dense key range (ids from zero, epoch seconds, counters, indices) lands at `slot == value`: one contiguous run with no gap. Linear probing then walked that whole run for any probe that entered it and did not find its key.

Average probe length for a **miss**:

| entries | before | after |
|---|---|---|
| 20,000 | 2,547 | 1.39 |
| 100,000 | 16,742 | 1.53 |
| 1,000,000 | 222,721 | 1.98 |

O(n) per unsuccessful lookup, reaching `get` returning null, `containsKey` returning false, and `put` of a key not adjacent to the run. 3M `containsKey` calls against a 100k map took **32.7 seconds**, against 49.9ms on HotSpot.

**Hits stayed at exactly one probe throughout**, which is why `hashMapChurn` -- get and put on keys that are present -- reported a healthy 1.12x the entire time it existed.

## The fix

The probe **sequence**, not the spread (CPython's dict recurrence). Scrambling the hash was tried first and rejected on measurement: it fixes the miss but destroys the sequential placement, and dense-key build/scan shapes regressed 1.8x-2.2x -- HotSpot's `HashMap` gets that same locality from that same weak spread. Keeping the first probe at `marker & mask` and perturbing only the steps after it keeps the locality and still leaves the run at once.

## Measured, interleaved best-of-N, all checksums bit-identical

| bench | before | after |
|---|---|---|
| missHeavy | 32,698 ms | 44.9 ms (728x) |
| tombstones | 7,781 ms | 16.5 ms (471x) |
| stringKeys | 33.6 ms | 25.5 ms |
| linkedStringKeys | 37.1 ms | 31.0 ms |
| largeTable | 26.6 ms | 33.3 ms (the cost) |
| hashtableBuild | 167.8 ms | 96.6 ms |
| identityMapLookup | 13.4 ms | 5.0 ms |
| identityMapBuild | 26.1 ms | 9.8 ms |

`vm/benchmarks` geomean moved 1.005, i.e. not at all.

## Hashtable

Given the compact layout it never received: no `Entry` per mapping, a power-of-two mask instead of the `%` integer division it did on every operation, and the same perturbed probe. Build 1.74x.

Lookup only 1.09x, and that is the useful part: with identical probe code `Hashtable` is still 3x `HashMap` on the same workload, and the difference is `synchronized`. This VM keeps monitors in an address-keyed side table rather than an object header word, so an uncontended accessor costs more than the whole lookup. Further work there belongs on the monitor, not the map.

## IdentityHashMap

**Do not port HotSpot's hash function to this VM.** Copying `java.util.IdentityHashMap`'s made it measurably *slower*. HotSpot's `identityHashCode` is a scrambled per-object value; ours is a truncated object **address**, measured 32-byte aligned. The JDK's `(h << 1) - (h << 8)` is `h * -254` -- an **even** multiplier, so it preserves those five zero bits and adds a sixth: 2045 distinct home slots out of 65536, 12.73 probes per lookup. The old `%` survived only because a non-power-of-two modulus folds high bits back in as a side effect.

Folding explicitly (`h ^= h >>> 16`) reaches 50000/65536 slots and 1.00 probes. Adding a multiply on top makes it worse again (2.36) -- sequential allocation means sequential addresses, so one fold is already near a perfect hash. 2.65x on lookup and build.

Its `rehash()` overflow guard also turned an overflowed length into `1` -- an odd array length, which would have split every key from its value.

## Tests

- `MapBench` adds the shapes `hashMapChurn` cannot reach: miss-heavy, String-keyed, large-table, tombstone-heavy, grow-dominated, identity-keyed. Deliberately outside `CommonWorkloads`, which `port_status.py` pins at exactly ten ids.
- `HtTorture` (69 assertions) and `IdmTorture` join the gauntlet. **`HtTorture` was written and verified against the chained `Hashtable` before the rewrite** -- a torture that only ever runs against new code proves nothing. `IdmTorture` was verified non-vacuous by injecting a relocation off-by-one, which it caught.
- `IdmProbe` is a diagnostic, not a benchmark: it must run on the target, because the identity-hash distribution is a property of the allocator.

`GAUNTLET GREEN` (all tortures bit-identical to HotSpot), `vm/benchmarks` checksums bit-identical.

Also removes three dead constants from `parparvm_runtime.js`, two of which named `HashMap` fields the compact layout deleted.

## Not addressed

`LinkedHashMap` inherits the compact layout but overrides `get`/`put`/`remove`/`clear` in Java rather than native (the natives are deliberately base-class-only), which measures 1.21x over `HashMap` on the same shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
