### PR TITLE
Developer guide: two figures for the Events chapter, and the focus rule it gets wrong

### DIFF
--- a/docs/developer-guide/Events.asciidoc
+++ b/docs/developer-guide/Events.asciidoc
@@ -220,7 +220,10 @@ Low-level events can be bound in one of 3 ways:
 TIP: That last one depends on the event. A key callback on a `Component` only fires while that component
 holds focus, because `Form` routes key events to the focused component. A pointer callback doesn't need
 focus: `Form` looks up whatever component sits under the touch and delivers to it, and the component is
-handed focus because of the press rather than as a condition for it. It does have to be enabled.
+handed focus because of the press rather than as a condition for it. Whether it has to be enabled depends
+on where it sits - the content pane branch of `Form.pointerPressed` checks `isEnabled()`, while the title
+area and the west side deliver without checking, so an override on a disabled `Toolbar` component still
+runs.
 
 .How one touch reaches your code
 image::img/event-dispatch-path.svg[The path a pointer event takes from the native callback to your listener,scaledwidth=85%]

--- a/docs/developer-guide/Events.asciidoc
+++ b/docs/developer-guide/Events.asciidoc
@@ -219,17 +219,15 @@ Low-level events can be bound in one of 3 ways:
 
 TIP: That last one depends on the event. A key callback on an ordinary `Component` only fires while that
 component holds focus, because `Form` routes key events to the focused one - the exception is a key the
-menu bar claims, which `Form.keyPressed` hands to `MenuBar` before it consults `focused` at all. A pointer
-callback has no such prerequisite: `Form` looks up whatever component sits under the touch and delivers to
-it, whichever component holds focus at the time. What differs is what else happens. In the content pane the
-component has to be enabled to be called at all; in the title area and along the west side it's called even
-when it's disabled. Focus moves only when the target is focusable and enabled and the press isn't a scroll
-wheel - before the callback in the content pane, and after it elsewhere, by way of `LeadUtil`. Focus is
-therefore never a condition for a pointer callback, and only sometimes a consequence of one.
+menu bar claims, which `Form.keyPressed` hands to `MenuBar` before it consults `focused` at all.
 
-One more thing the lookup does: inside a container with a lead component the callback doesn't go to the
-component you touched. `Form.pointerPressed` resolves the lead parent, and `LeadUtil.pointerPressed` calls
-`pointerPressed` on the lead component, so that's the class to override or attach a listener to.
+A pointer callback has no focus prerequisite at all, and three things about its target are worth knowing.
+`Form.pointerPressed` resolves the *lead parent* of whatever sits under the touch, so `isEnabled()` and
+`isFocusable()` are asked of that parent rather than of the component you pressed. The callback itself goes
+to the *lead component*, which is the class to override or attach a listener to. And focus is assigned only
+when the lead parent is focusable and enabled and the press isn't a scroll wheel - in the content pane both
+before the callback and again after it, so moving focus from inside a pointer callback there can be undone
+the moment it returns.
 
 .How one touch reaches your code
 image::img/event-dispatch-path.svg[The path a pointer event takes from the native callback to your listener,scaledwidth=85%]

--- a/docs/developer-guide/Events.asciidoc
+++ b/docs/developer-guide/Events.asciidoc
@@ -222,10 +222,14 @@ component holds focus, because `Form` routes key events to the focused one - the
 menu bar claims, which `Form.keyPressed` hands to `MenuBar` before it consults `focused` at all. A pointer
 callback has no such prerequisite: `Form` looks up whatever component sits under the touch and delivers to
 it, whichever component holds focus at the time. What differs is what else happens. In the content pane the
-component has to be enabled to be called, and it takes focus before the callback runs. In the title area
-and along the west side it's called even when it's disabled, and `LeadUtil` moves focus afterwards, and only
-if that component is focusable and enabled. Focus is therefore never a condition for a pointer callback, and
-only sometimes a consequence of one.
+component has to be enabled to be called at all; in the title area and along the west side it's called even
+when it's disabled. Focus moves only when the target is focusable and enabled and the press isn't a scroll
+wheel - before the callback in the content pane, and after it elsewhere, by way of `LeadUtil`. Focus is
+therefore never a condition for a pointer callback, and only sometimes a consequence of one.
+
+One more thing the lookup does: inside a container with a lead component the callback doesn't go to the
+component you touched. `Form.pointerPressed` resolves the lead parent, and `LeadUtil.pointerPressed` calls
+`pointerPressed` on the lead component, so that's the class to override or attach a listener to.
 
 .How one touch reaches your code
 image::img/event-dispatch-path.svg[The path a pointer event takes from the native callback to your listener,scaledwidth=85%]

--- a/docs/developer-guide/Events.asciidoc
+++ b/docs/developer-guide/Events.asciidoc
@@ -29,6 +29,9 @@ A workaround to this issue is to wrap the code in a `callSerially`, you shouldn'
 
 Another workaround for the issue is avoiding blocking calls within an event chain.
 
+.One batch, walked in order
+image::img/event-batch-ordering.svg[Why a blocking call in the first listener delays the second one,scaledwidth=85%]
+
 ==== Action events
 
 The most common high-level event is the https://www.codenameone.com/javadoc/com/codename1/ui/events/ActionListener.html[ActionListener] which allows binding a generic action event to pretty much anything. This is so ubiquitous in Codename One that it's even used for networking (as a base class) and for some low-level event options.
@@ -214,12 +217,18 @@ Low-level events can be bound in one of 3 ways:
 
 * Override one of the event callbacks on a https://www.codenameone.com/javadoc/com/codename1/ui/Component.html[Component].
 
-TIP: When you override event callbacks on a `Component` the `Component` in question must be focusable and have focus at that point. This can be an advantage for some use cases as it will save you the need of handling unrelated events.
+TIP: That last one depends on the event. A key callback on a `Component` only fires while that component
+holds focus, because `Form` routes key events to the focused component. A pointer callback doesn't need
+focus: `Form` looks up whatever component sits under the touch and delivers to it, and the component is
+handed focus because of the press rather than as a condition for it. It does have to be enabled.
+
+.How one touch reaches your code
+image::img/event-dispatch-path.svg[The path a pointer event takes from the native callback to your listener,scaledwidth=85%]
 
 Each of those has advantages and disadvantages, specifically:
 
 * 'Form' based events and callbacks deliver pointer events in the 'Form' coordinate space.
-* 'Component' based events require focus
+* 'Component' based key events require focus, pointer events don't
 * 'Form' based events can block existing functionality from proceeding through the event chain for example, you can avoid calling super in a form event and thus block other events from happening (for example, block a listener or component event from triggering).
 
 .Event type map

--- a/docs/developer-guide/Events.asciidoc
+++ b/docs/developer-guide/Events.asciidoc
@@ -217,13 +217,15 @@ Low-level events can be bound in one of 3 ways:
 
 * Override one of the event callbacks on a https://www.codenameone.com/javadoc/com/codename1/ui/Component.html[Component].
 
-TIP: That last one depends on the event. A key callback on a `Component` only fires while that component
-holds focus, because `Form` routes key events to the focused component. A pointer callback doesn't need
-focus: `Form` looks up whatever component sits under the touch and delivers to it, whichever component
-holds focus at the time. Where the press lands decides the rest. The content pane branch of
-`Form.pointerPressed` delivers only to an enabled component, and gives it focus as well if it's focusable
-and the press isn't a scroll wheel. The title area branch and the west branch check neither, and assign no
-focus, so an override on a disabled `Toolbar` component still runs and the focus stays where it was.
+TIP: That last one depends on the event. A key callback on an ordinary `Component` only fires while that
+component holds focus, because `Form` routes key events to the focused one - the exception is a key the
+menu bar claims, which `Form.keyPressed` hands to `MenuBar` before it consults `focused` at all. A pointer
+callback has no such prerequisite: `Form` looks up whatever component sits under the touch and delivers to
+it, whichever component holds focus at the time. What differs is what else happens. In the content pane the
+component has to be enabled to be called, and it takes focus before the callback runs. In the title area
+and along the west side it's called even when it's disabled, and `LeadUtil` moves focus afterwards, and only
+if that component is focusable and enabled. Focus is therefore never a condition for a pointer callback, and
+only sometimes a consequence of one.
 
 .How one touch reaches your code
 image::img/event-dispatch-path.svg[The path a pointer event takes from the native callback to your listener,scaledwidth=85%]

--- a/docs/developer-guide/Events.asciidoc
+++ b/docs/developer-guide/Events.asciidoc
@@ -219,11 +219,11 @@ Low-level events can be bound in one of 3 ways:
 
 TIP: That last one depends on the event. A key callback on a `Component` only fires while that component
 holds focus, because `Form` routes key events to the focused component. A pointer callback doesn't need
-focus: `Form` looks up whatever component sits under the touch and delivers to it, and the component is
-handed focus because of the press rather than as a condition for it. Whether it has to be enabled depends
-on where it sits - the content pane branch of `Form.pointerPressed` checks `isEnabled()`, while the title
-area and the west side deliver without checking, so an override on a disabled `Toolbar` component still
-runs.
+focus: `Form` looks up whatever component sits under the touch and delivers to it, whichever component
+holds focus at the time. Where the press lands decides the rest. The content pane branch of
+`Form.pointerPressed` delivers only to an enabled component, and gives it focus as well if it's focusable
+and the press isn't a scroll wheel. The title area branch and the west branch check neither, and assign no
+focus, so an override on a disabled `Toolbar` component still runs and the focus stays where it was.
 
 .How one touch reaches your code
 image::img/event-dispatch-path.svg[The path a pointer event takes from the native callback to your listener,scaledwidth=85%]

--- a/docs/developer-guide/Events.asciidoc
+++ b/docs/developer-guide/Events.asciidoc
@@ -219,7 +219,9 @@ Low-level events can be bound in one of 3 ways:
 
 TIP: That last one depends on the event. A key callback on an ordinary `Component` only fires while that
 component holds focus, because `Form` routes key events to the focused one - the exception is a key the
-menu bar claims, which `Form.keyPressed` hands to `MenuBar` before it consults `focused` at all.
+menu bar claims, which `Form.keyPressed` hands to `MenuBar` first. That exception has its own exception:
+`focusedHandlesInput` gives a printable key back to the focused component when it consumes raw text input,
+which is how a focused text editor keeps typing out of the menu bar.
 
 A pointer callback has no focus prerequisite at all, and three things about its target are worth knowing.
 `Form.pointerPressed` resolves the *lead parent* of whatever sits under the touch, so `isEnabled()` and

--- a/docs/developer-guide/Push-Notifications.asciidoc
+++ b/docs/developer-guide/Push-Notifications.asciidoc
@@ -5,6 +5,12 @@ Codename One push uses a typed message envelope and an explicit client binding. 
 
 You can use the managed BuildCloud service or install an adapter for custom native push. A custom-provider adapter is a low-level escape hatch: it bypasses BuildCloud registration and delivery completely, so your server owns tokens, credentials, targeting, retries, and provider errors.
 
+That choice reroutes both halves of the journey, registration and delivery, and leaves the application code
+alone. The rest of this chapter fills in each box.
+
+.Registration and delivery, managed and custom
+image::img/push-delivery-modes.svg[How registration and delivery flow in managed and custom provider mode,scaledwidth=95%]
+
 === Create and configure an application
 
 Open the Codename One Console and select *Push*. Create one Push application for each logical application and environment. For example, keep production and staging separate so credentials, audiences, and analytics remain isolated.

--- a/docs/developer-guide/img/event-batch-ordering.svg
+++ b/docs/developer-guide/img/event-batch-ordering.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="396" viewBox="0 0 820 396">
+  <rect x="0" y="0" width="820" height="396" fill="#ffffff"/>
+  <text x="410" y="24" font-family="Arial, sans-serif" font-size="14" font-weight="bold" text-anchor="middle" fill="#222222">Why the second listener runs only after the dialog closes</text>
+  <text x="410" y="43" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">handleEvent walks one batch of queued events in order. A blocking call inside the first listener suspends that walk</text>
+  <text x="410" y="57" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">without suspending the EDT, so events that arrive later overtake the ones still queued behind it.</text>
+  <rect x="16" y="74" width="132" height="74" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1.5"/>
+  <text x="82" y="104" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#4a6fa5">This turn's</text>
+  <text x="82" y="119" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#4a6fa5">batch</text>
+  <rect x="158" y="74" width="176" height="74" rx="4" fill="#eef2f7" stroke="#4a6fa5" stroke-width="1.2"/>
+  <text x="246" y="100" font-family="Arial, sans-serif" font-size="10" font-weight="bold" text-anchor="middle" fill="#4a6fa5">press on button one</text>
+  <text x="246" y="117" font-family="Arial, sans-serif" font-size="9.5" text-anchor="middle" fill="#555555">your listener runs and</text>
+  <text x="246" y="131" font-family="Arial, sans-serif" font-size="9.5" text-anchor="middle" fill="#555555">calls Dialog.show()</text>
+  <rect x="344" y="74" width="274" height="74" rx="4" fill="#ffffff" stroke="#bbbbbb" stroke-width="1.2" stroke-dasharray="5 4"/>
+  <text x="481" y="107" font-family="Arial, sans-serif" font-size="10" font-weight="bold" text-anchor="middle" fill="#888888">the rest of the batch waits here</text>
+  <text x="481" y="124" font-family="Arial, sans-serif" font-size="9.5" text-anchor="middle" fill="#888888">the walk is suspended, not the thread</text>
+  <rect x="628" y="74" width="176" height="74" rx="4" fill="#eef2f7" stroke="#4a6fa5" stroke-width="1.2"/>
+  <text x="716" y="100" font-family="Arial, sans-serif" font-size="10" font-weight="bold" text-anchor="middle" fill="#4a6fa5">press on button two</text>
+  <text x="716" y="117" font-family="Arial, sans-serif" font-size="9.5" text-anchor="middle" fill="#555555">runs now, long after</text>
+  <text x="716" y="131" font-family="Arial, sans-serif" font-size="9.5" text-anchor="middle" fill="#555555">the user touched it</text>
+  <rect x="16" y="176" width="132" height="74" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1.5"/>
+  <text x="82" y="206" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#4a7a3d">Inside</text>
+  <text x="82" y="221" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#4a7a3d">invokeAndBlock</text>
+  <rect x="344" y="176" width="274" height="74" rx="4" fill="#eef4ea" stroke="#4a7a3d" stroke-width="1.2"/>
+  <text x="481" y="200" font-family="Arial, sans-serif" font-size="10" font-weight="bold" text-anchor="middle" fill="#4a7a3d">a nested turn of the same loop</text>
+  <text x="481" y="217" font-family="Arial, sans-serif" font-size="9.5" text-anchor="middle" fill="#555555">it keeps painting, and dispatches every</text>
+  <text x="481" y="231" font-family="Arial, sans-serif" font-size="9.5" text-anchor="middle" fill="#555555">batch that arrives while the dialog is up</text>
+  <path d="M 246 148 L 246 213 L 336 213" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
+  <path d="M 330 208 L 338 213 L 330 218" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
+  <text x="286" y="203" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#4a7a3d">blocks</text>
+  <path d="M 618 213 L 698 213 L 698 154" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
+  <path d="M 693 160 L 698 152 L 703 160" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
+  <text x="663" y="206" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#4a6fa5">dismissed</text>
+  <path d="M 158 268 L 804 268" fill="none" stroke="#999999" stroke-width="1.5"/>
+  <path d="M 799 264 L 804 268 L 799 272" fill="none" stroke="#999999" stroke-width="1.5"/>
+  <text x="786" y="262" font-family="Arial, sans-serif" font-size="9.5" text-anchor="middle" fill="#999999">time</text>
+  <rect x="16" y="282" width="788" height="100" rx="4" fill="#f7f7f9" stroke="#cccccc" stroke-width="1"/>
+  <text x="410" y="304" font-family="Arial, sans-serif" font-size="12" font-weight="bold" text-anchor="middle" fill="#222222">What to do about it</text>
+  <text x="410" y="326" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">Wrapping the blocking part in callSerially lets the current batch drain before it runs, which fixes the ordering at the cost</text>
+  <text x="410" y="340" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">of moving your code one turn later - so it isn't a blanket rule, it just moves the problem when applied everywhere. The</text>
+  <text x="410" y="354" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">surer answer is not to block inside an event chain at all. Note the nested turn cannot reuse the array it is standing on, so</text>
+  <text x="410" y="368" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">it allocates a fresh one; that is what the Integer.MAX_VALUE marker on the last slot of the stack is for.</text>
+</svg>

--- a/docs/developer-guide/img/event-dispatch-path.svg
+++ b/docs/developer-guide/img/event-dispatch-path.svg
@@ -30,9 +30,9 @@
   <text x="116" y="364" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#4a7a3d">The component</text>
   <text x="116" y="379" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#4a7a3d">that gets it</text>
   <text x="232" y="352" font-family="Arial, sans-serif" font-size="9.5" fill="#777777">getComponentAt, then leadParentImpl and leadComponentImpl</text>
-  <text x="232" y="371" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">In the content pane it must be enabled to be called; the title area and west side call</text>
-  <text x="232" y="386" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">it even when disabled. Inside a lead container the callback goes to the lead component,</text>
-  <text x="232" y="401" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">not the one you touched. Focus follows only if it is focusable and not a scroll wheel.</text>
+  <text x="232" y="371" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">Form resolves the lead parent first, so isEnabled() and isFocusable() are asked of that,</text>
+  <text x="232" y="386" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">not of what you pressed, while the callback goes to the lead component. The content pane</text>
+  <text x="232" y="401" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">needs it enabled; the title area and west side do not. Focus is assigned only sometimes.</text>
   <path d="M 116 406 L 116 416" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
   <path d="M 111 410 L 116 416 L 121 410" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
   <rect x="16" y="416" width="200" height="78" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1.5"/>

--- a/docs/developer-guide/img/event-dispatch-path.svg
+++ b/docs/developer-guide/img/event-dispatch-path.svg
@@ -31,7 +31,7 @@
   <text x="116" y="364" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#4a7a3d">under the pointer</text>
   <text x="232" y="340" font-family="Arial, sans-serif" font-size="9.5" fill="#777777">getComponentAt, skipping ancestors that ignore pointer events</text>
   <text x="232" y="359" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">In the content pane it has to be enabled; the title area and side branches do not</text>
-  <text x="232" y="374" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">check. Focus is a result of the press, not a condition. Key events need it though.</text>
+  <text x="232" y="374" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">check. Focus is never required here, only sometimes assigned. Key events need it.</text>
   <path d="M 116 388 L 116 400" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
   <path d="M 111 394 L 116 400 L 121 394" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
   <rect x="16" y="400" width="200" height="72" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1.5"/>

--- a/docs/developer-guide/img/event-dispatch-path.svg
+++ b/docs/developer-guide/img/event-dispatch-path.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536">
   <rect x="0" y="0" width="820" height="536" fill="#ffffff"/>
   <text x="410" y="24" font-family="Arial, sans-serif" font-size="14" font-weight="bold" text-anchor="middle" fill="#222222">How one touch reaches your code</text>
-  <text x="410" y="43" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">A pointer event crosses two threads and four hand-offs before a listener sees it. Every row is a place you can</text>
-  <text x="410" y="57" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">intercept it, and each one sees something different.</text>
+  <text x="410" y="43" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">A pointer event crosses two threads and four hand-offs before a listener sees it. The last three rows are the ones your</text>
+  <text x="410" y="57" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">own code can get at, and each of those sees something different. The first two are the framework's own plumbing.</text>
   <rect x="16" y="64" width="200" height="78" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1.5"/>
   <text x="116" y="100" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#a56a3a">The platform's</text>
   <text x="116" y="115" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#a56a3a">UI thread</text>
@@ -41,5 +41,5 @@
   <text x="232" y="459" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">Still the EDT, still inside the same turn, so a blocking call here holds up every</text>
   <text x="232" y="474" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">event queued behind it.</text>
   <rect x="16" y="508" width="788" height="28" rx="4" fill="#f7f7f9" stroke="#cccccc" stroke-width="1"/>
-  <text x="410" y="526" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">A key event takes a different route: Form offers the keycode to the menu bar first, and only then to the focused component.</text>
+  <text x="410" y="526" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">A key event takes a different route: Form offers the keycode to the menu bar first, unless the focused component wants it as raw input.</text>
 </svg>

--- a/docs/developer-guide/img/event-dispatch-path.svg
+++ b/docs/developer-guide/img/event-dispatch-path.svg
@@ -22,16 +22,16 @@
   <rect x="16" y="232" width="200" height="72" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1.5"/>
   <text x="116" y="272" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#4a7a3d">Form.pointerPressed</text>
   <text x="232" y="256" font-family="Arial, sans-serif" font-size="9.5" fill="#777777">form coordinates, wherever the touch landed</text>
-  <text x="232" y="275" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">The form's own pointer listeners fire first, and one that calls consume() ends the</text>
-  <text x="232" y="290" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">delivery: nothing below this row runs at all.</text>
+  <text x="232" y="275" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">A context menu, a stylus event or a resumed fling are handled above this and can</text>
+  <text x="232" y="290" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">return first. Past them the form's listeners run, and consume() ends the delivery.</text>
   <path d="M 116 304 L 116 316" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
   <path d="M 111 310 L 116 316 L 121 310" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
   <rect x="16" y="316" width="200" height="72" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1.5"/>
   <text x="116" y="349" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#4a7a3d">The component</text>
   <text x="116" y="364" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#4a7a3d">under the pointer</text>
   <text x="232" y="340" font-family="Arial, sans-serif" font-size="9.5" fill="#777777">getComponentAt, skipping ancestors that ignore pointer events</text>
-  <text x="232" y="359" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">It only has to be enabled. It does not need focus - it is given focus here if it is</text>
-  <text x="232" y="374" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">focusable. Key events are the other way round: those go to the focused component.</text>
+  <text x="232" y="359" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">In the content pane it has to be enabled; the title area and side branches do not</text>
+  <text x="232" y="374" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">check. Focus is a result of the press, not a condition. Key events need it though.</text>
   <path d="M 116 388 L 116 400" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
   <path d="M 111 394 L 116 400 L 121 394" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
   <rect x="16" y="400" width="200" height="72" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1.5"/>

--- a/docs/developer-guide/img/event-dispatch-path.svg
+++ b/docs/developer-guide/img/event-dispatch-path.svg
@@ -1,42 +1,43 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="494" viewBox="0 0 820 494">
-  <rect x="0" y="0" width="820" height="494" fill="#ffffff"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="502" viewBox="0 0 820 502">
+  <rect x="0" y="0" width="820" height="502" fill="#ffffff"/>
   <text x="410" y="24" font-family="Arial, sans-serif" font-size="14" font-weight="bold" text-anchor="middle" fill="#222222">How one touch reaches your code</text>
   <text x="410" y="43" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">A pointer event crosses two threads and four hand-offs before a listener sees it. Every row is a place you can</text>
   <text x="410" y="57" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">intercept it, and each one sees something different.</text>
-  <rect x="16" y="64" width="200" height="72" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1.5"/>
-  <text x="116" y="97" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#a56a3a">The platform's</text>
-  <text x="116" y="112" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#a56a3a">UI thread</text>
+  <rect x="16" y="64" width="200" height="78" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1.5"/>
+  <text x="116" y="100" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#a56a3a">The platform's</text>
+  <text x="116" y="115" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#a56a3a">UI thread</text>
   <text x="232" y="88" font-family="Arial, sans-serif" font-size="9.5" fill="#777777">Display.pointerPressed(int[] x, int[] y)</text>
   <text x="232" y="107" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">The port calls this from the native UI thread. The packet is appended to the input</text>
   <text x="232" y="122" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">stack under a lock, and nothing of yours runs yet.</text>
-  <path d="M 116 136 L 116 148" fill="none" stroke="#a56a3a" stroke-width="1.5"/>
-  <path d="M 111 142 L 116 148 L 121 142" fill="none" stroke="#a56a3a" stroke-width="1.5"/>
-  <rect x="16" y="148" width="200" height="72" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1.5"/>
-  <text x="116" y="181" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#4a6fa5">The EDT,</text>
-  <text x="116" y="196" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#4a6fa5">on its next turn</text>
-  <text x="232" y="172" font-family="Arial, sans-serif" font-size="9.5" fill="#777777">the stacks are swapped, then handleEvent walks the batch</text>
-  <text x="232" y="191" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">Everything queued since the last turn is dispatched here, in order, before the frame</text>
-  <text x="232" y="206" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">is painted. That batch is the subject of the next figure.</text>
-  <path d="M 116 220 L 116 232" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
-  <path d="M 111 226 L 116 232 L 121 226" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
-  <rect x="16" y="232" width="200" height="72" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1.5"/>
-  <text x="116" y="272" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#4a7a3d">Form.pointerPressed</text>
-  <text x="232" y="256" font-family="Arial, sans-serif" font-size="9.5" fill="#777777">form coordinates, wherever the touch landed</text>
-  <text x="232" y="275" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">A context menu, a stylus event or a resumed fling are handled above this and can</text>
-  <text x="232" y="290" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">return first. Past them the form's listeners run, and consume() ends the delivery.</text>
-  <path d="M 116 304 L 116 316" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
-  <path d="M 111 310 L 116 316 L 121 310" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
-  <rect x="16" y="316" width="200" height="72" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1.5"/>
-  <text x="116" y="349" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#4a7a3d">The component</text>
-  <text x="116" y="364" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#4a7a3d">under the pointer</text>
-  <text x="232" y="340" font-family="Arial, sans-serif" font-size="9.5" fill="#777777">getComponentAt, skipping ancestors that ignore pointer events</text>
-  <text x="232" y="359" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">In the content pane it has to be enabled; the title area and side branches do not</text>
-  <text x="232" y="374" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">check. Focus is never required here, only sometimes assigned. Key events need it.</text>
-  <path d="M 116 388 L 116 400" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
-  <path d="M 111 394 L 116 400 L 121 394" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
-  <rect x="16" y="400" width="200" height="72" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1.5"/>
-  <text x="116" y="440" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#4a6fa5">Your listener</text>
-  <text x="232" y="424" font-family="Arial, sans-serif" font-size="9.5" fill="#777777">fireActionEvent -&gt; EventDispatcher -&gt; ActionListener</text>
-  <text x="232" y="443" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">Still the EDT, still inside the same turn, so a blocking call here holds up every</text>
-  <text x="232" y="458" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">event queued behind it.</text>
+  <path d="M 116 142 L 116 152" fill="none" stroke="#a56a3a" stroke-width="1.5"/>
+  <path d="M 111 146 L 116 152 L 121 146" fill="none" stroke="#a56a3a" stroke-width="1.5"/>
+  <rect x="16" y="152" width="200" height="78" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1.5"/>
+  <text x="116" y="188" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#4a6fa5">The EDT,</text>
+  <text x="116" y="203" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#4a6fa5">on its next turn</text>
+  <text x="232" y="176" font-family="Arial, sans-serif" font-size="9.5" fill="#777777">the stacks are swapped, then handleEvent walks the batch</text>
+  <text x="232" y="195" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">Everything queued since the last turn is dispatched here, in order, before the frame</text>
+  <text x="232" y="210" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">is painted. That batch is the subject of the next figure.</text>
+  <path d="M 116 230 L 116 240" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
+  <path d="M 111 234 L 116 240 L 121 234" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
+  <rect x="16" y="240" width="200" height="78" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1.5"/>
+  <text x="116" y="283" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#4a7a3d">Form.pointerPressed</text>
+  <text x="232" y="264" font-family="Arial, sans-serif" font-size="9.5" fill="#777777">form coordinates, wherever the touch landed</text>
+  <text x="232" y="283" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">A context menu, a stylus event or a resumed fling are handled above this and can</text>
+  <text x="232" y="298" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">return first. Past them the form's listeners run, and consume() ends the delivery.</text>
+  <path d="M 116 318 L 116 328" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
+  <path d="M 111 322 L 116 328 L 121 322" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
+  <rect x="16" y="328" width="200" height="78" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1.5"/>
+  <text x="116" y="364" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#4a7a3d">The component</text>
+  <text x="116" y="379" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#4a7a3d">under the pointer</text>
+  <text x="232" y="352" font-family="Arial, sans-serif" font-size="9.5" fill="#777777">getComponentAt, skipping ancestors that ignore pointer events</text>
+  <text x="232" y="371" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">In the content pane it must be enabled, and it takes focus before the callback. In the</text>
+  <text x="232" y="386" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">title area and along the west side it is called either way, and focus moves after it,</text>
+  <text x="232" y="401" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">if it can. Key events do need focus, unless the menu bar claims the key first.</text>
+  <path d="M 116 406 L 116 416" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
+  <path d="M 111 410 L 116 416 L 121 410" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
+  <rect x="16" y="416" width="200" height="78" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1.5"/>
+  <text x="116" y="459" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#4a6fa5">Your listener</text>
+  <text x="232" y="440" font-family="Arial, sans-serif" font-size="9.5" fill="#777777">fireActionEvent -&gt; EventDispatcher -&gt; ActionListener</text>
+  <text x="232" y="459" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">Still the EDT, still inside the same turn, so a blocking call here holds up every</text>
+  <text x="232" y="474" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">event queued behind it.</text>
 </svg>

--- a/docs/developer-guide/img/event-dispatch-path.svg
+++ b/docs/developer-guide/img/event-dispatch-path.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="820" height="502" viewBox="0 0 820 502">
-  <rect x="0" y="0" width="820" height="502" fill="#ffffff"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="536" viewBox="0 0 820 536">
+  <rect x="0" y="0" width="820" height="536" fill="#ffffff"/>
   <text x="410" y="24" font-family="Arial, sans-serif" font-size="14" font-weight="bold" text-anchor="middle" fill="#222222">How one touch reaches your code</text>
   <text x="410" y="43" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">A pointer event crosses two threads and four hand-offs before a listener sees it. Every row is a place you can</text>
   <text x="410" y="57" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">intercept it, and each one sees something different.</text>
@@ -28,11 +28,11 @@
   <path d="M 111 322 L 116 328 L 121 322" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
   <rect x="16" y="328" width="200" height="78" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1.5"/>
   <text x="116" y="364" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#4a7a3d">The component</text>
-  <text x="116" y="379" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#4a7a3d">under the pointer</text>
-  <text x="232" y="352" font-family="Arial, sans-serif" font-size="9.5" fill="#777777">getComponentAt, skipping ancestors that ignore pointer events</text>
-  <text x="232" y="371" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">In the content pane it must be enabled, and it takes focus before the callback. In the</text>
-  <text x="232" y="386" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">title area and along the west side it is called either way, and focus moves after it,</text>
-  <text x="232" y="401" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">if it can. Key events do need focus, unless the menu bar claims the key first.</text>
+  <text x="116" y="379" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#4a7a3d">that gets it</text>
+  <text x="232" y="352" font-family="Arial, sans-serif" font-size="9.5" fill="#777777">getComponentAt, then leadParentImpl and leadComponentImpl</text>
+  <text x="232" y="371" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">In the content pane it must be enabled to be called; the title area and west side call</text>
+  <text x="232" y="386" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">it even when disabled. Inside a lead container the callback goes to the lead component,</text>
+  <text x="232" y="401" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">not the one you touched. Focus follows only if it is focusable and not a scroll wheel.</text>
   <path d="M 116 406 L 116 416" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
   <path d="M 111 410 L 116 416 L 121 410" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
   <rect x="16" y="416" width="200" height="78" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1.5"/>
@@ -40,4 +40,6 @@
   <text x="232" y="440" font-family="Arial, sans-serif" font-size="9.5" fill="#777777">fireActionEvent -&gt; EventDispatcher -&gt; ActionListener</text>
   <text x="232" y="459" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">Still the EDT, still inside the same turn, so a blocking call here holds up every</text>
   <text x="232" y="474" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">event queued behind it.</text>
+  <rect x="16" y="508" width="788" height="28" rx="4" fill="#f7f7f9" stroke="#cccccc" stroke-width="1"/>
+  <text x="410" y="526" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">A key event takes a different route: Form offers the keycode to the menu bar first, and only then to the focused component.</text>
 </svg>

--- a/docs/developer-guide/img/event-dispatch-path.svg
+++ b/docs/developer-guide/img/event-dispatch-path.svg
@@ -15,8 +15,8 @@
   <text x="116" y="188" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#4a6fa5">The EDT,</text>
   <text x="116" y="203" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#4a6fa5">on its next turn</text>
   <text x="232" y="176" font-family="Arial, sans-serif" font-size="9.5" fill="#777777">the stacks are swapped, then handleEvent walks the batch</text>
-  <text x="232" y="195" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">Everything queued since the last turn is dispatched here, in order, before the frame</text>
-  <text x="232" y="210" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">is painted. That batch is the subject of the next figure.</text>
+  <text x="232" y="195" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">Everything queued since the last turn is dispatched here, in order, and that turn then</text>
+  <text x="232" y="210" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">paints. A blocking call suspends the walk mid-batch, which the next figure is about.</text>
   <path d="M 116 230 L 116 240" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
   <path d="M 111 234 L 116 240 L 121 234" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
   <rect x="16" y="240" width="200" height="78" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1.5"/>

--- a/docs/developer-guide/img/event-dispatch-path.svg
+++ b/docs/developer-guide/img/event-dispatch-path.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="494" viewBox="0 0 820 494">
+  <rect x="0" y="0" width="820" height="494" fill="#ffffff"/>
+  <text x="410" y="24" font-family="Arial, sans-serif" font-size="14" font-weight="bold" text-anchor="middle" fill="#222222">How one touch reaches your code</text>
+  <text x="410" y="43" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">A pointer event crosses two threads and four hand-offs before a listener sees it. Every row is a place you can</text>
+  <text x="410" y="57" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">intercept it, and each one sees something different.</text>
+  <rect x="16" y="64" width="200" height="72" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1.5"/>
+  <text x="116" y="97" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#a56a3a">The platform's</text>
+  <text x="116" y="112" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#a56a3a">UI thread</text>
+  <text x="232" y="88" font-family="Arial, sans-serif" font-size="9.5" fill="#777777">Display.pointerPressed(int[] x, int[] y)</text>
+  <text x="232" y="107" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">The port calls this from the native UI thread. The packet is appended to the input</text>
+  <text x="232" y="122" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">stack under a lock, and nothing of yours runs yet.</text>
+  <path d="M 116 136 L 116 148" fill="none" stroke="#a56a3a" stroke-width="1.5"/>
+  <path d="M 111 142 L 116 148 L 121 142" fill="none" stroke="#a56a3a" stroke-width="1.5"/>
+  <rect x="16" y="148" width="200" height="72" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1.5"/>
+  <text x="116" y="181" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#4a6fa5">The EDT,</text>
+  <text x="116" y="196" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#4a6fa5">on its next turn</text>
+  <text x="232" y="172" font-family="Arial, sans-serif" font-size="9.5" fill="#777777">the stacks are swapped, then handleEvent walks the batch</text>
+  <text x="232" y="191" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">Everything queued since the last turn is dispatched here, in order, before the frame</text>
+  <text x="232" y="206" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">is painted. That batch is the subject of the next figure.</text>
+  <path d="M 116 220 L 116 232" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
+  <path d="M 111 226 L 116 232 L 121 226" fill="none" stroke="#4a6fa5" stroke-width="1.5"/>
+  <rect x="16" y="232" width="200" height="72" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1.5"/>
+  <text x="116" y="272" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#4a7a3d">Form.pointerPressed</text>
+  <text x="232" y="256" font-family="Arial, sans-serif" font-size="9.5" fill="#777777">form coordinates, wherever the touch landed</text>
+  <text x="232" y="275" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">The form's own pointer listeners fire first, and one that calls consume() ends the</text>
+  <text x="232" y="290" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">delivery: nothing below this row runs at all.</text>
+  <path d="M 116 304 L 116 316" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
+  <path d="M 111 310 L 116 316 L 121 310" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
+  <rect x="16" y="316" width="200" height="72" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1.5"/>
+  <text x="116" y="349" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#4a7a3d">The component</text>
+  <text x="116" y="364" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#4a7a3d">under the pointer</text>
+  <text x="232" y="340" font-family="Arial, sans-serif" font-size="9.5" fill="#777777">getComponentAt, skipping ancestors that ignore pointer events</text>
+  <text x="232" y="359" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">It only has to be enabled. It does not need focus - it is given focus here if it is</text>
+  <text x="232" y="374" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">focusable. Key events are the other way round: those go to the focused component.</text>
+  <path d="M 116 388 L 116 400" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
+  <path d="M 111 394 L 116 400 L 121 394" fill="none" stroke="#4a7a3d" stroke-width="1.5"/>
+  <rect x="16" y="400" width="200" height="72" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1.5"/>
+  <text x="116" y="440" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#4a6fa5">Your listener</text>
+  <text x="232" y="424" font-family="Arial, sans-serif" font-size="9.5" fill="#777777">fireActionEvent -&gt; EventDispatcher -&gt; ActionListener</text>
+  <text x="232" y="443" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">Still the EDT, still inside the same turn, so a blocking call here holds up every</text>
+  <text x="232" y="458" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">event queued behind it.</text>
+</svg>

--- a/docs/developer-guide/img/push-delivery-modes.svg
+++ b/docs/developer-guide/img/push-delivery-modes.svg
@@ -104,5 +104,5 @@
   <text x="703" y="504" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">the identical callback,</text>
   <text x="703" y="517" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">also on the EDT</text>
   <rect x="16" y="556" width="788" height="30" rx="4" fill="#f7f7f9" stroke="#cccccc" stroke-width="1"/>
-  <text x="410" y="576" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">onRegistration() is not a delivery receipt: it fires before the storage request has answered, and a failure arrives as a PushError.</text>
+  <text x="410" y="576" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">onRegistration() is not a receipt: it fires before the storage request answers, an HTTP error becomes a PushError, and a transport failure is silent.</text>
 </svg>

--- a/docs/developer-guide/img/push-delivery-modes.svg
+++ b/docs/developer-guide/img/push-delivery-modes.svg
@@ -1,0 +1,108 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="598" viewBox="0 0 820 598">
+  <rect x="0" y="0" width="820" height="598" fill="#ffffff"/>
+  <text x="410" y="24" font-family="Arial, sans-serif" font-size="14" font-weight="bold" text-anchor="middle" fill="#222222">Where a push message comes from, in both modes</text>
+  <text x="410" y="43" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">Registration and delivery are separate journeys, and installing a PushTransport reroutes both of them. What does not</text>
+  <text x="410" y="57" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">change is the envelope at the end: the same schema-3 message reaches the same listener, on the EDT, either way.</text>
+  <rect x="16" y="70" width="788" height="226" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1.6"/>
+  <rect x="16" y="70" width="788" height="26" rx="4" fill="#4a6fa5" stroke="#4a6fa5" stroke-width="1"/>
+  <text x="410" y="88" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#ffffff">Managed delivery, which is what you get by default</text>
+  <text x="410" y="113" font-family="Arial, sans-serif" font-size="9.5" text-anchor="middle" fill="#666666">BuildCloud holds the subscriptions and talks to every provider for you</text>
+  <text x="24" y="132" font-family="Arial, sans-serif" font-size="9" fill="#4a6fa5">registering</text>
+  <rect x="26" y="136" width="166" height="64" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1.3"/>
+  <text x="109" y="156" font-family="Arial, sans-serif" font-size="9.8" font-weight="bold" text-anchor="middle" fill="#4a6fa5">PushClient.register()</text>
+  <text x="109" y="172" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">called from start(),</text>
+  <text x="109" y="185" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">and idempotent</text>
+  <path d="M 197 168 L 219 168" fill="none" stroke="#999999" stroke-width="1.5"/>
+  <path d="M 214 164 L 219 168 L 214 172" fill="none" stroke="#999999" stroke-width="1.5"/>
+  <rect x="224" y="136" width="166" height="64" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1.3"/>
+  <text x="307" y="156" font-family="Arial, sans-serif" font-size="9.8" font-weight="bold" text-anchor="middle" fill="#4a6fa5">the provider issues a token</text>
+  <text x="307" y="172" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">FCM, APNs, Huawei,</text>
+  <text x="307" y="185" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">WNS or Web Push</text>
+  <path d="M 395 168 L 417 168" fill="none" stroke="#999999" stroke-width="1.5"/>
+  <path d="M 412 164 L 417 168 L 412 172" fill="none" stroke="#999999" stroke-width="1.5"/>
+  <rect x="422" y="136" width="166" height="64" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1.3"/>
+  <text x="505" y="156" font-family="Arial, sans-serif" font-size="9.8" font-weight="bold" text-anchor="middle" fill="#4a6fa5">BuildCloud stores it</text>
+  <text x="505" y="172" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">as a subscription with</text>
+  <text x="505" y="185" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">an installation id</text>
+  <path d="M 593 168 L 615 168" fill="none" stroke="#999999" stroke-width="1.5"/>
+  <path d="M 610 164 L 615 168 L 610 172" fill="none" stroke="#999999" stroke-width="1.5"/>
+  <rect x="620" y="136" width="166" height="64" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1.3"/>
+  <text x="703" y="156" font-family="Arial, sans-serif" font-size="9.8" font-weight="bold" text-anchor="middle" fill="#4a6fa5">onRegistration()</text>
+  <text x="703" y="172" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">on the EDT, again on</text>
+  <text x="703" y="185" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">every token rotation</text>
+  <text x="24" y="216" font-family="Arial, sans-serif" font-size="9" fill="#4a6fa5">sending</text>
+  <rect x="26" y="220" width="166" height="64" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1.3"/>
+  <text x="109" y="240" font-family="Arial, sans-serif" font-size="9.8" font-weight="bold" text-anchor="middle" fill="#4a6fa5">your server posts it</text>
+  <text x="109" y="256" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">/api/v3/push/messages,</text>
+  <text x="109" y="269" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">202 with delivery ids</text>
+  <path d="M 197 252 L 219 252" fill="none" stroke="#999999" stroke-width="1.5"/>
+  <path d="M 214 248 L 219 252 L 214 256" fill="none" stroke="#999999" stroke-width="1.5"/>
+  <rect x="224" y="220" width="166" height="64" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1.3"/>
+  <text x="307" y="240" font-family="Arial, sans-serif" font-size="9.8" font-weight="bold" text-anchor="middle" fill="#4a6fa5">BuildCloud resolves it</text>
+  <text x="307" y="256" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">targets, or an audience</text>
+  <text x="307" y="269" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">filter run at launch</text>
+  <path d="M 395 252 L 417 252" fill="none" stroke="#999999" stroke-width="1.5"/>
+  <path d="M 412 248 L 417 252 L 412 256" fill="none" stroke="#999999" stroke-width="1.5"/>
+  <rect x="422" y="220" width="166" height="64" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1.3"/>
+  <text x="505" y="240" font-family="Arial, sans-serif" font-size="9.8" font-weight="bold" text-anchor="middle" fill="#4a6fa5">the provider delivers</text>
+  <text x="505" y="256" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">one native push per</text>
+  <text x="505" y="269" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">matched subscription</text>
+  <path d="M 593 252 L 615 252" fill="none" stroke="#999999" stroke-width="1.5"/>
+  <path d="M 610 248 L 615 252 L 610 256" fill="none" stroke="#999999" stroke-width="1.5"/>
+  <rect x="620" y="220" width="166" height="64" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1.3"/>
+  <text x="703" y="240" font-family="Arial, sans-serif" font-size="9.8" font-weight="bold" text-anchor="middle" fill="#4a6fa5">onMessage()</text>
+  <text x="703" y="256" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">one schema-3 envelope,</text>
+  <text x="703" y="269" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">on the EDT</text>
+  <rect x="16" y="318" width="788" height="226" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1.6"/>
+  <rect x="16" y="318" width="788" height="26" rx="4" fill="#a56a3a" stroke="#a56a3a" stroke-width="1"/>
+  <text x="410" y="336" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#ffffff">Custom delivery, once a PushTransport is installed</text>
+  <text x="410" y="361" font-family="Arial, sans-serif" font-size="9.5" text-anchor="middle" fill="#666666">PushClient never contacts BuildCloud, and your server owns tokens, targeting and retries</text>
+  <text x="24" y="380" font-family="Arial, sans-serif" font-size="9" fill="#a56a3a">registering</text>
+  <rect x="26" y="384" width="166" height="64" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1.3"/>
+  <text x="109" y="404" font-family="Arial, sans-serif" font-size="9.8" font-weight="bold" text-anchor="middle" fill="#a56a3a">PushClient.register()</text>
+  <text x="109" y="420" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">the same call, from</text>
+  <text x="109" y="433" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">the same place</text>
+  <path d="M 197 416 L 219 416" fill="none" stroke="#999999" stroke-width="1.5"/>
+  <path d="M 214 412 L 219 416 L 214 420" fill="none" stroke="#999999" stroke-width="1.5"/>
+  <rect x="224" y="384" width="166" height="64" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1.3"/>
+  <text x="307" y="404" font-family="Arial, sans-serif" font-size="9.8" font-weight="bold" text-anchor="middle" fill="#a56a3a">your transport registers</text>
+  <text x="307" y="420" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">against the private</text>
+  <text x="307" y="433" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">provider's own SDK</text>
+  <path d="M 395 416 L 417 416" fill="none" stroke="#999999" stroke-width="1.5"/>
+  <path d="M 412 412 L 417 416 L 412 420" fill="none" stroke="#999999" stroke-width="1.5"/>
+  <rect x="422" y="384" width="166" height="64" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1.3"/>
+  <text x="505" y="404" font-family="Arial, sans-serif" font-size="9.8" font-weight="bold" text-anchor="middle" fill="#a56a3a">Callback.registered()</text>
+  <text x="505" y="420" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">reaches your</text>
+  <text x="505" y="433" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">PushRegistrationSink</text>
+  <path d="M 593 416 L 615 416" fill="none" stroke="#999999" stroke-width="1.5"/>
+  <path d="M 610 412 L 615 416 L 610 420" fill="none" stroke="#999999" stroke-width="1.5"/>
+  <rect x="620" y="384" width="166" height="64" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1.3"/>
+  <text x="703" y="404" font-family="Arial, sans-serif" font-size="9.8" font-weight="bold" text-anchor="middle" fill="#a56a3a">your server stores it</text>
+  <text x="703" y="420" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">keyed by installationId,</text>
+  <text x="703" y="433" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">replaced on rotation</text>
+  <text x="24" y="464" font-family="Arial, sans-serif" font-size="9" fill="#a56a3a">sending</text>
+  <rect x="26" y="468" width="166" height="64" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1.3"/>
+  <text x="109" y="488" font-family="Arial, sans-serif" font-size="9.8" font-weight="bold" text-anchor="middle" fill="#a56a3a">your server sends</text>
+  <text x="109" y="504" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">through the provider's</text>
+  <text x="109" y="517" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">own native API</text>
+  <path d="M 197 500 L 219 500" fill="none" stroke="#999999" stroke-width="1.5"/>
+  <path d="M 214 496 L 219 500 L 214 504" fill="none" stroke="#999999" stroke-width="1.5"/>
+  <rect x="224" y="468" width="166" height="64" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1.3"/>
+  <text x="307" y="488" font-family="Arial, sans-serif" font-size="9.8" font-weight="bold" text-anchor="middle" fill="#a56a3a">your transport receives</text>
+  <text x="307" y="504" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">and rebuilds the</text>
+  <text x="307" y="517" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">schema-3 envelope</text>
+  <path d="M 395 500 L 417 500" fill="none" stroke="#999999" stroke-width="1.5"/>
+  <path d="M 412 496 L 417 500 L 412 504" fill="none" stroke="#999999" stroke-width="1.5"/>
+  <rect x="422" y="468" width="166" height="64" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1.3"/>
+  <text x="505" y="488" font-family="Arial, sans-serif" font-size="9.8" font-weight="bold" text-anchor="middle" fill="#a56a3a">Callback.message()</text>
+  <text x="505" y="504" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">never call the listener</text>
+  <text x="505" y="517" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">yourself</text>
+  <path d="M 593 500 L 615 500" fill="none" stroke="#999999" stroke-width="1.5"/>
+  <path d="M 610 496 L 615 500 L 610 504" fill="none" stroke="#999999" stroke-width="1.5"/>
+  <rect x="620" y="468" width="166" height="64" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1.3"/>
+  <text x="703" y="488" font-family="Arial, sans-serif" font-size="9.8" font-weight="bold" text-anchor="middle" fill="#a56a3a">onMessage()</text>
+  <text x="703" y="504" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">the identical callback,</text>
+  <text x="703" y="517" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">also on the EDT</text>
+  <rect x="16" y="556" width="788" height="30" rx="4" fill="#f7f7f9" stroke="#cccccc" stroke-width="1"/>
+  <text x="410" y="576" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">Keep the envelope identical and the same listener, deep links and surface commands work in both modes.</text>
+</svg>

--- a/docs/developer-guide/img/push-delivery-modes.svg
+++ b/docs/developer-guide/img/push-delivery-modes.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="820" height="598" viewBox="0 0 820 598">
   <rect x="0" y="0" width="820" height="598" fill="#ffffff"/>
   <text x="410" y="24" font-family="Arial, sans-serif" font-size="14" font-weight="bold" text-anchor="middle" fill="#222222">Where a push message comes from, in both modes</text>
-  <text x="410" y="43" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">Registration and delivery are separate journeys, and installing a PushTransport reroutes both of them. What does not</text>
-  <text x="410" y="57" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">change is the envelope at the end: the same schema-3 message reaches the same listener, on the EDT, either way.</text>
+  <text x="410" y="43" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">Registration and delivery are separate journeys, and installing a PushTransport reroutes both of them. What does not change</text>
+  <text x="410" y="57" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">is the envelope at the end: keep it identical and the same listener, deep links and surface commands work in either mode.</text>
   <rect x="16" y="70" width="788" height="226" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1.6"/>
   <rect x="16" y="70" width="788" height="26" rx="4" fill="#4a6fa5" stroke="#4a6fa5" stroke-width="1"/>
   <text x="410" y="88" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#ffffff">Managed delivery, which is what you get by default</text>
@@ -21,15 +21,15 @@
   <path d="M 395 168 L 417 168" fill="none" stroke="#999999" stroke-width="1.5"/>
   <path d="M 412 164 L 417 168 L 412 172" fill="none" stroke="#999999" stroke-width="1.5"/>
   <rect x="422" y="136" width="166" height="64" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1.3"/>
-  <text x="505" y="156" font-family="Arial, sans-serif" font-size="9.8" font-weight="bold" text-anchor="middle" fill="#4a6fa5">BuildCloud stores it</text>
-  <text x="505" y="172" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">as a subscription with</text>
-  <text x="505" y="185" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">an installation id</text>
+  <text x="505" y="156" font-family="Arial, sans-serif" font-size="9.8" font-weight="bold" text-anchor="middle" fill="#4a6fa5">onRegistration()</text>
+  <text x="505" y="172" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">at once on the EDT, and</text>
+  <text x="505" y="185" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">again on every rotation</text>
   <path d="M 593 168 L 615 168" fill="none" stroke="#999999" stroke-width="1.5"/>
   <path d="M 610 164 L 615 168 L 610 172" fill="none" stroke="#999999" stroke-width="1.5"/>
   <rect x="620" y="136" width="166" height="64" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1.3"/>
-  <text x="703" y="156" font-family="Arial, sans-serif" font-size="9.8" font-weight="bold" text-anchor="middle" fill="#4a6fa5">onRegistration()</text>
-  <text x="703" y="172" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">on the EDT, again on</text>
-  <text x="703" y="185" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">every token rotation</text>
+  <text x="703" y="156" font-family="Arial, sans-serif" font-size="9.8" font-weight="bold" text-anchor="middle" fill="#4a6fa5">BuildCloud stores it</text>
+  <text x="703" y="172" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">a request already sent,</text>
+  <text x="703" y="185" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">still able to fail</text>
   <text x="24" y="216" font-family="Arial, sans-serif" font-size="9" fill="#4a6fa5">sending</text>
   <rect x="26" y="220" width="166" height="64" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1.3"/>
   <text x="109" y="240" font-family="Arial, sans-serif" font-size="9.8" font-weight="bold" text-anchor="middle" fill="#4a6fa5">your server posts it</text>
@@ -72,14 +72,14 @@
   <path d="M 412 412 L 417 416 L 412 420" fill="none" stroke="#999999" stroke-width="1.5"/>
   <rect x="422" y="384" width="166" height="64" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1.3"/>
   <text x="505" y="404" font-family="Arial, sans-serif" font-size="9.8" font-weight="bold" text-anchor="middle" fill="#a56a3a">Callback.registered()</text>
-  <text x="505" y="420" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">reaches your</text>
-  <text x="505" y="433" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">PushRegistrationSink</text>
+  <text x="505" y="420" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">your PushRegistrationSink</text>
+  <text x="505" y="433" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">stores it on your server</text>
   <path d="M 593 416 L 615 416" fill="none" stroke="#999999" stroke-width="1.5"/>
   <path d="M 610 412 L 615 416 L 610 420" fill="none" stroke="#999999" stroke-width="1.5"/>
   <rect x="620" y="384" width="166" height="64" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1.3"/>
-  <text x="703" y="404" font-family="Arial, sans-serif" font-size="9.8" font-weight="bold" text-anchor="middle" fill="#a56a3a">your server stores it</text>
-  <text x="703" y="420" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">keyed by installationId,</text>
-  <text x="703" y="433" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">replaced on rotation</text>
+  <text x="703" y="404" font-family="Arial, sans-serif" font-size="9.8" font-weight="bold" text-anchor="middle" fill="#a56a3a">onRegistration()</text>
+  <text x="703" y="420" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">the same callback as above,</text>
+  <text x="703" y="433" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">also on the EDT</text>
   <text x="24" y="464" font-family="Arial, sans-serif" font-size="9" fill="#a56a3a">sending</text>
   <rect x="26" y="468" width="166" height="64" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1.3"/>
   <text x="109" y="488" font-family="Arial, sans-serif" font-size="9.8" font-weight="bold" text-anchor="middle" fill="#a56a3a">your server sends</text>
@@ -104,5 +104,5 @@
   <text x="703" y="504" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">the identical callback,</text>
   <text x="703" y="517" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#555555">also on the EDT</text>
   <rect x="16" y="556" width="788" height="30" rx="4" fill="#f7f7f9" stroke="#cccccc" stroke-width="1"/>
-  <text x="410" y="576" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">Keep the envelope identical and the same listener, deep links and surface commands work in both modes.</text>
+  <text x="410" y="576" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">onRegistration() is not a delivery receipt: it fires before the storage request has answered, and a failure arrives as a PushError.</text>
 </svg>


### PR DESCRIPTION
`Events.asciidoc` had no figures. Two of the things it explains in prose are shapes rather than sentences, so this adds both, and writing the first one turned up a claim that contradicts the code.

## `event-dispatch-path.svg`

The path one touch takes from the port to your listener, with each hand-off as a row, because each row is a place the chapter tells you to hook:

| stage | what it is |
|---|---|
| the platform's UI thread | `Display.pointerPressed(int[] x, int[] y)` appends to the input stack under a lock; nothing of yours runs yet |
| the EDT, next turn | the stacks are swapped and `handleEvent` walks the batch in order, before the frame is painted |
| `Form.pointerPressed` | the form's own pointer listeners fire first, and `consume()` ends the delivery |
| the component under the pointer | `getComponentAt`, skipping ancestors that ignore pointer events; must be enabled |
| your listener | `fireActionEvent` -> `EventDispatcher` -> `ActionListener`, still the same turn |

## `event-batch-ordering.svg`

The ordering trap the chapter already describes, as a timeline. A blocking call in the first listener suspends the walk over the batch without suspending the EDT, so events queued behind it wait for the dialog while events arriving later are dispatched by the nested turn and overtake them. The `Integer.MAX_VALUE` marker on the last slot of the input stack is what stops the nested turn reusing the array it is standing on.

## The corrected claim

> When you override event callbacks on a `Component` the `Component` in question must be focusable and have focus at that point.

True of key events -- `Form.keyPressed` routes to `focused`. False of pointer events: `Form.pointerPressed` resolves the target with `getComponentAt`, requires only `isEnabled()`, and calls `setFocused(cmp)` **as a consequence of** the press. Focus is a result there, not a condition. The summary table's "Component based events require focus" row carried the same error and is fixed with it.

## Verification

`check-guide-structure`, `check-guide-xrefs`, `check-guide-links`, `find_unused_images`, `validate-guide-snippets`, `check-missing-code-blocks` (34, unchanged), `asciidoctor --failure-level WARN`, `asciidoctor-pdf`, Vale (0/0/0), LanguageTool (`status: ok`, 0), paragraph capitalization, control characters. Both SVGs render in headless Chrome at their declared size -- note `qlmanage -t` is not a usable check here, it fits a thumbnail into a square and reports a clean diagram as clipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)