### PR TITLE
Developer guide: document the promise API

### DIFF
--- a/CodenameOne/src/com/codename1/util/promise/Promise.java
+++ b/CodenameOne/src/com/codename1/util/promise/Promise.java
@@ -123,7 +123,10 @@ public class Promise<T> {
 
     }
 
-    /// The Promise.all() method takes an iterable of promises as an input, and returns a single Promise that resolves to an array of the results of the input promises. This returned promise will resolve when all of the input's promises have resolved, or if the input iterable contains no promises. It rejects immediately upon any of the input promises rejecting or non-promises throwing an error, and will reject with this first rejection message / error.
+    /// The Promise.all() method takes an iterable of promises as an input, and returns a single Promise that resolves to an array of the results of the input promises. This returned promise will resolve when all of the input's promises have resolved, or if the input iterable contains no promises. It rejects immediately upon any of the input promises rejecting or non-promises throwing an error. Note that
+    /// unlike the JavaScript original, when more than one input rejects the error reported is the last one
+    /// processed rather than the first: a rejection overwrites the stored error whatever state this promise is
+    /// already in.
     ///
     /// #### Parameters
     ///

--- a/CodenameOne/src/com/codename1/util/promise/Promise.java
+++ b/CodenameOne/src/com/codename1/util/promise/Promise.java
@@ -123,10 +123,10 @@ public class Promise<T> {
 
     }
 
-    /// The Promise.all() method takes an iterable of promises as an input, and returns a single Promise that resolves to an array of the results of the input promises. This returned promise will resolve when all of the input's promises have resolved, or if the input iterable contains no promises. It rejects immediately upon any of the input promises rejecting or non-promises throwing an error. Note that
-    /// unlike the JavaScript original, when more than one input rejects the error reported is the last one
-    /// processed rather than the first: a rejection overwrites the stored error whatever state this promise is
-    /// already in.
+    /// The Promise.all() method takes an iterable of promises as an input, and returns a single Promise that resolves to an array of the results of the input promises. This returned promise will resolve when all of the input's promises have resolved, or if the input iterable contains no promises. It rejects immediately upon any of the input promises rejecting or non-promises throwing an error. Unlike the
+    /// JavaScript original this makes no guarantee about WHICH error is reported when several inputs reject: a
+    /// handler already attached is called with the first, while one attached later reads the stored error, which
+    /// every subsequent rejection overwrites.
     ///
     /// #### Parameters
     ///

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PromisesJava001Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PromisesJava001Snippet.java
@@ -89,8 +89,13 @@ class PromisesJava001Snippet {
             resolve.call("hello");
         });
 
-        greeting.onSuccess(value -> Log.p(value))
-                .onFail(err -> Log.e((Throwable)err));
+        // ready() attaches both callbacks to this promise. Chaining
+        // onSuccess().onFail() instead would attach the failure handler to the
+        // promise onSuccess returns, which has already put the default casting
+        // rejection functor in the way
+        greeting.ready(
+                value -> Log.p(value),
+                err -> Log.e(err));
         // end::promises-java-001[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PromisesJava001Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PromisesJava001Snippet.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.util.promise.Promise;
+import com.codename1.util.promise.Functor;
+import java.util.*;
+
+
+class PromisesJava001Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    void snippet() throws Exception {
+        // tag::promises-java-001[]
+        Promise<String> greeting = new Promise<>((resolve, reject) -> {
+            // called once, on whatever thread you start the work from
+            Log.p("working");
+            resolve.call("hello");
+        });
+
+        greeting.onSuccess(value -> Log.p(value))
+                .onFail(err -> Log.e((Throwable)err));
+        // end::promises-java-001[]
+    }
+
+    com.codename1.util.AsyncResource<String> asyncCall() { return null; }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PromisesJava002Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PromisesJava002Snippet.java
@@ -96,8 +96,9 @@ class PromisesJava002Snippet {
                 // below on a failure
                 err -> { throw new RuntimeException((Throwable)err); })
             .then(upper -> "Hello " + upper)
-            .onSuccess(msg -> Log.p((String)msg))
-            .onFail(err -> Log.e((Throwable)err));
+            .ready(
+                msg -> Log.p((String)msg),
+                err -> Log.e((Throwable)err));
         // end::promises-java-002[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PromisesJava002Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PromisesJava002Snippet.java
@@ -86,10 +86,15 @@ class PromisesJava002Snippet {
         // then() pipes the return value of one step into the next, so each
         // Functor has to return something
         Promise<String> name = Promise.resolve("ada");
-        name.then(n -> ((String)n).toUpperCase())
+        name.then(
+                n -> ((String)n).toUpperCase(),
+                // handle the failure at the first step: a then() given no
+                // rejection functor installs one that casts to
+                // RuntimeException, which turns a checked reason into a
+                // ClassCastException further down
+                err -> { Log.e((Throwable)err); return null; })
             .then(upper -> "Hello " + upper)
-            .onSuccess(msg -> Log.p((String)msg))
-            .except(err -> { Log.e((Throwable)err); return null; });
+            .onSuccess(msg -> Log.p((String)msg));
         // end::promises-java-002[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PromisesJava002Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PromisesJava002Snippet.java
@@ -88,13 +88,16 @@ class PromisesJava002Snippet {
         Promise<String> name = Promise.resolve("ada");
         name.then(
                 n -> ((String)n).toUpperCase(),
-                // handle the failure at the first step: a then() given no
-                // rejection functor installs one that casts to
-                // RuntimeException, which turns a checked reason into a
-                // ClassCastException further down
-                err -> { Log.e((Throwable)err); return null; })
+                // a then() given no rejection functor installs one that casts
+                // to RuntimeException, turning a checked reason into a
+                // ClassCastException, so supply one. Rethrow wrapped rather
+                // than returning a value: anything returned here RESOLVES the
+                // rest of the chain, so returning null would run the steps
+                // below on a failure
+                err -> { throw new RuntimeException((Throwable)err); })
             .then(upper -> "Hello " + upper)
-            .onSuccess(msg -> Log.p((String)msg));
+            .onSuccess(msg -> Log.p((String)msg))
+            .onFail(err -> Log.e((Throwable)err));
         // end::promises-java-002[]
     }
 

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PromisesJava002Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PromisesJava002Snippet.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.util.promise.Promise;
+import com.codename1.util.promise.Functor;
+import java.util.*;
+
+
+class PromisesJava002Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    void snippet() throws Exception {
+        // tag::promises-java-002[]
+        // then() pipes the return value of one step into the next, so each
+        // Functor has to return something
+        Promise<String> name = Promise.resolve("ada");
+        name.then(n -> ((String)n).toUpperCase())
+            .then(upper -> "Hello " + upper)
+            .onSuccess(msg -> Log.p((String)msg))
+            .except(err -> { Log.e((Throwable)err); return null; });
+        // end::promises-java-002[]
+    }
+
+    com.codename1.util.AsyncResource<String> asyncCall() { return null; }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PromisesJava003Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PromisesJava003Snippet.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.util.promise.Promise;
+import com.codename1.util.promise.Functor;
+import java.util.*;
+
+
+class PromisesJava003Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    void snippet() throws Exception {
+        // tag::promises-java-003[]
+        Promise<String> a = Promise.resolve("one");
+        Promise<String> b = Promise.resolve("two");
+
+        // all() rejects the moment any input rejects
+        Promise.all(a, b).onSuccess(values -> Log.p("both arrived"));
+
+        // allSettled() waits for every input whatever the outcome
+        Promise.allSettled(a, b).onSuccess(results -> Log.p("all finished"));
+        // end::promises-java-003[]
+    }
+
+    com.codename1.util.AsyncResource<String> asyncCall() { return null; }
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PromisesJava004Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PromisesJava004Snippet.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.util.promise.Promise;
+import com.codename1.util.promise.Functor;
+import java.util.*;
+
+
+class PromisesJava004Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    void snippet() throws Exception {
+        // tag::promises-java-004[]
+        // an AsyncResource-returning API becomes a Promise
+        Promise<String> p = Promise.promisify(asyncCall());
+
+        // and back again, for an API that expects AsyncResource
+        com.codename1.util.AsyncResource<String> back = p.asAsyncResource();
+
+        // await() blocks with invokeAndBlock, so it is safe on the EDT; it
+        // throws AsyncResource.AsyncExecutionException if the promise rejected
+        String value = p.await();
+        Log.p(value + back.getClass().getName());
+        // end::promises-java-004[]
+    }
+
+    com.codename1.util.AsyncResource<String> asyncCall() { return null; }
+}

--- a/docs/developer-guide/Promises.asciidoc
+++ b/docs/developer-guide/Promises.asciidoc
@@ -14,9 +14,8 @@ chain instead of keeping it rejected, and returning `null` after a success
 replaces the value. Returning the incoming value keeps a
 successful chain unchanged, but it doesn't preserve a rejection: any non-promise
 return is treated as a result, so returning the `Throwable` fulfils the chain
-with it. To stay rejected, throw it, or return `Promise.reject(...)` -- a
-returned promise has its state adopted, and a thrown exception is caught and
-becomes the rejection.
+with it. To stay rejected, throw it: `processThens` catches
+whatever a functor throws and rejects the next promise with it.
 
 === Creating and consuming one
 
@@ -83,3 +82,9 @@ include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/g
 `await()` is the blocking form. It waits through `invokeAndBlock`, so calling it
 on the EDT doesn't freeze the UI, and it throws
 `AsyncResource.AsyncExecutionException` when the promise rejected.
+
+WARNING: A promise from `promisify` never settles if the underlying
+`AsyncResource` is cancelled. `AsyncResource.cancel` records the cancellation and
+notifies its observers without running the result callback `promisify`
+registered, so the promise stays `Pending` and an `await()` on it waits forever.
+Don't await a promise wrapping a resource something else can cancel.

--- a/docs/developer-guide/Promises.asciidoc
+++ b/docs/developer-guide/Promises.asciidoc
@@ -42,7 +42,11 @@ There are two families of callback and the difference is what they return.
 `then`, `except` and `always` take a `Functor`, whose return value becomes the
 input of the next step -- that's what makes a chain a pipeline. `onSuccess`,
 `onFail` and `onComplete` take a `SuccessCallback` instead, which returns
-nothing, so they suit the end of a chain where there is no value to pass on:
+nothing, so they suit the end of a chain where there is no value to pass on.
+Attach both outcomes with `ready(success, failure)` rather than chaining
+`onSuccess(...).onFail(...)`: the second form hangs the failure handler off the
+promise `onSuccess` returns, behind the default rejection functor described
+below:
 
 [source,java]
 ----

--- a/docs/developer-guide/Promises.asciidoc
+++ b/docs/developer-guide/Promises.asciidoc
@@ -11,8 +11,12 @@ for either outcome, but it isn't a `finally`: it's implemented as
 `then(f, f)`, so whatever the functor returns becomes the value of the promise
 `always` hands back. Returning `null` after a rejection resolves the rest of the
 chain instead of keeping it rejected, and returning `null` after a success
-replaces the value. Return the incoming value through it if the chain should
-carry on unchanged.
+replaces the value. Returning the incoming value keeps a
+successful chain unchanged, but it doesn't preserve a rejection: any non-promise
+return is treated as a result, so returning the `Throwable` fulfils the chain
+with it. To stay rejected, throw it, or return `Promise.reject(...)` -- a
+returned promise has its state adopted, and a thrown exception is caught and
+becomes the rejection.
 
 === Creating and consuming one
 

--- a/docs/developer-guide/Promises.asciidoc
+++ b/docs/developer-guide/Promises.asciidoc
@@ -14,8 +14,11 @@ chain instead of keeping it rejected, and returning `null` after a success
 replaces the value. Returning the incoming value keeps a
 successful chain unchanged, but it doesn't preserve a rejection: any non-promise
 return is treated as a result, so returning the `Throwable` fulfils the chain
-with it. To stay rejected, throw it: `processThens` catches
-whatever a functor throws and rejects the next promise with it.
+with it. To stay rejected you have to throw, because `processThens`
+catches what a functor throws and rejects with it -- but `Functor.call` declares
+no checked exceptions, so a checked reason can't simply be rethrown. Wrap it, as
+`throw new RuntimeException(err)`, or return a promise you rejected with the
+original reason, whose state the chain adopts.
 
 === Creating and consuming one
 
@@ -48,6 +51,12 @@ include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/g
 
 `getState()` reports `Pending`, `Fulfilled` or `Rejected`, and `getValue()`
 returns the resolved value once there is one.
+
+WARNING: Give the first `then` in a chain a rejection functor, as above. A
+`then` called with only a success functor installs a default one that does
+`throw (RuntimeException) reason`, so a rejection carrying a checked exception --
+an `IOException` from a network call, say -- fails that cast and reaches your
+`except` as a `ClassCastException` with the real cause gone.
 
 === Combining several
 
@@ -84,7 +93,9 @@ on the EDT doesn't freeze the UI, and it throws
 `AsyncResource.AsyncExecutionException` when the promise rejected.
 
 WARNING: A promise from `promisify` never settles if the underlying
-`AsyncResource` is cancelled. `AsyncResource.cancel` records the cancellation and
-notifies its observers without running the result callback `promisify`
-registered, so the promise stays `Pending` and an `await()` on it waits forever.
+`AsyncResource` is cancelled *after* `promisify` registered on it.
+`AsyncResource.cancel` records the cancellation and notifies its observers
+without running that callback, so the promise stays `Pending` and an `await()`
+waits forever. A resource already cancelled beforehand is fine: registering on a
+resource that has finished with an error fires the callback straight away.
 Don't await a promise wrapping a resource something else can cancel.

--- a/docs/developer-guide/Promises.asciidoc
+++ b/docs/developer-guide/Promises.asciidoc
@@ -1,0 +1,71 @@
+== Promises
+
+`com.codename1.util.promise.Promise` is an implementation of the JavaScript
+promise for Codename One. It exists to compose asynchronous work without
+nesting a callback inside a callback inside a callback: each step is a value you
+can hand around, chain onto and combine with others.
+
+Two method names differ from the JavaScript originals, because `catch` and
+`finally` are Java keywords. `except` takes the place of `catch`, and `always` takes the place of
+`finally`.
+
+=== Creating and consuming one
+
+The constructor takes an `ExecutorFunction`, which receives the two functions
+that settle the promise. It runs immediately, on the calling thread:
+
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PromisesJava001Snippet.java[tag=promises-java-001,indent=0]
+----
+
+Resolution is marshalled for you. `resolve` and `reject` check whether they're
+on the EDT and hand themselves to `callSerially` when they aren't, so the
+callbacks you attach always run on the EDT and can touch the UI directly. That
+is worth contrasting with `EasyThread`, whose result callback stays on the
+worker thread.
+
+=== Chaining
+
+There are two families of callback and the difference is what they return.
+`then`, `except` and `always` take a `Functor`, whose return value becomes the
+input of the next step -- that's what makes a chain a pipeline. `onSuccess`,
+`onFail` and `onComplete` take a `SuccessCallback` instead, which returns
+nothing, so they suit the end of a chain where there is no value to pass on:
+
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PromisesJava002Snippet.java[tag=promises-java-002,indent=0]
+----
+
+`getState()` reports `Pending`, `Fulfilled` or `Rejected`, and `getValue()`
+returns the resolved value once there is one.
+
+=== Combining several
+
+`all` and `allSettled` both take a varargs list of promises and return one
+promise, and they differ in how they treat a failure:
+
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PromisesJava003Snippet.java[tag=promises-java-003,indent=0]
+----
+
+`all` rejects the moment any input rejects, with that first error, so it fits
+work where one failure makes the rest pointless. `allSettled` waits for every
+input whatever happens to each, which fits independent tasks you want a full
+report on.
+
+=== Working with AsyncResource
+
+Much of the framework returns `AsyncResource` rather than a promise, and the
+conversion goes both ways:
+
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PromisesJava004Snippet.java[tag=promises-java-004,indent=0]
+----
+
+`await()` is the blocking form. It waits through `invokeAndBlock`, so calling it
+on the EDT doesn't freeze the UI, and it throws
+`AsyncResource.AsyncExecutionException` when the promise rejected.

--- a/docs/developer-guide/Promises.asciidoc
+++ b/docs/developer-guide/Promises.asciidoc
@@ -51,8 +51,11 @@ promise, and they differ in how they treat a failure:
 include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PromisesJava003Snippet.java[tag=promises-java-003,indent=0]
 ----
 
-`all` rejects the moment any input rejects, with that first error, so it fits
-work where one failure makes the rest pointless. `allSettled` waits for every
+`all` rejects as soon as any input rejects, so it fits work where one failure
+makes the rest pointless. Don't depend on which error you get when several
+inputs fail: a rejection overwrites the aggregate's stored error whatever state
+it's already in, so the one delivered is the last processed rather than the
+first. `allSettled` waits for every
 input whatever happens to each, which fits independent tasks you want a full
 report on.
 

--- a/docs/developer-guide/Promises.asciidoc
+++ b/docs/developer-guide/Promises.asciidoc
@@ -6,8 +6,13 @@ nesting a callback inside a callback inside a callback: each step is a value you
 can hand around, chain onto and combine with others.
 
 Two method names differ from the JavaScript originals, because `catch` and
-`finally` are Java keywords. `except` takes the place of `catch`, and `always` takes the place of
-`finally`.
+`finally` are Java keywords. `except` takes the place of `catch`. `always` runs
+for either outcome, but it isn't a `finally`: it's implemented as
+`then(f, f)`, so whatever the functor returns becomes the value of the promise
+`always` hands back. Returning `null` after a rejection resolves the rest of the
+chain instead of keeping it rejected, and returning `null` after a success
+replaces the value. Return the incoming value through it if the chain should
+carry on unchanged.
 
 === Creating and consuming one
 
@@ -53,11 +58,13 @@ include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/g
 
 `all` rejects as soon as any input rejects, so it fits work where one failure
 makes the rest pointless. Don't depend on which error you get when several
-inputs fail: a rejection overwrites the aggregate's stored error whatever state
-it's already in, so the one delivered is the last processed rather than the
-first. `allSettled` waits for every
-input whatever happens to each, which fits independent tasks you want a full
-report on.
+inputs fail. A handler attached before the rejections arrive is drained by the
+first one, while a handler attached afterward reads the stored error, which
+each later rejection overwrites. `allSettled` waits for every input whatever happens to
+each, which fits independent tasks. It resolves with the original array of
+promises rather than a list of outcome descriptors, so inspect each one with
+`getState()` and `getValue()`. There's no getter for a rejected promise's error,
+so attach a failure handler to an input if you need to see why it failed.
 
 === Working with AsyncResource
 

--- a/docs/developer-guide/developer-guide.asciidoc
+++ b/docs/developer-guide/developer-guide.asciidoc
@@ -53,6 +53,8 @@ include::Maven-Project-Workflow.asciidoc[]
 
 include::The-EDT---Event-Dispatch-Thread.asciidoc[]
 
+include::Promises.asciidoc[]
+
 include::Events.asciidoc[]
 
 include::Device-Input-And-Form-Factors.asciidoc[]


### PR DESCRIPTION
`com.codename1.util.promise` had **no prose anywhere in the guide** — not `Promise`, not `Functor`, not `ExecutorFunction`. It's a full JavaScript-style promise for composing asynchronous work, and a reader could only find it by reading the source.

New chapter in *Core concepts*, next to the EDT chapter, with four compiled snippets: creating one, the two callback families, the combinators, and the `AsyncResource` conversions.

## Everything asserted comes from the class

Not from the shape the API resembles:

- the **executor runs immediately on the calling thread** — visible in the constructor;
- **`resolve` and `reject` test `CN.isEdt()` and hand themselves to `callSerially`** when off it, so callbacks run on the EDT and may touch the UI. That's the opposite of `EasyThread`, whose result callback stays on the worker thread — a distinction #5712 had to correct in that chapter, so this one states it outright;
- `then`/`except`/`always` take a `Functor` and pipe its return value onward; `onSuccess`/`onFail`/`onComplete` take a `SuccessCallback` and return nothing;
- `all` rejects on the first rejection, `allSettled` waits for every input;
- `await()` blocks through `invokeAndBlock` and throws `AsyncExecutionException`.

`except` and `always` are named that way because `catch` and `finally` are Java keywords — explained rather than left as a puzzle.

I checked every method the prose names against `javap` output instead of trusting the draft: thirteen names, all present.

## A correction to the plan

The plan lists five packages as having zero prose. Measured by **class name** rather than by package string, only `promise` and `plugin` are actually empty — `share` has seven of eight classes documented, `ui.scene` four of eight, `javascript` two of five. My own first measurement made the same mistake, counting fully-qualified package names that chapters never use.

Verified: demos build green, all guide gates green, Vale and LanguageTool clean, sample audit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)