### PR TITLE
Developer guide: retire the Ant native layout, and an .andlib step that now fails the build

### DIFF
--- a/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
+++ b/docs/developer-guide/Advanced-Topics-Under-The-Hood.asciidoc
@@ -334,7 +334,7 @@ Implementing a native layer effectively means:
 
 .	Creating an interface that extends https://www.codenameone.com/javadoc/com/codename1/system/NativeInterface.html[NativeInterface] and defines methods with the arguments/return values declared in the previous paragraph.
 
-.	Creating the proper native implementation hierarchy based on the call conventions for every platform within the native directory
+.	Creating the proper native implementation hierarchy based on the call conventions for every platform, in each platform module's own source directory
 
 For example: to create a simple hello world interface do something like:
 
@@ -372,7 +372,7 @@ include::../demos/common/src/main/java/com/codenameone/developerguide/advancedto
 
 Notice that for this to work you must implement the native code on all supported platforms.
 
-You will start with Android which should be familiar and intuitive to many developers. The helper `MyNativeImplStub` class below mirrors the stub that the tooling generates under the `native/android` directory:
+You will start with Android which should be familiar and intuitive to many developers. The helper `MyNativeImplStub` class below mirrors the stub that the tooling generates under `android/src/main/java`:
 
 [source,java]
 ----
@@ -558,7 +558,7 @@ The problem with the synchronous call is that it will block the caller thread, i
 
 Cocoapods are the iOS equivalent of Gradle dependencies.
 
-CocoaPods allow you to add a native library dependency to iOS far more than Gradle. By default you target iOS 7.0 or newer which is supported by Intercom for older versions of the library. Annoyingly CocoaPods might seem to work but some specific APIs won't work since it fell back to an older version... To solve this you've to explicitly define the build hint `ios.pods.platform=8.0` to force iOS 8 or newer. You might need to force it to even newer versions as some libraries force an iOS 9 least etc.
+CocoaPods allow you to add a native library dependency to iOS far more than Gradle. A pod that needs a newer iOS than the rest of your app says so through the `ios.pods.platform` build hint. The deployment target the build uses is the highest of everything that asks for one -- the builder's own floor, `ios.deployment_target`, and `ios.pods.platform` -- so that hint can raise the target and never lower it.
 
 Including intercom itself required a single build hint: `ios.pods=Intercom` which you can obviously extend by using commas to include many libraries. You can search the https://cocoapods.org/[CocoaPods website] for supported 3rd party libraries which includes everything you would expect. One important advantage when working with CocoaPods is the faster build time as the upload to the Codename One website is smaller and the bandwidth you've to CocoaPods is faster. Another advantage is the ability to keep up with the latest developments from the library providers.
 
@@ -714,7 +714,7 @@ include::../demos/javascript/src/main/snippets/developer-guide/advanced-topics-u
 ----
 
 
-Notice that if you want to use a native library (jar,.a file etc.) places it within the appropriate native directory and it will be packaged into the final executable. You would be able to reference it from the native code and not from the Codename One code, which means you will need to build native interfaces to access it.
+Notice that if you want to use a native library (jar,.a file etc.) place it in the resources of the matching platform module -- `android/src/main/resources`, `ios/src/main/resources` -- and it will be packaged into the final executable. You would be able to reference it from the native code and not from the Codename One code, which means you will need to build native interfaces to access it.
 
 This is discussed further below.
 
@@ -864,7 +864,7 @@ A common way to implement features in Android is the `BroadcastReceiver` API. Th
 
 A good example is intercepting incoming SMS which is specific to Android so you'd need a broadcast receiver to implement that. This is often confusing to developers who sometimes derive the impl class from broadcast receiver. That's a mistake...
 
-The solution is to place any native Android class into the `native/android` directory. It will get compiled with the rest of the native code and "works." You can therefore place this class under `native/android/com/codename1/sms/intercept`:
+The solution is to place any native Android class into `android/src/main/java`. It will get compiled with the rest of the native code and "works." You can therefore place this class under `android/src/main/java/com/codename1/sms/intercept`:
 
 [source,java]
 ----
@@ -1250,9 +1250,8 @@ process isn't as straightforward.
 
 If you need to integrate such a library into your native calls you have the following options:
 
-. The first option (and the easiest one) is to place a Jar file in the native/android directory. This will link
-your binary with the jar file. Just place the jar under the native/android and the build server will pick it up and will
-add it to the classpath. +
+. The first option (and the easiest one) is to place a Jar file in `android/src/main/resources`. This will link
+your binary with the jar file, and the build server picks it up and adds it to the classpath. +
 Notice that Android release apps are obfuscated by default which might cause issues with such libraries if they
 reference APIs that are unavailable on Android. You can work around this by adding a build hint to the proguard
 obfuscation code that blocs the obfuscation of the problematic classes using the build hint: +
@@ -1261,12 +1260,12 @@ obfuscation code that blocs the obfuscation of the problematic classes using the
 . Another option is the `aar` file is a binary format Google introduced to represent an Android Library project (similarly to the cn1lib format). One of the problem with the Android Library projects was the fact that it required the project sources which made it difficult for 3rd party vendors to publish libraries. +
 As a result so android introduced the `aar` file which is a binary format that represents a Library project. To learn more about arr you can read link:https://developer.android.com/studio/projects/android-library.html#aar-contents[this]. +
 +
-You can link an `aar` file by placing it under the native/android and the build server will link it to the project.
+You can link an `aar` file by placing it in `android/src/main/resources` and the build server will link it to the project.
 
-. Another *obsolete approach* exists that you're mentioning for legacy purposes (for example: if you need to port code written with this legacy option). This predated the `aar` option from Google... Not all 3rd party tools can be packaged as a simple jar, some 3rd party tools need to declare activities add permissions, resources, assets, and/or even add native code (`.so` files). +
-To link a Library project to your Codename One project open the Library project in Eclipse or Android Studio and make sure the project builds, after the project was built successfully remove the bin directory from the project and zip the whole project. +
-+
-Rename the extension from `.zip` to `.andlib` and place the andlib file under the `native/android` directory. The build server will pick it up and will link it to the project.
+WARNING: Older material describes a third option, a zipped Eclipse library project renamed to `.andlib`.
+That format is gone. The Android builder stops with `andlib format is not supported anymore, use aar
+instead` the moment it finds one, so a project carrying an `.andlib` doesn't build at all. Convert it to
+an `aar`.
 
 
 === Integrating iOS 3rd party libraries
@@ -1450,18 +1449,25 @@ own configuration there; leave the user interface alone.
 
 
 
-=== Android Lollipop ActionBar customization
+=== Coloring the native Android chrome
 
-When running on Android Lollipop (5.0 or newer) the native action bar will use the Lollipop design. This isn't applicable
-if you use the https://www.codenameone.com/javadoc/com/codename1/ui/Toolbar.html[Toolbar] or https://www.codenameone.com/javadoc/com/codename1/ui/SideMenuBar.html[SideMenuBar] this will be used in the task switcher.
+Codename One switches the native action bar off -- the generated theme sets `android:windowActionBar` to
+`false` -- so the title you see belongs to the
+https://www.codenameone.com/javadoc/com/codename1/ui/Toolbar.html[Toolbar] or the
+https://www.codenameone.com/javadoc/com/codename1/ui/SideMenuBar.html[SideMenuBar] and Codename One draws
+it. What's left for the platform to color is the chrome around your app: the status bar, and the card the
+task switcher shows for it.
 
-To customize the colors of the native `ActionBar` on Lollipop define a `colors.xml` file in the `native/android` directory
-of your project. It should look like this:
+Define a `colors.xml` file under `android/src/main/resources` for that. Every `<color>` in it becomes an
+`android:` item in the generated theme, so each name has to be an Android theme attribute:
 
 [source,xml]
 ----
 include::../demos/common/src/main/snippets/developer-guide/advanced-topics-under-the-hood.xml[tag=advanced-topics-under-the-hood-xml-006,indent=0]
 ----
+
+NOTE: The colors reach the Material variant of the generated theme, so a device old enough to fall back to
+the Holo variant ignores them.
 
 === Intercepting URLs on iOS & Android
 

--- a/docs/developer-guide/Notifications-And-Background-Execution.asciidoc
+++ b/docs/developer-guide/Notifications-And-Background-Execution.asciidoc
@@ -82,7 +82,7 @@ no `R.drawable` constants). They're resolved at runtime per platform:
 | Parameter | What to provide | Android resolution | iOS resolution
 | `alertSound` / channel sound | a file whose name starts with `notification_sound`, bundled in the app | `res/raw/<name>` via `android.resource://` URI | `UNNotificationSound` from the app bundle
 | `alertImage` | image path placed in the app root | loaded from `assets/` | `UNNotificationAttachment` from the bundle
-| `Action` icon | a drawable name bundled in `native/android` | `getResources().getIdentifier(name, "drawable", pkg)` | not displayed
+| `Action` icon | a drawable name bundled in `android/src/main/resources` | `getResources().getIdentifier(name, "drawable", pkg)` | not displayed
 |===
 
 The file extension is optional for the action icon and is ignored. iOS notification

--- a/docs/developer-guide/Working-With-Javascript.asciidoc
+++ b/docs/developer-guide/Working-With-Javascript.asciidoc
@@ -519,7 +519,7 @@ For example: `MacIntel`, `Win32`, `FreeBSD i386`, "WebTV OS"
 [id="native_theme", reftext="Changing the Native Theme"]
 === Changing the native theme
 
-The JavaScript port selects a bundled native theme from the detected browser platform. You can override this behavior by setting the `javascript.native.theme` https://www.codenameone.com/javadoc/com/codename1/ui/Display.html[Display] property to the path of a theme included with your app. Place additional JavaScript-only themes in the `native/javascript` directory so they aren't bundled into other platforms.
+The JavaScript port selects a bundled native theme from the detected browser platform. You can override this behavior by setting the `javascript.native.theme` https://www.codenameone.com/javadoc/com/codename1/ui/Display.html[Display] property to the path of a theme included with your app. Place additional JavaScript-only themes in `javascript/src/main/resources` so they aren't bundled into other platforms.
 
 === Disabling the 'OnBeforeUnload' handler
 

--- a/docs/developer-guide/Working-With-iOS.asciidoc
+++ b/docs/developer-guide/Working-With-iOS.asciidoc
@@ -13,7 +13,7 @@ If you've access to a Mac, connect the device, open Xcode, and use the device ex
 - Check that you own the package name. For example, if you earlier installed an app with the same package name but a different certificate, a new install will fail. This is true for Android too. If you installed the kitchen sink from the store and then built your own app with the same package name, the installation will collide.
 - This can be a problem if you use a generic package name that someone else already claimed, so use your own domain.
 
-- Make sure the device has a recent enough version of iOS for the dependencies. As of 2024, Codename One builds target iOS 12.0 or newer by default. You can raise the need with the `ios.deployment_target` build hint if a library needs a newer version.
+- Make sure the device has a recent enough version of iOS for the dependencies. Codename One builds target iOS 14 unless you say otherwise, and never drop below iOS 13 whatever is asked for. Raise the floor with the `ios.deployment_target` build hint when a library needs a newer version.
 
 - Verify that you're using Safari when installing on the device. If you used a cable, that isn't a problem. Some developers had issues with Firefox not launching the install process.
 
@@ -27,7 +27,7 @@ Launch screen storyboards are the default approach for Codename One iOS builds. 
 
 ==== Key files
 
-The build server provides a minimal launch storyboard automatically. Customize it by adding any of the following files under your project's `native/ios` directory:
+The build server provides a minimal launch storyboard automatically. Customize it by adding any of the following files under your project's `ios/src/main/resources` directory:
 
 . `Launch.Foreground.png` - Shown in the center of the screen instead of your app icon.
 . `Launch.Background.png` - Drawn behind the content to provide a color or illustration.
@@ -78,7 +78,7 @@ When iterating locally with a Mac, open the generated Xcode project and run it o
 
 Local notifications are like push notifications, except that they're initiated locally by the app, rather than remotely. They're useful for communicating information to the user while the app is running in the background, since they manifest themselves as pop-up notifications on supported devices.
 
-TIP: To set the notification icon on Android place a 24×24 icon named `ic_stat_notify.png` under the `native/android` folder of the app. The icon can be white with transparency areas
+TIP: To set the notification icon on Android place a 24×24 icon named `ic_stat_notify.png` under `android/src/main/resources`. The icon can be white with transparency areas
 
 ==== Sending notifications
 
@@ -205,7 +205,7 @@ For example, it seems that Apple will reject your app if you include that and do
 
 NOTE: CocoaPods remains fully supported, but it's no longer the only supported iOS dependency path. Swift Package Manager (SPM) is also supported. The current guidance is documented in this section.
 
-https://cocoapods.org/[CocoaPods] is a dependency manager for Swift and Objective-C Cocoa projects. It has over eighteen thousand libraries and can help you scale your projects. Cocoapods can be used in your Codename One project to include native iOS libraries without having to go through the hassle of bundling the actual library into your project. Rather than bundling `.h` and `.a` files in your ios/native directory, you can specify which "pods" your app uses through the `ios.pods` build hint. (Other build hints also exist if you need more advanced features.)
+https://cocoapods.org/[CocoaPods] is a dependency manager for Swift and Objective-C Cocoa projects. It has over eighteen thousand libraries and can help you scale your projects. Cocoapods can be used in your Codename One project to include native iOS libraries without having to go through the hassle of bundling the actual library into your project. Rather than bundling `.h` and `.a` files in your `ios/src/main/resources` directory, you can specify which "pods" your app uses through the `ios.pods` build hint. (Other build hints also exist if you need more advanced features.)
 
 **Examples**
 
@@ -291,8 +291,8 @@ the dependency hints only if suppression is intentional, or switch to
 
 === Including dynamic frameworks
 
-If you need to use a dynamic framework (for example: SomeThirdPartySDK.framework), and it isn't available through CocoaPods, then you can add it to your project by zipping up the framework and copying it to your native/ios directory.
+If you need to use a dynamic framework (for example: SomeThirdPartySDK.framework), and it isn't available through CocoaPods, then you can add it to your project by zipping up the framework and copying it to `ios/src/main/resources`.
 
-For example: native/ios/SomeThirdPartySDK.framework.zip
+For example: `ios/src/main/resources/SomeThirdPartySDK.framework.zip`
 
 No build hints necessary for this approach. The build server will automatically detect the framework and link it into your app.


### PR DESCRIPTION
A pass over the native-integration material. Everything here was checked against the plugin and builder sources rather than against the surrounding prose.

## `native/<platform>` is the Ant layout

Eighteen sites told readers to put native code in `native/android`, `native/ios`, `native/javascript`. The Maven archetypes create no `native` directory at all -- they create `android/src/main/{java,resources}`, `ios/src/main/{objectivec,resources}`, `javascript/src/main/resources`.

The equivalence is not guesswork. `GenerateAppProjectMojo` is the Ant-to-Maven migration tool and its own mapping states it:

| Ant | Maven |
|---|---|
| `native/android/**/*.java` | `android/src/main/java` |
| `native/android/` everything else | `android/src/main/resources` |
| `native/ios` | `ios/src/main/objectivec` and `ios/src/main/resources` |

The builder confirms the other end: `unzip(androidPortSrcJar, srcDir, assetsDir, srcDir)` puts the android module's Java into the sources and everything else into assets, which is exactly where `ic_stat_notify.png` and `colors.xml` are looked for. `AbstractCN1Mojo.getProjectNativeSEDir()` and `Cn1libMojo.getNativeDir()` both survive with **no callers**.

`Analytics.asciidoc` and this chapter's own iOS-library section had already been corrected to the module paths in earlier passes; this applies that answer to the rest instead of inventing a second one.

## `.andlib` doesn't fail gracefully, it fails the build

`AndroidGradleBuilder`:

```java
if (file.getName().endsWith(".andlib")) {
    throw new BuildException("andlib format is not supported anymore, use aar instead");
}
```

The five lines telling readers to zip an Eclipse library project and rename it produced a build that could not start. Replaced with a warning naming the error and pointing at the `aar` option documented immediately above.

## "Android Lollipop ActionBar customization" customizes no action bar

The generated theme sets `android:windowActionBar` to `false`, so the title on screen belongs to `Toolbar` or `SideMenuBar` and Codename One draws it. `colors.xml` colors the *system chrome* -- status bar, task-switcher card. The builder inserts those entries into the Material variant of the generated theme only, so "Lollipop" dated the section without distinguishing anything now that every device runs Material. Retitled and rewritten around what the file actually does.

## The iOS deployment target

The CocoaPods paragraph offered `ios.pods.platform=8.0` to escape a default of iOS 7. `getDeploymentTarget` takes `maxVersionString` over a 13.0 floor, an implicit 14.0 when no target is given, `ios.deployment_target` and `ios.pods.platform` -- so the hint can only raise the target, and neither 7 nor 8 is reachable. `Working-With-iOS`'s "iOS 12.0 or newer by default" was stale the same way and now separates the floor from the default.

## Not included

The planned concurrent-GC figure needs a GC section to live in, and this chapter has none. Left for a pass that writes one rather than inventing a home for a diagram.

## Verification

`check-guide-structure`, `check-guide-xrefs`, `check-guide-links`, `find_unused_images`, `validate-guide-snippets`, `check-missing-code-blocks` (34, unchanged), `asciidoctor --failure-level WARN`, `asciidoctor-pdf`, Vale 0/0/0 on all four chapters, LanguageTool `status: ok` 0 on all four, paragraph capitalization, control characters, copyright headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)