### PR TITLE
Fix Promise.reject recursing forever and then() destroying checked errors

### DIFF
--- a/CodenameOne/src/com/codename1/util/promise/Promise.java
+++ b/CodenameOne/src/com/codename1/util/promise/Promise.java
@@ -234,7 +234,11 @@ public class Promise<T> {
         return new Promise(new ExecutorFunction() {
             @Override
             public void call(Functor resolve, Functor reject) {
-                reject(err);
+                // reject.call(err), NOT reject(err): the latter is a method
+                // invocation, so it binds to this very method rather than to the
+                // Functor parameter of the same name and recurses until the stack
+                // overflows. Compare resolve(V) above, which calls the functor.
+                reject.call(err);
             }
         });
     }
@@ -280,6 +284,20 @@ public class Promise<T> {
         }
         while (!then.isEmpty()) {
             PromiseHandler p = then.remove(0);
+            if (!resolved && p.reject == null) {
+                // then() was given no rejection handler, so the rejection passes
+                // through to the promise it returned -- carrying the ORIGINAL
+                // Throwable. This used to be done by defaulting rejectionFunc to a
+                // functor that rethrew, which the catch below turned back into a
+                // rejection; but Functor.call declares no checked exception, so that
+                // default had to write `throw (RuntimeException) o`. For a checked
+                // error the cast fails and the chain rejects with a
+                // ClassCastException instead of the real cause -- and because
+                // ParparVM does not check casts, iOS propagated the true error while
+                // the other ports did not. Propagating here needs no cast at all.
+                p.promise.reject.call(o);
+                continue;
+            }
             try {
                 Object result = resolved ? p.resolve.call(o) : p.reject.call(o);
                 if (result instanceof Promise) {
@@ -376,7 +394,7 @@ public class Promise<T> {
     ///
     /// - `resolutionFunc`: A Function called if the Promise is fulfilled. This function has one argument, the fulfillment value. If it is null, it is internally replaced with an "Identity" function (it returns the received argument).
     ///
-    /// - `rejectionFunc`: A Function called if the Promise is rejected. This function has one argument, the rejection reason. If it is null, it is internally replaced with a "Thrower" function (it throws an error it received as argument).
+    /// - `rejectionFunc`: A Function called if the Promise is rejected. This function has one argument, the rejection reason. If it is null, the rejection passes through unhandled to the promise this method returns, carrying the original reason.
     ///
     /// #### Returns
     ///
@@ -412,15 +430,6 @@ public class Promise<T> {
                 }
             };
         }
-        if (rejectionFunc == null) {
-            rejectionFunc = new Functor<Throwable, Object>() {
-                @Override
-                public Object call(Throwable o) {
-                    throw (RuntimeException) o;
-                }
-            };
-        }
-
         PromiseHandler handler = new PromiseHandler();
         handler.promise = new Promise(null);
         handler.resolve = resolutionFunc;

--- a/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PromisesJava002Snippet.java
+++ b/docs/demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/PromisesJava002Snippet.java
@@ -88,12 +88,12 @@ class PromisesJava002Snippet {
         Promise<String> name = Promise.resolve("ada");
         name.then(
                 n -> ((String)n).toUpperCase(),
-                // a then() given no rejection functor installs one that casts
-                // to RuntimeException, turning a checked reason into a
-                // ClassCastException, so supply one. Rethrow wrapped rather
-                // than returning a value: anything returned here RESOLVES the
-                // rest of the chain, so returning null would run the steps
-                // below on a failure
+                // a rejection functor is optional -- omit it and the reason
+                // passes through untouched to the next handler. Supply one, as
+                // here, and it has to rethrow: anything RETURNED from it
+                // RESOLVES the rest of the chain, so returning null would run
+                // the steps below on a failure. Functor.call declares no
+                // checked exception, hence the wrap
                 err -> { throw new RuntimeException((Throwable)err); })
             .then(upper -> "Hello " + upper)
             .ready(

--- a/docs/developer-guide/Promises.asciidoc
+++ b/docs/developer-guide/Promises.asciidoc
@@ -45,8 +45,8 @@ input of the next step -- that's what makes a chain a pipeline. `onSuccess`,
 nothing, so they suit the end of a chain where there is no value to pass on.
 Attach both outcomes with `ready(success, failure)` rather than chaining
 `onSuccess(...).onFail(...)`: the second form hangs the failure handler off the
-promise `onSuccess` returns, behind the default rejection functor described
-below:
+promise `onSuccess` returns, one link further down the chain than the promise
+whose failure you meant to catch:
 
 [source,java]
 ----
@@ -56,11 +56,11 @@ include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/g
 `getState()` reports `Pending`, `Fulfilled` or `Rejected`, and `getValue()`
 returns the resolved value once there is one.
 
-WARNING: Give the first `then` in a chain a rejection functor, as above. A
-`then` called with only a success functor installs a default one that does
-`throw (RuntimeException) reason`, so a rejection carrying a checked exception --
-an `IOException` from a network call, say -- fails that cast and reaches your
-`except` as a `ClassCastException` with the real cause gone.
+A `then` given only a success functor passes a rejection straight through to the
+promise it returns, carrying the original reason, so an `IOException` from a
+network call arrives at your `except` as that `IOException`. The success functor
+is skipped for a rejected promise, which is why a chain can end in a single
+`except` rather than handling failure at every link.
 
 === Combining several
 

--- a/maven/core-unittests/src/test/java/com/codename1/util/promise/PromiseTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/util/promise/PromiseTest.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 package com.codename1.util.promise;
 
 import com.codename1.junit.FormTest;
@@ -95,5 +117,132 @@ class PromiseTest extends UITestBase {
 
         flushSerialCalls();
         assertTrue(alwaysCalled.get());
+    }
+
+    /// `Promise.reject` used to call itself instead of the reject functor -- the
+    /// parameter and the method share the name `reject`, and `reject(err)` is a
+    /// method invocation -- so every call recursed until the stack overflowed.
+    /// Nothing covered the static factories, so it shipped.
+    @FormTest
+    void testStaticRejectProducesARejectedPromise() {
+        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        Throwable cause = new IllegalStateException("nope");
+
+        Promise.reject(cause).except(new Functor<Throwable, Object>() {
+            public Object call(Throwable t) {
+                error.set(t);
+                return null;
+            }
+        });
+
+        flushSerialCalls();
+        assertSame(cause, error.get());
+    }
+
+    @FormTest
+    void testStaticResolveProducesAFulfilledPromise() {
+        final AtomicReference<String> value = new AtomicReference<String>();
+
+        Promise.resolve("ready").onSuccess(new SuccessCallback<String>() {
+            public void onSucess(String result) {
+                value.set(result);
+            }
+        });
+
+        flushSerialCalls();
+        assertEquals("ready", value.get());
+    }
+
+    /// A link in the chain with no rejection handler must pass the ORIGINAL error
+    /// down. The old default rethrew it as `(RuntimeException) o`, so a checked
+    /// exception arrived at the far end as a ClassCastException with the real
+    /// cause gone.
+    @FormTest
+    void testCheckedExceptionSurvivesAThenWithNoRejectionHandler() {
+        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        final Throwable cause = new java.io.IOException("disk");
+
+        Promise<String> promise = new Promise<String>(new ExecutorFunction() {
+            public void call(Functor resolve, Functor reject) {
+                reject.call(cause);
+            }
+        });
+
+        promise.then(new Functor<String, Object>() {
+            public Object call(String s) {
+                return s;
+            }
+        }).except(new Functor<Throwable, Object>() {
+            public Object call(Throwable t) {
+                error.set(t);
+                return null;
+            }
+        });
+
+        flushSerialCalls();
+        assertSame(cause, error.get(),
+                "a then() without a rejection handler must forward the original error");
+    }
+
+    /// The unchecked case took the same broken path; it only happened to survive
+    /// it, so it is worth pinning alongside the checked one.
+    @FormTest
+    void testRuntimeExceptionSurvivesAThenWithNoRejectionHandler() {
+        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        final Throwable cause = new IllegalArgumentException("bad");
+
+        Promise<String> promise = new Promise<String>(new ExecutorFunction() {
+            public void call(Functor resolve, Functor reject) {
+                reject.call(cause);
+            }
+        });
+
+        promise.then(new Functor<String, Object>() {
+            public Object call(String s) {
+                return s;
+            }
+        }).except(new Functor<Throwable, Object>() {
+            public Object call(Throwable t) {
+                error.set(t);
+                return null;
+            }
+        });
+
+        flushSerialCalls();
+        assertSame(cause, error.get());
+    }
+
+    /// The pass-through must not swallow the rejection either: a handler attached
+    /// several links down still has to run.
+    @FormTest
+    void testRejectionTravelsThroughSeveralHandlerlessLinks() {
+        final AtomicReference<Throwable> error = new AtomicReference<Throwable>();
+        final AtomicBoolean successRan = new AtomicBoolean(false);
+        final Throwable cause = new java.io.IOException("deep");
+
+        Promise<String> promise = new Promise<String>(new ExecutorFunction() {
+            public void call(Functor resolve, Functor reject) {
+                reject.call(cause);
+            }
+        });
+
+        Functor<String, Object> onValue = new Functor<String, Object>() {
+            public Object call(String s) {
+                successRan.set(true);
+                return s;
+            }
+        };
+
+        promise.then(onValue).then(onValue).then(onValue)
+                .except(new Functor<Throwable, Object>() {
+                    public Object call(Throwable t) {
+                        error.set(t);
+                        return null;
+                    }
+                });
+
+        flushSerialCalls();
+        assertSame(cause, error.get());
+        assertFalse(successRan.get(), "a rejected promise must not run the success path");
     }
 }


### PR DESCRIPTION
Two defects found while writing the Promises chapter. Both survived because
nothing covered the paths they were on -- `PromiseTest` had four tests and
touched neither static factory.

### `Promise.reject(Throwable)` never produced a rejected promise

Its `ExecutorFunction` body called `reject(err)`. The functor parameter and the
enclosing static method are both named `reject`, and `reject(err)` is a *method*
invocation, so it bound to the method and recursed until the stack overflowed.
`resolve(V)` directly above it is written correctly, which is what makes the
slip easy to miss on a read.

### `then(fn)` with no rejection functor replaced the real error

The missing functor defaulted to one doing `throw (RuntimeException) o`, relying
on `processThens` catching the throw to reject the chained promise. For a
checked reason the cast fails, so an `IOException` arrived at the caller's
`except()` as a `ClassCastException` with the cause gone.

The two halves of the tree also disagreed: ParparVM does not check casts, so iOS
propagated the true error while every other port did not.

`Functor.call` declares no checked exception, so no throwing default can be
correct here. `processThens` now forwards the original `Throwable` when a link
has no rejection handler, which needs no cast at all.

### Verification

Revert probe with both fixes backed out: the static-reject test dies with
`StackOverflowError`, the two checked-exception tests fail with the
`ClassCastException` above, and the unchecked-exception test still passes -- the
one case the old path happened to survive, which is why it is pinned too.

Full `core-unittests` suite green (6610 tests, 0 failures), SpotBugs 0, and the
cast-semantics ratchet unchanged at 76 baselined with no entry in this file.

The guide chapter and the `then()` javadoc both described the old behaviour --
the chapter carried a WARNING telling readers to always supply a rejection
functor -- so both are corrected here rather than left to contradict the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)