### PR TITLE
Compile against API 37 in CI, and stop guessing at minor-versioned platforms

### DIFF
--- a/.github/workflows/scripts-android.yml
+++ b/.github/workflows/scripts-android.yml
@@ -15,6 +15,8 @@ name: Test Android build scripts
       - 'scripts/ci/retry.sh'
       - 'scripts/build-android-port.sh'
       - 'scripts/build-android-app.sh'
+      - 'scripts/verify-android-app-compile-sdk.sh'
+      - 'scripts/check-android-api-removals.py'
       - 'scripts/run-android-instrumentation-tests.sh'
       - 'scripts/generate-android-coverage-report.sh'
       - 'scripts/android/lib/**/*.java'
@@ -45,6 +47,8 @@ name: Test Android build scripts
       - 'scripts/ci/retry.sh'
       - 'scripts/build-android-port.sh'
       - 'scripts/build-android-app.sh'
+      - 'scripts/verify-android-app-compile-sdk.sh'
+      - 'scripts/check-android-api-removals.py'
       - 'scripts/run-android-instrumentation-tests.sh'
       - 'scripts/generate-android-coverage-report.sh'
       - 'scripts/android/lib/**/*.java'
@@ -190,6 +194,38 @@ jobs:
         run: bash scripts/ci/retry.sh ./scripts/setup-workspace.sh -q -DskipTests
       - name: Build Android port
         run: bash scripts/ci/retry.sh ./scripts/build-android-port.sh -q -DskipTests
+      # Only on the default leg. What this compares is the platform jar, not the
+      # JDK, so running it three times would answer the same question three
+      # times.
+      - name: Install Android platform 37
+        if: matrix.id == 'default'
+        run: |
+          # SDK-root copy first: a sdkmanager on PATH can belong to a
+          # different SDK root and install where the build never looks.
+          SDKMANAGER="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
+          [ -x "$SDKMANAGER" ] || SDKMANAGER="$(command -v sdkmanager)"
+          # No unsuffixed package exists at this level: sdkmanager offers
+          # android-37.0, android-37.1 and android-37.2 and nothing called
+          # android-37, so "platforms;android-37" installs nothing and exits 0.
+          # `yes` dies of SIGPIPE once sdkmanager stops reading prompts, so its
+          # status says nothing; assert on the jar that had to appear instead.
+          yes | "$SDKMANAGER" "platforms;android-37.0" > /dev/null || true
+          test -f "$ANDROID_SDK_ROOT/platforms/android-37.0/android.jar"
+      - name: Check the Android port against API 37
+        if: matrix.id == 'default'
+        run: |
+          set -euo pipefail
+          source "${RUNNER_TEMP}/codenameone-tools/tools/env.sh"
+          # The port's real compile classpath, so the raw error counts either
+          # side of the comparison stay small enough to read. The check does not
+          # depend on it being complete -- anything unresolved fails against
+          # both platforms and cancels out.
+          (cd maven && "$MAVEN_HOME/bin/mvn" -B -q -Pcompile-android -pl android \
+             dependency:build-classpath -DincludeScope=compile \
+             -Dmdep.outputFile="${RUNNER_TEMP}/android-port-classpath.txt")
+          python3 scripts/check-android-api-removals.py \
+            --classpath "$(cat "${RUNNER_TEMP}/android-port-classpath.txt")" \
+            --require-all
       - name: Build Hello Codename One Android app
         id: build-android-app
         run: |
@@ -209,6 +245,14 @@ jobs:
           target: google_apis
           disk-size: 2048M
           script: ./scripts/run-android-instrumentation-tests.sh "${{ steps.build-android-app.outputs.gradle_project_dir }}"
+      # After the emulator, deliberately: the instrumentation suite runs against
+      # the APK the primary build produced, and this rewrites that project in
+      # place. It is the end-to-end half of the API 37 coverage -- the offline
+      # check above sees javac only, while this one also puts AAPT, the manifest
+      # merger, aar metadata and packaging through the newer platform.
+      - name: Rebuild the generated app at API 37
+        if: matrix.id == 'default'
+        run: ./scripts/verify-android-app-compile-sdk.sh "${{ steps.build-android-app.outputs.gradle_project_dir }}" 37
       - name: Upload Android port status
         if: always() && matrix.id == 'default'
         uses: actions/upload-artifact@v7

--- a/.github/workflows/scripts-android.yml
+++ b/.github/workflows/scripts-android.yml
@@ -197,35 +197,40 @@ jobs:
       # Only on the default leg. What this compares is the platform jar, not the
       # JDK, so running it three times would answer the same question three
       # times.
-      - name: Install Android platform 37
+      - name: Install Android platforms 36 and 37
         if: matrix.id == 'default'
         run: |
           # SDK-root copy first: a sdkmanager on PATH can belong to a
           # different SDK root and install where the build never looks.
           SDKMANAGER="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
           [ -x "$SDKMANAGER" ] || SDKMANAGER="$(command -v sdkmanager)"
-          # No unsuffixed package exists at this level: sdkmanager offers
-          # android-37.0, android-37.1 and android-37.2 and nothing called
-          # android-37, so "platforms;android-37" installs nothing and exits 0.
+          # Both ends of the comparison, rather than trusting the runner image
+          # to carry the baseline: with only a 37 platform installed the check
+          # has nothing older to compare against and fails as "did not run".
+          #
+          # No unsuffixed package exists at 37: sdkmanager offers android-37.0,
+          # android-37.1 and android-37.2 and nothing called android-37, so
+          # "platforms;android-37" installs nothing and exits 0.
+          #
           # `yes` dies of SIGPIPE once sdkmanager stops reading prompts, so its
-          # status says nothing; assert on the jar that had to appear instead.
-          yes | "$SDKMANAGER" "platforms;android-37.0" > /dev/null || true
+          # status says nothing; assert on the jars that had to appear instead.
+          yes | "$SDKMANAGER" "platforms;android-36" "platforms;android-37.0" > /dev/null || true
+          test -f "$ANDROID_SDK_ROOT/platforms/android-36/android.jar"
           test -f "$ANDROID_SDK_ROOT/platforms/android-37.0/android.jar"
       - name: Check the Android port against API 37
         if: matrix.id == 'default'
         run: |
           set -euo pipefail
+          # For JAVA17_HOME, which setup-workspace.sh writes here rather than
+          # exporting into the job.
           source "${RUNNER_TEMP}/codenameone-tools/tools/env.sh"
-          # The port's real compile classpath, so the raw error counts either
-          # side of the comparison stay small enough to read. The check does not
-          # depend on it being complete -- anything unresolved fails against
-          # both platforms and cancels out.
-          (cd maven && "$MAVEN_HOME/bin/mvn" -B -q -Pcompile-android -pl android \
-             dependency:build-classpath -DincludeScope=compile \
-             -Dmdep.outputFile="${RUNNER_TEMP}/android-port-classpath.txt")
-          python3 scripts/check-android-api-removals.py \
-            --classpath "$(cat "${RUNNER_TEMP}/android-port-classpath.txt")" \
-            --require-all
+          # No classpath is passed: the script finds the cn1-binaries jars and
+          # the built core itself, and the comparison does not need more than
+          # that -- anything unresolved fails against both platforms and
+          # cancels out. Resolving the port's real classpath through Maven was
+          # tried and is wrong here, because -Pcompile-android reads its jars
+          # from maven/target/cn1-binaries, which this job never stages.
+          python3 scripts/check-android-api-removals.py --require-all
       - name: Build Hello Codename One Android app
         id: build-android-app
         run: |

--- a/.github/workflows/scripts-android.yml
+++ b/.github/workflows/scripts-android.yml
@@ -212,7 +212,14 @@ jobs:
           # it, and the builder gives a developer whichever revision their SDK
           # has -- so pinning the .0 here would let a regression introduced in
           # 37.1 or 37.2 merge green.
-          TARGET_PACKAGE=$(scripts/android/newest-platform-package.sh 37)
+          # Checked explicitly, not left to `set -e`: a failing command
+          # substitution in an assignment does not reliably abort, and an
+          # empty package name here would read as a successful resolution.
+          if ! TARGET_PACKAGE=$(scripts/android/newest-platform-package.sh 37); then
+            echo "could not determine the newest API 37 platform" >&2
+            exit 1
+          fi
+          test -n "$TARGET_PACKAGE"
           echo "Newest stable API 37 platform: $TARGET_PACKAGE"
           # The baseline stays the unsuffixed 36 deliberately: it has to sit
           # UNDER the whole range of removals being watched, and a later

--- a/.github/workflows/scripts-android.yml
+++ b/.github/workflows/scripts-android.yml
@@ -17,6 +17,7 @@ name: Test Android build scripts
       - 'scripts/build-android-app.sh'
       - 'scripts/verify-android-app-compile-sdk.sh'
       - 'scripts/check-android-api-removals.py'
+      - 'scripts/android/newest-platform-package.sh'
       - 'scripts/run-android-instrumentation-tests.sh'
       - 'scripts/generate-android-coverage-report.sh'
       - 'scripts/android/lib/**/*.java'
@@ -49,6 +50,7 @@ name: Test Android build scripts
       - 'scripts/build-android-app.sh'
       - 'scripts/verify-android-app-compile-sdk.sh'
       - 'scripts/check-android-api-removals.py'
+      - 'scripts/android/newest-platform-package.sh'
       - 'scripts/run-android-instrumentation-tests.sh'
       - 'scripts/generate-android-coverage-report.sh'
       - 'scripts/android/lib/**/*.java'
@@ -200,23 +202,27 @@ jobs:
       - name: Install Android platforms 36 and 37
         if: matrix.id == 'default'
         run: |
+          set -euo pipefail
           # SDK-root copy first: a sdkmanager on PATH can belong to a
           # different SDK root and install where the build never looks.
           SDKMANAGER="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
           [ -x "$SDKMANAGER" ] || SDKMANAGER="$(command -v sdkmanager)"
-          # Both ends of the comparison, rather than trusting the runner image
-          # to carry the baseline: with only a 37 platform installed the check
-          # has nothing older to compare against and fails as "did not run".
-          #
-          # No unsuffixed package exists at 37: sdkmanager offers android-37.0,
-          # android-37.1 and android-37.2 and nothing called android-37, so
-          # "platforms;android-37" installs nothing and exits 0.
+          # The NEWEST stable revision of 37, not its .0. An API level is not
+          # one platform from 37 onward, a removal can land in any revision of
+          # it, and the builder gives a developer whichever revision their SDK
+          # has -- so pinning the .0 here would let a regression introduced in
+          # 37.1 or 37.2 merge green.
+          TARGET_PACKAGE=$(scripts/android/newest-platform-package.sh 37)
+          echo "Newest stable API 37 platform: $TARGET_PACKAGE"
+          # The baseline stays the unsuffixed 36 deliberately: it has to sit
+          # UNDER the whole range of removals being watched, and a later
+          # revision of 36 could itself have removed something.
           #
           # `yes` dies of SIGPIPE once sdkmanager stops reading prompts, so its
           # status says nothing; assert on the jars that had to appear instead.
-          yes | "$SDKMANAGER" "platforms;android-36" "platforms;android-37.0" > /dev/null || true
+          yes | "$SDKMANAGER" "platforms;android-36" "$TARGET_PACKAGE" > /dev/null || true
           test -f "$ANDROID_SDK_ROOT/platforms/android-36/android.jar"
-          test -f "$ANDROID_SDK_ROOT/platforms/android-37.0/android.jar"
+          test -f "$ANDROID_SDK_ROOT/platforms/${TARGET_PACKAGE#platforms;}/android.jar"
       - name: Check the Android port against API 37
         if: matrix.id == 'default'
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,14 @@ they cannot compile here at all -- but they fail identically against both jars
 and cancel out. Error lines are compared whole, line numbers included, which is
 exact because both runs see byte-identical source.
 
+The platform goes on the **boot** class path, not the class path. Through
+`-cp` it supplies `android.*` and nothing else -- `java.*` keeps resolving from
+the host JDK's system modules, because the class path cannot override the core
+library -- so the gate was blind to Android's `java.*`. Measured with
+`java.lang.ProcessHandle`, which Android has never shipped: 0 errors through
+`-cp`, 1 through `-bootclasspath`. That forces `-source/-target 8`, which javac
+requires before it honours `-bootclasspath` at all.
+
 One trap it has to defend against: **a second `android.jar` on the classpath
 silently defeats it.** The port's Maven compile classpath carries the
 cn1-binaries stub, javac resolves the platform jar first, misses the removed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,89 @@ removing one can make a previously-used private method dead.
 
 Findings land in each module's `target/spotbugsXml.xml`.
 
+### Android removes API, and nothing used to notice
+
+Codename One issue #5701: API 37 deleted
+`android.hardware.fingerprint.FingerprintManager` and
+`Context.FINGERPRINT_SERVICE`, the port named both from files every generated
+application compiles, and an unmodified Hello World failed
+`:app:compileDebugJavaWithJavac` in sources the developer never wrote. Every
+check in the tree was green, and structurally had to be:
+
+- The port's Maven build compiles against the **cn1-binaries `android.jar`**,
+  which is old enough to still *contain* whatever a new platform removed.
+- The only place port sources meet a current platform is the **generated Gradle
+  project**, and `scripts/build-android-app.sh` pins its compile SDK so the
+  screenshot baselines and the emulator leg stay reproducible.
+
+Two checks close that, both in `scripts-android.yml` and both on the default
+leg only -- what they compare is the platform jar, not the JDK.
+
+```bash
+source tools/env.sh
+scripts/check-android-api-removals.py                 # offline, ~1 min
+scripts/check-android-api-removals.py --require-all   # what CI runs
+scripts/verify-android-app-compile-sdk.sh <gradle-project-dir> 37
+```
+
+`check-android-api-removals.py` compiles `Ports/Android/src` twice from the
+same sources, against two platform jars, and reports the errors that appear
+only against the newer one. **The comparison is what makes it work without a
+perfect classpath**: the port excludes its optional packages (`ai`, `ar`,
+`cipher`, `nearby`) from the module build, so their dependencies are absent and
+they cannot compile here at all -- but they fail identically against both jars
+and cancel out. Error lines are compared whole, line numbers included, which is
+exact because both runs see byte-identical source.
+
+One trap it has to defend against: **a second `android.jar` on the classpath
+silently defeats it.** The port's Maven compile classpath carries the
+cn1-binaries stub, javac resolves the platform jar first, misses the removed
+class, falls through to the stub and finds it -- so the target compile succeeds
+on exactly the symbol the gate exists to catch. Any entry named `android.jar`
+is therefore dropped from a supplied classpath.
+
+`verify-android-app-compile-sdk.sh` is the end-to-end half: it re-pins the
+project the primary build already produced and assembles it again, so AAPT, the
+manifest merger, aar metadata and packaging go through the newer platform too.
+It reuses the generated sources and the warm Gradle cache, so it costs one more
+assemble rather than another build.
+
+**Not covered: runtime.** No API 37 emulator runs anywhere -- the leg is at
+`api-level: 36`, and moving it would reseed every Android screenshot baseline.
+Android 17 behaviour changes are still unverified.
+
+#### API 37 is the first release with no unsuffixed platform
+
+`sdkmanager` offers `platforms;android-37.0`, `android-37.1` and
+`android-37.2`, and nothing called `android-37`. Consequences that have each
+already cost a fix:
+
+- **Installing by the bare number is a silent no-op.** `sdkmanager
+  "platforms;android-37"` exits 0 and installs nothing; the build then fails
+  much later on a missing target. Ask for `android-37.0`.
+- **The platform string the builder carries now has a dot in it.** It reaches
+  `Integer.parseInt` in `AndroidGradleBuilder`, which threw outright on the
+  legacy `android.useGradle8=false` path and made `compileSdkInt` answer 0 --
+  the value every caller reads as "could not be determined", so the manifest
+  fragments lost the compile SDK they check attribute values against. Reduce a
+  platform name to its API level before comparing it, and note that gathering
+  its digits (`"37.2"` -> 372) is worse than parsing it: 372 compares greater
+  than every floor in the class and defeats all of them silently.
+- **`android.suppressUnsupportedCompileSdk` wants the resolved name.** AGP
+  8.13.2 builds fine at `compileSdk 37` but warns, and it asks to be suppressed
+  with `37.0`, not the `37` the build requested. The property is a
+  comma-separated list, so both spellings go in rather than guessing.
+- **Prefer the `sdkmanager` inside the SDK root you are building against.** The
+  one on `PATH` can belong to a different root (the Homebrew cask), where it
+  installs the platform somewhere the build never looks. It also needs JDK 17
+  or newer, so a script that has sourced `tools/env.sh` (JDK 8) must run it
+  with `JAVA17_HOME`.
+
+Removals are recorded in the platform's own
+`data/api-versions.xml`, and against the **minor** they happened in, never the
+bare major -- a query for `removed="37"` matches nothing, while `37.0` and
+`37.1` are the real answers. The gate prints the whole set when it fails.
+
 ### Build hints
 
 A build hint is a `codename1.arg.<name>=<value>` line the builders read as

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
@@ -897,6 +897,16 @@ public class AndroidGradleBuilder extends Executor {
     private boolean playServicesWallet;
     private boolean playServicesWear;
     private String xPermissions, xQueries;
+    /**
+     * The names of the installed platforms, as sdkmanager reports them.
+     *
+     * <p>Names, not levels, because from API 37 the two differ: the level is
+     * 37 and the name is android-37.0, android-37.1 or android-37.2. Every
+     * numeric decision in this class uses the level; only the value written as
+     * {@code compileSdkVersion} needs the name, and it needs it exactly.</p>
+     */
+    private final List<String> installedPlatformNames = new ArrayList<>();
+
     private int buildToolsVersionInt;
     private String buildToolsVersion;
     private boolean useAndroidX;
@@ -1282,6 +1292,7 @@ public class AndroidGradleBuilder extends Executor {
                     }
 
                     installedPlatforms.add(platform);
+                    installedPlatformNames.add(platform);
                 }
             }
         }
@@ -7376,7 +7387,9 @@ public class AndroidGradleBuilder extends Executor {
                 + "\n"
                 + "android {\n"
                 + request.getArg("android.gradle.androidx", "") + "\n"
-                + "    compileSdkVersion " + compileSdkVersion + "\n"
+                + "    compileSdkVersion "
+                + compileSdkGradleValue(compileSdkVersion,
+                        installedPlatformNames) + "\n"
                 // For maven builder explicitly specifying buildtools version caused some problems
                 // leave it out and just let Android studio choose the version installed.
                 //+ "    buildToolsVersion " + quotedBuildToolsVersion + "\n"
@@ -7567,7 +7580,9 @@ public class AndroidGradleBuilder extends Executor {
         Integer compileSdkInt = parseSdkInt(compileSdkVersion);
         if (compileSdkInt != null && compileSdkInt >= 35) {
             gradlePropertiesObject.setProperty("android.suppressUnsupportedCompileSdk",
-                    suppressUnsupportedCompileSdkValue(compileSdkInt));
+                    suppressUnsupportedCompileSdkValue(compileSdkInt,
+                            compileSdkPlatformName(compileSdkInt,
+                                    installedPlatformNames)));
         }
 
         // Configure R8 optimization mode to prevent reflection issues
@@ -10560,6 +10575,90 @@ public class AndroidGradleBuilder extends Executor {
     }
 
     /**
+     * The installed platform this build should compile against, by name.
+     *
+     * <p>{@code compileSdkVersion 37} is a request for the platform whose hash
+     * string is {@code android-37}, and AGP does not fall back to another
+     * revision of the level: with only android-37.2 installed it fails with
+     * "Failed to find target with hash string 'android-37'" rather than using
+     * it. Measured against AGP 8.13.2. Since API 37 ships only as
+     * android-37.0, -37.1 and -37.2, and {@code sdkmanager
+     * "platforms;android-37.2"} is an ordinary thing to have run, the bare
+     * number can name a platform nobody has.</p>
+     *
+     * @param compileSdk the API level this build compiles against
+     * @param installed  the platform names the SDK reports, e.g. "36", "37.2"
+     * @return the name to compile against, or null when the level is not
+     *         installed at all -- in which case the caller should keep asking
+     *         for the bare number and let AGP fetch it
+     */
+    static String compileSdkPlatformName(int compileSdk, List<String> installed) {
+        if (installed == null) {
+            return null;
+        }
+        String bare = String.valueOf(compileSdk);
+        String best = null;
+        int bestMinor = -1;
+        for (String name : installed) {
+            if (name == null) {
+                continue;
+            }
+            String trimmed = name.trim();
+            if (trimmed.equals(bare)) {
+                // The unsuffixed platform is installed, which is the case for
+                // every level up to 36 and for any SDK that took android-37.0.
+                // Nothing to do: the number AGP was going to resolve is there.
+                return bare;
+            }
+            Integer level = parseSdkInt(trimmed);
+            if (level == null || level != compileSdk) {
+                continue;
+            }
+            int dot = trimmed.indexOf('.');
+            String minorText = dot >= 0 ? trimmed.substring(dot + 1) : "";
+            int minor = 0;
+            try {
+                minor = Integer.parseInt(minorText);
+            } catch (NumberFormatException notANumber) {
+                continue;
+            }
+            if (minor > bestMinor) {
+                bestMinor = minor;
+                best = trimmed;
+            }
+        }
+        return best;
+    }
+
+    /**
+     * The value to write after {@code compileSdkVersion} in build.gradle.
+     *
+     * <p>The bare number wherever the unsuffixed platform exists, which keeps
+     * every build that works today byte-identical. Only when the level is
+     * installed solely as a minor revision does this switch to the quoted hash
+     * string -- {@code 'android-37.2'} -- which AGP 8.13.2 accepts and
+     * resolves to that exact platform. The int property has no way to say
+     * "37.2" (compileSdkMinor is AGP 9), so the hash string is the only
+     * spelling available.</p>
+     *
+     * @param compileSdkVersion the compile SDK settled on, as a string
+     * @param installed         the platform names the SDK reports
+     * @return the Groovy literal to emit
+     */
+    static String compileSdkGradleValue(String compileSdkVersion,
+            List<String> installed) {
+        Integer compileSdk = parseSdkInt(compileSdkVersion);
+        if (compileSdk == null) {
+            return compileSdkVersion;
+        }
+        String name = compileSdkPlatformName(compileSdk, installed);
+        if (name == null || name.indexOf('.') < 0) {
+            return String.valueOf(compileSdk);
+        }
+        return "'android-" + name + "'";
+    }
+
+    /**
      * The value {@code android.suppressUnsupportedCompileSdk} has to carry to
      * silence AGP for a given compile SDK.
      *
@@ -10567,22 +10666,30 @@ public class AndroidGradleBuilder extends Executor {
      * <em>resolved</em>, not against the number the build asked for, and from
      * API 37 those differ: there is no {@code platforms;android-37}, so
      * {@code compileSdkVersion 37} resolves to android-37.0 and AGP asks for
-     * {@code 37.0}. Writing the bare {@code 37} the build requested left the
-     * "We recommend using a newer Android Gradle plugin" warning in every
-     * API 37 build log -- measured against AGP 8.13.2, which is what
+     * {@code 37.0}. Compiling against android-37.2 it asks for {@code 37.2}.
+     * Writing the bare {@code 37} the build requested left the "We recommend
+     * using a newer Android Gradle plugin" warning in every API 37 build log
+     * -- all three spellings measured against AGP 8.13.2, which is what
      * {@link #ANDROID_GRADLE_PLUGIN_8_VERSION} pins.</p>
      *
      * <p>The property takes a comma-separated list, so rather than predict
-     * which spelling a future AGP will resolve to, emit both. The redundant
-     * one is inert: on an API level whose platform has no minor the {@code
-     * .0} form simply never matches, and AGP does not warn about entries that
-     * match nothing.</p>
+     * which spelling AGP will resolve to, emit every one this build could
+     * produce. The redundant entries are inert: AGP does not warn about an
+     * entry that matches nothing.</p>
      *
-     * @param compileSdk the API level this build compiles against
-     * @return the property value, covering both spellings of that level
+     * @param compileSdk   the API level this build compiles against
+     * @param platformName the platform name it will resolve to, or null
+     * @return the property value, covering every spelling of that level
      */
-    static String suppressUnsupportedCompileSdkValue(int compileSdk) {
-        return compileSdk + "," + compileSdk + ".0";
+    static String suppressUnsupportedCompileSdkValue(int compileSdk,
+            String platformName) {
+        StringBuilder value = new StringBuilder();
+        value.append(compileSdk).append(',').append(compileSdk).append(".0");
+        if (platformName != null && platformName.indexOf('.') > 0
+                && !platformName.equals(compileSdk + ".0")) {
+            value.append(',').append(platformName);
+        }
+        return value.toString();
     }
 
     /**

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
@@ -1313,6 +1313,19 @@ public class AndroidGradleBuilder extends Executor {
             maxPlatformVersion = "31";
         }
 
+        // sdkmanager reports a platform by its full name, and from API 37 that
+        // name always carries a minor: there is no "platforms;android-37", only
+        // android-37.0, android-37.1 and android-37.2. The string above is
+        // therefore "37.2" where every earlier release gave "36", and it is fed
+        // to Integer.parseInt in three places that predate minor SDKs -- the
+        // targetSdkVersion below throws NumberFormatException outright, and
+        // compileSdkInt answers 0, which every caller reads as "could not be
+        // determined". Reduce it to the API level once, here, so the rest of
+        // the builder keeps seeing the integer form it was written against.
+        // The gradle8 branch below already did exactly this and so was never
+        // exposed; doing it unconditionally is what covers the legacy path.
+        maxPlatformVersion = "" + maxPlatformVersionInt;
+
         if (maxBuildToolsVersionInt == 0) {
             maxBuildToolsVersionInt = 31;
             maxBuildToolsVersion = "31";
@@ -1325,6 +1338,8 @@ public class AndroidGradleBuilder extends Executor {
             maxBuildToolsVersion = "" + maxBuildToolsVersionInt;
 
             maxPlatformVersionInt = Math.max(36, maxPlatformVersionInt);
+            // Re-derived because the floor above may have raised it; the
+            // minor-version reduction itself already happened for every path.
             maxPlatformVersion = "" + maxPlatformVersionInt;
         }
 
@@ -7212,7 +7227,7 @@ public class AndroidGradleBuilder extends Executor {
                 usesCustomTunnel));
         String supportLibVersion = maxPlatformVersion;
         String[] supportLadder = {"28", "29", "30", "31", "32", "33", "34",
-            "35", "36"};
+            "35", "36", "37"};
         for (int i = 0; i < supportLadder.length; i++) {
             if (buildToolsVersion.startsWith(supportLadder[i])) {
                 supportLibVersion = "28";
@@ -7551,7 +7566,8 @@ public class AndroidGradleBuilder extends Executor {
         }
         Integer compileSdkInt = parseSdkInt(compileSdkVersion);
         if (compileSdkInt != null && compileSdkInt >= 35) {
-            gradlePropertiesObject.setProperty("android.suppressUnsupportedCompileSdk", String.valueOf(compileSdkInt));
+            gradlePropertiesObject.setProperty("android.suppressUnsupportedCompileSdk",
+                    suppressUnsupportedCompileSdkValue(compileSdkInt));
         }
 
         // Configure R8 optimization mode to prevent reflection issues
@@ -10543,11 +10559,60 @@ public class AndroidGradleBuilder extends Executor {
         return compileSdkVersion;
     }
 
+    /**
+     * The value {@code android.suppressUnsupportedCompileSdk} has to carry to
+     * silence AGP for a given compile SDK.
+     *
+     * <p>AGP compares the property against the name of the platform it
+     * <em>resolved</em>, not against the number the build asked for, and from
+     * API 37 those differ: there is no {@code platforms;android-37}, so
+     * {@code compileSdkVersion 37} resolves to android-37.0 and AGP asks for
+     * {@code 37.0}. Writing the bare {@code 37} the build requested left the
+     * "We recommend using a newer Android Gradle plugin" warning in every
+     * API 37 build log -- measured against AGP 8.13.2, which is what
+     * {@link #ANDROID_GRADLE_PLUGIN_8_VERSION} pins.</p>
+     *
+     * <p>The property takes a comma-separated list, so rather than predict
+     * which spelling a future AGP will resolve to, emit both. The redundant
+     * one is inert: on an API level whose platform has no minor the {@code
+     * .0} form simply never matches, and AGP does not warn about entries that
+     * match nothing.</p>
+     *
+     * @param compileSdk the API level this build compiles against
+     * @return the property value, covering both spellings of that level
+     */
+    static String suppressUnsupportedCompileSdkValue(int compileSdk) {
+        return compileSdk + "," + compileSdk + ".0";
+    }
+
+    /**
+     * The API level named by a compile or target SDK string.
+     *
+     * <p>Accepts the spellings the SDK and the build hints actually produce:
+     * a bare {@code 36}, the quoted {@code android-36} the legacy Gradle
+     * files use, and -- since Android 17 -- a platform name carrying a minor,
+     * {@code 37.2}. Only the major matters to every caller: AGP's
+     * {@code compileSdk} is an API level, and the minor selects which
+     * revision of that level the platform is.</p>
+     *
+     * <p>The minor is dropped before the digits are gathered rather than
+     * after, because gathering first turns "37.2" into 372 -- an API level
+     * three hundred short of anything real, which compares greater than every
+     * floor in this class and so would silently defeat all of them.</p>
+     *
+     * @param value the SDK string, or null
+     * @return the API level, or null when there is no number in it
+     */
     private static Integer parseSdkInt(String value) {
         if (value == null) {
             return null;
         }
-        String digits = value.replaceAll("\\D", "");
+        String major = value.trim();
+        int dot = major.indexOf('.');
+        if (dot >= 0) {
+            major = major.substring(0, dot);
+        }
+        String digits = major.replaceAll("\\D", "");
         if (digits.isEmpty()) {
             return null;
         }
@@ -10638,7 +10703,8 @@ public class AndroidGradleBuilder extends Executor {
             boolean usesAnyNearby, boolean usesCallVoip,
             boolean usesCustomTunnel) {
         String compileSdkVersion = maxPlatformVersion;
-        String[] ladder = {"28", "29", "30", "31", "32", "33", "34", "35", "36"};
+        String[] ladder = {"28", "29", "30", "31", "32", "33", "34", "35", "36",
+            "37"};
         for (int i = 0; i < ladder.length; i++) {
             if (buildToolsVersion != null
                     && buildToolsVersion.startsWith(ladder[i])) {
@@ -10678,11 +10744,13 @@ public class AndroidGradleBuilder extends Executor {
         // requires the attribute has already made it writable. The daemon
         // copy raises to the target only inside its container path, which is
         // why it needs the rule stated separately.
-        try {
-            return Integer.parseInt(compileSdkVersion.trim());
-        } catch (NumberFormatException notANumber) {
-            return 0;
-        }
+        // Through parseSdkInt rather than Integer.parseInt: a platform name
+        // with a minor in it ("37.2") is a NumberFormatException here, and the
+        // 0 that catch returns reads to every caller as "could not be
+        // determined" -- so an API 37 build lost the compile SDK that the
+        // manifest fragments check their attribute values against.
+        Integer parsed = parseSdkInt(compileSdkVersion);
+        return parsed == null ? 0 : parsed;
     }
 
 }

--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
@@ -1292,7 +1292,21 @@ public class AndroidGradleBuilder extends Executor {
                     }
 
                     installedPlatforms.add(platform);
-                    installedPlatformNames.add(platform);
+                    // Only genuinely installed rows here. sdkmanager --list
+                    // prints the installed packages with a fourth column
+                    // holding their location and the available ones with
+                    // three, and the branch above accepts either -- so
+                    // installedPlatforms has always carried platforms nobody
+                    // has. That is survivable where the answer is only a
+                    // number, because AGP downloads a level it is asked for.
+                    // It is not survivable here: this list is used to name an
+                    // exact platform, and naming one that was merely on offer
+                    // turns a working build into a download, or into a
+                    // failure with no network. The build-tools branch above
+                    // already requires the fourth column for the same reason.
+                    if (columns.length >= 4) {
+                        installedPlatformNames.add(platform);
+                    }
                 }
             }
         }
@@ -10633,13 +10647,22 @@ public class AndroidGradleBuilder extends Executor {
     /**
      * The value to write after {@code compileSdkVersion} in build.gradle.
      *
-     * <p>The bare number wherever the unsuffixed platform exists, which keeps
-     * every build that works today byte-identical. Only when the level is
-     * installed solely as a minor revision does this switch to the quoted hash
-     * string -- {@code 'android-37.2'} -- which AGP 8.13.2 accepts and
+     * <p>The bare number wherever the unsuffixed platform exists, which is
+     * every level up to 36 and keeps those builds byte-identical. Where the
+     * level is installed only as a minor revision this switches to the quoted
+     * hash string -- {@code 'android-37.2'} -- which AGP 8.13.2 accepts and
      * resolves to that exact platform. The int property has no way to say
      * "37.2" (compileSdkMinor is AGP 9), so the hash string is the only
      * spelling available.</p>
+     *
+     * <p>Worth being blunt about the reach of that: from API 37 there is no
+     * unsuffixed platform at all, so the quoted form is what an API 37 build
+     * gets, not a rare fallback. Anything that reads the generated
+     * {@code compileSdkVersion} back has to cope with it -- {@code
+     * PatchGradleFiles}, which the build scripts use to re-pin a generated
+     * project, matched only digits and so inserted a second declaration
+     * instead of replacing this one, leaving the original later in the block
+     * where Groovy let it win.</p>
      *
      * @param compileSdkVersion the compile SDK settled on, as a string
      * @param installed         the platform names the SDK reports

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/AndroidMinorPlatformVersionTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/AndroidMinorPlatformVersionTest.java
@@ -24,7 +24,12 @@ package com.codename1.builders;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -107,9 +112,76 @@ class AndroidMinorPlatformVersionTest {
      */
     @Test
     void theSuppressionKeyCarriesBothSpellings() {
-        String value = AndroidGradleBuilder.suppressUnsupportedCompileSdkValue(37);
+        String value = AndroidGradleBuilder.suppressUnsupportedCompileSdkValue(
+                37, "37.0");
         assertEquals("37,37.0", value);
         assertTrue(value.contains("37.0"),
                 "AGP 8.13.2 asks for the resolved platform name, which is 37.0");
+    }
+
+    /**
+     * Compiling against a later revision, AGP asks for that revision by name.
+     */
+    @Test
+    void theSuppressionKeyCoversTheResolvedRevision() {
+        assertEquals("37,37.0,37.2",
+                AndroidGradleBuilder.suppressUnsupportedCompileSdkValue(37, "37.2"));
+    }
+
+    /**
+     * The unsuffixed platform is what a build asks for when it is installed.
+     *
+     * <p>Which is every level up to 36, and any SDK that took android-37.0.
+     * Emitting the hash string there would be a gratuitous change to a build
+     * that already works.</p>
+     */
+    @Test
+    void theBarePlatformIsPreferredWhenInstalled() {
+        List<String> installed = Arrays.asList("34", "36", "37", "37.2");
+        assertEquals("37", AndroidGradleBuilder.compileSdkPlatformName(37, installed));
+        assertEquals("37", AndroidGradleBuilder.compileSdkGradleValue("37", installed));
+        assertEquals("36", AndroidGradleBuilder.compileSdkGradleValue("36", installed));
+    }
+
+    /**
+     * With only a minor revision installed, name it -- or nothing builds.
+     *
+     * <p>`compileSdkVersion 37` is a request for the platform whose hash
+     * string is `android-37`, and AGP does not fall back to another revision
+     * of the level. Measured against AGP 8.13.2: with only android-37.2
+     * installed it fails with "Failed to find target with hash string
+     * 'android-37'", and `compileSdkVersion 'android-37.2'` builds. Since API
+     * 37 ships only as 37.0/37.1/37.2, running `sdkmanager
+     * "platforms;android-37.2"` is enough to reach this.</p>
+     */
+    @Test
+    void aMinorOnlyInstallIsNamedExactly() {
+        List<String> installed = Arrays.asList("35", "36", "37.2");
+        assertEquals("37.2", AndroidGradleBuilder.compileSdkPlatformName(37, installed));
+        assertEquals("'android-37.2'",
+                AndroidGradleBuilder.compileSdkGradleValue("37", installed));
+    }
+
+    /**
+     * The newest installed revision wins, and "37.10" is newer than "37.2".
+     */
+    @Test
+    void theNewestRevisionWinsNumerically() {
+        assertEquals("37.10", AndroidGradleBuilder.compileSdkPlatformName(
+                37, Arrays.asList("37.2", "37.10", "37.1")));
+    }
+
+    /**
+     * A level nothing is installed for keeps the bare number.
+     *
+     * <p>So AGP can fetch it, which is what it does today. Inventing a name
+     * for a platform that is not there would turn a download into a failure.
+     * </p>
+     */
+    @Test
+    void anAbsentLevelKeepsTheBareNumber() {
+        List<String> installed = Collections.singletonList("36");
+        assertNull(AndroidGradleBuilder.compileSdkPlatformName(37, installed));
+        assertEquals("37", AndroidGradleBuilder.compileSdkGradleValue("37", installed));
     }
 }

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/AndroidMinorPlatformVersionTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/AndroidMinorPlatformVersionTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.builders;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The builder's arithmetic on a minor-versioned Android platform.
+ *
+ * <p>Android 17 is the first release that ships no unsuffixed platform:
+ * sdkmanager offers android-37.0, android-37.1 and android-37.2 and no
+ * "android-37" at all. The name is what the SDK list gives the builder, so
+ * from API 37 onward the platform string it carries around has a minor in it
+ * for the first time, and the arithmetic below predates that.</p>
+ */
+class AndroidMinorPlatformVersionTest {
+
+    /**
+     * The build-tools cap in {@link AndroidGradleBuilder#compileSdkInt}.
+     *
+     * <p>The ladder maps a build-tools version back to the compile SDK it can
+     * drive. It stopped at 36, so build-tools 37 matched no rung and the cap
+     * quietly stopped applying -- the compile SDK then came from the newest
+     * installed platform with nothing holding it down.</p>
+     */
+    @Test
+    void buildTools37CapsTheCompileSdkAt37() {
+        assertEquals(37, AndroidGradleBuilder.compileSdkInt("38", "37.0.0", "28",
+                false, false, false, false));
+    }
+
+    /**
+     * The rung below still has to behave, or the new one is untested luck.
+     */
+    @Test
+    void buildTools36StillCapsAt36() {
+        assertEquals(36, AndroidGradleBuilder.compileSdkInt("38", "36.0.0", "28",
+                false, false, false, false));
+    }
+
+    /**
+     * A platform name carrying a minor used to make this answer 0.
+     *
+     * <p>{@code compileSdkInt} ended in {@code Integer.parseInt}, which throws
+     * on "37.2" and was caught into a 0 return meaning "could not be
+     * determined". Every caller reads that as "impose no floor", so the
+     * manifest fragments lost the compile SDK they check attribute values
+     * against.</p>
+     *
+     * <p>The build-tools version here deliberately matches no rung of the
+     * ladder, so the platform string reaches the end of the method unreduced
+     * -- which is the path that used to throw. Reducing it at the call site
+     * would have left this one intact.</p>
+     */
+    @Test
+    void aMinorVersionedPlatformStillYieldsAnApiLevel() {
+        assertEquals(37, AndroidGradleBuilder.compileSdkInt("37.2", "38.0.0",
+                "28", false, false, false, false));
+    }
+
+    /**
+     * The minor must not be folded into the number itself.
+     *
+     * <p>Gathering the digits of "37.2" and then parsing them gives 372, which
+     * is greater than every floor in the class -- so the ranging floor below
+     * would compare satisfied, leave the string alone, and then fail the final
+     * parse into the same 0. Both halves have to drop the minor first, and
+     * this is the case that tells the two implementations apart: it answers 37
+     * now and answered 0 before.</p>
+     */
+    @Test
+    void aMinorVersionedPlatformSurvivesAFeatureFloor() {
+        assertEquals(37, AndroidGradleBuilder.compileSdkInt("37.2", "38.0.0",
+                "28", true, true, false, false));
+    }
+
+    /**
+     * The value AGP reads to stop warning about an untested compile SDK.
+     *
+     * <p>AGP names the platform it resolved rather than the number requested,
+     * so at API 37 it asks for "37.0" and the bare "37" the build requested
+     * suppressed nothing. The property is a comma-separated list, so both
+     * spellings go in and whichever one AGP resolves to matches.</p>
+     */
+    @Test
+    void theSuppressionKeyCarriesBothSpellings() {
+        String value = AndroidGradleBuilder.suppressUnsupportedCompileSdkValue(37);
+        assertEquals("37,37.0", value);
+        assertTrue(value.contains("37.0"),
+                "AGP 8.13.2 asks for the resolved platform name, which is 37.0");
+    }
+}

--- a/scripts/android/lib/PatchGradleFiles.java
+++ b/scripts/android/lib/PatchGradleFiles.java
@@ -40,7 +40,16 @@ public class PatchGradleFiles {
     private static final Pattern ANDROID_BLOCK_PATTERN = Pattern.compile("(?m)^\\s*android\\s*\\{");
     private static final Pattern DEFAULT_CONFIG_PATTERN = Pattern.compile("(?ms)^\\s*defaultConfig\\s*\\{.*?^\\s*\\}");
     private static final Pattern DEFAULT_CONFIG_HEADER_PATTERN = Pattern.compile("(?ms)^\\s*defaultConfig\\s*\\{");
-    private static final Pattern COMPILE_SDK_PATTERN = Pattern.compile("(?m)^\\s*compileSdkVersion\\s+\\d+");
+    // The value is not always a number. Where an API level ships only as minor
+    // revisions -- which is every level from 37, whose platforms are
+    // android-37.0/.1/.2 and never android-37 -- the builder names the exact
+    // platform instead: compileSdkVersion 'android-37.0'. Matching only digits
+    // meant no match, and the no-match branch below INSERTS a declaration
+    // rather than replacing one, leaving the original later in the same
+    // android block where Groovy lets it win. The pin then silently did
+    // nothing.
+    private static final Pattern COMPILE_SDK_PATTERN = Pattern.compile(
+            "(?m)^\\s*compileSdkVersion\\s+(?:\\d+|'[^']*'|\"[^\"]*\")");
     private static final Pattern TARGET_SDK_PATTERN = Pattern.compile("(?m)^\\s*targetSdkVersion\\s+\\d+");
     private static final Pattern TEST_INSTRUMENTATION_PATTERN = Pattern.compile("(?m)^\\s*testInstrumentationRunner\\s*\".*?\"\\s*$");
     private static final Pattern USE_LIBRARY_PATTERN = Pattern.compile("(?m)^\\s*useLibrary\\s+'android\\.test\\.(?:base|mock|runner)'\\s*$");

--- a/scripts/android/lib/PatchGradleFiles.java
+++ b/scripts/android/lib/PatchGradleFiles.java
@@ -150,7 +150,7 @@ public class PatchGradleFiles {
      * coverage report task there are configuration for tests that do not exist, and the report
      * finalizer fails on a module with nothing to report.</p>
      */
-    private static boolean patchAppBuildGradle(Path path, int compileSdk, int targetSdk,
+    private static boolean patchAppBuildGradle(Path path, String compileSdk, int targetSdk,
             boolean instrumented) throws IOException {
         String content = Files.readString(path, StandardCharsets.UTF_8);
         boolean changed = false;
@@ -183,7 +183,7 @@ public class PatchGradleFiles {
         return changed;
     }
 
-    private static Result ensureAndroidBlock(String content, int compileSdk, int targetSdk) {
+    private static Result ensureAndroidBlock(String content, String compileSdk, int targetSdk) {
         Matcher androidBlockMatcher = ANDROID_BLOCK_PATTERN.matcher(content);
         if (!androidBlockMatcher.find()) {
             if (!content.endsWith("\n")) {
@@ -419,20 +419,54 @@ afterEvaluate {
         final Path root;
         /** Every application module to pin; --app may be repeated. */
         final java.util.List<Path> apps;
-        final int compileSdk;
+        /**
+         * The compile SDK to pin, as it will be written.
+         *
+         * <p>A String, not an int, because an API level is not always one
+         * platform: from API 37 there is no unsuffixed platform and the
+         * revisions are android-37.0, android-37.1 and android-37.2. Pinning
+         * the bare level always resolves to the .0, so a caller that wants to
+         * build against the revision a developer's SDK actually settled on has
+         * to be able to name it.</p>
+         */
+        final String compileSdk;
         final int targetSdk;
 
-        Arguments(Path root, java.util.List<Path> apps, int compileSdk, int targetSdk) {
+        Arguments(Path root, java.util.List<Path> apps, String compileSdk, int targetSdk) {
             this.root = root;
             this.apps = apps;
             this.compileSdk = compileSdk;
             this.targetSdk = targetSdk;
         }
 
+        /**
+         * The Groovy literal for a requested compile SDK, or null if invalid.
+         *
+         * <p>Digits stay a bare number, which is what every level up to 36
+         * wants and keeps those generated files unchanged. A platform name --
+         * "37.2", or "android-37.2" -- becomes the quoted hash string AGP
+         * resolves to that exact platform, because the int property has no way
+         * to say a minor (compileSdkMinor is AGP 9).</p>
+         */
+        static String normalizeCompileSdk(String value) {
+            String trimmed = value == null ? "" : value.trim();
+            if (trimmed.matches("\\d+")) {
+                return trimmed;
+            }
+            String name = trimmed.startsWith("android-")
+                    ? trimmed.substring("android-".length()) : trimmed;
+            if (name.matches("\\d+\\.\\d+")) {
+                return "'android-" + name + "'";
+            }
+            System.err.println("Invalid --compile-sdk: " + value
+                    + " (expected 37, 37.2 or android-37.2)");
+            return null;
+        }
+
         static Arguments parse(String[] args) {
             Path root = null;
             java.util.List<Path> apps = new java.util.ArrayList<>();
-            int compileSdk = 36;
+            String compileSdk = "36";
             int targetSdk = 36;
             for (int i = 0; i < args.length; i++) {
                 String arg = args[i];
@@ -456,7 +490,10 @@ afterEvaluate {
                             System.err.println("Missing value for --compile-sdk");
                             return null;
                         }
-                        compileSdk = Integer.parseInt(args[++i]);
+                        compileSdk = normalizeCompileSdk(args[++i]);
+                        if (compileSdk == null) {
+                            return null;
+                        }
                     }
                     case "--target-sdk" -> {
                         if (i + 1 >= args.length) {

--- a/scripts/android/newest-platform-package.sh
+++ b/scripts/android/newest-platform-package.sh
@@ -35,25 +35,38 @@ elif command -v sdkmanager >/dev/null 2>&1; then
   SDKMANAGER="sdkmanager"
 fi
 
-fallback() {
-  # What the level would have been called before minor revisions existed, and
-  # the first revision after. Used only when sdkmanager cannot be consulted.
-  if [ "$API" -ge 37 ]; then echo "platforms;android-$API.0"; else echo "platforms;android-$API"; fi
-}
-
+# No fallback, deliberately. The obvious one -- assume the ".0" -- is the
+# single answer this script must never give: ".0" is the oldest revision of a
+# level, it is usually the one already on a runner, and returning it would let
+# the jar assertions and both API checks pass while testing exactly the
+# revision this script exists to stop them pinning. A resolver that quietly
+# degrades to the thing it was written to prevent is worse than no resolver,
+# because the coverage looks present. Anything that stops it answering is
+# therefore fatal, and the caller's `set -e` turns that into a failed step.
 if [ -z "$SDKMANAGER" ]; then
-  fallback
-  exit 0
+  echo "$0: no sdkmanager on PATH or under ANDROID_SDK_ROOT/ANDROID_HOME," \
+       "so the newest API $API platform cannot be determined" >&2
+  exit 1
 fi
 
 # JDK 17+, or sdkmanager refuses to run at all; a script that sourced the
 # workspace env has JAVA_HOME pointing at the JDK 8 the framework is built with.
-LIST=$(JAVA_HOME="${JDK_HOME:-${JAVA17_HOME:-${JAVA_HOME:-}}}" "$SDKMANAGER" --list 2>/dev/null || true)
+if ! LIST=$(JAVA_HOME="${JDK_HOME:-${JAVA17_HOME:-${JAVA_HOME:-}}}" "$SDKMANAGER" --list 2>&1); then
+  echo "$0: sdkmanager --list failed, so the newest API $API platform cannot" \
+       "be determined:" >&2
+  echo "$LIST" | tail -5 >&2
+  exit 1
+fi
 if [ -z "$LIST" ]; then
-  fallback
-  exit 0
+  echo "$0: sdkmanager --list printed nothing, so the newest API $API" \
+       "platform cannot be determined" >&2
+  exit 1
 fi
 
+# `|| true` because a grep that matches nothing exits 1, and under `set -o
+# pipefail` that killed the script here -- before the explicit "offers no
+# platform" check below could say so. The failure was silent: exit 1, no
+# message, which is the shape of bug this whole script exists to refuse.
 BEST=$(echo "$LIST" \
   | grep -oE "platforms;android-${API}(\.[0-9]+)?([^0-9a-zA-Z.-]|$)" \
   | grep -oE "platforms;android-${API}(\.[0-9]+)?" \
@@ -61,11 +74,12 @@ BEST=$(echo "$LIST" \
   | sed "s/^platforms;android-${API}//" \
   | sed 's/^\.//' \
   | sort -n \
-  | tail -1)
+  | tail -1 || true)
 
 if [ -z "$BEST" ]; then
-  fallback
-elif [ "$BEST" = "$API" ] || [ -z "$BEST" ]; then
+  echo "$0: sdkmanager offers no platform for API $API" >&2
+  exit 1
+elif [ "$BEST" = "$API" ]; then
   echo "platforms;android-$API"
 else
   echo "platforms;android-$API.$BEST"

--- a/scripts/android/newest-platform-package.sh
+++ b/scripts/android/newest-platform-package.sh
@@ -67,20 +67,50 @@ fi
 # pipefail` that killed the script here -- before the explicit "offers no
 # platform" check below could say so. The failure was silent: exit 1, no
 # message, which is the shape of bug this whole script exists to refuse.
-BEST=$(echo "$LIST" \
+#
+# The trailing character class is what keeps neighbours out: it rejects the
+# "-" of android-36-ext18 and of the 37.2-beta1 previews, while accepting the
+# space or end-of-line that follows a real package id.
+MATCHES=$(echo "$LIST" \
   | grep -oE "platforms;android-${API}(\.[0-9]+)?([^0-9a-zA-Z.-]|$)" \
   | grep -oE "platforms;android-${API}(\.[0-9]+)?" \
-  | sort -u \
-  | sed "s/^platforms;android-${API}//" \
-  | sed 's/^\.//' \
-  | sort -n \
-  | tail -1 || true)
+  | sort -u || true)
 
-if [ -z "$BEST" ]; then
+if [ -z "$MATCHES" ]; then
   echo "$0: sdkmanager offers no platform for API $API" >&2
   exit 1
-elif [ "$BEST" = "$API" ]; then
-  echo "platforms;android-$API"
-else
-  echo "platforms;android-$API.$BEST"
 fi
+
+# Pick the newest revision and print THAT LINE, rather than reconstructing an
+# id from a stripped suffix. Stripping lost the unsuffixed package: for
+# "platforms;android-36" the suffix is the empty string, which is
+# indistinguishable from "nothing matched" -- so a level offered only without a
+# minor, which is every level up to 36, was reported as unavailable.
+#
+# An unsuffixed package is the level's original release and older than any
+# explicit minor, so it sorts as -1 and any real minor beats it.
+BEST_PACKAGE=""
+BEST_MINOR=-2
+while IFS= read -r PKG; do
+  [ -n "$PKG" ] || continue
+  SUFFIX="${PKG#platforms;android-${API}}"
+  if [ -z "$SUFFIX" ]; then
+    MINOR=-1
+  else
+    MINOR="${SUFFIX#.}"
+  fi
+  if [ "$MINOR" -gt "$BEST_MINOR" ]; then
+    BEST_MINOR="$MINOR"
+    BEST_PACKAGE="$PKG"
+  fi
+done <<MATCHED_PACKAGES
+$MATCHES
+MATCHED_PACKAGES
+
+if [ -z "$BEST_PACKAGE" ]; then
+  echo "$0: could not pick a platform for API $API from:" >&2
+  echo "$MATCHES" >&2
+  exit 1
+fi
+
+echo "$BEST_PACKAGE"

--- a/scripts/android/newest-platform-package.sh
+++ b/scripts/android/newest-platform-package.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Print the newest stable sdkmanager package for an Android API level.
+#
+#   scripts/android/newest-platform-package.sh 37   ->  platforms;android-37.2
+#   scripts/android/newest-platform-package.sh 36   ->  platforms;android-36
+#
+# Needed because an API level is not one platform. From API 37 there is no
+# unsuffixed package at all -- sdkmanager offers android-37.0, android-37.1 and
+# android-37.2 -- and a removal can land in any of those revisions, so pinning
+# the ".0" of a level tests the oldest one and merges a regression introduced
+# in a later revision. Asking sdkmanager which revisions exist keeps that from
+# going stale, at the cost of a check that can turn red when Google ships a new
+# minor: which is the point, since that is exactly when we want to know.
+#
+# Previews are excluded. Their version carries a suffix (37.2-beta3), they are
+# not what a developer's SDK will settle on, and a beta that removes something
+# is not yet a fact about a shipped release.
+
+set -euo pipefail
+
+API="${1:-}"
+if [ -z "$API" ]; then
+  echo "usage: $0 <api-level>" >&2
+  exit 2
+fi
+
+# SDK-root copy first; the one on PATH can belong to a different SDK root.
+SDKMANAGER=""
+if [ -x "${ANDROID_SDK_ROOT:-}/cmdline-tools/latest/bin/sdkmanager" ]; then
+  SDKMANAGER="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
+elif [ -x "${ANDROID_HOME:-}/cmdline-tools/latest/bin/sdkmanager" ]; then
+  SDKMANAGER="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
+elif command -v sdkmanager >/dev/null 2>&1; then
+  SDKMANAGER="sdkmanager"
+fi
+
+fallback() {
+  # What the level would have been called before minor revisions existed, and
+  # the first revision after. Used only when sdkmanager cannot be consulted.
+  if [ "$API" -ge 37 ]; then echo "platforms;android-$API.0"; else echo "platforms;android-$API"; fi
+}
+
+if [ -z "$SDKMANAGER" ]; then
+  fallback
+  exit 0
+fi
+
+# JDK 17+, or sdkmanager refuses to run at all; a script that sourced the
+# workspace env has JAVA_HOME pointing at the JDK 8 the framework is built with.
+LIST=$(JAVA_HOME="${JDK_HOME:-${JAVA17_HOME:-${JAVA_HOME:-}}}" "$SDKMANAGER" --list 2>/dev/null || true)
+if [ -z "$LIST" ]; then
+  fallback
+  exit 0
+fi
+
+BEST=$(echo "$LIST" \
+  | grep -oE "platforms;android-${API}(\.[0-9]+)?([^0-9a-zA-Z.-]|$)" \
+  | grep -oE "platforms;android-${API}(\.[0-9]+)?" \
+  | sort -u \
+  | sed "s/^platforms;android-${API}//" \
+  | sed 's/^\.//' \
+  | sort -n \
+  | tail -1)
+
+if [ -z "$BEST" ]; then
+  fallback
+elif [ "$BEST" = "$API" ] || [ -z "$BEST" ]; then
+  echo "platforms;android-$API"
+else
+  echo "platforms;android-$API.$BEST"
+fi

--- a/scripts/build-android-app.sh
+++ b/scripts/build-android-app.sh
@@ -120,7 +120,28 @@ if [ -z "$GRADLE_PROJECT_DIR" ]; then
   exit 1
 fi
 
-ba_log "Normalizing Android Gradle project in $GRADLE_PROJECT_DIR"
+# The API level this build compiles and targets. 36 by default, which is what
+# the screenshot baselines and the emulator leg were taken against, so a change
+# here changes what the suite is comparing. Overridable so the same script can
+# be pointed at a newer platform -- see scripts/verify-android-app-compile-sdk.sh,
+# which is how CI proves the generated project still builds at API 37.
+ANDROID_APP_COMPILE_SDK="${CN1_ANDROID_COMPILE_SDK:-36}"
+ANDROID_APP_TARGET_SDK="${CN1_ANDROID_TARGET_SDK:-$ANDROID_APP_COMPILE_SDK}"
+
+# The sdkmanager package that carries a platform. Every level up to 36 is named
+# by the bare number; from 37 there is no unsuffixed package at all -- only
+# android-37.0, android-37.1 and android-37.2 -- so asking for "android-37"
+# installs nothing and the build then fails on a missing target rather than on
+# anything real.
+android_platform_package() {
+  if [ "$1" -ge 37 ]; then
+    echo "platforms;android-$1.0"
+  else
+    echo "platforms;android-$1"
+  fi
+}
+
+ba_log "Normalizing Android Gradle project in $GRADLE_PROJECT_DIR (compileSdk $ANDROID_APP_COMPILE_SDK, targetSdk $ANDROID_APP_TARGET_SDK)"
 
 # --- Install Android instrumentation harness for coverage ---
 # CN1_ANDROID_TEST_SOURCE_DIR overrides the instrumentation sources (the
@@ -148,7 +169,8 @@ ba_log "Installed Android instrumentation tests in $ANDROID_TEST_JAVA_DIR"
 GRADLE_PROPS="$GRADLE_PROJECT_DIR/gradle.properties"
 grep -q '^android.useAndroidX=' "$GRADLE_PROPS" 2>/dev/null || echo 'android.useAndroidX=true' >> "$GRADLE_PROPS"
 grep -q '^android.enableJetifier=' "$GRADLE_PROPS" 2>/dev/null || echo 'android.enableJetifier=true' >> "$GRADLE_PROPS"
-grep -q '^android.suppressUnsupportedCompileSdk=' "$GRADLE_PROPS" 2>/dev/null || echo 'android.suppressUnsupportedCompileSdk=36' >> "$GRADLE_PROPS"
+grep -q '^android.suppressUnsupportedCompileSdk=' "$GRADLE_PROPS" 2>/dev/null || \
+  echo "android.suppressUnsupportedCompileSdk=$ANDROID_APP_COMPILE_SDK,$ANDROID_APP_COMPILE_SDK.0" >> "$GRADLE_PROPS"
 
 # More heap than the builder's generated default, for this script only.
 #
@@ -194,9 +216,10 @@ PATCH_GRADLE_MODULES=(--app "$APP_BUILD_GRADLE")
 # the phone one, so that both modules compile against the platform this job installs rather than
 # whichever one happens to be newest on the runner. AGP 8.13.2 is tested up to 36 and only warns
 # above it, and the suite's targetSdk-dependent behaviour is what the screenshots were taken
-# against, so the pin is about reproducibility. It is NOT a workaround for API 37 any more:
-# the port no longer names FingerprintManager (see pruneBiometricSourcesForCompileSdk), and a
-# compileSdk 37 / targetSdk 37 build of this sample was verified by hand.
+# against, so the pin is about reproducibility -- not about API 37, which the port has compiled
+# against since #5723. That claim is no longer taken on trust: the same project is rebuilt at
+# API 37 by scripts/verify-android-app-compile-sdk.sh, and the port's sources are compared
+# against the two platforms by scripts/check-android-api-removals.py.
 WEAR_BUILD_GRADLE="$GRADLE_PROJECT_DIR/wear/build.gradle"
 if [ -f "$WEAR_BUILD_GRADLE" ]; then
   ba_log "Wear module present; pinning its SDK levels too"
@@ -206,8 +229,8 @@ fi
 "$PATCH_GRADLE_JAVA" "$PATCH_GRADLE_SOURCE_PATH/$PATCH_GRADLE_MAIN_CLASS.java" \
   --root "$ROOT_BUILD_GRADLE" \
   "${PATCH_GRADLE_MODULES[@]}" \
-  --compile-sdk 36 \
-  --target-sdk 36
+  --compile-sdk "$ANDROID_APP_COMPILE_SDK" \
+  --target-sdk "$ANDROID_APP_TARGET_SDK"
 # --- END: robust Gradle patch ---
 
 echo "----- app/build.gradle tail -----"
@@ -220,14 +243,21 @@ ORIGINAL_JAVA_HOME="$JAVA_HOME"
 export JAVA_HOME="${JDK_HOME:-$JAVA17_HOME}"
 (
   cd "$GRADLE_PROJECT_DIR"
-  if command -v sdkmanager >/dev/null 2>&1; then
-    ba_log "Ensuring Android SDK platform/build-tools 36 are installed"
-    yes | sdkmanager "platforms;android-36" "build-tools;36.0.0" >/dev/null 2>&1 || ba_log "Warning: unable to install Android SDK 36 components"
-    yes | sdkmanager --licenses >/dev/null 2>&1 || true
-  elif [ -x "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" ]; then
-    ba_log "Ensuring Android SDK platform/build-tools 36 are installed"
-    yes | "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" "platforms;android-36" "build-tools;36.0.0" >/dev/null 2>&1 || ba_log "Warning: unable to install Android SDK 36 components"
-    yes | "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" --licenses >/dev/null 2>&1 || true
+  SDK_PLATFORM_PACKAGE=$(android_platform_package "$ANDROID_APP_COMPILE_SDK")
+  SDK_BUILD_TOOLS_PACKAGE="build-tools;$ANDROID_APP_COMPILE_SDK.0.0"
+  # SDK-root copy first; see scripts/verify-android-app-compile-sdk.sh for why
+  # the one on PATH is the wrong default.
+  SDKMANAGER=""
+  if [ -x "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" ]; then
+    SDKMANAGER="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
+  elif command -v sdkmanager >/dev/null 2>&1; then
+    SDKMANAGER="sdkmanager"
+  fi
+  if [ -n "$SDKMANAGER" ]; then
+    ba_log "Ensuring $SDK_PLATFORM_PACKAGE and $SDK_BUILD_TOOLS_PACKAGE are installed"
+    yes | "$SDKMANAGER" "$SDK_PLATFORM_PACKAGE" "$SDK_BUILD_TOOLS_PACKAGE" >/dev/null 2>&1 || \
+      ba_log "Warning: unable to install Android SDK $ANDROID_APP_COMPILE_SDK components"
+    yes | "$SDKMANAGER" --licenses >/dev/null 2>&1 || true
   fi
   # --stacktrace, always. A packaging failure inside
   # PackageAndroidArtifact$IncrementalSplitterRunnable reports only "a failure

--- a/scripts/check-android-api-removals.py
+++ b/scripts/check-android-api-removals.py
@@ -334,6 +334,10 @@ def main():
           % (len(source_files), ', '.join(roots)))
     print('  baseline API %d: %s' % (baseline_api, baseline))
     print('  target   API %d: %s' % (target_api, target))
+    # Printed because an empty classpath is survivable but not silent: it
+    # raises the error counts on both sides, and a reader comparing two runs
+    # needs to know which of them was resolving dependencies.
+    print('  classpath entries: %d' % len(without_platform_stubs(classpath)))
 
     with tempfile.TemporaryDirectory(prefix='cn1-api-removals-') as workdir:
         baseline_errors = compile_against(

--- a/scripts/check-android-api-removals.py
+++ b/scripts/check-android-api-removals.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Compile the Android port against a newer platform and report what broke.
+
+Android removes API. Codename One issue #5701 was the first time it cost us:
+API 37 deleted `android.hardware.fingerprint.FingerprintManager` and
+`Context.FINGERPRINT_SERVICE`, the port named both from files every generated
+application compiles, and an unmodified Hello World failed
+`:app:compileDebugJavaWithJavac` in sources the developer never wrote.
+
+Nothing in the tree could have caught that. The port's own Maven build
+compiles against the cn1-binaries `android.jar`, which is old enough to still
+*contain* the removed class, and the only place port sources ever meet a
+current platform is the generated Gradle project -- which CI pins to a fixed
+compile SDK for reproducibility. So the port could regress against a new
+platform and every check stayed green.
+
+This closes that. It compiles the port twice from the same sources, against
+two platform jars, and reports the errors that appear only against the newer
+one. The comparison is what makes it usable without a perfect classpath: the
+port deliberately excludes its optional packages (ai, ar, cipher, nearby) from
+the module build, so their dependencies are absent and they cannot compile
+here at all -- but they fail *identically* against both jars, so their noise
+cancels and a real removal still stands out. Error lines are compared whole,
+line numbers included, which is exact because the two runs see byte-identical
+source.
+
+    scripts/check-android-api-removals.py
+    scripts/check-android-api-removals.py --api 37 --baseline 36
+    scripts/check-android-api-removals.py --require-all   # what CI runs
+
+With no platform new enough installed the check reports that it did not run
+and succeeds, so a partial local SDK still gives a useful answer. CI passes
+--require-all, where "did not run" is a failure -- a check that is satisfied
+by having nothing to check is not a check.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import xml.etree.ElementTree as ElementTree
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# The API level this gate exists for. Anything installed at or above it is a
+# candidate target; below it there is nothing new to say, because the port is
+# built and tested against those platforms elsewhere.
+MIN_TARGET_API = 37
+
+DEFAULT_SOURCE_ROOTS = [os.path.join('Ports', 'Android', 'src')]
+
+ERROR_LINE = re.compile(r'^(.*?):(\d+): error: (.*)$')
+
+
+def sdk_root():
+    """The Android SDK to read platforms out of."""
+    for candidate in (os.environ.get('ANDROID_HOME'),
+                      os.environ.get('ANDROID_SDK_ROOT'),
+                      os.path.expanduser('~/Library/Android/sdk'),
+                      os.path.expanduser('~/Android/Sdk')):
+        if candidate and os.path.isdir(os.path.join(candidate, 'platforms')):
+            return candidate
+    return None
+
+
+def platform_api_level(platform_dir):
+    """The API level a platform directory holds, as an int, or None.
+
+    Read from source.properties rather than the directory name because from
+    API 37 the name carries a minor -- there is no `platforms;android-37`,
+    only android-37.0, android-37.1 and android-37.2 -- and the minor selects
+    a revision of the level, not a level of its own. A preview platform
+    (`android-Baklava`) has no number and is skipped: its API is not final,
+    so a removal seen there is not yet a fact about a shipped release.
+    """
+    properties = os.path.join(platform_dir, 'source.properties')
+    if os.path.isfile(properties):
+        with open(properties, encoding='utf-8', errors='replace') as handle:
+            for line in handle:
+                if line.startswith('AndroidVersion.ApiLevel='):
+                    value = line.split('=', 1)[1].strip().split('.')[0]
+                    if value.isdigit():
+                        return int(value)
+    name = os.path.basename(platform_dir)
+    if name.startswith('android-'):
+        value = name[len('android-'):].split('.')[0]
+        if value.isdigit():
+            return int(value)
+    return None
+
+
+def platform_minor(platform_dir):
+    """The minor of a platform's API level, as an int, 0 when it has none.
+
+    Sorted numerically rather than as text on purpose: "37.10" is newer than
+    "37.2" and sorts before it as a string, which would pick the older jar the
+    first time a level reaches ten revisions.
+    """
+    name = os.path.basename(platform_dir)
+    _, _, suffix = name.partition('.')
+    return int(suffix) if suffix.isdigit() else 0
+
+
+def installed_platforms(root):
+    """Every usable platform, as a list of (api_level, path), newest first.
+
+    A platform with no android.jar is not usable and is left out rather than
+    reported: it is an interrupted download, not something this gate has an
+    opinion about.
+    """
+    found = []
+    platforms_dir = os.path.join(root, 'platforms')
+    for name in sorted(os.listdir(platforms_dir)):
+        path = os.path.join(platforms_dir, name)
+        if not os.path.isfile(os.path.join(path, 'android.jar')):
+            continue
+        api = platform_api_level(path)
+        if api is not None:
+            found.append((api, path))
+    return sorted(found, key=lambda entry: (entry[0], platform_minor(entry[1])),
+                  reverse=True)
+
+
+def pick(platforms, api):
+    """The newest installed revision of exactly `api`."""
+    for level, path in platforms:
+        if level == api:
+            return path
+    return None
+
+
+def removed_at(platform_dir, api):
+    """What the platform's own api-versions.xml says it removed at `api`.
+
+    Diagnostics only -- the compile above is what decides. Worth printing
+    because a "cannot find symbol" against a platform jar says nothing about
+    why the symbol went away, and this names the whole set in one place.
+
+    Note the file records a removal against the minor it happened in ("37.0",
+    "37.1"), never the bare major, which is why this matches on the prefix.
+    """
+    path = os.path.join(platform_dir, 'data', 'api-versions.xml')
+    if not os.path.isfile(path):
+        return []
+    try:
+        root = ElementTree.parse(path).getroot()
+    except ElementTree.ParseError:
+        return []
+    prefix = str(api)
+    removals = []
+    for element in root.iter('class'):
+        name = (element.get('name') or '').replace('/', '.')
+        if (element.get('removed') or '').split('.')[0] == prefix:
+            removals.append('class %s' % name)
+        for kind in ('method', 'field'):
+            for member in element.findall(kind):
+                if (member.get('removed') or '').split('.')[0] == prefix:
+                    removals.append('%s %s.%s'
+                                    % (kind, name, member.get('name')))
+    return removals
+
+
+def javac():
+    """The compiler to use, preferring the JDK the Android port needs."""
+    for home in (os.environ.get('JAVA17_HOME'), os.environ.get('JDK_HOME'),
+                 os.environ.get('JAVA_HOME')):
+        if home:
+            candidate = os.path.join(home, 'bin', 'javac')
+            if os.access(candidate, os.X_OK):
+                return candidate
+    for directory in os.environ.get('PATH', '').split(os.pathsep):
+        candidate = os.path.join(directory, 'javac')
+        if os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+def sources(roots):
+    found = []
+    for root in roots:
+        absolute = root if os.path.isabs(root) else os.path.join(REPO, root)
+        for directory, _, names in os.walk(absolute):
+            for name in names:
+                if name.endswith('.java'):
+                    found.append(os.path.join(directory, name))
+    return sorted(found)
+
+
+def without_platform_stubs(entries):
+    """Drop any second android.jar from a classpath.
+
+    The port's Maven compile classpath carries the cn1-binaries android.jar,
+    and that jar is old enough to still contain what newer platforms removed.
+    Left in, javac resolves the platform jar first, misses the removed class,
+    falls through to the stub and finds it -- so the target compile succeeds
+    on exactly the symbol this gate exists to catch. Verified: with the stub
+    present a probe naming FingerprintManager reported only the removed field
+    and not the removed class.
+
+    Matching on the file name is exact rather than lucky. A platform stub is
+    always android.jar, in the SDK and in cn1-binaries alike, and no library
+    ships under that name.
+    """
+    return [entry for entry in entries
+            if os.path.basename(entry) != 'android.jar']
+
+
+def compile_against(compiler, android_jar, classpath, source_files, workdir):
+    """Compile everything and return the set of error lines javac printed.
+
+    -Xmaxerrs is raised because the default of 100 truncates, and a truncated
+    run against one jar and not the other invents a difference that is really
+    just where javac stopped counting.
+    """
+    output = os.path.join(workdir, 'classes')
+    os.makedirs(output, exist_ok=True)
+    argfile = os.path.join(workdir, 'sources.txt')
+    with open(argfile, 'w', encoding='utf-8') as handle:
+        handle.write('\n'.join(source_files))
+    entries = [android_jar] + without_platform_stubs(
+        [item for item in classpath if item])
+    command = [compiler, '-nowarn', '-proc:none', '-Xmaxerrs', '100000',
+               '-d', output, '-cp', os.pathsep.join(entries), '@' + argfile]
+    result = subprocess.run(command, stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT, universal_newlines=True)
+    errors = set()
+    for line in result.stdout.splitlines():
+        if ERROR_LINE.match(line):
+            errors.add(line.strip())
+    return errors
+
+
+def auto_classpath():
+    """A best-effort classpath, so the check is useful with no arguments.
+
+    Incompleteness here is survivable by design: whatever fails to resolve
+    fails against both jars and cancels out of the comparison. It is only
+    worth supplying a real classpath (--classpath, as CI does from Maven) to
+    keep the raw error counts small enough to read.
+    """
+    entries = []
+    for candidate in (os.environ.get('CN1_BINARIES'),
+                      os.path.join(REPO, 'maven', 'target', 'cn1-binaries'),
+                      os.path.join(os.path.dirname(REPO), 'cn1-binaries')):
+        android = os.path.join(candidate, 'android') if candidate else None
+        if android and os.path.isdir(android):
+            for name in sorted(os.listdir(android)):
+                if name.endswith('.jar') and name != 'android.jar':
+                    entries.append(os.path.join(android, name))
+            break
+    core = os.path.join(REPO, 'maven', 'core', 'target', 'classes')
+    if os.path.isdir(core):
+        entries.append(core)
+    return entries
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument('--api', type=int,
+                        help='target API level (default: newest installed at '
+                             'or above %d)' % MIN_TARGET_API)
+    parser.add_argument('--baseline', type=int,
+                        help='API level to compare against (default: newest '
+                             'installed below the target)')
+    parser.add_argument('--classpath', default='',
+                        help='extra classpath entries, %r separated'
+                             % os.pathsep)
+    parser.add_argument('--source-root', action='append', default=[],
+                        metavar='DIR',
+                        help='source tree to compile (repeatable; default: %s)'
+                             % ', '.join(DEFAULT_SOURCE_ROOTS))
+    parser.add_argument('--require-all', action='store_true',
+                        help='treat "could not run" as a failure, which is '
+                             'what CI wants')
+    arguments = parser.parse_args()
+
+    def cannot_run(reason):
+        print('check-android-api-removals: did not run: %s' % reason)
+        if arguments.require_all:
+            print('  --require-all was passed, so this is a failure.')
+            return 1
+        return 0
+
+    root = sdk_root()
+    if root is None:
+        return cannot_run('no Android SDK (set ANDROID_HOME)')
+
+    platforms = installed_platforms(root)
+    if not platforms:
+        return cannot_run('no platform with an android.jar under %s' % root)
+
+    target_api = arguments.api
+    if target_api is None:
+        candidates = [level for level, _ in platforms if level >= MIN_TARGET_API]
+        if not candidates:
+            return cannot_run('no platform at API %d or newer is installed; '
+                              'install one with "sdkmanager \'platforms;'
+                              'android-%d.0\'"' % (MIN_TARGET_API,
+                                                   MIN_TARGET_API))
+        target_api = max(candidates)
+
+    target = pick(platforms, target_api)
+    if target is None:
+        return cannot_run('no platform at API %d is installed' % target_api)
+
+    baseline_api = arguments.baseline
+    if baseline_api is None:
+        below = [level for level, _ in platforms if level < target_api]
+        if not below:
+            return cannot_run('nothing older than API %d to compare against'
+                              % target_api)
+        baseline_api = max(below)
+
+    baseline = pick(platforms, baseline_api)
+    if baseline is None:
+        return cannot_run('no platform at API %d is installed' % baseline_api)
+
+    compiler = javac()
+    if compiler is None:
+        return cannot_run('no javac (set JAVA17_HOME)')
+
+    roots = arguments.source_root or DEFAULT_SOURCE_ROOTS
+    source_files = sources(roots)
+    if not source_files:
+        return cannot_run('no .java under %s' % ', '.join(roots))
+
+    classpath = auto_classpath()
+    classpath += [entry for entry in arguments.classpath.split(os.pathsep)
+                  if entry]
+
+    print('check-android-api-removals: %d sources from %s'
+          % (len(source_files), ', '.join(roots)))
+    print('  baseline API %d: %s' % (baseline_api, baseline))
+    print('  target   API %d: %s' % (target_api, target))
+
+    with tempfile.TemporaryDirectory(prefix='cn1-api-removals-') as workdir:
+        baseline_errors = compile_against(
+            compiler, os.path.join(baseline, 'android.jar'), classpath,
+            source_files, os.path.join(workdir, 'baseline'))
+        target_errors = compile_against(
+            compiler, os.path.join(target, 'android.jar'), classpath,
+            source_files, os.path.join(workdir, 'target'))
+
+    new_errors = sorted(target_errors - baseline_errors)
+    print('  errors at baseline: %d, at target: %d, new at target: %d'
+          % (len(baseline_errors), len(target_errors), len(new_errors)))
+
+    if not new_errors:
+        print('OK: the port compiles against API %d wherever it compiles '
+              'against API %d.' % (target_api, baseline_api))
+        return 0
+
+    print('')
+    print('FAIL: %d error(s) appear against API %d and not against API %d.'
+          % (len(new_errors), target_api, baseline_api))
+    for line in new_errors:
+        print('  %s' % line.replace(REPO + os.sep, ''))
+
+    removals = removed_at(target, target_api)
+    if removals:
+        print('')
+        print('API %d removed the following, per its own api-versions.xml:'
+              % target_api)
+        for entry in removals:
+            print('  %s' % entry)
+    print('')
+    print('A platform API the port names has gone away. Reach it by name '
+          'from a package the builder can delete, or route through an '
+          'androidx compat class, the way com.codename1.impl.android'
+          '.fingerprint does -- do not simply raise the floor, because the '
+          'APK still has to run on the older devices where the removed API '
+          'is the only one there is.')
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/check-android-api-removals.py
+++ b/scripts/check-android-api-removals.py
@@ -35,6 +35,7 @@ by having nothing to check is not a check.
 """
 
 import argparse
+import collections
 import os
 import re
 import subprocess
@@ -52,6 +53,20 @@ MIN_TARGET_API = 37
 DEFAULT_SOURCE_ROOTS = [os.path.join('Ports', 'Android', 'src')]
 
 ERROR_LINE = re.compile(r'^(.*?):(\d+): error: (.*)$')
+
+# Everything that ends an error's continuation lines. javac follows a header
+# with the source line, a caret, and indented "symbol:"/"location:" detail --
+# but it also emits notes and a trailing count, and those belong to nobody.
+# Left attached they ride on whichever error happened to be last, and the
+# count ("576 errors") differs between the two runs by construction, so the
+# last diagnostic always looked new. Note the capital N: javac writes
+# "Note: Some input files ..." at column 0, which a lowercase-only pattern
+# missed.
+STOP_LINE = re.compile(
+    r'^(?:\d+\s+(?:error|warning)s?\s*$'
+    r'|[Nn]ote:\s'
+    r'|[Ww]arning:\s'
+    r'|(?:.*?):\d+:\s(?:warning|note):\s)')
 
 
 def sdk_root():
@@ -207,12 +222,55 @@ def without_platform_stubs(entries):
             if os.path.basename(entry) != 'android.jar']
 
 
+class CompilerFailure(Exception):
+    """javac did not run far enough to have an opinion about the source."""
+
+
+def parse_diagnostics(output):
+    """Every error javac reported, each as one whole multi-line string.
+
+    The header line alone is not enough to tell two errors apart. javac writes
+    "cannot find symbol" and then, on following lines, the symbol and the
+    location that could not be found -- and those detail lines are the only
+    thing distinguishing one missing symbol from another on the same source
+    line. Comparing headers, a line that already fails against the baseline
+    (an optional package whose dependency is absent) would absorb a NEW
+    removal on that same line and the gate would report nothing.
+
+    Returned as a list rather than a set for the same reason at a smaller
+    scale: one source line can carry two missing symbols, and collapsing them
+    hides the second.
+    """
+    diagnostics = []
+    current = None
+    for line in output.splitlines():
+        if ERROR_LINE.match(line):
+            if current is not None:
+                diagnostics.append('\n'.join(current))
+            current = [line.rstrip()]
+        elif current is not None:
+            if STOP_LINE.match(line):
+                diagnostics.append('\n'.join(current))
+                current = None
+            else:
+                current.append(line.rstrip())
+    if current is not None:
+        diagnostics.append('\n'.join(current))
+    return diagnostics
+
+
 def compile_against(compiler, android_jar, classpath, source_files, workdir):
-    """Compile everything and return the set of error lines javac printed.
+    """Compile everything and return every error javac reported.
 
     -Xmaxerrs is raised because the default of 100 truncates, and a truncated
     run against one jar and not the other invents a difference that is really
     just where javac stopped counting.
+
+    A javac that exits non-zero having reported nothing did not compile the
+    source -- it rejected an option, could not read the platform jar, or was
+    killed. That is not "no errors", and silently reading it as one is how a
+    broken toolchain satisfies this gate: both sides come back empty, the
+    difference is empty, and the check reports OK.
     """
     output = os.path.join(workdir, 'classes')
     os.makedirs(output, exist_ok=True)
@@ -225,11 +283,13 @@ def compile_against(compiler, android_jar, classpath, source_files, workdir):
                '-d', output, '-cp', os.pathsep.join(entries), '@' + argfile]
     result = subprocess.run(command, stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT, universal_newlines=True)
-    errors = set()
-    for line in result.stdout.splitlines():
-        if ERROR_LINE.match(line):
-            errors.add(line.strip())
-    return errors
+    diagnostics = parse_diagnostics(result.stdout)
+    if result.returncode != 0 and not diagnostics:
+        raise CompilerFailure(
+            'javac exited %d against %s without reporting a single source '
+            'diagnostic, so it never compiled anything:\n%s'
+            % (result.returncode, android_jar, result.stdout.strip()[:4000]))
+    return diagnostics
 
 
 def auto_classpath():
@@ -339,15 +399,27 @@ def main():
     # needs to know which of them was resolving dependencies.
     print('  classpath entries: %d' % len(without_platform_stubs(classpath)))
 
-    with tempfile.TemporaryDirectory(prefix='cn1-api-removals-') as workdir:
-        baseline_errors = compile_against(
-            compiler, os.path.join(baseline, 'android.jar'), classpath,
-            source_files, os.path.join(workdir, 'baseline'))
-        target_errors = compile_against(
-            compiler, os.path.join(target, 'android.jar'), classpath,
-            source_files, os.path.join(workdir, 'target'))
+    try:
+        with tempfile.TemporaryDirectory(prefix='cn1-api-removals-') as workdir:
+            baseline_errors = compile_against(
+                compiler, os.path.join(baseline, 'android.jar'), classpath,
+                source_files, os.path.join(workdir, 'baseline'))
+            target_errors = compile_against(
+                compiler, os.path.join(target, 'android.jar'), classpath,
+                source_files, os.path.join(workdir, 'target'))
+    except CompilerFailure as broken:
+        return cannot_run(str(broken))
 
-    new_errors = sorted(target_errors - baseline_errors)
+    # A multiset difference, not a set one: two identical diagnostics are two
+    # errors, and an error that appears twice against the target and once
+    # against the baseline is a new one.
+    remaining = collections.Counter(baseline_errors)
+    new_errors = []
+    for diagnostic in target_errors:
+        if remaining[diagnostic] > 0:
+            remaining[diagnostic] -= 1
+        else:
+            new_errors.append(diagnostic)
     print('  errors at baseline: %d, at target: %d, new at target: %d'
           % (len(baseline_errors), len(target_errors), len(new_errors)))
 
@@ -359,8 +431,9 @@ def main():
     print('')
     print('FAIL: %d error(s) appear against API %d and not against API %d.'
           % (len(new_errors), target_api, baseline_api))
-    for line in new_errors:
-        print('  %s' % line.replace(REPO + os.sep, ''))
+    for diagnostic in new_errors:
+        for line in diagnostic.replace(REPO + os.sep, '').splitlines():
+            print('  %s' % line)
 
     removals = removed_at(target, target_api)
     if removals:

--- a/scripts/check-android-api-removals.py
+++ b/scripts/check-android-api-removals.py
@@ -62,6 +62,9 @@ ERROR_LINE = re.compile(r'^(.*?):(\d+): error: (.*)$')
 # last diagnostic always looked new. Note the capital N: javac writes
 # "Note: Some input files ..." at column 0, which a lowercase-only pattern
 # missed.
+# javac's closing tally, which every run that reported an error prints.
+ERROR_SUMMARY = re.compile(r'^(\d+)\s+errors?$')
+
 STOP_LINE = re.compile(
     r'^(?:\d+\s+(?:error|warning)s?\s*$'
     r'|[Nn]ote:\s'
@@ -300,11 +303,42 @@ def compile_against(compiler, android_jar, classpath, source_files, workdir):
     result = subprocess.run(command, stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT, universal_newlines=True)
     diagnostics = parse_diagnostics(result.stdout)
+    # A negative status is death by signal -- the OOM killer, most plausibly,
+    # on a run that holds two compiles of the whole port. Fatal however many
+    # diagnostics preceded it: a truncated target run reports a SUBSET of the
+    # baseline's errors, the multiset difference of a subset is empty, and the
+    # gate would print OK precisely because the compile was cut short.
+    if result.returncode < 0:
+        raise CompilerFailure(
+            'javac was killed by signal %d against %s after %d diagnostic(s), '
+            'so its output is a fragment of the compile'
+            % (-result.returncode, android_jar, len(diagnostics)))
     if result.returncode != 0 and not diagnostics:
         raise CompilerFailure(
             'javac exited %d against %s without reporting a single source '
             'diagnostic, so it never compiled anything:\n%s'
             % (result.returncode, android_jar, result.stdout.strip()[:4000]))
+    # javac's own tally, against ours. It closes the same hole for a truncation
+    # that somehow arrives as a normal exit status, and it double-entries the
+    # parser above: if grouping continuation lines ever merges two errors or
+    # splits one, the counts stop matching and this says so instead of quietly
+    # comparing the wrong things. Measured equal (608 and 608) over the port.
+    reported = None
+    for line in result.stdout.splitlines():
+        match = ERROR_SUMMARY.match(line.strip())
+        if match:
+            reported = int(match.group(1))
+    if diagnostics and reported is None:
+        raise CompilerFailure(
+            'javac reported %d diagnostic(s) against %s but never printed its '
+            'error summary, so it did not run to completion'
+            % (len(diagnostics), android_jar))
+    if reported is not None and reported != len(diagnostics):
+        raise CompilerFailure(
+            'javac counted %d error(s) against %s and %d were parsed out of '
+            'its output; one of the two is wrong, and comparing runs on this '
+            'is not safe'
+            % (reported, android_jar, len(diagnostics)))
     return diagnostics
 
 

--- a/scripts/check-android-api-removals.py
+++ b/scripts/check-android-api-removals.py
@@ -277,9 +277,25 @@ def compile_against(compiler, android_jar, classpath, source_files, workdir):
     argfile = os.path.join(workdir, 'sources.txt')
     with open(argfile, 'w', encoding='utf-8') as handle:
         handle.write('\n'.join(source_files))
-    entries = [android_jar] + without_platform_stubs(
-        [item for item in classpath if item])
+    entries = without_platform_stubs([item for item in classpath if item])
+    # The platform goes on the BOOT class path, not the class path. Handed to
+    # -cp it supplies android.* and nothing else: java.* keeps resolving from
+    # the host JDK's own system modules, because the class path cannot override
+    # the platform's core library. The gate would then be blind to Android's
+    # java.* -- an API Android has never had compiles clean here, and a
+    # java.* removal would fail in neither run and cancel out. Demonstrated
+    # with java.lang.ProcessHandle, which Android has no version of: 0 errors
+    # through -cp, 1 through -bootclasspath.
+    #
+    # -source/-target 8 because javac only honours -bootclasspath at 8 or
+    # below, which costs nothing here: this is the Android port, and the
+    # generated app compiles it at 8 unless the project asks for more. On a
+    # JDK new enough to have dropped source 8 javac refuses the option outright
+    # rather than ignoring it, and that lands in the non-diagnostic failure
+    # path below instead of passing quietly.
     command = [compiler, '-nowarn', '-proc:none', '-Xmaxerrs', '100000',
+               '-source', '8', '-target', '8',
+               '-bootclasspath', android_jar,
                '-d', output, '-cp', os.pathsep.join(entries), '@' + argfile]
     result = subprocess.run(command, stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT, universal_newlines=True)

--- a/scripts/check-android-api-removals.py
+++ b/scripts/check-android-api-removals.py
@@ -367,10 +367,19 @@ def main():
 
     baseline_api = arguments.baseline
     if baseline_api is None:
-        below = [level for level, _ in platforms if level < target_api]
+        # Below MIN_TARGET_API, not merely below the target. Once a runner
+        # carries API 38 the newest-below-target rule would pick 37 as the
+        # baseline, and every removal API 37 made would then fail identically
+        # in both compilations and cancel out -- the gate would go on passing
+        # while quietly no longer checking the level it was built for. The
+        # baseline has to sit under the whole range of removals being watched,
+        # so it is pinned below the first of them and only the target floats.
+        bound = min(target_api, MIN_TARGET_API)
+        below = [level for level, _ in platforms if level < bound]
         if not below:
-            return cannot_run('nothing older than API %d to compare against'
-                              % target_api)
+            return cannot_run('nothing older than API %d to compare against; '
+                              'install a baseline platform below the first '
+                              'API level this gate watches' % bound)
         baseline_api = max(below)
 
     baseline = pick(platforms, baseline_api)

--- a/scripts/verify-android-app-compile-sdk.sh
+++ b/scripts/verify-android-app-compile-sdk.sh
@@ -49,15 +49,16 @@ if [ ! -f "$GRADLE_PROJECT_DIR/gradlew" ]; then
   exit 2
 fi
 
-# From API 37 there is no unsuffixed platform package: sdkmanager offers
-# android-37.0, android-37.1 and android-37.2 and nothing called android-37, so
-# installing by the bare number is a silent no-op that surfaces later as a
-# missing build target.
-if [ "$API_LEVEL" -ge 37 ]; then
-  PLATFORM_PACKAGE="platforms;android-$API_LEVEL.0"
-else
-  PLATFORM_PACKAGE="platforms;android-$API_LEVEL"
-fi
+# The NEWEST stable revision of the level, not its ".0". An API level is not
+# one platform from 37 onward -- android-37.0, .1 and .2 are separate packages
+# and a removal can land in any of them -- and the builder picks the newest
+# revision a developer's SDK has, so pinning the .0 here would verify a
+# platform no user compiles against and merge a regression introduced later in
+# the level.
+PLATFORM_PACKAGE=$("$SCRIPT_DIR/android/newest-platform-package.sh" "$API_LEVEL")
+# The name AGP has to be given to reach exactly that platform: the bare level
+# always resolves to the .0.
+PLATFORM_NAME="${PLATFORM_PACKAGE#platforms;android-}"
 
 # The sdkmanager INSIDE the SDK root we are about to build against, before the
 # one on PATH. On a machine with the Homebrew android-commandlinetools cask the
@@ -121,11 +122,13 @@ if [ -f "$GRADLE_PROJECT_DIR/wear/build.gradle" ]; then
   PATCH_GRADLE_MODULES+=(--app "$GRADLE_PROJECT_DIR/wear/build.gradle")
 fi
 
-log "Re-pinning $GRADLE_PROJECT_DIR to compileSdk/targetSdk $API_LEVEL"
+# compileSdk names the exact platform installed above; targetSdk stays the
+# integer level, because that is an API level in the manifest and has no minor.
+log "Re-pinning $GRADLE_PROJECT_DIR to compileSdk $PLATFORM_NAME, targetSdk $API_LEVEL"
 "$PATCH_GRADLE_JAVA" "$PATCH_GRADLE_SOURCE_PATH/PatchGradleFiles.java" \
   --root "$GRADLE_PROJECT_DIR/build.gradle" \
   "${PATCH_GRADLE_MODULES[@]}" \
-  --compile-sdk "$API_LEVEL" \
+  --compile-sdk "$PLATFORM_NAME" \
   --target-sdk "$API_LEVEL"
 
 # AGP compares this against the name of the platform it RESOLVED, and from API
@@ -137,7 +140,7 @@ if [ -f "$GRADLE_PROPS" ]; then
   grep -v '^android.suppressUnsupportedCompileSdk=' "$GRADLE_PROPS" > "$GRADLE_PROPS.tmp" || true
   mv "$GRADLE_PROPS.tmp" "$GRADLE_PROPS"
 fi
-echo "android.suppressUnsupportedCompileSdk=$API_LEVEL,$API_LEVEL.0" >> "$GRADLE_PROPS"
+echo "android.suppressUnsupportedCompileSdk=$API_LEVEL,$API_LEVEL.0,$PLATFORM_NAME" >> "$GRADLE_PROPS"
 
 log "Assembling at API $API_LEVEL"
 ORIGINAL_JAVA_HOME="${JAVA_HOME:-}"
@@ -149,4 +152,4 @@ export JAVA_HOME="${JDK_HOME:-$JAVA17_HOME}"
 )
 export JAVA_HOME="$ORIGINAL_JAVA_HOME"
 
-log "OK: the generated project builds at compileSdk/targetSdk $API_LEVEL"
+log "OK: the generated project builds at compileSdk $PLATFORM_NAME, targetSdk $API_LEVEL"

--- a/scripts/verify-android-app-compile-sdk.sh
+++ b/scripts/verify-android-app-compile-sdk.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# Rebuild an already-generated Codename One Android project at a different API
+# level, to prove the whole generated project still builds there.
+#
+# scripts/build-android-app.sh pins compileSdk and targetSdk so the screenshot
+# baselines and the emulator leg stay reproducible, which means the suite only
+# ever exercises that one level. Issue #5701 was exactly what that misses: API
+# 37 removed FingerprintManager, the port named it, and every generated app
+# failed :app:compileDebugJavaWithJavac in sources the developer never wrote --
+# with our CI green, because our CI never compiled against 37.
+#
+# This re-patches the project the primary build already produced and assembles
+# it again at the requested level. It reuses the generated sources, the
+# resolved dependencies and the warm Gradle cache, so it costs one more
+# assemble rather than another full build, and it covers what an offline javac
+# comparison cannot: AAPT, the manifest merger, aar metadata and packaging.
+#
+#   scripts/verify-android-app-compile-sdk.sh <gradle-project-dir> [api-level]
+#
+# The API level defaults to 37. The project directory is the one
+# build-android-app.sh reports as its gradle_project_dir output.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+log() { echo "[verify-compile-sdk] $*"; }
+
+# Same workspace environment build-android-app.sh loads, and for the same
+# reason: JAVA17_HOME is written there by setup-workspace.sh rather than
+# exported into the job, so a step that does not source it has no JDK 17.
+TMPDIR="${TMPDIR:-/tmp}"; TMPDIR="${TMPDIR%/}"
+ENV_FILE="${TMPDIR}/codenameone-tools/tools/env.sh"
+if [ -f "$ENV_FILE" ]; then
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+fi
+
+GRADLE_PROJECT_DIR="${1:-}"
+API_LEVEL="${2:-37}"
+
+if [ -z "$GRADLE_PROJECT_DIR" ]; then
+  log "usage: $0 <gradle-project-dir> [api-level]" >&2
+  exit 2
+fi
+if [ ! -f "$GRADLE_PROJECT_DIR/gradlew" ]; then
+  log "not a generated Gradle project: $GRADLE_PROJECT_DIR" >&2
+  exit 2
+fi
+
+# From API 37 there is no unsuffixed platform package: sdkmanager offers
+# android-37.0, android-37.1 and android-37.2 and nothing called android-37, so
+# installing by the bare number is a silent no-op that surfaces later as a
+# missing build target.
+if [ "$API_LEVEL" -ge 37 ]; then
+  PLATFORM_PACKAGE="platforms;android-$API_LEVEL.0"
+else
+  PLATFORM_PACKAGE="platforms;android-$API_LEVEL"
+fi
+
+# The sdkmanager INSIDE the SDK root we are about to build against, before the
+# one on PATH. On a machine with the Homebrew android-commandlinetools cask the
+# PATH copy belongs to a different SDK root entirely, so it installs the
+# platform somewhere the build will never look -- and it reports that as a
+# plain failure or, worse, as success. Measured here: /opt/homebrew/bin/
+# sdkmanager exits 1 for a package the SDK-root copy installs fine.
+SDKMANAGER=""
+if [ -x "${ANDROID_SDK_ROOT:-}/cmdline-tools/latest/bin/sdkmanager" ]; then
+  SDKMANAGER="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
+elif [ -x "${ANDROID_HOME:-}/cmdline-tools/latest/bin/sdkmanager" ]; then
+  SDKMANAGER="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
+elif command -v sdkmanager >/dev/null 2>&1; then
+  SDKMANAGER="sdkmanager"
+fi
+
+if [ -z "$SDKMANAGER" ]; then
+  log "no sdkmanager on PATH or under ANDROID_SDK_ROOT/ANDROID_HOME" >&2
+  exit 1
+fi
+
+# sdkmanager reads a handful of license prompts off stdin and then stops
+# reading, which kills `yes` with SIGPIPE -- exit 141, and under `pipefail`
+# that is the status of the whole pipeline even though sdkmanager itself
+# succeeded. Read sdkmanager's own status out of PIPESTATUS instead, so the
+# check below tests the install rather than the writer at the other end.
+sdk_install() {
+  local status
+  set +o pipefail
+  # JDK 17, not the workspace default. env.sh above sets JAVA_HOME to the JDK 8
+  # the framework is built with, and sdkmanager refuses to run on it -- "This
+  # tool requires JDK 17 or later", exit 1, which reads as "the package could
+  # not be installed" and has nothing to do with the package.
+  yes | JAVA_HOME="${JDK_HOME:-$JAVA17_HOME}" "$SDKMANAGER" "$@" >/dev/null
+  status=${PIPESTATUS[1]}
+  set -o pipefail
+  return "$status"
+}
+
+log "Installing $PLATFORM_PACKAGE"
+# Not tolerated the way build-android-app.sh tolerates it. There the platform
+# is usually preinstalled on the runner and a failed install still leaves a
+# working build; here the whole point is to compile against a platform that is
+# NOT preinstalled, so a failed install would otherwise leave Gradle to fall
+# back and quietly verify the level we already tested.
+if ! sdk_install "$PLATFORM_PACKAGE"; then
+  log "failed to install $PLATFORM_PACKAGE" >&2
+  exit 1
+fi
+sdk_install --licenses || true
+
+PATCH_GRADLE_SOURCE_PATH="$SCRIPT_DIR/android/lib"
+PATCH_GRADLE_JAVA="${JDK_HOME:-${JAVA17_HOME:-}}/bin/java"
+if [ ! -x "$PATCH_GRADLE_JAVA" ]; then
+  log "JDK java binary missing at $PATCH_GRADLE_JAVA (set JAVA17_HOME)" >&2
+  exit 1
+fi
+
+PATCH_GRADLE_MODULES=(--app "$GRADLE_PROJECT_DIR/app/build.gradle")
+if [ -f "$GRADLE_PROJECT_DIR/wear/build.gradle" ]; then
+  PATCH_GRADLE_MODULES+=(--app "$GRADLE_PROJECT_DIR/wear/build.gradle")
+fi
+
+log "Re-pinning $GRADLE_PROJECT_DIR to compileSdk/targetSdk $API_LEVEL"
+"$PATCH_GRADLE_JAVA" "$PATCH_GRADLE_SOURCE_PATH/PatchGradleFiles.java" \
+  --root "$GRADLE_PROJECT_DIR/build.gradle" \
+  "${PATCH_GRADLE_MODULES[@]}" \
+  --compile-sdk "$API_LEVEL" \
+  --target-sdk "$API_LEVEL"
+
+# AGP compares this against the name of the platform it RESOLVED, and from API
+# 37 that name carries a minor -- compileSdk 37 resolves to android-37.0 and
+# AGP asks to be suppressed with "37.0", so the bare number silences nothing.
+# The property is a comma-separated list, so both spellings go in.
+GRADLE_PROPS="$GRADLE_PROJECT_DIR/gradle.properties"
+if [ -f "$GRADLE_PROPS" ]; then
+  grep -v '^android.suppressUnsupportedCompileSdk=' "$GRADLE_PROPS" > "$GRADLE_PROPS.tmp" || true
+  mv "$GRADLE_PROPS.tmp" "$GRADLE_PROPS"
+fi
+echo "android.suppressUnsupportedCompileSdk=$API_LEVEL,$API_LEVEL.0" >> "$GRADLE_PROPS"
+
+log "Assembling at API $API_LEVEL"
+ORIGINAL_JAVA_HOME="${JAVA_HOME:-}"
+export JAVA_HOME="${JDK_HOME:-$JAVA17_HOME}"
+(
+  cd "$GRADLE_PROJECT_DIR"
+  chmod +x ./gradlew
+  ./gradlew --no-daemon --stacktrace assembleDebug
+)
+export JAVA_HOME="$ORIGINAL_JAVA_HOME"
+
+log "OK: the generated project builds at compileSdk/targetSdk $API_LEVEL"

--- a/scripts/verify-android-app-compile-sdk.sh
+++ b/scripts/verify-android-app-compile-sdk.sh
@@ -55,7 +55,19 @@ fi
 # revision a developer's SDK has, so pinning the .0 here would verify a
 # platform no user compiles against and merge a regression introduced later in
 # the level.
-PLATFORM_PACKAGE=$("$SCRIPT_DIR/android/newest-platform-package.sh" "$API_LEVEL")
+# Checked explicitly rather than left to `set -e`: the status of a failing
+# command substitution in an assignment does not reliably abort under every
+# shell, and this one silently produced an empty package name that then read
+# as a successful resolution.
+if ! PLATFORM_PACKAGE=$("$SCRIPT_DIR/android/newest-platform-package.sh" "$API_LEVEL"); then
+  log "cannot determine the newest API $API_LEVEL platform; refusing to fall" >&2
+  log "back to the .0, which is the revision this check exists to stop pinning" >&2
+  exit 1
+fi
+if [ -z "$PLATFORM_PACKAGE" ]; then
+  log "newest-platform-package.sh printed nothing for API $API_LEVEL" >&2
+  exit 1
+fi
 # The name AGP has to be given to reach exactly that platform: the bare level
 # always resolves to the .0.
 PLATFORM_NAME="${PLATFORM_PACKAGE#platforms;android-}"


### PR DESCRIPTION
Closes the API 37 readiness gaps found while auditing the tree. The port itself
was already fine -- #5723 fixed it -- but nothing verified that, and the builder
still did arithmetic that predates minor-versioned platforms.

## The gap

Issue #5701 was found by hand and fixed by hand. Nothing in the tree could have
caught it, and structurally nothing could:

- the port's Maven build compiles against the **cn1-binaries `android.jar`**,
  which is old enough to still *contain* whatever a new platform removed, and
- the only place port sources meet a current platform is the **generated Gradle
  project**, whose compile SDK `build-android-app.sh` pins for reproducibility.

So "the port compiles against 37" was a claim in a comment, and the next
removal would have landed the same way.

## Two checks

Both on the default leg of `scripts-android.yml` -- what they compare is the
platform jar, not the JDK, so running them three times would answer the same
question three times.

**`scripts/check-android-api-removals.py`** compiles `Ports/Android/src` twice
from the same sources against two platform jars and reports the errors that
appear only against the newer one. The comparison is what makes it work without
a perfect classpath: the port excludes its optional packages (`ai`, `ar`,
`cipher`, `nearby`) from the module build, so their dependencies are absent and
they cannot compile here at all -- but they fail identically against both jars
and cancel out. Error lines are compared whole, line numbers included, which is
exact because both runs see byte-identical source.

It has to defend against one thing to be worth anything: **a second
`android.jar` on the classpath silently defeats it.** The port's Maven compile
classpath carries the cn1-binaries stub, javac resolves the platform jar first,
misses the removed class, falls through to the stub and finds it. Measured, not
supposed -- with the stub present a probe naming `FingerprintManager` reported
only the removed *field* and not the removed *class*. Any entry named
`android.jar` is dropped.

**`scripts/verify-android-app-compile-sdk.sh`** is the end-to-end half: it
re-pins the project the primary build already produced and assembles it again,
putting AAPT, the manifest merger, aar metadata and packaging through the newer
platform too. It reuses the generated sources and the warm Gradle cache, so it
costs one more assemble rather than another build.

## Builder fixes: API 37 has no unsuffixed platform

`sdkmanager` offers `android-37.0`, `android-37.1` and `android-37.2`, and
nothing called `android-37`. Each of these was a real defect:

- **The platform name now has a dot in it.** It reaches `Integer.parseInt`,
  which threw outright on the legacy `useGradle8=false` path and made
  `compileSdkInt` answer 0 -- the value every caller reads as "could not be
  determined", so the manifest fragments lost the compile SDK they check
  attribute values against. Reduced to the API level once, for every path, and
  `parseSdkInt` now drops the minor **before** gathering digits: gathering
  first turns `"37.2"` into 372, which compares greater than every floor in the
  class and defeats all of them silently.
- **Both build-tools ladders stopped at 36**, so build-tools 37 matched no
  rung. The compile-SDK cap stopped applying, and `supportLibVersion` asked
  Gradle for `com.android.support:support-v4:37.+`, an artifact that does not
  exist.
- **`android.suppressUnsupportedCompileSdk` is compared against the platform
  AGP *resolved*,** not the number requested, so at 37 it wants `37.0` and the
  bare `37` suppressed nothing. Measured against AGP 8.13.2: `37` leaves the
  warning, `37.0` removes it, and the property takes a comma-separated list --
  so both spellings go in rather than predicting the next one.
- **Prefer the `sdkmanager` inside the SDK root being built against.** The one
  on `PATH` can belong to a different root (the Homebrew cask), where it
  installs the platform somewhere the build never looks; measured here, it
  exits 1 for a package the SDK-root copy installs fine. It also needs JDK 17
  or newer, so a script that has sourced `tools/env.sh` has to invoke it with
  `JAVA17_HOME`.

## Verification

Every claim above was measured, and every check was shown to fail before it
was shown to pass.

- **The gate bites.** A throwaway file naming `FingerprintManager` and
  `Context.FINGERPRINT_SERVICE` makes it report 3 new errors; removing the file
  returns it to `new at target: 0`.
- **The end-to-end check bites.** Run against a generated project built from
  pre-#5723 sources it reproduces #5701 exactly -- `compileDebugJavaWithJavac`
  fails on `android.hardware.fingerprint`. With the post-#5723 sources synced
  in, the same project reports `BUILD SUCCESSFUL` at compileSdk/targetSdk 37
  and emits no AGP warning, which is the suppression key change working in a
  real project.
- **The unit tests bite.** Reverting the four builder fixes and re-running
  fails 4 of the 5 with the exact pre-fix values (0, 38, `37`); the fifth is
  the control and passes both ways.
- The full plugin suite is green (1989 tests), and SpotBugs reports 0 findings
  on a freshly regenerated report.
- The removal set itself comes from the platform's own `api-versions.xml`:
  API 37 removed `FingerprintManager` (4 classes) plus
  `Context.FINGERPRINT_SERVICE` at 37.0, and the `java.util.jar` `ZipConstants`
  field family at 37.1. Nothing in the tree uses the latter. Note removals are
  recorded against the **minor**, so a query for `removed="37"` matches nothing.

## Not covered

**Runtime.** No API 37 emulator runs anywhere -- the leg is at `api-level: 36`,
and moving it would reseed every Android screenshot baseline. Android 17
behaviour changes are still unverified and want their own change.

The BuildDaemon twin is out of scope here by request; it has its own process
for 37.

The `Math.max(36, ...)` compile-SDK floor is deliberately left alone: raising it
to 37 would change every customer build's targetSdk and force a platform
download, which is a policy call rather than a readiness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)