### PR TITLE
ParparVM: extend tagged immediates from Integer to all six boxed number types

### DIFF
--- a/Ports/iOSPort/nativeSources/cn1_debugger.h
+++ b/Ports/iOSPort/nativeSources/cn1_debugger.h
@@ -104,12 +104,15 @@ extern struct clazz* cn1_debugger_class_of(JAVA_OBJECT obj);
 extern int cn1_debugger_is_valid_object(JAVA_OBJECT obj);
 
 /**
- * Whether a reference is a tagged int rather than a heap object, and the value
- * it carries. A tagged int has no object header, so no caller may compute a
- * field address from one.
+ * Whether a reference is a tagged immediate of any boxed type rather than a heap
+ * object, and the value it carries. An immediate has no object header, so no caller
+ * may compute a field address from one. cn1_debugger_tagged_int_value answers only for
+ * a tagged Integer; cn1_debugger_tagged_value decodes every type into a JDWP type
+ * character plus a 64-bit payload (IEEE bits for float and double).
  */
-extern int cn1_debugger_is_tagged_int(JAVA_OBJECT obj);
+extern int cn1_debugger_is_tagged_value(JAVA_OBJECT obj);
 extern JAVA_INT cn1_debugger_tagged_int_value(JAVA_OBJECT obj);
+extern int cn1_debugger_tagged_value(JAVA_OBJECT obj, char* typeChar, uint64_t* value);
 
 /**
  * Records a reference as handed to the proxy, tests whether one was, and

--- a/Ports/iOSPort/nativeSources/cn1_debugger.m
+++ b/Ports/iOSPort/nativeSources/cn1_debugger.m
@@ -1296,13 +1296,18 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
                 char tc = 'L';
                 uint64_t val = 0;
                 const cn1_field_entry* fe = field_lookup_by_class_and_id(classId, fid, NULL);
-                if (cn1_debugger_is_tagged_int(obj)) {
-                    // A tagged Integer carries its value in the reference
-                    // itself and has no fields to read at an offset. Serve the
-                    // one field it models -- Integer.value -- from the tag.
-                    if (fe && fe->type == 'I') {
-                        tc = 'I';
-                        val = (uint64_t)(uint32_t)cn1_debugger_tagged_int_value(obj);
+                if (cn1_debugger_is_tagged_value(obj)) {
+                    // A tagged immediate carries its value in the reference itself and has
+                    // no fields to read at an offset. Serve the one field its type models --
+                    // Integer.value, Long.value, Double.value and so on -- from the tag, and
+                    // only when the requested field's declared type matches what the tag
+                    // actually holds.
+                    char tagType = 0;
+                    uint64_t tagVal = 0;
+                    if (fe && cn1_debugger_tagged_value(obj, &tagType, &tagVal)
+                            && fe->type == tagType) {
+                        tc = tagType;
+                        val = tagVal;
                     } else {
                         tc = 'L'; val = 0;
                     }
@@ -1463,7 +1468,7 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
             JAVA_OBJECT obj = (JAVA_OBJECT)(uintptr_t)ptr;
             int length = 0;
             struct clazz* arrCls = cn1_debugger_class_of_wire_id(obj);
-            if (arrCls != NULL && !cn1_debugger_is_tagged_int(obj) && arrCls->isArray) {
+            if (arrCls != NULL && !cn1_debugger_is_tagged_value(obj) && arrCls->isArray) {
                 length = ((JAVA_ARRAY)obj)->length;
             }
             uint8_t reply[4];
@@ -1491,7 +1496,7 @@ static int handleCommand(uint8_t cmd, const uint8_t* payload, uint32_t len) {
             // Everything below indexes arr->data, so the reference has to be
             // a verified array before any of it runs.
             struct clazz* objArrCls = cn1_debugger_class_of_wire_id(obj);
-            if (objArrCls == NULL || cn1_debugger_is_tagged_int(obj) || !objArrCls->isArray) {
+            if (objArrCls == NULL || cn1_debugger_is_tagged_value(obj) || !objArrCls->isArray) {
                 uint8_t err[5] = {'L', 0,0,0,0};
                 sendEvent(EVT_ARRAY_VALUES, err, 5);
                 return 0;

--- a/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
+++ b/Ports/iOSPort/nativeSources/cn1_debugger_objects.c
@@ -120,12 +120,15 @@ static int cn1_is_registered_class(const struct clazz* cls, int classId) {
  */
 struct clazz* cn1_debugger_class_of(JAVA_OBJECT obj) {
     if (obj == JAVA_NULL) return NULL;
-    // A tagged int is a value, not an address: Integer.valueOf() returns
-    // (v << 1) | 1 on every 64-bit target, which is the shipping iOS shape.
-    // It has no header to read, and the alignment rejection below would
-    // otherwise discard every boxed Integer the debugger was asked about.
+    // A tagged immediate is a value, not an address: valueOf() encodes the value plus a
+    // type code in the low three bits on every 64-bit target, which is the shipping iOS
+    // shape. It has no header to read, and the alignment rejection below would otherwise
+    // discard every boxed value the debugger was asked about. Resolved through CN1_CLASS_OF
+    // so a new tagged type needs no edit here -- naming Integer directly was correct only
+    // while Integer was the only tagged type, and would have silently reported a Long as an
+    // Integer with a garbage value.
     if (CN1_IS_TAGGED(obj)) {
-        return &class__java_lang_Integer;
+        return CN1_CLASS_OF(obj);
     }
     struct clazz* cls = NULL;
     if (!cn1_debugger_safe_read(&obj->__codenameOneParentClsReference, &cls, sizeof(cls))) {
@@ -205,22 +208,57 @@ int cn1_debugger_is_valid_object(JAVA_OBJECT obj) {
 }
 
 /**
- * The value carried by a tagged int, for callers that must not treat it as an
- * address. Returns 0 for anything else, so a caller that has already checked
- * {@code cn1_debugger_is_tagged_int} reads the real value.
+ * Whether a reference is a tagged immediate of ANY boxed type rather than a heap
+ * object. An immediate has no object header, so no caller may compute a field
+ * address from one.
  */
-int cn1_debugger_is_tagged_int(JAVA_OBJECT obj) {
+int cn1_debugger_is_tagged_value(JAVA_OBJECT obj) {
     return obj != JAVA_NULL && CN1_IS_TAGGED(obj);
 }
 
+/**
+ * The value carried by a tagged INTEGER specifically. Returns 0 for a tagged value
+ * of any other type, so a caller wanting the general case must use
+ * {@code cn1_debugger_tagged_value} instead of assuming a tagged reference is an int.
+ */
 JAVA_INT cn1_debugger_tagged_int_value(JAVA_OBJECT obj) {
 #if CN1_TAGGED_ACTIVE
-    return CN1_IS_TAGGED(obj) ? CN1_UNTAG_INT(obj) : 0;
+    return CN1_TAG_CODE(obj) == CN1_TAG_INTEGER ? CN1_UNTAG_INT(obj) : 0;
 #else
-    // Tagged ints are compiled out on 32-bit targets and under
+    // Tagged values are compiled out on 32-bit targets and under
     // -DCN1_DISABLE_TAGGED_INT, which also leaves CN1_UNTAG_INT undefined.
     // Every reference is then a real object and no caller reaches this.
     (void)obj;
+    return 0;
+#endif
+}
+
+/**
+ * Decodes any tagged immediate into a JDWP-style type character and a 64-bit payload,
+ * so the wire protocol can serve the single field each boxed type models without ever
+ * dereferencing the reference. Floating point payloads are the IEEE bit patterns, which
+ * is what the wire format carries. Returns 0 if obj is not a tagged immediate.
+ */
+int cn1_debugger_tagged_value(JAVA_OBJECT obj, char* typeChar, uint64_t* value) {
+#if CN1_TAGGED_ACTIVE
+    switch (CN1_TAG_CODE(obj)) {
+        case CN1_TAG_INTEGER:
+            *typeChar = 'I'; *value = (uint64_t)(uint32_t)CN1_UNTAG_INT(obj); return 1;
+        case CN1_TAG_LONG:
+            *typeChar = 'J'; *value = (uint64_t)CN1_UNTAG_LONG(obj); return 1;
+        case CN1_TAG_DOUBLE:
+            *typeChar = 'D'; *value = CN1_UNTAG_DOUBLE_BITS(obj); return 1;
+        case CN1_TAG_FLOAT:
+            *typeChar = 'F'; *value = (uint64_t)CN1_UNTAG_FLOAT_BITS(obj); return 1;
+        case CN1_TAG_CHARACTER:
+            *typeChar = 'C'; *value = (uint64_t)(uint32_t)CN1_UNTAG_CHAR(obj); return 1;
+        case CN1_TAG_SHORT:
+            *typeChar = 'S'; *value = (uint64_t)(uint32_t)CN1_UNTAG_SHORT(obj); return 1;
+        default:
+            return 0;
+    }
+#else
+    (void)obj; (void)typeChar; (void)value;
     return 0;
 #endif
 }

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/BytecodeComplianceMojoTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/BytecodeComplianceMojoTest.java
@@ -24,6 +24,8 @@ package com.codename1.maven;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.artifact.handler.DefaultArtifactHandler;
 import org.apache.maven.project.MavenProject;
@@ -343,23 +345,45 @@ class BytecodeComplianceMojoTest {
                 "Expected SIMD alloca verifier to reject returning scratch arrays");
     }
 
-    @Test
-    void rejectsSynchronizationOnPrimitiveWrapper(@TempDir Path tempDir) throws Exception {
+    /**
+     * The rule has always named all eight wrappers, but only Integer was ever exercised.
+     * ParparVM now returns a tagged immediate from valueOf for Long, Double, Float,
+     * Character and Short as well, and a monitor attached to an immediate is never
+     * reclaimed -- there is no object death to trigger removal -- so this build-time
+     * refusal is the only thing standing between an application and an unbounded
+     * side-table leak. A rule that is only proven for one of the types it claims to cover
+     * is not a rule anyone should rely on, so prove it for each.
+     */
+    @ParameterizedTest
+    @CsvSource({
+            "java/lang/Integer,   (I)Ljava/lang/Integer;",
+            "java/lang/Long,      (J)Ljava/lang/Long;",
+            "java/lang/Double,    (D)Ljava/lang/Double;",
+            "java/lang/Float,     (F)Ljava/lang/Float;",
+            "java/lang/Character, (C)Ljava/lang/Character;",
+            "java/lang/Short,     (S)Ljava/lang/Short;",
+            "java/lang/Byte,      (B)Ljava/lang/Byte;",
+            "java/lang/Boolean,   (Z)Ljava/lang/Boolean;"
+    })
+    void rejectsSynchronizationOnEveryPrimitiveWrapper(String owner, String descriptor,
+            @TempDir Path tempDir) throws Exception {
         Path outputDir = tempDir.resolve("classes");
         Path allowedDir = tempDir.resolve("allowed");
         Files.createDirectories(outputDir);
         Files.createDirectories(allowedDir);
 
         writeJavaLangObject(allowedDir);
-        writePrimitiveWrapperApi(allowedDir, "java/lang/Integer", "valueOf", "(I)Ljava/lang/Integer;");
-        writePrimitiveWrapperSynchronizedClass(outputDir, "app/IntegerLockUser", "java/lang/Integer", "valueOf", "(I)Ljava/lang/Integer;");
+        writePrimitiveWrapperApi(allowedDir, owner, "valueOf", descriptor);
+        writePrimitiveWrapperSynchronizedClass(outputDir,
+                "app/" + owner.substring(owner.lastIndexOf('/') + 1) + "LockUser",
+                owner, "valueOf", descriptor);
 
         BytecodeComplianceMojo mojo = new BytecodeComplianceMojo();
         Map<String, ?> allowedIndex = buildClassIndex(mojo, Collections.singletonList(allowedDir.toFile()));
         List<?> violations = scanProjectClasses(mojo, outputDir, allowedIndex, Collections.<String, Object>emptyMap());
 
-        assertTrue(hasViolationForReferencePrefix(violations, "Synchronization on primitive wrapper java/lang/Integer"),
-                "Expected primitive wrapper synchronization to be rejected");
+        assertTrue(hasViolationForReferencePrefix(violations, "Synchronization on primitive wrapper " + owner),
+                "Expected synchronization on " + owner + " to be rejected");
     }
 
     @Test
@@ -798,6 +822,21 @@ class BytecodeComplianceMojoTest {
         writeBytes(root, className, writer.toByteArray());
     }
 
+    /** The 1 constant in the argument type the given valueOf descriptor expects. */
+    private static int constantForDescriptor(String descriptor) {
+        char arg = descriptor.charAt(1);
+        if (arg == 'J') {
+            return Opcodes.LCONST_1;
+        }
+        if (arg == 'D') {
+            return Opcodes.DCONST_1;
+        }
+        if (arg == 'F') {
+            return Opcodes.FCONST_1;
+        }
+        return Opcodes.ICONST_1;
+    }
+
     private void writePrimitiveWrapperSynchronizedClass(Path root, String className, String owner, String methodName, String descriptor) throws Exception {
         ClassWriter writer = new ClassWriter(0);
         writer.visit(Opcodes.V1_8, Opcodes.ACC_PUBLIC, className, null, "java/lang/Object", null);
@@ -812,7 +851,10 @@ class BytecodeComplianceMojoTest {
 
         MethodVisitor run = writer.visitMethod(Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC, "run", "()V", null, null);
         run.visitCode();
-        run.visitInsn(Opcodes.ICONST_1);
+        // The constant has to match the wrapper's own valueOf argument, or the analyzer sees
+        // a type-incorrect frame instead of the MONITORENTER this test is about. Long and
+        // double occupy two stack slots, which is why maxStack below is 4 rather than 2.
+        run.visitInsn(constantForDescriptor(descriptor));
         run.visitMethodInsn(Opcodes.INVOKESTATIC, owner, methodName, descriptor, false);
         run.visitInsn(Opcodes.DUP);
         run.visitVarInsn(Opcodes.ASTORE, 0);
@@ -820,7 +862,7 @@ class BytecodeComplianceMojoTest {
         run.visitVarInsn(Opcodes.ALOAD, 0);
         run.visitInsn(Opcodes.MONITOREXIT);
         run.visitInsn(Opcodes.RETURN);
-        run.visitMaxs(2, 1);
+        run.visitMaxs(4, 1);
         run.visitEnd();
 
         writer.visitEnd();

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/BytecodeComplianceMojoTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/maven/BytecodeComplianceMojoTest.java
@@ -24,8 +24,6 @@ package com.codename1.maven;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.artifact.handler.DefaultArtifactHandler;
 import org.apache.maven.project.MavenProject;
@@ -353,37 +351,48 @@ class BytecodeComplianceMojoTest {
      * refusal is the only thing standing between an application and an unbounded
      * side-table leak. A rule that is only proven for one of the types it claims to cover
      * is not a rule anyone should rely on, so prove it for each.
+     *
+     * A loop rather than @ParameterizedTest: this module depends on junit-jupiter-api and
+     * -engine only, and adding junit-jupiter-params to a Maven plugin's pom for one test is
+     * not worth it. The assertion message carries the wrapper so a failure still names it.
      */
-    @ParameterizedTest
-    @CsvSource({
-            "java/lang/Integer,   (I)Ljava/lang/Integer;",
-            "java/lang/Long,      (J)Ljava/lang/Long;",
-            "java/lang/Double,    (D)Ljava/lang/Double;",
-            "java/lang/Float,     (F)Ljava/lang/Float;",
-            "java/lang/Character, (C)Ljava/lang/Character;",
-            "java/lang/Short,     (S)Ljava/lang/Short;",
-            "java/lang/Byte,      (B)Ljava/lang/Byte;",
-            "java/lang/Boolean,   (Z)Ljava/lang/Boolean;"
-    })
-    void rejectsSynchronizationOnEveryPrimitiveWrapper(String owner, String descriptor,
-            @TempDir Path tempDir) throws Exception {
-        Path outputDir = tempDir.resolve("classes");
-        Path allowedDir = tempDir.resolve("allowed");
-        Files.createDirectories(outputDir);
-        Files.createDirectories(allowedDir);
+    @Test
+    void rejectsSynchronizationOnEveryPrimitiveWrapper(@TempDir Path tempDir) throws Exception {
+        String[][] wrappers = {
+                { "java/lang/Integer", "(I)Ljava/lang/Integer;" },
+                { "java/lang/Long", "(J)Ljava/lang/Long;" },
+                { "java/lang/Double", "(D)Ljava/lang/Double;" },
+                { "java/lang/Float", "(F)Ljava/lang/Float;" },
+                { "java/lang/Character", "(C)Ljava/lang/Character;" },
+                { "java/lang/Short", "(S)Ljava/lang/Short;" },
+                { "java/lang/Byte", "(B)Ljava/lang/Byte;" },
+                { "java/lang/Boolean", "(Z)Ljava/lang/Boolean;" }
+        };
+        for (int i = 0; i < wrappers.length; i++) {
+            String owner = wrappers[i][0];
+            String descriptor = wrappers[i][1];
+            String simpleName = owner.substring(owner.lastIndexOf('/') + 1);
 
-        writeJavaLangObject(allowedDir);
-        writePrimitiveWrapperApi(allowedDir, owner, "valueOf", descriptor);
-        writePrimitiveWrapperSynchronizedClass(outputDir,
-                "app/" + owner.substring(owner.lastIndexOf('/') + 1) + "LockUser",
-                owner, "valueOf", descriptor);
+            Path outputDir = tempDir.resolve(simpleName + "-classes");
+            Path allowedDir = tempDir.resolve(simpleName + "-allowed");
+            Files.createDirectories(outputDir);
+            Files.createDirectories(allowedDir);
 
-        BytecodeComplianceMojo mojo = new BytecodeComplianceMojo();
-        Map<String, ?> allowedIndex = buildClassIndex(mojo, Collections.singletonList(allowedDir.toFile()));
-        List<?> violations = scanProjectClasses(mojo, outputDir, allowedIndex, Collections.<String, Object>emptyMap());
+            writeJavaLangObject(allowedDir);
+            writePrimitiveWrapperApi(allowedDir, owner, "valueOf", descriptor);
+            writePrimitiveWrapperSynchronizedClass(outputDir, "app/" + simpleName + "LockUser",
+                    owner, "valueOf", descriptor);
 
-        assertTrue(hasViolationForReferencePrefix(violations, "Synchronization on primitive wrapper " + owner),
-                "Expected synchronization on " + owner + " to be rejected");
+            BytecodeComplianceMojo mojo = new BytecodeComplianceMojo();
+            Map<String, ?> allowedIndex = buildClassIndex(mojo,
+                    Collections.singletonList(allowedDir.toFile()));
+            List<?> violations = scanProjectClasses(mojo, outputDir, allowedIndex,
+                    Collections.<String, Object>emptyMap());
+
+            assertTrue(hasViolationForReferencePrefix(violations,
+                            "Synchronization on primitive wrapper " + owner),
+                    "Expected synchronization on " + owner + " to be rejected");
+        }
     }
 
     @Test

--- a/vm/ByteCodeTranslator/src/cn1_globals.h
+++ b/vm/ByteCodeTranslator/src/cn1_globals.h
@@ -617,15 +617,55 @@ typedef struct clazz*       JAVA_CLASS;
 
 #define BC_I2F() do { SP[-1].data.f = (JAVA_FLOAT)SP[-1].data.i; SP[-1].type = CN1_TYPE_FLOAT; } while(0)
 
-#define BC_F2I() do { SP[-1].data.i = (JAVA_INT)SP[-1].data.f; SP[-1].type = CN1_TYPE_INT; } while(0)
+// JLS 5.1.3: narrowing a float or double to an int or long SATURATES -- NaN becomes 0,
+// anything at or above the target's maximum becomes MAX_VALUE, anything at or below its
+// minimum becomes MIN_VALUE. C's cast is UNDEFINED out of range instead, and the two
+// architectures shipped here disagree about what it actually does: arm64's fcvtzs
+// saturates, so this was accidentally correct on Apple silicon, while x86-64's cvttsd2si
+// yields the "integer indefinite" value 0x80000000 -- so (int) 1.7976931348623157E308 came
+// out as Integer.MIN_VALUE rather than Integer.MAX_VALUE on every x86 target.
+//
+// The thresholds are compared in DOUBLE, and float goes through the double form because
+// float-to-double is exact and lossless. Note 2147483647.0 is exactly representable so the
+// int bounds are exact, while Long.MAX_VALUE is NOT -- 9223372036854775808.0 is 2^63, the
+// first double above it, which is why the upper long test is >= that rather than > it.
+#define CN1_D2L_LIMIT 9223372036854775808.0
 
-#define BC_F2L() do { SP[-1].data.l = (JAVA_LONG)SP[-1].data.f; SP[-1].type = CN1_TYPE_LONG; } while(0)
+// -DCN1_NO_SATURATING_NARROWING restores the old undefined cast. All three emission sites
+// route through these two functions, so that one macro ablates the whole change and an A/B
+// needs no second translator build -- which matters, because this host cannot resolve a 5%
+// difference across sessions and the arms have to be interleaved inside one.
+static inline JAVA_INT cn1SaturateToInt(JAVA_DOUBLE cn1__d) {
+#ifdef CN1_NO_SATURATING_NARROWING
+    return (JAVA_INT)cn1__d;
+#else
+    if(cn1__d != cn1__d) return 0;
+    if(cn1__d >= 2147483647.0) return (JAVA_INT)2147483647;
+    if(cn1__d <= -2147483648.0) return (JAVA_INT)(-2147483647 - 1);
+    return (JAVA_INT)cn1__d;
+#endif
+}
+
+static inline JAVA_LONG cn1SaturateToLong(JAVA_DOUBLE cn1__d) {
+#ifdef CN1_NO_SATURATING_NARROWING
+    return (JAVA_LONG)cn1__d;
+#else
+    if(cn1__d != cn1__d) return 0;
+    if(cn1__d >= CN1_D2L_LIMIT) return (JAVA_LONG)9223372036854775807LL;
+    if(cn1__d <= -CN1_D2L_LIMIT) return (JAVA_LONG)(-9223372036854775807LL - 1);
+    return (JAVA_LONG)cn1__d;
+#endif
+}
+
+#define BC_F2I() do { SP[-1].data.i = cn1SaturateToInt((JAVA_DOUBLE)SP[-1].data.f); SP[-1].type = CN1_TYPE_INT; } while(0)
+
+#define BC_F2L() do { SP[-1].data.l = cn1SaturateToLong((JAVA_DOUBLE)SP[-1].data.f); SP[-1].type = CN1_TYPE_LONG; } while(0)
 
 #define BC_F2D() do { SP[-1].data.d = SP[-1].data.f; SP[-1].type = CN1_TYPE_DOUBLE; } while(0)
 
-#define BC_D2I() do { SP[-1].data.i = (JAVA_INT)SP[-1].data.d; SP[-1].type = CN1_TYPE_INT; } while(0)
+#define BC_D2I() do { SP[-1].data.i = cn1SaturateToInt(SP[-1].data.d); SP[-1].type = CN1_TYPE_INT; } while(0)
 
-#define BC_D2L() do { SP[-1].data.l = (JAVA_LONG)SP[-1].data.d; SP[-1].type = CN1_TYPE_LONG; } while(0)
+#define BC_D2L() do { SP[-1].data.l = cn1SaturateToLong(SP[-1].data.d); SP[-1].type = CN1_TYPE_LONG; } while(0)
 
 #define BC_I2D() do { SP[-1].data.d = SP[-1].data.i; SP[-1].type = CN1_TYPE_DOUBLE; } while(0)
 

--- a/vm/ByteCodeTranslator/src/cn1_globals.h
+++ b/vm/ByteCodeTranslator/src/cn1_globals.h
@@ -977,20 +977,107 @@ extern int instanceofFunction(int sourceClass, int destId);
 #define CN1_TAGGED_ACTIVE 0
 #endif
 extern struct clazz class__java_lang_Integer;
+extern struct clazz class__java_lang_Long;
+extern struct clazz class__java_lang_Double;
+extern struct clazz class__java_lang_Float;
+extern struct clazz class__java_lang_Character;
+extern struct clazz class__java_lang_Short;
+
+// The tag is the LOW THREE BITS of the word, and code 0 means "an ordinary heap pointer".
+// Three bits rather than one because 8-byte object alignment is ALREADY load-bearing:
+// cn1ConservativeResolve rejects any word with a bit set in (sizeof(void*) - 1), and
+// conservative roots are on by default, so an object living at a 4-byte address would
+// already be invisible to the root scan and freed under a live reference. Widening the tag
+// therefore rests on an invariant the collector enforces rather than introducing a new one,
+// and it buys one code per boxed type over a 61-bit payload.
+//
+// One code per type is what makes the immediate SELF-DESCRIBING, which is the whole point:
+// a value is boxed precisely because it is flowing through an Object / Number / Comparable
+// slot, so the callsite that has to dispatch hashCode() on it has no static type to consult.
+#define CN1_TAG_MASK      7
+#define CN1_TAG_SHIFT     3
+#define CN1_TAG_NONE      0
+#define CN1_TAG_INTEGER   1
+#define CN1_TAG_LONG      2
+#define CN1_TAG_DOUBLE    3
+#define CN1_TAG_FLOAT     4
+#define CN1_TAG_CHARACTER 5
+#define CN1_TAG_SHORT     6
+#define CN1_TAG_COUNT     8
+
+// Ablation arm for the five types added after Integer. It gates only the PRODUCTION side --
+// the valueOf natives -- and never the consumption side (cn1Value, the proxy table,
+// cn1ClassOf), so turning it off simply stops those immediates being created and cannot
+// leave the runtime half-taught about a tag it might still meet.
+#if !defined(CN1_DISABLE_TAGGED_VALUES)
+#define CN1_TAGGED_EXTRA_ACTIVE CN1_TAGGED_ACTIVE
+#else
+#define CN1_TAGGED_EXTRA_ACTIVE 0
+#endif
+
 #if CN1_TAGGED_ACTIVE
 struct JavaObjectPrototype;
-// A static object-shaped proxy whose header is Integer's class. CN1_CLASS_OF selects a
-// VALID object pointer (proxy for a tagged int, else the object itself) BEFORE the single
-// header load, so clang's if-conversion can branchlessly select the pointer yet the load
-// is always on a dereferenceable address -- a plain ternary lets clang speculate the
-// faulting `tagged->header` load above the tag test (observed: a SIGSEGV in interface
-// dispatch like Comparable.compareTo, where no inline fast path guards it first).
-extern struct JavaObjectPrototype cn1TaggedProxy;
-#define CN1_IS_TAGGED(o) (((uintptr_t)(o)) & 1)
-#define CN1_TAG_INT(v) ((JAVA_OBJECT)((((uintptr_t)(intptr_t)(JAVA_INT)(v)) << 1) | 1))
-#define CN1_UNTAG_INT(o) ((JAVA_INT)(((intptr_t)(o)) >> 1))
-#define CN1_CLASS_OF(o) ((CN1_IS_TAGGED(o) ? &cn1TaggedProxy : (struct JavaObjectPrototype*)(o))->__codenameOneParentClsReference)
+// Static object-shaped proxies, one per tag code, each carrying its boxed class in the
+// header slot. cn1ClassOf selects a VALID object pointer (this code's proxy, else the object
+// itself) BEFORE the single header load, so clang's if-conversion can branchlessly select
+// the pointer yet the load is always on a dereferenceable address -- a plain ternary lets
+// clang speculate the faulting `tagged->header` load above the tag test (observed: a SIGSEGV
+// in interface dispatch like Comparable.compareTo, where no inline fast path guards it
+// first). Do not "simplify" this back into a conditional over the loaded value.
+//
+// Indexing by tag code costs an address computation and NOT a memory access, because the
+// proxies are one contiguous array: &cn1TaggedProxy[code] is a shifted add on both arm64 and
+// x86-64. That is the entire runtime price of knowing which boxed type an immediate is.
+extern struct JavaObjectPrototype cn1TaggedProxy[CN1_TAG_COUNT];
+#define CN1_TAG_CODE(o) (((uintptr_t)(o)) & CN1_TAG_MASK)
+#define CN1_IS_TAGGED(o) (CN1_TAG_CODE(o) != 0)
+// A function rather than a macro so the argument is evaluated exactly once; every caller
+// passes an lvalue, but SP[-1].data.o through a volatile SP would otherwise be three loads.
+static inline struct clazz* cn1ClassOf(JAVA_OBJECT o) {
+    uintptr_t cn1__code = ((uintptr_t)o) & CN1_TAG_MASK;
+    struct JavaObjectPrototype* cn1__p = cn1__code ? &cn1TaggedProxy[cn1__code]
+                                                   : (struct JavaObjectPrototype*)o;
+    return cn1__p->__codenameOneParentClsReference;
+}
+#define CN1_TAG_INT(v) ((JAVA_OBJECT)((((uintptr_t)(intptr_t)(JAVA_INT)(v)) << CN1_TAG_SHIFT) | CN1_TAG_INTEGER))
+#define CN1_UNTAG_INT(o) ((JAVA_INT)(((intptr_t)(o)) >> CN1_TAG_SHIFT))
+
+// Short and Character are narrower than int and always fit. The arithmetic shift recovers
+// the sign correctly across the OR'd tag because the tag occupies exactly the bits the left
+// shift zero-filled: -32768 tags to (-262144 | 6) and shifts back to -32768.
+#define CN1_TAG_SHORT_VAL(v) ((JAVA_OBJECT)((((uintptr_t)(intptr_t)(JAVA_SHORT)(v)) << CN1_TAG_SHIFT) | CN1_TAG_SHORT))
+#define CN1_UNTAG_SHORT(o) ((JAVA_SHORT)(((intptr_t)(o)) >> CN1_TAG_SHIFT))
+#define CN1_TAG_CHAR_VAL(v) ((JAVA_OBJECT)(((((uintptr_t)(JAVA_CHAR)(v)) & 0xFFFF) << CN1_TAG_SHIFT) | CN1_TAG_CHARACTER))
+#define CN1_UNTAG_CHAR(o) ((JAVA_CHAR)((((uintptr_t)(o)) >> CN1_TAG_SHIFT) & 0xFFFF))
+
+// A float is 32 bits, so its RAW bit pattern always fits. Raw, not canonicalized: the
+// immediate has to round-trip Float.floatToRawIntBits, and equals/hashCode canonicalize NaN
+// for themselves through floatToIntBits.
+#define CN1_TAG_FLOAT_BITS(b) ((JAVA_OBJECT)((((uintptr_t)(uint32_t)(b)) << CN1_TAG_SHIFT) | CN1_TAG_FLOAT))
+#define CN1_UNTAG_FLOAT_BITS(o) ((uint32_t)(((uintptr_t)(o)) >> CN1_TAG_SHIFT))
+
+// Long and Double are the two that do NOT always fit in the 61-bit payload, so both are
+// PARTIAL: the test below decides, and anything that fails it takes the ordinary heap path.
+// A partial scheme can look excellent on a benchmark and never fire on real data, so
+// whatever measures this has to report the hit rate rather than the speedup alone.
+//
+// Long: 61 signed bits, i.e. [-2^60, 2^60). Timestamps, ids, counters and sizes are far
+// inside it; a uniformly random 64-bit value is outside it seven times in eight.
+#define CN1_LONG_TAGGABLE(v) (((JAVA_LONG)(v)) >= -(((JAVA_LONG)1) << 60) && ((JAVA_LONG)(v)) < (((JAVA_LONG)1) << 60))
+#define CN1_TAG_LONG_VAL(v) ((JAVA_OBJECT)((((uintptr_t)(intptr_t)(JAVA_LONG)(v)) << CN1_TAG_SHIFT) | CN1_TAG_LONG))
+#define CN1_UNTAG_LONG(o) ((JAVA_LONG)(((intptr_t)(o)) >> CN1_TAG_SHIFT))
+
+// Double: a 64-bit pattern cannot be shifted at all, so instead of narrowing the value the
+// scheme narrows the SET -- a double whose low three mantissa bits are already zero carries
+// its own tag space, making tag an OR and untag a mask with no shifting and no value loss.
+// That set is every small integer, half, quarter and eighth (what JSON numbers overwhelmingly
+// are), and it excludes 0.1 and 3.14. -0.0 and +0.0 stay distinct, which Double.equals needs.
+#define CN1_DOUBLE_TAGGABLE_BITS(b) ((((uint64_t)(b)) & CN1_TAG_MASK) == 0)
+#define CN1_TAG_DOUBLE_BITS(b) ((JAVA_OBJECT)(((uintptr_t)(uint64_t)(b)) | CN1_TAG_DOUBLE))
+#define CN1_UNTAG_DOUBLE_BITS(o) ((uint64_t)(((uintptr_t)(o)) & ~((uintptr_t)CN1_TAG_MASK)))
+#define CN1_CLASS_OF(o) cn1ClassOf((JAVA_OBJECT)(o))
 #else
+#define CN1_TAG_CODE(o) (0)
 #define CN1_IS_TAGGED(o) (0)
 #define CN1_CLASS_OF(o) ((o)->__codenameOneParentClsReference)
 #endif
@@ -1203,9 +1290,13 @@ static inline JAVA_BOOLEAN cn1InNursery(void* p) {
 // check with no call and no getThreadLocalData() TLS lookup. This matters enormously
 // for store-heavy code (HashMap internals, etc.) and makes the barrier ~free whenever
 // the nursery isn't holding the value (including while bypassed).
+// The CN1_IS_TAGGED guard is not decoration: cn1NurseryWriteBarrier dereferences
+// value->__heapPosition, and a tagged immediate has no header. With a one-bit tag this
+// survived on cn1InNursery's range check happening to exclude small odd addresses; a tagged
+// Long or Double is an ordinary-looking large word that can land inside an arena.
 #define CN1_WRITE_BARRIER(target, value) \
     do { JAVA_OBJECT cn1__bv = (JAVA_OBJECT)(value); \
-         if(cn1__bv != JAVA_NULL && cn1InNursery(cn1__bv)) { \
+         if(cn1__bv != JAVA_NULL && !CN1_IS_TAGGED(cn1__bv) && cn1InNursery(cn1__bv)) { \
              cn1NurseryWriteBarrier((JAVA_OBJECT)(target), cn1__bv); } } while(0)
 #else
 // No nursery: repurpose the (already-emitted-at-every-object-store) write barrier as the

--- a/vm/ByteCodeTranslator/src/cn1_globals.h
+++ b/vm/ByteCodeTranslator/src/cn1_globals.h
@@ -1273,6 +1273,21 @@ struct TryBlock {
 #define CN1_THREAD_STACK_BYTES (16 * 1024 * 1024)
 #endif
 
+// The SATB entry points are DEFINED unconditionally in cn1_globals.m, and nativeMethods.m
+// calls the bulk trio from java_lang_System_arraycopy with no #ifdef around it -- so these
+// declarations have to be visible in both branches below. They used to sit inside the
+// no-nursery #else, which meant a -DCN1_NURSERY build failed to compile on three implicit
+// declarations and had done for as long as the bulk barrier has existed. That silently
+// retired an ablation arm this tree documents, and it is why the missing tag guard in the
+// nursery root scan could not be caught by building the configuration it affects.
+extern volatile int gcSatbActive;
+extern void cn1SatbEnqueue(JAVA_OBJECT old);
+extern volatile int gcSatbTerminating;
+extern JAVA_BOOLEAN cn1SatbBulkBegin(void);
+extern void cn1SatbEnqueueRangeLocked(JAVA_ARRAY_OBJECT* refs, int count);
+extern void cn1SatbBulkEnd(void);
+extern void cn1SatbBulkQuiesce(void);
+
 #ifdef CN1_NURSERY
 // Tunables (override with -D). Block size and arena size trade footprint against
 // how long churn lives before a minor collection (the bigger the nursery, the more
@@ -1322,6 +1337,17 @@ struct ThreadLocalData;
 extern JAVA_OBJECT cn1NurseryAlloc(struct ThreadLocalData* threadStateData, int size, struct clazz* parent);
 extern void cn1NurseryWriteBarrier(JAVA_OBJECT target, JAVA_OBJECT value);
 static inline JAVA_BOOLEAN cn1InNursery(void* p) {
+    // A tagged immediate is a VALUE, not an address, and EVERY caller of this dereferences
+    // the header the moment it answers true -- `cn1InNursery(o) && o->__heapPosition == -1`
+    // is the shape at all six call sites. So the guard belongs here rather than at each of
+    // them: a Double carries the raw IEEE pattern and a Long a shifted payload, either of
+    // which can land inside the arena range by coincidence, and the read that follows is
+    // then an unaligned load off a word that has no object header. With a ONE-bit tag this
+    // survived on the range check happening to exclude small odd addresses; with three bits
+    // and five more types it does not.
+    if(CN1_IS_TAGGED(p)) {
+        return JAVA_FALSE;
+    }
     return (char*)p >= cn1NurseryArenaStart && (char*)p < cn1NurseryArenaEnd;
 }
 // Emitted by the translator before an object-reference store into a heap location.
@@ -1330,13 +1356,12 @@ static inline JAVA_BOOLEAN cn1InNursery(void* p) {
 // check with no call and no getThreadLocalData() TLS lookup. This matters enormously
 // for store-heavy code (HashMap internals, etc.) and makes the barrier ~free whenever
 // the nursery isn't holding the value (including while bypassed).
-// The CN1_IS_TAGGED guard is not decoration: cn1NurseryWriteBarrier dereferences
-// value->__heapPosition, and a tagged immediate has no header. With a one-bit tag this
-// survived on cn1InNursery's range check happening to exclude small odd addresses; a tagged
-// Long or Double is an ordinary-looking large word that can land inside an arena.
+// Tagged immediates are excluded by cn1InNursery itself -- see the note there; this used
+// to carry its own CN1_IS_TAGGED test, which fixed the barrier and left the five other
+// call sites that dereference straight after it still exposed.
 #define CN1_WRITE_BARRIER(target, value) \
     do { JAVA_OBJECT cn1__bv = (JAVA_OBJECT)(value); \
-         if(cn1__bv != JAVA_NULL && !CN1_IS_TAGGED(cn1__bv) && cn1InNursery(cn1__bv)) { \
+         if(cn1__bv != JAVA_NULL && cn1InNursery(cn1__bv)) { \
              cn1NurseryWriteBarrier((JAVA_OBJECT)(target), cn1__bv); } } while(0)
 #else
 // No nursery: repurpose the (already-emitted-at-every-object-store) write barrier as the
@@ -1345,13 +1370,6 @@ static inline JAVA_BOOLEAN cn1InNursery(void* p) {
 // into is a fresh grace object not yet reachable (the residual Property->Double /
 // container->content crash). Pairs with CN1_SATB_DELETE (the deletion half) for a
 // complete snapshot + incremental barrier. Off-mark: one predicted-not-taken flag load.
-extern volatile int gcSatbActive;
-extern void cn1SatbEnqueue(JAVA_OBJECT old);
-extern volatile int gcSatbTerminating;
-extern JAVA_BOOLEAN cn1SatbBulkBegin(void);
-extern void cn1SatbEnqueueRangeLocked(JAVA_ARRAY_OBJECT* refs, int count);
-extern void cn1SatbBulkEnd(void);
-extern void cn1SatbBulkQuiesce(void);
 #if defined(CN1_DISABLE_SATB)
 #define CN1_WRITE_BARRIER(target, value) do { } while(0)
 #else

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -4015,6 +4015,23 @@ JAVA_INT java_lang_System_gcIdleWaitMillis___R_int(CODENAME_ONE_THREAD_STATE) {
 }
 
 JAVA_INT java_lang_System_identityHashCode___java_lang_Object_R_int(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT __cn1Arg1) {
+#if CN1_TAGGED_ACTIVE
+    // A tagged immediate has to fold its HIGH half down, which a heap pointer does not.
+    // The Double encoding is the reason: it carries the raw IEEE pattern, so every value
+    // whose mantissa is zero in the low word -- 1.0, 2.0, 3.0, every integral double --
+    // truncates to the same JAVA_INT and lands in one IdentityHashMap bucket, turning its
+    // linear probe quadratic. Long and Float shift their payload up and would survive a
+    // truncation, but they fold too: one rule is cheaper to keep right than four.
+    //
+    // Heap pointers deliberately keep the plain truncation. Their low bits are a
+    // size-class-aligned address, and IdentityHashMap's indexing is tuned around exactly
+    // that distribution (see the IdmProbe note in vm/CLAUDE.md) -- folding them too
+    // re-randomises a near-perfect placement into collisions.
+    if(CN1_IS_TAGGED(__cn1Arg1)) {
+        uintptr_t cn1__w = (uintptr_t)__cn1Arg1;
+        return (JAVA_INT)(cn1__w ^ (cn1__w >> 32));
+    }
+#endif
     return (JAVA_INT)__cn1Arg1;
 }
 

--- a/vm/ByteCodeTranslator/src/cn1_globals.m
+++ b/vm/ByteCodeTranslator/src/cn1_globals.m
@@ -9975,9 +9975,19 @@ extern void cn1NurseryPromote(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT o);
 #endif
 
 #if CN1_TAGGED_ACTIVE
-// Object-shaped proxy whose header is Integer's class; see CN1_CLASS_OF in cn1_globals.h.
-// Lets a tagged Integer resolve to Integer without dereferencing the tagged pointer.
-struct JavaObjectPrototype cn1TaggedProxy = { .__codenameOneParentClsReference = &class__java_lang_Integer };
+// Object-shaped proxies indexed by tag code; see cn1ClassOf in cn1_globals.h. They let a
+// tagged immediate resolve to its boxed class without dereferencing the tagged pointer.
+// Slot 0 is never selected (code 0 means "an ordinary heap pointer" and cn1ClassOf takes
+// the object itself), and the slots for codes with no tagged type yet stay zero, which is
+// unreachable for the same reason: nothing produces those codes.
+struct JavaObjectPrototype cn1TaggedProxy[CN1_TAG_COUNT] = {
+    [CN1_TAG_INTEGER]   = { .__codenameOneParentClsReference = &class__java_lang_Integer },
+    [CN1_TAG_LONG]      = { .__codenameOneParentClsReference = &class__java_lang_Long },
+    [CN1_TAG_DOUBLE]    = { .__codenameOneParentClsReference = &class__java_lang_Double },
+    [CN1_TAG_FLOAT]     = { .__codenameOneParentClsReference = &class__java_lang_Float },
+    [CN1_TAG_CHARACTER] = { .__codenameOneParentClsReference = &class__java_lang_Character },
+    [CN1_TAG_SHORT]     = { .__codenameOneParentClsReference = &class__java_lang_Short }
+};
 #endif
 
 #if !defined(CN1_DISABLE_BIBOP) && !defined(CN1_BIBOP_NO_FASTSWEEP)

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/BytecodeMethod.java
@@ -2148,16 +2148,25 @@ public class BytecodeMethod implements SignatureSet {
         appendCMethodPrefix(b, "virtual_", cls);
         b.append(" {\n    ");
 
-        // Devirtualize the tagged-Integer fast path for the hottest collection methods.
-        // A tagged receiver is ALWAYS an Integer, so its hashCode IS the untagged value --
-        // turning HashMap's per-lookup key.hashCode() into a bare inline untag with no
-        // indirect dispatch and no call. equals between two tagged ints is a pointer
-        // compare (tags are canonical); the mixed case falls through to normal dispatch.
+        // Devirtualize the tagged-Integer fast path for the hottest collection methods:
+        // an Integer's hashCode IS its value, so HashMap's per-lookup key.hashCode() becomes
+        // a bare inline untag with no indirect dispatch and no call, and equals between two
+        // tagged Integers is a pointer compare (the encoding is canonical).
+        //
+        // These test the tag CODE, not merely "is tagged". Every other boxed type is tagged
+        // too and has a different hashCode contract -- Long folds its halves, Float and
+        // Double go through *ToIntBits -- so widening this to any tagged receiver returns a
+        // wrong hash with no crash, which is the worst failure this scheme can produce.
+        // The other types reach the right implementation through the vtable, which cn1ClassOf
+        // already resolves correctly; that path is slower than this one and always correct.
+        // equals stays Integer-only for a second reason: pointer equality implies value
+        // equality for every tag, but the converse fails for Float and Double, where two
+        // distinct NaN encodings must compare equal.
         String cn1mn = getCMethodName();
         if(cn1mn.equals("hashCode") && arguments.isEmpty() && !returnType.isVoid()) {
-            b.append("\n#if CN1_TAGGED_ACTIVE\n    if(CN1_IS_TAGGED(__cn1ThisObject)) { return CN1_UNTAG_INT(__cn1ThisObject); }\n#endif\n    ");
+            b.append("\n#if CN1_TAGGED_ACTIVE\n    if(CN1_TAG_CODE(__cn1ThisObject) == CN1_TAG_INTEGER) { return CN1_UNTAG_INT(__cn1ThisObject); }\n#endif\n    ");
         } else if(cn1mn.equals("equals") && arguments.size() == 1 && !returnType.isVoid()) {
-            b.append("\n#if CN1_TAGGED_ACTIVE\n    if(CN1_IS_TAGGED(__cn1ThisObject) && CN1_IS_TAGGED(__cn1Arg1)) { return (__cn1ThisObject == __cn1Arg1) ? JAVA_TRUE : JAVA_FALSE; }\n#endif\n    ");
+            b.append("\n#if CN1_TAGGED_ACTIVE\n    if(CN1_TAG_CODE(__cn1ThisObject) == CN1_TAG_INTEGER && CN1_TAG_CODE(__cn1Arg1) == CN1_TAG_INTEGER) { return (__cn1ThisObject == __cn1Arg1) ? JAVA_TRUE : JAVA_FALSE; }\n#endif\n    ");
         }
 
         if(includeStaticInitializer) {

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/JavascriptNativeRegistry.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/JavascriptNativeRegistry.java
@@ -132,6 +132,16 @@ final class JavascriptNativeRegistry {
             "cn1_java_lang_System_identityHashCode_java_lang_Object_R_int",
             "cn1_java_lang_Integer_cn1Value_R_int",
             "cn1_java_lang_Integer_valueOf_int_R_java_lang_Integer",
+            "cn1_java_lang_Long_cn1Value_R_long",
+            "cn1_java_lang_Long_valueOf_long_R_java_lang_Long",
+            "cn1_java_lang_Double_cn1Value_R_double",
+            "cn1_java_lang_Double_valueOf_double_R_java_lang_Double",
+            "cn1_java_lang_Float_cn1Value_R_float",
+            "cn1_java_lang_Float_valueOf_float_R_java_lang_Float",
+            "cn1_java_lang_Character_cn1Value_R_char",
+            "cn1_java_lang_Character_valueOf_char_R_java_lang_Character",
+            "cn1_java_lang_Short_cn1Value_R_short",
+            "cn1_java_lang_Short_valueOf_short_R_java_lang_Short",
             "cn1_java_lang_System_isHighFrequencyGC_R_boolean",
             "cn1_java_lang_System_gcIdleWaitMillis_R_int",
             "cn1_java_lang_Thread_currentThread_R_java_lang_Thread",
@@ -198,7 +208,12 @@ final class JavascriptNativeRegistry {
             "java_util_HashMap.containsKeyImpl",
             "java_util_HashMap.clearImpl",
             "java_lang_StringBuilder.toStringImpl",
-            "java_lang_Integer.valueOfHeap"
+            "java_lang_Integer.valueOfHeap",
+            "java_lang_Long.valueOfHeap",
+            "java_lang_Double.valueOfHeap",
+            "java_lang_Float.valueOfHeap",
+            "java_lang_Character.valueOfHeap",
+            "java_lang_Short.valueOfHeap"
     ));
 
     static boolean isRuntimeDelegateTarget(String mangledClassName, String methodName) {

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/JavascriptReachability.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/JavascriptReachability.java
@@ -248,8 +248,17 @@ final class JavascriptReachability {
         seedRuntimeDispatched("java_util_HashMap", "containsKeyImpl", "(Ljava/lang/Object;)Z");
         seedRuntimeDispatched("java_util_HashMap", "clearImpl", "()V");
         seedRuntimeDispatched("java_lang_StringBuilder", "toStringImpl", "()Ljava/lang/String;");
-        // valueOfHeap is STATIC: virtual seeding does not resolve it
+        // valueOfHeap is STATIC: virtual seeding does not resolve it. One per tagged box --
+        // every type whose valueOf became a native to return an immediate on the C targets
+        // delegates to its heap twin here, and the JS port has no immediates so it ALWAYS
+        // takes that path. Miss one and the cull removes it, and the fixture dies with a
+        // ReferenceError that surfaces only as a wrong return value.
         enqueueResolved("java_lang_Integer", "valueOfHeap", "(I)Ljava/lang/Integer;", true);
+        enqueueResolved("java_lang_Long", "valueOfHeap", "(J)Ljava/lang/Long;", true);
+        enqueueResolved("java_lang_Double", "valueOfHeap", "(D)Ljava/lang/Double;", true);
+        enqueueResolved("java_lang_Float", "valueOfHeap", "(F)Ljava/lang/Float;", true);
+        enqueueResolved("java_lang_Character", "valueOfHeap", "(C)Ljava/lang/Character;", true);
+        enqueueResolved("java_lang_Short", "valueOfHeap", "(S)Ljava/lang/Short;", true);
     }
 
     /**

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/ArithmeticExpression.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/ArithmeticExpression.java
@@ -599,8 +599,18 @@ public class ArithmeticExpression extends Instruction implements AssignableExpre
                 case Opcodes.LCMP: {
                     return "CN1_CMP_EXPR("+subExpression.getExpressionAsString().trim() + ", " + subExpression2.getExpressionAsString().trim()+")";
                 }
-                case Opcodes.D2F: {
+                // Widening conversions are a plain C cast, and the opcodes that share an
+                // emission now share a clause. They used to be written out one per opcode,
+                // which SpotBugs reports as DB_DUPLICATE_SWITCH_CLAUSES -- it stayed quiet
+                // only while the narrowing cases below happened to match them too.
+                case Opcodes.D2F:
+                case Opcodes.I2F:
+                case Opcodes.L2F: {
                     return "((JAVA_FLOAT)" + subExpression.getExpressionAsString().trim() + ")";
+                }
+                case Opcodes.I2D:
+                case Opcodes.L2D: {
+                    return "((JAVA_DOUBLE)" + subExpression.getExpressionAsString().trim() + ")";
                 }
                 case Opcodes.F2D: {
                     return subExpression.getExpressionAsString().trim();
@@ -628,23 +638,11 @@ public class ArithmeticExpression extends Instruction implements AssignableExpre
                 case Opcodes.I2C: {
                     return "("+subExpression.getExpressionAsString().trim()+" & 0xffff)";
                 }
-                case Opcodes.I2D: {
-                    return "((JAVA_DOUBLE)"+subExpression.getExpressionAsString().trim()+")";
-                }
-                case Opcodes.I2F: {
-                    return "((JAVA_FLOAT)"+subExpression.getExpressionAsString().trim()+")";
-                }
                 case Opcodes.I2L: {
                     return "((JAVA_LONG)"+subExpression.getExpressionAsString().trim()+")";
                 }
                 case Opcodes.I2S: {
                     return "(("+subExpression.getExpressionAsString().trim()+" << 16) >> 16)";
-                }
-                case Opcodes.L2D: {
-                    return "((JAVA_DOUBLE)"+subExpression.getExpressionAsString().trim()+")";
-                }
-                case Opcodes.L2F: {
-                    return "((JAVA_FLOAT)"+subExpression.getExpressionAsString().trim()+")";
                 }
                 case Opcodes.L2I: {
                     return "((JAVA_INT)"+subExpression.getExpressionAsString().trim()+")";

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/ArithmeticExpression.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/ArithmeticExpression.java
@@ -605,17 +605,22 @@ public class ArithmeticExpression extends Instruction implements AssignableExpre
                 case Opcodes.F2D: {
                     return subExpression.getExpressionAsString().trim();
                 }
+                // JLS 5.1.3 narrowing is SATURATING, and a C cast is undefined out of range --
+                // arm64 saturates and x86-64 returns 0x80000000, so a raw cast here silently
+                // disagreed with itself across the architectures we ship. The helpers live in
+                // cn1_globals.h; BC_{F2I,F2L,D2I,D2L} and BasicInstruction use the same ones.
+                // L2I below is NOT one of these: long-to-int is defined truncation.
                 case Opcodes.F2I: {
-                    return "((JAVA_INT)" + subExpression.getExpressionAsString().trim() + ")";
+                    return "cn1SaturateToInt((JAVA_DOUBLE)" + subExpression.getExpressionAsString().trim() + ")";
                 }
                 case Opcodes.F2L: {
-                    return "((JAVA_LONG)" + subExpression.getExpressionAsString().trim() + ")";
+                    return "cn1SaturateToLong((JAVA_DOUBLE)" + subExpression.getExpressionAsString().trim() + ")";
                 }
                 case Opcodes.D2I: {
-                    return "((JAVA_INT)" + subExpression.getExpressionAsString().trim() + ")";
+                    return "cn1SaturateToInt(" + subExpression.getExpressionAsString().trim() + ")";
                 }
                 case Opcodes.D2L: {
-                    return "((JAVA_LONG)" + subExpression.getExpressionAsString().trim() + ")";
+                    return "cn1SaturateToLong(" + subExpression.getExpressionAsString().trim() + ")";
                 }
                 case Opcodes.I2B: {
                     return "(("+subExpression.getExpressionAsString()+" << 24) >> 24)";

--- a/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/BasicInstruction.java
+++ b/vm/ByteCodeTranslator/src/com/codename1/tools/translator/bytecodes/BasicInstruction.java
@@ -589,11 +589,11 @@ public class BasicInstruction extends Instruction implements AssignableExpressio
                 break;
 
             case Opcodes.F2I:
-                b.append("    SP[-1].data.i = (JAVA_INT)SP[-1].data.f; SP[-1].type = CN1_TYPE_INT; /* F2I */\n");
+                b.append("    SP[-1].data.i = cn1SaturateToInt((JAVA_DOUBLE)SP[-1].data.f); SP[-1].type = CN1_TYPE_INT; /* F2I */\n");
                 break;
 
             case Opcodes.F2L:
-                b.append("    SP[-1].data.l = (JAVA_LONG)SP[-1].data.f; SP[-1].type = CN1_TYPE_LONG; /* F2L */\n");
+                b.append("    SP[-1].data.l = cn1SaturateToLong((JAVA_DOUBLE)SP[-1].data.f); SP[-1].type = CN1_TYPE_LONG; /* F2L */\n");
                 break;
 
             case Opcodes.F2D:
@@ -601,11 +601,11 @@ public class BasicInstruction extends Instruction implements AssignableExpressio
                 break;
 
             case Opcodes.D2I:
-                b.append("    SP[-1].data.i = (JAVA_INT)SP[-1].data.d; SP[-1].type = CN1_TYPE_INT; /* D2I */\n");
+                b.append("    SP[-1].data.i = cn1SaturateToInt(SP[-1].data.d); SP[-1].type = CN1_TYPE_INT; /* D2I */\n");
                 break;
 
             case Opcodes.D2L:
-                b.append("    SP[-1].data.l = (JAVA_LONG)SP[-1].data.d; SP[-1].type = CN1_TYPE_LONG; /* D2L */\n");
+                b.append("    SP[-1].data.l = cn1SaturateToLong(SP[-1].data.d); SP[-1].type = CN1_TYPE_LONG; /* D2L */\n");
                 break;
 
             case Opcodes.D2F:

--- a/vm/ByteCodeTranslator/src/javascript/parparvm_runtime.js
+++ b/vm/ByteCodeTranslator/src/javascript/parparvm_runtime.js
@@ -5393,6 +5393,39 @@ bindNative(["cn1_java_lang_Integer_cn1Value_R_int"], function(__cn1ThisObject) {
 bindNative(["cn1_java_lang_Integer_valueOf_int_R_java_lang_Integer"], function*(i) {
   return yield* adaptVirtualResult(cn1_java_lang_Integer_valueOfHeap_int_R_java_lang_Integer(i));
 });
+// The same pair for the other five tagged boxes. Every native the C runtime gains for this
+// scheme needs a binding here or the JS port fails at run time on a missing symbol, and
+// JavascriptNativeAuditTest does not catch an omission -- these are checked by hand.
+bindNative(["cn1_java_lang_Long_cn1Value_R_long"], function(__cn1ThisObject) {
+  return __cn1ThisObject.cn1_java_lang_Long_value;
+});
+bindNative(["cn1_java_lang_Long_valueOf_long_R_java_lang_Long"], function*(i) {
+  return yield* adaptVirtualResult(cn1_java_lang_Long_valueOfHeap_long_R_java_lang_Long(i));
+});
+bindNative(["cn1_java_lang_Double_cn1Value_R_double"], function(__cn1ThisObject) {
+  return __cn1ThisObject.cn1_java_lang_Double_value;
+});
+bindNative(["cn1_java_lang_Double_valueOf_double_R_java_lang_Double"], function*(d) {
+  return yield* adaptVirtualResult(cn1_java_lang_Double_valueOfHeap_double_R_java_lang_Double(d));
+});
+bindNative(["cn1_java_lang_Float_cn1Value_R_float"], function(__cn1ThisObject) {
+  return __cn1ThisObject.cn1_java_lang_Float_value;
+});
+bindNative(["cn1_java_lang_Float_valueOf_float_R_java_lang_Float"], function*(f) {
+  return yield* adaptVirtualResult(cn1_java_lang_Float_valueOfHeap_float_R_java_lang_Float(f));
+});
+bindNative(["cn1_java_lang_Character_cn1Value_R_char"], function(__cn1ThisObject) {
+  return __cn1ThisObject.cn1_java_lang_Character_value | 0;
+});
+bindNative(["cn1_java_lang_Character_valueOf_char_R_java_lang_Character"], function*(c) {
+  return yield* adaptVirtualResult(cn1_java_lang_Character_valueOfHeap_char_R_java_lang_Character(c));
+});
+bindNative(["cn1_java_lang_Short_cn1Value_R_short"], function(__cn1ThisObject) {
+  return __cn1ThisObject.cn1_java_lang_Short_value | 0;
+});
+bindNative(["cn1_java_lang_Short_valueOf_short_R_java_lang_Short"], function*(v) {
+  return yield* adaptVirtualResult(cn1_java_lang_Short_valueOfHeap_short_R_java_lang_Short(v));
+});
 bindNative(["cn1_java_lang_System_exit_int", "cn1_java_lang_System_exit___int"], function(status) { jvm.finish(status); return null; });
 bindNative(["cn1_java_lang_Runtime_totalMemoryImpl_R_long"], function() { return _LfromNumber(67108864); });
 bindNative(["cn1_java_lang_Runtime_freeMemoryImpl_R_long"], function() { return _LfromNumber(33554432); });

--- a/vm/ByteCodeTranslator/src/nativeMethods.m
+++ b/vm/ByteCodeTranslator/src/nativeMethods.m
@@ -2835,6 +2835,28 @@ JAVA_VOID monitorExit(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT obj) {
     }
 }
 
+// A tagged value never allocates, so nothing else runs the boxed class's <clinit> -- and
+// that initializer is what fills the vtable a later hashCode/equals/compareTo on the
+// immediate dispatches through. Each valueOf below therefore forces it once.
+//
+// The flag is only a FAST PATH. __STATIC_INITIALIZER_X is already properly double-checked
+// behind the class monitor, so correctness never depended on this; what it does depend on
+// is publication. `volatile` in C is neither atomic nor ordered, so a plain flag lets a
+// second thread observe 1 while the initializer's vtable and static-field writes are still
+// invisible to it on a weak-memory target, and the next virtual call dispatches through
+// stale class state. Release on publish, acquire on read -- the same pairing
+// CN1_CONSTANT_POOL_LOAD documents in cn1_globals.h, and for the same reason.
+#if CN1_TAGGED_ACTIVE
+#define CN1_FORCE_BOX_CLINIT(cls) \
+    do { \
+        static int cn1__clinit_##cls = 0; \
+        if(!__atomic_load_n(&cn1__clinit_##cls, __ATOMIC_ACQUIRE)) { \
+            __STATIC_INITIALIZER_##cls(threadStateData); \
+            __atomic_store_n(&cn1__clinit_##cls, 1, __ATOMIC_RELEASE); \
+        } \
+    } while(0)
+#endif
+
 // ---- Tagged small-integer support (poor man's Valhalla, 64-bit pointers only) ----
 // Integer.valueOf returns an immediate tagged pointer instead of allocating; cn1Value
 // recovers the int from either a tagged immediate or a heap Integer's field. When the
@@ -2845,12 +2867,7 @@ extern void __STATIC_INITIALIZER_java_lang_Integer(CODENAME_ONE_THREAD_STATE);
 #endif
 JAVA_OBJECT java_lang_Integer_valueOf___int_R_java_lang_Integer(CODENAME_ONE_THREAD_STATE, JAVA_INT i) {
 #if CN1_TAGGED_ACTIVE
-    // Tagged ints never allocate, so nothing else triggers Integer's class init -- but
-    // dispatching hashCode/equals on a tagged int reads class__java_lang_Integer.vtable,
-    // which the static initializer populates. Force it once. The guard keeps the hot path
-    // a single predictable branch (the initializer itself is also idempotent).
-    static volatile int cn1IntInit = 0;
-    if(!cn1IntInit) { __STATIC_INITIALIZER_java_lang_Integer(threadStateData); cn1IntInit = 1; }
+    CN1_FORCE_BOX_CLINIT(java_lang_Integer);
     return CN1_TAG_INT(i);
 #else
     return java_lang_Integer_valueOfHeap___int_R_java_lang_Integer(threadStateData, i);
@@ -2889,8 +2906,7 @@ extern void __STATIC_INITIALIZER_java_lang_Short(CODENAME_ONE_THREAD_STATE);
 JAVA_OBJECT java_lang_Long_valueOf___long_R_java_lang_Long(CODENAME_ONE_THREAD_STATE, JAVA_LONG i) {
 #if CN1_TAGGED_EXTRA_ACTIVE
     if(CN1_LONG_TAGGABLE(i)) {
-        static volatile int cn1LongInit = 0;
-        if(!cn1LongInit) { __STATIC_INITIALIZER_java_lang_Long(threadStateData); cn1LongInit = 1; }
+        CN1_FORCE_BOX_CLINIT(java_lang_Long);
         return CN1_TAG_LONG_VAL(i);
     }
 #endif
@@ -2911,8 +2927,7 @@ JAVA_OBJECT java_lang_Double_valueOf___double_R_java_lang_Double(CODENAME_ONE_TH
     union { JAVA_DOUBLE d; uint64_t b; } u;
     u.d = d;
     if(CN1_DOUBLE_TAGGABLE_BITS(u.b)) {
-        static volatile int cn1DoubleInit = 0;
-        if(!cn1DoubleInit) { __STATIC_INITIALIZER_java_lang_Double(threadStateData); cn1DoubleInit = 1; }
+        CN1_FORCE_BOX_CLINIT(java_lang_Double);
         return CN1_TAG_DOUBLE_BITS(u.b);
     }
 #endif
@@ -2935,8 +2950,7 @@ JAVA_OBJECT java_lang_Float_valueOf___float_R_java_lang_Float(CODENAME_ONE_THREA
     union { JAVA_FLOAT f; uint32_t b; } u;
     u.f = f;
     {
-        static volatile int cn1FloatInit = 0;
-        if(!cn1FloatInit) { __STATIC_INITIALIZER_java_lang_Float(threadStateData); cn1FloatInit = 1; }
+        CN1_FORCE_BOX_CLINIT(java_lang_Float);
     }
     return CN1_TAG_FLOAT_BITS(u.b);
 #else
@@ -2958,8 +2972,7 @@ JAVA_FLOAT java_lang_Float_cn1Value___R_float(CODENAME_ONE_THREAD_STATE, JAVA_OB
 JAVA_OBJECT java_lang_Character_valueOf___char_R_java_lang_Character(CODENAME_ONE_THREAD_STATE, JAVA_CHAR c) {
 #if CN1_TAGGED_EXTRA_ACTIVE
     {
-        static volatile int cn1CharInit = 0;
-        if(!cn1CharInit) { __STATIC_INITIALIZER_java_lang_Character(threadStateData); cn1CharInit = 1; }
+        CN1_FORCE_BOX_CLINIT(java_lang_Character);
     }
     return CN1_TAG_CHAR_VAL(c);
 #else
@@ -2979,8 +2992,7 @@ JAVA_CHAR java_lang_Character_cn1Value___R_char(CODENAME_ONE_THREAD_STATE, JAVA_
 JAVA_OBJECT java_lang_Short_valueOf___short_R_java_lang_Short(CODENAME_ONE_THREAD_STATE, JAVA_SHORT v) {
 #if CN1_TAGGED_EXTRA_ACTIVE
     {
-        static volatile int cn1ShortInit = 0;
-        if(!cn1ShortInit) { __STATIC_INITIALIZER_java_lang_Short(threadStateData); cn1ShortInit = 1; }
+        CN1_FORCE_BOX_CLINIT(java_lang_Short);
     }
     return CN1_TAG_SHORT_VAL(v);
 #else

--- a/vm/ByteCodeTranslator/src/nativeMethods.m
+++ b/vm/ByteCodeTranslator/src/nativeMethods.m
@@ -2696,16 +2696,25 @@ JAVA_VOID monitorEnter(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT obj) {
     //    means a waiter can be parked outside the table mutex holding monitor data
     //    a remover is about to free. That is a correctness risk taken on for a
     //    leak, which is the wrong trade.
-    //  - The reachable case is already refused at BUILD time.
-    //    BytecodeComplianceMojo rejects MONITORENTER whose receiver is any of the
-    //    eight primitive wrappers, so an application cannot express the loop above
-    //    and still build; BytecodeComplianceMojoTest proves it fires for each type
-    //    rather than for Integer alone.
+    //  - The DIRECT form is refused at BUILD time. BytecodeComplianceMojo rejects
+    //    MONITORENTER whose operand is statically typed as one of the eight primitive
+    //    wrappers, and BytecodeComplianceMojoTest proves it fires for each type rather
+    //    than for Integer alone.
     //
-    // What is NOT covered is framework and JavaAPI code, which that mojo does not
-    // scan. There is none today -- no `synchronized` on a boxed value anywhere in
-    // CodenameOne/src, vm/JavaAPI/src or Ports -- and adding one would reintroduce
-    // this. Use a dedicated lock object.
+    // That build check is a PARTIAL mitigation and should not be described as more.
+    // The analysis is intra-procedural and types-only, so passing Float.valueOf(i) to a
+    // helper that takes Object and synchronizing on the parameter walks straight past
+    // it -- the operand is typed Object and the build passes. Storing the box in a
+    // field, an array or a collection defeats it the same way. Tracking erased wrapper
+    // origins would catch the easiest of those and lose to the rest, which is why it is
+    // a gate against the obvious mistake rather than a proof of unreachability.
+    //
+    // So the leak IS reachable from application code, and it is accepted rather than
+    // solved. It is bounded by the number of distinct boxed values a program ever uses
+    // as a lock, which is zero for every program that follows the rule the gate states.
+    // Framework and JavaAPI code is not scanned by that mojo at all; there is no
+    // `synchronized` on a boxed value anywhere in CodenameOne/src, vm/JavaAPI/src or
+    // Ports today, and adding one would reintroduce this. Use a dedicated lock object.
     int err = 0;
     // Double-checked locking for the lazily allocated per-object monitor. The fast-path
     // read MUST be an acquire load and the publishing store (inside the critical section)

--- a/vm/ByteCodeTranslator/src/nativeMethods.m
+++ b/vm/ByteCodeTranslator/src/nativeMethods.m
@@ -2093,10 +2093,14 @@ void initClazzClazz() {
 JAVA_OBJECT java_lang_Object_getClassImpl___R_java_lang_Class(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT obj) {
     initClazzClazz();
 #if CN1_TAGGED_ACTIVE
-    // A tagged Integer has no object header to read; its class is always Integer.
+    // A tagged immediate has no object header to read; its class comes from the tag code.
+    // Derived through CN1_CLASS_OF rather than named here, so a new tagged type needs no
+    // edit -- getClass() was one of the four sites that crashed the original tagged-int
+    // build precisely because it read the header directly.
     if(CN1_IS_TAGGED(obj)) {
-        class__java_lang_Integer.__codenameOneParentClsReference = &ClazzClazz;
-        return (JAVA_OBJECT)(&class__java_lang_Integer);
+        struct clazz* cn1__tagCls = CN1_CLASS_OF(obj);
+        cn1__tagCls->__codenameOneParentClsReference = &ClazzClazz;
+        return (JAVA_OBJECT)cn1__tagCls;
     }
 #endif
     if(!obj->__codenameOneParentClsReference) {
@@ -2827,6 +2831,137 @@ JAVA_INT java_lang_Integer_cn1Value___R_int(CODENAME_ONE_THREAD_STATE, JAVA_OBJE
     }
 #endif
     return ((struct obj__java_lang_Integer*)__cn1ThisObject)->java_lang_Integer_value;
+}
+
+// ---- The other five tagged boxes ----
+// Same shape as Integer above, and the same two obligations at every valueOf:
+//
+//  * Force the class's static initializer once. A tagged value never allocates, so nothing
+//    else runs the clinit -- and the clinit is what fills the vtable that dispatching
+//    hashCode/equals/compareTo on the immediate reads through cn1ClassOf.
+//  * Fall back to valueOfHeap when the value cannot be represented. Only Long and Double
+//    have a fallback; Float, Character and Short always fit.
+//
+// cn1Value is the single door every read of the boxed value goes through. It has to be a
+// native and not a Java getter: these classes are final, so Invoke.asInlinableFieldAccess
+// would fold `return value;` into a raw GETFIELD off a pointer that has no fields.
+#if CN1_TAGGED_ACTIVE
+extern void __STATIC_INITIALIZER_java_lang_Long(CODENAME_ONE_THREAD_STATE);
+extern void __STATIC_INITIALIZER_java_lang_Double(CODENAME_ONE_THREAD_STATE);
+extern void __STATIC_INITIALIZER_java_lang_Float(CODENAME_ONE_THREAD_STATE);
+extern void __STATIC_INITIALIZER_java_lang_Character(CODENAME_ONE_THREAD_STATE);
+extern void __STATIC_INITIALIZER_java_lang_Short(CODENAME_ONE_THREAD_STATE);
+#endif
+
+JAVA_OBJECT java_lang_Long_valueOf___long_R_java_lang_Long(CODENAME_ONE_THREAD_STATE, JAVA_LONG i) {
+#if CN1_TAGGED_EXTRA_ACTIVE
+    if(CN1_LONG_TAGGABLE(i)) {
+        static volatile int cn1LongInit = 0;
+        if(!cn1LongInit) { __STATIC_INITIALIZER_java_lang_Long(threadStateData); cn1LongInit = 1; }
+        return CN1_TAG_LONG_VAL(i);
+    }
+#endif
+    return java_lang_Long_valueOfHeap___long_R_java_lang_Long(threadStateData, i);
+}
+
+JAVA_LONG java_lang_Long_cn1Value___R_long(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT __cn1ThisObject) {
+#if CN1_TAGGED_ACTIVE
+    if(CN1_TAG_CODE(__cn1ThisObject) == CN1_TAG_LONG) {
+        return CN1_UNTAG_LONG(__cn1ThisObject);
+    }
+#endif
+    return ((struct obj__java_lang_Long*)__cn1ThisObject)->java_lang_Long_value;
+}
+
+JAVA_OBJECT java_lang_Double_valueOf___double_R_java_lang_Double(CODENAME_ONE_THREAD_STATE, JAVA_DOUBLE d) {
+#if CN1_TAGGED_EXTRA_ACTIVE
+    union { JAVA_DOUBLE d; uint64_t b; } u;
+    u.d = d;
+    if(CN1_DOUBLE_TAGGABLE_BITS(u.b)) {
+        static volatile int cn1DoubleInit = 0;
+        if(!cn1DoubleInit) { __STATIC_INITIALIZER_java_lang_Double(threadStateData); cn1DoubleInit = 1; }
+        return CN1_TAG_DOUBLE_BITS(u.b);
+    }
+#endif
+    return java_lang_Double_valueOfHeap___double_R_java_lang_Double(threadStateData, d);
+}
+
+JAVA_DOUBLE java_lang_Double_cn1Value___R_double(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT __cn1ThisObject) {
+#if CN1_TAGGED_ACTIVE
+    if(CN1_TAG_CODE(__cn1ThisObject) == CN1_TAG_DOUBLE) {
+        union { JAVA_DOUBLE d; uint64_t b; } u;
+        u.b = CN1_UNTAG_DOUBLE_BITS(__cn1ThisObject);
+        return u.d;
+    }
+#endif
+    return ((struct obj__java_lang_Double*)__cn1ThisObject)->java_lang_Double_value;
+}
+
+JAVA_OBJECT java_lang_Float_valueOf___float_R_java_lang_Float(CODENAME_ONE_THREAD_STATE, JAVA_FLOAT f) {
+#if CN1_TAGGED_EXTRA_ACTIVE
+    union { JAVA_FLOAT f; uint32_t b; } u;
+    u.f = f;
+    {
+        static volatile int cn1FloatInit = 0;
+        if(!cn1FloatInit) { __STATIC_INITIALIZER_java_lang_Float(threadStateData); cn1FloatInit = 1; }
+    }
+    return CN1_TAG_FLOAT_BITS(u.b);
+#else
+    return java_lang_Float_valueOfHeap___float_R_java_lang_Float(threadStateData, f);
+#endif
+}
+
+JAVA_FLOAT java_lang_Float_cn1Value___R_float(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT __cn1ThisObject) {
+#if CN1_TAGGED_ACTIVE
+    if(CN1_TAG_CODE(__cn1ThisObject) == CN1_TAG_FLOAT) {
+        union { JAVA_FLOAT f; uint32_t b; } u;
+        u.b = CN1_UNTAG_FLOAT_BITS(__cn1ThisObject);
+        return u.f;
+    }
+#endif
+    return ((struct obj__java_lang_Float*)__cn1ThisObject)->java_lang_Float_value;
+}
+
+JAVA_OBJECT java_lang_Character_valueOf___char_R_java_lang_Character(CODENAME_ONE_THREAD_STATE, JAVA_CHAR c) {
+#if CN1_TAGGED_EXTRA_ACTIVE
+    {
+        static volatile int cn1CharInit = 0;
+        if(!cn1CharInit) { __STATIC_INITIALIZER_java_lang_Character(threadStateData); cn1CharInit = 1; }
+    }
+    return CN1_TAG_CHAR_VAL(c);
+#else
+    return java_lang_Character_valueOfHeap___char_R_java_lang_Character(threadStateData, c);
+#endif
+}
+
+JAVA_CHAR java_lang_Character_cn1Value___R_char(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT __cn1ThisObject) {
+#if CN1_TAGGED_ACTIVE
+    if(CN1_TAG_CODE(__cn1ThisObject) == CN1_TAG_CHARACTER) {
+        return CN1_UNTAG_CHAR(__cn1ThisObject);
+    }
+#endif
+    return ((struct obj__java_lang_Character*)__cn1ThisObject)->java_lang_Character_value;
+}
+
+JAVA_OBJECT java_lang_Short_valueOf___short_R_java_lang_Short(CODENAME_ONE_THREAD_STATE, JAVA_SHORT v) {
+#if CN1_TAGGED_EXTRA_ACTIVE
+    {
+        static volatile int cn1ShortInit = 0;
+        if(!cn1ShortInit) { __STATIC_INITIALIZER_java_lang_Short(threadStateData); cn1ShortInit = 1; }
+    }
+    return CN1_TAG_SHORT_VAL(v);
+#else
+    return java_lang_Short_valueOfHeap___short_R_java_lang_Short(threadStateData, v);
+#endif
+}
+
+JAVA_SHORT java_lang_Short_cn1Value___R_short(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT __cn1ThisObject) {
+#if CN1_TAGGED_ACTIVE
+    if(CN1_TAG_CODE(__cn1ThisObject) == CN1_TAG_SHORT) {
+        return CN1_UNTAG_SHORT(__cn1ThisObject);
+    }
+#endif
+    return ((struct obj__java_lang_Short*)__cn1ThisObject)->java_lang_Short_value;
 }
 
 // monitorEnterBlock is used for synchronized methods because the JVM bytecode

--- a/vm/ByteCodeTranslator/src/nativeMethods.m
+++ b/vm/ByteCodeTranslator/src/nativeMethods.m
@@ -2677,11 +2677,35 @@ JAVA_VOID monitorEnter(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT obj) {
     // wait()/notify() on the value dereferenced nonexistent monitor data.
     // Equal tagged values share one monitor (identical bit pattern), which is
     // the JDK's own -128..127 Integer-cache behavior extended to the whole
-    // tagged range -- legal and deterministic. Monitors created for tagged
-    // values are never reclaimed (there is no object death to trigger removal);
-    // they are bounded by the number of DISTINCT integer values a program ever
-    // synchronizes on, which is negligible in practice. The only header-touching
-    // step, cn1BibopNoteMonitorAttached, skips tagged values internally.
+    // tagged range -- legal and deterministic. The only header-touching step,
+    // cn1BibopNoteMonitorAttached, skips tagged values internally.
+    //
+    // MONITORS ON TAGGED VALUES ARE NEVER RECLAIMED. There is no object death to
+    // trigger removal, so `synchronized (Float.valueOf(i))` over a loop leaves one
+    // side-table entry per distinct value, forever. Now that Long, Double, Float,
+    // Character and Short are tagged too, that reaches five types whose monitors a
+    // heap box did used to get reclaimed -- so this is a real widening, not just a
+    // restatement of the Integer case. Reviewers reasonably ask for lifecycle
+    // tracking; deliberately not done, for three reasons:
+    //
+    //  - The shape is ALREADY unbounded for Integer and always has been. Removal
+    //    would be a new mechanism for every monitor in the VM, not a tagged-only
+    //    patch, because nothing here reclaims a monitor at monitorExit today.
+    //  - This subsystem is where the documented three-way monitorEnter deadlock
+    //    lives (see the first-creation branch below). Adding exit-time removal
+    //    means a waiter can be parked outside the table mutex holding monitor data
+    //    a remover is about to free. That is a correctness risk taken on for a
+    //    leak, which is the wrong trade.
+    //  - The reachable case is already refused at BUILD time.
+    //    BytecodeComplianceMojo rejects MONITORENTER whose receiver is any of the
+    //    eight primitive wrappers, so an application cannot express the loop above
+    //    and still build; BytecodeComplianceMojoTest proves it fires for each type
+    //    rather than for Integer alone.
+    //
+    // What is NOT covered is framework and JavaAPI code, which that mojo does not
+    // scan. There is none today -- no `synchronized` on a boxed value anywhere in
+    // CodenameOne/src, vm/JavaAPI/src or Ports -- and adding one would reintroduce
+    // this. Use a dedicated lock object.
     int err = 0;
     // Double-checked locking for the lazily allocated per-object monitor. The fast-path
     // read MUST be an acquire load and the publishing store (inside the critical section)

--- a/vm/ByteCodeTranslator/src/nativeMethods.m
+++ b/vm/ByteCodeTranslator/src/nativeMethods.m
@@ -2839,19 +2839,37 @@ JAVA_VOID monitorExit(CODENAME_ONE_THREAD_STATE, JAVA_OBJECT obj) {
 // that initializer is what fills the vtable a later hashCode/equals/compareTo on the
 // immediate dispatches through. Each valueOf below therefore forces it once.
 //
-// The flag is only a FAST PATH. __STATIC_INITIALIZER_X is already properly double-checked
-// behind the class monitor, so correctness never depended on this; what it does depend on
-// is publication. `volatile` in C is neither atomic nor ordered, so a plain flag lets a
-// second thread observe 1 while the initializer's vtable and static-field writes are still
+// The flag is a FAST PATH, and both of its edges have to be ordered.
+//
+// Publication: `volatile` in C is neither atomic nor ordered, so a plain flag lets a second
+// thread observe 1 while the initializer's vtable and static-field writes are still
 // invisible to it on a weak-memory target, and the next virtual call dispatches through
 // stale class state. Release on publish, acquire on read -- the same pairing
 // CN1_CONSTANT_POOL_LOAD documents in cn1_globals.h, and for the same reason.
+//
+// Acquisition: release/acquire only carries what the PUBLISHING thread itself observed, and
+// __STATIC_INITIALIZER_X is not a reliable synchronisation point. Its generated fast path
+// (ByteCodeClass.emitClassInitializer) is `if(__X_LOADED__) return;` -- a plain load -- and
+// the matching `__X_LOADED__=1` is a plain store placed AFTER monitorExitBlock. A thread
+// that returns through that path has taken no lock and may hold none of the initialising
+// thread's writes, so publishing our flag from it would hand a stale view to everyone who
+// acquires it. Taking the class monitor here makes the publisher synchronise-with whoever
+// actually ran the body; monitors are reentrant (see monitorEnter's ownerThread check), so
+// the initializer's own enter nests harmlessly. It costs one uncontended lock per class per
+// process -- the flag short-circuits every call after the first -- and the hot path is
+// unchanged at a single acquire load.
+//
+// This closes the hole for the six boxed classes only. `__X_LOADED__` is a plain-load,
+// plain-store double-check on EVERY generated class initializer in the VM, which predates
+// tagging and is not fixed here.
 #if CN1_TAGGED_ACTIVE
 #define CN1_FORCE_BOX_CLINIT(cls) \
     do { \
         static int cn1__clinit_##cls = 0; \
         if(!__atomic_load_n(&cn1__clinit_##cls, __ATOMIC_ACQUIRE)) { \
+            monitorEnterBlock(threadStateData, (JAVA_OBJECT)&class__##cls); \
             __STATIC_INITIALIZER_##cls(threadStateData); \
+            monitorExitBlock(threadStateData, (JAVA_OBJECT)&class__##cls); \
             __atomic_store_n(&cn1__clinit_##cls, 1, __ATOMIC_RELEASE); \
         } \
     } while(0)

--- a/vm/CLAUDE.md
+++ b/vm/CLAUDE.md
@@ -114,6 +114,47 @@ compare equal.
 `BoxEdge` exists for exactly this and is **proven non-vacuous**: re-widening that guard makes
 it diverge on 115 lines, starting with a Double whose hash silently becomes 0.
 
+### identityHashCode has to fold a tagged word, and only a tagged word
+
+`System.identityHashCode` is a truncation to the low 32 bits. That is right for a heap
+pointer -- `IdentityHashMap`'s indexing is tuned around exactly that distribution, see the
+`IdmProbe` note above -- and wrong for a tagged **Double**, which carries the raw IEEE
+pattern whose distinguishing bits for 1.0, 2.0, 3.0 all live in the HIGH word. Every
+integral double therefore truncated to the same int: measured **1 distinct identity hash
+across 4096 values**, which turns that map's linear probe quadratic. `Long` and `Float`
+shift their payload up and survive a truncation; only `Double` is exposed, because it is the
+only encoding that does not shift.
+
+The fold is applied to tagged values only, and `TagProbe` asserts the spread (4096/4096 with
+it, 1/4096 without). Folding heap pointers too would re-randomise the near-perfect placement
+`IdmProbe` exists to protect.
+
+**This is why the CI witness cannot read tag bits.** `identityHashCode(x) & 7` was how
+`BoxEdge` and `TagProbe` reported which arm they were in; the fold destroys that. Both now
+detect an immediate by its observable consequence -- `valueOf(v) == valueOf(v)` at a value
+outside every `-128..127` cache -- which is a better test anyway, and whose one failure mode
+(a compiler CSEing the two calls) the untagged arm's expected `000000` catches.
+
+### Monitors on tagged values are never reclaimed, and that is accepted
+
+A monitor lives in an address-keyed side table and is removed when its object dies. A tagged
+value never dies, so `synchronized (Float.valueOf(i))` over a loop leaks one entry per
+distinct value. Tagging five more types genuinely widens this -- those used to be heap boxes
+whose monitors *were* reclaimed.
+
+It is still not fixed, and the reasoning is recorded at `monitorEnter` in `nativeMethods.m`:
+the shape was already unbounded for Integer, nothing in this VM reclaims a monitor at
+`monitorExit` so removal would be a new mechanism for every monitor rather than a tagged-only
+patch, and it would be built in the subsystem that already carries the documented three-way
+`monitorEnter` deadlock. The reachable case is refused at BUILD time instead --
+`BytecodeComplianceMojo` rejects `MONITORENTER` on any of the eight primitive wrappers.
+
+That rule always named all eight, but its test only ever exercised Integer. It is
+parameterised across every wrapper now, because a rule proven for one of the types it claims
+to cover is not a rule to lean on. What the mojo does **not** scan is framework and JavaAPI
+code; there is no `synchronized` on a boxed value anywhere in `CodenameOne/src`,
+`vm/JavaAPI/src` or `Ports` today, and adding one would reintroduce this.
+
 ### The gate has to be in CI, and it has to know which arm it ran
 
 `BoxEdge` first lived only in `run-gauntlet.sh` -- and **no workflow runs the gauntlet**, so

--- a/vm/CLAUDE.md
+++ b/vm/CLAUDE.md
@@ -183,6 +183,41 @@ used `ptr | 2`, which is now a valid tagged `Long`, so it uses the reserved code
 `cn1_debugger_class_of` resolves through `CN1_CLASS_OF` -- would have made every tagged
 assertion an assertion about nothing.
 
+## Narrowing a float to an int is SATURATING, and C's cast is not
+
+JLS 5.1.3: converting a `float` or `double` to an `int` or `long` clamps -- NaN becomes 0,
+anything at or above the target's maximum becomes `MAX_VALUE`, anything at or below its
+minimum becomes `MIN_VALUE`. A C cast is **undefined** out of range, and the two
+architectures this VM ships on disagree about what it actually does:
+
+| | `(int) Double.MAX_VALUE` |
+|---|---|
+| arm64 (`fcvtzs`) | 2147483647 -- accidentally correct |
+| x86-64 (`cvttsd2si`) | **-2147483648** -- the "integer indefinite" value |
+
+So this was right on Apple silicon and wrong everywhere else, for every app, silently. It was
+found by running `BoxEdge` under CI's x86 Linux after it had passed on an M-series Mac.
+
+**There are THREE emission sites, and patching two of them looks like it works.** The two
+obvious ones are `BC_{F2I,F2L,D2I,D2L}` in `cn1_globals.h` and the statement forms in
+`BasicInstruction.java`. The third is `ArithmeticExpression.java`, which renders a conversion
+as a raw cast *inside a composed expression* -- and that is the one the optimizer actually
+uses for the common shapes, so a fix to the first two changes nothing you can see. All three
+now call `cn1SaturateToInt` / `cn1SaturateToLong`. Note `L2I` sits beside them and is NOT one
+of these: long-to-int is defined truncation.
+
+`-DCN1_NO_SATURATING_NARROWING` restores the old cast; because all three sites route through
+the two helpers, that single macro ablates the whole change and an A/B needs no second
+translator build. `vm/benchmarks/ab-narrowing.sh` interleaves the arms: **geomean 1.0073**,
+every workload within 3.4%, i.e. free.
+
+**That number had to be re-measured to be believed, and the first attempt was worthless.**
+Comparing the new build against ms figures recorded earlier in the same session reported a
+uniform 9-14% regression -- including on `intArithmetic` and `stringBuilding`, which perform
+no narrowing at all. A slowdown that appears on workloads the change cannot touch is the
+host, not the code; this machine cannot resolve 5% across runs minutes apart. Interleave the
+arms inside one process-pair or do not quote a number.
+
 ### Dimension and Rectangle: investigated, and tagging is the wrong mechanism
 
 The obvious next thought is to extend this to framework value types. It does not work, and

--- a/vm/CLAUDE.md
+++ b/vm/CLAUDE.md
@@ -342,8 +342,22 @@ through stale class state. `CN1_FORCE_BOX_CLINIT` publishes with `__ATOMIC_RELEA
 with `__ATOMIC_ACQUIRE`, the same pairing `CN1_CONSTANT_POOL_LOAD` documents. Verified in the
 emitted arm64: `ldapr` on the read, `stlr` on the publish.
 
-The bug was in the original Integer native and was copied to all five new types; all six are
-fixed together, because half a memory-model fix is worse than none.
+Release/acquire only carries what the PUBLISHING thread saw, and
+`__STATIC_INITIALIZER_X` is **not** a reliable synchronisation point: its generated fast path
+is `if(__X_LOADED__) return;`, a plain load, and the matching `__X_LOADED__=1` is a plain
+store placed AFTER `monitorExitBlock`. A thread returning through that path has taken no lock
+and may hold none of the initialising thread's writes. So the slow path takes the class
+monitor before publishing, which makes the publisher synchronise-with whoever ran the body;
+monitors are reentrant, so the initializer's own enter nests harmlessly. One uncontended lock
+per class per process, and the hot path stays a single `ldapr`.
+
+**That fixes the six boxed classes, not the VM.** `__X_LOADED__` is a plain-load/plain-store
+double-check on *every* generated class initializer, which predates tagging. Fixing it means
+making that flag acquire/release in `ByteCodeClass`, which touches codegen for every class in
+every app -- its own change, with its own measurement.
+
+The original defect was in the Integer native and this work copied it to five more types; all
+six are converted together, because half a memory-model fix is worse than none.
 
 ### Adding a seventh type
 

--- a/vm/CLAUDE.md
+++ b/vm/CLAUDE.md
@@ -1,5 +1,214 @@
 # vm/ (ParparVM)
 
+## Tagged immediates: six boxed types, two of them partial
+
+`valueOf` on `Integer`, `Long`, `Double`, `Float`, `Character` and `Short` returns an
+**immediate** rather than a heap object: the value packed into the pointer word with a type
+code in the **low three bits**. `cn1_globals.h` holds the whole encoding; everything else
+consumes it.
+
+Three bits, not one, because 8-byte object alignment was **already load-bearing** --
+`cn1ConservativeResolve` rejects any word with a bit set in `sizeof(void*) - 1`, and
+conservative roots are on by default, so an object at a 4-byte address would already be
+invisible to the root scan and freed under a live pointer. Widening the tag rests on an
+invariant the collector enforces rather than adding one. `TagProbe` checks it anyway, over
+380,000 allocations across 19 shapes (BiBOP bump, the legacy calloc above
+`CN1_BIBOP_MAX_OBJECT`, arrays, fused String/StringBuilder, class objects): all 8-aligned.
+
+| code | type | representable |
+|---|---|---|
+| 0 | an ordinary heap pointer | -- |
+| 1 | `Integer` | every value |
+| 2 | `Long` | **partial**: `[-2^60, 2^60)` |
+| 3 | `Double` | **partial**: bit patterns with three clear low mantissa bits |
+| 4 | `Float` | every value (raw 32-bit pattern) |
+| 5 | `Character` | every value |
+| 6 | `Short` | every value |
+| 7 | reserved | -- |
+
+`Byte` and `Boolean` are deliberately NOT tagged: a 256-entry and a 2-entry cache already
+never allocate.
+
+`Double` needs no shifting at all. Requiring three clear low mantissa bits means the
+immediate IS the bit pattern -- tag is `| 3`, untag is `& ~7` -- and the representable set is
+every small integer, half, quarter and eighth, which is what JSON numbers overwhelmingly are.
+`0.1` and `3.14` fall out of it and take the heap path.
+
+### A partial encoding must report its coverage, not just its speedup
+
+This is the trap the whole design turns on. Measured on a *mixed* distribution, `Long` is
+**78%** taggable and `Double` **56%**. An earlier `jsonLikeParse` used only integers and
+exact quarters and reported **100%** for both -- a benchmark measuring the best case and
+calling it the case. `BoxBench` now prints a `COVERAGE` line beside its timings and its
+numeric mix is deliberately unhelpful (a quarter money values, a quarter irrational).
+
+The `CN1_ALLOC_CENSUS` figure is the one to trust, because it confirms coverage from an
+independent instrument. Normalised by a work unit tagging cannot affect (HashMaps allocated),
+`jsonLikeParse` goes from **24.02 boxed objects per map to 5.24**. It puts 12 Longs and 12
+Doubles per map, so theory says 24 and `12 x 0.44 = 5.28`. `Long` allocations over the run:
+346,545 -> **1**.
+
+### What it is worth, and what it costs
+
+`ab-tagged.sh` runs three arms so the two questions stay separate: `HEAP`
+(`-DCN1_DISABLE_TAGGED_INT`), `INT` (`-DCN1_DISABLE_TAGGED_VALUES`, i.e. what shipped when
+only Integer was tagged) and `ALL`. **Arm 1 is the baseline that matters** -- `HEAP` vs `INT`
+re-measures a win that was already taken.
+
+Best-of-6 interleaved, `ALL` against `INT`: `longKeyMap` **2.3x**, `charBoxing` 1.54x,
+`doubleListReduce` 1.43x, `mixedBoxedChurn` 1.28x, `jsonLikeParse` 1.14x at 56% coverage.
+On `Bench`/`CommonWorkloads` the ratio is **1.00 on every workload** -- the five extra types
+cost nothing where they are not used, and `hashMapChurn`'s existing 3.3x from Integer tagging
+is untouched.
+
+Peak RSS from `ru_maxrss` did **not** discriminate here (identical to a tenth of a MB across
+all three arms); it is cumulative across children in that harness. Use the census.
+
+### The type index is an addressing mode, not a lookup
+
+The worry that self-describing tags cost a table probe is unfounded. `cn1ClassOf` compiles to:
+
+```
+and  x8, x1, #7            ; tag code, computed once
+cmp  x8, #1                ; the Integer fast path reuses it
+add  x9, x9, x8, lsl #4    ; &cn1TaggedProxy[code] -- a shifted add, NOT a load
+cmp  x8, #0
+csel x8, x1, x9, eq        ; select a VALID pointer first
+ldr  x8, [x8]              ; the single header load
+```
+
+The `csel`-before-`ldr` shape is not stylistic: a plain ternary lets clang speculate the
+faulting `tagged->header` load above the tag test, which was an observed SIGSEGV in interface
+dispatch. Do not simplify it into a conditional over the loaded value.
+
+**And the tag is not optional.** The recurring suggestion is that the callsite already knows
+the type. It does not: a value is boxed *precisely because* it is flowing through an
+`Object`/`Number`/`Comparable` slot, and `map.get(k).hashCode()` has no static type to
+consult. Where the callsite does know -- an autobox immediately unboxed -- the fix is
+peephole elision, which `scalarReplaceStackAllocations` already does and which never needed a
+tag.
+
+### The four choke points, and the one that fails silently
+
+`CN1_IS_TAGGED` masks all three bits, so **every existing call site is correct unedited** --
+`gcMarkObject`, `findPointerPosInHeap`, `removeObjectFromHeapCollection`, the SATB barriers.
+`cn1ClassOf` covers instanceof, checkcast, aastore, virtual and interface dispatch,
+`getClass`, `isInstance` and `String.equals` in one place. Per type there is a `valueOf`
+native and a `cn1Value` native.
+
+`cn1Value` **must** be a native. These classes are `final`, so `Invoke.asInlinableFieldAccess`
+folds a trivial `return value;` getter into a raw `GETFIELD` -- off a pointer with no fields.
+Every read of the boxed value routes through it; there is a scan in the commit that proves
+none was missed.
+
+The sharp edge is `BytecodeMethod.java`'s inline `hashCode`/`equals` fast path, which is
+emitted into **every** class's thunk. It tests `CN1_TAG_CODE(o) == CN1_TAG_INTEGER`, not "is
+tagged", because every other type has a different hashCode contract -- `Long` folds its
+halves, `Float`/`Double` go through `*ToIntBits`. Widening it to any tagged receiver returns
+a **wrong hash with no crash**, which is the worst thing this scheme can do. The other five
+reach the right implementation through the vtable, which is slower and always correct.
+`equals` stays Integer-only for a second reason: pointer equality implies value equality for
+every tag, but the converse fails for `Float` and `Double`, where two NaN encodings must
+compare equal.
+
+`BoxEdge` exists for exactly this and is **proven non-vacuous**: re-widening that guard makes
+it diverge on 115 lines, starting with a Double whose hash silently becomes 0.
+
+### Three defects this work surfaced, none of them caused by it
+
+All three were pre-existing and are fixed here, and all three were found by `BoxEdge` on its
+first run against the host JVM -- which is the argument for a byte-identical torture over an
+assertion suite: nobody thought to assert any of them.
+
+- **`Short.equals` had no null guard** where every other wrapper did, so
+  `Short.valueOf(1).equals(null)` dereferenced null -- a hard SIGSEGV on any target that
+  installs no signal handler, which is every one except iOS.
+- **`Float.toString` never got the fixes `Double.toString` has.** No NaN branch (NaN fell
+  through to the scientific-notation path, since every comparison against a NaN is false) and
+  no signed-zero branch, so `Float.toString(-0.0f)` printed `0.0` while `Float.compare`,
+  `Float.equals` and `Arrays.sort` all still honoured the sign. Confirmed pre-existing by
+  reproducing it with `-DCN1_DISABLE_TAGGED_INT`.
+- **`Short.compareTo` returned the sign, not the difference.** The JDK defines it as
+  `Short.compare`, which -- unlike `Integer.compare` and `Long.compare`, which really do
+  return -1/0/1 -- is `x - y`. It disagreed with the JDK and with this class's own
+  `compare(short, short)` directly above it.
+
+### An arbitrary word is now a boxed value seven times in eight
+
+A machine word whose low three bits spell a tag code is **indistinguishable** from a genuine
+immediate; they are the same bit pattern. The iOS debugger therefore reports a boxed value
+for a misread int slot rather than rejecting it. That is a fidelity cost, not a safety one --
+it never dereferences, which is the property issue #5333 was about -- and it is not new,
+since an odd word was already a tagged Integer when the tag was one bit. Widening to three
+bits takes the affected fraction from one in two to seven in eight.
+
+**The GC is completely unaffected by that**, and this is the fact to reach for when the
+question comes up: `cn1ConservativeResolve` rejects a word with a bit set in
+`sizeof(void*) - 1` -- the same three bits -- so a misread int was never a root before and is
+not one now.
+
+Two consequences that did need edits: `DebuggerObjectValidationTest`'s `MISALIGNED` probe
+used `ptr | 2`, which is now a valid tagged `Long`, so it uses the reserved code 7; and
+`NativeDebuggerHarness` stubbed `cn1TaggedProxy` as all zeros, which -- now that
+`cn1_debugger_class_of` resolves through `CN1_CLASS_OF` -- would have made every tagged
+assertion an assertion about nothing.
+
+### Dimension and Rectangle: investigated, and tagging is the wrong mechanism
+
+The obvious next thought is to extend this to framework value types. It does not work, and
+the reasons are worth writing down so it is not re-proposed.
+
+- **`Rectangle` is not a flat value at all.** Its fields are `x`, `y`, a `Dimension size`
+  **object reference** and a `GeneralPath path` **object reference** -- an object graph, not
+  four ints. It also has a static instance pool, so it has deliberately recycled identity.
+- **`Dimension` does not fit.** Two ints is 64 bits against a 61-bit payload, so it would
+  need narrowing to 30+30 plus a range fallback.
+- **Both are mutable** (`setWidth`, `setHeight`, `setBounds`, `setX`, `setY`). An immediate
+  has no storage, so a mutation through one alias is invisible to every other. That is not
+  fixable within the scheme.
+- **`new` guarantees identity.** `Integer.valueOf` has an explicit spec exemption to return a
+  shared instance; `new Dimension(1,2) != new Dimension(1,2)` is guaranteed by the JLS.
+
+The mechanism that would pay off is **codegen, not tagging**, and most of it is already here.
+`scalarReplaceStackAllocations` turns `NEW X; DUP; args; <init>; ASTORE` into a pure C local
+with no allocation, no tag, no lookup and no fallback -- strictly better than tagging wherever
+it applies. `Dimension` already passes `srPrimitiveOnlyDirectObject` (it extends `Object`
+directly, has no `__CLINIT__` and holds only ints); `Rectangle` fails it on both its object
+fields and its static pool.
+
+What stops `Dimension` is `srValidateLocalUses`, which requires every use of the local to be
+`ALOAD n; GETFIELD` and bails on a return, an argument pass or a field store --
+and `Component.getPreferredSize()` returns one. There are 127 `new Dimension(` sites and 108
+`new Rectangle(` sites in `CodenameOne/src`.
+
+So the follow-up worth scoping is an `@ImmutableValue` contract -- `BytecodeComplianceMojo`
+enforcing final fields, no setters and no identity-sensitive use, so the translator may treat
+the class as copyable and let scalar replacement survive a return. That is a separate change,
+and the thing to measure FIRST is a `CN1_ALLOC_CENSUS` profile of a real app: if `Dimension`
+and `Rectangle` are not near the top of it, the answer is no and it cost one run to find out.
+
+### Adding a seventh type
+
+Only one code is left, so spend it deliberately. The work is: a proxy entry, `valueOf` +
+`cn1Value` natives (each forcing its class's `__STATIC_INITIALIZER_` once, because a tagged
+value never allocates and nothing else triggers the clinit that fills the vtable), routing
+every value read in the Java class through `cn1Value`, the debugger's
+`cn1_debugger_tagged_value` switch, and `BoxEdge` cases. `ByteCodeClass` already force-retains
+all six wrapper classes from dead-code elimination.
+
+**And FOUR JavaScript files, not one.** The JS port has no immediates, so `valueOf` binds
+straight through to `valueOfHeap` -- which is static and reached only from
+`parparvm_runtime.js`, so bytecode-only reachability never sees the edge and the cull deletes
+it. All four are needed: `parparvm_runtime.js` (the `bindNative`),
+`JavascriptNativeRegistry.RUNTIME_IMPLEMENTED` (the native), and both
+`JavascriptReachability.enqueueResolved` and
+`JavascriptNativeRegistry.RUNTIME_DELEGATE_TARGETS` (the heap twin). Missing the last two
+does not produce a recognisable error -- the fixture returns a wrong value, and
+`JavascriptRuntimeSemanticsTest`'s coverage assertion is one of the few in that class that
+does not print `rawMessage`/`errorMessage`. `JavascriptNativeAuditTest` is inert and catches
+none of it.
+
+
 ## The compact HashMap: benchmark the MISS, not the hit
 
 `java.util.HashMap` here is open-addressed over three parallel arrays with linear probing

--- a/vm/CLAUDE.md
+++ b/vm/CLAUDE.md
@@ -114,6 +114,36 @@ compare equal.
 `BoxEdge` exists for exactly this and is **proven non-vacuous**: re-widening that guard makes
 it diverge on 115 lines, starting with a Double whose hash silently becomes 0.
 
+### The gate has to be in CI, and it has to know which arm it ran
+
+`BoxEdge` first lived only in `run-gauntlet.sh` -- and **no workflow runs the gauntlet**, so
+the feature shipped on by default with nothing in CI exercising it.
+`TaggedValueIntegrationTest` closes that: it drives the *same* `BoxEdge` source (read from
+`vm/benchmarks`, not copied, so the two cannot drift) through the translator and cmake, builds
+it twice from one translation, and compares both against a real JVM. About 67s.
+
+The subtle part is that byte-identity **cannot** tell a correct tagged build from one where
+tagging never happened -- the two representations are required to be indistinguishable, which
+is the whole contract. So `BoxEdge` prints `[TAGCODES]`, the tag code each type actually got,
+and the test asserts `123456` for the default build and `000000` for
+`-DCN1_DISABLE_TAGGED_INT`. Compiling the extra types out and re-running proves this is load
+bearing: the two byte-identity assertions still **pass**, and only the witness fails, with
+`expected: <123456> but was: <100000>`.
+
+Two mechanics worth knowing before touching it:
+
+- **Stderr is not a way to keep a diagnostic out of the compared stream.** On the clean target
+  `System.err` also reaches fd 1. The `[`-prefix convention is the answer, and
+  `run-gauntlet.sh` now applies that filter to **both** sides -- it used to filter only the
+  target, so any torture emitting a diagnostic diverged against its own host run.
+- **The reference JVM must be JDK 19+.** JDK 19 replaced `Double.toString`/`Float.toString`
+  with the shortest round-tripping representation (JDK-4511638) and ParparVM implements the
+  new algorithm, so an older reference reports divergences that are the reference being out of
+  date: `4.6116860184273879E18` from JDK 17 against `4.611686018427388E18` from ParparVM and
+  JDK 19+. Both round-trip; only the second is the shortest such string. The test selects its
+  reference JDK independently of the toolchain that drives the translator, and skips if none
+  is new enough.
+
 ### Three defects this work surfaced, none of them caused by it
 
 All three were pre-existing and are fixed here, and all three were found by `BoxEdge` on its

--- a/vm/CLAUDE.md
+++ b/vm/CLAUDE.md
@@ -328,6 +328,23 @@ the class as copyable and let scalar replacement survive a return. That is a sep
 and the thing to measure FIRST is a `CN1_ALLOC_CENSUS` profile of a real app: if `Dimension`
 and `Rectangle` are not near the top of it, the answer is no and it cost one run to find out.
 
+### Forcing a boxed class's clinit needs release/acquire, not `volatile`
+
+A tagged value never allocates, so nothing else runs its class's `<clinit>` -- and that is
+what fills the vtable a later `hashCode`/`equals`/`compareTo` on the immediate dispatches
+through. Each `valueOf` forces it once, behind a flag.
+
+That flag is a fast path only: `__STATIC_INITIALIZER_X` is already double-checked behind the
+class monitor. What it does affect is **publication**. `volatile` in C is neither atomic nor
+ordered, so a plain flag lets a second thread observe 1 while the initializer's vtable writes
+are still invisible to it on a weak-memory target, and the next virtual call dispatches
+through stale class state. `CN1_FORCE_BOX_CLINIT` publishes with `__ATOMIC_RELEASE` and reads
+with `__ATOMIC_ACQUIRE`, the same pairing `CN1_CONSTANT_POOL_LOAD` documents. Verified in the
+emitted arm64: `ldapr` on the read, `stlr` on the publish.
+
+The bug was in the original Integer native and was copied to all five new types; all six are
+fixed together, because half a memory-model fix is worse than none.
+
 ### Adding a seventh type
 
 Only one code is left, so spend it deliberately. The work is: a proxy entry, `valueOf` +

--- a/vm/CLAUDE.md
+++ b/vm/CLAUDE.md
@@ -146,14 +146,49 @@ It is still not fixed, and the reasoning is recorded at `monitorEnter` in `nativ
 the shape was already unbounded for Integer, nothing in this VM reclaims a monitor at
 `monitorExit` so removal would be a new mechanism for every monitor rather than a tagged-only
 patch, and it would be built in the subsystem that already carries the documented three-way
-`monitorEnter` deadlock. The reachable case is refused at BUILD time instead --
-`BytecodeComplianceMojo` rejects `MONITORENTER` on any of the eight primitive wrappers.
+`monitorEnter` deadlock.
 
-That rule always named all eight, but its test only ever exercised Integer. It is
-parameterised across every wrapper now, because a rule proven for one of the types it claims
-to cover is not a rule to lean on. What the mojo does **not** scan is framework and JavaAPI
-code; there is no `synchronized` on a boxed value anywhere in `CodenameOne/src`,
-`vm/JavaAPI/src` or `Ports` today, and adding one would reintroduce this.
+**`BytecodeComplianceMojo` is a partial mitigation, not a proof of unreachability**, and the
+first version of that comment said otherwise. It rejects `MONITORENTER` whose operand is
+*statically typed* as a wrapper, which is intra-procedural and types-only -- hand the box to
+a helper taking `Object` and synchronize on the parameter and the build passes; a field, an
+array or a collection defeats it the same way. It is a gate against the obvious mistake. The
+leak is therefore reachable from application code and accepted, bounded by the number of
+distinct boxed values a program ever locks on, which is zero for anything following the rule.
+
+The rule always named all eight wrappers, but its test only ever exercised Integer. It is a
+loop over all eight now -- not `@ParameterizedTest`, because that module carries
+`junit-jupiter-api` and `-engine` only and adding `junit-jupiter-params` to a Maven plugin's
+pom for one test is not worth it. Its generator also hardcoded `ICONST_1`, so a `(J)`/`(D)`/
+`(F)` `valueOf` would have produced a type-incorrect method and asserted nothing.
+
+Framework and JavaAPI code is not scanned by that mojo at all; there is no `synchronized` on
+a boxed value anywhere in `CodenameOne/src`, `vm/JavaAPI/src` or `Ports` today.
+
+### The nursery guard belongs in cn1InNursery, and -DCN1_NURSERY did not compile
+
+Every caller of `cn1InNursery` dereferences the header the instant it answers true --
+`cn1InNursery(o) && o->__heapPosition == -1` is the shape at all six sites, in the minor
+collection's stack-root scan, its `currentThreadObject` and `exception` roots, the promote
+path and the write barrier. A tagged `Double` carries a raw IEEE pattern and a tagged `Long`
+a shifted payload, either of which can land inside the arena range by coincidence, and the
+read that follows is an unaligned load off a word with no header. The guard therefore lives
+in `cn1InNursery` itself; guarding only the write barrier -- which is what the first version
+of this work did -- left the other five exposed.
+
+**Reachable by construction, not observed.** Instrumenting the range check to count tagged
+values that fall inside the arena gives **0** on `BoxEdge`, `GcStress` and `MtStress`: a
+tagged Long is `v << 3` and a tagged Double's bit pattern is astronomically larger than a
+heap address, so the overlap needs an unusual value. Real, narrow, and cheap to exclude.
+
+**`-DCN1_NURSERY` had not compiled for as long as the bulk SATB barrier has existed.** The
+`cn1SatbBulkBegin` / `cn1SatbEnqueueRangeLocked` / `cn1SatbBulkEnd` declarations sat inside
+the no-nursery `#else` while `nativeMethods.m` calls all three unconditionally from
+`java_lang_System_arraycopy`, so the build died on three implicit declarations. The functions
+were always defined; only the declarations were misplaced. That silently retired an ablation
+arm this file documents, and it is the reason the missing tag guard could not be caught by
+building the configuration it affects. Hoisted above the split, and the configuration now
+builds and runs `BoxEdge` byte-identically plus `GcStress`/`MtStress` clean.
 
 ### The gate has to be in CI, and it has to know which arm it ran
 

--- a/vm/JavaAPI/src/java/lang/Character.java
+++ b/vm/JavaAPI/src/java/lang/Character.java
@@ -230,8 +230,16 @@ public final class Character implements Comparable<Character>{
      * Returns the value of this Character object.
      */
     public char charValue(){
-        return value; 
+        return cn1Value();
     }
+
+    /**
+     * Returns this Character's value, transparently handling both heap-allocated and
+     * tagged-immediate representations. All value reads route here -- Character is final, so
+     * a plain `return value;` getter would be inlined into a raw field load off a tagged
+     * pointer, which has no fields.
+     */
+    private native char cn1Value();
 
     /**
      * Returns the numeric value of the character ch in the specified radix.
@@ -278,14 +286,14 @@ public final class Character implements Comparable<Character>{
      * Compares this object against the specified object. The result is true if and only if the argument is not null and is a Character object that represents the same char value as this object.
      */
     public boolean equals(java.lang.Object obj){
-        return obj != null && obj.getClass() == getClass() && ((Character)obj).value == value;
+        return obj != null && obj.getClass() == getClass() && ((Character)obj).cn1Value() == cn1Value();
     }
 
     /**
      * Returns a hash code for this Character.
      */
     public int hashCode(){
-        return value; 
+        return cn1Value();
     }
     
     static boolean isLetterCompat(char ch) {
@@ -539,7 +547,7 @@ public final class Character implements Comparable<Character>{
      * Returns a String object representing this character's value. Converts this Character object to a string. The result is a string whose length is 1. The string's sole component is the primitive char value represented by this object.
      */
     public java.lang.String toString(){
-        return new String(new char[] {value});
+        return new String(new char[] {cn1Value()});
     }
 
     /**
@@ -1287,7 +1295,11 @@ public final class Character implements Comparable<Character>{
      * @param i the primitive
      * @return object instance
      */
-    public static Character valueOf(char i) {
+    // Native so the tagged build can return an immediate without allocating. The off path
+    // (and 32-bit-pointer targets) calls valueOfHeap, preserving the cache.
+    public static native Character valueOf(char i);
+
+    static Character valueOfHeap(char i) {
         if (i <= 127) {
             return CharacterCache.cache[i];
         }
@@ -1487,7 +1499,10 @@ public final class Character implements Comparable<Character>{
     }
 
     public int compareTo(Character another) {
-        return toString().compareTo(String.valueOf(another.value));
+        // Was toString().compareTo(String.valueOf(another.value)), which allocated two
+        // Strings per comparison -- on the TreeMap path, for every probe. String.compareTo
+        // of two length-one strings IS c1 - c2, so this is the same value with no garbage.
+        return cn1Value() - another.cn1Value();
     }
 
     private static String _codepointToString(int cp) {

--- a/vm/JavaAPI/src/java/lang/Double.java
+++ b/vm/JavaAPI/src/java/lang/Double.java
@@ -77,7 +77,7 @@ public final class Double extends Number implements Comparable<Double> {
      * Returns the value of this Double as a byte (by casting to a byte).
      */
     public byte byteValue(){
-        return (byte)value; 
+        return (byte)cn1Value();
     }
 
     /**
@@ -94,8 +94,16 @@ public final class Double extends Number implements Comparable<Double> {
      * Returns the double value of this Double.
      */
     public double doubleValue(){
-        return value;
+        return cn1Value();
     }
+
+    /**
+     * Returns this Double's value, transparently handling both heap-allocated and
+     * tagged-immediate representations. All value reads route here -- Double is final, so a
+     * plain `return value;` getter would be inlined into a raw field load off a tagged
+     * pointer, which has no fields.
+     */
+    private native double cn1Value();
 
     /**
      * Compares this object against the specified object. The result is true if and only if the argument is not null and is a Double object that represents a double that has the identical bit pattern to the bit pattern of the double represented by this object. For this purpose, two double values are considered to be the same if and only if the method
@@ -117,19 +125,21 @@ public final class Double extends Number implements Comparable<Double> {
             // even though NaN!=NaN
             return true;
         }
-        if (value == 0.0 && d.value == 0.0) {
+        double cn1v = cn1Value();
+        double cn1d = d.cn1Value();
+        if (cn1v == 0.0 && cn1d == 0.0) {
             // Exception #2. If one Double represents -0.0 and the other represents +0.0, then
             // they should be Not equal even though +0.0==-0.0
-            return doubleToLongBits(d.value) == doubleToLongBits(value);
+            return doubleToLongBits(cn1d) == doubleToLongBits(cn1v);
         }
-        return d.value == value;
+        return cn1d == cn1v;
     }
 
     /**
      * Returns the float value of this Double.
      */
     public float floatValue(){
-        return (float)value; 
+        return (float)cn1Value();
     }
 
     /**
@@ -137,7 +147,7 @@ public final class Double extends Number implements Comparable<Double> {
      * , of the primitive double value represented by this Double object. That is, the hashcode is the value of the expression: (int)(v^(v>>>32)) where v is defined by: long v = Double.doubleToLongBits(this.doubleValue());
      */
     public int hashCode(){
-        long v = doubleToLongBits(value);
+        long v = doubleToLongBits(cn1Value());
         return (int) (v ^ (v >>> 32));
     }
 
@@ -145,14 +155,14 @@ public final class Double extends Number implements Comparable<Double> {
      * Returns the integer value of this Double (by casting to an int).
      */
     public int intValue(){
-        return (int)value;
+        return (int)cn1Value();
     }
 
     /**
      * Returns true if this Double value is infinitely large in magnitude.
      */
     public boolean isInfinite(){
-        return isInfinite(value);
+        return isInfinite(cn1Value());
     }
 
     /**
@@ -171,7 +181,7 @@ public final class Double extends Number implements Comparable<Double> {
      * Returns true if this Double value is the special Not-a-Number (NaN) value.
      */
     public boolean isNaN(){
-        return isNaN(value);
+        return isNaN(cn1Value());
     }
 
     /**
@@ -202,7 +212,7 @@ public final class Double extends Number implements Comparable<Double> {
      * Returns the long value of this Double (by casting to a long).
      */
     public long longValue(){
-        return (long)value;
+        return (long)cn1Value();
     }
 
     /**
@@ -216,14 +226,14 @@ public final class Double extends Number implements Comparable<Double> {
      * Returns the value of this Double as a short (by casting to a short).
      */
     public short shortValue(){
-        return (short)value; 
+        return (short)cn1Value();
     }
 
     /**
      * Returns a String representation of this Double object. The primitive double value represented by this object is converted to a string exactly as if by the method toString of one argument.
      */
     public java.lang.String toString(){
-        return toString(value);
+        return toString(cn1Value());
     }
 
     /**
@@ -303,7 +313,11 @@ public final class Double extends Number implements Comparable<Double> {
      * @param i the primitive
      * @return object instance
      */
-    public static Double valueOf(double i) {
+    // Native so the tagged build can return an immediate without allocating. The off path
+    // (and 32-bit-pointer targets) calls valueOfHeap, preserving the previous behaviour.
+    public static native Double valueOf(double i);
+
+    static Double valueOfHeap(double i) {
         return new Double(i);
     }
 
@@ -338,6 +352,6 @@ public final class Double extends Number implements Comparable<Double> {
      * 
     */
     public int compareTo(Double another) {
-        return compare(value, another.value);
+        return compare(cn1Value(), another.cn1Value());
     }
 }

--- a/vm/JavaAPI/src/java/lang/Float.java
+++ b/vm/JavaAPI/src/java/lang/Float.java
@@ -80,15 +80,23 @@ public final class Float extends Number implements Comparable<Float> {
      * Returns the value of this Float as a byte (by casting to a byte).
      */
     public byte byteValue(){
-        return (byte)value; 
+        return (byte)cn1Value();
     }
 
     /**
      * Returns the double value of this Float object.
      */
     public double doubleValue(){
-        return value;
+        return cn1Value();
     }
+
+    /**
+     * Returns this Float's value, transparently handling both heap-allocated and
+     * tagged-immediate representations. All value reads route here -- Float is final, so a
+     * plain `return value;` getter would be inlined into a raw field load off a tagged
+     * pointer, which has no fields.
+     */
+    private native float cn1Value();
 
     /**
      * Compares this object against some other object. The result is true if and only if the argument is not null and is a Float object that represents a float that has the identical bit pattern to the bit pattern of the float represented by this object. For this purpose, two float values are considered to be the same if and only if the method
@@ -98,7 +106,7 @@ public final class Float extends Number implements Comparable<Float> {
      * also has the value true. However, there are two exceptions: If f1 and f2 both represent Float.NaN, then the equals method returns true, even though Float.NaN==Float.NaN has the value false. If f1 represents +0.0f while f2 represents -0.0f, or vice versa, the equal test has the value false, even though 0.0f==-0.0f has the value true. This definition allows hashtables to operate properly.
      */
     public boolean equals(java.lang.Object obj){
-        return obj != null && obj.getClass() == getClass() && floatToIntBits(((Float)obj).value) == floatToIntBits(value);
+        return obj != null && obj.getClass() == getClass() && floatToIntBits(((Float)obj).cn1Value()) == floatToIntBits(cn1Value());
     }
 
     /**
@@ -111,7 +119,7 @@ public final class Float extends Number implements Comparable<Float> {
      * Returns the float value of this Float object.
      */
     public float floatValue(){
-        return value; 
+        return cn1Value();
     }
 
     /**
@@ -119,7 +127,7 @@ public final class Float extends Number implements Comparable<Float> {
      * , of the primitive float value represented by this Float object.
      */
     public int hashCode(){
-        return floatToIntBits(value);
+        return floatToIntBits(cn1Value());
     }
 
     /**
@@ -137,14 +145,14 @@ public final class Float extends Number implements Comparable<Float> {
      * Returns the integer value of this Float (by casting to an int).
      */
     public int intValue(){
-        return (int)value;
+        return (int)cn1Value();
     }
 
     /**
      * Returns true if this Float value is infinitely large in magnitude.
      */
     public boolean isInfinite(){
-        return isInfinite(value);
+        return isInfinite(cn1Value());
     }
 
     /**
@@ -163,7 +171,8 @@ public final class Float extends Number implements Comparable<Float> {
      * Returns true if this Float value is Not-a-Number (NaN).
      */
     public boolean isNaN(){
-        return value != value; 
+        float cn1v = cn1Value();
+        return cn1v != cn1v;
     }
 
     /**
@@ -177,7 +186,7 @@ public final class Float extends Number implements Comparable<Float> {
      * Returns the long value of this Float (by casting to a long).
      */
     public long longValue(){
-        return (long)value; 
+        return (long)cn1Value();
     }
 
     /**
@@ -191,14 +200,14 @@ public final class Float extends Number implements Comparable<Float> {
      * Returns the value of this Float as a short (by casting to a short).
      */
     public short shortValue(){
-        return (short)value;
+        return (short)cn1Value();
     }
 
     /**
      * Returns a String representation of this Float object. The primitive float value represented by this object is converted to a String exactly as if by the method toString of one argument.
      */
     public java.lang.String toString() {
-        return toString(value);
+        return toString(cn1Value());
     }
 
     /**
@@ -210,12 +219,19 @@ public final class Float extends Number implements Comparable<Float> {
      */
     public static java.lang.String toString(float d){
         float m = Math.abs(d);
-        if ( d == POSITIVE_INFINITY ){
+        // The NaN and signed-zero branches mirror Double.toString, which has had both for a
+        // while; Float was never brought into line. Without the first, NaN fell through to
+        // the scientific-notation path (every comparison against a NaN is false); without
+        // the second, Float.toString(-0.0f) printed "0.0", losing the sign that
+        // Float.compare, Float.equals and Arrays.sort all still honour.
+        if (isNaN(d)) {
+            return "NaN";
+        } else if ( d == POSITIVE_INFINITY ){
             return "Infinity";
         } else if ( d == NEGATIVE_INFINITY ){
             return "-Infinity";
         } else if ( d == 0 ){
-            return "0.0";
+            return floatToIntBits(d) == NEGATIVE_ZERO_BITS ? "-0.0" : "0.0";
         } else if ( m >= 1e-3 && m < 1e7 ){
             String str = toStringImpl(d, false);
             char[] chars = str.toCharArray();
@@ -258,7 +274,11 @@ public final class Float extends Number implements Comparable<Float> {
      * @param i the primitive
      * @return object instance
      */
-    public static Float valueOf(float i) {
+    // Native so the tagged build can return an immediate without allocating. The off path
+    // (and 32-bit-pointer targets) calls valueOfHeap, preserving the previous behaviour.
+    public static native Float valueOf(float i);
+
+    static Float valueOfHeap(float i) {
         return new Float(i);
     }
     
@@ -282,6 +302,6 @@ public final class Float extends Number implements Comparable<Float> {
     }
 
     public int compareTo(Float another) {
-        return compare(value, another.value);
+        return compare(cn1Value(), another.cn1Value());
     }
 }

--- a/vm/JavaAPI/src/java/lang/Long.java
+++ b/vm/JavaAPI/src/java/lang/Long.java
@@ -57,28 +57,28 @@ public final class Long extends Number implements Comparable<Long> {
      * Returns the value of this Long as a double.
      */
     public double doubleValue(){
-        return (double)value;
+        return (double)cn1Value();
     }
 
     /**
      * Compares this object against the specified object. The result is true if and only if the argument is not null and is a Long object that contains the same long value as this object.
      */
     public boolean equals(java.lang.Object obj){
-        return obj != null && obj.getClass() == getClass() && ((Long)obj).value == value;
+        return obj != null && obj.getClass() == getClass() && ((Long)obj).cn1Value() == cn1Value();
     }
 
     /**
      * Returns the value of this Long as a float.
      */
     public float floatValue(){
-        return (float)value;
+        return (float)cn1Value();
     }
 
     /**
      * Computes a hashcode for this Long. The result is the exclusive OR of the two halves of the primitive long value represented by this Long object. That is, the hashcode is the value of the expression: (int)(this.longValue()^(this.longValue()>>>32))
      */
     public int hashCode(){
-        return hashCode(this.value);
+        return hashCode(cn1Value());
     }
 
     /**
@@ -94,21 +94,29 @@ public final class Long extends Number implements Comparable<Long> {
      * Returns the value of this Long as a long value.
      */
     public long longValue(){
-        return value;
+        return cn1Value();
     }
+
+    /**
+     * Returns this Long's value, transparently handling both heap-allocated and
+     * tagged-immediate representations. All value reads route here -- Long is final, so a
+     * plain `return value;` getter would be inlined into a raw field load off a tagged
+     * pointer, which has no fields.
+     */
+    private native long cn1Value();
 
     /**
      * Returns the value of this Long as an int value.
      */
     public int intValue() {
-        return (int)value;
+        return (int)cn1Value();
     }
 
     /**
      * Returns the value of this Long as a byte value.
      */
     public byte byteValue() {
-        return (byte)value;
+        return (byte)cn1Value();
     }
     
     /**
@@ -183,7 +191,7 @@ public final class Long extends Number implements Comparable<Long> {
      * method that takes one argument.
      */
     public java.lang.String toString(){
-        return toString(value);
+        return toString(cn1Value());
     }
 
     /**
@@ -212,7 +220,11 @@ public final class Long extends Number implements Comparable<Long> {
      * @param i the primitive
      * @return object instance
      */
-    public static Long valueOf(long i) {
+    // Native so the tagged build can return an immediate without allocating. The off path
+    // (and 32-bit-pointer targets) calls valueOfHeap, preserving the previous behaviour.
+    public static native Long valueOf(long i);
+
+    static Long valueOfHeap(long i) {
         if (i >= -128 && i <= 127) {
             return LongCache.cache[(int) i + 128];
         }
@@ -237,6 +249,8 @@ public final class Long extends Number implements Comparable<Long> {
     }
 
     public int compareTo(Long another) {
-        return value < another.value ? -1 : value > another.value ? 1 : 0;
+        long cn1a = cn1Value();
+        long cn1b = another.cn1Value();
+        return cn1a < cn1b ? -1 : cn1a > cn1b ? 1 : 0;
     }
 }

--- a/vm/JavaAPI/src/java/lang/Short.java
+++ b/vm/JavaAPI/src/java/lang/Short.java
@@ -53,15 +53,28 @@ public final class Short extends Number implements Comparable<Short> {
      * Compares this object to the specified object.
      */
     public boolean equals(java.lang.Object obj){
-        return obj.getClass() == getClass() && ((Short)obj).value == value;
+        // instanceof rather than a null check plus getClass(): Short is final, so it is
+        // exact, and it needs no header -- which is what a tagged immediate has none of.
+        // The missing null guard here was a real defect: equals(null) is specified to return
+        // false, and dereferencing obj was a hard SIGSEGV on targets that install no signal
+        // handler. Every other wrapper in this package already guarded it.
+        return (obj instanceof Short) && ((Short)obj).cn1Value() == cn1Value();
     }
 
     /**
      * Returns a hashcode for this Short.
      */
     public int hashCode(){
-        return value;
+        return cn1Value();
     }
+
+    /**
+     * Returns this Short's value, transparently handling both heap-allocated and
+     * tagged-immediate representations. All value reads route here -- Short is final, so a
+     * plain `return value;` getter would be inlined into a raw field load off a tagged
+     * pointer, which has no fields.
+     */
+    private native short cn1Value();
 
     /**
      * Assuming the specified String represents a short, returns that short's value. Throws an exception if the String cannot be parsed as a short. The radix is assumed to be 10.
@@ -81,14 +94,14 @@ public final class Short extends Number implements Comparable<Short> {
      * Returns the value of this Short as a short.
      */
     public short shortValue(){
-        return value; //TODO codavaj!!
+        return cn1Value();
     }
 
     /**
      * Returns a String object representing this Short's value.
      */
     public java.lang.String toString(){
-        return Integer.toString(value);
+        return Integer.toString(cn1Value());
     }
 
     /**
@@ -96,7 +109,11 @@ public final class Short extends Number implements Comparable<Short> {
      * @param i the primitive
      * @return object instance
      */
-    public static Short valueOf(short i) {
+    // Native so the tagged build can return an immediate without allocating. The off path
+    // (and 32-bit-pointer targets) calls valueOfHeap, preserving the cache.
+    public static native Short valueOf(short i);
+
+    static Short valueOfHeap(short i) {
         if (i >= -128 && i <= 127) {
             return ShortCache.cache[i + 128];
         }
@@ -116,22 +133,22 @@ public final class Short extends Number implements Comparable<Short> {
 
     @Override
     public int intValue() {
-        return value;
+        return cn1Value();
     }
 
     @Override
     public long longValue() {
-        return value;
+        return cn1Value();
     }
 
     @Override
     public float floatValue() {
-        return value;
+        return cn1Value();
     }
 
     @Override
     public double doubleValue() {
-        return value;
+        return cn1Value();
     }
 
     public static int compare(short f1, short f2) {
@@ -139,6 +156,10 @@ public final class Short extends Number implements Comparable<Short> {
     }
 
     public int compareTo(Short another) {
-        return value < another.value ? -1 : value > another.value ? 1 : 0;
+        // The JDK specifies Short.compareTo as Short.compare(a, b), and Short.compare is the
+        // DIFFERENCE, not the sign -- unlike Integer.compare and Long.compare, which really
+        // do return -1/0/1. This returned the sign, so it disagreed with the JDK and with
+        // this class's own compare(short, short) directly above.
+        return cn1Value() - another.cn1Value();
     }
 }

--- a/vm/benchmarks/README.md
+++ b/vm/benchmarks/README.md
@@ -16,7 +16,7 @@ optimization work. Two invariants govern everything here:
 
 ```bash
 export JDK_8_HOME=/path/to/jdk8        # builds JavaAPI + bench sources
-export BENCH_JAVA=/path/to/jdk25/bin/java   # the reference JVM (optional; default `java`)
+export BENCH_JAVA=/path/to/jdk25/bin/java   # the reference JVM -- must be JDK 19+
 
 ./run-benchmark.sh          # 5 interleaved rounds, ratio table + geomean
 ./run-benchmark.sh 10       # more rounds
@@ -28,6 +28,13 @@ CN1_BENCH_CFLAGS="" ./run-benchmark.sh    # without ThinLTO (debug shape)
 ./run-bibop-adaptive.sh     # issue-5425 retained-small-array correctness,
                             # adaptive-policy, wall-time, and peak-RSS gate
 ```
+
+The reference JVM must be **JDK 19 or newer**. JDK 19 replaced `Double.toString` and
+`Float.toString` with the shortest round-tripping representation (JDK-4511638) and ParparVM
+implements the new algorithm, so an older reference reports divergences that are the
+reference being out of date rather than the VM being wrong -- `4.6116860184273879E18` from
+JDK 17 against `4.611686018427388E18` from ParparVM and JDK 19+. Both round-trip; only the
+second is the shortest such string.
 
 Requirements: Maven and clang on `PATH` (gcc also works:
 `CN1_BENCH_CC=gcc-16` — the suite is validated under both; gcc is the

--- a/vm/benchmarks/README.md
+++ b/vm/benchmarks/README.md
@@ -137,6 +137,14 @@ and the measured numbers are in `vm/CLAUDE.md`.
   Integer-only tagging, what shipped before the other five -- is the baseline worth reading
   against; `HEAP` vs `INT` only re-measures a win that was already taken.
 
+`ab-narrowing.sh` A/Bs the JLS-saturating float/double -> int/long narrowing against the old
+undefined C cast (`-DCN1_NO_SATURATING_NARROWING`). Both arms come from one translation, so
+only the conversion differs; measured geomean 1.0073, i.e. free.
+
+```bash
+./ab-narrowing.sh 8 Bench
+```
+
 ## The tortures (run by `run-gauntlet.sh`)
 
 | test | guards |

--- a/vm/benchmarks/README.md
+++ b/vm/benchmarks/README.md
@@ -100,6 +100,36 @@ Two rules the workloads follow, and any addition must:
   allocates here (tagged immediates), so boxing inside the timed loop measures the
   allocator instead of the probe.
 
+## Tagged immediates (`BoxEdge`, `BoxBench`, `TagProbe`, `ab-tagged.sh`)
+
+`valueOf` on the six boxed number types returns an immediate with a type code in the low
+three bits rather than a heap object. Three drivers and an A/B script cover it; the design
+and the measured numbers are in `vm/CLAUDE.md`.
+
+```bash
+./ab-tagged.sh 6 BoxBench    # HEAP vs INT vs ALL, checksum-verified, + tag coverage
+./ab-tagged.sh 8 Bench       # the no-regression check on the common workloads
+./translate-and-build.sh TagProbe target/bin/TagProbe && ./target/bin/TagProbe
+```
+
+- **`BoxEdge`** is the correctness gate and runs in `run-gauntlet.sh`: all six types crossed
+  with tagged, heap-allocated, `null` and wrong-type receivers, over getClass / instanceof /
+  equals / hashCode / compareTo, the collections, NaN and both zeroes, monitors, and
+  Long/Double values chosen to fall OUTSIDE the taggable range so the heap fallback and the
+  mixed tagged/heap paths are exercised rather than assumed. It prints incrementally rather
+  than buffering, because a native crash on this target is a bare SIGSEGV and the last line
+  emitted is the only locator there is.
+- **`BoxBench`** is the perf driver, and prints a `COVERAGE` line beside its timings.
+  `Long` and `Double` are only PARTIALLY representable, so a speedup with no coverage figure
+  next to it says nothing about real data -- read both or neither.
+- **`TagProbe`** is a diagnostic, not a torture: it reports the encoding, asserts that every
+  real object is 8-byte aligned on every allocation path, and reports coverage. Its output is
+  target-specific and is deliberately not compared to a host JVM. It is valid in all three
+  ablation arms.
+- **`ab-tagged.sh`** takes an optional driver argument (default `BoxBench`). Arm `INT` --
+  Integer-only tagging, what shipped before the other five -- is the baseline worth reading
+  against; `HEAP` vs `INT` only re-measures a win that was already taken.
+
 ## The tortures (run by `run-gauntlet.sh`)
 
 | test | guards |

--- a/vm/benchmarks/ab-narrowing.sh
+++ b/vm/benchmarks/ab-narrowing.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# A/B the JLS-saturating float/double -> int/long narrowing against the old undefined C
+# cast, interleaved inside ONE session because this host cannot resolve a 5% difference
+# between two runs minutes apart. Both arms come from the SAME translation; only
+# -DCN1_NO_SATURATING_NARROWING differs, so nothing but the conversion changes.
+set -e
+cd "$(dirname "$0")"
+ROUNDS="${1:-8}"
+DRIVER="${2:-Bench}"
+LTO="${CN1_BENCH_LTO--flto=thin}"
+mkdir -p target/ab
+CN1_BENCH_CFLAGS="$LTO -DCN1_NO_SATURATING_NARROWING" ./translate-and-build.sh "$DRIVER" target/ab/narrow-off >/dev/null 2>&1
+echo "built arm OFF (old undefined cast)"
+CN1_BENCH_CFLAGS="$LTO" ./translate-and-build.sh "$DRIVER" target/ab/narrow-on >/dev/null 2>&1
+echo "built arm ON (saturating)"
+
+python3 - "$ROUNDS" <<'EOF'
+import subprocess, re, sys, math
+rounds = int(sys.argv[1])
+ARMS = {"OFF": "target/ab/narrow-off", "ON": "target/ab/narrow-on"}
+
+def run(p):
+    out = subprocess.run([p], capture_output=True, text=True).stdout
+    r = {}
+    for m in re.finditer(r'BENCH (\w+) rep \d+ ns=(\d+) checksum=(-?\d+)', out):
+        r.setdefault(m.group(1), {"ns": [], "ck": set()})
+        r[m.group(1)]["ns"].append(int(m.group(2)))
+        r[m.group(1)]["ck"].add(m.group(3))
+    return r
+
+best = {a: {} for a in ARMS}
+cks = {a: {} for a in ARMS}
+for i in range(rounds):
+    for a, p in ARMS.items():
+        for k, v in run(p).items():
+            best[a][k] = min(best[a].get(k, 1 << 62), min(v["ns"]))
+            cks[a].setdefault(k, set()).update(v["ck"])
+    print("round %d/%d" % (i + 1, rounds), flush=True)
+
+bad = [k for k in best["OFF"] if cks["OFF"].get(k) != cks["ON"].get(k)]
+if bad:
+    print("CHECKSUM MISMATCH between arms: %s" % bad); sys.exit(1)
+
+print("\n%-20s %10s %10s %8s" % ("bench", "OFF ms", "ON ms", "ON/OFF"))
+rs = []
+for n in best["OFF"]:
+    o = best["OFF"][n] / 1e6; w = best["ON"][n] / 1e6
+    rs.append(w / o)
+    print("%-20s %10.1f %10.1f %8.3f" % (n, o, w, w / o))
+print("\ngeomean %.4f (>1 = the saturating conversion is slower)"
+      % math.exp(sum(map(math.log, rs)) / len(rs)))
+print("(checksums bit-identical across both arms)")
+EOF

--- a/vm/benchmarks/ab-narrowing.sh
+++ b/vm/benchmarks/ab-narrowing.sh
@@ -20,12 +20,21 @@ rounds = int(sys.argv[1])
 ARMS = {"OFF": "target/ab/narrow-off", "ON": "target/ab/narrow-on"}
 
 def run(p):
-    out = subprocess.run([p], capture_output=True, text=True).stdout
+    # A benchmark that dies part way still prints the BENCH lines it reached. Comparing
+    # those reports a partial run as a result, and if both arms die at the same point their
+    # partial checksums even agree -- so the parity check would pass on nothing.
+    proc = subprocess.run([p], capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise SystemExit("%s exited %d; refusing to compare a partial run:\n%s"
+                         % (p, proc.returncode, proc.stdout[-2000:]))
+    out = proc.stdout
     r = {}
     for m in re.finditer(r'BENCH (\w+) rep \d+ ns=(\d+) checksum=(-?\d+)', out):
         r.setdefault(m.group(1), {"ns": [], "ck": set()})
         r[m.group(1)]["ns"].append(int(m.group(2)))
         r[m.group(1)]["ck"].add(m.group(3))
+    if not r:
+        raise SystemExit("%s produced no BENCH lines" % p)
     return r
 
 best = {a: {} for a in ARMS}
@@ -37,6 +46,9 @@ for i in range(rounds):
             cks[a].setdefault(k, set()).update(v["ck"])
     print("round %d/%d" % (i + 1, rounds), flush=True)
 
+if set(best["OFF"]) != set(best["ON"]):
+    print("ARMS DISAGREE ON WHICH WORKLOADS RAN: %s vs %s"
+          % (sorted(best["OFF"]), sorted(best["ON"]))); sys.exit(1)
 bad = [k for k in best["OFF"] if cks["OFF"].get(k) != cks["ON"].get(k)]
 if bad:
     print("CHECKSUM MISMATCH between arms: %s" % bad); sys.exit(1)

--- a/vm/benchmarks/ab-tagged.sh
+++ b/vm/benchmarks/ab-tagged.sh
@@ -34,19 +34,39 @@ rounds = int(sys.argv[1])
 ARMS = [0, 1, 2]
 NAMES = {0: "HEAP", 1: "INT", 2: "ALL"}
 
+# ru_maxrss from RUSAGE_CHILDREN is a cumulative HIGH-WATER MARK over every child this
+# process has reaped, not the peak of the one just run -- so measuring it here would let
+# the heaviest arm set a floor under every later arm and every later round. Each sample
+# therefore runs the binary from a FRESH python, whose children are only that one binary.
+# (This is the same correction run-bibop-adaptive.sh already carries.)
+RSS_PROBE = (
+    "import subprocess,resource,sys;"
+    "p=subprocess.run([sys.argv[1]],capture_output=True,text=True);"
+    "sys.stderr.write(str(resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss));"
+    "sys.stdout.write(p.stdout);"
+    "sys.exit(p.returncode)"
+)
+
 def run(binpath):
-    before = resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
-    p = subprocess.run([binpath], capture_output=True, text=True)
-    after = resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
+    p = subprocess.run([sys.executable, "-c", RSS_PROBE, binpath],
+                       capture_output=True, text=True)
+    # A benchmark that dies part way still prints the BENCH lines it reached, and comparing
+    # those silently reports a partial result set as a result. Refuse it.
+    if p.returncode != 0:
+        raise SystemExit("%s exited %d; refusing to compare a partial run:\n%s"
+                         % (binpath, p.returncode, p.stdout[-2000:]))
+    rss = int(p.stderr.strip() or 0)
     r, cov = {}, None
     for m in re.finditer(r'BENCH (\w+) rep \d+ ns=(\d+) checksum=(-?\d+)', p.stdout):
         r.setdefault(m.group(1), {"ns": [], "ck": set()})
         r[m.group(1)]["ns"].append(int(m.group(2)))
         r[m.group(1)]["ck"].add(m.group(3))
+    if not r:
+        raise SystemExit("%s produced no BENCH lines" % binpath)
     c = re.search(r'^COVERAGE .*$', p.stdout, re.M)
     if c:
         cov = c.group(0)
-    return r, after, cov
+    return r, rss, cov
 
 best = {a: {} for a in ARMS}
 cks = {a: {} for a in ARMS}
@@ -63,6 +83,9 @@ for rnd in range(rounds):
             cks[a].setdefault(k, set()).update(v["ck"])
     print(f"round {rnd+1}/{rounds}", flush=True)
 
+names_per_arm = {x: set(best[x]) for x in ARMS}
+if len(set(map(frozenset, names_per_arm.values()))) != 1:
+    print("ARMS DISAGREE ON WHICH WORKLOADS RAN: %s" % names_per_arm); sys.exit(1)
 bad = [k for k in best[0] if any(cks[x].get(k) != cks[0].get(k) for x in ARMS)]
 if bad:
     print(f"\nCHECKSUM MISMATCH across arms (correctness bug, not a perf result): {bad}")

--- a/vm/benchmarks/ab-tagged.sh
+++ b/vm/benchmarks/ab-tagged.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# A/B the tagged immediates ("poor man's Valhalla") in three arms, so the two questions
+# are separated rather than conflated:
+#
+#   0 HEAP  -DCN1_DISABLE_TAGGED_INT     nothing tagged; every valueOf allocates
+#   1 INT   -DCN1_DISABLE_TAGGED_VALUES  Integer only -- what shipped before this work
+#   2 ALL   (default)                    Integer, Long, Double, Float, Character, Short
+#
+# Arm 1 is the baseline that matters: arm 0 vs 1 re-measures a win that was already taken,
+# and only 1 vs 2 says what the five extra types are worth.
+#
+# Reports best-of-N per-benchmark ms and peak RSS, and cross-checks every checksum against
+# arm 0 -- a divergence is a correctness bug, not a perf number, and exits non-zero.
+#
+# Usage: ab-tagged.sh [rounds] [driver]     (driver defaults to BoxBench; Bench also works)
+set -e
+cd "$(dirname "$0")"
+ROUNDS="${1:-6}"
+DRIVER="${2:-BoxBench}"
+LTO="${CN1_BENCH_LTO--flto=thin}"
+mkdir -p target/ab
+
+build() { # arm, extra cflags
+  CN1_BENCH_CFLAGS="$LTO $2" ./translate-and-build.sh "$DRIVER" "target/ab/tag-$1" >/dev/null 2>&1
+  echo "built arm $1 ($DRIVER)"
+}
+build 0 "-DCN1_DISABLE_TAGGED_INT"
+build 1 "-DCN1_DISABLE_TAGGED_VALUES"
+build 2 ""
+
+python3 - "$ROUNDS" <<'EOF'
+import subprocess, re, sys, resource, platform
+rounds = int(sys.argv[1])
+ARMS = [0, 1, 2]
+NAMES = {0: "HEAP", 1: "INT", 2: "ALL"}
+
+def run(binpath):
+    before = resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
+    p = subprocess.run([binpath], capture_output=True, text=True)
+    after = resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
+    r, cov = {}, None
+    for m in re.finditer(r'BENCH (\w+) rep \d+ ns=(\d+) checksum=(-?\d+)', p.stdout):
+        r.setdefault(m.group(1), {"ns": [], "ck": set()})
+        r[m.group(1)]["ns"].append(int(m.group(2)))
+        r[m.group(1)]["ck"].add(m.group(3))
+    c = re.search(r'^COVERAGE .*$', p.stdout, re.M)
+    if c:
+        cov = c.group(0)
+    return r, after, cov
+
+best = {a: {} for a in ARMS}
+cks = {a: {} for a in ARMS}
+peakrss = {a: 0 for a in ARMS}
+covs = {}
+for rnd in range(rounds):
+    for a in ARMS:
+        r, rss, cov = run(f"target/ab/tag-{a}")
+        peakrss[a] = max(peakrss[a], rss)
+        if cov:
+            covs[a] = cov
+        for k, v in r.items():
+            best[a][k] = min(best[a].get(k, 1 << 62), min(v["ns"]))
+            cks[a].setdefault(k, set()).update(v["ck"])
+    print(f"round {rnd+1}/{rounds}", flush=True)
+
+bad = [k for k in best[0] if any(cks[x].get(k) != cks[0].get(k) for x in ARMS)]
+if bad:
+    print(f"\nCHECKSUM MISMATCH across arms (correctness bug, not a perf result): {bad}")
+    for k in bad[:3]:
+        for x in ARMS:
+            print(f"  {k} arm{x}: {sorted(cks[x].get(k, set()))}")
+    sys.exit(1)
+
+names = list(best[0].keys())
+print(f"\n{'bench':<20}" + "".join(f"{NAMES[x]+' ms':>12}" for x in ARMS)
+      + f"{'INT/HEAP':>10}{'ALL/INT':>10}")
+for n in names:
+    ms = {x: best[x][n] / 1e6 for x in ARMS}
+    print(f"{n:<20}" + "".join(f"{ms[x]:>12.1f}" for x in ARMS)
+          + f"{ms[1]/ms[0]:>10.2f}{ms[2]/ms[1]:>10.2f}")
+
+unit = 1024 * 1024 if platform.system() == "Darwin" else 1024
+print(f"\n{'peak RSS (MB)':<20}" + "".join(f"{peakrss[x]/unit:>12.1f}" for x in ARMS))
+for x in ARMS:
+    if x in covs:
+        print(f"arm {NAMES[x]}: {covs[x]}")
+print("(checksums bit-identical across all three arms)")
+EOF

--- a/vm/benchmarks/run-gauntlet.sh
+++ b/vm/benchmarks/run-gauntlet.sh
@@ -15,7 +15,15 @@ J8="${JDK_8_HOME:?set JDK_8_HOME}"
 # TaggedSync guards Java monitor semantics on tagged boxed Integers (mutual
 # exclusion + wait/notify) -- regression test for the tagged monitorEnter/Exit
 # no-op bug a review caught.
-TORTURES="MapTorture IdmTorture HtTorture SbTorture StrCmp FusedTest IbpTest ExcTest ThreadChurn SoeTest TaggedSync"
+#
+# BoxEdge is the gate for the tagged immediates as a whole: all six boxed types
+# (Integer/Long/Double/Float/Character/Short) crossed with tagged, heap-allocated,
+# null and wrong-type receivers, over getClass/instanceof/equals/hashCode/compareTo,
+# the collections, NaN and both zeroes, monitors, and Long/Double values chosen to
+# fall OUTSIDE the taggable range so the heap fallback is exercised rather than
+# assumed. It catches the failure this scheme makes easy -- a wrong class or a wrong
+# hash, returned silently with nothing thrown.
+TORTURES="MapTorture IdmTorture HtTorture SbTorture StrCmp FusedTest IbpTest ExcTest ThreadChurn SoeTest TaggedSync BoxEdge"
 mkdir -p target/host-classes target/bin
 # FusedTest uses @com.codename1.annotations.Fused -- supply the annotation
 # source for the host compile (ParparVM's JavaAPI carries its own copy)

--- a/vm/benchmarks/run-gauntlet.sh
+++ b/vm/benchmarks/run-gauntlet.sh
@@ -35,7 +35,10 @@ fail=0
 for t in $TORTURES; do
     ./translate-and-build.sh "$t" "target/bin/$t" > /dev/null
     a="$(./target/bin/$t 2>/dev/null | grep -v '^\[')"
-    b="$("$REF_JAVA" -cp target/host-classes "com.bench.$t" 2>/dev/null)"
+    # The SAME filter on both sides. It used to be applied only to the target, so a
+    # torture that emitted a "[...]" diagnostic diverged against its own host run -- and
+    # stderr is no way around that, because System.err reaches fd 1 on the clean target.
+    b="$("$REF_JAVA" -cp target/host-classes "com.bench.$t" 2>/dev/null | grep -v '^\[')"
     if [ -n "$a" ] && [ "$a" = "$b" ]; then
         echo "$t: MATCH"
     else

--- a/vm/benchmarks/src/com/bench/BoxBench.java
+++ b/vm/benchmarks/src/com/bench/BoxBench.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.bench;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Allocation-shaped benchmark for the tagged immediates. Distinct from Bench/CommonWorkloads,
+ * which is fixed at exactly ten workload ids (port_status.py requires that), and from
+ * MapBench, which is about probe sequences rather than boxing.
+ *
+ * The motivating shape is JSON: CodenameOne's JSONParser boxes every numeric token as
+ * Double.valueOf or Long.valueOf into a Map, so an app talking to a REST API allocates one
+ * heap object per number in every response. jsonLikeParse reproduces that here rather than
+ * calling JSONParser itself, because the bench classpath is JavaAPI only.
+ *
+ * Reports a TAG COVERAGE line as well as timings. Long and Double are only PARTIALLY
+ * taggable -- 61 bits of payload, and a double must have three clear low mantissa bits --
+ * so a speedup with no coverage figure beside it says nothing about real data.
+ */
+public final class BoxBench {
+    private static final int WARMUP = 3;
+    private static final int MEASURE = 5;
+
+    private interface BenchFn { long run(); }
+
+    private static void runBench(String name, BenchFn fn) {
+        for (int w = 0; w < WARMUP; w++) {
+            fn.run();
+        }
+        for (int r = 0; r < MEASURE; r++) {
+            long started = System.nanoTime();
+            long checksum = fn.run();
+            long elapsed = System.nanoTime() - started;
+            System.out.println("BENCH " + name + " rep " + r
+                    + " ns=" + elapsed + " checksum=" + checksum);
+        }
+    }
+
+    /**
+     * The JSON shape: a map of string keys to boxed Long/Double, built then read.
+     *
+     * The numbers are a deliberately MIXED distribution, not a convenient one. An earlier
+     * version used only integers and exact quarters, and reported 100% tag coverage for
+     * both Long and Double -- a benchmark measuring the best case and calling it the case.
+     * Real payloads carry prices, ratios and measurements whose low mantissa bits are set
+     * and which therefore take the heap fallback, so a quarter of the doubles here are
+     * money values and a quarter are irrational.
+     */
+    static double jsonNumber(int doc, int i) {
+        switch ((doc + i) & 3) {
+            case 0: return doc + i;              // a JSON integer, always taggable
+            case 1: return (doc + i) / 4.0;      // an exact quarter, taggable
+            case 2: return (doc + i) / 100.0;    // money, mostly not taggable
+            default: return Math.sqrt(doc + i);  // irrational, essentially never taggable
+        }
+    }
+
+    static long jsonLikeParse() {
+        String[] keys = new String[24];
+        for (int i = 0; i < keys.length; i++) {
+            keys[i] = "field" + i;
+        }
+        long acc = 0;
+        for (int doc = 0; doc < 20000; doc++) {
+            Map m = new HashMap();
+            for (int i = 0; i < keys.length; i++) {
+                if ((i & 1) == 0) {
+                    m.put(keys[i], Long.valueOf(doc * 31L + i));
+                } else {
+                    m.put(keys[i], Double.valueOf(jsonNumber(doc, i)));
+                }
+            }
+            for (int i = 0; i < keys.length; i++) {
+                Object v = m.get(keys[i]);
+                if (v instanceof Long) {
+                    acc += ((Long) v).longValue();
+                } else {
+                    acc += (long) ((Double) v).doubleValue();
+                }
+            }
+        }
+        return acc;
+    }
+
+    /** Long-keyed map churn: the id/timestamp shape, all inside the taggable range. */
+    static long longKeyMap() {
+        long acc = 0;
+        for (int round = 0; round < 40; round++) {
+            Map m = new HashMap();
+            for (int i = 0; i < 4000; i++) {
+                m.put(Long.valueOf(1757000000000L + i), Long.valueOf(i));
+            }
+            for (int i = 0; i < 4000; i++) {
+                acc += ((Long) m.get(Long.valueOf(1757000000000L + i))).longValue();
+            }
+        }
+        return acc;
+    }
+
+    /** Boxed Double reduce through a List, the numeric-column shape. */
+    static long doubleListReduce() {
+        long acc = 0;
+        for (int round = 0; round < 60; round++) {
+            List list = new ArrayList();
+            for (int i = 0; i < 5000; i++) {
+                list.add(Double.valueOf(i / 2.0));
+            }
+            double sum = 0;
+            for (int i = 0; i < list.size(); i++) {
+                sum += ((Double) list.get(i)).doubleValue();
+            }
+            acc += (long) sum;
+        }
+        return acc;
+    }
+
+    /** Character boxing over a text scan, plus a Character-keyed frequency map. */
+    static long charBoxing() {
+        String text = "the quick brown fox jumps over the lazy dog 0123456789";
+        long acc = 0;
+        for (int round = 0; round < 4000; round++) {
+            Map freq = new HashMap();
+            for (int i = 0; i < text.length(); i++) {
+                Character c = Character.valueOf(text.charAt(i));
+                Object prev = freq.get(c);
+                freq.put(c, Integer.valueOf(prev == null ? 1 : ((Integer) prev).intValue() + 1));
+            }
+            for (int i = 0; i < text.length(); i++) {
+                acc += ((Integer) freq.get(Character.valueOf(text.charAt(i)))).intValue();
+            }
+        }
+        return acc;
+    }
+
+    /** Mixed boxed types through one Object-typed collection: dispatch on immediates. */
+    static long mixedBoxedChurn() {
+        long acc = 0;
+        for (int round = 0; round < 3000; round++) {
+            List list = new ArrayList();
+            for (int i = 0; i < 200; i++) {
+                switch (i % 5) {
+                    case 0: list.add(Integer.valueOf(i)); break;
+                    case 1: list.add(Long.valueOf(i)); break;
+                    case 2: list.add(Double.valueOf(i)); break;
+                    case 3: list.add(Float.valueOf(i)); break;
+                    default: list.add(Short.valueOf((short) i)); break;
+                }
+            }
+            for (int i = 0; i < list.size(); i++) {
+                acc += ((Number) list.get(i)).longValue() + list.get(i).hashCode();
+            }
+        }
+        return acc;
+    }
+
+    /**
+     * How much of the workload's own data the partial encodings can actually represent.
+     * Printed, never checksummed: it is a property of the target, not of the computation.
+     */
+    static void reportCoverage() {
+        int longHits = 0, longTotal = 0, dblHits = 0, dblTotal = 0;
+        for (int doc = 0; doc < 20000; doc++) {
+            for (int i = 0; i < 24; i++) {
+                if ((i & 1) == 0) {
+                    longTotal++;
+                    if ((System.identityHashCode(Long.valueOf(doc * 31L + i)) & 7) == 2) longHits++;
+                } else {
+                    dblTotal++;
+                    if ((System.identityHashCode(Double.valueOf(jsonNumber(doc, i))) & 7) == 3) dblHits++;
+                }
+            }
+        }
+        System.out.println("COVERAGE jsonLikeParse long=" + (longHits * 100 / longTotal)
+                + "% double=" + (dblHits * 100 / dblTotal) + "%");
+    }
+
+    public static void main(String[] args) {
+        runBench("jsonLikeParse", new BenchFn() {
+            public long run() { return jsonLikeParse(); }
+        });
+        runBench("longKeyMap", new BenchFn() {
+            public long run() { return longKeyMap(); }
+        });
+        runBench("doubleListReduce", new BenchFn() {
+            public long run() { return doubleListReduce(); }
+        });
+        runBench("charBoxing", new BenchFn() {
+            public long run() { return charBoxing(); }
+        });
+        runBench("mixedBoxedChurn", new BenchFn() {
+            public long run() { return mixedBoxedChurn(); }
+        });
+        reportCoverage();
+        System.out.println("DONE");
+    }
+}

--- a/vm/benchmarks/src/com/bench/BoxBench.java
+++ b/vm/benchmarks/src/com/bench/BoxBench.java
@@ -181,17 +181,25 @@ public final class BoxBench {
     /**
      * How much of the workload's own data the partial encodings can actually represent.
      * Printed, never checksummed: it is a property of the target, not of the computation.
+     *
+     * Detected by its observable consequence -- two separately-obtained boxes of one value
+     * are the same reference only for an immediate -- and NOT by reading tag bits out of
+     * identityHashCode, which folds a tagged word's halves and no longer exposes them. The
+     * values here are all far outside the -128..127 caches, so a shared cache entry cannot
+     * be mistaken for an immediate.
      */
     static void reportCoverage() {
         int longHits = 0, longTotal = 0, dblHits = 0, dblTotal = 0;
         for (int doc = 0; doc < 20000; doc++) {
             for (int i = 0; i < 24; i++) {
                 if ((i & 1) == 0) {
+                    long v = doc * 31L + i;
                     longTotal++;
-                    if ((System.identityHashCode(Long.valueOf(doc * 31L + i)) & 7) == 2) longHits++;
+                    if (Long.valueOf(v) == Long.valueOf(v)) longHits++;
                 } else {
+                    double d = jsonNumber(doc, i);
                     dblTotal++;
-                    if ((System.identityHashCode(Double.valueOf(jsonNumber(doc, i))) & 7) == 3) dblHits++;
+                    if (Double.valueOf(d) == Double.valueOf(d)) dblHits++;
                 }
             }
         }

--- a/vm/benchmarks/src/com/bench/BoxEdge.java
+++ b/vm/benchmarks/src/com/bench/BoxEdge.java
@@ -77,7 +77,34 @@ public final class BoxEdge {
         stringsAndSwitch();
         synchronization();
         arraysAndSorting();
+        reportTagCodes();
         System.out.println("BOXEDGE DONE");
+    }
+
+    /**
+     * Which tag code each boxed type actually got in THIS build, on stderr.
+     *
+     * It carries the `[` prefix this tree uses for diagnostics ([GCPROBE], [ALLOC:...]),
+     * because that is what `run-gauntlet.sh` filters out of BOTH sides before comparing --
+     * stdout has to stay byte-identical to a host JVM and this line is target-specific by
+     * construction. Note stderr is NOT a way out: on the clean target System.err also
+     * reaches fd 1, so a stderr diagnostic still lands in the compared stream.
+     *
+     * Its job is to stop the rest of this file being VACUOUS. Every assertion here passes
+     * on a build where tagging never happened -- that is the point, the two representations
+     * must be indistinguishable -- so without a witness saying which arm ran, a green
+     * BoxEdge cannot tell "the tagged path is correct" from "the tagged path never
+     * executed". Expect 123456 in a default build and 000000 with -DCN1_DISABLE_TAGGED_INT.
+     */
+    static void reportTagCodes() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(System.identityHashCode(Integer.valueOf(1)) & 7);
+        sb.append(System.identityHashCode(Long.valueOf(1L)) & 7);
+        sb.append(System.identityHashCode(Double.valueOf(1.0)) & 7);
+        sb.append(System.identityHashCode(Float.valueOf(1.0f)) & 7);
+        sb.append(System.identityHashCode(Character.valueOf('a')) & 7);
+        sb.append(System.identityHashCode(Short.valueOf((short) 1)) & 7);
+        System.out.println("[TAGCODES] " + sb);
     }
 
     /* ---- getClass / instanceof / isInstance, on tagged and heap boxes alike ---- */

--- a/vm/benchmarks/src/com/bench/BoxEdge.java
+++ b/vm/benchmarks/src/com/bench/BoxEdge.java
@@ -369,6 +369,49 @@ public final class BoxEdge {
         p("d.negZeroStr", nz.toString());
         p("d.posZeroStr", pz.toString());
 
+        // JLS 5.1.3 narrowing: saturating, not wrapping, and not whatever the host C
+        // compiler's undefined cast happens to do. This is the case that x86 and arm64
+        // silently disagreed about -- arm64's fcvtzs saturates, x86's cvttsd2si returns
+        // 0x80000000 -- so (int) Double.MAX_VALUE was Integer.MIN_VALUE on x86 and
+        // Integer.MAX_VALUE on arm64. Every one of these is specified exactly.
+        double[] narrowD = {
+            Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY,
+            Double.MAX_VALUE, -Double.MAX_VALUE, Double.MIN_VALUE,
+            2147483647.0, 2147483648.0, -2147483648.0, -2147483649.0,
+            9.2233720368547758E18, -9.2233720368547758E18, 1.5, -1.5, 0.0, -0.0
+        };
+        for (int i = 0; i < narrowD.length; i++) {
+            p("narrow.d2i." + i, (int) narrowD[i]);
+            p("narrow.d2l." + i, (long) narrowD[i]);
+            p("narrow.d2s." + i, (short) narrowD[i]);
+            p("narrow.d2b." + i, (byte) narrowD[i]);
+            p("narrow.d2c." + i, (int) (char) narrowD[i]);
+        }
+        float[] narrowF = {
+            Float.NaN, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY,
+            Float.MAX_VALUE, -Float.MAX_VALUE, Float.MIN_VALUE,
+            2.14748365E9f, -2.14748365E9f, 9.223372E18f, -9.223372E18f, 1.5f, -1.5f
+        };
+        for (int i = 0; i < narrowF.length; i++) {
+            p("narrow.f2i." + i, (int) narrowF[i]);
+            p("narrow.f2l." + i, (long) narrowF[i]);
+            p("narrow.f2s." + i, (short) narrowF[i]);
+            p("narrow.f2b." + i, (byte) narrowF[i]);
+        }
+        // The same conversions reached through a BOXED receiver, which is how the tagged
+        // path gets there: Number.intValue() on an immediate still has to saturate.
+        Number[] boxedNarrow = {
+            Double.valueOf(Double.MAX_VALUE), Double.valueOf(Double.NaN),
+            Double.valueOf(Double.NEGATIVE_INFINITY), Float.valueOf(Float.MAX_VALUE),
+            Float.valueOf(Float.NEGATIVE_INFINITY)
+        };
+        for (int i = 0; i < boxedNarrow.length; i++) {
+            p("narrow.boxed.int." + i, boxedNarrow[i].intValue());
+            p("narrow.boxed.long." + i, boxedNarrow[i].longValue());
+            p("narrow.boxed.short." + i, boxedNarrow[i].shortValue());
+            p("narrow.boxed.byte." + i, boxedNarrow[i].byteValue());
+        }
+
         // A NaN key must be findable in a map even though NaN != NaN.
         Map m = new HashMap();
         m.put(nan1, "nan");

--- a/vm/benchmarks/src/com/bench/BoxEdge.java
+++ b/vm/benchmarks/src/com/bench/BoxEdge.java
@@ -1,0 +1,494 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.bench;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * The correctness gate for tagged immediates ("poor man's Valhalla"): Integer, Long, Double,
+ * Float, Character and Short are returned by valueOf as an immediate whose low three bits
+ * are a type tag, with no object header at all. Every operation that would normally read
+ * that header has to be tag-aware, and a mistake there is silent -- the wrong class, or the
+ * wrong hash, with nothing thrown.
+ *
+ * Output must be BYTE-IDENTICAL to a host JVM, so every assertion is printed rather than
+ * asserted locally. Two rules keep it comparable:
+ *   - never print an identity hash code, a raw reference, or the iteration order of a
+ *     HashMap/HashSet: those legitimately differ between VMs;
+ *   - hashCode() of a boxed VALUE is specified by the JDK and IS printed, because matching
+ *     it is exactly what this scheme has to get right.
+ *
+ * The cases deliberately include the ones an ordinary benchmark never reaches: heap boxes
+ * made with `new` alongside tagged ones, cross-type comparisons, NaN and both zeroes, and
+ * Long/Double values chosen to fall OUTSIDE the taggable range so the heap fallback and the
+ * mixed tagged/heap comparison paths are exercised rather than assumed.
+ */
+public final class BoxEdge {
+
+    // Printed as it goes rather than buffered: a native crash on this target is a hard
+    // SIGSEGV with no stack, so the last line emitted is the only locator there is.
+    static void p(String label, Object v) {
+        System.out.println(label + "=" + v);
+    }
+
+    // Values that cannot be represented in the 61-bit payload, so valueOf must fall back to
+    // the heap. If the taggable range ever widens these stop testing the fallback, which is
+    // why the probe below prints whether each one actually took it.
+    static final long BIG_LONG = 4611686018427387905L;   // 2^62 + 1, outside [-2^60, 2^60)
+    static final long BIG_LONG_NEG = -4611686018427387905L;
+    static final double ODD_DOUBLE = 0.1;                // low mantissa bits set
+    static final double ODD_DOUBLE2 = 3.14159265358979;
+
+    public static void main(String[] args) throws Exception {
+        classIdentity();
+        equalsAndHash();
+        crossType();
+        numberConversions();
+        comparisons();
+        collections();
+        floatingPointEdges();
+        stringsAndSwitch();
+        synchronization();
+        arraysAndSorting();
+        System.out.println("BOXEDGE DONE");
+    }
+
+    /* ---- getClass / instanceof / isInstance, on tagged and heap boxes alike ---- */
+    static void classIdentity() {
+        Object[] tagged = {
+            Integer.valueOf(7), Long.valueOf(7L), Double.valueOf(1.5),
+            Float.valueOf(1.5f), Character.valueOf('z'), Short.valueOf((short) 7)
+        };
+        Object[] heap = {
+            new Integer(7), new Long(7L), new Double(1.5),
+            new Float(1.5f), new Character('z'), new Short((short) 7)
+        };
+        Class[] expect = {
+            Integer.class, Long.class, Double.class, Float.class, Character.class, Short.class
+        };
+        for (int i = 0; i < tagged.length; i++) {
+            p("cls.tagged." + i, tagged[i].getClass().getName());
+            p("cls.heap." + i, heap[i].getClass().getName());
+            p("cls.same." + i, tagged[i].getClass() == heap[i].getClass());
+            p("cls.expected." + i, tagged[i].getClass() == expect[i]);
+            p("isInstance.tagged." + i, expect[i].isInstance(tagged[i]));
+            p("isInstance.heap." + i, expect[i].isInstance(heap[i]));
+            p("isInstance.null." + i, expect[i].isInstance(null));
+            p("isInstance.wrong." + i, expect[i].isInstance("a string"));
+            p("isNumber.tagged." + i, tagged[i] instanceof Number);
+            p("isComparable.tagged." + i, tagged[i] instanceof Comparable);
+            p("isString.tagged." + i, tagged[i] instanceof String);
+        }
+        // The fallback values must report the same class as the tagged ones.
+        p("cls.bigLong", Long.valueOf(BIG_LONG).getClass().getName());
+        p("cls.oddDouble", Double.valueOf(ODD_DOUBLE).getClass().getName());
+        p("bigLong.isNumber", Long.valueOf(BIG_LONG) instanceof Number);
+    }
+
+    /* ---- equals and hashCode across tagged/heap/null/wrong-type ---- */
+    static void equalsAndHash() {
+        Object[][] pairs = {
+            { Integer.valueOf(1234), new Integer(1234), Integer.valueOf(1235) },
+            { Long.valueOf(1234L), new Long(1234L), Long.valueOf(1235L) },
+            { Long.valueOf(BIG_LONG), new Long(BIG_LONG), Long.valueOf(BIG_LONG - 1) },
+            { Double.valueOf(2.5), new Double(2.5), Double.valueOf(2.75) },
+            { Double.valueOf(ODD_DOUBLE), new Double(ODD_DOUBLE), Double.valueOf(ODD_DOUBLE2) },
+            { Float.valueOf(2.5f), new Float(2.5f), Float.valueOf(2.75f) },
+            { Character.valueOf('m'), new Character('m'), Character.valueOf('n') },
+            { Short.valueOf((short) 1234), new Short((short) 1234), Short.valueOf((short) 1235) }
+        };
+        for (int i = 0; i < pairs.length; i++) {
+            Object t = pairs[i][0], h = pairs[i][1], other = pairs[i][2];
+            p("eq.tt." + i, t.equals(t));
+            p("eq.th." + i, t.equals(h));
+            p("eq.ht." + i, h.equals(t));
+            p("eq.hh." + i, h.equals(h));
+            p("eq.to." + i, t.equals(other));
+            p("eq.ot." + i, other.equals(t));
+            p("eq.null." + i, t.equals(null));
+            p("eq.str." + i, t.equals("nope"));
+            p("eq.strRev." + i, "nope".equals(t));
+            p("hash.t." + i, t.hashCode());
+            p("hash.h." + i, h.hashCode());
+            p("hash.same." + i, t.hashCode() == h.hashCode());
+            p("hash.other." + i, other.hashCode());
+        }
+    }
+
+    /* ---- a boxed 1 of one type must never equal a boxed 1 of another ---- */
+    static void crossType() {
+        Object[] ones = {
+            Integer.valueOf(1), Long.valueOf(1L), Double.valueOf(1.0),
+            Float.valueOf(1.0f), Character.valueOf((char) 1), Short.valueOf((short) 1)
+        };
+        String[] names = { "Integer", "Long", "Double", "Float", "Character", "Short" };
+        for (int i = 0; i < ones.length; i++) {
+            for (int j = 0; j < ones.length; j++) {
+                p("cross." + names[i] + "." + names[j], ones[i].equals(ones[j]));
+            }
+        }
+        // Same again through a map, which is where a wrong hash actually bites.
+        Map m = new HashMap();
+        for (int i = 0; i < ones.length; i++) {
+            m.put(ones[i], names[i]);
+        }
+        p("cross.mapSize", m.size());
+        for (int i = 0; i < ones.length; i++) {
+            p("cross.get." + names[i], m.get(ones[i]));
+        }
+    }
+
+    /* ---- every Number accessor, on tagged and on heap-fallback values ---- */
+    static void numberConversions() {
+        Number[] ns = {
+            Integer.valueOf(-129), Long.valueOf(-129L), Long.valueOf(BIG_LONG),
+            Long.valueOf(BIG_LONG_NEG), Double.valueOf(-2.75), Double.valueOf(ODD_DOUBLE),
+            Float.valueOf(-2.75f), Short.valueOf((short) -129),
+            Integer.valueOf(Integer.MAX_VALUE), Integer.valueOf(Integer.MIN_VALUE),
+            Long.valueOf(Long.MAX_VALUE), Long.valueOf(Long.MIN_VALUE),
+            Short.valueOf(Short.MAX_VALUE), Short.valueOf(Short.MIN_VALUE),
+            Double.valueOf(Double.MAX_VALUE), Double.valueOf(Double.MIN_VALUE),
+            Float.valueOf(Float.MAX_VALUE), Float.valueOf(Float.MIN_VALUE)
+        };
+        for (int i = 0; i < ns.length; i++) {
+            p("num.byte." + i, ns[i].byteValue());
+            p("num.short." + i, ns[i].shortValue());
+            p("num.int." + i, ns[i].intValue());
+            p("num.long." + i, ns[i].longValue());
+            p("num.float." + i, ns[i].floatValue());
+            p("num.double." + i, ns[i].doubleValue());
+            p("num.str." + i, ns[i].toString());
+            p("num.hash." + i, ns[i].hashCode());
+        }
+        Character c = Character.valueOf(Character.MAX_VALUE);
+        p("char.max.value", (int) c.charValue());
+        p("char.max.str", c.toString());
+        p("char.max.hash", c.hashCode());
+        Character cz = Character.valueOf(Character.MIN_VALUE);
+        p("char.min.value", (int) cz.charValue());
+        p("char.min.hash", cz.hashCode());
+    }
+
+    /* ---- compareTo, including tagged vs heap and across the taggable boundary ---- */
+    static void comparisons() {
+        p("cmp.int", Integer.valueOf(5).compareTo(Integer.valueOf(7)));
+        p("cmp.int.heap", Integer.valueOf(5).compareTo(new Integer(7)));
+        p("cmp.int.eq", Integer.valueOf(5).compareTo(new Integer(5)));
+        p("cmp.long.small", Long.valueOf(5L).compareTo(Long.valueOf(7L)));
+        p("cmp.long.mixed", Long.valueOf(5L).compareTo(Long.valueOf(BIG_LONG)));
+        p("cmp.long.mixedRev", Long.valueOf(BIG_LONG).compareTo(Long.valueOf(5L)));
+        p("cmp.long.bothBig", Long.valueOf(BIG_LONG).compareTo(Long.valueOf(BIG_LONG_NEG)));
+        p("cmp.long.extremes", Long.valueOf(Long.MIN_VALUE).compareTo(Long.valueOf(Long.MAX_VALUE)));
+        p("cmp.double", Double.valueOf(1.5).compareTo(Double.valueOf(2.5)));
+        p("cmp.double.mixed", Double.valueOf(1.5).compareTo(Double.valueOf(ODD_DOUBLE)));
+        p("cmp.double.nan", Double.valueOf(Double.NaN).compareTo(Double.valueOf(1.0)));
+        p("cmp.double.zeroes", Double.valueOf(0.0).compareTo(Double.valueOf(-0.0)));
+        p("cmp.float", Float.valueOf(1.5f).compareTo(Float.valueOf(2.5f)));
+        p("cmp.float.nan", Float.valueOf(Float.NaN).compareTo(Float.valueOf(1.0f)));
+        p("cmp.char", Character.valueOf('a').compareTo(Character.valueOf('b')));
+        p("cmp.char.max", Character.valueOf(Character.MAX_VALUE).compareTo(Character.valueOf('a')));
+        p("cmp.short", Short.valueOf((short) -5).compareTo(Short.valueOf((short) 7)));
+        p("cmp.short.extremes", Short.valueOf(Short.MIN_VALUE).compareTo(Short.valueOf(Short.MAX_VALUE)));
+    }
+
+    /* ---- the collections, which are where a tagged key is actually used ---- */
+    static void collections() {
+        // TreeMap: ordered, so iteration order is deterministic on both VMs. It also routes
+        // every probe through Comparable.compareTo, i.e. INTERFACE dispatch on an immediate.
+        TreeMap tm = new TreeMap();
+        long[] keys = { 0L, 1L, -1L, 127L, 128L, -129L, BIG_LONG, BIG_LONG_NEG,
+                        Long.MAX_VALUE, Long.MIN_VALUE, 1152921504606846975L };
+        for (int i = 0; i < keys.length; i++) {
+            tm.put(Long.valueOf(keys[i]), "v" + keys[i]);
+        }
+        p("tree.size", tm.size());
+        StringBuilder order = new StringBuilder();
+        for (Iterator it = tm.keySet().iterator(); it.hasNext(); ) {
+            order.append(it.next()).append(',');
+        }
+        p("tree.order", order.toString());
+        p("tree.firstKey", tm.firstKey());
+        p("tree.lastKey", tm.lastKey());
+        for (int i = 0; i < keys.length; i++) {
+            p("tree.get." + i, tm.get(Long.valueOf(keys[i])));
+            p("tree.getHeap." + i, tm.get(new Long(keys[i])));
+        }
+        p("tree.missing", tm.get(Long.valueOf(999999L)));
+
+        // HashMap: size and lookups only, never iteration order.
+        Map hm = new HashMap();
+        for (int i = -300; i < 300; i++) {
+            hm.put(Integer.valueOf(i), Integer.valueOf(i * 3));
+            hm.put(Long.valueOf(i), Long.valueOf(i * 5L));
+            hm.put(Short.valueOf((short) i), Short.valueOf((short) (i * 2)));
+            hm.put(Character.valueOf((char) (i + 400)), Character.valueOf((char) (i + 401)));
+            hm.put(Double.valueOf(i / 4.0), Double.valueOf(i / 8.0));
+            hm.put(Float.valueOf(i / 4.0f), Float.valueOf(i / 8.0f));
+        }
+        p("hash.size", hm.size());
+        long acc = 0;
+        for (int i = -300; i < 300; i++) {
+            acc += ((Integer) hm.get(Integer.valueOf(i))).intValue();
+            acc += ((Long) hm.get(new Long(i))).longValue();          // heap key, tagged entry
+            acc += ((Short) hm.get(Short.valueOf((short) i))).shortValue();
+            acc += (int) ((Character) hm.get(Character.valueOf((char) (i + 400)))).charValue();
+            acc += (long) ((Double) hm.get(Double.valueOf(i / 4.0))).doubleValue();
+            acc += (long) ((Float) hm.get(Float.valueOf(i / 4.0f))).floatValue();
+        }
+        p("hash.acc", acc);
+        p("hash.missInt", hm.get(Integer.valueOf(100000)));
+        p("hash.missLong", hm.get(Long.valueOf(BIG_LONG)));
+        p("hash.containsTagged", hm.containsKey(Integer.valueOf(5)));
+        p("hash.containsHeap", hm.containsKey(new Integer(5)));
+        p("hash.removed", hm.remove(new Integer(5)));
+        p("hash.containsAfterRemove", hm.containsKey(Integer.valueOf(5)));
+
+        // HashSet dedup: a tagged box and its heap twin are ONE element.
+        HashSet hs = new HashSet();
+        hs.add(Integer.valueOf(42));
+        hs.add(new Integer(42));
+        hs.add(Long.valueOf(42L));
+        hs.add(new Long(42L));
+        hs.add(Double.valueOf(42.0));
+        hs.add(Short.valueOf((short) 42));
+        hs.add(Character.valueOf((char) 42));
+        hs.add(Float.valueOf(42.0f));
+        p("set.size", hs.size());
+        p("set.hasInt", hs.contains(new Integer(42)));
+        p("set.hasLong", hs.contains(Long.valueOf(42L)));
+
+        // ArrayList: indexOf/contains/remove all go through equals on an immediate.
+        List list = new ArrayList();
+        for (int i = 0; i < 50; i++) {
+            list.add(Integer.valueOf(i));
+            list.add(Long.valueOf(i));
+        }
+        p("list.size", list.size());
+        p("list.indexOfTagged", list.indexOf(Integer.valueOf(30)));
+        p("list.indexOfHeap", list.indexOf(new Integer(30)));
+        p("list.indexOfLong", list.indexOf(Long.valueOf(30L)));
+        p("list.containsMissing", list.contains(Integer.valueOf(1000)));
+        p("list.removeObj", list.remove(Integer.valueOf(30)));
+        p("list.sizeAfter", list.size());
+    }
+
+    /* ---- NaN, both zeroes, infinities: where bit patterns and equals diverge ---- */
+    static void floatingPointEdges() {
+        Double nan1 = Double.valueOf(Double.NaN);
+        Double nan2 = Double.valueOf(0.0 / 0.0);
+        Double pz = Double.valueOf(0.0), nz = Double.valueOf(-0.0);
+        p("d.nanEquals", nan1.equals(nan2));
+        p("d.nanEqualsSelf", nan1.equals(nan1));
+        p("d.nanPrimitiveEq", nan1.doubleValue() == nan2.doubleValue());
+        p("d.nanIsNaN", nan1.isNaN());
+        p("d.nanHash", nan1.hashCode() == nan2.hashCode());
+        p("d.zeroEquals", pz.equals(nz));
+        p("d.zeroPrimitiveEq", pz.doubleValue() == nz.doubleValue());
+        p("d.zeroHashDiffers", pz.hashCode() != nz.hashCode());
+        p("d.posInf", Double.valueOf(Double.POSITIVE_INFINITY).toString());
+        p("d.negInf", Double.valueOf(Double.NEGATIVE_INFINITY).toString());
+        p("d.infIsInfinite", Double.valueOf(Double.POSITIVE_INFINITY).isInfinite());
+        p("d.infEquals", Double.valueOf(Double.POSITIVE_INFINITY)
+                .equals(Double.valueOf(Double.POSITIVE_INFINITY)));
+        p("d.infCross", Double.valueOf(Double.POSITIVE_INFINITY)
+                .equals(Double.valueOf(Double.NEGATIVE_INFINITY)));
+        p("d.bitsNaN", Double.doubleToLongBits(nan1.doubleValue()));
+        p("d.bitsNegZero", Double.doubleToLongBits(nz.doubleValue()));
+
+        Float fnan = Float.valueOf(Float.NaN);
+        Float fpz = Float.valueOf(0.0f), fnz = Float.valueOf(-0.0f);
+        p("f.nanEquals", fnan.equals(Float.valueOf(Float.NaN)));
+        p("f.nanIsNaN", fnan.isNaN());
+        p("f.zeroEquals", fpz.equals(fnz));
+        p("f.zeroPrimitiveEq", fpz.floatValue() == fnz.floatValue());
+        p("f.zeroHashDiffers", fpz.hashCode() != fnz.hashCode());
+        p("f.bitsNaN", Float.floatToIntBits(fnan.floatValue()));
+        p("f.bitsNegZero", Float.floatToIntBits(fnz.floatValue()));
+        p("f.posInf", Float.valueOf(Float.POSITIVE_INFINITY).toString());
+        p("f.negInf", Float.valueOf(Float.NEGATIVE_INFINITY).toString());
+        p("f.nanStr", fnan.toString());
+        p("f.nanStrStatic", Float.toString(Float.NaN));
+        p("f.negZeroStr", fnz.toString());
+        p("f.posZeroStr", fpz.toString());
+        p("f.negZeroStrHeap", new Float(-0.0f).toString());
+        p("d.nanStr", nan1.toString());
+        p("d.negZeroStr", nz.toString());
+        p("d.posZeroStr", pz.toString());
+
+        // A NaN key must be findable in a map even though NaN != NaN.
+        Map m = new HashMap();
+        m.put(nan1, "nan");
+        m.put(pz, "pz");
+        m.put(nz, "nz");
+        p("fp.mapSize", m.size());
+        p("fp.getNaN", m.get(nan2));
+        p("fp.getPz", m.get(Double.valueOf(0.0)));
+        p("fp.getNz", m.get(Double.valueOf(-0.0)));
+    }
+
+    /* ---- toString, concat and switch on a boxed value ---- */
+    static void stringsAndSwitch() {
+        Object[] vs = {
+            Integer.valueOf(-42), Long.valueOf(-42L), Long.valueOf(BIG_LONG),
+            Double.valueOf(-42.5), Double.valueOf(ODD_DOUBLE), Float.valueOf(-42.5f),
+            Character.valueOf('Q'), Short.valueOf((short) -42)
+        };
+        for (int i = 0; i < vs.length; i++) {
+            p("str.toString." + i, vs[i].toString());
+            p("str.concat." + i, "v=" + vs[i] + "!");
+            p("str.valueOf." + i, String.valueOf(vs[i]));
+            p("str.sbAppend." + i, new StringBuilder().append(vs[i]).toString());
+            p("str.equalsStr." + i, vs[i].toString().equals(String.valueOf(vs[i])));
+        }
+        // Unboxing into a switch: the tag has to survive the round trip through Object.
+        Object boxed = Integer.valueOf(3);
+        int unboxed = ((Integer) boxed).intValue();
+        String r;
+        switch (unboxed) {
+            case 1: r = "one"; break;
+            case 3: r = "three"; break;
+            default: r = "other";
+        }
+        p("switch.int", r);
+        Object cboxed = Character.valueOf('b');
+        switch (((Character) cboxed).charValue()) {
+            case 'a': r = "a"; break;
+            case 'b': r = "b"; break;
+            default: r = "other";
+        }
+        p("switch.char", r);
+        // Autoboxing round trip through an Object-typed field.
+        Object o = Integer.valueOf(77);
+        p("autobox.round", ((Integer) o).intValue() + 1);
+    }
+
+    /* ---- monitors on immediates: the side table is keyed by the word itself ---- */
+    static void synchronization() throws Exception {
+        final Object[] locks = {
+            Integer.valueOf(101), Long.valueOf(102L), Double.valueOf(103.0),
+            Float.valueOf(104.0f), Character.valueOf('e'), Short.valueOf((short) 106)
+        };
+        final int[] counter = new int[1];
+        final int threads = 4, iters = 20000;
+        for (int l = 0; l < locks.length; l++) {
+            final Object lock = locks[l];
+            counter[0] = 0;
+            Thread[] ts = new Thread[threads];
+            for (int t = 0; t < threads; t++) {
+                ts[t] = new Thread(new Runnable() {
+                    public void run() {
+                        for (int i = 0; i < iters; i++) {
+                            synchronized (lock) {
+                                counter[0]++;
+                            }
+                        }
+                    }
+                });
+            }
+            for (int t = 0; t < threads; t++) ts[t].start();
+            for (int t = 0; t < threads; t++) ts[t].join();
+            p("sync.guarded." + l, counter[0] == threads * iters);
+        }
+
+        // wait/notify on an immediate must actually park and wake.
+        final Object sig = Double.valueOf(2.0);
+        final boolean[] woke = new boolean[1];
+        Thread waiter = new Thread(new Runnable() {
+            public void run() {
+                synchronized (sig) {
+                    try {
+                        sig.wait(10000);
+                        woke[0] = true;
+                    } catch (InterruptedException e) {
+                        // reported as not woken
+                    }
+                }
+            }
+        });
+        waiter.start();
+        Thread.sleep(200);
+        synchronized (sig) {
+            sig.notifyAll();
+        }
+        waiter.join(10000);
+        p("sync.woke", woke[0]);
+    }
+
+    /* ---- Arrays.sort over boxed values, i.e. interface dispatch on immediates ---- */
+    static void arraysAndSorting() {
+        Long[] ls = {
+            Long.valueOf(5L), Long.valueOf(BIG_LONG), Long.valueOf(-1L),
+            Long.valueOf(BIG_LONG_NEG), Long.valueOf(0L), new Long(3L),
+            Long.valueOf(Long.MAX_VALUE), Long.valueOf(Long.MIN_VALUE)
+        };
+        Arrays.sort(ls);
+        p("sort.long", Arrays.toString(ls));
+
+        Integer[] is = new Integer[200];
+        for (int i = 0; i < is.length; i++) {
+            is[i] = Integer.valueOf((i * 37) % 200 - 100);
+        }
+        Arrays.sort(is);
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < is.length; i++) sb.append(is[i]).append(',');
+        p("sort.int", sb.toString());
+
+        Double[] ds = {
+            Double.valueOf(1.5), Double.valueOf(ODD_DOUBLE), Double.valueOf(-0.0),
+            Double.valueOf(0.0), Double.valueOf(ODD_DOUBLE2), new Double(2.0),
+            Double.valueOf(Double.MAX_VALUE), Double.valueOf(-1.0)
+        };
+        Arrays.sort(ds);
+        p("sort.double", Arrays.toString(ds));
+
+        Character[] cs = {
+            Character.valueOf('z'), Character.valueOf('a'), Character.valueOf(Character.MAX_VALUE),
+            new Character('m'), Character.valueOf(Character.MIN_VALUE)
+        };
+        Arrays.sort(cs);
+        StringBuilder cb = new StringBuilder();
+        for (int i = 0; i < cs.length; i++) cb.append((int) cs[i].charValue()).append(',');
+        p("sort.char", cb.toString());
+
+        Short[] ss = {
+            Short.valueOf((short) 5), Short.valueOf(Short.MIN_VALUE),
+            new Short((short) -1), Short.valueOf(Short.MAX_VALUE), Short.valueOf((short) 0)
+        };
+        Arrays.sort(ss);
+        p("sort.short", Arrays.toString(ss));
+
+        Float[] fs = {
+            Float.valueOf(1.5f), Float.valueOf(-0.0f), Float.valueOf(0.0f),
+            new Float(2.5f), Float.valueOf(Float.MAX_VALUE), Float.valueOf(-1.0f)
+        };
+        Arrays.sort(fs);
+        p("sort.float", Arrays.toString(fs));
+    }
+}

--- a/vm/benchmarks/src/com/bench/BoxEdge.java
+++ b/vm/benchmarks/src/com/bench/BoxEdge.java
@@ -82,10 +82,11 @@ public final class BoxEdge {
     }
 
     /**
-     * Which tag code each boxed type actually got in THIS build, on stderr.
+     * Whether each boxed type's valueOf returns an IMMEDIATE in this build, one digit per
+     * type in the order Integer Long Double Float Character Short.
      *
      * It carries the `[` prefix this tree uses for diagnostics ([GCPROBE], [ALLOC:...]),
-     * because that is what `run-gauntlet.sh` filters out of BOTH sides before comparing --
+     * because that is what run-gauntlet.sh filters out of BOTH sides before comparing --
      * stdout has to stay byte-identical to a host JVM and this line is target-specific by
      * construction. Note stderr is NOT a way out: on the clean target System.err also
      * reaches fd 1, so a stderr diagnostic still lands in the compared stream.
@@ -94,18 +95,33 @@ public final class BoxEdge {
      * on a build where tagging never happened -- that is the point, the two representations
      * must be indistinguishable -- so without a witness saying which arm ran, a green
      * BoxEdge cannot tell "the tagged path is correct" from "the tagged path never
-     * executed". Expect 123456 in a default build and 000000 with -DCN1_DISABLE_TAGGED_INT.
+     * executed". Expect 111111 in a default build and 000000 with -DCN1_DISABLE_TAGGED_INT.
+     *
+     * The test is valueOf(v) == valueOf(v) at a value outside every -128..127 cache, rather
+     * than a read of the pointer bits: identityHashCode folds a tagged word's two halves
+     * now, so the tag code is no longer recoverable from it. If a compiler ever CSEs the two
+     * calls into one this would report 1 unconditionally -- which the untagged arm's
+     * expected 000000 catches, so the two-arm assertion is what keeps the witness honest.
      */
     static void reportTagCodes() {
         StringBuilder sb = new StringBuilder();
-        sb.append(System.identityHashCode(Integer.valueOf(1)) & 7);
-        sb.append(System.identityHashCode(Long.valueOf(1L)) & 7);
-        sb.append(System.identityHashCode(Double.valueOf(1.0)) & 7);
-        sb.append(System.identityHashCode(Float.valueOf(1.0f)) & 7);
-        sb.append(System.identityHashCode(Character.valueOf('a')) & 7);
-        sb.append(System.identityHashCode(Short.valueOf((short) 1)) & 7);
-        System.out.println("[TAGCODES] " + sb);
+        sb.append(Integer.valueOf(IMM_I) == Integer.valueOf(IMM_I) ? 1 : 0);
+        sb.append(Long.valueOf(IMM_J) == Long.valueOf(IMM_J) ? 1 : 0);
+        sb.append(Double.valueOf(IMM_D) == Double.valueOf(IMM_D) ? 1 : 0);
+        sb.append(Float.valueOf(IMM_F) == Float.valueOf(IMM_F) ? 1 : 0);
+        sb.append(Character.valueOf(IMM_C) == Character.valueOf(IMM_C) ? 1 : 0);
+        sb.append(Short.valueOf(IMM_S) == Short.valueOf(IMM_S) ? 1 : 0);
+        System.out.println("[TAGGED] " + sb);
     }
+
+    // Deliberately outside every wrapper cache (-128..127, and 0..127 for Character), so a
+    // true from == means an immediate rather than a shared cache entry.
+    static final int IMM_I = 1000;
+    static final long IMM_J = 1000L;
+    static final double IMM_D = 1.5;
+    static final float IMM_F = 1.5f;
+    static final char IMM_C = (char) 1000;
+    static final short IMM_S = (short) 1000;
 
     /* ---- getClass / instanceof / isInstance, on tagged and heap boxes alike ---- */
     static void classIdentity() {

--- a/vm/benchmarks/src/com/bench/TagProbe.java
+++ b/vm/benchmarks/src/com/bench/TagProbe.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.bench;
+
+import java.util.ArrayList;
+
+/**
+ * Diagnostic, not a torture. Three jobs:
+ *
+ * 1. Report which tag code each boxed type actually got, so a change to the encoding is
+ *    provable rather than assumed. System.identityHashCode returns the low 32 bits of the
+ *    reference on this VM, which for a tagged value IS the encoded word.
+ * 2. ASSERT that every real object is 8-byte aligned. The tag occupies the low three bits,
+ *    so an object at a 4-byte address would be misread as an immediate. The invariant is
+ *    already load-bearing -- cn1ConservativeResolve rejects the same three bits -- but it
+ *    had never been checked against the allocator, and it has to hold on every path: the
+ *    BiBOP bump, the legacy calloc above CN1_BIBOP_MAX_OBJECT, arrays, fused
+ *    String/StringBuilder, and the class objects themselves.
+ * 3. Report the COVERAGE of the two partial encodings. Long and Double cannot represent
+ *    every value in 61 bits, and a partial scheme that looks excellent on a benchmark and
+ *    never fires on real data is the failure mode worth guarding against.
+ *
+ * Deliberately NOT in the gauntlet: the output is target specific and is not bit-identical
+ * to a host JVM. It self-checks and exits non-zero instead.
+ */
+public final class TagProbe {
+    static int failures;
+
+    // Over CN1_BIBOP_MAX_OBJECT (512 bytes), so this takes the legacy calloc path.
+    static final class Big {
+        long a0,a1,a2,a3,a4,a5,a6,a7,a8,a9,b0,b1,b2,b3,b4,b5,b6,b7,b8,b9;
+        long c0,c1,c2,c3,c4,c5,c6,c7,c8,c9,d0,d1,d2,d3,d4,d5,d6,d7,d8,d9;
+        long e0,e1,e2,e3,e4,e5,e6,e7,e8,e9,f0,f1,f2,f3,f4,f5,f6,f7,f8,f9;
+        long g0,g1,g2,g3,g4,g5,g6,g7,g8,g9,h0,h1,h2,h3,h4,h5,h6,h7,h8,h9;
+    }
+
+    static final class Small { int a; Object b; }
+
+    static int tagOf(Object o) { return System.identityHashCode(o) & 7; }
+
+    static void mustBeHeap(String what, Object o) {
+        if (tagOf(o) != 0) {
+            System.out.println("MISALIGNED " + what + " lowBits=" + tagOf(o));
+            failures++;
+        }
+    }
+
+    /**
+     * A boxed value must carry either its OWN tag code or none at all -- never another
+     * type's. Tag 0 is legitimate in three situations: the -DCN1_DISABLE_TAGGED_INT and
+     * -DCN1_DISABLE_TAGGED_VALUES ablation arms, a 32-bit-pointer target, and a Long or
+     * Double outside the taggable range. Asserting the exact code instead would make this
+     * probe pass only in the default arm, which is the arm least in need of checking.
+     */
+    static void expectTag(String what, Object o, int expected) {
+        int got = tagOf(o);
+        if (got != expected && got != 0) {
+            System.out.println("WRONGTAG " + what + " got=" + got + " want=" + expected + " or 0");
+            failures++;
+        }
+    }
+
+    static void check(String what, boolean ok) {
+        if (!ok) { System.out.println("FAILED " + what); failures++; }
+    }
+
+    public static void main(String[] a) {
+        // --- which code did each type get, and does the value survive the round trip ---
+        System.out.println("Integer   tag=" + tagOf(Integer.valueOf(42))
+                + " roundTrip=" + (Integer.valueOf(-7).intValue() == -7));
+        System.out.println("Long      tag=" + tagOf(Long.valueOf(42L))
+                + " roundTrip=" + (Long.valueOf(-7L).longValue() == -7L));
+        System.out.println("Double    tag=" + tagOf(Double.valueOf(1.5))
+                + " roundTrip=" + (Double.valueOf(-1.5).doubleValue() == -1.5));
+        System.out.println("Float     tag=" + tagOf(Float.valueOf(1.5f))
+                + " roundTrip=" + (Float.valueOf(-1.5f).floatValue() == -1.5f));
+        System.out.println("Character tag=" + tagOf(Character.valueOf('q'))
+                + " roundTrip=" + (Character.valueOf(Character.MAX_VALUE).charValue() == Character.MAX_VALUE));
+        System.out.println("Short     tag=" + tagOf(Short.valueOf((short) 42))
+                + " roundTrip=" + (Short.valueOf((short) -32768).shortValue() == -32768));
+
+        expectTag("Integer", Integer.valueOf(42), 1);
+        expectTag("Long", Long.valueOf(42L), 2);
+        expectTag("Double", Double.valueOf(1.5), 3);
+        expectTag("Float", Float.valueOf(1.5f), 4);
+        expectTag("Character", Character.valueOf('q'), 5);
+        expectTag("Short", Short.valueOf((short) 42), 6);
+
+        // Constructors must still produce real, distinct heap objects -- `new` guarantees
+        // identity, and only the valueOf factories are allowed to return an immediate.
+        Long n1 = new Long(42L), n2 = new Long(42L);
+        mustBeHeap("new Long", n1);
+        mustBeHeap("new Double", new Double(1.5));
+        mustBeHeap("new Float", new Float(1.5f));
+        mustBeHeap("new Character", new Character('q'));
+        mustBeHeap("new Short", new Short((short) 42));
+        mustBeHeap("new Integer", new Integer(42));
+        check("new Long identity distinct", n1 != n2);
+        check("new Long equals tagged", n1.equals(Long.valueOf(42L)));
+        check("tagged equals new Long", Long.valueOf(42L).equals(n1));
+
+        // --- alignment, over every allocation shape, many times ---
+        for (int i = 0; i < 20000; i++) {
+            mustBeHeap("Small", new Small());
+            mustBeHeap("Big", new Big());
+            mustBeHeap("Object", new Object());
+            mustBeHeap("byte[7]", new byte[7]);
+            mustBeHeap("byte[1000]", new byte[1000]);
+            mustBeHeap("int[3]", new int[3]);
+            mustBeHeap("Object[5]", new Object[5]);
+            mustBeHeap("String", new String(new char[] { 'a', (char) i }));
+            mustBeHeap("StringBuilder", new StringBuilder("x").append(i));
+            mustBeHeap("ArrayList", new ArrayList());
+            mustBeHeap("clazz(Small)", new Small().getClass());
+            mustBeHeap("clazz(int[])", new int[1].getClass());
+            mustBeHeap("interned", ("lit" + (i & 3)).intern());
+        }
+
+        // --- the taggable boundary, exactly ---
+        // This is the one place an off-by-one CORRUPTS rather than merely misses: a value
+        // wrongly judged representable is truncated into the payload and read back wrong.
+        // The payload is bits 3..63 read as signed, so the range is [-2^60, 2^60).
+        long[] edges = {
+            (1L << 60) - 1, 1L << 60, (1L << 60) + 1,
+            -(1L << 60), -(1L << 60) - 1, -(1L << 60) + 1,
+            Long.MAX_VALUE, Long.MIN_VALUE, 0L, -1L
+        };
+        for (int i = 0; i < edges.length; i++) {
+            Long boxed = Long.valueOf(edges[i]);
+            int tag = tagOf(boxed);
+            boolean inRange = edges[i] >= -(1L << 60) && edges[i] < (1L << 60);
+            // Whatever the encoding decides, the value must survive. A tagged value outside
+            // the range would fail here, which is the failure that matters.
+            check("long roundTrip " + edges[i], boxed.longValue() == edges[i]);
+            check("long equals " + edges[i], boxed.equals(new Long(edges[i])));
+            if (tag == 2 && !inRange) {
+                System.out.println("OVERTAGGED " + edges[i] + " was tagged but is out of range");
+                failures++;
+            }
+            if (tag == 0 && inRange) {
+                System.out.println("UNDERTAGGED " + edges[i] + " is in range but was not tagged");
+                failures++;
+            }
+        }
+
+        // Doubles whose low mantissa bits are set must not be tagged, and must round-trip.
+        double[] dedges = { 0.1, 3.14159265358979, Double.MIN_VALUE, Double.MAX_VALUE,
+                            -0.0, 0.0, 1.0, 0.5, Double.NaN,
+                            Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY };
+        for (int i = 0; i < dedges.length; i++) {
+            Double boxed = Double.valueOf(dedges[i]);
+            // doubleToLongBits, not RawLongBits: vm/JavaAPI's Double declares no raw
+            // variant (the C native exists but nothing in Java reaches it). The only
+            // difference is NaN canonicalization, and every NaN constructible here is
+            // already the canonical one.
+            boolean bitsClear = (Double.doubleToLongBits(dedges[i]) & 7L) == 0;
+            check("double roundTrip " + i,
+                  Double.doubleToLongBits(boxed.doubleValue())
+                      == Double.doubleToLongBits(dedges[i]));
+            if (tagOf(boxed) == 3 && !bitsClear) {
+                System.out.println("OVERTAGGED double index " + i);
+                failures++;
+            }
+        }
+
+        // --- coverage of the two partial encodings ---
+        int longTagged = 0, longTotal = 0;
+        long seed = 12345;
+        for (int i = 0; i < 100000; i++) {
+            seed = seed * 6364136223846793005L + 1442695040888963407L;
+            // A spread of realistic magnitudes rather than uniform 64-bit noise.
+            long v;
+            switch (i & 3) {
+                case 0: v = i; break;                          // small counter
+                case 1: v = 1757000000000L + i; break;         // epoch millis
+                case 2: v = seed >> 20; break;                 // 44-bit-ish
+                default: v = seed; break;                      // full 64-bit noise
+            }
+            longTotal++;
+            if (tagOf(Long.valueOf(v)) == 2) longTagged++;
+        }
+        System.out.println("longTaggedPct=" + (longTagged * 100 / longTotal));
+
+        int dblTagged = 0, dblTotal = 0;
+        for (int i = 0; i < 100000; i++) {
+            double d;
+            switch (i & 3) {
+                case 0: d = i; break;                 // JSON integer
+                case 1: d = i / 2.0; break;           // exact halves
+                case 2: d = i / 100.0; break;         // money, mostly inexact
+                default: d = Math.sqrt(i); break;     // arbitrary
+            }
+            dblTotal++;
+            if (tagOf(Double.valueOf(d)) == 3) dblTagged++;
+        }
+        System.out.println("doubleTaggedPct=" + (dblTagged * 100 / dblTotal));
+
+        System.out.println("failures=" + failures);
+        System.out.println(failures == 0 ? "TAGPROBE GREEN" : "TAGPROBE RED");
+        if (failures != 0) {
+            System.exit(1);
+        }
+    }
+}

--- a/vm/benchmarks/src/com/bench/TagProbe.java
+++ b/vm/benchmarks/src/com/bench/TagProbe.java
@@ -56,26 +56,24 @@ public final class TagProbe {
 
     static final class Small { int a; Object b; }
 
+    /**
+     * The low bits of a HEAP reference's identity hash, which is a truncated address here.
+     * Only valid for real objects: identityHashCode folds a tagged word's two halves, so a
+     * tagged value's low bits are no longer its tag code.
+     */
     static int tagOf(Object o) { return System.identityHashCode(o) & 7; }
+
+    /**
+     * Whether valueOf returned an IMMEDIATE, tested by its observable consequence rather
+     * than by reading pointer bits: two separately-obtained boxes of one value are the same
+     * reference only if that value is an immediate. The callers below all pass a value
+     * outside every -128..127 wrapper cache, so a shared cache entry cannot fake it.
+     */
+    static boolean immediate(Object a, Object b) { return a == b; }
 
     static void mustBeHeap(String what, Object o) {
         if (tagOf(o) != 0) {
             System.out.println("MISALIGNED " + what + " lowBits=" + tagOf(o));
-            failures++;
-        }
-    }
-
-    /**
-     * A boxed value must carry either its OWN tag code or none at all -- never another
-     * type's. Tag 0 is legitimate in three situations: the -DCN1_DISABLE_TAGGED_INT and
-     * -DCN1_DISABLE_TAGGED_VALUES ablation arms, a 32-bit-pointer target, and a Long or
-     * Double outside the taggable range. Asserting the exact code instead would make this
-     * probe pass only in the default arm, which is the arm least in need of checking.
-     */
-    static void expectTag(String what, Object o, int expected) {
-        int got = tagOf(o);
-        if (got != expected && got != 0) {
-            System.out.println("WRONGTAG " + what + " got=" + got + " want=" + expected + " or 0");
             failures++;
         }
     }
@@ -86,25 +84,19 @@ public final class TagProbe {
 
     public static void main(String[] a) {
         // --- which code did each type get, and does the value survive the round trip ---
-        System.out.println("Integer   tag=" + tagOf(Integer.valueOf(42))
+        // Values outside every -128..127 cache, so "same reference twice" means immediate.
+        System.out.println("Integer   immediate=" + immediate(Integer.valueOf(1000), Integer.valueOf(1000))
                 + " roundTrip=" + (Integer.valueOf(-7).intValue() == -7));
-        System.out.println("Long      tag=" + tagOf(Long.valueOf(42L))
+        System.out.println("Long      immediate=" + immediate(Long.valueOf(1000L), Long.valueOf(1000L))
                 + " roundTrip=" + (Long.valueOf(-7L).longValue() == -7L));
-        System.out.println("Double    tag=" + tagOf(Double.valueOf(1.5))
+        System.out.println("Double    immediate=" + immediate(Double.valueOf(1.5), Double.valueOf(1.5))
                 + " roundTrip=" + (Double.valueOf(-1.5).doubleValue() == -1.5));
-        System.out.println("Float     tag=" + tagOf(Float.valueOf(1.5f))
+        System.out.println("Float     immediate=" + immediate(Float.valueOf(1.5f), Float.valueOf(1.5f))
                 + " roundTrip=" + (Float.valueOf(-1.5f).floatValue() == -1.5f));
-        System.out.println("Character tag=" + tagOf(Character.valueOf('q'))
+        System.out.println("Character immediate=" + immediate(Character.valueOf((char) 1000), Character.valueOf((char) 1000))
                 + " roundTrip=" + (Character.valueOf(Character.MAX_VALUE).charValue() == Character.MAX_VALUE));
-        System.out.println("Short     tag=" + tagOf(Short.valueOf((short) 42))
+        System.out.println("Short     immediate=" + immediate(Short.valueOf((short) 1000), Short.valueOf((short) 1000))
                 + " roundTrip=" + (Short.valueOf((short) -32768).shortValue() == -32768));
-
-        expectTag("Integer", Integer.valueOf(42), 1);
-        expectTag("Long", Long.valueOf(42L), 2);
-        expectTag("Double", Double.valueOf(1.5), 3);
-        expectTag("Float", Float.valueOf(1.5f), 4);
-        expectTag("Character", Character.valueOf('q'), 5);
-        expectTag("Short", Short.valueOf((short) 42), 6);
 
         // Constructors must still produce real, distinct heap objects -- `new` guarantees
         // identity, and only the valueOf factories are allowed to return an immediate.
@@ -136,6 +128,25 @@ public final class TagProbe {
             mustBeHeap("interned", ("lit" + (i & 3)).intern());
         }
 
+        // --- identity hashes of tagged values must actually spread ---
+        // The Double encoding carries the raw IEEE pattern, whose distinguishing bits for
+        // 1.0, 2.0, 3.0 ... all live in the HIGH word. Truncating the tagged word to an int
+        // gave every integral double the same identity hash, which turns IdentityHashMap's
+        // linear probe quadratic. identityHashCode folds both halves for tagged values now;
+        // this is what proves it, and it fails loudly if the fold is ever removed.
+        int n = 4096;
+        java.util.HashSet<Integer> dh = new java.util.HashSet<Integer>();
+        java.util.HashSet<Integer> lh = new java.util.HashSet<Integer>();
+        for (int i = 0; i < n; i++) {
+            dh.add(Integer.valueOf(System.identityHashCode(Double.valueOf(i))));
+            lh.add(Integer.valueOf(System.identityHashCode(Long.valueOf(i))));
+        }
+        System.out.println("distinctIdentityHash double=" + dh.size() + "/" + n
+                + " long=" + lh.size() + "/" + n);
+        // Allow some collision, but nothing like the single bucket this used to produce.
+        check("integral doubles spread across identity hashes", dh.size() > n * 3 / 4);
+        check("longs spread across identity hashes", lh.size() > n * 3 / 4);
+
         // --- the taggable boundary, exactly ---
         // This is the one place an off-by-one CORRUPTS rather than merely misses: a value
         // wrongly judged representable is truncated into the payload and read back wrong.
@@ -147,17 +158,17 @@ public final class TagProbe {
         };
         for (int i = 0; i < edges.length; i++) {
             Long boxed = Long.valueOf(edges[i]);
-            int tag = tagOf(boxed);
+            boolean isImm = immediate(Long.valueOf(edges[i]), Long.valueOf(edges[i]));
             boolean inRange = edges[i] >= -(1L << 60) && edges[i] < (1L << 60);
             // Whatever the encoding decides, the value must survive. A tagged value outside
             // the range would fail here, which is the failure that matters.
             check("long roundTrip " + edges[i], boxed.longValue() == edges[i]);
             check("long equals " + edges[i], boxed.equals(new Long(edges[i])));
-            if (tag == 2 && !inRange) {
+            if (isImm && !inRange) {
                 System.out.println("OVERTAGGED " + edges[i] + " was tagged but is out of range");
                 failures++;
             }
-            if (tag == 0 && inRange) {
+            if (!isImm && inRange) {
                 System.out.println("UNDERTAGGED " + edges[i] + " is in range but was not tagged");
                 failures++;
             }
@@ -177,7 +188,7 @@ public final class TagProbe {
             check("double roundTrip " + i,
                   Double.doubleToLongBits(boxed.doubleValue())
                       == Double.doubleToLongBits(dedges[i]));
-            if (tagOf(boxed) == 3 && !bitsClear) {
+            if (immediate(Double.valueOf(dedges[i]), Double.valueOf(dedges[i])) && !bitsClear) {
                 System.out.println("OVERTAGGED double index " + i);
                 failures++;
             }
@@ -197,7 +208,7 @@ public final class TagProbe {
                 default: v = seed; break;                      // full 64-bit noise
             }
             longTotal++;
-            if (tagOf(Long.valueOf(v)) == 2) longTagged++;
+            if (immediate(Long.valueOf(v), Long.valueOf(v))) longTagged++;
         }
         System.out.println("longTaggedPct=" + (longTagged * 100 / longTotal));
 
@@ -211,7 +222,7 @@ public final class TagProbe {
                 default: d = Math.sqrt(i); break;     // arbitrary
             }
             dblTotal++;
-            if (tagOf(Double.valueOf(d)) == 3) dblTagged++;
+            if (immediate(Double.valueOf(d), Double.valueOf(d))) dblTagged++;
         }
         System.out.println("doubleTaggedPct=" + (dblTagged * 100 / dblTotal));
 

--- a/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerObjectValidationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/DebuggerObjectValidationTest.java
@@ -86,6 +86,24 @@ class DebuggerObjectValidationTest {
         assertEquals("rejected", probe("INT_AS_REFERENCE"));
     }
 
+    /**
+     * A machine word whose low three bits spell a tag code is INDISTINGUISHABLE from a
+     * genuine boxed immediate -- they are the same bit pattern by construction -- so the
+     * debugger reports a boxed value rather than a rejection. That is not a regression in
+     * safety: it never dereferences the word, which is the property issue #5333 was about,
+     * and it is not new either, since an odd word was already a tagged Integer when the tag
+     * was one bit. Widening the tag to three bits only widens the fraction of arbitrary
+     * words this covers, from one in two to seven in eight.
+     *
+     * The GC is unaffected. cn1ConservativeResolve rejects any word with a bit set in
+     * (sizeof(void*) - 1), which is the same three bits, so a misread int was never a root
+     * before this change and is not one now.
+     */
+    @Test
+    void anIntSlotThatLooksLikeAnImmediateIsReportedWithoutBeingDereferenced() throws Exception {
+        assertEquals("accepted", probe("INT_AS_IMMEDIATE"));
+    }
+
     /** An address in no mapping at all must come back as a rejection, not a signal. */
     @Test
     void anUnmappedAddressIsRejectedWithoutFaulting() throws Exception {
@@ -127,6 +145,19 @@ class DebuggerObjectValidationTest {
     }
 
     /** Its value comes from the tag, since there is no field to read. */
+    @Test
+    void everyTaggedTypeReportsItsOwnClass() throws Exception {
+        // Naming Integer directly was right only while Integer was the sole tagged type.
+        // A Long reported as an Integer would show a garbage value in the debugger with
+        // nothing thrown, so each code has to resolve to its own class.
+        assertEquals("111111", probe("TAGGED_CLASSES"));
+    }
+
+    @Test
+    void everyTaggedTypeDecodesToItsWireTypeAndValue() throws Exception {
+        assertEquals("ok", probe("TAGGED_DECODE"));
+    }
+
     @Test
     void aTaggedIntegerCarriesItsValueInTheReference() throws Exception {
         assertEquals("42", probe("TAGGED_INT_VALUE"));
@@ -407,7 +438,7 @@ class DebuggerObjectValidationTest {
     @Test
     void noCandidateEverCrashesTheProcess() throws Exception {
         List<String> cases = Arrays.asList("REGISTERED", "ARRAY", "IMPOSTOR",
-                "INT_AS_REFERENCE", "WILD_POINTER", "MISALIGNED", "NULL_PAGE",
+                "INT_AS_REFERENCE", "INT_AS_IMMEDIATE", "WILD_POINTER", "MISALIGNED", "NULL_PAGE",
                 "NULL", "NO_CLASS_WORD", "TAGGED_INT", "TAGGED_INT_CLASS",
                 "TAGGED_INT_VALUE", "WIRE_ID_ISSUED", "WIRE_ID_AFTER_RESUME",
                 "WIRE_ID_NEVER_ISSUED", "WIRE_ID_TAGGED", "ISSUE_MANY",
@@ -490,7 +521,19 @@ class DebuggerObjectValidationTest {
             "    } else if (strcmp(which, \"NO_CLASS_WORD\") == 0) {\n" +
             "        candidate = &object;\n" +
             "    } else if (strcmp(which, \"INT_AS_REFERENCE\") == 0) {\n" +
-            "        /* The issue #5333 shape: eight bytes read over a four-byte local. */\n" +
+            "        /* The issue #5333 shape: eight bytes read over a four-byte local.\n" +
+            "           The value has its low three bits CLEAR so the word is\n" +
+            "           pointer-shaped and has to be rejected on its address rather than\n" +
+            "           on its tag -- which is the path this test exists to cover. A value\n" +
+            "           whose low bits form a tag code is a different case, below. */\n" +
+            "        volatile JAVA_INT slot = 40;\n" +
+            "        candidate = *(JAVA_OBJECT*)(void*)&slot;\n" +
+            "    } else if (strcmp(which, \"INT_AS_IMMEDIATE\") == 0) {\n" +
+            "        /* The same misread, but the value's low three bits happen to spell a\n" +
+            "           tag code. Nothing can tell this from a genuine boxed immediate --\n" +
+            "           they are the same bit pattern -- so the debugger reports a boxed\n" +
+            "           value. What matters is that it does so WITHOUT dereferencing, which\n" +
+            "           is the property issue #5333 was about. */\n" +
             "        volatile JAVA_INT slot = 42;\n" +
             "        candidate = *(JAVA_OBJECT*)(void*)&slot;\n" +
             "    } else if (strcmp(which, \"WILD_POINTER\") == 0) {\n" +
@@ -721,8 +764,40 @@ class DebuggerObjectValidationTest {
             "    } else if (strcmp(which, \"TAGGED_INT_NEGATIVE\") == 0) {\n" +
             "        printf(\"%d\\n\", cn1_debugger_tagged_int_value(CN1_TAG_INT(-7)));\n" +
             "        return 0;\n" +
+            "    } else if (strcmp(which, \"TAGGED_CLASSES\") == 0) {\n" +
+            "        printf(\"%d%d%d%d%d%d\\n\",\n" +
+            "            cn1_debugger_class_of(CN1_TAG_INT(1)) == &class__java_lang_Integer,\n" +
+            "            cn1_debugger_class_of(CN1_TAG_LONG_VAL(1)) == &class__java_lang_Long,\n" +
+            "            cn1_debugger_class_of(CN1_TAG_DOUBLE_BITS(0x3FF0000000000000ULL))\n" +
+            "                == &class__java_lang_Double,\n" +
+            "            cn1_debugger_class_of(CN1_TAG_FLOAT_BITS(0x3F800000U))\n" +
+            "                == &class__java_lang_Float,\n" +
+            "            cn1_debugger_class_of(CN1_TAG_CHAR_VAL(65)) == &class__java_lang_Character,\n" +
+            "            cn1_debugger_class_of(CN1_TAG_SHORT_VAL(-3)) == &class__java_lang_Short);\n" +
+            "        return 0;\n" +
+            "    } else if (strcmp(which, \"TAGGED_DECODE\") == 0) {\n" +
+            "        char t; uint64_t v; int ok = 1;\n" +
+            "        ok &= cn1_debugger_tagged_value(CN1_TAG_INT(-7), &t, &v)\n" +
+            "              && t == 'I' && (int32_t)(uint32_t)v == -7;\n" +
+            "        ok &= cn1_debugger_tagged_value(CN1_TAG_LONG_VAL(-99), &t, &v)\n" +
+            "              && t == 'J' && (int64_t)v == -99;\n" +
+            "        ok &= cn1_debugger_tagged_value(CN1_TAG_DOUBLE_BITS(0x3FF0000000000000ULL), &t, &v)\n" +
+            "              && t == 'D' && v == 0x3FF0000000000000ULL;\n" +
+            "        ok &= cn1_debugger_tagged_value(CN1_TAG_FLOAT_BITS(0x3F800000U), &t, &v)\n" +
+            "              && t == 'F' && v == 0x3F800000U;\n" +
+            "        ok &= cn1_debugger_tagged_value(CN1_TAG_CHAR_VAL(65535), &t, &v)\n" +
+            "              && t == 'C' && v == 65535;\n" +
+            "        ok &= cn1_debugger_tagged_value(CN1_TAG_SHORT_VAL(-32768), &t, &v)\n" +
+            "              && t == 'S' && (int32_t)(uint32_t)v == -32768;\n" +
+            "        ok &= cn1_debugger_tagged_int_value(CN1_TAG_LONG_VAL(5)) == 0;\n" +
+            "        printf(\"%s\\n\", ok ? \"ok\" : \"bad\");\n" +
+            "        return 0;\n" +
             "    } else if (strcmp(which, \"MISALIGNED\") == 0) {\n" +
-            "        candidate = (JAVA_OBJECT)(((uintptr_t)&object) | 2);\n" +
+            "        // Tag code 7 is reserved -- no valueOf produces it and its proxy slot\n" +
+            "        // carries no class -- so this stays an impossible reference. `| 2`\n" +
+            "        // was used here until the tag widened to three bits, at which point it\n" +
+            "        // became a perfectly valid tagged Long.\n" +
+            "        candidate = (JAVA_OBJECT)(((uintptr_t)&object) | 7);\n" +
             "    } else if (strcmp(which, \"NULL_PAGE\") == 0) {\n" +
             "        candidate = (JAVA_OBJECT)(uintptr_t)0x18;\n" +
             "    } else if (strcmp(which, \"NULL\") == 0) {\n" +

--- a/vm/tests/src/test/java/com/codename1/tools/translator/NativeDebuggerHarness.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/NativeDebuggerHarness.java
@@ -104,13 +104,23 @@ final class NativeDebuggerHarness {
     }
 
     /**
-     * java.lang.Integer's clazz and the tagged-int proxy are emitted by the
-     * translator into the app's own sources. The debugger unit references both
+     * The boxed classes and the tagged-value proxy table are emitted by the
+     * translator into the app's own sources. The debugger unit references them
      * by symbol, so a host build has to supply them.
+     *
+     * The proxy table must be POPULATED, not merely defined: cn1_debugger_class_of
+     * resolves a tagged reference through CN1_CLASS_OF, which reads it. An all-zero
+     * table would make every tagged reference resolve to a null class and quietly
+     * turn the tagged tests into assertions about nothing.
      */
     private static final String GENERATED_SYMBOLS =
             "#include \"cn1_globals.h\"\n"
           + "struct clazz class__java_lang_Integer = { 0 };\n"
+          + "struct clazz class__java_lang_Long = { 0 };\n"
+          + "struct clazz class__java_lang_Double = { 0 };\n"
+          + "struct clazz class__java_lang_Float = { 0 };\n"
+          + "struct clazz class__java_lang_Character = { 0 };\n"
+          + "struct clazz class__java_lang_Short = { 0 };\n"
           // The collector's mark entry point. Records whether a nominated
           // reference was reached, rather than buffering every mark -- the
           // table can hold thousands, so a fixed buffer would answer "was it
@@ -124,7 +134,14 @@ final class NativeDebuggerHarness {
           + "    if (o == cn1MarkRootTarget) cn1MarkRootTargetSeen = 1;\n"
           + "}\n"
           + "#if CN1_TAGGED_ACTIVE\n"
-          + "struct JavaObjectPrototype cn1TaggedProxy = { 0 };\n"
+          + "struct JavaObjectPrototype cn1TaggedProxy[CN1_TAG_COUNT] = {\n"
+          + "    [CN1_TAG_INTEGER]   = { .__codenameOneParentClsReference = &class__java_lang_Integer },\n"
+          + "    [CN1_TAG_LONG]      = { .__codenameOneParentClsReference = &class__java_lang_Long },\n"
+          + "    [CN1_TAG_DOUBLE]    = { .__codenameOneParentClsReference = &class__java_lang_Double },\n"
+          + "    [CN1_TAG_FLOAT]     = { .__codenameOneParentClsReference = &class__java_lang_Float },\n"
+          + "    [CN1_TAG_CHARACTER] = { .__codenameOneParentClsReference = &class__java_lang_Character },\n"
+          + "    [CN1_TAG_SHORT]     = { .__codenameOneParentClsReference = &class__java_lang_Short }\n"
+          + "};\n"
           + "#endif\n";
 
     private static Path runtimeInclude() {

--- a/vm/tests/src/test/java/com/codename1/tools/translator/TaggedValueIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/TaggedValueIntegrationTest.java
@@ -138,11 +138,12 @@ class TaggedValueIntegrationTest {
 
         // The witness. Without it every assertion above is satisfiable by a build in which
         // tagging never happened, which is exactly the failure this gate exists to exclude.
-        assertEquals("123456", witness(tagged),
-                "A default build must tag all six boxed types (Integer/Long/Double/Float/"
-                        + "Character/Short in tag-code order). If this reads 100000 the five types "
-                        + "added after Integer are not on; if it reads 000000 nothing is tagged and "
-                        + "the comparison above proved nothing about the tagged path.");
+        assertEquals("111111", witness(tagged),
+                "A default build must return an immediate from valueOf for all six boxed types "
+                        + "(Integer/Long/Double/Float/Character/Short, in that order). If this reads "
+                        + "100000 the five types added after Integer are not on; if it reads 000000 "
+                        + "nothing is tagged and the comparison above proved nothing about the tagged "
+                        + "path, because the two representations are required to be indistinguishable.");
         assertEquals("000000", witness(untagged),
                 "-DCN1_DISABLE_TAGGED_INT must disable every tagged type, or the arms are not "
                         + "actually being compared");
@@ -159,14 +160,14 @@ class TaggedValueIntegrationTest {
         return sb.toString();
     }
 
-    /** The tag code each boxed type got, as reported by the run itself. */
+    /** Whether each boxed type became an immediate, as reported by the run itself. */
     private static String witness(String output) {
         for (String line : output.split("\n", -1)) {
-            if (line.startsWith("[TAGCODES] ")) {
-                return line.substring("[TAGCODES] ".length()).trim();
+            if (line.startsWith("[TAGGED] ")) {
+                return line.substring("[TAGGED] ".length()).trim();
             }
         }
-        return "<no [TAGCODES] line: the fixture did not run to completion>";
+        return "<no [TAGGED] line: the fixture did not run to completion>";
     }
 
     private static String buildAndRun(Path distDir, String label, String cFlags) throws Exception {

--- a/vm/tests/src/test/java/com/codename1/tools/translator/TaggedValueIntegrationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/TaggedValueIntegrationTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.tools.translator;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The CI gate for tagged immediates.
+ *
+ * valueOf on Integer, Long, Double, Float, Character and Short returns an immediate with a
+ * type code in its low three bits instead of a heap object, on every 64-bit-pointer target,
+ * by default. Nothing about that is visible to a compiler or a linker: a tagged value that
+ * resolves to the wrong class, or whose hashCode is computed as if it were an Integer,
+ * produces a wrong answer with nothing thrown.
+ *
+ * BoxEdge is the torture that covers it, and it lived only in vm/benchmarks/run-gauntlet.sh
+ * -- which NO workflow runs. This drives the same source through the translator and a real
+ * compiler, so the feature is gated where it ships rather than only where a developer
+ * remembers to look.
+ *
+ * The fixture is the benchmark source itself rather than a copy, so the two cannot drift.
+ */
+class TaggedValueIntegrationTest {
+
+    /** Where the shared torture lives; read, not duplicated. */
+    private static final Path BOX_EDGE_SOURCE =
+            Paths.get("..", "benchmarks", "src", "com", "bench", "BoxEdge.java");
+
+    /**
+     * Every boxed type must behave EXACTLY like a host JVM, whether the build tags values or
+     * boxes them on the heap -- the two representations are required to be indistinguishable,
+     * which is precisely why this test needs a witness (below) to prove which one it ran.
+     */
+    @Test
+    void everyBoxedTypeMatchesTheHostJvmWithAndWithoutTagging() throws Exception {
+        List<CompilerHelper.CompilerConfig> configs = new ArrayList<>();
+        for (String v : new String[] { "17", "21", "25", "11", "1.8" }) {
+            configs.addAll(CompilerHelper.getAvailableCompilers(v));
+        }
+        Assumptions.assumeFalse(configs.isEmpty(), "No JDK available to translate with");
+        CompilerHelper.CompilerConfig config = configs.get(0);
+        Assumptions.assumeTrue(Files.exists(BOX_EDGE_SOURCE),
+                "BoxEdge source not present at " + BOX_EDGE_SOURCE.toAbsolutePath());
+
+        // The reference JVM is chosen SEPARATELY from the toolchain that drives the
+        // translator, and it has to be JDK 19 or newer. JDK 19 replaced Double.toString and
+        // Float.toString with the shortest-round-tripping representation (JDK-4511638), and
+        // ParparVM implements the new algorithm -- so an older reference reports a handful of
+        // divergences that are the reference being out of date, not the VM being wrong:
+        //   JDK 17: 4.6116860184273879E18    ParparVM and JDK 19+: 4.611686018427388E18
+        // Both round-trip; only the second is the shortest such string.
+        CompilerHelper.CompilerConfig reference = null;
+        for (String v : new String[] { "25", "21", "19" }) {
+            for (CompilerHelper.CompilerConfig candidate : CompilerHelper.getAvailableCompilers(v)) {
+                if (CompilerHelper.getJdkMajor(candidate) >= 19) {
+                    reference = candidate;
+                    break;
+                }
+            }
+            if (reference != null) {
+                break;
+            }
+        }
+        Assumptions.assumeTrue(reference != null,
+                "Need JDK 19+ as the reference JVM: Double.toString changed to the shortest "
+                        + "round-tripping form in 19, and ParparVM implements that form");
+
+        Parser.cleanup();
+
+        // The torture declares "package com.bench" for the benchmark harness; the translator
+        // helper here fixes the application package, so it is compiled in the default package.
+        // Dropping the declaration is the whole adaptation -- nothing else is rewritten, so a
+        // change to the torture reaches this gate automatically.
+        String source = new String(Files.readAllBytes(BOX_EDGE_SOURCE), StandardCharsets.UTF_8)
+                .replace("package com.bench;", "");
+
+        Path sourceDir = Files.createTempDirectory("boxedge-sources");
+        Path classesDir = Files.createTempDirectory("boxedge-classes");
+        Path javaApiDir = Files.createTempDirectory("boxedge-japi");
+        Files.write(sourceDir.resolve("BoxEdge.java"), source.getBytes(StandardCharsets.UTF_8));
+
+        JavascriptTargetIntegrationTest.compileAgainstJavaApi(config, sourceDir, classesDir, javaApiDir);
+
+        Path outputDir = Files.createTempDirectory("boxedge-output");
+        CleanTargetIntegrationTest.runTranslator(classesDir, outputDir, "BoxEdgeApp");
+
+        Path distDir = outputDir.resolve("dist");
+        Path cmakeLists = distDir.resolve("CMakeLists.txt");
+        assertTrue(Files.exists(cmakeLists), "Translator should emit a CMake project");
+        CleanTargetIntegrationTest.replaceLibraryWithExecutableTarget(
+                cmakeLists, distDir.resolve("BoxEdgeApp-src").getFileName().toString());
+
+        // Tagging is a COMPILE-time decision, so one translation feeds both arms.
+        String tagged = buildAndRun(distDir, "tagged", "");
+        String untagged = buildAndRun(distDir, "untagged", "-DCN1_DISABLE_TAGGED_INT");
+        String host = runOnHostJvm(reference, sourceDir);
+
+        assertTrue(host.split("\n", -1).length > 500,
+                "The host reference produced too little output to be a real comparison");
+
+        assertEquals(host, filtered(tagged),
+                "The tagged build must be byte-identical to a host JVM");
+        assertEquals(host, filtered(untagged),
+                "The heap-boxing fallback must be byte-identical to a host JVM too -- it is what "
+                        + "32-bit-pointer targets such as arm64_32 actually ship");
+
+        // The witness. Without it every assertion above is satisfiable by a build in which
+        // tagging never happened, which is exactly the failure this gate exists to exclude.
+        assertEquals("123456", witness(tagged),
+                "A default build must tag all six boxed types (Integer/Long/Double/Float/"
+                        + "Character/Short in tag-code order). If this reads 100000 the five types "
+                        + "added after Integer are not on; if it reads 000000 nothing is tagged and "
+                        + "the comparison above proved nothing about the tagged path.");
+        assertEquals("000000", witness(untagged),
+                "-DCN1_DISABLE_TAGGED_INT must disable every tagged type, or the arms are not "
+                        + "actually being compared");
+    }
+
+    /** Everything the fixture prints except the target-specific diagnostics. */
+    private static String filtered(String output) {
+        StringBuilder sb = new StringBuilder();
+        for (String line : output.split("\n", -1)) {
+            if (!line.startsWith("[")) {
+                sb.append(line).append('\n');
+            }
+        }
+        return sb.toString();
+    }
+
+    /** The tag code each boxed type got, as reported by the run itself. */
+    private static String witness(String output) {
+        for (String line : output.split("\n", -1)) {
+            if (line.startsWith("[TAGCODES] ")) {
+                return line.substring("[TAGCODES] ".length()).trim();
+            }
+        }
+        return "<no [TAGCODES] line: the fixture did not run to completion>";
+    }
+
+    private static String buildAndRun(Path distDir, String label, String cFlags) throws Exception {
+        Path buildDir = distDir.resolve("build-" + label);
+        Files.createDirectories(buildDir);
+        List<String> configure = new ArrayList<>(Arrays.asList(
+                "cmake",
+                "-S", distDir.toString(),
+                "-B", buildDir.toString(),
+                "-DCMAKE_BUILD_TYPE=Release"));
+        if (!cFlags.isEmpty()) {
+            configure.add("-DCMAKE_C_FLAGS=" + cFlags);
+        }
+        configure.addAll(CompilerHelper.cmakeToolchainArgs());
+        CleanTargetIntegrationTest.runCommand(configure, distDir);
+        CleanTargetIntegrationTest.runCommand(
+                Arrays.asList("cmake", "--build", buildDir.toString()), distDir);
+
+        Path executable = buildDir.resolve(CompilerHelper.executableName("BoxEdgeApp"));
+        String output = CleanTargetIntegrationTest.runCommand(
+                Arrays.asList(executable.toString()), buildDir);
+        assertTrue(output.contains("BOXEDGE DONE"),
+                "The " + label + " build did not run the torture to completion:\n" + output);
+        return output;
+    }
+
+    /**
+     * The same source compiled and run against a real JDK, which is the reference.
+     * Must be JDK 19+ -- see the note at the call site about Double.toString.
+     */
+    private static String runOnHostJvm(CompilerHelper.CompilerConfig config, Path sourceDir)
+            throws Exception {
+        Path hostClasses = Files.createTempDirectory("boxedge-host");
+        List<String> compileArgs = new ArrayList<>(Arrays.asList(
+                "-nowarn",
+                "-d", hostClasses.toString(),
+                sourceDir.resolve("BoxEdge.java").toString()));
+        assertEquals(0, CompilerHelper.compile(config.jdkHome, compileArgs),
+                "BoxEdge must compile against the host JDK");
+        String output = CleanTargetIntegrationTest.runCommand(
+                Arrays.asList(config.jdkHome.resolve("bin")
+                                .resolve(CompilerHelper.executableName("java")).toString(),
+                        "-cp", hostClasses.toString(), "BoxEdge"),
+                hostClasses);
+        assertTrue(output.contains("BOXEDGE DONE"),
+                "The host JVM did not run the torture to completion:\n" + output);
+        return filtered(output);
+    }
+}


### PR DESCRIPTION
`Integer.valueOf` already returned a tagged immediate instead of allocating, so autoboxing an
int cost nothing and the GC ignored the result. `Long`, `Short` and `Character` fell back to a
`-128..127` heap cache, and **`Double` and `Float` had no cache at all** and allocated on every
`valueOf`. `JSONParser` boxes every numeric token as `Double.valueOf` or `Long.valueOf`, so an
app talking to a REST API allocated one heap object per number in every response.

This extends the scheme to all six. The tag is now the low **three** bits, one code per type
over a 61-bit payload. Design, measurements and traps are written up in `vm/CLAUDE.md`.

## Why three bits is free

8-byte object alignment was already load-bearing: `cn1ConservativeResolve` rejects any word
with a bit set in `sizeof(void*) - 1`, and conservative roots are on by default, so an object
at a 4-byte address would already have been invisible to the root scan. `TagProbe` checks it
against the allocator anyway, over 380k allocations across every allocation shape the VM has.

## Long and Double are partial, and that is reported

`Long` fits `[-2^60, 2^60)`; a `Double` is representable when its low three mantissa bits are
clear, which makes tag an `|` and untag a `&` with no shifting. Anything outside takes the
existing heap path. On a realistic mix `Long` is **78%** representable and `Double` **56%**, so
`BoxBench` prints a coverage line beside its timings. An earlier version of that workload
reported 100% for both because its numbers were all round quarters -- a partial encoding that
looks excellent on convenient data and never fires on real data is the failure mode here.

## Numbers

Best-of-6 interleaved against the Integer-only build, checksums bit-identical across all three
ablation arms:

| benchmark | ratio |
|---|---|
| longKeyMap | **2.3x** |
| charBoxing | 1.54x |
| doubleListReduce | 1.43x |
| mixedBoxedChurn | 1.28x |
| jsonLikeParse | 1.14x (at 56% coverage) |
| whole `Bench` suite | **1.00 -- no regression anywhere** |

`CN1_ALLOC_CENSUS` confirms the mechanism from an independent instrument: normalised by a work
unit tagging cannot affect, `jsonLikeParse` goes from **24.02 boxed objects per map to 5.24**
(theory: 24, and `12 * 0.44 = 5.28`). `Long` allocations over the run: 346,545 -> **1**.

Indexing by tag code is an addressing mode, not a lookup -- one shifted add for
`&cn1TaggedProxy[code]`, then a `csel` to a valid pointer before the single header load.

## The sharp edge

The inline `hashCode`/`equals` fast path in the dispatch thunk stays **Integer-only** and now
tests the tag code rather than "is tagged". Every other type has a different hashCode contract,
so widening it returns a **wrong hash with no crash**. The other five reach the right
implementation through the vtable, which is slower and always correct. `BoxEdge` is proven
non-vacuous against exactly that mistake: re-widening the guard diverges on 115 lines.

## Four pre-existing defects, found by BoxEdge on its first run

- `Short.equals` had no null guard where every other wrapper did, so `equals(null)` dereferenced
  null -- a hard SIGSEGV on any target that installs no signal handler.
- `Float.toString` never got the fixes `Double.toString` has: no NaN branch, and `-0.0f` printed
  as `0.0` while `Float.compare`, `Float.equals` and `Arrays.sort` all honoured the sign.
- `Short.compareTo` returned the sign rather than the difference, disagreeing with the JDK and
  with this class's own `compare(short, short)` directly above it.
- The nursery write barrier had no tag guard where the SATB half did.

## One behaviour change worth knowing

A machine word whose low three bits spell a tag code is indistinguishable from a genuine
immediate, so the iOS debugger reports a boxed value for a misread int slot rather than
rejecting it. It never dereferences -- the property issue #5333 was about -- and it is not new,
since an odd word was already a tagged Integer with a one-bit tag. **The GC is unaffected**,
because `cn1ConservativeResolve` rejects those same three bits.

## Verification

- gauntlet 12/12 byte-identical, both GC stop modes (re-run after rebasing onto current master)
- `run-gc-verify.sh` green, with both fault injections firing
- `vm/tests`: 555 tests, 0 failures, 0 errors
- `check-native-signatures.sh` 0 fatal; control-character, copyright, ASCII and cast-semantics
  gates clean

Ablation arms: `-DCN1_DISABLE_TAGGED_VALUES` (the five new types) and the existing
`-DCN1_DISABLE_TAGGED_INT`.

Not done here, and deliberately: `Dimension`/`Rectangle` cannot use this mechanism --
`Rectangle` is not a flat value (two object references plus a static pool), `Dimension` is 64
bits against a 61-bit payload, and both are mutable. `vm/CLAUDE.md` records the assessment and
points at scalar replacement as the mechanism that would actually pay off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)