### PR TITLE
Developer guide: diagrams for the EDT cycle and the four data stores

### DIFF
--- a/docs/developer-guide/The-Components-Of-Codename-One.asciidoc
+++ b/docs/developer-guide/The-Components-Of-Codename-One.asciidoc
@@ -43,6 +43,13 @@ You can learn more about lead components in <<lead-component-section,here>>.
 
 === Form
 
+A `Form` isn't one surface. It's a title area, a content pane and any number of
+layered panes. Knowing which of them receives a component explains most of what
+happens next:
+
+.The parts of a Form, and which accessor reaches each one
+image::img/form-anatomy.svg[The parts of a Form: title area, content pane, layered pane and safe area,scaledwidth=85%]
+
 https://www.codenameone.com/javadoc/com/codename1/ui/Form.html[Form] is the top-level container in Codename One. `Form` derives from `Container` and is the element the app shows. Only one form can be visible at any given time. You can get the visible `Form` with the code:
 
 [source,java]

--- a/docs/developer-guide/The-Components-Of-Codename-One.asciidoc
+++ b/docs/developer-guide/The-Components-Of-Codename-One.asciidoc
@@ -43,9 +43,10 @@ You can learn more about lead components in <<lead-component-section,here>>.
 
 === Form
 
-A `Form` isn't one surface. It's a title area, a content pane and any number of
-layered panes. Knowing which of them receives a component explains most of what
-happens next:
+A `Form` isn't one surface. It's a title area, a content pane, any number of
+layered panes, and on ports that place commands in a soft-key or button bar, a
+menu bar as well. Knowing which of them receives a component explains most of
+what happens next:
 
 .The parts of a Form, and which accessor reaches each one
 image::img/form-anatomy.svg[The parts of a Form: title area, content pane, layered pane and safe area,scaledwidth=85%]

--- a/docs/developer-guide/The-EDT---Event-Dispatch-Thread.asciidoc
+++ b/docs/developer-guide/The-EDT---Event-Dispatch-Thread.asciidoc
@@ -33,6 +33,12 @@ Codename One includes helper methods in the https://www.codenameone.com/javadoc/
 
 `isEDT()` is useful for generic code that needs to test whether the current code is executing on the EDT.
 
+The two methods that hand work to the EDT do quite different things, and the
+difference is easiest to see against the cycle they feed:
+
+.The EDT's cycle, and where callSerially and invokeAndBlock enter it
+image::img/edt-loop-and-blocking.svg[The EDT cycle and how callSerially and invokeAndBlock hand work to it,scaledwidth=85%]
+
 === Call Serially (And Wait)
 
 `callSerially(Runnable)` should normally be called off the EDT (in a separate thread), the run method within the submitted runnable will be invoked on the EDT.

--- a/docs/developer-guide/The-EDT---Event-Dispatch-Thread.asciidoc
+++ b/docs/developer-guide/The-EDT---Event-Dispatch-Thread.asciidoc
@@ -35,8 +35,10 @@ Codename One includes helper methods in the https://www.codenameone.com/javadoc/
 
 The two methods that coordinate work with the EDT pull in opposite directions,
 and the difference is easiest to see against the cycle itself. `callSerially`
-moves a `Runnable` onto the EDT; `invokeAndBlock` moves one off it, onto a
-pooled thread, so don't touch the UI from inside that one:
+moves a `Runnable` onto the EDT. `invokeAndBlock` moves one the other way:
+called on the EDT it hands the `Runnable` to a pooled thread, and called off
+the EDT it simply runs it on the calling thread. Either way that `Runnable`
+isn't on the EDT, so don't touch the UI from inside it:
 
 .The EDT's cycle, and where callSerially and invokeAndBlock enter it
 image::img/edt-loop-and-blocking.svg[The EDT cycle and how callSerially and invokeAndBlock hand work to it,scaledwidth=85%]

--- a/docs/developer-guide/The-EDT---Event-Dispatch-Thread.asciidoc
+++ b/docs/developer-guide/The-EDT---Event-Dispatch-Thread.asciidoc
@@ -33,8 +33,10 @@ Codename One includes helper methods in the https://www.codenameone.com/javadoc/
 
 `isEDT()` is useful for generic code that needs to test whether the current code is executing on the EDT.
 
-The two methods that hand work to the EDT do quite different things, and the
-difference is easiest to see against the cycle they feed:
+The two methods that coordinate work with the EDT pull in opposite directions,
+and the difference is easiest to see against the cycle itself. `callSerially`
+moves a `Runnable` onto the EDT; `invokeAndBlock` moves one off it, onto a
+pooled thread, so don't touch the UI from inside that one:
 
 .The EDT's cycle, and where callSerially and invokeAndBlock enter it
 image::img/edt-loop-and-blocking.svg[The EDT cycle and how callSerially and invokeAndBlock hand work to it,scaledwidth=85%]

--- a/docs/developer-guide/img/edt-loop-and-blocking.svg
+++ b/docs/developer-guide/img/edt-loop-and-blocking.svg
@@ -15,15 +15,15 @@
   <rect x="44" y="146" width="210" height="34" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1"/>
   <text x="149" y="167" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#222222">deliver input events</text>
 
-  <rect x="44" y="194" width="210" height="46" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="2"/>
-  <text x="149" y="213" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#222222">run serial calls</text>
-  <text x="149" y="230" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">everything callSerially queued</text>
+  <rect x="44" y="194" width="210" height="34" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1"/>
+  <text x="149" y="215" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#222222">paint what is dirty</text>
 
-  <rect x="44" y="254" width="210" height="34" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1"/>
-  <text x="149" y="275" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#222222">advance animations</text>
+  <rect x="44" y="242" width="210" height="34" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1"/>
+  <text x="149" y="263" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#222222">advance animations</text>
 
-  <rect x="44" y="302" width="210" height="34" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1"/>
-  <text x="149" y="323" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#222222">paint the form</text>
+  <rect x="44" y="290" width="210" height="46" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="2"/>
+  <text x="149" y="309" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#222222">run serial calls</text>
+  <text x="149" y="326" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">everything callSerially queued</text>
 
   <path d="M 44 336 L 30 336 L 30 115 L 44 115" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
   <path d="M 40 110 L 44 115 L 40 120" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
@@ -40,10 +40,10 @@
   <path d="M 610 112 L 616 117 L 610 122" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
   <rect x="620" y="96" width="156" height="42" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1"/>
   <text x="698" y="113" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#222222">serial call queue</text>
-  <text x="698" y="129" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">drained by the step above</text>
+  <text x="698" y="129" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">drained at the end of a cycle</text>
   <text x="563" y="160" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">Returns at once. The Runnable executes on a later cycle,</text>
   <text x="563" y="176" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">which is how off-EDT code touches the UI safely.</text>
-  <text x="563" y="196" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Called while already on the EDT it still queues, so it defers rather than recurses.</text>
+  <text x="563" y="196" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Serial calls run after that cycle has painted, so work queued from an event is drawn on the next one.</text>
 
   <rect x="330" y="228" width="466" height="178" rx="6" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
   <text x="563" y="250" font-family="Arial, sans-serif" font-size="13" font-weight="bold"
@@ -60,6 +60,6 @@
   <path d="M 420 314 L 425 308 L 430 314" fill="none" stroke="#a56a3a" stroke-width="1.5"/>
   <text x="563" y="350" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">Your line of code is suspended, but the EDT is not: it keeps</text>
   <text x="563" y="366" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">looping, so input and painting carry on while you wait.</text>
-  <text x="563" y="386" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Execution resumes on the EDT once the Runnable returns. This is what every</text>
-  <text x="563" y="400" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">andWait() method in the framework is built on.</text>
+  <text x="563" y="386" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Execution resumes on the EDT once the Runnable returns. Note callSeriallyAndWait is NOT</text>
+  <text x="563" y="400" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">this: it waits on a lock and refuses to run on the EDT at all.</text>
 </svg>

--- a/docs/developer-guide/img/edt-loop-and-blocking.svg
+++ b/docs/developer-guide/img/edt-loop-and-blocking.svg
@@ -60,6 +60,6 @@
   <path d="M 420 314 L 425 308 L 430 314" fill="none" stroke="#a56a3a" stroke-width="1.5"/>
   <text x="563" y="350" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">Your line of code is suspended, but the EDT is not: it keeps</text>
   <text x="563" y="366" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">looping, so input and painting carry on while you wait.</text>
-  <text x="563" y="386" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Execution resumes on the EDT once the Runnable returns. Note callSeriallyAndWait is NOT</text>
-  <text x="563" y="400" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">this: it waits on a lock and refuses to run on the EDT at all.</text>
+  <text x="563" y="386" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Execution resumes on the EDT once the Runnable returns. callSeriallyAndWait is NOT this: it waits</text>
+  <text x="563" y="400" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">on a lock. Its no-timeout form throws on the EDT; the timed one does not, and freezes it instead.</text>
 </svg>

--- a/docs/developer-guide/img/edt-loop-and-blocking.svg
+++ b/docs/developer-guide/img/edt-loop-and-blocking.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="430" viewBox="0 0 820 430">
-  <rect x="0" y="0" width="820" height="430" fill="#ffffff"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="440" viewBox="0 0 820 440">
+  <rect x="0" y="0" width="820" height="440" fill="#ffffff"/>
 
   <text x="410" y="26" font-family="Arial, sans-serif" font-size="15" font-weight="bold"
         text-anchor="middle" fill="#222222">The EDT, and the two ways to hand it work</text>
@@ -45,7 +45,7 @@
   <text x="563" y="176" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">which is how off-EDT code touches the UI safely.</text>
   <text x="563" y="196" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Serial calls run after that cycle has painted, so work queued from an event is drawn on the next one.</text>
 
-  <rect x="330" y="228" width="466" height="178" rx="6" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
+  <rect x="330" y="228" width="466" height="192" rx="6" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
   <text x="563" y="250" font-family="Arial, sans-serif" font-size="13" font-weight="bold"
         text-anchor="middle" fill="#a56a3a">invokeAndBlock, from the EDT</text>
   <rect x="350" y="264" width="150" height="42" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1"/>
@@ -59,7 +59,8 @@
   <path d="M 698 306 L 698 330 L 425 330 L 425 308" fill="none" stroke="#a56a3a" stroke-width="1.5"/>
   <path d="M 420 314 L 425 308 L 430 314" fill="none" stroke="#a56a3a" stroke-width="1.5"/>
   <text x="563" y="350" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">Your line of code is suspended, but the EDT is not: it keeps</text>
-  <text x="563" y="366" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">looping, so input and painting carry on while you wait.</text>
-  <text x="563" y="386" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Execution resumes on the EDT once the Runnable returns. callSeriallyAndWait is NOT this: it waits</text>
-  <text x="563" y="400" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">on a lock. Its no-timeout form throws on the EDT; the timed one does not, and freezes it instead.</text>
+  <text x="563" y="366" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">looping and painting while you wait. Input keeps arriving too, unless</text>
+  <text x="563" y="379" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">you pass invokeAndBlock(r, true), which discards it.</text>
+  <text x="563" y="397" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Execution resumes on the EDT once the Runnable returns. callSeriallyAndWait is NOT this: it waits on a lock.</text>
+  <text x="563" y="410" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Its no-timeout form throws on the EDT; the timed one does not, and freezes it instead.</text>
 </svg>

--- a/docs/developer-guide/img/edt-loop-and-blocking.svg
+++ b/docs/developer-guide/img/edt-loop-and-blocking.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="440" viewBox="0 0 820 440">
-  <rect x="0" y="0" width="820" height="440" fill="#ffffff"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="462" viewBox="0 0 820 462">
+  <rect x="0" y="0" width="820" height="462" fill="#ffffff"/>
 
   <text x="410" y="26" font-family="Arial, sans-serif" font-size="15" font-weight="bold"
         text-anchor="middle" fill="#222222">The EDT, and the two ways to hand it work</text>
@@ -27,40 +27,42 @@
 
   <path d="M 44 336 L 30 336 L 30 115 L 44 115" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
   <path d="M 40 110 L 44 115 L 40 120" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
-  <text x="149" y="356" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">a long step here freezes the app</text>
-  <text x="149" y="372" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">because nothing else paints</text>
+  <text x="149" y="360" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">a long step here freezes the app</text>
+  <text x="149" y="376" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">because nothing else paints</text>
 
-  <rect x="330" y="60" width="466" height="150" rx="6" fill="#f7faf4" stroke="#4a7a3d" stroke-width="1.5"/>
-  <text x="563" y="82" font-family="Arial, sans-serif" font-size="13" font-weight="bold"
+  <rect x="330" y="46" width="466" height="172" rx="6" fill="#f7faf4" stroke="#4a7a3d" stroke-width="1.5"/>
+  <text x="563" y="68" font-family="Arial, sans-serif" font-size="13" font-weight="bold"
         text-anchor="middle" fill="#4a7a3d">callSerially, from another thread</text>
-  <rect x="350" y="96" width="150" height="42" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1"/>
-  <text x="425" y="113" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#222222">your background</text>
-  <text x="425" y="129" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#222222">thread</text>
-  <path d="M 500 117 L 616 117" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
-  <path d="M 610 112 L 616 117 L 610 122" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
-  <rect x="620" y="96" width="156" height="42" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1"/>
-  <text x="698" y="113" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#222222">serial call queue</text>
-  <text x="698" y="129" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">drained at the end of a cycle</text>
-  <text x="563" y="160" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">Returns at once. The Runnable executes on a later cycle,</text>
-  <text x="563" y="176" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">which is how off-EDT code touches the UI safely.</text>
-  <text x="563" y="196" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Serial calls run after that cycle has painted, so work queued from an event is drawn on the next one.</text>
+  <rect x="350" y="82" width="150" height="42" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1"/>
+  <text x="425" y="99" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#222222">your background</text>
+  <text x="425" y="115" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#222222">thread</text>
+  <path d="M 500 103 L 616 103" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
+  <path d="M 610 98 L 616 103 L 610 108" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
+  <rect x="620" y="82" width="156" height="42" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1"/>
+  <text x="698" y="99" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#222222">serial call queue</text>
+  <text x="698" y="115" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">drained at the end of a cycle</text>
+  <text x="563" y="146" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">Returns at once. The Runnable runs when the queue is</text>
+  <text x="563" y="162" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">next drained, which is how off-EDT code reaches the UI.</text>
+  <text x="563" y="182" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">That may be the cycle already running, since the drain comes last.</text>
+  <text x="563" y="196" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Either way it happens after that cycle has painted.</text>
 
-  <rect x="330" y="228" width="466" height="192" rx="6" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
-  <text x="563" y="250" font-family="Arial, sans-serif" font-size="13" font-weight="bold"
+  <rect x="330" y="236" width="466" height="210" rx="6" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
+  <text x="563" y="258" font-family="Arial, sans-serif" font-size="13" font-weight="bold"
         text-anchor="middle" fill="#a56a3a">invokeAndBlock, from the EDT</text>
-  <rect x="350" y="264" width="150" height="42" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1"/>
-  <text x="425" y="281" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#222222">your code, on</text>
-  <text x="425" y="297" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#222222">the EDT</text>
-  <path d="M 500 285 L 616 285" fill="none" stroke="#a56a3a" stroke-width="1.5"/>
-  <path d="M 610 280 L 616 285 L 610 290" fill="none" stroke="#a56a3a" stroke-width="1.5"/>
-  <rect x="620" y="264" width="156" height="42" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1"/>
-  <text x="698" y="281" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#222222">pooled thread</text>
-  <text x="698" y="297" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">runs your Runnable</text>
-  <path d="M 698 306 L 698 330 L 425 330 L 425 308" fill="none" stroke="#a56a3a" stroke-width="1.5"/>
-  <path d="M 420 314 L 425 308 L 430 314" fill="none" stroke="#a56a3a" stroke-width="1.5"/>
-  <text x="563" y="350" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">Your line of code is suspended, but the EDT is not: it keeps</text>
-  <text x="563" y="366" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">looping and painting while you wait. Input keeps arriving too, unless</text>
-  <text x="563" y="379" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">you pass invokeAndBlock(r, true), which discards it.</text>
-  <text x="563" y="397" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Execution resumes on the EDT once the Runnable returns. callSeriallyAndWait is NOT this: it waits on a lock.</text>
-  <text x="563" y="410" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Its no-timeout form throws on the EDT; the timed one does not, and freezes it instead.</text>
+  <rect x="350" y="272" width="150" height="42" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1"/>
+  <text x="425" y="289" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#222222">your code, on</text>
+  <text x="425" y="305" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#222222">the EDT</text>
+  <path d="M 500 293 L 616 293" fill="none" stroke="#a56a3a" stroke-width="1.5"/>
+  <path d="M 610 288 L 616 293 L 610 298" fill="none" stroke="#a56a3a" stroke-width="1.5"/>
+  <rect x="620" y="272" width="156" height="42" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1"/>
+  <text x="698" y="289" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#222222">pooled thread</text>
+  <text x="698" y="305" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">runs your Runnable</text>
+  <path d="M 698 314 L 698 334 L 425 334 L 425 316" fill="none" stroke="#a56a3a" stroke-width="1.5"/>
+  <path d="M 420 322 L 425 316 L 430 322" fill="none" stroke="#a56a3a" stroke-width="1.5"/>
+  <text x="563" y="356" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">Your line of code is suspended, but the EDT is not: it</text>
+  <text x="563" y="372" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">keeps looping and painting while you wait. Input keeps</text>
+  <text x="563" y="388" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">arriving too, unless you pass invokeAndBlock(r, true).</text>
+  <text x="563" y="408" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Execution resumes on the EDT once the Runnable returns.</text>
+  <text x="563" y="422" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">callSeriallyAndWait is NOT this: it waits on a lock. Its no-timeout form</text>
+  <text x="563" y="436" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">throws on the EDT; the timed one does not, and freezes it instead.</text>
 </svg>

--- a/docs/developer-guide/img/edt-loop-and-blocking.svg
+++ b/docs/developer-guide/img/edt-loop-and-blocking.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="430" viewBox="0 0 820 430">
+  <rect x="0" y="0" width="820" height="430" fill="#ffffff"/>
+
+  <text x="410" y="26" font-family="Arial, sans-serif" font-size="15" font-weight="bold"
+        text-anchor="middle" fill="#222222">The EDT, and the two ways to hand it work</text>
+
+  <rect x="24" y="46" width="250" height="360" rx="6" fill="#f4f7fb" stroke="#4a6fa5" stroke-width="1.5"/>
+  <text x="149" y="68" font-family="Arial, sans-serif" font-size="13" font-weight="bold"
+        text-anchor="middle" fill="#4a6fa5">Event Dispatch Thread</text>
+  <text x="149" y="84" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">one thread, one cycle, forever</text>
+
+  <rect x="44" y="98" width="210" height="34" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1"/>
+  <text x="149" y="119" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#222222">sleep until there is work</text>
+
+  <rect x="44" y="146" width="210" height="34" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1"/>
+  <text x="149" y="167" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#222222">deliver input events</text>
+
+  <rect x="44" y="194" width="210" height="46" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="2"/>
+  <text x="149" y="213" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#222222">run serial calls</text>
+  <text x="149" y="230" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">everything callSerially queued</text>
+
+  <rect x="44" y="254" width="210" height="34" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1"/>
+  <text x="149" y="275" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#222222">advance animations</text>
+
+  <rect x="44" y="302" width="210" height="34" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1"/>
+  <text x="149" y="323" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#222222">paint the form</text>
+
+  <path d="M 44 336 L 30 336 L 30 115 L 44 115" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
+  <path d="M 40 110 L 44 115 L 40 120" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
+  <text x="149" y="356" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">a long step here freezes the app</text>
+  <text x="149" y="372" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">because nothing else paints</text>
+
+  <rect x="330" y="60" width="466" height="150" rx="6" fill="#f7faf4" stroke="#4a7a3d" stroke-width="1.5"/>
+  <text x="563" y="82" font-family="Arial, sans-serif" font-size="13" font-weight="bold"
+        text-anchor="middle" fill="#4a7a3d">callSerially, from another thread</text>
+  <rect x="350" y="96" width="150" height="42" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1"/>
+  <text x="425" y="113" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#222222">your background</text>
+  <text x="425" y="129" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#222222">thread</text>
+  <path d="M 500 117 L 616 117" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
+  <path d="M 610 112 L 616 117 L 610 122" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
+  <rect x="620" y="96" width="156" height="42" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1"/>
+  <text x="698" y="113" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#222222">serial call queue</text>
+  <text x="698" y="129" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">drained by the step above</text>
+  <text x="563" y="160" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">Returns at once. The Runnable executes on a later cycle,</text>
+  <text x="563" y="176" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">which is how off-EDT code touches the UI safely.</text>
+  <text x="563" y="196" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Called while already on the EDT it still queues, so it defers rather than recurses.</text>
+
+  <rect x="330" y="228" width="466" height="178" rx="6" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
+  <text x="563" y="250" font-family="Arial, sans-serif" font-size="13" font-weight="bold"
+        text-anchor="middle" fill="#a56a3a">invokeAndBlock, from the EDT</text>
+  <rect x="350" y="264" width="150" height="42" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1"/>
+  <text x="425" y="281" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#222222">your code, on</text>
+  <text x="425" y="297" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#222222">the EDT</text>
+  <path d="M 500 285 L 616 285" fill="none" stroke="#a56a3a" stroke-width="1.5"/>
+  <path d="M 610 280 L 616 285 L 610 290" fill="none" stroke="#a56a3a" stroke-width="1.5"/>
+  <rect x="620" y="264" width="156" height="42" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1"/>
+  <text x="698" y="281" font-family="Arial, sans-serif" font-size="12" text-anchor="middle" fill="#222222">pooled thread</text>
+  <text x="698" y="297" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">runs your Runnable</text>
+  <path d="M 698 306 L 698 330 L 425 330 L 425 308" fill="none" stroke="#a56a3a" stroke-width="1.5"/>
+  <path d="M 420 314 L 425 308 L 430 314" fill="none" stroke="#a56a3a" stroke-width="1.5"/>
+  <text x="563" y="350" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">Your line of code is suspended, but the EDT is not: it keeps</text>
+  <text x="563" y="366" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">looping, so input and painting carry on while you wait.</text>
+  <text x="563" y="386" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Execution resumes on the EDT once the Runnable returns. This is what every</text>
+  <text x="563" y="400" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">andWait() method in the framework is built on.</text>
+</svg>

--- a/docs/developer-guide/img/form-anatomy.svg
+++ b/docs/developer-guide/img/form-anatomy.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="420" viewBox="0 0 820 420">
-  <rect x="0" y="0" width="820" height="420" fill="#ffffff"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="432" viewBox="0 0 820 432">
+  <rect x="0" y="0" width="820" height="432" fill="#ffffff"/>
 
   <text x="410" y="26" font-family="Arial, sans-serif" font-size="15" font-weight="bold"
         text-anchor="middle" fill="#222222">What a Form is made of</text>
@@ -43,11 +43,12 @@
   <text x="598" y="238" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">setScrollable() forwards here too, which is why scrolling</text>
   <text x="598" y="251" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">moves the components and leaves the title in place.</text>
 
-  <rect x="400" y="270" width="396" height="118" rx="6" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
+  <rect x="400" y="270" width="396" height="130" rx="6" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
   <text x="598" y="290" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#a56a3a">getLayeredPane() and getSafeArea()</text>
   <text x="598" y="310" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">The layered pane is for things that sit over the UI:</text>
   <text x="598" y="326" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">a badge, a hint, an overlay. Ask for one by class and</text>
   <text x="598" y="342" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">your layer stays separate from anyone else's.</text>
-  <text x="598" y="364" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">getSafeArea() is the rectangle clear of the insets above. A Form is a safe</text>
-  <text x="598" y="377" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">area root, so its children are kept out of the notch and home indicator.</text>
+  <text x="598" y="364" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">getSafeArea() is the rectangle clear of the insets above. The Form is only the frame that</text>
+  <text x="598" y="377" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">it is measured against: a container is padded clear of the insets only once you</text>
+  <text x="598" y="390" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">call setSafeArea(true) on it, so custom content can still overlap a notch.</text>
 </svg>

--- a/docs/developer-guide/img/form-anatomy.svg
+++ b/docs/developer-guide/img/form-anatomy.svg
@@ -35,9 +35,9 @@
 
   <rect x="400" y="60" width="396" height="90" rx="6" fill="#f4f7fb" stroke="#4a6fa5" stroke-width="1.5"/>
   <text x="598" y="80" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#4a6fa5">getTitleArea() / getToolbar()</text>
-  <text x="598" y="100" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">Commands, the title, the side menu and the</text>
-  <text x="598" y="116" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">overflow menu are all Toolbar concerns.</text>
-  <text x="598" y="136" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Add to the Toolbar, not to the title area directly.</text>
+  <text x="598" y="100" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">With a Toolbar installed, the title, commands, the side menu</text>
+  <text x="598" y="116" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">and the overflow menu are Toolbar concerns: add them there.</text>
+  <text x="598" y="136" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Without one, Form.addCommand() goes to the MenuBar instead.</text>
 
   <rect x="400" y="162" width="396" height="124" rx="6" fill="#f7faf4" stroke="#4a7a3d" stroke-width="1.5"/>
   <text x="598" y="182" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#4a7a3d">getContentPane() and getMenuBar()</text>

--- a/docs/developer-guide/img/form-anatomy.svg
+++ b/docs/developer-guide/img/form-anatomy.svg
@@ -1,10 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="432" viewBox="0 0 820 432">
-  <rect x="0" y="0" width="820" height="432" fill="#ffffff"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="430" viewBox="0 0 820 430">
+  <rect x="0" y="0" width="820" height="430" fill="#ffffff"/>
 
   <text x="410" y="26" font-family="Arial, sans-serif" font-size="15" font-weight="bold"
         text-anchor="middle" fill="#222222">What a Form is made of</text>
 
-  <rect x="60" y="52" width="300" height="336" rx="10" fill="#ffffff" stroke="#222222" stroke-width="1.5"/>
+  <rect x="60" y="52" width="300" height="348" rx="10" fill="#ffffff" stroke="#222222" stroke-width="1.5"/>
   <text x="210" y="72" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#666666">Form (itself a Container)</text>
 
   <rect x="72" y="82" width="276" height="20" rx="3" fill="#eeeeee" stroke="#999999" stroke-width="1"/>
@@ -14,21 +14,24 @@
   <text x="210" y="127" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#4a6fa5">title area</text>
   <text x="210" y="144" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">holds the Toolbar when one is set</text>
 
-  <rect x="72" y="162" width="276" height="176" rx="4" fill="#f7faf4" stroke="#4a7a3d" stroke-width="1.5"/>
+  <rect x="72" y="162" width="276" height="160" rx="4" fill="#f7faf4" stroke="#4a7a3d" stroke-width="1.5"/>
   <text x="210" y="182" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#4a7a3d">content pane</text>
   <text x="210" y="199" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">your components live here</text>
-  <rect x="92" y="212" width="236" height="26" rx="3" fill="#ffffff" stroke="#4a7a3d" stroke-width="1"/>
-  <rect x="92" y="246" width="236" height="26" rx="3" fill="#ffffff" stroke="#4a7a3d" stroke-width="1"/>
-  <rect x="92" y="280" width="236" height="26" rx="3" fill="#ffffff" stroke="#4a7a3d" stroke-width="1"/>
-  <text x="210" y="326" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#4a7a3d">this is the part that scrolls</text>
+  <rect x="92" y="210" width="236" height="24" rx="3" fill="#ffffff" stroke="#4a7a3d" stroke-width="1"/>
+  <rect x="92" y="240" width="236" height="24" rx="3" fill="#ffffff" stroke="#4a7a3d" stroke-width="1"/>
+  <rect x="92" y="270" width="236" height="24" rx="3" fill="#ffffff" stroke="#4a7a3d" stroke-width="1"/>
+  <text x="210" y="312" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#4a7a3d">this is the part that scrolls</text>
 
-  <rect x="72" y="346" width="276" height="20" rx="3" fill="#eeeeee" stroke="#999999" stroke-width="1"/>
-  <text x="210" y="360" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">system inset: home indicator</text>
+  <rect x="190" y="228" width="146" height="54" rx="4" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
+  <text x="263" y="246" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#a56a3a">layered pane</text>
+  <text x="263" y="261" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#a56a3a">floats above the content,</text>
+  <text x="263" y="274" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#a56a3a">does not scroll with it</text>
 
-  <rect x="188" y="240" width="148" height="58" rx="4" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
-  <text x="262" y="260" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#a56a3a">layered pane</text>
-  <text x="262" y="276" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#a56a3a">floats above the content,</text>
-  <text x="262" y="289" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#a56a3a">does not scroll with it</text>
+  <rect x="72" y="330" width="276" height="20" rx="3" fill="#ffffff" stroke="#4a6fa5" stroke-width="1" stroke-dasharray="4 3"/>
+  <text x="210" y="344" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#4a6fa5">menu bar (only on some ports)</text>
+
+  <rect x="72" y="358" width="276" height="20" rx="3" fill="#eeeeee" stroke="#999999" stroke-width="1"/>
+  <text x="210" y="372" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">system inset: home indicator</text>
 
   <rect x="400" y="60" width="396" height="90" rx="6" fill="#f4f7fb" stroke="#4a6fa5" stroke-width="1.5"/>
   <text x="598" y="80" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#4a6fa5">getTitleArea() / getToolbar()</text>
@@ -36,19 +39,19 @@
   <text x="598" y="116" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">overflow menu are all Toolbar concerns.</text>
   <text x="598" y="136" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Add to the Toolbar, not to the title area directly.</text>
 
-  <rect x="400" y="162" width="396" height="96" rx="6" fill="#f7faf4" stroke="#4a7a3d" stroke-width="1.5"/>
-  <text x="598" y="182" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#4a7a3d">getContentPane()</text>
-  <text x="598" y="202" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">form.add(...) adds here, and the form's layout</text>
-  <text x="598" y="218" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">manager is the content pane's layout manager.</text>
-  <text x="598" y="238" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">setScrollable() forwards here too, which is why scrolling</text>
-  <text x="598" y="251" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">moves the components and leaves the title in place.</text>
+  <rect x="400" y="162" width="396" height="124" rx="6" fill="#f7faf4" stroke="#4a7a3d" stroke-width="1.5"/>
+  <text x="598" y="182" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#4a7a3d">getContentPane() and getMenuBar()</text>
+  <text x="598" y="202" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">form.add(...) adds to the content pane, and the form's</text>
+  <text x="598" y="218" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">layout manager is the content pane's layout manager.</text>
+  <text x="598" y="240" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">setScrollable() forwards here too, which is why scrolling moves</text>
+  <text x="598" y="254" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">the components and leaves the title in place. A menu bar is added</text>
+  <text x="598" y="268" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">to BorderLayout.SOUTH on ports that put commands in a bar.</text>
 
-  <rect x="400" y="270" width="396" height="130" rx="6" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
-  <text x="598" y="290" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#a56a3a">getLayeredPane() and getSafeArea()</text>
-  <text x="598" y="310" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">The layered pane is for things that sit over the UI:</text>
-  <text x="598" y="326" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">a badge, a hint, an overlay. Ask for one by class and</text>
-  <text x="598" y="342" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">your layer stays separate from anyone else's.</text>
-  <text x="598" y="364" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">getSafeArea() is the rectangle clear of the insets above. The Form is only the frame that</text>
-  <text x="598" y="377" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">it is measured against: a container is padded clear of the insets only once you</text>
-  <text x="598" y="390" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">call setSafeArea(true) on it, so custom content can still overlap a notch.</text>
+  <rect x="400" y="298" width="396" height="118" rx="6" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
+  <text x="598" y="318" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#a56a3a">getLayeredPane() and getSafeArea()</text>
+  <text x="598" y="338" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">The layered pane is for things that sit over the UI: a badge,</text>
+  <text x="598" y="354" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">a hint, an overlay. Ask for one by class and your layer</text>
+  <text x="598" y="370" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">stays separate from anyone else's.</text>
+  <text x="598" y="390" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">getSafeArea() is the rectangle clear of the insets. The Form is only the</text>
+  <text x="598" y="404" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">frame it is measured against: padding comes from setSafeArea(true).</text>
 </svg>

--- a/docs/developer-guide/img/form-anatomy.svg
+++ b/docs/developer-guide/img/form-anatomy.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="420" viewBox="0 0 820 420">
+  <rect x="0" y="0" width="820" height="420" fill="#ffffff"/>
+
+  <text x="410" y="26" font-family="Arial, sans-serif" font-size="15" font-weight="bold"
+        text-anchor="middle" fill="#222222">What a Form is made of</text>
+
+  <rect x="60" y="52" width="300" height="336" rx="10" fill="#ffffff" stroke="#222222" stroke-width="1.5"/>
+  <text x="210" y="72" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#666666">Form (itself a Container)</text>
+
+  <rect x="72" y="82" width="276" height="20" rx="3" fill="#eeeeee" stroke="#999999" stroke-width="1"/>
+  <text x="210" y="96" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">system inset: status bar, notch</text>
+
+  <rect x="72" y="108" width="276" height="46" rx="4" fill="#f4f7fb" stroke="#4a6fa5" stroke-width="1.5"/>
+  <text x="210" y="127" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#4a6fa5">title area</text>
+  <text x="210" y="144" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">holds the Toolbar when one is set</text>
+
+  <rect x="72" y="162" width="276" height="176" rx="4" fill="#f7faf4" stroke="#4a7a3d" stroke-width="1.5"/>
+  <text x="210" y="182" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#4a7a3d">content pane</text>
+  <text x="210" y="199" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">your components live here</text>
+  <rect x="92" y="212" width="236" height="26" rx="3" fill="#ffffff" stroke="#4a7a3d" stroke-width="1"/>
+  <rect x="92" y="246" width="236" height="26" rx="3" fill="#ffffff" stroke="#4a7a3d" stroke-width="1"/>
+  <rect x="92" y="280" width="236" height="26" rx="3" fill="#ffffff" stroke="#4a7a3d" stroke-width="1"/>
+  <text x="210" y="326" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#4a7a3d">this is the part that scrolls</text>
+
+  <rect x="72" y="346" width="276" height="20" rx="3" fill="#eeeeee" stroke="#999999" stroke-width="1"/>
+  <text x="210" y="360" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">system inset: home indicator</text>
+
+  <rect x="188" y="240" width="148" height="58" rx="4" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
+  <text x="262" y="260" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#a56a3a">layered pane</text>
+  <text x="262" y="276" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#a56a3a">floats above the content,</text>
+  <text x="262" y="289" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#a56a3a">does not scroll with it</text>
+
+  <rect x="400" y="60" width="396" height="90" rx="6" fill="#f4f7fb" stroke="#4a6fa5" stroke-width="1.5"/>
+  <text x="598" y="80" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#4a6fa5">getTitleArea() / getToolbar()</text>
+  <text x="598" y="100" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">Commands, the title, the side menu and the</text>
+  <text x="598" y="116" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">overflow menu are all Toolbar concerns.</text>
+  <text x="598" y="136" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Add to the Toolbar, not to the title area directly.</text>
+
+  <rect x="400" y="162" width="396" height="96" rx="6" fill="#f7faf4" stroke="#4a7a3d" stroke-width="1.5"/>
+  <text x="598" y="182" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#4a7a3d">getContentPane()</text>
+  <text x="598" y="202" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">form.add(...) adds here, and the form's layout</text>
+  <text x="598" y="218" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">manager is the content pane's layout manager.</text>
+  <text x="598" y="238" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">setScrollable() forwards here too, which is why scrolling</text>
+  <text x="598" y="251" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">moves the components and leaves the title in place.</text>
+
+  <rect x="400" y="270" width="396" height="118" rx="6" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
+  <text x="598" y="290" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#a56a3a">getLayeredPane() and getSafeArea()</text>
+  <text x="598" y="310" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">The layered pane is for things that sit over the UI:</text>
+  <text x="598" y="326" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">a badge, a hint, an overlay. Ask for one by class and</text>
+  <text x="598" y="342" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">your layer stays separate from anyone else's.</text>
+  <text x="598" y="364" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">getSafeArea() is the rectangle clear of the insets above. A Form is a safe</text>
+  <text x="598" y="377" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">area root, so its children are kept out of the notch and home indicator.</text>
+</svg>

--- a/docs/developer-guide/img/storage-model.svg
+++ b/docs/developer-guide/img/storage-model.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="452" viewBox="0 0 820 452">
-  <rect x="0" y="0" width="820" height="452" fill="#ffffff"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="466" viewBox="0 0 820 466">
+  <rect x="0" y="0" width="820" height="466" fill="#ffffff"/>
 
   <text x="410" y="26" font-family="Arial, sans-serif" font-size="15" font-weight="bold"
         text-anchor="middle" fill="#222222">Four places to put data, and what each one is for</text>
@@ -48,12 +48,13 @@
   <path d="M 307 252 L 312 246 L 317 252" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
   <text x="214" y="284" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Preferences is built on Storage, so it is not a separate store</text>
 
-  <rect x="24" y="300" width="772" height="136" rx="6" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
+  <rect x="24" y="300" width="772" height="150" rx="6" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
   <text x="410" y="322" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#a56a3a">Choosing between them</text>
   <text x="410" y="342" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">Settings go in Preferences. Objects your app alone reads go in Storage. Files another API opens</text>
   <text x="410" y="358" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">by path go in FileSystemStorage. Size alone does not call for a Database: both of those stream,</text>
   <text x="410" y="374" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">so reach for a Database when you need to QUERY structured data rather than read it whole.</text>
   <text x="410" y="392" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">None of these is reclaimed behind your back, with one exception: files under FileSystemStorage.getCachesDir() are a platform cache the system may delete.</text>
   <text x="410" y="406" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#a56a3a">All four are plaintext by default: a Database takes a DatabaseConfig to encrypt it, and Storage can be wrapped through setStorageInstance. For auth</text>
-  <text x="410" y="420" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#a56a3a">tokens, refresh tokens and API keys, reach for SecureStorage instead: it keeps them in the platform keychain rather than in app storage at all.</text>
+  <text x="410" y="420" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#a56a3a">tokens, refresh tokens and API keys, reach for SecureStorage: it encrypts them under a key the platform keystore holds, though on Android the</text>
+  <text x="410" y="434" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#a56a3a">ciphertext still sits in app storage. A port without support stores nothing and returns false from set(), so check what it gives back.</text>
 </svg>

--- a/docs/developer-guide/img/storage-model.svg
+++ b/docs/developer-guide/img/storage-model.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="430" viewBox="0 0 820 430">
-  <rect x="0" y="0" width="820" height="430" fill="#ffffff"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="452" viewBox="0 0 820 452">
+  <rect x="0" y="0" width="820" height="452" fill="#ffffff"/>
 
   <text x="410" y="26" font-family="Arial, sans-serif" font-size="15" font-weight="bold"
         text-anchor="middle" fill="#222222">Four places to put data, and what each one is for</text>
@@ -48,11 +48,12 @@
   <path d="M 307 252 L 312 246 L 317 252" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
   <text x="214" y="284" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Preferences is built on Storage, so it is not a separate store</text>
 
-  <rect x="24" y="300" width="772" height="114" rx="6" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
+  <rect x="24" y="300" width="772" height="136" rx="6" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
   <text x="410" y="322" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#a56a3a">Choosing between them</text>
   <text x="410" y="342" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">Settings go in Preferences. Objects your app alone reads go in Storage. Files another API opens</text>
   <text x="410" y="358" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">by path go in FileSystemStorage. Size alone does not call for a Database: both of those stream,</text>
   <text x="410" y="374" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">so reach for a Database when you need to QUERY structured data rather than read it whole.</text>
   <text x="410" y="392" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">None of these is reclaimed behind your back, with one exception: files under FileSystemStorage.getCachesDir() are a platform cache the system may delete.</text>
-  <text x="410" y="406" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#a56a3a">All four are plaintext on disk. Auth tokens, refresh tokens and API keys belong in SecureStorage, which keeps them in the platform keychain.</text>
+  <text x="410" y="406" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#a56a3a">All four are plaintext by default: a Database takes a DatabaseConfig to encrypt it, and Storage can be wrapped through setStorageInstance. For auth</text>
+  <text x="410" y="420" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#a56a3a">tokens, refresh tokens and API keys, reach for SecureStorage instead: it keeps them in the platform keychain rather than in app storage at all.</text>
 </svg>

--- a/docs/developer-guide/img/storage-model.svg
+++ b/docs/developer-guide/img/storage-model.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="416" viewBox="0 0 820 416">
-  <rect x="0" y="0" width="820" height="416" fill="#ffffff"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="430" viewBox="0 0 820 430">
+  <rect x="0" y="0" width="820" height="430" fill="#ffffff"/>
 
   <text x="410" y="26" font-family="Arial, sans-serif" font-size="15" font-weight="bold"
         text-anchor="middle" fill="#222222">Four places to put data, and what each one is for</text>
@@ -8,8 +8,8 @@
   <text x="116" y="70" font-family="Arial, sans-serif" font-size="13" font-weight="bold" text-anchor="middle" fill="#4a6fa5">Preferences</text>
   <text x="116" y="92" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">named settings</text>
   <text x="116" y="110" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">get / set by key</text>
-  <text x="116" y="136" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">a flag, a token, the last</text>
-  <text x="116" y="150" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">screen the user was on</text>
+  <text x="116" y="136" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">a flag, a sort order, the</text>
+  <text x="116" y="150" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">last screen the user was on</text>
   <text x="116" y="176" font-family="Arial, sans-serif" font-size="10" font-weight="bold" text-anchor="middle" fill="#a56a3a">whole map is rewritten</text>
   <text x="116" y="190" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#a56a3a">on every set: keep it small</text>
   <text x="116" y="222" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">stored as one Storage entry</text>
@@ -48,10 +48,11 @@
   <path d="M 307 252 L 312 246 L 317 252" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
   <text x="214" y="284" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Preferences is built on Storage, so it is not a separate store</text>
 
-  <rect x="24" y="300" width="772" height="98" rx="6" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
+  <rect x="24" y="300" width="772" height="114" rx="6" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
   <text x="410" y="322" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#a56a3a">Choosing between them</text>
   <text x="410" y="342" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">Settings go in Preferences. Objects your app alone reads go in Storage. Files another API opens</text>
   <text x="410" y="358" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">by path go in FileSystemStorage. Size alone does not call for a Database: both of those stream,</text>
   <text x="410" y="374" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">so reach for a Database when you need to QUERY structured data rather than read it whole.</text>
   <text x="410" y="392" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">None of these is reclaimed behind your back, with one exception: files under FileSystemStorage.getCachesDir() are a platform cache the system may delete.</text>
+  <text x="410" y="406" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#a56a3a">All four are plaintext on disk. Auth tokens, refresh tokens and API keys belong in SecureStorage, which keeps them in the platform keychain.</text>
 </svg>

--- a/docs/developer-guide/img/storage-model.svg
+++ b/docs/developer-guide/img/storage-model.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="400" viewBox="0 0 820 400">
-  <rect x="0" y="0" width="820" height="400" fill="#ffffff"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="416" viewBox="0 0 820 416">
+  <rect x="0" y="0" width="820" height="416" fill="#ffffff"/>
 
   <text x="410" y="26" font-family="Arial, sans-serif" font-size="15" font-weight="bold"
         text-anchor="middle" fill="#222222">Four places to put data, and what each one is for</text>
@@ -22,7 +22,7 @@
   <text x="312" y="150" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">streams your app owns</text>
   <text x="312" y="176" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">names, not paths: there</text>
   <text x="312" y="190" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">are no directories here</text>
-  <text x="312" y="222" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">portable everywhere</text>
+  <text x="312" y="222" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">portable, and streamable</text>
 
   <rect x="416" y="48" width="184" height="196" rx="6" fill="#f4f7fb" stroke="#4a6fa5" stroke-width="1.5"/>
   <text x="508" y="70" font-family="Arial, sans-serif" font-size="13" font-weight="bold" text-anchor="middle" fill="#4a6fa5">FileSystemStorage</text>
@@ -40,17 +40,18 @@
   <text x="704" y="110" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">openOrCreate(name)</text>
   <text x="704" y="136" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">data you query rather</text>
   <text x="704" y="150" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">than load whole</text>
-  <text x="704" y="176" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">the only option that reads</text>
-  <text x="704" y="190" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">part of a large data set</text>
+  <text x="704" y="176" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">the only one that can query</text>
+  <text x="704" y="190" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">a subset by its contents</text>
   <text x="704" y="222" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">not present on every port</text>
 
   <path d="M 116 244 L 116 268 L 312 268 L 312 246" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
   <path d="M 307 252 L 312 246 L 317 252" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
   <text x="214" y="284" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Preferences is built on Storage, so it is not a separate store</text>
 
-  <rect x="24" y="300" width="772" height="80" rx="6" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
+  <rect x="24" y="300" width="772" height="98" rx="6" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
   <text x="410" y="322" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#a56a3a">Choosing between them</text>
-  <text x="410" y="342" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">Settings go in Preferences. Objects your app alone reads go in Storage. Files another</text>
-  <text x="410" y="358" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">API opens by path go in FileSystemStorage. Data too large to load at once goes in a Database.</text>
-  <text x="410" y="374" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">None of them is a cache the platform may reclaim: deleting what you no longer need is your job.</text>
+  <text x="410" y="342" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">Settings go in Preferences. Objects your app alone reads go in Storage. Files another API opens</text>
+  <text x="410" y="358" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">by path go in FileSystemStorage. Size alone does not call for a Database: both of those stream,</text>
+  <text x="410" y="374" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">so reach for a Database when you need to QUERY structured data rather than read it whole.</text>
+  <text x="410" y="392" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">None of these is reclaimed behind your back, with one exception: files under FileSystemStorage.getCachesDir() are a platform cache the system may delete.</text>
 </svg>

--- a/docs/developer-guide/img/storage-model.svg
+++ b/docs/developer-guide/img/storage-model.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="400" viewBox="0 0 820 400">
+  <rect x="0" y="0" width="820" height="400" fill="#ffffff"/>
+
+  <text x="410" y="26" font-family="Arial, sans-serif" font-size="15" font-weight="bold"
+        text-anchor="middle" fill="#222222">Four places to put data, and what each one is for</text>
+
+  <rect x="24" y="48" width="184" height="196" rx="6" fill="#f4f7fb" stroke="#4a6fa5" stroke-width="1.5"/>
+  <text x="116" y="70" font-family="Arial, sans-serif" font-size="13" font-weight="bold" text-anchor="middle" fill="#4a6fa5">Preferences</text>
+  <text x="116" y="92" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">named settings</text>
+  <text x="116" y="110" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">get / set by key</text>
+  <text x="116" y="136" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">a flag, a token, the last</text>
+  <text x="116" y="150" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">screen the user was on</text>
+  <text x="116" y="176" font-family="Arial, sans-serif" font-size="10" font-weight="bold" text-anchor="middle" fill="#a56a3a">whole map is rewritten</text>
+  <text x="116" y="190" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#a56a3a">on every set: keep it small</text>
+  <text x="116" y="222" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">stored as one Storage entry</text>
+
+  <rect x="220" y="48" width="184" height="196" rx="6" fill="#f4f7fb" stroke="#4a6fa5" stroke-width="1.5"/>
+  <text x="312" y="70" font-family="Arial, sans-serif" font-size="13" font-weight="bold" text-anchor="middle" fill="#4a6fa5">Storage</text>
+  <text x="312" y="92" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">named entries</text>
+  <text x="312" y="110" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">writeObject / readObject</text>
+  <text x="312" y="136" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">serialized objects and</text>
+  <text x="312" y="150" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">streams your app owns</text>
+  <text x="312" y="176" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">names, not paths: there</text>
+  <text x="312" y="190" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">are no directories here</text>
+  <text x="312" y="222" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">portable everywhere</text>
+
+  <rect x="416" y="48" width="184" height="196" rx="6" fill="#f4f7fb" stroke="#4a6fa5" stroke-width="1.5"/>
+  <text x="508" y="70" font-family="Arial, sans-serif" font-size="13" font-weight="bold" text-anchor="middle" fill="#4a6fa5">FileSystemStorage</text>
+  <text x="508" y="92" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">real files and paths</text>
+  <text x="508" y="110" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">roots, directories, streams</text>
+  <text x="508" y="136" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">anything you must hand to</text>
+  <text x="508" y="150" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">the platform by path</text>
+  <text x="508" y="176" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">getAppHomePath() is the</text>
+  <text x="508" y="190" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">private area you may write</text>
+  <text x="508" y="222" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">roots differ per platform</text>
+
+  <rect x="612" y="48" width="184" height="196" rx="6" fill="#f4f7fb" stroke="#4a6fa5" stroke-width="1.5"/>
+  <text x="704" y="70" font-family="Arial, sans-serif" font-size="13" font-weight="bold" text-anchor="middle" fill="#4a6fa5">Database</text>
+  <text x="704" y="92" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">SQLite, via SQL</text>
+  <text x="704" y="110" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">openOrCreate(name)</text>
+  <text x="704" y="136" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">data you query rather</text>
+  <text x="704" y="150" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">than load whole</text>
+  <text x="704" y="176" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">the only option that reads</text>
+  <text x="704" y="190" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">part of a large data set</text>
+  <text x="704" y="222" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">not present on every port</text>
+
+  <path d="M 116 244 L 116 268 L 312 268 L 312 246" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
+  <path d="M 307 252 L 312 246 L 317 252" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
+  <text x="214" y="284" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Preferences is built on Storage, so it is not a separate store</text>
+
+  <rect x="24" y="300" width="772" height="80" rx="6" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
+  <text x="410" y="322" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#a56a3a">Choosing between them</text>
+  <text x="410" y="342" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">Settings go in Preferences. Objects your app alone reads go in Storage. Files another</text>
+  <text x="410" y="358" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">API opens by path go in FileSystemStorage. Data too large to load at once goes in a Database.</text>
+  <text x="410" y="374" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">None of them is a cache the platform may reclaim: deleting what you no longer need is your job.</text>
+</svg>

--- a/docs/developer-guide/img/storage-model.svg
+++ b/docs/developer-guide/img/storage-model.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="466" viewBox="0 0 820 466">
-  <rect x="0" y="0" width="820" height="466" fill="#ffffff"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="484" viewBox="0 0 820 484">
+  <rect x="0" y="0" width="820" height="484" fill="#ffffff"/>
 
   <text x="410" y="26" font-family="Arial, sans-serif" font-size="15" font-weight="bold"
         text-anchor="middle" fill="#222222">Four places to put data, and what each one is for</text>
@@ -48,13 +48,14 @@
   <path d="M 307 252 L 312 246 L 317 252" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
   <text x="214" y="284" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Preferences is built on Storage, so it is not a separate store</text>
 
-  <rect x="24" y="300" width="772" height="150" rx="6" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
+  <rect x="24" y="300" width="772" height="168" rx="6" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
   <text x="410" y="322" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#a56a3a">Choosing between them</text>
   <text x="410" y="342" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">Settings go in Preferences. Objects your app alone reads go in Storage. Files another API opens</text>
   <text x="410" y="358" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">by path go in FileSystemStorage. Size alone does not call for a Database: both of those stream,</text>
   <text x="410" y="374" font-family="Arial, sans-serif" font-size="11" text-anchor="middle" fill="#222222">so reach for a Database when you need to QUERY structured data rather than read it whole.</text>
-  <text x="410" y="392" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">None of these is reclaimed behind your back, with one exception: files under FileSystemStorage.getCachesDir() are a platform cache the system may delete.</text>
-  <text x="410" y="406" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#a56a3a">All four are plaintext by default: a Database takes a DatabaseConfig to encrypt it, and Storage can be wrapped through setStorageInstance. For auth</text>
-  <text x="410" y="420" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#a56a3a">tokens, refresh tokens and API keys, reach for SecureStorage: it encrypts them under a key the platform keystore holds, though on Android the</text>
-  <text x="410" y="434" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#a56a3a">ciphertext still sits in app storage. A port without support stores nothing and returns false from set(), so check what it gives back.</text>
+  <text x="410" y="392" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">None of these is reclaimed behind your back, with one exception: files under</text>
+  <text x="410" y="405" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">FileSystemStorage.getCachesDir() are a platform cache the system may delete.</text>
+  <text x="410" y="423" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#a56a3a">All four are plaintext by default: a Database takes a DatabaseConfig to encrypt it, and Storage can be wrapped through setStorageInstance.</text>
+  <text x="410" y="437" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#a56a3a">For auth tokens and API keys reach for SecureStorage, which on iOS and Android encrypts under a key the platform keystore holds.</text>
+  <text x="410" y="451" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#a56a3a">It is not uniform: the web port writes through Storage in plaintext, and a port with no support stores nothing and returns false from set().</text>
 </svg>

--- a/docs/developer-guide/io.asciidoc
+++ b/docs/developer-guide/io.asciidoc
@@ -40,6 +40,12 @@ Just like in Java SE, the entries within the "JAR" are read and can't be modifie
 
 === Storage
 
+Codename One gives you four places to keep data, and picking the wrong one is
+the usual source of trouble later:
+
+.What each store is for, and what it isn't
+image::img/storage-model.svg[The four Codename One data stores and what each is for,scaledwidth=85%]
+
 https://www.codenameone.com/javadoc/com/codename1/io/Storage.html[Storage] is accessed through the `Storage` class. It's a flat, filesystem-like interface that can list, delete, and write named storage entries.
 
 The `Storage` API also provides convenient methods to write objects to `Storage` and read them back with `readObject` and `writeObject`.


### PR DESCRIPTION
The plan's original survey found **one** conceptual diagram in the entire
manual, and the EDT chapter explains the single most important threading rule
in Codename One across 202 lines without a picture of it. These are the first
two of the planned set.

### The EDT cycle

Draws the loop -- sleep, deliver input, run serial calls, advance animations,
paint -- and hangs both entry points off it, because the difference only makes
sense against that loop:

- `callSerially` queues onto the step the loop already drains, so it returns at
  once and the Runnable executes on a later cycle.
- `invokeAndBlock` moves the Runnable to a pooled thread and lets the loop keep
  going -- which is why the app still paints while your line of code waits, and
  why every `andWait()` method in the framework is built on it.

### The four data stores

Separates four things the guide currently describes only one at a time:
Preferences for settings, Storage for named objects, FileSystemStorage for real
paths, Database for data too large to load whole. It also records two facts a
reader otherwise learns the hard way: Preferences is a single Storage entry and
rewrites the whole map on every `set`, and none of the four is a cache the
platform reclaims.

### Accuracy and rendering

Both are drawn from source rather than memory -- the loop order from
`edtLoopImpl`/`mainEDTLoop`, the pooled thread from
`RunnableWrapper.pushToThreadPool`, the Preferences claim from its own
`writeObject` call.

Both follow the in-tree SVG conventions (presentation attributes only, no
`style` block, explicit `viewBox`), and I checked them in a browser-grade
renderer rather than ImageMagick -- whose internal SVG support silently drops
`path` elements and made the arrows appear missing. The `asciidoctor-pdf` build
renders both with no prawn-svg warning.

Gates: structure, xrefs, snippets, links (including the new Java-source figure
URL check), missing-code-blocks, unused images, capitalization, asciidoctor
`--failure-level WARN`, Vale 0, LanguageTool `ok 0`, control characters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)