### PR TITLE
Stop a minor-versioned Android platform from breaking the build

### DIFF
--- a/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
+++ b/maven/codenameone-maven-plugin/src/main/java/com/codename1/builders/AndroidGradleBuilder.java
@@ -1003,6 +1003,57 @@ public class AndroidGradleBuilder extends Executor {
             return false;
         }
     }
+    /**
+     * The value that actually suppresses AGP's untested-compileSdk warning.
+     *
+     * <p>AGP matches this property against the platform's api string, and from
+     * API 37 that string carries the minor version -- {@code "37.0"}, not
+     * {@code "37"} -- because Google publishes those levels as minor-versioned
+     * platforms. The bare major therefore suppressed nothing and the warning
+     * printed on every API 37 build, which reads like a fault in a customer's log.
+     * AGP names the exact string it wants in the warning itself.</p>
+     *
+     * <p>Below 37 the value is inert either way: AGP's maximum recommended compile
+     * SDK is 36.1, so nothing warns there at all. Only the levels that can warn are
+     * spelled with the minor, which keeps a working path untouched.</p>
+     *
+     * @param compileSdkInt the compile SDK the project will use
+     * @return the {@code android.suppressUnsupportedCompileSdk} value
+     */
+    static String suppressUnsupportedCompileSdkValue(int compileSdkInt) {
+        return compileSdkInt >= 37 ? compileSdkInt + ".0" : String.valueOf(compileSdkInt);
+    }
+
+    /**
+     * The API level of the newest installed platform, or 0 when none parses.
+     *
+     * <p>The MAJOR, deliberately, and not the directory name the scan produced.
+     * From API 36 Google publishes MINOR-versioned platforms -- {@code android-36.1},
+     * {@code android-37.0} -- so the scan hands this method strings like
+     * {@code "36.1"} and {@code "37.0"}. The value it returns becomes
+     * {@code maxPlatformVersion}, which becomes {@code defaultVersion}, which
+     * becomes the target SDK; and every consumer of that wants an integer. The
+     * target-SDK parse is not guarded, so returning {@code "37.0"} threw a
+     * {@link NumberFormatException} naming none of this, and the compile-SDK and
+     * support-library ladders would have compared it as a string. Only the
+     * {@code useGradle8} branch overwrote it with the int, which is the sole reason
+     * the modern path survived a developer installing one of those platforms.</p>
+     *
+     * @param installedPlatforms platform names with the {@code android-} prefix
+     *                           already stripped
+     * @return the highest API level found, or 0 for an empty or unparseable list
+     */
+    int newestInstalledPlatformApi(List<String> installedPlatforms) {
+        int newest = 0;
+        for (String ver : installedPlatforms) {
+            int verInt = parseVersionStringAsInt(ver);
+            if (verInt > newest) {
+                newest = verInt;
+            }
+        }
+        return newest;
+    }
+
     private int parseVersionStringAsInt(String versionString) {
         if (versionString.indexOf(".") > 0) {
             try {
@@ -1298,15 +1349,8 @@ public class AndroidGradleBuilder extends Executor {
             }
         }
 
-        int maxPlatformVersionInt = 0;
-        String maxPlatformVersion = "0";
-        for (String ver : installedPlatforms) {
-            int verInt = parseVersionStringAsInt(ver);
-            if (verInt > maxPlatformVersionInt) {
-                maxPlatformVersionInt = verInt;
-                maxPlatformVersion = ver;
-            }
-        }
+        int maxPlatformVersionInt = newestInstalledPlatformApi(installedPlatforms);
+        String maxPlatformVersion = String.valueOf(maxPlatformVersionInt);
 
         if (maxPlatformVersionInt == 0) {
             maxPlatformVersionInt = 31;
@@ -7551,7 +7595,8 @@ public class AndroidGradleBuilder extends Executor {
         }
         Integer compileSdkInt = parseSdkInt(compileSdkVersion);
         if (compileSdkInt != null && compileSdkInt >= 35) {
-            gradlePropertiesObject.setProperty("android.suppressUnsupportedCompileSdk", String.valueOf(compileSdkInt));
+            gradlePropertiesObject.setProperty("android.suppressUnsupportedCompileSdk",
+                    suppressUnsupportedCompileSdkValue(compileSdkInt));
         }
 
         // Configure R8 optimization mode to prevent reflection issues

--- a/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/AndroidGradleBuilderSdkVersionTest.java
+++ b/maven/codenameone-maven-plugin/src/test/java/com/codename1/builders/AndroidGradleBuilderSdkVersionTest.java
@@ -22,11 +22,44 @@
  */
 package com.codename1.builders;
 
+import java.util.Arrays;
+import java.util.Collections;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class AndroidGradleBuilderSdkVersionTest {
+
+    @Test
+    void newestInstalledPlatformIsReportedAsItsMajorApiLevel() {
+        AndroidGradleBuilder b = new AndroidGradleBuilder();
+        assertEquals(36, b.newestInstalledPlatformApi(Arrays.asList("30", "33", "36")));
+        // The regression this exists for. From API 36 Google publishes
+        // MINOR-versioned platforms, so the SDK scan yields "37.0" -- and this
+        // value becomes the target SDK, which is parsed as an int without a
+        // guard. Returning the major is what keeps that parse alive.
+        assertEquals(37, b.newestInstalledPlatformApi(Arrays.asList("36", "37.0")));
+        assertEquals(36, b.newestInstalledPlatformApi(Arrays.asList("36.1")));
+        // Extension platforms do not parse and must not win; a developer who has
+        // one alongside a real platform still gets the real one.
+        assertEquals(36, b.newestInstalledPlatformApi(Arrays.asList("36", "36-ext18")));
+        assertEquals(0, b.newestInstalledPlatformApi(Arrays.asList("36-ext18")));
+        assertEquals(0, b.newestInstalledPlatformApi(Collections.<String>emptyList()));
+    }
+
+    @Test
+    void compileSdkSuppressionValueCarriesTheMinorFromApi37() {
+        // AGP matches this against the platform's api string and names the exact
+        // string it wants in the warning: "37.0". The bare major suppresses
+        // nothing.
+        assertEquals("37.0", AndroidGradleBuilder.suppressUnsupportedCompileSdkValue(37));
+        assertEquals("38.0", AndroidGradleBuilder.suppressUnsupportedCompileSdkValue(38));
+        // Below 37 nothing warns -- AGP's maximum recommended compile SDK is 36.1 --
+        // so these keep the spelling they already had.
+        assertEquals("36", AndroidGradleBuilder.suppressUnsupportedCompileSdkValue(36));
+        assertEquals("35", AndroidGradleBuilder.suppressUnsupportedCompileSdkValue(35));
+    }
 
     @Test
     void raisesCompileSdkToTargetSdk() {


### PR DESCRIPTION
Companion to BuildDaemon#214 (Android API 37 on the cloud builders). The plugin pairing needed
no change here — this builder is already on **AGP 8.13.2 / Gradle 8.13**, the first stable 8.x
that resolves `compileSdk 37` to the `android-37.0` platform. What it does need is two fixes.

## 1. A minor-versioned platform crashes the build (reachable today)

From API 36 Google publishes **minor-versioned** platforms — `android-36.1`, `android-37.0` —
and there is no plain `platforms;android-37`. The SDK scan strips the prefix and yields `"36.1"`
or `"37.0"`, which was kept verbatim as `maxPlatformVersion`. That becomes `defaultVersion`,
then the target SDK, and every consumer wants an integer:

- the target-SDK `Integer.parseInt` is **not guarded** → `NumberFormatException` naming none of this;
- `compileSdkInt` and the support-library ladder compare it as a string.

Only the `useGradle8` branch overwrote it with the int, which is the sole reason the modern path
survived. **`android-36.1` already ships**, so this is reachable today with
`android.useGradle8=false` — it is not a hypothetical about API 37.

## 2. The compileSdk warning suppression never worked at 37

AGP matches `android.suppressUnsupportedCompileSdk` against the platform's api string, which from
37 carries the minor: `37.0`, not `37`. The bare major suppressed nothing, so AGP's
untested-compileSdk warning printed on every API 37 build. AGP names the exact string it wants in
the warning text. Below 37 the value is inert either way (AGP's max recommended compile SDK is
36.1, so nothing warns), so only the levels that can warn changed spelling.

## Verification

Built the way CI does — JDK 8, `-Plocal-dev-javase`: **BUILD SUCCESS**, 7 tests in
`AndroidGradleBuilderSdkVersionTest`, 0 failures. Both fixes sit behind helpers so they are
asserted without an SDK on disk, matching how `compileSdkInt` and `ensureCompileSdkAtLeastTarget`
are already tested.

## Deliberately not included

The support-library ladder tops out at `"36"`, so build-tools 37 on the non-AndroidX path would
ask for `support-v4:37.+`, which does not exist. Pre-existing, unrelated to minor versions, and
changing legacy support-lib selection deserves its own PR.