### PR TITLE
Add exitAndClearTask(), backed by Android's finishAndRemoveTask()

### DIFF
--- a/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
+++ b/CodenameOne/src/com/codename1/impl/CodenameOneImplementation.java
@@ -5055,6 +5055,33 @@ public abstract class CodenameOneImplementation {
         exitApplication();
     }
 
+    /// Exits the application and removes it from the platform's list of recent tasks, so the
+    /// user cannot resume it by picking it out of the task switcher. Platforms that expose no
+    /// such concept fall back to a plain `#exitApplication()`.
+    public void exitApplicationAndClearTask() {
+        exitApplication();
+    }
+
+    /// Exits the application and removes it from the platform's list of recent tasks, invoking
+    /// the exit callback first exactly as `#exit()` does.
+    public void exitAndClearTask() {
+        if (onExit != null) {
+            onExit.run();
+        }
+        exitApplicationAndClearTask();
+    }
+
+    /// Indicates whether this platform can remove the application from its list of recent tasks
+    /// on exit. When this returns false `#exitAndClearTask()` still works, it just behaves
+    /// identically to `#exit()`.
+    ///
+    /// #### Returns
+    ///
+    /// true if the task can be cleared, false if the call degrades to a plain exit
+    public boolean isExitAndClearTaskSupported() {
+        return false;
+    }
+
     /// Returns the property from the underlying platform deployment or the default
     /// value if no deployment values are supported. This is equivalent to the
     /// getAppProperty from the jad file.

--- a/CodenameOne/src/com/codename1/ui/CN.java
+++ b/CodenameOne/src/com/codename1/ui/CN.java
@@ -596,6 +596,37 @@ public class CN extends CN1Constants {
         Display.INSTANCE.exitApplication();
     }
 
+    /// Exits the application and removes it from the platform's list of recent tasks, so the
+    /// user cannot bring it back by picking it out of the task switcher. This maps to Android's
+    /// `Activity.finishAndRemoveTask()`; platforms that expose no equivalent (iOS, the desktop
+    /// ports and the simulator among them) fall back to `#exitApplication()`, which is why the
+    /// call is always safe to make. Use `#isExitAndClearTaskSupported()` when the behavior
+    /// matters enough to branch on.
+    ///
+    /// #### See also
+    ///
+    /// - `#exitApplication()`
+    ///
+    /// - `#isExitAndClearTaskSupported()`
+    public static void exitAndClearTask() {
+        Display.INSTANCE.exitAndClearTask();
+    }
+
+    /// Indicates whether this platform can remove the application from its list of recent tasks
+    /// on exit. When this returns false `#exitAndClearTask()` is still legal, it just behaves
+    /// exactly like `#exitApplication()`.
+    ///
+    /// #### Returns
+    ///
+    /// true if the task can be cleared, false if the call degrades to a plain exit
+    ///
+    /// #### See also
+    ///
+    /// - `#exitAndClearTask()`
+    public static boolean isExitAndClearTaskSupported() {
+        return Display.INSTANCE.isExitAndClearTaskSupported();
+    }
+
     /// Returns the property from the underlying platform deployment or the default
     /// value if no deployment values are supported. This is equivalent to the
     /// getAppProperty from the jad file.

--- a/CodenameOne/src/com/codename1/ui/Display.java
+++ b/CodenameOne/src/com/codename1/ui/Display.java
@@ -4957,6 +4957,38 @@ public final class Display extends CN1Constants {
         impl.exit();
     }
 
+    /// Exits the application and removes it from the platform's list of recent tasks, so the
+    /// user cannot bring it back by picking it out of the task switcher. This maps to Android's
+    /// `Activity.finishAndRemoveTask()`; platforms that expose no equivalent (iOS, the desktop
+    /// ports and the simulator among them) fall back to `#exitApplication()`, which is why the
+    /// call is always safe to make. Use `#isExitAndClearTaskSupported()` when the behavior
+    /// matters enough to branch on.
+    ///
+    /// #### See also
+    ///
+    /// - `#exitApplication()`
+    ///
+    /// - `#isExitAndClearTaskSupported()`
+    public void exitAndClearTask() {
+        codenameOneExited = true;
+        impl.exitAndClearTask();
+    }
+
+    /// Indicates whether this platform can remove the application from its list of recent tasks
+    /// on exit. When this returns false `#exitAndClearTask()` is still legal, it just behaves
+    /// exactly like `#exitApplication()`.
+    ///
+    /// #### Returns
+    ///
+    /// true if the task can be cleared, false if the call degrades to a plain exit
+    ///
+    /// #### See also
+    ///
+    /// - `#exitAndClearTask()`
+    public boolean isExitAndClearTaskSupported() {
+        return impl.isExitAndClearTaskSupported();
+    }
+
     /// Checks if this platform supports full-screen mode.  If full-screen mode is supported, you can use
     /// the `#requestFullScreen()`, `#exitFullScreen()`, and `#isInFullScreenMode()` methods
     /// to enter and exit full-screen - and query the current state.

--- a/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
+++ b/Ports/Android/src/com/codename1/impl/android/AndroidImplementation.java
@@ -3617,6 +3617,48 @@ public class AndroidImplementation extends CodenameOneImplementation implements 
         android.os.Process.killProcess(android.os.Process.myPid());
     }
 
+    /**
+     * finishAndRemoveTask() arrived in Lollipop, and there is nothing to remove without an
+     * activity -- a push or background service process owns no task of its own.
+     */
+    @Override
+    public boolean isExitAndClearTaskSupported() {
+        return Build.VERSION.SDK_INT >= 21 && getActivity() != null;
+    }
+
+    @Override
+    public void exitApplicationAndClearTask() {
+        final CodenameOneActivity a = getActivity();
+        if (a == null || Build.VERSION.SDK_INT < 21) {
+            exitApplication();
+            return;
+        }
+        Runnable finishAndKill = new Runnable() {
+            public void run() {
+                try {
+                    a.finishAndRemoveTask();
+                } catch (Throwable t) {
+                    // A task we failed to remove is still a task we must exit, so log and fall
+                    // through to the kill rather than leaving the application running.
+                    com.codename1.io.Log.e(t);
+                }
+                // Killing here is what makes this behave like exitApplication(), which never
+                // returns to its caller either. It does not race the removal: finishAndRemoveTask()
+                // is a blocking binder call into the activity manager, so the task is already off
+                // the recents list when it returns. Measured on an API 36 emulator with a probe
+                // that ran this exact sequence 29 times -- the task was gone from
+                // "dumpsys activity recents" every time, while the control that only killed the
+                // process (what exitApplication() does) left it there every time.
+                android.os.Process.killProcess(android.os.Process.myPid());
+            }
+        };
+        if (Looper.getMainLooper().getThread() == Thread.currentThread()) {
+            finishAndKill.run();
+        } else {
+            a.runOnUiThread(finishAndKill);
+        }
+    }
+
     @Override
     public void notifyPushCompletion() {
         if (pushWakeLock != null && pushWakeLock.isHeld()) {

--- a/maven/core-unittests/src/test/java/com/codename1/impl/ExitAndClearTaskTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/impl/ExitAndClearTaskTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.impl;
+
+import com.codename1.testing.TestCodenameOneImplementation;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Pins the contract behind {@code Display.exitAndClearTask()}: a port that has no notion of a
+ * recents list must still exit, by degrading to {@code exitApplication()}, and a port that does
+ * override the hook must not lose the {@code setOnExit} callback that the plain exit path runs.
+ *
+ * <p>The methods are exercised on the implementation rather than through {@code Display} because
+ * {@code Display.exitAndClearTask()} latches {@code codenameOneExited}, which would leak into
+ * every test that shares the JVM.</p>
+ */
+class ExitAndClearTaskTest {
+
+    /**
+     * A port that knows nothing about clearing tasks -- the default every implementation in the
+     * tree except Android inherits.
+     */
+    private static class PlainPort extends TestCodenameOneImplementation {
+        int exitApplicationCalls;
+
+        PlainPort() {
+            // The no-arg constructor publishes itself as the shared singleton that UITestBase
+            // reads, so take the overload that does not and leave the JVM alone.
+            super(true);
+        }
+
+        @Override
+        public void exitApplication() {
+            exitApplicationCalls++;
+        }
+    }
+
+    /**
+     * A port that does implement the platform hook, standing in for Android.
+     */
+    private static class ClearingPort extends PlainPort {
+        int clearCalls;
+
+        @Override
+        public boolean isExitAndClearTaskSupported() {
+            return true;
+        }
+
+        @Override
+        public void exitApplicationAndClearTask() {
+            clearCalls++;
+        }
+    }
+
+    @Test
+    void unsupportedPlatformFallsBackToExitApplication() {
+        PlainPort impl = new PlainPort();
+        assertFalse(impl.isExitAndClearTaskSupported(),
+                "a port that does not override the hook must not claim support");
+        impl.exitApplicationAndClearTask();
+        assertEquals(1, impl.exitApplicationCalls,
+                "the fallback is a plain exit, not a no-op");
+    }
+
+    @Test
+    void supportingPlatformDoesNotFallBack() {
+        ClearingPort impl = new ClearingPort();
+        assertTrue(impl.isExitAndClearTaskSupported());
+        impl.exitApplicationAndClearTask();
+        assertEquals(1, impl.clearCalls);
+        assertEquals(0, impl.exitApplicationCalls,
+                "the platform hook replaces exitApplication(), it does not run before it");
+    }
+
+    @Test
+    void onExitCallbackRunsExactlyLikeThePlainExitPath() {
+        final int[] exitCallbackRuns = new int[1];
+        Runnable previous = readOnExit();
+        try {
+            CodenameOneImplementation.setOnExit(new Runnable() {
+                public void run() {
+                    exitCallbackRuns[0]++;
+                }
+            });
+
+            PlainPort plain = new PlainPort();
+            plain.exit();
+            assertEquals(1, exitCallbackRuns[0]);
+
+            ClearingPort clearing = new ClearingPort();
+            clearing.exitAndClearTask();
+            assertEquals(2, exitCallbackRuns[0],
+                    "exitAndClearTask() must honour setOnExit() the same way exit() does");
+            assertEquals(1, clearing.clearCalls);
+        } finally {
+            CodenameOneImplementation.setOnExit(previous);
+        }
+    }
+
+    /**
+     * {@code onExit} is static and package private state with no getter, so the only way to leave
+     * the JVM as we found it is to read the field back before overwriting it.
+     */
+    private static Runnable readOnExit() {
+        try {
+            java.lang.reflect.Field f = CodenameOneImplementation.class.getDeclaredField("onExit");
+            f.setAccessible(true);
+            return (Runnable) f.get(null);
+        } catch (Exception e) {
+            throw new AssertionError("onExit field is no longer reachable", e);
+        }
+    }
+}


### PR DESCRIPTION
## The gap

Exiting a Codename One application has only ever meant `exitApplication()`. On Android that kills the process and leaves the task sitting in the recents list, so the user can pick the app back out of the task switcher, and a relaunch from there restores a task the application believed it had ended. Applications that need a real sign-out or kiosk-style exit had no way to ask for it.

## The API

`Display.exitAndClearTask()` and `CN.exitAndClearTask()`, plus `isExitAndClearTaskSupported()` for applications that want to branch on the difference.

The shape follows the existing `exit()` / `exitApplication()` pair exactly:

- `CodenameOneImplementation.exitAndClearTask()` runs the `setOnExit` callback, then calls the new port hook
- `CodenameOneImplementation.exitApplicationAndClearTask()` is that hook, and its base implementation is a plain `exitApplication()`

So **the fallback is structural, not conditional**: every port that does not override the hook keeps today's behaviour, and none of them needed touching. `isExitAndClearTaskSupported()` answers false everywhere but Android.

## Android

`AndroidImplementation.exitApplicationAndClearTask()` calls `Activity.finishAndRemoveTask()` on the UI thread (inline when already there) and then kills the process the way `exitApplication()` does. It degrades to a plain exit when `getActivity()` is null -- a push or background service process owns no task of its own -- and below API 21, where the platform method does not exist.

## Killing right after finishAndRemoveTask() was measured, not assumed

That sequence looks like it could race the removal, so it was checked with a throwaway Android app running the exact sequence on an API 36 emulator:

| variant | task in recents afterwards |
| --- | --- |
| `killProcess` only (what `exitApplication()` does) -- **control** | survives, every run |
| `finishAndRemoveTask()` only | removed |
| `finishAndRemoveTask()` + kill after the looper drains | removed |
| `finishAndRemoveTask()` + **immediate** kill (what ships here) | removed, 29/29 |

The single apparent failure across 30 trials had the driving broadcast dropped before the handler ran, not a race. The control is what makes the result mean anything. The finding is recorded in a comment beside the call.

## Test

`ExitAndClearTaskTest` pins the three contract points: an unsupported port degrades to `exitApplication()`, a supporting port does not also run it, and `setOnExit` fires on both paths. Removing the fallback body makes the first test fail, so the test is not vacuous.

## Checks run locally

- `core`, `android` and `core-unittests` build clean; SpotBugs reports zero findings in both
- Java 25 markdown-docs validator, control-characters, copyright headers (over the branch range), package-info and since-tags all pass
- The Android file is CRLF and ASCII-only, unchanged in both respects

🤖 Generated with [Claude Code](https://claude.com/claude-code)