### PR TITLE
Migrate Foojay syndication to GitHub article submissions

### DIFF
--- a/.github/workflows/blog-syndication.yml
+++ b/.github/workflows/blog-syndication.yml
@@ -42,6 +42,8 @@ jobs:
       - name: Run syndication regression tests
         run: |
           python3 scripts/website/test_syndicate_blog_posts.py
+          python3 scripts/website/test_syndicate_foojay_posts.py
+          python3 scripts/website/test_syndicate_browser_posts.py
           python3 scripts/website/test_queue_browser_syndication.py
           python3 scripts/website/test_queue_social_posts.py
           python3 scripts/website/test_syndication_health.py
@@ -59,41 +61,10 @@ jobs:
             python3 scripts/website/syndicate_blog_posts.py
           fi
 
-      - name: Detect browser-syndication credentials
-        id: browser_creds
-        env:
-          FOOJAY_USER: ${{ secrets.FOOJAY_USER }}
-        run: |
-          if [ -n "${FOOJAY_USER}" ]; then
-            echo "any_configured=true" >> "${GITHUB_OUTPUT}"
-          else
-            echo "any_configured=false" >> "${GITHUB_OUTPUT}"
-          fi
-
       - name: Install markdown package (for browser-extension queue HTML)
         run: |
           set -euo pipefail
           pip install markdown
-
-      - name: Install Playwright dependencies
-        if: ${{ steps.browser_creds.outputs.any_configured == 'true' }}
-        run: |
-          set -euo pipefail
-          pip install playwright
-          playwright install --with-deps chromium
-
-      - name: Run browser syndication script
-        if: ${{ steps.browser_creds.outputs.any_configured == 'true' }}
-        env:
-          FOOJAY_USER: ${{ secrets.FOOJAY_USER }}
-          FOOJAY_PASSWORD: ${{ secrets.FOOJAY_PASSWORD }}
-        run: |
-          set -euo pipefail
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
-            python3 scripts/website/syndicate_browser_posts.py --dry-run
-          else
-            python3 scripts/website/syndicate_browser_posts.py
-          fi
 
       - name: Queue browser-extension syndication tasks (Medium)
         run: |
@@ -108,6 +79,20 @@ jobs:
         run: |
           set -euo pipefail
           python3 scripts/website/queue_social_posts.py --validate-only
+
+      # Run after queue creation so missing cross-repository credentials cannot
+      # prevent the existing local publisher from receiving its Medium work.
+      - name: Submit Foojay article for editorial review
+        env:
+          FOOJAY_GITHUB_TOKEN: ${{ secrets.FOOJAY_GITHUB_TOKEN }}
+          FOOJAY_HEAD_REPO: ${{ vars.FOOJAY_HEAD_REPO }}
+        run: |
+          set -euo pipefail
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            python3 scripts/website/syndicate_foojay_posts.py --dry-run
+          else
+            python3 scripts/website/syndicate_foojay_posts.py --submit
+          fi
 
       - name: Upload syndication screenshots on failure
         if: ${{ always() && hashFiles('docs/website/reports/syndication-screenshots/**/*.png') != '' }}

--- a/.github/workflows/syndication-health.yml
+++ b/.github/workflows/syndication-health.yml
@@ -179,7 +179,7 @@ jobs:
               '',
               `Last checked: ${new Date().toISOString()}`,
               '',
-              'The GitHub workflow publishes DEV/Foojay and creates queue tasks. The signed-in local runner publishes Medium, Hashnode, and LinkedIn. This issue stays open until both paths recover.',
+              'The GitHub workflow publishes DEV, submits Foojay editorial PRs, and creates queue tasks. The signed-in local runner publishes Medium, Hashnode, and LinkedIn. This issue stays open until both paths recover.',
             ].join('\n');
 
             const assignees = process.env.ALERT_ASSIGNEE ? [process.env.ALERT_ASSIGNEE] : undefined;

--- a/scripts/website/foojay-syndication.md
+++ b/scripts/website/foojay-syndication.md
@@ -1,0 +1,85 @@
+# Foojay article submissions
+
+Foojay moved from WordPress to Hugo in September 2026. Its
+[submission guide](https://foojayio.github.io/website/today/how-to-submit-your-next-article-on-foojay-io/)
+now asks for `draft/<slug>/index.md` and images in the same folder, submitted as a
+pull request to `foojayio/website`. A maintainer reviews the article, sets its
+publication date, and moves it into `content/posts/`. The schema comes from
+[template/post.md](https://github.com/foojayio/website/blob/main/template/post.md).
+
+`syndicate_foojay_posts.py` replaces the retired WordPress browser adapter. It
+reuses the shared post discovery and state, selects only Friday posts at least
+seven days old, and submits at most one article per run. Existing WordPress
+entries remain recorded: migration does not resubmit the historical backlog.
+
+The bundle uses the existing `shai-almog` author profile, the `Java` category,
+a description below 160 characters, a date without a time, and `canonical`
+pointing to the original CN1 article. The suggested date is the source date plus
+seven days; the editor chooses the final date. Images are copied from the local
+website static directory where possible, with external body images fetched when
+preparing a bundle. Image descriptions are retained. The preview must be a still
+JPEG or PNG under 800 KB, each image must stay within Foojay's 4 MB limit, and
+the bundle must stay under 15 MB. Prefer their
+recommended 1600 × 900 preview under 300 KB when authoring the original post.
+Mermaid shortcodes become native fenced diagrams; CN1 post links and footer
+removal use the shared renderer.
+
+## One-time GitHub setup
+
+The Actions `GITHUB_TOKEN` is scoped to the CN1 repository and cannot submit
+articles to another repository. The old `FOOJAY_USER` / `FOOJAY_PASSWORD`
+secrets are no longer used.
+
+1. Use an account with direct write access to `foojayio/website`, or create a
+   fork in that account. For example:
+   `gh repo fork foojayio/website --clone=false`.
+2. Set CN1's Actions variable `FOOJAY_HEAD_REPO` to the writable `owner/website`
+   repository. If unset, it defaults to `foojayio/website` for direct contributors.
+3. Set CN1's Actions secret `FOOJAY_GITHUB_TOKEN` to a token that can write Git
+   contents in the head repository and open pull requests against the public
+   upstream repository. Choose credentials that support the fork-to-upstream
+   route; a token restricted to CN1 alone cannot do this. Keep the token out of
+   command arguments and logs.
+
+The script verifies write permission, fork ancestry, and the upstream author
+profile before creating a branch. A missing token fails an eligible CI
+submission with a setup message instead of silently dropping Foojay.
+
+## Preview and submission
+
+Offline selection only (no GitHub calls, image reads, or state changes):
+
+```sh
+python3 scripts/website/syndicate_foojay_posts.py --dry-run
+```
+
+Prepare an eligible bundle for review without submitting or changing state:
+
+```sh
+python3 scripts/website/syndicate_foojay_posts.py --output-dir /tmp/foojay-review
+```
+
+After configuration, the daily workflow uses `--submit`. To explicitly submit
+the next eligible article locally, use authenticated `gh` or the token above:
+
+```sh
+python3 scripts/website/syndicate_foojay_posts.py --submit --head-repo YOUR_ACCOUNT/website
+```
+
+The deterministic `cn1-syndication/<slug>` branch contains one atomic commit
+with the whole bundle. Retries recover an existing open or merged PR if the
+CN1 state commit was lost. A closed, unmerged PR or a mismatched existing branch
+fails for manual review. An article with the same slug already in Foojay's
+published or draft tree also blocks duplicate submission.
+
+State records the PR URL with `status: submitted` and `published: false`.
+Recovering a merged PR records `status: merged`, still without claiming public
+publication. The existing health checker treats an editorial submission URL as
+completed delivery, just as it previously treated a WordPress draft URL; it does
+not monitor Foojay's editorial acceptance or public availability.
+
+Run the offline regressions with:
+
+```sh
+python3 scripts/website/test_syndicate_foojay_posts.py
+```

--- a/scripts/website/queue_browser_syndication.py
+++ b/scripts/website/queue_browser_syndication.py
@@ -8,8 +8,8 @@ inside a signed-in browser session.
 
 Daily flow:
 
-  1. CI runs the API syndicator (dev.to) and the Playwright syndicator
-     (foojay) directly.
+  1. CI runs the API syndicator (dev.to) and the GitHub PR syndicator
+     (Foojay) directly.
   2. CI runs *this* script for `medium` (or whatever browser
      platforms are configured) — it appends a task entry to
      syndication-queue.json for every eligible post that does not
@@ -58,8 +58,8 @@ DEFAULT_PLATFORMS = "medium"
 PAUSED_PLATFORMS = {"dzone"}
 
 # Platforms that only receive the weekly Friday digest post, rather than every
-# eligible post. This mirrors FoojayAdapter.accepts in
-# syndicate_browser_posts.py (post.date.weekday() == 4 -> Friday); deep-dive
+# eligible post. This mirrors accepts in
+# syndicate_foojay_posts.py (post.date.weekday() == 4 -> Friday); deep-dive
 # posts published on other weekdays are not syndicated to these platforms.
 WEEKLY_FRIDAY_PLATFORMS = {"dzone"}
 

--- a/scripts/website/syndicate_browser_posts.py
+++ b/scripts/website/syndicate_browser_posts.py
@@ -16,15 +16,14 @@ Usage:
 
     # First-time setup, watch the browser, take screenshots of the editor:
     python3 scripts/website/syndicate_browser_posts.py \
-        --platforms foojay --validate-only --headed --today 2026-05-08
+        --platforms hashnode --validate-only --headed
 
     # Real syndication (headless, daily-cron style):
-    python3 scripts/website/syndicate_browser_posts.py --platforms foojay
+    python3 scripts/website/syndicate_browser_posts.py --platforms hashnode
 
 Required env vars per platform (script auto-skips a platform when its creds
 are missing, just like the API script):
 
-    foojay     : FOOJAY_USER, FOOJAY_PASSWORD
     hashnode   : a signed-in session, resolved in priority order —
                    1. HASHNODE_STORAGE_STATE env var (base64 Playwright
                       storageState; this is how CI would receive it),
@@ -52,6 +51,9 @@ the session is resolved automatically (see the per-platform env-var note
 above): being logged in to Hashnode in Firefox is enough, so the
 platform no longer silently drops out when a shell forgets to export a
 secret.
+
+Foojay moved to GitHub article bundles in September 2026; its submission
+flow now lives in ``syndicate_foojay_posts.py``.
 
 HackerNoon was previously supported here but removed: HackerNoon
 charges business sites for canonical URL support, which makes it
@@ -103,7 +105,7 @@ SCREENSHOT_DIR = Path(__file__).resolve().parents[2] / "docs" / "website" / "rep
 # profile; see _resolve_hashnode_storage_state). CI holds none of those so
 # the platform is skipped automatically in cron runs; the maintainer runs
 # the script locally, where a logged-in Firefox session is enough.
-DEFAULT_PLATFORMS = "foojay,hashnode"
+DEFAULT_PLATFORMS = "hashnode"
 
 _UA_STR = (
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_0) AppleWebKit/537.36 "
@@ -300,293 +302,6 @@ def _save_screenshot(page, slug: str, label: str) -> Path:
     except Exception:  # noqa: BLE001 — never let a screenshot failure mask the real error
         return path
     return path
-
-
-class FoojayAdapter:
-    """foojay.io — Playwright login + REST API draft creation.
-
-    Pure UI submission to foojay does not work reliably: Cloudflare in front
-    of foojay challenges form POSTs to /wp-admin/post.php and drops the
-    form payload during the challenge, so the draft is never created. The
-    REST API is not subject to the same challenge, but Wordfence has
-    Application Passwords disabled, so token auth is also out.
-
-    The working hybrid: drive wp-login.php with Playwright to obtain a real
-    user session (cookies), pull the WP REST nonce from /wp-admin/, then
-    POST the draft through /wp-json/wp/v2/posts with cookie + X-WP-Nonce
-    auth. Behaves "as a website user" end-to-end while sidestepping both
-    the app-password block and the Cloudflare POST challenge.
-    """
-
-    name = "foojay"
-    LOGIN_URL = "https://foojay.io/wp-login.php"
-    BASE_URL = "https://foojay.io"
-    REST_POSTS_ENDPOINT = "https://foojay.io/wp-json/wp/v2/posts"
-    REST_TAGS_ENDPOINT = "https://foojay.io/wp-json/wp/v2/tags"
-    REST_MEDIA_ENDPOINT = "https://foojay.io/wp-json/wp/v2/media"
-    XMLRPC_ENDPOINT = "https://foojay.io/xmlrpc.php"
-
-    # Pre-resolved category and tag IDs (from /wp-json/wp/v2/categories?search=java
-    # and /wp-json/wp/v2/tags?slug=codenameone). The tag is created lazily on
-    # first use if it does not yet exist.
-    JAVA_CATEGORY_ID = 1722
-    CODENAMEONE_TAG_SLUG = "codenameone"
-    CODENAMEONE_TAG_NAME = "Codename One"
-
-    USER_SELECTORS = ["#user_login"]
-    PASSWORD_SELECTORS = ["#user_pass"]
-    SUBMIT_SELECTORS = ["#wp-submit"]
-
-    @staticmethod
-    def is_configured() -> bool:
-        return bool(os.environ.get("FOOJAY_USER") and os.environ.get("FOOJAY_PASSWORD"))
-
-    @staticmethod
-    def accepts(post: Post) -> bool:
-        # foojay only receives the weekly Friday digest post; the deep-dive
-        # posts published on other weekdays are not syndicated there.
-        return post.date.weekday() == 4
-
-    def login(self, page) -> None:
-        page.goto(self.LOGIN_URL, wait_until="domcontentloaded")
-        _find_first(page, self.USER_SELECTORS).fill(os.environ["FOOJAY_USER"])
-        _find_first(page, self.PASSWORD_SELECTORS).fill(os.environ["FOOJAY_PASSWORD"])
-        _find_first(page, self.SUBMIT_SELECTORS).click()
-        try:
-            page.wait_for_url("**/wp-admin/**", timeout=90000)
-        except Exception:  # noqa: BLE001
-            page.wait_for_selector("#wpadminbar", timeout=30000)
-
-    def submit_draft(self, page, ctx: AdapterContext) -> dict[str, Any]:
-        # Land on wp-admin so wpApiSettings (which carries the nonce) is in scope.
-        page.goto("https://foojay.io/wp-admin/", wait_until="domcontentloaded", timeout=60000)
-        nonce = page.evaluate(
-            "() => (window.wpApiSettings && window.wpApiSettings.nonce) || null"
-        )
-        if not nonce:
-            raise AdapterError("could not extract wpApiSettings.nonce from /wp-admin/")
-
-        if ctx.validate_only:
-            shot = _save_screenshot(page, ctx.post.slug, "foojay-editor")
-            return {"validated": True, "screenshot": str(shot), "nonce_acquired": True}
-
-        cookies = page.context.cookies("https://foojay.io/")
-        cookie_header = "; ".join(f"{c['name']}={c['value']}" for c in cookies)
-
-        # Resolve / create the codenameone tag.
-        tag_id = self._ensure_tag(cookie_header, nonce)
-        # Upload the cover image into the WP media library and use the
-        # returned media ID as the post's featured image.
-        featured_media_id: int | None = None
-        if ctx.post.cover_image:
-            try:
-                featured_media_id = self._upload_featured_media(
-                    cookie_header, nonce, ctx.post.cover_image, ctx.post.title
-                )
-            except Exception as err:  # noqa: BLE001 — featured image is best-effort
-                print(f"  [foojay] featured image upload failed (non-fatal): {err}", file=sys.stderr)
-
-        # Yoast canonical (_yoast_wpseo_canonical) is not registered for REST
-        # writes on this Yoast install. We send it in `meta` regardless (it's
-        # silently ignored if rejected, accepted if registered) AND surface it
-        # as a hidden HTML comment at the top of the body so the editor can
-        # spot the original URL when filling Yoast's metabox.
-        excerpt = str(ctx.post.front_matter.get("description") or "").strip()
-        canonical_prefix = f"<!-- Original / canonical: {ctx.post.canonical_url} -->\n\n"
-
-        payload: dict[str, Any] = {
-            "title": ctx.post.title,
-            "content": canonical_prefix + ctx.body_markdown,
-            "status": "draft",
-            "categories": [self.JAVA_CATEGORY_ID],
-            "tags": [tag_id] if tag_id else [],
-            "meta": {
-                "_yoast_wpseo_canonical": ctx.post.canonical_url,
-                "_yoast_wpseo_title": ctx.post.title,
-                "_yoast_wpseo_metadesc": excerpt[:155] if excerpt else "",
-            },
-        }
-        if featured_media_id:
-            payload["featured_media"] = featured_media_id
-        if excerpt:
-            payload["excerpt"] = excerpt[:500]
-
-        data = self._rest_post(self.REST_POSTS_ENDPOINT, cookie_header, nonce, payload)
-        post_id = data.get("id")
-        if not post_id:
-            raise AdapterError(f"REST response missing post id: {data}")
-
-        # Yoast meta (canonical / SEO title / metadesc) is not REST-writable on
-        # foojay's Yoast install. wp-admin form-submit is blocked by Cloudflare.
-        # XML-RPC's wp.editPost with custom_fields bypasses both restrictions
-        # and successfully writes the underscore-prefixed meta keys.
-        yoast_set = False
-        try:
-            self._set_yoast_meta_via_xmlrpc(
-                post_id=post_id,
-                canonical=ctx.post.canonical_url,
-                seo_title=ctx.post.title,
-                metadesc=_trim_for_meta_description(excerpt),
-            )
-            yoast_set = True
-        except Exception as err:  # noqa: BLE001 — Yoast meta is best-effort
-            print(f"  [foojay] XML-RPC Yoast meta write failed (non-fatal): {err}", file=sys.stderr)
-
-        return {
-            "id": post_id,
-            "url": f"https://foojay.io/wp-admin/post.php?post={post_id}&action=edit",
-            "preview_url": data.get("link"),
-            "featured_media_id": featured_media_id,
-            "yoast_meta_set": yoast_set,
-            "syndicated_at": dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds"),
-        }
-
-    # ----- helpers -----
-
-    def _ensure_tag(self, cookie_header: str, nonce: str) -> int | None:
-        """Return the WP tag id for `codenameone`, creating it if missing."""
-        import urllib.parse as _up
-        try:
-            existing = self._rest_get(
-                f"{self.REST_TAGS_ENDPOINT}?slug={_up.quote(self.CODENAMEONE_TAG_SLUG)}",
-                cookie_header,
-                nonce,
-            )
-            if isinstance(existing, list) and existing:
-                return existing[0].get("id")
-            created = self._rest_post(
-                self.REST_TAGS_ENDPOINT,
-                cookie_header,
-                nonce,
-                {"name": self.CODENAMEONE_TAG_NAME, "slug": self.CODENAMEONE_TAG_SLUG},
-            )
-            return created.get("id")
-        except Exception as err:  # noqa: BLE001 — tag is best-effort
-            print(f"  [foojay] tag resolve/create failed (non-fatal): {err}", file=sys.stderr)
-            return None
-
-    def _upload_featured_media(self, cookie_header: str, nonce: str,
-                               image_url: str, title: str) -> int:
-        """Download the cover image and POST it into WP's media library."""
-        import urllib.request as _ur
-        # Download bytes
-        req = _ur.Request(image_url, headers={"User-Agent": _UA_STR})
-        with _ur.urlopen(req, timeout=120) as resp:
-            image_bytes = resp.read()
-            content_type = resp.headers.get("Content-Type", "image/jpeg")
-        filename = image_url.rsplit("/", 1)[-1].split("?", 1)[0] or "cover.jpg"
-
-        upload = _ur.Request(self.REST_MEDIA_ENDPOINT, data=image_bytes, method="POST")
-        upload.add_header("Content-Type", content_type)
-        upload.add_header("Content-Disposition", f'attachment; filename="{filename}"')
-        upload.add_header("X-WP-Nonce", nonce)
-        upload.add_header("Cookie", cookie_header)
-        upload.add_header("User-Agent", _UA_STR)
-        with _ur.urlopen(upload, timeout=120) as response:
-            data = json.loads(response.read().decode("utf-8"))
-        media_id = data.get("id")
-        if not media_id:
-            raise RuntimeError(f"media upload returned no id: {str(data)[:200]}")
-        # Set a friendlier title on the media item.
-        try:
-            self._rest_post(
-                f"{self.REST_MEDIA_ENDPOINT}/{media_id}", cookie_header, nonce,
-                {"title": title, "alt_text": title},
-            )
-        except Exception:  # noqa: BLE001
-            # The media-item title and alt text are cosmetic — the upload
-            # itself already succeeded and the post will reference the
-            # returned media id regardless. Swallow any follow-up rename
-            # error so the caller still gets the upload result.
-            pass
-        return media_id
-
-    def _set_yoast_meta_via_xmlrpc(self, post_id: int, canonical: str,
-                                   seo_title: str, metadesc: str) -> None:
-        """Update Yoast SEO post meta via XML-RPC's wp.editPost custom_fields.
-
-        REST silently drops these meta keys (not registered for REST writes)
-        and the wp-admin form-submit path is challenged by Cloudflare.
-        XML-RPC accepts underscore-prefixed meta keys via custom_fields and
-        is not Cloudflare-protected on foojay.
-        """
-        import urllib.error as _ue
-        import urllib.request as _ur
-        import xml.sax.saxutils as _su
-
-        user = os.environ["FOOJAY_USER"]
-        pwd = os.environ["FOOJAY_PASSWORD"]
-
-        def cf_member(key: str, value: str) -> str:
-            return (
-                "<value><struct>"
-                f"<member><name>key</name><value><string>{_su.escape(key)}</string></value></member>"
-                f"<member><name>value</name><value><string>{_su.escape(value)}</string></value></member>"
-                "</struct></value>"
-            )
-
-        custom_fields_xml = "".join([
-            cf_member("_yoast_wpseo_canonical", canonical),
-            cf_member("_yoast_wpseo_title", seo_title),
-            cf_member("_yoast_wpseo_metadesc", metadesc),
-        ])
-        envelope = (
-            '<?xml version="1.0"?>'
-            '<methodCall><methodName>wp.editPost</methodName><params>'
-            "<param><value><int>1</int></value></param>"
-            f"<param><value><string>{_su.escape(user)}</string></value></param>"
-            f"<param><value><string>{_su.escape(pwd)}</string></value></param>"
-            f"<param><value><int>{int(post_id)}</int></value></param>"
-            "<param><value><struct>"
-            f"<member><name>custom_fields</name><value><array><data>{custom_fields_xml}</data></array></value></member>"
-            "</struct></value></param>"
-            "</params></methodCall>"
-        )
-        req = _ur.Request(
-            self.XMLRPC_ENDPOINT,
-            data=envelope.encode("utf-8"),
-            method="POST",
-        )
-        req.add_header("Content-Type", "text/xml")
-        req.add_header("User-Agent", _UA_STR)
-        try:
-            with _ur.urlopen(req, timeout=60) as response:
-                body = response.read().decode("utf-8", errors="replace")
-        except _ue.HTTPError as err:
-            detail = err.read().decode("utf-8", errors="replace")
-            raise RuntimeError(f"xmlrpc HTTP {err.code}: {detail}") from err
-        if "<fault>" in body:
-            raise RuntimeError(f"xmlrpc fault: {body[:500]}")
-        if "<boolean>1</boolean>" not in body:
-            raise RuntimeError(f"xmlrpc unexpected response: {body[:500]}")
-
-    def _rest_get(self, url: str, cookie_header: str, nonce: str) -> Any:
-        import urllib.request as _ur
-        req = _ur.Request(url, method="GET")
-        req.add_header("Accept", "application/json")
-        req.add_header("X-WP-Nonce", nonce)
-        req.add_header("Cookie", cookie_header)
-        req.add_header("User-Agent", _UA_STR)
-        with _ur.urlopen(req, timeout=60) as response:
-            return json.loads(response.read().decode("utf-8"))
-
-    def _rest_post(self, url: str, cookie_header: str, nonce: str,
-                   payload: dict[str, Any]) -> dict[str, Any]:
-        import urllib.error as _ue
-        import urllib.request as _ur
-        req = _ur.Request(url, data=json.dumps(payload).encode("utf-8"), method="POST")
-        req.add_header("Content-Type", "application/json")
-        req.add_header("Accept", "application/json")
-        req.add_header("X-WP-Nonce", nonce)
-        req.add_header("Cookie", cookie_header)
-        req.add_header("User-Agent", _UA_STR)
-        try:
-            with _ur.urlopen(req, timeout=120) as response:
-                raw = response.read().decode("utf-8")
-        except _ue.HTTPError as err:
-            detail = err.read().decode("utf-8", errors="replace")
-            raise AdapterError(f"REST POST {url} failed HTTP {err.code}: {detail}") from err
-        return json.loads(raw) if raw else {}
 
 
 class HashnodeAdapter:
@@ -1133,7 +848,6 @@ class HashnodeAdapter:
 
 
 ADAPTERS: dict[str, Callable[[], Any]] = {
-    "foojay": FoojayAdapter,
     "hashnode": HashnodeAdapter,
 }
 
@@ -1142,7 +856,6 @@ ADAPTERS: dict[str, Callable[[], Any]] = {
 # quiet; locally they almost always mean a missing/expired session, which is
 # exactly how Hashnode silently fell out of the rotation after #4956.
 SETUP_HINTS: dict[str, str] = {
-    "foojay": "set FOOJAY_USER and FOOJAY_PASSWORD",
     "hashnode": (
         "log in to Hashnode in Firefox, or capture a session with "
         "`python3 scripts/website/export_storage_state.py --site hashnode --from-firefox-profile`"
@@ -1179,8 +892,7 @@ def run_adapter(adapter, post: Post, body_markdown: str, headed: bool, validate_
         # Adapters that authenticate via a saved Playwright storageState
         # (Hashnode, and historically Medium/DZone) expose a
         # `storage_state_path()` classmethod that returns a path to the
-        # decoded JSON. FoojayAdapter logs in with user+password and does
-        # not define it.
+        # decoded JSON.
         storage_state_method = getattr(adapter, "storage_state_path", None)
         if callable(storage_state_method):
             try:

--- a/scripts/website/syndicate_foojay_posts.py
+++ b/scripts/website/syndicate_foojay_posts.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Prepare or submit Friday digests using Foojay's GitHub article-bundle workflow.
+
+Reuses the existing discovery, seven-day delay, body renderer and state file.
+The default is an offline dry run; --submit creates a PR for editorial review.
+See foojay-syndication.md for token/fork setup and migration behavior.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import datetime as dt
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.parse
+import urllib.request
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+from syndicate_blog_posts import (
+    BLOG_DIR, ELIGIBILITY_FLOOR, MIN_AGE_DAYS, REPO_ROOT,
+    STATE_FILE, USER_AGENT, Post, State, _MERMAID_BLOCK_RE,
+    discover_posts, render_syndicated_body, select_candidate,
+)
+
+UPSTREAM = "foojayio/website"
+AUTHOR = "shai-almog"
+MAX_IMAGE_BYTES = 4_000_000  # Foojay scripts/validate/Frontmatter.java
+MAX_HERO_BYTES = 800_000
+MAX_BUNDLE_BYTES = 15_000_000
+STATIC_DIR = REPO_ROOT / "docs/website/static"
+IMAGE_RE = re.compile(r'(!\[[^\]]*\]\()([^\s)]+)([^)]*\))')
+HTML_IMAGE_RE = re.compile(r'(<img\b[^>]*\bsrc=["\'])([^"\']+)(["\'])', re.I)
+
+
+def accepts(post: Post) -> bool:
+    return post.date.weekday() == 4
+
+
+def validate_slug(slug: str) -> None:
+    if not re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", slug):
+        raise ValueError(f"Invalid Foojay article slug: {slug!r}")
+
+
+def render_body(post: Post, posts: list[Post], today: dt.date) -> str:
+    # Foojay supports native Mermaid fences. Convert before the shared renderer
+    # would replace CN1's shortcode with an externally hosted diagram image.
+    body = _MERMAID_BLOCK_RE.sub(
+        lambda m: "\n```mermaid\n" + m.group(1).strip() + "\n```\n", post.body,
+    )
+    return render_syndicated_body(replace(post, body=body), posts, today)
+
+
+def read_image(url: str, static_dir: Path) -> bytes:
+    parsed = urllib.parse.urlsplit(url)
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError(f"Unsupported image URL: {url}")
+    if parsed.netloc in {"www.codenameone.com", "codenameone.com"}:
+        root = static_dir.resolve()
+        local = (root / urllib.parse.unquote(parsed.path).lstrip("/")).resolve()
+        if not local.is_relative_to(root):
+            raise ValueError("Image path escapes the static directory")
+        data = local.read_bytes()
+    else:
+        request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+        with urllib.request.urlopen(request, timeout=60) as response:
+            data = response.read(MAX_IMAGE_BYTES + 1)
+    if not data or len(data) > MAX_IMAGE_BYTES:
+        raise ValueError(f"Image is empty or exceeds Foojay's 4 MB limit: {url}")
+    return data
+
+
+def build_bundle(post: Post, posts: list[Post], today: dt.date,
+                 static_dir: Path = STATIC_DIR) -> dict[str, bytes]:
+    validate_slug(post.slug)
+    if str(post.front_matter.get("author", "")).strip() != "Shai Almog":
+        raise ValueError("Foojay author mapping is only configured for Shai Almog")
+    description = " ".join(str(post.front_matter.get("description") or "").split())
+    if not description or not post.title.strip():
+        raise ValueError("Foojay requires a title and description")
+    if len(description) >= 160:
+        description = description[:156].rsplit(" ", 1)[0] + "..."
+    if not post.cover_image:
+        raise ValueError("Foojay requires a preview image")
+    files: dict[str, bytes] = {}
+    names: dict[str, str] = {}
+
+    def bundle_image(url: str) -> str:
+        if url in names:
+            return names[url]
+        parsed = urllib.parse.urlsplit(url)
+        suffix = Path(parsed.path).suffix.lower()
+        if suffix not in {".jpg", ".jpeg", ".png", ".gif", ".webp", ".svg", ".avif"}:
+            raise ValueError(f"Unsupported image format: {url}")
+        # URL digest avoids collisions between different images with the same name.
+        stem = re.sub(r"[^a-zA-Z0-9_-]", "-", Path(parsed.path).stem)[:80]
+        name = f"{stem}-{hashlib.sha256(url.encode()).hexdigest()[:10]}{suffix}"
+        files[name] = read_image(url, static_dir)
+        names[url] = name
+        return name
+
+    cover = bundle_image(post.cover_image)
+    cover_data = files[cover]
+    is_jpeg = cover_data.startswith(b"\xff\xd8\xff")
+    is_png = cover_data.startswith(b"\x89PNG\r\n\x1a\n")
+    if not (is_jpeg or is_png) or (is_png and b"acTL" in cover_data):
+        raise ValueError("Foojay preview image must be a still JPEG or PNG")
+    if len(cover_data) > MAX_HERO_BYTES:
+        raise ValueError("Compress the Foojay preview below 800 KB (recommended: below 300 KB)")
+    body = render_body(post, posts, today)
+    # Leave code examples alone; URLs there are source code, not image assets.
+    fence: str | None = None
+    lines = []
+    for line in body.splitlines():
+        marker = re.match(r"^\s*(`{3,}|~{3,})", line)
+        if marker:
+            value = marker.group(1)
+            if fence is None:
+                fence = value
+            elif value[0] == fence[0] and len(value) >= len(fence):
+                fence = None
+            lines.append(line)
+            continue
+        if fence is None:
+            line = IMAGE_RE.sub(lambda m: m[1] + bundle_image(m[2]) + m[3], line)
+            line = HTML_IMAGE_RE.sub(lambda m: m[1] + bundle_image(m[2]) + m[3], line)
+            if re.match(r"^#\s", line):
+                raise ValueError("Foojay body headings must start at H2")
+        lines.append(line)
+    fields = {
+        "title": post.title, "date": (post.date + dt.timedelta(days=MIN_AGE_DAYS)).isoformat(), "description": description,
+        "authors": [AUTHOR], "image": cover, "categories": ["Java"],
+        "canonical": post.canonical_url,
+    }
+    # JSON scalars/arrays are valid YAML and correctly escape quotes/newlines.
+    frontmatter = "\n".join(f"{key}: {json.dumps(value, ensure_ascii=False)}"
+                            for key, value in fields.items())
+    files["index.md"] = ("---\n" + frontmatter + "\n---\n\n" +
+                         "\n".join(lines) + "\n").encode("utf-8")
+    if sum(map(len, files.values())) > MAX_BUNDLE_BYTES:
+        raise ValueError("Foojay article bundle exceeds the 15 MB budget")
+    return {f"draft/{post.slug}/{name}": data for name, data in files.items()}
+
+
+class GitHub:
+    """Use the authenticated gh CLI; credentials never enter command arguments."""
+
+    def api(self, endpoint: str, payload: dict | None = None,
+            *, optional: bool = False) -> Any:
+        command = ["gh", "api", "--hostname", "github.com", endpoint]
+        if payload is not None:
+            command += ["--method", "POST", "--input", "-"]
+        env = os.environ.copy()
+        if env.get("FOOJAY_GITHUB_TOKEN"):
+            env["GH_TOKEN"] = env["FOOJAY_GITHUB_TOKEN"]
+        result = subprocess.run(command, input=json.dumps(payload) if payload is not None else None,
+                                text=True, capture_output=True, env=env, timeout=120)
+        if result.returncode:
+            if optional and "HTTP 404" in result.stderr:
+                return None
+            raise RuntimeError(f"GitHub request failed ({endpoint}): {result.stderr.strip()}")
+        return json.loads(result.stdout)
+
+
+def pr_result(pr: dict) -> dict:
+    if pr.get("state") == "closed" and not pr.get("merged_at"):
+        raise RuntimeError(f"Foojay PR was closed without merging; review it before retrying: {pr['html_url']}")
+    if not pr.get("html_url") or not pr.get("number"):
+        raise RuntimeError("GitHub response missing pull-request URL/number")
+    return {
+        "id": pr["number"], "url": pr["html_url"], "pull_request_url": pr["html_url"],
+        "status": "merged" if pr.get("merged_at") else "submitted",
+        "published": False,  # merging a draft bundle is not public publication
+        "syndicated_at": dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds"),
+    }
+
+
+def submit_bundle(post: Post, files: dict[str, bytes], head_repo: str,
+                  github: GitHub) -> dict:
+    validate_slug(post.slug)
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", head_repo):
+        raise ValueError("FOOJAY_HEAD_REPO must be owner/repository")
+    branch = f"cn1-syndication/{post.slug}"
+    owner = head_repo.split("/")[0]
+    query = urllib.parse.urlencode({"state": "all", "head": f"{owner}:{branch}", "per_page": 100})
+    existing = github.api(f"repos/{UPSTREAM}/pulls?{query}")
+    for pr in existing:
+        if (pr.get("head", {}).get("repo") or {}).get("full_name", "").lower() == head_repo.lower():
+            # Recover a successful submission even if CN1's state commit was lost.
+            return pr_result(pr)
+
+    upstream = github.api(f"repos/{UPSTREAM}")
+    head = github.api(f"repos/{head_repo}")
+    if not head.get("permissions", {}).get("push"):
+        raise RuntimeError(f"Token needs Contents write access to {head_repo}; see foojay-syndication.md")
+    if head_repo != UPSTREAM and (head.get("source") or {}).get("full_name") != UPSTREAM:
+        raise RuntimeError(f"{head_repo} must be a fork of {UPSTREAM}")
+    base = upstream["default_branch"]
+    commit = github.api(f"repos/{UPSTREAM}/commits/{base}")
+    base_sha = commit["sha"]
+    base_tree = commit["commit"]["tree"]["sha"]
+    github.api(f"repos/{UPSTREAM}/contents/content/authors/{AUTHOR}/_index.md?ref={base_sha}")
+    tree = github.api(f"repos/{UPSTREAM}/git/trees/{base_tree}?recursive=1")
+    if tree.get("truncated"):
+        raise RuntimeError("Foojay tree was truncated; cannot safely check for duplicate article slugs")
+    for item in tree["tree"]:
+        path = item["path"]
+        if (path.startswith("content/posts/") or path.startswith("draft/")) and re.search(
+                rf"/{re.escape(post.slug)}/index\.(md|adoc)$", path):
+            raise RuntimeError(f"Foojay already contains {path}; reconcile state before submitting")
+
+    # A deterministic branch also recovers a crash after commit but before PR.
+    ref = github.api(f"repos/{head_repo}/git/ref/heads/{branch}", optional=True)
+    if ref:
+        # Never overwrite a branch or silently submit a partial/different bundle.
+        branch_commit = github.api(f"repos/{head_repo}/git/commits/{ref['object']['sha']}")
+        branch_tree = github.api(f"repos/{head_repo}/git/trees/{branch_commit['tree']['sha']}?recursive=1")
+        expected = {path: hashlib.sha1(b"blob " + str(len(data)).encode() + b"\0" + data).hexdigest()
+                    for path, data in files.items()}
+        actual = {item["path"]: item["sha"] for item in branch_tree["tree"]
+                  if item["path"].startswith(f"draft/{post.slug}/") and item["type"] == "blob"}
+        if branch_tree.get("truncated") or actual != expected:
+            raise RuntimeError(f"Existing {branch} differs from the prepared bundle; review it before retrying")
+        comparison = github.api(f"repos/{head_repo}/compare/{base_sha}...{branch}")
+        changed = comparison.get("files", [])
+        if (len(changed) >= 300 or {item['filename'] for item in changed} != set(files)
+                or any(item['status'] != 'added' for item in changed)):
+            raise RuntimeError(f"Existing {branch} changes files outside the article bundle; review it before retrying")
+    else:
+        entries = []
+        for path, data in sorted(files.items()):
+            blob = github.api(f"repos/{head_repo}/git/blobs", {
+                "content": base64.b64encode(data).decode("ascii"), "encoding": "base64",
+            })
+            entries.append({"path": path, "mode": "100644", "type": "blob", "sha": blob["sha"]})
+        new_tree = github.api(f"repos/{head_repo}/git/trees", {"base_tree": base_tree, "tree": entries})
+        new_commit = github.api(f"repos/{head_repo}/git/commits", {
+            "message": f"Submit article: {post.title}", "tree": new_tree["sha"], "parents": [base_sha],
+        })
+        github.api(f"repos/{head_repo}/git/refs", {"ref": f"refs/heads/{branch}", "sha": new_commit["sha"]})
+    pr = github.api(f"repos/{UPSTREAM}/pulls", {
+        "title": post.title, "head": f"{owner}:{branch}", "base": base, "draft": False,
+        "body": (f"Submit **{post.title}** by Shai Almog for editorial review.\n\n"
+                 f"Originally published at {post.canonical_url}\n\n"
+                 f"The article and its images are in `draft/{post.slug}/`. "
+                 "Frontmatter includes the original canonical URL and the existing "
+                 "`shai-almog` author profile. The date is a suggested day; "
+                 "please set it when moving the bundle into the publication folder."),
+    })
+    return pr_result(pr)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--submit", action="store_true", help="Create a Foojay editorial PR and record it.")
+    mode.add_argument("--dry-run", action="store_true", help="Print the candidate without network calls (default).")
+    parser.add_argument("--output-dir", type=Path, help="Prepare a reviewable bundle here; may fetch remote body images.")
+    parser.add_argument("--today", type=dt.date.fromisoformat, default=dt.date.today())
+    parser.add_argument("--blog-dir", type=Path, default=BLOG_DIR)
+    parser.add_argument("--static-dir", type=Path, default=STATIC_DIR)
+    parser.add_argument("--state-file", type=Path, default=STATE_FILE)
+    parser.add_argument("--head-repo", default=os.environ.get("FOOJAY_HEAD_REPO") or UPSTREAM)
+    args = parser.parse_args(argv)
+    if args.dry_run and args.output_dir:
+        parser.error("Use --output-dir by itself to prepare a bundle; --dry-run is offline selection only")
+    try:
+        posts = discover_posts(args.blog_dir)
+        state = State.load(args.state_file)
+        post = select_candidate(posts, state, ["foojay"], args.today,
+                                ELIGIBILITY_FLOOR, MIN_AGE_DAYS,
+                                platform_filters={"foojay": accepts})
+        if post is None:
+            print("[foojay] No eligible Friday digest awaiting submission.")
+            return 0
+        print(f"[foojay] Selected {post.slug}; canonical {post.canonical_url}")
+        if not args.submit and not args.output_dir:
+            print(f"[foojay] Dry run: would prepare draft/{post.slug}/ and open an editorial PR.")
+            return 0
+        if args.submit and os.environ.get("GITHUB_ACTIONS") == "true" and not os.environ.get("FOOJAY_GITHUB_TOKEN"):
+            raise RuntimeError("Set FOOJAY_GITHUB_TOKEN: the workflow GITHUB_TOKEN cannot write to Foojay or a fork")
+        files = build_bundle(post, posts, args.today, args.static_dir)
+        if args.output_dir:
+            for relative, data in files.items():
+                target = args.output_dir / relative
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_bytes(data)
+            print(f"[foojay] Prepared {len(files)} files under {args.output_dir / 'draft' / post.slug}")
+        if args.submit:
+            result = submit_bundle(post, files, args.head_repo, GitHub())
+            state.record(post.slug, "foojay", result)
+            state.save(args.state_file)
+            print(f"[foojay] {result['status']}: {result['url']} (editorial submission, not verified public)")
+        return 0
+    except (OSError, ValueError, RuntimeError, subprocess.SubprocessError) as error:
+        print(f"[foojay] FAILED: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/website/test_syndicate_foojay_posts.py
+++ b/scripts/website/test_syndicate_foojay_posts.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Offline regressions for Foojay bundles and retry-safe editorial submission."""
+
+import datetime as dt
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from syndicate_blog_posts import Post, State, select_candidate
+from syndicate_foojay_posts import (
+    UPSTREAM, accepts, build_bundle, main, pr_result, read_image, submit_bundle,
+)
+
+FRIDAY = dt.date(2026, 9, 4)
+TODAY = dt.date(2026, 9, 11)
+JPEG = b"\xff\xd8\xff" + b"test-image"
+
+
+def post(slug="friday", date=FRIDAY):
+    return Post(Path(f"{slug}.md"), slug, 'Java: "A useful feature"', date,
+                {"description": "A source-grounded feature description.", "author": "Shai Almog"},
+                '![A phone beside a laptop](/blog/cover.jpg)\n\n'
+                'Intro with a [guide](/guide/).\n\n'
+                '## Example\n\n```java\nString example = "![fake](/blog/missing.png)";\n```\n\n'
+                '{{< mermaid >}}\ngraph LR\n A --> B\n{{< /mermaid >}}\n\n'
+                '---\n\n## Discussion\nWebsite-only comments.')
+
+
+def pr(state="open", merged_at=None):
+    return {"number": 42, "html_url": "https://github.com/foojayio/website/pull/42",
+            "state": state, "merged_at": merged_at,
+            "head": {"repo": {"full_name": "writer/website"}}}
+
+
+class BundleTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        (self.root / "blog").mkdir()
+        (self.root / "blog/cover.jpg").write_bytes(JPEG)
+
+    def test_bundle_matches_foojay_template_and_preserves_content(self):
+        files = build_bundle(post(), [], TODAY, self.root)
+        self.assertEqual(2, len(files))
+        text = files["draft/friday/index.md"].decode()
+        self.assertIn('authors: ["shai-almog"]', text)
+        self.assertIn('categories: ["Java"]', text)
+        self.assertIn('date: "2026-09-11"', text)
+        self.assertIn('canonical: "https://www.codenameone.com/blog/friday/"', text)
+        self.assertIn('title: ' + json.dumps(post().title), text)
+        self.assertIn('```mermaid\ngraph LR\n A --> B\n```', text)
+        self.assertNotIn('mermaid.ink', text)
+        self.assertNotIn('{{<', text)
+        self.assertNotIn('Website-only comments', text)
+        self.assertIn('[guide](https://www.codenameone.com/guide/)', text)
+        self.assertIn('![A phone beside a laptop](cover-', text)
+        self.assertIn('String example = "![fake]', text)
+        self.assertEqual(JPEG, next(data for path, data in files.items() if path.endswith('.jpg')))
+
+    def test_submission_date_is_stable_across_retries(self):
+        self.assertEqual(build_bundle(post(), [], TODAY, self.root),
+                         build_bundle(post(), [], TODAY + dt.timedelta(days=1), self.root))
+
+    def test_description_is_short_and_yaml_safe(self):
+        p = post()
+        p.front_matter['description'] = 'Quoted "words": ' + 'many words ' * 30
+        text = build_bundle(p, [], TODAY, self.root)['draft/friday/index.md'].decode()
+        description = json.loads(next(line.split(': ', 1)[1] for line in text.splitlines()
+                                      if line.startswith('description: ')))
+        self.assertLess(len(description), 160)
+        self.assertTrue(description.endswith('...'))
+
+    def test_same_filename_different_urls_do_not_collide(self):
+        (self.root / 'other').mkdir()
+        (self.root / 'other/cover.jpg').write_bytes(JPEG + b'2')
+        p = post()
+        p.body += '\n![Different diagram](/other/cover.jpg)'
+        # Append before the website footer, which is intentionally stripped.
+        p.body = p.body.replace('---\n\n## Discussion\nWebsite-only comments.', '')
+        files = build_bundle(p, [], TODAY, self.root)
+        self.assertEqual(3, len(files))
+
+    def test_invalid_input_fails_before_submission(self):
+        for slug in ['../escape', 'bad/slug']:
+            with self.subTest(slug=slug), self.assertRaises(ValueError):
+                build_bundle(post(slug), [], TODAY, self.root)
+        p = post()
+        p.front_matter['author'] = 'Someone Else'
+        with self.assertRaisesRegex(ValueError, 'author mapping'):
+            build_bundle(p, [], TODAY, self.root)
+        p = post()
+        p.body = 'No preview image'
+        with self.assertRaisesRegex(ValueError, 'preview image'):
+            build_bundle(p, [], TODAY, self.root)
+        (self.root / 'blog/cover.jpg').write_bytes(b'<html>not an image</html>')
+        with self.assertRaisesRegex(ValueError, 'still JPEG or PNG'):
+            build_bundle(post(), [], TODAY, self.root)
+
+    def test_missing_and_oversize_images_fail(self):
+        with self.assertRaises(FileNotFoundError):
+            read_image('https://www.codenameone.com/blog/missing.jpg', self.root)
+        with patch('syndicate_foojay_posts.MAX_IMAGE_BYTES', 3):
+            with self.assertRaisesRegex(ValueError, '4 MB'):
+                build_bundle(post(), [], TODAY, self.root)
+
+    def test_image_cannot_escape_static_root(self):
+        with self.assertRaisesRegex(ValueError, 'escapes'):
+            read_image('https://www.codenameone.com/%2e%2e/secret.png', self.root)
+
+    def test_friday_delay_and_legacy_wordpress_state_are_preserved(self):
+        friday = post()
+        thursday = post('thursday', FRIDAY - dt.timedelta(days=1))
+        state = State.load(self.root / 'state.json')
+        args = ([thursday, friday], state, ['foojay'])
+        floor = dt.date(2026, 4, 30)
+        self.assertIsNone(select_candidate(*args, TODAY - dt.timedelta(days=1), floor, 7,
+                                           platform_filters={'foojay': accepts}))
+        self.assertEqual(friday, select_candidate(*args, TODAY, floor, 7,
+                                                  platform_filters={'foojay': accepts}))
+        state.record('friday', 'foojay', {'url': 'https://foojay.io/wp-admin/post.php?post=123'})
+        self.assertIsNone(select_candidate(*args, TODAY, floor, 7,
+                                           platform_filters={'foojay': accepts}))
+
+
+class SubmissionTest(unittest.TestCase):
+    def fake(self, *, existing=None, duplicate=False, ref=None, branch_tree=None):
+        github = Mock()
+
+        def api(endpoint, payload=None, **kwargs):
+            if '/pulls?' in endpoint:
+                return existing or []
+            if payload is not None:
+                if endpoint.endswith('/pulls'):
+                    return pr()
+                return {'sha': 'created'}
+            if endpoint == 'repos/' + UPSTREAM:
+                return {'default_branch': 'main'}
+            if endpoint == 'repos/writer/website':
+                return {'permissions': {'push': True}, 'source': {'full_name': UPSTREAM}}
+            if '/commits/main' in endpoint:
+                return {'sha': 'base', 'commit': {'tree': {'sha': 'tree'}}}
+            if '/contents/content/authors/' in endpoint:
+                return {'name': '_index.md'}
+            if '/git/trees/tree?' in endpoint:
+                return {'tree': [{'path': 'content/posts/2026/09/01/friday/index.md'}] if duplicate else []}
+            if '/git/ref/heads/' in endpoint:
+                return ref
+            if '/git/commits/retry' in endpoint:
+                return {'tree': {'sha': 'retry'}}
+            if '/git/trees/retry?' in endpoint:
+                return branch_tree
+            if '/compare/' in endpoint:
+                return {'files': [{'filename': 'draft/friday/index.md', 'status': 'added'}]}
+            raise AssertionError(f'Unexpected API call: {endpoint}')
+        github.api.side_effect = api
+        return github
+
+    def test_existing_pr_recovers_lost_state_without_writes(self):
+        github = self.fake(existing=[pr()])
+        result = submit_bundle(post(), {}, 'writer/website', github)
+        self.assertEqual('submitted', result['status'])
+        self.assertFalse(result['published'])
+        self.assertEqual(1, github.api.call_count)
+
+    def test_closed_unmerged_pr_requires_review(self):
+        github = self.fake(existing=[pr('closed')])
+        with self.assertRaisesRegex(RuntimeError, 'closed without merging'):
+            submit_bundle(post(), {}, 'writer/website', github)
+        self.assertEqual(1, github.api.call_count)
+
+    def test_merged_draft_is_not_claimed_public(self):
+        result = pr_result(pr('closed', '2026-09-11T12:00:00Z'))
+        self.assertEqual('merged', result['status'])
+        self.assertFalse(result['published'])
+
+    def test_new_submission_uses_atomic_bundle_commit_and_regular_pr(self):
+        github = self.fake()
+        files = {'draft/friday/index.md': b'article', 'draft/friday/cover.jpg': JPEG}
+        result = submit_bundle(post(), files, 'writer/website', github)
+        self.assertEqual('submitted', result['status'])
+        writes = [call.args for call in github.api.call_args_list if len(call.args) > 1]
+        self.assertEqual(['blobs', 'blobs', 'trees', 'commits', 'refs', 'pulls'],
+                         [args[0].rsplit('/', 1)[1] for args in writes])
+        self.assertEqual('tree', writes[2][1]['base_tree'])
+        self.assertEqual(set(files), {entry['path'] for entry in writes[2][1]['tree']})
+        self.assertEqual(['base'], writes[3][1]['parents'])
+        self.assertEqual('refs/heads/cn1-syndication/friday', writes[4][1]['ref'])
+        self.assertFalse(writes[-1][1]['draft'])
+        self.assertEqual('writer:cn1-syndication/friday', writes[-1][1]['head'])
+        self.assertIn(post().canonical_url, writes[-1][1]['body'])
+
+    def test_duplicate_migrated_article_prevents_writes(self):
+        github = self.fake(duplicate=True)
+        with self.assertRaisesRegex(RuntimeError, 'already contains'):
+            submit_bundle(post(), {}, 'writer/website', github)
+        self.assertTrue(all(len(call.args) == 1 for call in github.api.call_args_list))
+
+    def test_partial_branch_is_not_submitted_or_overwritten(self):
+        github = self.fake(ref={'object': {'sha': 'retry'}}, branch_tree={'tree': []})
+        with self.assertRaisesRegex(RuntimeError, 'differs'):
+            submit_bundle(post(), {'draft/friday/index.md': b'article'}, 'writer/website', github)
+        self.assertTrue(all(len(call.args) == 1 for call in github.api.call_args_list))
+
+    def test_complete_branch_recovers_crash_before_pr(self):
+        data = b'article'
+        blob_sha = hashlib.sha1(b'blob 7\0' + data).hexdigest()
+        github = self.fake(ref={'object': {'sha': 'retry'}}, branch_tree={'tree': [
+            {'path': 'draft/friday/index.md', 'sha': blob_sha, 'type': 'blob'}]})
+        submit_bundle(post(), {'draft/friday/index.md': data}, 'writer/website', github)
+        writes = [call.args[0] for call in github.api.call_args_list if len(call.args) > 1]
+        self.assertEqual(['repos/' + UPSTREAM + '/pulls'], writes)
+
+    def test_branch_with_unrelated_changes_is_not_submitted(self):
+        data = b'article'
+        blob_sha = hashlib.sha1(b'blob 7\0' + data).hexdigest()
+        github = self.fake(ref={'object': {'sha': 'retry'}}, branch_tree={'tree': [
+            {'path': 'draft/friday/index.md', 'sha': blob_sha, 'type': 'blob'}]})
+        normal = github.api.side_effect
+        github.api.side_effect = lambda endpoint, *args, **kwargs: (
+            {'files': [{'filename': 'hugo.toml', 'status': 'modified'}]}
+            if '/compare/' in endpoint else normal(endpoint, *args, **kwargs))
+        with self.assertRaisesRegex(RuntimeError, 'outside the article bundle'):
+            submit_bundle(post(), {'draft/friday/index.md': data}, 'writer/website', github)
+        self.assertTrue(all(len(call.args) == 1 for call in github.api.call_args_list))
+
+    def test_failed_submission_leaves_state_unchanged(self):
+        with tempfile.TemporaryDirectory() as directory:
+            state_path = Path(directory) / 'state.json'
+            State(raw={'posts': {}}).save(state_path)
+            before = state_path.read_bytes()
+            with patch('syndicate_foojay_posts.discover_posts', return_value=[post()]), \
+                 patch.dict('os.environ', {'GITHUB_ACTIONS': 'false'}), \
+                 patch('syndicate_foojay_posts.build_bundle', return_value={}), \
+                 patch('syndicate_foojay_posts.submit_bundle', side_effect=RuntimeError('API failure')):
+                self.assertEqual(2, main(['--submit', '--today', str(TODAY), '--state-file', str(state_path)]))
+            self.assertEqual(before, state_path.read_bytes())
+
+    def test_success_records_pr_and_preserves_other_platforms(self):
+        with tempfile.TemporaryDirectory() as directory:
+            state_path = Path(directory) / 'state.json'
+            State(raw={'posts': {'friday': {'devto': {'url': 'https://dev.to/example'}}}}).save(state_path)
+            with patch('syndicate_foojay_posts.discover_posts', return_value=[post()]), \
+                 patch.dict('os.environ', {'GITHUB_ACTIONS': 'false'}), \
+                 patch('syndicate_foojay_posts.build_bundle', return_value={}), \
+                 patch('syndicate_foojay_posts.submit_bundle', return_value=pr_result(pr())):
+                self.assertEqual(0, main(['--submit', '--today', str(TODAY), '--state-file', str(state_path)]))
+            saved = State.load(state_path).raw['posts']['friday']
+            self.assertEqual('https://dev.to/example', saved['devto']['url'])
+            self.assertEqual('submitted', saved['foojay']['status'])
+            self.assertFalse(saved['foojay']['published'])
+
+    def test_ci_missing_token_fails_before_preparing_or_submitting(self):
+        with tempfile.TemporaryDirectory() as directory, \
+             patch('syndicate_foojay_posts.discover_posts', return_value=[post()]), \
+             patch.dict('os.environ', {'GITHUB_ACTIONS': 'true', 'FOOJAY_GITHUB_TOKEN': ''}), \
+             patch('syndicate_foojay_posts.build_bundle') as bundle, \
+             patch('syndicate_foojay_posts.GitHub') as github:
+            self.assertEqual(2, main(['--submit', '--today', str(TODAY),
+                                      '--state-file', str(Path(directory) / 'state.json')]))
+            bundle.assert_not_called()
+            github.assert_not_called()
+
+    def test_dry_run_never_reads_images_or_calls_github(self):
+        with tempfile.TemporaryDirectory() as directory, \
+             patch('syndicate_foojay_posts.discover_posts', return_value=[post()]), \
+             patch('syndicate_foojay_posts.build_bundle') as bundle, \
+             patch('syndicate_foojay_posts.GitHub') as github:
+            path = Path(directory) / 'state.json'
+            self.assertEqual(0, main(['--dry-run', '--today', str(TODAY), '--state-file', str(path)]))
+            bundle.assert_not_called()
+            github.assert_not_called()
+            self.assertFalse(path.exists())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Foojay moved from WordPress to Hugo and now accepts article bundles through GitHub pull requests. Replace the WordPress adapter with a GitHub submission flow that creates `draft/<slug>/index.md` and local images, uses the existing `shai-almog` author profile, preserves the CN1 canonical URL, and renders Mermaid as native fenced diagrams.

The existing Friday-only selection, seven-day delay, and historical WordPress state remain intact. A deterministic branch and PR lookup recover interrupted submissions without duplicating articles. State records editorial submission separately from public publication. The workflow runs Foojay after Medium queue creation so a Foojay configuration failure cannot block that queue.

**Setup required before enabling:** create a writable fork of `foojayio/website` (or obtain direct write access), set the `FOOJAY_HEAD_REPO` Actions variable, and add a `FOOJAY_GITHUB_TOKEN` secret with the required head-repository write and upstream PR permissions. These are not currently configured. The old WordPress secrets are no longer used. Setup and preview commands are documented in `scripts/website/foojay-syndication.md`.

Validation:
- 33 publisher tests passed, including 20 new Foojay regressions for packaging, eligibility, legacy state, interrupted submissions, closed PRs, duplicate slugs, and failure-safe state recording.
- Existing browser-queue, social-queue, health, and schedule-SLA suites passed.
- Generated the next eligible `voip-vpn-builders` bundle locally and passed Foojay’s current `scripts/validate/Frontmatter.java` validator against it.
- No Foojay submission or public article was created during validation; GitHub mutation behavior is covered with mocked API tests.

Source: https://foojayio.github.io/website/today/how-to-submit-your-next-article-on-foojay-io/
