### PR TITLE
Simulator reported the host machine's pixel ratio instead of the simulated device's

### DIFF
--- a/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
+++ b/Ports/JavaSE/src/com/codename1/impl/javase/JavaSEPort.java
@@ -971,7 +971,31 @@ public class JavaSEPort extends CodenameOneImplementation {
     /// port draws with. Changing only this accessor would just split the two.
     @Override
     public float getDevicePixelRatio() {
-        return retinaScale > 0 ? (float) retinaScale : super.getDevicePixelRatio();
+        return devicePixelRatioFor(isDesktop(), retinaScale, super.getDevicePixelRatio());
+    }
+
+    /// Decides the reported ratio from the three things that determine it.
+    ///
+    /// Separated from the accessor so it can be exercised without constructing a
+    /// port: the constructor initialises a look and feel, which needs a native
+    /// library that is not present on every machine the tests run on.
+    ///
+    /// The host display's backing scale is reported ONLY when no skin is loaded.
+    /// A skin means this process is standing in for another device, and the
+    /// host's scale is not that device's -- a 2x machine showing a 3x phone skin
+    /// would report 2, and everything laid out in the platform's logical units
+    /// comes out two thirds of its size.
+    ///
+    /// With a skin the answer is the "not reported" value, which the documented
+    /// contract already defines: the caller derives the ratio from the density
+    /// bucket, which describes the device being simulated rather than the
+    /// machine simulating it, and is what this call resolved to before the
+    /// platform reported a scale at all.
+    static float devicePixelRatioFor(boolean desktop, double hostScale, float notReported) {
+        if (!desktop) {
+            return notReported;
+        }
+        return hostScale > 0 ? (float) hostScale : notReported;
     }
 
     public int getDeviceDensity() {

--- a/maven/javase/src/test/java/com/codename1/impl/javase/JavaSEPortDevicePixelRatioTest.java
+++ b/maven/javase/src/test/java/com/codename1/impl/javase/JavaSEPortDevicePixelRatioTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.impl.javase;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * getDevicePixelRatio must describe the device being simulated, not the machine
+ * simulating it.
+ *
+ * <p>The simulator loads a skin to stand in for a phone, and the host display's
+ * backing scale is then the wrong number entirely: a 2x machine showing a 3x
+ * phone skin would report 2, and anything laying out in the platform's logical
+ * units comes out two thirds of its size. The contract already defines the
+ * "not reported" answer, which sends the caller to the density bucket -- that
+ * describes the simulated device, and is what this call resolved to before the
+ * platform reported a scale at all.</p>
+ *
+ * <p>With no skin the process really is a desktop application on this display,
+ * and the backing scale is exactly what was asked for.</p>
+ *
+ * <p>Exercises the decision directly rather than through a constructed port:
+ * JavaSEPort's constructor initialises a look and feel that needs a native
+ * library absent on some machines, which is why several tests in this module
+ * cannot run everywhere. The decision is the part that was wrong.</p>
+ */
+public class JavaSEPortDevicePixelRatioTest {
+
+    @Test
+    public void aSkinnedSimulatorDoesNotReportTheHostScale() {
+        assertEquals(0f, JavaSEPort.devicePixelRatioFor(false, 2.0, 0f), 0.0001f,
+                "a skin stands in for another device, so the host's scale is not its scale");
+    }
+
+    @Test
+    public void aDesktopApplicationReportsTheHostScale() {
+        assertEquals(2f, JavaSEPort.devicePixelRatioFor(true, 2.0, 0f), 0.0001f,
+                "with no skin this is a desktop app on this display, which is what the API asks");
+    }
+
+    @Test
+    public void anUnknownHostScaleFallsBackRatherThanReportingZeroPointZero() {
+        assertEquals(0f, JavaSEPort.devicePixelRatioFor(true, 0.0, 0f), 0.0001f,
+                "a host that reports no scale is 'not reported', not a ratio of zero");
+    }
+}


### PR DESCRIPTION
## What is wrong

`JavaSEPort.getDevicePixelRatio()` returns the host display's backing scale
unconditionally. In the simulator that describes the wrong machine: a loaded
skin means the process is standing in for another device, so a 2x desktop
showing a 3x phone skin reports 2.

Anything that lays out in the platform's logical units is then two thirds of its
intended size. The method is new in #5686, so this is a regression introduced
there rather than long-standing behaviour.

## The fix

Report the backing scale only when no skin is loaded — which is a real desktop
application on this display, and exactly what the API asks.

With a skin, answer the documented "not reported" value. That sends the caller
to the density bucket, which describes the device being simulated rather than
the machine simulating it, and is what this call resolved to before the platform
reported a scale at all.

## Why the logic moved into a helper

`JavaSEPort`'s constructor initialises a look and feel that needs a native
library which is not present on every machine — several existing tests in this
module cannot run because of it. The part that was wrong is the decision, and a
decision needs no port, so it sits in a package-private
`devicePixelRatioFor(desktop, hostScale, notReported)` that the accessor
delegates to.

## Verification

`JavaSEPortDevicePixelRatioTest` pins three cases: a skinned simulator must not
report the host scale, a desktop application must, and a host reporting no scale
falls back to "not reported" rather than a ratio of zero.

Confirmed by removing the check again — the skinned case then reports `2.0`
where `0` is expected, which is the regression. Restored, 3/3 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)