### PR TITLE
Fix iOS push completion linker failure and add native regression coverage

### DIFF
--- a/.github/workflows/ios-push-completion.yml
+++ b/.github/workflows/ios-push-completion.yml
@@ -1,0 +1,36 @@
+name: iOS push completion contract
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [master]
+    paths:
+      - 'Ports/iOSPort/nativeSources/IOSNative.m'
+      - 'Ports/iOSPort/nativeSources/CodenameOne_GLAppDelegate.m'
+      - 'maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java'
+      - 'scripts/ios/push-completion-tests/**'
+      - '.github/workflows/ios-push-completion.yml'
+  push:
+    branches: [master]
+    paths:
+      - 'Ports/iOSPort/nativeSources/IOSNative.m'
+      - 'Ports/iOSPort/nativeSources/CodenameOne_GLAppDelegate.m'
+      - 'maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java'
+      - 'scripts/ios/push-completion-tests/**'
+      - '.github/workflows/ios-push-completion.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ios-push-completion-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  native-contract:
+    runs-on: macos-15
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Compile, link, and exercise push completion with push enabled and disabled
+        run: python3 scripts/ios/push-completion-tests/check.py

--- a/Ports/iOSPort/nativeSources/IOSNative.m
+++ b/Ports/iOSPort/nativeSources/IOSNative.m
@@ -1726,7 +1726,7 @@ void com_codename1_impl_ios_IOSNative_resizeNativeTextView___int_int_int_int_int
 #endif // !TARGET_OS_WATCH
 #endif
 }
-#ifdef INCLUDE_CN1_PUSH_2
+#ifdef INCLUDE_CN1_PUSH2
 typedef void (^CN1PushCompletionHandlerType)(void);
 
 // One record per notification rather than one global.
@@ -1852,7 +1852,7 @@ void CN1PushCompletionReleaseOldest(void) {
 #endif
 
 void com_codename1_impl_ios_IOSNative_firePushCompletionHandler___long(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject, JAVA_LONG completionId) {
-#ifdef INCLUDE_CN1_PUSH_2
+#ifdef INCLUDE_CN1_PUSH2
     long long cid = (long long)completionId;
     dispatch_async(dispatch_get_main_queue(), ^{
         CN1PushCompletionRelease(cid);
@@ -1861,7 +1861,7 @@ void com_codename1_impl_ios_IOSNative_firePushCompletionHandler___long(CN1_THREA
 }
 
 void com_codename1_impl_ios_IOSNative_releaseOldestPushCompletionHandler__(CN1_THREAD_STATE_MULTI_ARG JAVA_OBJECT instanceObject) {
-#ifdef INCLUDE_CN1_PUSH_2
+#ifdef INCLUDE_CN1_PUSH2
     dispatch_async(dispatch_get_main_queue(), ^{
         CN1PushCompletionReleaseOldest();
     });

--- a/scripts/ios/push-completion-tests/check.py
+++ b/scripts/ios/push-completion-tests/check.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Compile/link the production push completion block and run its native contract.
+
+Requires macOS and Xcode command-line tools; no generated app or signing is needed.
+Only the surrounding VM ABI is stubbed. Keep the production preprocessor guards,
+including those on the Java entry points, so a misspelled flag cannot pass.
+"""
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[3]
+NATIVE = ROOT / 'Ports/iOSPort/nativeSources'
+source = (NATIVE / 'IOSNative.m').read_text()
+delegate = (NATIVE / 'CodenameOne_GLAppDelegate.m').read_text()
+builder = (ROOT / 'maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/IPhoneBuilder.java').read_text()
+
+# Use the template's flag and the builder's actual disabling replacement.
+flag = re.search(r'^#define INCLUDE_CN1_PUSH2\s*$', source, re.M).group(0)
+disabling = re.search(r'str\.replace\("(#define INCLUDE_CN1_PUSH2)", "([^"]+)"\)', builder)
+assert disabling, 'Builder push configuration changed; update the test staging'
+start = source.index('typedef void (^CN1PushCompletionHandlerType)')
+start = source.rindex('#ifdef', 0, start)
+end = source.index('#ifdef INCLUDE_CN1_BACKGROUND_FETCH', start)
+implementation = source[start:end]
+# Declarations come from the real caller, in a separate translation unit.
+start = delegate.index('typedef void (^CN1PushCompletionHandlerType)')
+end = delegate.index('-(void)cn1RoutePush:', start)
+declarations = delegate[start:end]
+abi = '''#import <Foundation/Foundation.h>
+#import <dispatch/dispatch.h>
+typedef void *JAVA_OBJECT;
+typedef long long JAVA_LONG;
+#define CN1_THREAD_STATE_MULTI_ARG
+'''
+with tempfile.TemporaryDirectory(prefix='cn1-push-completion-') as tmp:
+    tmp = Path(tmp)
+    for enabled in (True, False):
+        configuration = flag if enabled else flag.replace(*disabling.groups())
+        (tmp / 'implementation.m').write_text(abi + configuration + '\n' + implementation)
+        (tmp / 'caller.h').write_text(declarations)
+        executable = tmp / 'check'
+        subprocess.run([
+            'xcrun', 'clang', '-fblocks', '-fno-objc-arc', '-framework', 'Foundation',
+            '-I', str(tmp), '-DPUSH_ENABLED=' + str(int(enabled)),
+            str(tmp / 'implementation.m'), str(Path(__file__).with_name('contract.m')),
+            '-o', str(executable),
+        ], check=True, timeout=60)
+        subprocess.run([str(executable)], check=True, timeout=20)
+        print('PASS: push ' + ('enabled' if enabled else 'disabled'), flush=True)

--- a/scripts/ios/push-completion-tests/contract.m
+++ b/scripts/ios/push-completion-tests/contract.m
@@ -1,0 +1,58 @@
+#import <Foundation/Foundation.h>
+#import <dispatch/dispatch.h>
+#include <assert.h>
+#include <stdlib.h>
+#if PUSH_ENABLED
+#include "caller.h"
+#endif
+
+extern void com_codename1_impl_ios_IOSNative_firePushCompletionHandler___long(void *, long long);
+extern void com_codename1_impl_ios_IOSNative_releaseOldestPushCompletionHandler__(void *);
+
+int main(void) {
+    // Production routing and completion bookkeeping both run on the main queue.
+    dispatch_async(dispatch_get_main_queue(), ^{
+        @autoreleasepool {
+#if PUSH_ENABLED
+            __block int first = 0, second = 0, empty = 0;
+            long long a = CN1PushCompletionBegin(^{ first++; });
+            long long b = CN1PushCompletionBegin(^{ second++; });
+            assert(a != 0 && b != 0 && a != b);
+            assert(CN1PushCompletionBegin(nil) == 0);
+            // A type-3 notification has two callbacks; an overlapping push has one.
+            CN1PushCompletionRetain(a);
+            CN1PushCompletionRetain(a);
+            CN1PushCompletionRetain(b);
+            CN1PushCompletionFinishRouting(a);
+            CN1PushCompletionFinishRouting(b);
+            assert(first == 0 && second == 0);
+            CN1PushCompletionFinishRouting(CN1PushCompletionBegin(^{ empty++; }));
+            assert(empty == 1);
+
+            com_codename1_impl_ios_IOSNative_firePushCompletionHandler___long(NULL, b);
+            com_codename1_impl_ios_IOSNative_releaseOldestPushCompletionHandler__(NULL);
+            dispatch_async(dispatch_get_main_queue(), ^{
+                assert(second == 1 && first == 0);
+                com_codename1_impl_ios_IOSNative_releaseOldestPushCompletionHandler__(NULL);
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    assert(first == 1 && second == 1);
+                    // Late/duplicate completions must not fire a grant twice.
+                    com_codename1_impl_ios_IOSNative_firePushCompletionHandler___long(NULL, a);
+                    com_codename1_impl_ios_IOSNative_firePushCompletionHandler___long(NULL, b);
+                    com_codename1_impl_ios_IOSNative_releaseOldestPushCompletionHandler__(NULL);
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        assert(first == 1 && second == 1);
+                        exit(0);
+                    });
+                });
+            });
+#else
+            // Push-disabled apps still link the Java entry points as no-op stubs.
+            com_codename1_impl_ios_IOSNative_firePushCompletionHandler___long(NULL, 0);
+            com_codename1_impl_ios_IOSNative_releaseOldestPushCompletionHandler__(NULL);
+            exit(0);
+#endif
+        }
+    });
+    dispatch_main();
+}

--- a/scripts/ios/push-completion-tests/contract.m
+++ b/scripts/ios/push-completion-tests/contract.m
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
 #import <Foundation/Foundation.h>
 #import <dispatch/dispatch.h>
 #include <assert.h>


### PR DESCRIPTION
iOS builds with push enabled fail to link because `IOSNative.m` guards the push completion definitions with `INCLUDE_CN1_PUSH_2`, while the native template and builder use `INCLUDE_CN1_PUSH2`. Use the existing flag for the completion implementation and both Java completion entry points.

Add a native regression test that compiles the production completion block with its preprocessor guards intact and links a separate caller using the app delegate's declarations. It exercises overlapping notifications, multiple callbacks per notification, empty routing, duplicate completion, and both asynchronous Java completion entry points. It also compiles and runs with push disabled using the builder's disabling replacement. A focused macOS workflow runs the contract on PRs and master changes to its source, builder, test, or workflow inputs; no signing or generated app is required.

Validation:
- `python3 scripts/ios/push-completion-tests/check.py` passes with push enabled and disabled.
- Restoring all three original guards reproduces the missing completion symbol failure.
- Restoring each guard independently fails the test: compilation/linking for the implementation guard and runtime assertions for either Java entry point.
- `git diff --check` passes.

This checks the isolated production native completion code; a complete signed iOS application build was not run locally.
