### PR TITLE
Developer guide: diagrams for peer painting and the UIID style cascade

### DIFF
--- a/docs/developer-guide/Advanced-Theming.asciidoc
+++ b/docs/developer-guide/Advanced-Theming.asciidoc
@@ -19,6 +19,12 @@ UIIDs can be customized in the GUI builder and support per-component styling.
 
 NOTE: The component class name often matches the UIID, but the two remain separate entities.
 
+Looking a UIID up isn't a single lookup. The state, the appearance and any
+`derive` chain each get a turn before the default style is reached:
+
+.The order UIManager searches when a component asks for its style
+image::img/theme-style-cascade.svg[The order UIManager searches to resolve a UIID into a Style,scaledwidth=85%]
+
 [[theme-layering-section]]
 === Theme layering
 

--- a/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
+++ b/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
@@ -1690,7 +1690,7 @@ NOTE: This was also the case in AWT/Swing to one degree or another...
 
 A form transition tells the peers about itself without any help from you: `initTransition` puts both
 forms into lightweight mode, which is how the framework says that a peer isn't truly visible for a
-while. What a peer does about that is the peer's own business, and it varies by port. Arbitrary overlap
+while. How a peer responds is left to the peer, and it varies by port. Arbitrary overlap
 is the part that isn't automatic anywhere. Codename One grabs a screenshot of the peer, hide it and then you can show the screenshot. Since the screenshot is static it can be rendered through the standard UI. You can't do that always since grabbing a screenshot is an expensive process on all platforms and must be performed on the native device thread.
 
 `PeerComponent` declares that callback empty, so a port opts into the still by overriding it. The iOS

--- a/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
+++ b/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
@@ -1688,16 +1688,22 @@ NOTE: This was also the case in AWT/Swing to one degree or another...
 
 ==== Showing dialogs on top of peer components
 
+Under the first two models this needs nothing from you: a `Dialog` paints after the peer and covers it.
+What follows is for the third, where the system composites the peer's own surface and no amount of
+painting reaches it.
+
 A form transition tells the peers about itself without any help from you: `initTransition` puts both
 forms into lightweight mode, which is how the framework says that a peer isn't truly visible for a
-while. How a peer responds is left to the peer, and it varies by port. Arbitrary overlap
-is the part that isn't automatic anywhere. Codename One grabs a screenshot of the peer, hide it and then you can show the screenshot. Since the screenshot is static it can be rendered through the standard UI. You can't do that always since grabbing a screenshot is an expensive process on all platforms and must be performed on the native device thread.
+while. How a peer responds is left to the peer, and it varies by port. Codename One grabs a screenshot of the peer, hide it and then you can show the screenshot. Since the screenshot is static it can be rendered through the standard UI. You can't do that always since grabbing a screenshot is an expensive process on all platforms and must be performed on the native device thread.
 
 `PeerComponent` declares that callback empty, so a port opts into the still by overriding it. The iOS
 and Android peers do, and on Android what the still contains varies again: the browser peer overrides
 the capture and draws its `WebView` into the bitmap, the default renders the `View` the ordinary way,
-and a peer that owns a surface has nothing there to render, so its still is blank and it vanishes for
-the length of the transition. The OpenGL peer keeps a copy of each frame read back with `glReadPixels`,
+and a peer that owns a surface has nothing there to render, so its still is blank. That doesn't hide the
+peer, though. In super peer mode `setLightweightMode` only generates the image, it never changes the
+view's visibility, and `AndroidGLSurface` asks for `setZOrderMediaOverlay(true)`, so the live surface goes
+on drawing above the Codename One canvas while a blank still is painted into the canvas underneath it.
+The transition animates around a peer that never moved. The OpenGL peer keeps a copy of each frame read back with `glReadPixels`,
 but that copy feeds the screenshot path rather than the peer's still image, so it doesn't cover this.
 The JavaScript peer overrides nothing, so it stays live throughout.
 

--- a/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
+++ b/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
@@ -1669,10 +1669,12 @@ This means that drawing looks something like this:
 
 . Loop over all native peer components and paint them.
 
-This means that all peer components are drawn on top of the Codename One components.
+On a port that paints peers in front, which is the default, this means peer components are drawn on top of the Codename One components.
 
-.The two painting passes, and what the order costs you
-image::img/peer-component-painting.svg[Why a native peer component is always painted above the Codename One layer,scaledwidth=85%]
+Newer ports invert that. iOS and the JavaScript port both return `true` from `paintNativePeersBehind()`, so the native layer sits underneath and Codename One paints above it, punching a hole through its own surface with `clearRect` wherever a peer belongs. Components can therefore be laid over a peer on those ports.
+
+.Where a peer sits, and what follows from it
+image::img/peer-component-painting.svg[Where a native peer is composited relative to the Codename One layer, and how it differs by port,scaledwidth=85%]
 
 NOTE: This was also the case in AWT/Swing to one degree or another...
 

--- a/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
+++ b/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
@@ -1671,6 +1671,9 @@ This means that drawing looks something like this:
 
 This means that all peer components are drawn on top of the Codename One components.
 
+.The two painting passes, and what the order costs you
+image::img/peer-component-painting.svg[Why a native peer component is always painted above the Codename One layer,scaledwidth=85%]
+
 NOTE: This was also the case in AWT/Swing to one degree or another...
 
 ==== Showing dialogs on top of peer components

--- a/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
+++ b/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
@@ -1663,15 +1663,23 @@ Codename One does pretty much everything on the EDT (Event Dispatch Thread), thi
 for example: modal dialogs, invokeAndBlock etc.
 
 For example native widgets have to be drawn on the devices native UI thread. +
-This means that drawing looks something like this:
+The oldest answer to that was to paint in two passes: loop over the Codename One components and paint
+them, then loop over the native peers and let the platform paint those over the result. That's where
+the rule that a peer always covers whatever sits under it comes from, and it isn't how the current
+ports work.
 
-. Loop over all Codename One components and paint them.
+`Display` asks the implementation one question, `paintNativePeersBehind()`, and a `false` answer
+doesn't mean the peer can't be covered. It leaves the compositing to the port, and the ports differ:
 
-. Loop over all native peer components and paint them.
+* iOS and the JavaScript port answer `true`. The native layer sits underneath and Codename One paints
+above it, punching a hole through its own surface with `clearRect` wherever a peer belongs.
 
-On a port that paints peers in front, which is the default, this means peer components are drawn on top of the Codename One components.
+* Android hands the peer's native `View` to the same ordered stream of drawing operations as every
+other component, so a component painted after the peer covers it. The simulator does the same for a
+peer that renders into a buffer.
 
-Newer ports invert that. iOS and the JavaScript port both return `true` from `paintNativePeersBehind()`, so the native layer sits underneath and Codename One paints above it, punching a hole through its own surface with `clearRect` wherever a peer belongs. Components can therefore be laid over a peer on those ports.
+* Where the peer owns a surface of its own, the system composites that surface and paint order never
+reaches it. That's the case the screenshot technique below was written for.
 
 .Where a peer sits, and what follows from it
 image::img/peer-component-painting.svg[Where a native peer is composited relative to the Codename One layer, and how it differs by port,scaledwidth=85%]
@@ -1680,7 +1688,8 @@ NOTE: This was also the case in AWT/Swing to one degree or another...
 
 ==== Showing dialogs on top of peer components
 
-Codename One grabs a screenshot of the peer, hide it and then you can show the screenshot. Since the screenshot is static it can be rendered through the standard UI. You can't do that always since grabbing a screenshot is an expensive process on all platforms and must be performed on the native device thread.
+Where the platform composites the peer itself, painting over it isn't an option, so the still image
+stands in for it. Codename One grabs a screenshot of the peer, hide it and then you can show the screenshot. Since the screenshot is static it can be rendered through the standard UI. You can't do that always since grabbing a screenshot is an expensive process on all platforms and must be performed on the native device thread.
 
 ==== Why can't you combine peer component scrolling and Codename One scrolling
 

--- a/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
+++ b/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
@@ -1679,7 +1679,7 @@ other component, so a component painted after the peer covers it. The simulator 
 peer that renders into a buffer.
 
 * Where the peer owns a surface of its own, the system composites that surface and paint order never
-reaches it. That's the case the screenshot technique below was written for.
+reaches it. The screenshot technique below can't reach it either, for the same reason.
 
 .Where a peer sits, and what follows from it
 image::img/peer-component-painting.svg[Where a native peer is composited relative to the Codename One layer, and how it differs by port,scaledwidth=85%]
@@ -1688,8 +1688,14 @@ NOTE: This was also the case in AWT/Swing to one degree or another...
 
 ==== Showing dialogs on top of peer components
 
-Where the platform composites the peer itself, painting over it isn't an option, so the still image
-stands in for it. Codename One grabs a screenshot of the peer, hide it and then you can show the screenshot. Since the screenshot is static it can be rendered through the standard UI. You can't do that always since grabbing a screenshot is an expensive process on all platforms and must be performed on the native device thread.
+A form transition doesn't need anything from you here: `initTransition` puts both forms into
+lightweight mode, and the ports answer that by standing a still image in for the peer while the
+transition runs. Arbitrary overlap is the part that isn't automatic. Codename One grabs a screenshot of the peer, hide it and then you can show the screenshot. Since the screenshot is static it can be rendered through the standard UI. You can't do that always since grabbing a screenshot is an expensive process on all platforms and must be performed on the native device thread.
+
+A peer that renders into a surface of its own is the case the capture can't cover at all: the ordinary
+view capture reads nothing back from such a surface. A port that needs the contents anyway has to keep
+its own copy, which is what the OpenGL peer does with `glReadPixels` so that its last frame still
+reaches a screenshot.
 
 ==== Why can't you combine peer component scrolling and Codename One scrolling
 

--- a/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
+++ b/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
@@ -1688,15 +1688,18 @@ NOTE: This was also the case in AWT/Swing to one degree or another...
 
 ==== Showing dialogs on top of peer components
 
-A form transition doesn't need anything from you here: `initTransition` puts both forms into
-lightweight mode, and the peer is asked for a still image to stand in for it while the transition
-runs. Arbitrary overlap is the part that isn't automatic. Codename One grabs a screenshot of the peer, hide it and then you can show the screenshot. Since the screenshot is static it can be rendered through the standard UI. You can't do that always since grabbing a screenshot is an expensive process on all platforms and must be performed on the native device thread.
+A form transition tells the peers about itself without any help from you: `initTransition` puts both
+forms into lightweight mode, which is how the framework says that a peer isn't truly visible for a
+while. What a peer does about that is the peer's own business, and it varies by port. Arbitrary overlap
+is the part that isn't automatic anywhere. Codename One grabs a screenshot of the peer, hide it and then you can show the screenshot. Since the screenshot is static it can be rendered through the standard UI. You can't do that always since grabbing a screenshot is an expensive process on all platforms and must be performed on the native device thread.
 
-What that still contains is up to the peer. On Android the browser peer overrides the capture and draws
-its `WebView` into the bitmap, while the default renders the `View` the ordinary way. A peer that owns a
-surface has nothing there to render, so its still is blank and it disappears for the length of the
-transition. The OpenGL peer does keep a copy of each frame, read back with `glReadPixels`, but that copy
-feeds the screenshot path rather than the peer's still image, so it doesn't cover this case.
+`PeerComponent` declares that callback empty, so a port opts into the still by overriding it. The iOS
+and Android peers do, and on Android what the still contains varies again: the browser peer overrides
+the capture and draws its `WebView` into the bitmap, the default renders the `View` the ordinary way,
+and a peer that owns a surface has nothing there to render, so its still is blank and it vanishes for
+the length of the transition. The OpenGL peer keeps a copy of each frame read back with `glReadPixels`,
+but that copy feeds the screenshot path rather than the peer's still image, so it doesn't cover this.
+The JavaScript peer overrides nothing, so it stays live throughout.
 
 ==== Why can't you combine peer component scrolling and Codename One scrolling
 

--- a/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
+++ b/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
@@ -1689,13 +1689,14 @@ NOTE: This was also the case in AWT/Swing to one degree or another...
 ==== Showing dialogs on top of peer components
 
 A form transition doesn't need anything from you here: `initTransition` puts both forms into
-lightweight mode, and the ports answer that by standing a still image in for the peer while the
-transition runs. Arbitrary overlap is the part that isn't automatic. Codename One grabs a screenshot of the peer, hide it and then you can show the screenshot. Since the screenshot is static it can be rendered through the standard UI. You can't do that always since grabbing a screenshot is an expensive process on all platforms and must be performed on the native device thread.
+lightweight mode, and the peer is asked for a still image to stand in for it while the transition
+runs. Arbitrary overlap is the part that isn't automatic. Codename One grabs a screenshot of the peer, hide it and then you can show the screenshot. Since the screenshot is static it can be rendered through the standard UI. You can't do that always since grabbing a screenshot is an expensive process on all platforms and must be performed on the native device thread.
 
-A peer that renders into a surface of its own is the case the capture can't cover at all: the ordinary
-view capture reads nothing back from such a surface. A port that needs the contents anyway has to keep
-its own copy, which is what the OpenGL peer does with `glReadPixels` so that its last frame still
-reaches a screenshot.
+What that still contains is up to the peer. On Android the browser peer overrides the capture and draws
+its `WebView` into the bitmap, while the default renders the `View` the ordinary way. A peer that owns a
+surface has nothing there to render, so its still is blank and it disappears for the length of the
+transition. The OpenGL peer does keep a copy of each frame, read back with `glReadPixels`, but that copy
+feeds the screenshot path rather than the peer's still image, so it doesn't cover this case.
 
 ==== Why can't you combine peer component scrolling and Codename One scrolling
 

--- a/docs/developer-guide/img/peer-component-painting.svg
+++ b/docs/developer-guide/img/peer-component-painting.svg
@@ -1,33 +1,36 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="430" viewBox="0 0 820 430">
-  <rect x="0" y="0" width="820" height="430" fill="#ffffff"/>
-  <text x="410" y="26" font-family="Arial, sans-serif" font-size="15" font-weight="bold" text-anchor="middle" fill="#222222">Why a native peer always sits on top</text>
-  <text x="410" y="44" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Every frame is painted in two passes, and they do not interleave.</text>
-  <rect x="24" y="62" width="370" height="150" rx="6" fill="#f7faf4" stroke="#4a7a3d" stroke-width="1.5"/>
-  <text x="209" y="84" font-family="Arial, sans-serif" font-size="13" font-weight="bold" text-anchor="middle" fill="#4a7a3d">Pass 1: Codename One</text>
-  <text x="209" y="104" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#222222">every lightweight component, drawn by</text>
-  <text x="209" y="120" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#222222">Codename One itself onto one surface</text>
-  <rect x="60" y="134" width="298" height="26" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1"/>
-  <text x="209" y="151" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#222222">title, buttons, labels, your components</text>
-  <text x="209" y="180" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">This is the layer the theme styles, and the</text>
-  <text x="209" y="193" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">layer a Dialog or a Toolbar is drawn into.</text>
-  <rect x="426" y="62" width="370" height="150" rx="6" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
-  <text x="611" y="84" font-family="Arial, sans-serif" font-size="13" font-weight="bold" text-anchor="middle" fill="#a56a3a">Pass 2: native peers</text>
-  <text x="611" y="104" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#222222">each PeerComponent, drawn by the</text>
-  <text x="611" y="120" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#222222">platform on its own UI thread</text>
-  <rect x="462" y="134" width="298" height="26" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1"/>
-  <text x="611" y="151" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#222222">map, web view, native video, native input</text>
-  <text x="611" y="180" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">Codename One never draws these, so it</text>
-  <text x="611" y="193" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">cannot draw anything over them either.</text>
-  <path d="M 410 212 L 410 232" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
-  <path d="M 405 226 L 410 232 L 415 226" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
-  <rect x="24" y="234" width="772" height="72" rx="6" fill="#f4f7fb" stroke="#4a6fa5" stroke-width="1.5"/>
-  <text x="410" y="254" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#4a6fa5">What follows from the order</text>
-  <text x="410" y="274" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">A peer covers any Codename One component that overlaps it, whatever the z-order in your container says. That</text>
-  <text x="410" y="288" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">includes the title area and a Dialog: the peer is painted after them, so it lands on top of both.</text>
-  <rect x="24" y="318" width="772" height="100" rx="6" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
-  <text x="410" y="338" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#a56a3a">The two workarounds, and what they cost</text>
-  <text x="410" y="358" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">To put a Dialog over a peer, Codename One takes a screenshot of the peer, hides the peer and shows the still image,</text>
-  <text x="410" y="372" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">which the normal UI can draw over. That capture runs on the native thread and is expensive, so it is not automatic.</text>
-  <text x="410" y="392" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Peer scrolling nested inside Codename One scrolling is left alone for the same reason: the peer paints over the title,</text>
-  <text x="410" y="406" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">clipping it is difficult, and a drag inside the peer would fight the scroll outside it.</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="446" viewBox="0 0 820 446">
+  <rect x="0" y="0" width="820" height="446" fill="#ffffff"/>
+  <text x="410" y="26" font-family="Arial, sans-serif" font-size="15" font-weight="bold" text-anchor="middle" fill="#222222">Where a native peer sits, and why it depends on the port</text>
+  <text x="410" y="44" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Display asks the implementation once: paintNativePeersBehind(). The answer changes the compositing entirely.</text>
+  <rect x="24" y="62" width="370" height="168" rx="6" fill="#f7faf4" stroke="#4a7a3d" stroke-width="1.5"/>
+  <text x="209" y="84" font-family="Arial, sans-serif" font-size="13" font-weight="bold" text-anchor="middle" fill="#4a7a3d">In front: the default</text>
+  <text x="209" y="102" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#222222">paintNativePeersBehind() is false</text>
+  <text x="209" y="118" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">Android, and any port that does not override it</text>
+  <rect x="60" y="132" width="298" height="24" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1"/>
+  <text x="209" y="148" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#222222">1. Codename One paints its components</text>
+  <rect x="60" y="162" width="298" height="24" rx="4" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1"/>
+  <text x="209" y="178" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#222222">2. the platform paints each peer, over that</text>
+  <text x="209" y="204" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">Nothing Codename One draws can cover a peer,</text>
+  <text x="209" y="217" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">the title area and a Dialog included.</text>
+  <rect x="426" y="62" width="370" height="168" rx="6" fill="#f4f7fb" stroke="#4a6fa5" stroke-width="1.5"/>
+  <text x="611" y="84" font-family="Arial, sans-serif" font-size="13" font-weight="bold" text-anchor="middle" fill="#4a6fa5">Behind: iOS and JavaScript</text>
+  <text x="611" y="102" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#222222">paintNativePeersBehind() is true</text>
+  <text x="611" y="118" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">both ports override it to return true</text>
+  <rect x="462" y="132" width="298" height="24" rx="4" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1"/>
+  <text x="611" y="148" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#222222">1. the native layer sits underneath</text>
+  <rect x="462" y="162" width="298" height="24" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1"/>
+  <text x="611" y="178" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#222222">2. Codename One paints above it, with a hole</text>
+  <text x="611" y="204" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">drawPeerComponent calls clearRect over the peer's</text>
+  <text x="611" y="217" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">bounds, so the native view shows through it.</text>
+  <rect x="24" y="246" width="772" height="86" rx="6" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
+  <text x="410" y="266" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#a56a3a">Why the difference matters</text>
+  <text x="410" y="286" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Where peers are in front, a peer covers whatever Codename One drew underneath it, whatever the z-order in your</text>
+  <text x="410" y="300" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">container says. Where they are behind, the Codename One surface is the top layer and only the punched hole lets</text>
+  <text x="410" y="314" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">the peer through, so components can be laid over a peer on those ports.</text>
+  <rect x="24" y="346" width="772" height="86" rx="6" fill="#f4f7fb" stroke="#4a6fa5" stroke-width="1.5"/>
+  <text x="410" y="366" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#4a6fa5">The older workarounds, and where they still apply</text>
+  <text x="410" y="386" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">To show a Dialog over a peer on a front-painting port, Codename One captures a screenshot of the peer, hides the</text>
+  <text x="410" y="400" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">peer and shows the still image, which the normal UI can draw over. That capture runs on the native thread and is</text>
+  <text x="410" y="414" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">expensive, which is why it is not automatic. Nested peer scrolling is avoided on either mode: clipping a peer is</text>
+  <text x="410" y="428" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">difficult, and a drag inside the peer fights the scroll outside it.</text>
 </svg>

--- a/docs/developer-guide/img/peer-component-painting.svg
+++ b/docs/developer-guide/img/peer-component-painting.svg
@@ -1,36 +1,62 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="446" viewBox="0 0 820 446">
-  <rect x="0" y="0" width="820" height="446" fill="#ffffff"/>
-  <text x="410" y="26" font-family="Arial, sans-serif" font-size="15" font-weight="bold" text-anchor="middle" fill="#222222">Where a native peer sits, and why it depends on the port</text>
-  <text x="410" y="44" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Display asks the implementation once: paintNativePeersBehind(). The answer changes the compositing entirely.</text>
-  <rect x="24" y="62" width="370" height="168" rx="6" fill="#f7faf4" stroke="#4a7a3d" stroke-width="1.5"/>
-  <text x="209" y="84" font-family="Arial, sans-serif" font-size="13" font-weight="bold" text-anchor="middle" fill="#4a7a3d">In front: the default</text>
-  <text x="209" y="102" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#222222">paintNativePeersBehind() is false</text>
-  <text x="209" y="118" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">Android, and any port that does not override it</text>
-  <rect x="60" y="132" width="298" height="24" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1"/>
-  <text x="209" y="148" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#222222">1. Codename One paints its components</text>
-  <rect x="60" y="162" width="298" height="24" rx="4" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1"/>
-  <text x="209" y="178" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#222222">2. the platform paints each peer, over that</text>
-  <text x="209" y="204" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">Nothing Codename One draws can cover a peer,</text>
-  <text x="209" y="217" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">the title area and a Dialog included.</text>
-  <rect x="426" y="62" width="370" height="168" rx="6" fill="#f4f7fb" stroke="#4a6fa5" stroke-width="1.5"/>
-  <text x="611" y="84" font-family="Arial, sans-serif" font-size="13" font-weight="bold" text-anchor="middle" fill="#4a6fa5">Behind: iOS and JavaScript</text>
-  <text x="611" y="102" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#222222">paintNativePeersBehind() is true</text>
-  <text x="611" y="118" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">both ports override it to return true</text>
-  <rect x="462" y="132" width="298" height="24" rx="4" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1"/>
-  <text x="611" y="148" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#222222">1. the native layer sits underneath</text>
-  <rect x="462" y="162" width="298" height="24" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1"/>
-  <text x="611" y="178" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#222222">2. Codename One paints above it, with a hole</text>
-  <text x="611" y="204" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">drawPeerComponent calls clearRect over the peer's</text>
-  <text x="611" y="217" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">bounds, so the native view shows through it.</text>
-  <rect x="24" y="246" width="772" height="86" rx="6" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
-  <text x="410" y="266" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#a56a3a">Why the difference matters</text>
-  <text x="410" y="286" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Where peers are in front, a peer covers whatever Codename One drew underneath it, whatever the z-order in your</text>
-  <text x="410" y="300" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">container says. Where they are behind, the Codename One surface is the top layer and only the punched hole lets</text>
-  <text x="410" y="314" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">the peer through, so components can be laid over a peer on those ports.</text>
-  <rect x="24" y="346" width="772" height="86" rx="6" fill="#f4f7fb" stroke="#4a6fa5" stroke-width="1.5"/>
-  <text x="410" y="366" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#4a6fa5">The older workarounds, and where they still apply</text>
-  <text x="410" y="386" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">To show a Dialog over a peer on a front-painting port, Codename One captures a screenshot of the peer, hides the</text>
-  <text x="410" y="400" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">peer and shows the still image, which the normal UI can draw over. That capture runs on the native thread and is</text>
-  <text x="410" y="414" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">expensive, which is why it is not automatic. Nested peer scrolling is avoided on either mode: clipping a peer is</text>
-  <text x="410" y="428" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">difficult, and a drag inside the peer fights the scroll outside it.</text>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="470" viewBox="0 0 820 470">
+  <rect x="0" y="0" width="820" height="470" fill="#ffffff"/>
+  <text x="410" y="24" font-family="Arial, sans-serif" font-size="14" font-weight="bold" text-anchor="middle" fill="#222222">How a native peer is composited, and why the answer is per port</text>
+  <text x="410" y="43" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">Display asks the implementation one question: paintNativePeersBehind(). A false answer does not mean the peer</text>
+  <text x="410" y="57" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">cannot be covered - it leaves the compositing to the port, and the three ports here resolve it differently.</text>
+  <rect x="16" y="76" width="252" height="250" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1.5"/>
+  <rect x="16" y="76" width="252" height="30" rx="4" fill="#4a6fa5" stroke="#4a6fa5" stroke-width="1"/>
+  <text x="142" y="96" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#ffffff">Behind, through a hole</text>
+  <text x="142" y="123" font-family="Arial, sans-serif" font-size="10.5" font-weight="bold" text-anchor="middle" fill="#4a6fa5">iOS and the JavaScript port</text>
+  <text x="142" y="140" font-family="Arial, sans-serif" font-size="9.5" text-anchor="middle" fill="#666666">paintNativePeersBehind() returns true</text>
+  <text x="142" y="164" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">The native view sits under the Codename One</text>
+  <text x="142" y="178" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">surface. drawPeerComponent calls clearRect</text>
+  <text x="142" y="192" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">over the peer's bounds, so the view shows</text>
+  <text x="142" y="206" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">through that hole while everything painted</text>
+  <text x="142" y="220" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">outside it stays on top.</text>
+  <rect x="284" y="76" width="252" height="250" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1.5"/>
+  <rect x="284" y="76" width="252" height="30" rx="4" fill="#4a7a3d" stroke="#4a7a3d" stroke-width="1"/>
+  <text x="410" y="96" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#ffffff">Drawn into the canvas</text>
+  <text x="410" y="123" font-family="Arial, sans-serif" font-size="10.5" font-weight="bold" text-anchor="middle" fill="#4a7a3d">Android, and the simulator</text>
+  <text x="410" y="140" font-family="Arial, sans-serif" font-size="9.5" text-anchor="middle" fill="#666666">paintNativePeersBehind() returns false</text>
+  <text x="410" y="164" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">Android hands the peer's View to the same</text>
+  <text x="410" y="178" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">ordered stream of drawing operations as</text>
+  <text x="410" y="192" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">every other component, so a component</text>
+  <text x="410" y="206" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">painted later covers it. The simulator does</text>
+  <text x="410" y="220" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">the same for a peer that renders to a buffer.</text>
+  <rect x="552" y="76" width="252" height="250" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1.5"/>
+  <rect x="552" y="76" width="252" height="30" rx="4" fill="#a56a3a" stroke="#a56a3a" stroke-width="1"/>
+  <text x="678" y="96" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#ffffff">Left to the platform</text>
+  <text x="678" y="123" font-family="Arial, sans-serif" font-size="10.5" font-weight="bold" text-anchor="middle" fill="#a56a3a">a peer that owns a surface</text>
+  <text x="678" y="140" font-family="Arial, sans-serif" font-size="9.5" text-anchor="middle" fill="#666666">no Codename One pixels are involved</text>
+  <text x="678" y="164" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">Where the peer's content lives in its own</text>
+  <text x="678" y="178" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">surface, the system composites it and paint</text>
+  <text x="678" y="192" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">order never reaches it. That is the case the</text>
+  <text x="678" y="206" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">workaround below was written for, and the</text>
+  <text x="678" y="220" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">one the old always-on-top rule described.</text>
+  <rect x="36" y="246" width="96" height="22" rx="3" fill="#ffffff" stroke="#4a6fa5" stroke-width="1"/>
+  <text x="84" y="260" font-family="Arial, sans-serif" font-size="9.5" text-anchor="middle" fill="#4a6fa5">CN1</text>
+  <rect x="152" y="246" width="96" height="22" rx="3" fill="#ffffff" stroke="#4a6fa5" stroke-width="1"/>
+  <text x="200" y="260" font-family="Arial, sans-serif" font-size="9.5" text-anchor="middle" fill="#4a6fa5">CN1</text>
+  <text x="142" y="261" font-family="Arial, sans-serif" font-size="8.5" text-anchor="middle" fill="#888888">hole</text>
+  <rect x="36" y="272" width="212" height="22" rx="3" fill="#4a6fa5" stroke="#4a6fa5" stroke-width="1"/>
+  <text x="142" y="286" font-family="Arial, sans-serif" font-size="9.5" text-anchor="middle" fill="#ffffff">native view, underneath</text>
+  <rect x="304" y="246" width="212" height="48" rx="3" fill="#ffffff" stroke="#4a7a3d" stroke-width="1"/>
+  <text x="410" y="273" font-family="Arial, sans-serif" font-size="9.5" text-anchor="middle" fill="#4a7a3d"></text>
+  <rect x="312" y="254" width="96" height="32" rx="3" fill="#e8f0e4" stroke="#4a7a3d" stroke-width="1"/>
+  <text x="360" y="273" font-family="Arial, sans-serif" font-size="9.5" text-anchor="middle" fill="#4a7a3d">peer</text>
+  <rect x="378" y="268" width="96" height="18" rx="3" fill="#4a7a3d" stroke="#4a7a3d" stroke-width="1"/>
+  <text x="426" y="280" font-family="Arial, sans-serif" font-size="9.5" text-anchor="middle" fill="#ffffff">painted later</text>
+  <text x="410" y="240" font-family="Arial, sans-serif" font-size="8.5" text-anchor="middle" fill="#4a7a3d">one canvas, one paint order</text>
+  <rect x="572" y="246" width="100" height="22" rx="3" fill="#ffffff" stroke="#a56a3a" stroke-width="1"/>
+  <text x="622" y="260" font-family="Arial, sans-serif" font-size="9.5" text-anchor="middle" fill="#a56a3a">app window</text>
+  <rect x="684" y="246" width="100" height="22" rx="3" fill="#a56a3a" stroke="#a56a3a" stroke-width="1"/>
+  <text x="734" y="260" font-family="Arial, sans-serif" font-size="9.5" text-anchor="middle" fill="#ffffff">peer surface</text>
+  <rect x="572" y="272" width="212" height="22" rx="3" fill="#f5efe8" stroke="#a56a3a" stroke-width="1"/>
+  <text x="678" y="286" font-family="Arial, sans-serif" font-size="9.5" text-anchor="middle" fill="#a56a3a">system compositor</text>
+  <rect x="16" y="342" width="788" height="92" rx="4" fill="#f7f7f9" stroke="#cccccc" stroke-width="1"/>
+  <text x="410" y="364" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#222222">What follows when you build a screen</text>
+  <text x="410" y="386" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">On the first two models Codename One content painted after a peer covers it, so a component on the layered pane is not</text>
+  <text x="410" y="400" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">blocked by the peer as a rule. Where the platform composites the peer itself, the older answer still applies: capture the</text>
+  <text x="410" y="414" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">peer, hide it, and show the still image, which the normal UI paints over. That capture runs on the native thread and is</text>
+  <text x="410" y="428" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">expensive, which is why it never became automatic.</text>
 </svg>

--- a/docs/developer-guide/img/peer-component-painting.svg
+++ b/docs/developer-guide/img/peer-component-painting.svg
@@ -55,8 +55,8 @@
   <text x="678" y="286" font-family="Arial, sans-serif" font-size="9.5" text-anchor="middle" fill="#a56a3a">system compositor</text>
   <rect x="16" y="342" width="788" height="92" rx="4" fill="#f7f7f9" stroke="#cccccc" stroke-width="1"/>
   <text x="410" y="364" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#222222">What follows when you build a screen</text>
-  <text x="410" y="386" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">On the first two models Codename One content painted after a peer covers it, so a component on the layered pane is not</text>
-  <text x="410" y="400" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">blocked by the peer as a rule. A form transition puts both forms into lightweight mode, and what a peer does about that</text>
-  <text x="410" y="414" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">is the peer's own business: iOS and Android stand a still image in for it, a peer that owns a surface has nothing to render</text>
-  <text x="410" y="428" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">and goes blank, and the JavaScript peer overrides nothing and stays live. Arbitrary overlap is not automatic on any of them.</text>
+  <text x="410" y="386" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">On the first two models Codename One content painted after a peer covers it, so a component on the layered pane needs</text>
+  <text x="410" y="400" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">nothing from you. The capture-hide-and-show dance belongs to the third: a surface the system composites stays above the</text>
+  <text x="410" y="414" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">Codename One canvas whatever you paint over it, and the ordinary capture cannot read it back to stand in for it either.</text>
+  <text x="410" y="428" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">A form transition puts both forms into lightweight mode, but what a peer does with that is the peer's own business.</text>
 </svg>

--- a/docs/developer-guide/img/peer-component-painting.svg
+++ b/docs/developer-guide/img/peer-component-painting.svg
@@ -30,9 +30,9 @@
   <text x="678" y="140" font-family="Arial, sans-serif" font-size="9.5" text-anchor="middle" fill="#666666">no Codename One pixels are involved</text>
   <text x="678" y="164" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">Where the peer's content lives in its own</text>
   <text x="678" y="178" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">surface, the system composites it and paint</text>
-  <text x="678" y="192" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">order never reaches it. The ordinary capture</text>
-  <text x="678" y="206" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">reads nothing back from it either, so the GL</text>
-  <text x="678" y="220" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">peer keeps its own copy of the last frame.</text>
+  <text x="678" y="192" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">order never reaches it. Nor does the ordinary</text>
+  <text x="678" y="206" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">capture, so only the screenshot path sees a GL</text>
+  <text x="678" y="220" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">frame, and only through its own readback.</text>
   <rect x="36" y="246" width="96" height="22" rx="3" fill="#ffffff" stroke="#4a6fa5" stroke-width="1"/>
   <text x="84" y="260" font-family="Arial, sans-serif" font-size="9.5" text-anchor="middle" fill="#4a6fa5">CN1</text>
   <rect x="152" y="246" width="96" height="22" rx="3" fill="#ffffff" stroke="#4a6fa5" stroke-width="1"/>
@@ -56,7 +56,7 @@
   <rect x="16" y="342" width="788" height="92" rx="4" fill="#f7f7f9" stroke="#cccccc" stroke-width="1"/>
   <text x="410" y="364" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#222222">What follows when you build a screen</text>
   <text x="410" y="386" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">On the first two models Codename One content painted after a peer covers it, so a component on the layered pane is not</text>
-  <text x="410" y="400" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">blocked by the peer as a rule. A form transition needs nothing from you on any of the three: initTransition puts both</text>
-  <text x="410" y="414" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">forms into lightweight mode and the ports stand a still image in for the peer. Arbitrary overlap is the part that is not</text>
-  <text x="410" y="428" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">automatic, because that capture is expensive - and against a surface it reads nothing back at all.</text>
+  <text x="410" y="400" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">blocked by the peer as a rule. A form transition asks the peer for a still: initTransition puts both forms into lightweight</text>
+  <text x="410" y="414" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">mode, and what comes back depends on the peer - the browser peer draws its WebView, and a peer that owns a surface</text>
+  <text x="410" y="428" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">has nothing to render and goes blank for the length of it. Arbitrary overlap is not automatic at all: that capture is expensive.</text>
 </svg>

--- a/docs/developer-guide/img/peer-component-painting.svg
+++ b/docs/developer-guide/img/peer-component-painting.svg
@@ -56,7 +56,7 @@
   <rect x="16" y="342" width="788" height="92" rx="4" fill="#f7f7f9" stroke="#cccccc" stroke-width="1"/>
   <text x="410" y="364" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#222222">What follows when you build a screen</text>
   <text x="410" y="386" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">On the first two models Codename One content painted after a peer covers it, so a component on the layered pane is not</text>
-  <text x="410" y="400" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">blocked by the peer as a rule. A form transition asks the peer for a still: initTransition puts both forms into lightweight</text>
-  <text x="410" y="414" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">mode, and what comes back depends on the peer - the browser peer draws its WebView, and a peer that owns a surface</text>
-  <text x="410" y="428" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">has nothing to render and goes blank for the length of it. Arbitrary overlap is not automatic at all: that capture is expensive.</text>
+  <text x="410" y="400" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">blocked by the peer as a rule. A form transition puts both forms into lightweight mode, and what a peer does about that</text>
+  <text x="410" y="414" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">is the peer's own business: iOS and Android stand a still image in for it, a peer that owns a surface has nothing to render</text>
+  <text x="410" y="428" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">and goes blank, and the JavaScript peer overrides nothing and stays live. Arbitrary overlap is not automatic on any of them.</text>
 </svg>

--- a/docs/developer-guide/img/peer-component-painting.svg
+++ b/docs/developer-guide/img/peer-component-painting.svg
@@ -30,9 +30,9 @@
   <text x="678" y="140" font-family="Arial, sans-serif" font-size="9.5" text-anchor="middle" fill="#666666">no Codename One pixels are involved</text>
   <text x="678" y="164" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">Where the peer's content lives in its own</text>
   <text x="678" y="178" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">surface, the system composites it and paint</text>
-  <text x="678" y="192" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">order never reaches it. That is the case the</text>
-  <text x="678" y="206" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">workaround below was written for, and the</text>
-  <text x="678" y="220" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">one the old always-on-top rule described.</text>
+  <text x="678" y="192" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">order never reaches it. The ordinary capture</text>
+  <text x="678" y="206" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">reads nothing back from it either, so the GL</text>
+  <text x="678" y="220" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">peer keeps its own copy of the last frame.</text>
   <rect x="36" y="246" width="96" height="22" rx="3" fill="#ffffff" stroke="#4a6fa5" stroke-width="1"/>
   <text x="84" y="260" font-family="Arial, sans-serif" font-size="9.5" text-anchor="middle" fill="#4a6fa5">CN1</text>
   <rect x="152" y="246" width="96" height="22" rx="3" fill="#ffffff" stroke="#4a6fa5" stroke-width="1"/>
@@ -56,7 +56,7 @@
   <rect x="16" y="342" width="788" height="92" rx="4" fill="#f7f7f9" stroke="#cccccc" stroke-width="1"/>
   <text x="410" y="364" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#222222">What follows when you build a screen</text>
   <text x="410" y="386" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">On the first two models Codename One content painted after a peer covers it, so a component on the layered pane is not</text>
-  <text x="410" y="400" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">blocked by the peer as a rule. Where the platform composites the peer itself, the older answer still applies: capture the</text>
-  <text x="410" y="414" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">peer, hide it, and show the still image, which the normal UI paints over. That capture runs on the native thread and is</text>
-  <text x="410" y="428" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">expensive, which is why it never became automatic.</text>
+  <text x="410" y="400" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">blocked by the peer as a rule. A form transition needs nothing from you on any of the three: initTransition puts both</text>
+  <text x="410" y="414" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">forms into lightweight mode and the ports stand a still image in for the peer. Arbitrary overlap is the part that is not</text>
+  <text x="410" y="428" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">automatic, because that capture is expensive - and against a surface it reads nothing back at all.</text>
 </svg>

--- a/docs/developer-guide/img/peer-component-painting.svg
+++ b/docs/developer-guide/img/peer-component-painting.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="430" viewBox="0 0 820 430">
+  <rect x="0" y="0" width="820" height="430" fill="#ffffff"/>
+  <text x="410" y="26" font-family="Arial, sans-serif" font-size="15" font-weight="bold" text-anchor="middle" fill="#222222">Why a native peer always sits on top</text>
+  <text x="410" y="44" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Every frame is painted in two passes, and they do not interleave.</text>
+  <rect x="24" y="62" width="370" height="150" rx="6" fill="#f7faf4" stroke="#4a7a3d" stroke-width="1.5"/>
+  <text x="209" y="84" font-family="Arial, sans-serif" font-size="13" font-weight="bold" text-anchor="middle" fill="#4a7a3d">Pass 1: Codename One</text>
+  <text x="209" y="104" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#222222">every lightweight component, drawn by</text>
+  <text x="209" y="120" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#222222">Codename One itself onto one surface</text>
+  <rect x="60" y="134" width="298" height="26" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1"/>
+  <text x="209" y="151" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#222222">title, buttons, labels, your components</text>
+  <text x="209" y="180" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">This is the layer the theme styles, and the</text>
+  <text x="209" y="193" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">layer a Dialog or a Toolbar is drawn into.</text>
+  <rect x="426" y="62" width="370" height="150" rx="6" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
+  <text x="611" y="84" font-family="Arial, sans-serif" font-size="13" font-weight="bold" text-anchor="middle" fill="#a56a3a">Pass 2: native peers</text>
+  <text x="611" y="104" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#222222">each PeerComponent, drawn by the</text>
+  <text x="611" y="120" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#222222">platform on its own UI thread</text>
+  <rect x="462" y="134" width="298" height="26" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1"/>
+  <text x="611" y="151" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#222222">map, web view, native video, native input</text>
+  <text x="611" y="180" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">Codename One never draws these, so it</text>
+  <text x="611" y="193" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">cannot draw anything over them either.</text>
+  <path d="M 410 212 L 410 232" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
+  <path d="M 405 226 L 410 232 L 415 226" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
+  <rect x="24" y="234" width="772" height="72" rx="6" fill="#f4f7fb" stroke="#4a6fa5" stroke-width="1.5"/>
+  <text x="410" y="254" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#4a6fa5">What follows from the order</text>
+  <text x="410" y="274" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">A peer covers any Codename One component that overlaps it, whatever the z-order in your container says. That</text>
+  <text x="410" y="288" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">includes the title area and a Dialog: the peer is painted after them, so it lands on top of both.</text>
+  <rect x="24" y="318" width="772" height="100" rx="6" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
+  <text x="410" y="338" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#a56a3a">The two workarounds, and what they cost</text>
+  <text x="410" y="358" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">To put a Dialog over a peer, Codename One takes a screenshot of the peer, hides the peer and shows the still image,</text>
+  <text x="410" y="372" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">which the normal UI can draw over. That capture runs on the native thread and is expensive, so it is not automatic.</text>
+  <text x="410" y="392" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Peer scrolling nested inside Codename One scrolling is left alone for the same reason: the peer paints over the title,</text>
+  <text x="410" y="406" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">clipping it is difficult, and a drag inside the peer would fight the scroll outside it.</text>
+</svg>

--- a/docs/developer-guide/img/theme-style-cascade.svg
+++ b/docs/developer-guide/img/theme-style-cascade.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="470" viewBox="0 0 820 470">
+  <rect x="0" y="0" width="820" height="470" fill="#ffffff"/>
+  <text x="410" y="26" font-family="Arial, sans-serif" font-size="15" font-weight="bold" text-anchor="middle" fill="#222222">How a UIID becomes a Style</text>
+  <text x="410" y="44" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Every component asks UIManager for the style of its UIID. This is the order it looks in.</text>
+  <rect x="24" y="70" width="240" height="52" rx="4" fill="#f7faf4" stroke="#4a7a3d" stroke-width="1.5"/>
+  <text x="144" y="92" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#4a7a3d">the UIID</text>
+  <rect x="280" y="70" width="516" height="52" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1"/>
+  <text x="538" y="92" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">a Button asks for "Button"</text>
+  <path d="M 144 122 L 144 138" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
+  <path d="M 139 132 L 144 138 L 149 132" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
+  <rect x="24" y="140" width="240" height="52" rx="4" fill="#f7faf4" stroke="#4a7a3d" stroke-width="1.5"/>
+  <text x="144" y="162" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#4a7a3d">plus the state</text>
+  <rect x="280" y="140" width="516" height="52" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1"/>
+  <text x="538" y="162" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">".sel", ".press" or ".dis" is appended for the selected,</text>
+  <text x="538" y="177" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">pressed and disabled styles</text>
+  <path d="M 144 192 L 144 208" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
+  <path d="M 139 202 L 144 208 L 149 202" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
+  <rect x="24" y="210" width="240" height="52" rx="4" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
+  <text x="144" y="232" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#a56a3a">$Dark first, in dark mode</text>
+  <rect x="280" y="210" width="516" height="52" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1"/>
+  <text x="538" y="232" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">shouldUseDarkStyle prefixes the id; if the theme has no dark</text>
+  <text x="538" y="247" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">entry it falls back to the light one</text>
+  <path d="M 144 262 L 144 278" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
+  <path d="M 139 272 L 144 278 L 149 272" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
+  <rect x="24" y="280" width="240" height="52" rx="4" fill="#f7faf4" stroke="#4a7a3d" stroke-width="1.5"/>
+  <text x="144" y="302" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#4a7a3d">follow derive</text>
+  <rect x="280" y="280" width="516" height="52" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1"/>
+  <text x="538" y="302" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">a theme entry may name a parent with derive, and that parent</text>
+  <text x="538" y="317" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">is resolved the same way</text>
+  <path d="M 144 332 L 144 348" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
+  <path d="M 139 342 L 144 348 L 149 342" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
+  <rect x="24" y="350" width="240" height="52" rx="4" fill="#f4f7fb" stroke="#4a6fa5" stroke-width="1.5"/>
+  <text x="144" y="372" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#4a6fa5">otherwise the default style</text>
+  <rect x="280" y="350" width="516" height="52" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1"/>
+  <text x="538" y="372" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">a UIID the theme never mentions gets a copy of the default</text>
+  <text x="538" y="387" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">style, not an error</text>
+  <rect x="24" y="418" width="772" height="44" rx="6" fill="#f4f7fb" stroke="#4a6fa5" stroke-width="1.5"/>
+  <text x="410" y="438" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">An overlay theme is layered on top of the one below it, so a project theme can change a handful of UIIDs without</text>
+  <text x="410" y="452" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">restating the rest. @OverlayThemes in a theme names the resources to load over it.</text>
+</svg>

--- a/docs/developer-guide/img/theme-style-cascade.svg
+++ b/docs/developer-guide/img/theme-style-cascade.svg
@@ -31,10 +31,10 @@
   <path d="M 144 332 L 144 348" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
   <path d="M 139 342 L 144 348 L 149 342" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
   <rect x="24" y="350" width="240" height="52" rx="4" fill="#f4f7fb" stroke="#4a6fa5" stroke-width="1.5"/>
-  <text x="144" y="372" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#4a6fa5">otherwise the default style</text>
+  <text x="144" y="372" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#4a6fa5">otherwise a default style</text>
   <rect x="280" y="350" width="516" height="52" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1"/>
-  <text x="538" y="372" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">a UIID the theme never mentions gets a copy of the default</text>
-  <text x="538" y="387" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">style, not an error</text>
+  <text x="538" y="372" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">a UIID the theme never mentions gets defaultStyle,</text>
+  <text x="538" y="387" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">or defaultSelectedStyle when a state was asked for</text>
   <rect x="24" y="418" width="772" height="58" rx="6" fill="#f4f7fb" stroke="#4a6fa5" stroke-width="1.5"/>
   <text x="410" y="438" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">An overlay theme is layered over the one below it, so a project theme can change a handful of UIIDs without</text>
   <text x="410" y="452" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">restating the rest. Name them in a theme constant called OverlayThemes: the Designer and the CSS compiler add</text>

--- a/docs/developer-guide/img/theme-style-cascade.svg
+++ b/docs/developer-guide/img/theme-style-cascade.svg
@@ -34,7 +34,7 @@
   <text x="144" y="372" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#4a6fa5">otherwise a default style</text>
   <rect x="280" y="350" width="516" height="52" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1"/>
   <text x="538" y="372" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">a UIID the theme never mentions gets defaultStyle,</text>
-  <text x="538" y="387" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">or defaultSelectedStyle when a state was asked for</text>
+  <text x="538" y="387" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">or defaultSelectedStyle if the request was sel#</text>
   <rect x="24" y="418" width="772" height="58" rx="6" fill="#f4f7fb" stroke="#4a6fa5" stroke-width="1.5"/>
   <text x="410" y="438" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">An overlay theme is layered over the one below it, so a project theme can change a handful of UIIDs without</text>
   <text x="410" y="452" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">restating the rest. Name them in a theme constant called OverlayThemes: the Designer and the CSS compiler add</text>

--- a/docs/developer-guide/img/theme-style-cascade.svg
+++ b/docs/developer-guide/img/theme-style-cascade.svg
@@ -1,32 +1,33 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="470" viewBox="0 0 820 470">
-  <rect x="0" y="0" width="820" height="470" fill="#ffffff"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="490" viewBox="0 0 820 490">
+  <rect x="0" y="0" width="820" height="490" fill="#ffffff"/>
   <text x="410" y="26" font-family="Arial, sans-serif" font-size="15" font-weight="bold" text-anchor="middle" fill="#222222">How a UIID becomes a Style</text>
   <text x="410" y="44" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">Every component asks UIManager for the style of its UIID. This is the order it looks in.</text>
   <rect x="24" y="70" width="240" height="52" rx="4" fill="#f7faf4" stroke="#4a7a3d" stroke-width="1.5"/>
   <text x="144" y="92" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#4a7a3d">the UIID</text>
   <rect x="280" y="70" width="516" height="52" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1"/>
-  <text x="538" y="92" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">a Button asks for "Button"</text>
+  <text x="538" y="92" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">a Button asks for "Button", which becomes the key prefix</text>
+  <text x="538" y="107" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">"Button."</text>
   <path d="M 144 122 L 144 138" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
   <path d="M 139 132 L 144 138 L 149 132" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
   <rect x="24" y="140" width="240" height="52" rx="4" fill="#f7faf4" stroke="#4a7a3d" stroke-width="1.5"/>
   <text x="144" y="162" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#4a7a3d">plus the state</text>
   <rect x="280" y="140" width="516" height="52" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1"/>
-  <text x="538" y="162" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">".sel", ".press" or ".dis" is appended for the selected,</text>
-  <text x="538" y="177" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">pressed and disabled styles</text>
+  <text x="538" y="162" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">".sel#", ".press#" and ".dis#" are appended, giving keys like</text>
+  <text x="538" y="177" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">Button.sel#fgColor</text>
   <path d="M 144 192 L 144 208" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
   <path d="M 139 202 L 144 208 L 149 202" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
   <rect x="24" y="210" width="240" height="52" rx="4" fill="#fbf6f2" stroke="#a56a3a" stroke-width="1.5"/>
   <text x="144" y="232" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#a56a3a">$Dark first, in dark mode</text>
   <rect x="280" y="210" width="516" height="52" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1"/>
-  <text x="538" y="232" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">shouldUseDarkStyle prefixes the id; if the theme has no dark</text>
-  <text x="538" y="247" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">entry it falls back to the light one</text>
+  <text x="538" y="232" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">shouldUseDarkStyle prefixes the id; with no dark entry it</text>
+  <text x="538" y="247" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">falls back to the light one</text>
   <path d="M 144 262 L 144 278" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
   <path d="M 139 272 L 144 278 L 149 272" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
   <rect x="24" y="280" width="240" height="52" rx="4" fill="#f7faf4" stroke="#4a7a3d" stroke-width="1.5"/>
   <text x="144" y="302" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#4a7a3d">follow derive</text>
   <rect x="280" y="280" width="516" height="52" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1"/>
   <text x="538" y="302" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">a theme entry may name a parent with derive, and that parent</text>
-  <text x="538" y="317" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">is resolved the same way</text>
+  <text x="538" y="317" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">resolves the same way</text>
   <path d="M 144 332 L 144 348" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
   <path d="M 139 342 L 144 348 L 149 342" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
   <rect x="24" y="350" width="240" height="52" rx="4" fill="#f4f7fb" stroke="#4a6fa5" stroke-width="1.5"/>
@@ -34,7 +35,8 @@
   <rect x="280" y="350" width="516" height="52" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1"/>
   <text x="538" y="372" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">a UIID the theme never mentions gets a copy of the default</text>
   <text x="538" y="387" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#666666">style, not an error</text>
-  <rect x="24" y="418" width="772" height="44" rx="6" fill="#f4f7fb" stroke="#4a6fa5" stroke-width="1.5"/>
-  <text x="410" y="438" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">An overlay theme is layered on top of the one below it, so a project theme can change a handful of UIIDs without</text>
-  <text x="410" y="452" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">restating the rest. @OverlayThemes in a theme names the resources to load over it.</text>
+  <rect x="24" y="418" width="772" height="58" rx="6" fill="#f4f7fb" stroke="#4a6fa5" stroke-width="1.5"/>
+  <text x="410" y="438" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">An overlay theme is layered over the one below it, so a project theme can change a handful of UIIDs without</text>
+  <text x="410" y="452" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">restating the rest. Name them in a theme constant called OverlayThemes: the Designer and the CSS compiler add</text>
+  <text x="410" y="466" font-family="Arial, sans-serif" font-size="10" text-anchor="middle" fill="#666666">the prefix themselves, and writing @OverlayThemes yourself stores @@OverlayThemes, which nothing reads.</text>
 </svg>


### PR DESCRIPTION
Two more of the planned diagram set, both based on master.

### Why a native peer always sits on top

The chapter states the two painting passes and that peers land on top, then
explains the screenshot trick and the scrolling restriction several paragraphs
apart — the shape is there but scattered. The diagram puts the passes side by
side and hangs both consequences off the order: a peer covers whatever it
overlaps regardless of z-order, a `Dialog` over a peer needs an expensive
native screenshot, and nested scrolling is left alone because clipping a peer is
hard and the two drags would fight.

### How a UIID becomes a Style

Nothing in the guide says what `UIManager` actually searches. `createStyle`
appends the state suffix, prefixes `$Dark` when the app is dark **and the entry
exists**, follows a `derive` chain, and falls back to a copy of the default
style rather than failing.

The `$Dark` fallback to the light entry isn't documented anywhere. The order
shown matches what `css.asciidoc` already says about `$DarkButton.selected` —
state suffix retained, `$Dark` prefixed — which I checked so the new figure
agrees with the existing prose rather than contradicting it.

### Process

Both were verified in source before drawing, and the surrounding prose was
checked for staleness as well as agreement — the two failure modes the last two
PRs turned up. The generator's overlap check flagged the nested boxes in the
peer diagram until the containers were marked as containers, which is the check
working as intended.

Gates: structure, xrefs, snippets, links, missing-code-blocks, unused images,
capitalization, asciidoctor `--failure-level WARN`, Vale 0, LanguageTool `ok 0`
on both chapters, control characters, and an `asciidoctor-pdf` build with no
prawn-svg warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)