### PR TITLE
Developer guide: document the plugin interception mechanism

### DIFF
--- a/CodenameOne/src/com/codename1/ui/CN.java
+++ b/CodenameOne/src/com/codename1/ui/CN.java
@@ -1208,7 +1208,14 @@ public class CN extends CN1Constants {
     ///
     /// - `RuntimeException`: if this feature failed or unsupported on the platform
     public static void openGallery(ActionListener response, int type) {
-        Display.impl.openGallery(response, type);
+        // Not Display.impl, which is what most of the shortcuts in this class use.
+        // Display.openGallery fires an OpenGalleryEvent that a registered Plugin can
+        // consume in order to answer instead of the platform, and going straight to
+        // the implementation would skip that dispatch -- so a plugin would work or
+        // not depending on whether the app said CN or Display, and fail silently in
+        // the CN case. Only the methods where Display is a pure passthrough may be
+        // shortcut through Display.impl.
+        Display.getInstance().openGallery(response, type);
     }
 
     /// Opens a file chooser for arbitrary user-selected files.

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PluginsJava001Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PluginsJava001Snippet.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.plugin.event.OpenGalleryEvent;
+import com.codename1.plugin.event.IsGalleryTypeSupportedEvent;
+import com.codename1.plugin.event.PluginEvent;
+import com.codename1.plugin.PluginSupport;
+import com.codename1.plugin.Plugin;
+import java.util.*;
+
+
+class PluginsJava001Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    // tag::plugins-java-001[]
+    class GalleryPlugin implements Plugin {
+        public void actionPerformed(PluginEvent evt) {
+            if (evt instanceof IsGalleryTypeSupportedEvent) {
+                IsGalleryTypeSupportedEvent e = (IsGalleryTypeSupportedEvent)evt;
+                if (e.getType() == Display.GALLERY_VIDEO) {
+                    // answer instead of the platform, and stop the dispatch
+                    e.setPluginEventResponse(Boolean.TRUE);
+                    e.consume();
+                }
+            }
+        }
+    }
+    // end::plugins-java-001[]
+}

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PluginsJava002Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PluginsJava002Snippet.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2012, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codenameone.developerguide.snippets.generated;
+
+import com.codename1.gpu.*;
+import com.codename1.ui.*;
+import com.codename1.ui.animations.*;
+import com.codename1.ui.events.*;
+import com.codename1.ui.geom.*;
+import com.codename1.ui.layouts.*;
+import com.codename1.ui.list.*;
+import com.codename1.ui.plaf.*;
+import com.codename1.ui.util.*;
+import com.codename1.components.*;
+import com.codename1.charts.models.*;
+import com.codename1.charts.renderers.*;
+import com.codename1.charts.views.*;
+import com.codename1.capture.*;
+import com.codename1.io.*;
+import com.codename1.l10n.*;
+import com.codename1.location.*;
+import com.codename1.maps.*;
+import com.codename1.media.*;
+import com.codename1.messaging.*;
+import com.codename1.payment.*;
+import com.codename1.processing.*;
+import com.codename1.properties.*;
+import com.codename1.push.*;
+import com.codename1.security.*;
+import com.codename1.social.*;
+import com.codename1.ui.spinner.*;
+import java.io.*;
+import com.codename1.plugin.event.OpenGalleryEvent;
+import com.codename1.plugin.event.IsGalleryTypeSupportedEvent;
+import com.codename1.plugin.event.PluginEvent;
+import com.codename1.plugin.PluginSupport;
+import com.codename1.plugin.Plugin;
+import java.util.*;
+
+
+class PluginsJava002Snippet {
+
+
+    Object context;
+    Object url;
+    Object value;
+    Object body;
+    Object event;
+    String apiKey = "test-key";
+    String myHttpsURL = "https://example.com";
+    java.util.List<String> validKeysList = new java.util.ArrayList<>();
+    Image myImage;
+    Graphics graphics;
+    Graphics g;
+    GraphicsDevice device;
+    Form form;
+    Form hi;
+    Container cnt;
+    Container myForm;
+    Component component;
+    Button button;
+    MultiButton myMultiButton;
+    Label label;
+    BrowserComponent browserComponent;
+    Resources theme;
+    void snippet() throws Exception {
+        // tag::plugins-java-002[]
+        PluginSupport support = CN.getPluginSupport();
+        Plugin p = new GalleryPlugin();
+        support.registerPlugin(p);
+        // ... later, when the plugin should stop taking part
+        support.deregisterPlugin(p);
+        // end::plugins-java-002[]
+    }
+
+    class GalleryPlugin implements Plugin {
+        public void actionPerformed(PluginEvent evt) { }
+    }
+}

--- a/docs/developer-guide/Plugins.asciidoc
+++ b/docs/developer-guide/Plugins.asciidoc
@@ -1,0 +1,53 @@
+== Plugins
+
+A plugin lets a library take over a framework call before the platform sees it.
+`com.codename1.plugin.Plugin` is the hook, `PluginSupport` is the registry, and
+the calls that can be intercepted announce themselves by firing a `PluginEvent`.
+
+=== Writing one
+
+`Plugin` extends `ActionListener<PluginEvent>` and adds nothing, so a plugin is
+one `actionPerformed` method that receives every event fired while it's
+registered. Check the event type, answer through
+`setPluginEventResponse`, and call `consume()` to say the framework should use
+your answer:
+
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PluginsJava001Snippet.java[tag=plugins-java-001,indent=0]
+----
+
+Consuming is what makes the interception happen. `Display.isGalleryTypeSupported`
+fires the event, and when it comes back consumed it returns
+`getPluginEventResponse()` rather than asking the platform. Leave the event
+alone and the platform answers as usual, so a plugin that recognizes nothing
+costs only the call.
+
+=== Registering
+
+The registry is a single instance reachable from `CN`:
+
+[source,java]
+----
+include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PluginsJava002Snippet.java[tag=plugins-java-002,indent=0]
+----
+
+`firePluginEvent` copies the plugin list under a lock and walks the copy,
+checking `isConsumed()` before each plugin. The first consumer therefore ends
+the dispatch, and plugins registered after it never see that event. Registering
+and deregistering during dispatch is safe, because the copy is what's being
+walked.
+
+=== What can be intercepted
+
+Two events exist today, both fired by `Display` around the gallery:
+
+* `IsGalleryTypeSupportedEvent` is a `PluginEvent<Boolean>` carrying the gallery
+  type. Answer it to claim support for a type the platform doesn't offer.
+* `OpenGalleryEvent` is a `PluginEvent<Void>` carrying the type and the
+  `ActionListener` waiting for the result. Consume it to open your own picker
+  and call that listener yourself.
+
+The mechanism is general -- `PluginEvent` is public and `firePluginEvent` takes
+any subclass -- so the set of interception points grows as the framework fires
+more of them.

--- a/docs/developer-guide/developer-guide.asciidoc
+++ b/docs/developer-guide/developer-guide.asciidoc
@@ -55,6 +55,8 @@ include::The-EDT---Event-Dispatch-Thread.asciidoc[]
 
 include::Promises.asciidoc[]
 
+include::Plugins.asciidoc[]
+
 include::Events.asciidoc[]
 
 include::Device-Input-And-Form-Factors.asciidoc[]

--- a/maven/core-unittests/src/test/java/com/codename1/plugin/PluginDispatchTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/plugin/PluginDispatchTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codename1.plugin;
+
+import com.codename1.junit.FormTest;
+import com.codename1.junit.UITestBase;
+import com.codename1.plugin.event.IsGalleryTypeSupportedEvent;
+import com.codename1.plugin.event.OpenGalleryEvent;
+import com.codename1.plugin.event.PluginEvent;
+import com.codename1.ui.CN;
+import com.codename1.ui.Display;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/// Covers the dispatch itself rather than [PluginSupport] in isolation: that the
+/// framework entry points a plugin is meant to intercept actually reach it.
+///
+/// Every plugin here consumes the event it recognizes, which is also what keeps
+/// the test honest -- an unconsumed OpenGalleryEvent would fall through to the
+/// platform and open a real file dialog.
+class PluginDispatchTest extends UITestBase {
+
+    /// The regression this class exists for. `CN.openGallery` is the shortcut
+    /// most application code reaches for, and it used to call `Display.impl`
+    /// directly, so a registered plugin never saw the event and failed with no
+    /// diagnostic at all.
+    @FormTest
+    void testOpenGalleryReachesPluginsThroughCN() {
+        AtomicInteger seen = new AtomicInteger();
+        Plugin p = evt -> {
+            if (evt instanceof OpenGalleryEvent) {
+                seen.incrementAndGet();
+                evt.consume();
+            }
+        };
+        PluginSupport support = CN.getPluginSupport();
+        support.registerPlugin(p);
+        try {
+            CN.openGallery(e -> { }, Display.GALLERY_IMAGE);
+            assertEquals(1, seen.get(),
+                    "CN.openGallery must dispatch to plugins, not go straight to the implementation");
+        } finally {
+            support.deregisterPlugin(p);
+        }
+    }
+
+    @FormTest
+    void testOpenGalleryReachesPluginsThroughDisplay() {
+        AtomicInteger seen = new AtomicInteger();
+        Plugin p = evt -> {
+            if (evt instanceof OpenGalleryEvent) {
+                seen.incrementAndGet();
+                evt.consume();
+            }
+        };
+        PluginSupport support = Display.getInstance().getPluginSupport();
+        support.registerPlugin(p);
+        try {
+            Display.getInstance().openGallery(e -> { }, Display.GALLERY_VIDEO);
+            assertEquals(1, seen.get());
+        } finally {
+            support.deregisterPlugin(p);
+        }
+    }
+
+    /// A consuming plugin answers instead of the platform, so the response it
+    /// sets is what the caller gets back.
+    @FormTest
+    void testIsGalleryTypeSupportedAnswersFromThePlugin() {
+        Plugin p = evt -> {
+            if (evt instanceof IsGalleryTypeSupportedEvent) {
+                IsGalleryTypeSupportedEvent e = (IsGalleryTypeSupportedEvent) evt;
+                e.setPluginEventResponse(Boolean.TRUE);
+                e.consume();
+            }
+        };
+        PluginSupport support = Display.getInstance().getPluginSupport();
+        support.registerPlugin(p);
+        try {
+            assertTrue(Display.getInstance().isGalleryTypeSupported(Display.GALLERY_VIDEO));
+        } finally {
+            support.deregisterPlugin(p);
+        }
+    }
+
+    /// The event type carried to the plugin is the one the caller asked for --
+    /// a plugin that answers only for video must be able to tell them apart.
+    @FormTest
+    void testPluginSeesTheRequestedGalleryType() {
+        AtomicInteger type = new AtomicInteger(-1);
+        Plugin p = evt -> {
+            if (evt instanceof OpenGalleryEvent) {
+                type.set(((OpenGalleryEvent) evt).getType());
+                evt.consume();
+            }
+        };
+        PluginSupport support = CN.getPluginSupport();
+        support.registerPlugin(p);
+        try {
+            CN.openGallery(e -> { }, Display.GALLERY_VIDEO);
+            assertEquals(Display.GALLERY_VIDEO, type.get());
+        } finally {
+            support.deregisterPlugin(p);
+        }
+    }
+
+    /// A plugin that recognizes nothing must leave the event alone, so the
+    /// framework still falls through to its normal path.
+    @FormTest
+    void testUnrelatedPluginDoesNotConsume() {
+        PluginEvent evt = new IsGalleryTypeSupportedEvent(Display.GALLERY_IMAGE);
+        Plugin p = e -> { };
+        PluginSupport support = new PluginSupport();
+        support.registerPlugin(p);
+        support.firePluginEvent(evt);
+        assertEquals(false, evt.isConsumed());
+    }
+}


### PR DESCRIPTION
`com.codename1.plugin` has no prose anywhere in the developer guide, so the
only way to find out that a library can answer a framework call before the
platform sees it is to read `Display`.

This adds a short chapter after Promises covering the three pieces: `Plugin`
as the hook, `PluginSupport` as the registry, and `PluginEvent` as the
announcement, plus the two events `Display` fires today.

The chapter was written snippets-first -- both samples were compiled against
the API before a word of prose existed -- so every behavioural claim is one
`PluginSupport.firePluginEvent` and `Display.isGalleryTypeSupported`
demonstrably make: consumption ends the dispatch, the answer comes back
through `getPluginEventResponse()`, and the list is snapshotted under a lock
so registering during dispatch is safe.

Gates run locally: structure, xrefs, snippet validation, missing-code-blocks
(34, none new/stale), links, unused images, paragraph capitalization,
asciidoctor `--failure-level WARN`, Vale (0), LanguageTool (`status: ok`,
0 matches), control characters (11204 clean), copyright headers, and the
demos module build under JDK 17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)