### PR TITLE
Fix iOS on-device debugger compilation with Apple UI aliases

### DIFF
--- a/Ports/iOSPort/nativeSources/cn1_debugger.m
+++ b/Ports/iOSPort/nativeSources/cn1_debugger.m
@@ -38,6 +38,9 @@
 #ifdef CN1_ON_DEVICE_DEBUG
 
 #import <Foundation/Foundation.h>
+#if !TARGET_OS_WATCH
+#import "CN1AppleUI.h"
+#endif
 #include <pthread.h>
 #include <sys/socket.h>
 #include <netinet/in.h>


### PR DESCRIPTION
Enabling `ios.onDeviceDebug=true` fails iOS archive compilation because `cn1_debugger.m` uses `CN1View` and `CN1Font` without importing their definitions. The aliases were introduced by the native macOS port in #5601.

Import `CN1AppleUI.h` inside the debugger guard and exclude watchOS, matching the existing overlay guard. This makes the UI aliases available to the debugger while preserving the watch slice's lack of UIKit overlay support.

Validation:
- Reproduced the original unknown `CN1View` and undeclared `CN1Font` errors with Apple Clang and the iOS 26.2 SDK before the fix.
- The complete debugger source passes `clang -fsyntax-only` for arm64 iOS with on-device debugging enabled after the fix (three existing UIKit deprecation warnings).
- The source also passes for watchOS arm64_32 with debugging enabled and iOS arm64 with debugging disabled.
- Checks use the real runtime headers and a minimal generated class-index header defining `cn1_array_start_offset`; no full customer archive or signing was run.
- `git diff --check` passes.

The corrected native sources must be rebuilt into the `nativeios.jar` bundled with BuildDaemon for hosted builds to receive the fix.
