### PR TITLE
Fix iOS accessibility queries off the UIKit main thread

### DIFF
--- a/.github/workflows/ios-accessibility-thread.yml
+++ b/.github/workflows/ios-accessibility-thread.yml
@@ -1,0 +1,32 @@
+name: iOS accessibility thread contract
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [master]
+    paths:
+      - 'Ports/iOSPort/nativeSources/IOSNative.m'
+      - 'scripts/ios/accessibility-thread-tests/**'
+      - '.github/workflows/ios-accessibility-thread.yml'
+  push:
+    branches: [master]
+    paths:
+      - 'Ports/iOSPort/nativeSources/IOSNative.m'
+      - 'scripts/ios/accessibility-thread-tests/**'
+      - '.github/workflows/ios-accessibility-thread.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ios-accessibility-thread-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  native-contract:
+    runs-on: macos-15
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check accessibility queries and cached state across Apple platform guards
+        run: python3 scripts/ios/accessibility-thread-tests/check.py

--- a/Ports/iOSPort/nativeSources/IOSNative.m
+++ b/Ports/iOSPort/nativeSources/IOSNative.m
@@ -18849,14 +18849,14 @@ void cn1RegisterAccessibilityStatusObservers(void);
 static BOOL cn1A11yLatched = NO;
 
 BOOL cn1AccessibilityEagerLatched(void) {
-    return cn1A11yLatched;
+    return __atomic_load_n(&cn1A11yLatched, __ATOMIC_ACQUIRE);
 }
 
 #if !TARGET_OS_OSX
 static void cn1AccessibilityStatusChanged(CFNotificationCenterRef center, void *observer,
                                           CFStringRef name, const void *object,
                                           CFDictionaryRef userInfo) {
-    cn1A11yLatched = YES;
+    __atomic_store_n(&cn1A11yLatched, YES, __ATOMIC_RELEASE);
     com_codename1_impl_ios_IOSImplementation_assistiveTechnologyStatusChanged__(
             CN1_THREAD_GET_STATE_PASS_SINGLE_ARG);
 }
@@ -18867,10 +18867,9 @@ static void cn1AccessibilityStatusChanged(CFNotificationCenterRef center, void *
 // the tree. This, not the running flags, is what makes the gate correct for the
 // technologies UIKit will not report -- see the comment on that getter.
 void cn1AccessibilityNoteClientQuery(void) {
-    if(cn1A11yLatched) {
+    if(__atomic_exchange_n(&cn1A11yLatched, YES, __ATOMIC_ACQ_REL)) {
         return;   // one transition only; this is on a UIKit query path
     }
-    cn1A11yLatched = YES;
     // Reached on the native macOS port too, now that its rendering view
     // publishes a tree and hangs this call off accessibilityChildren. It is the
     // ONLY trigger there: macOS gives no running flag for Switch Control or
@@ -18937,11 +18936,11 @@ JAVA_BOOLEAN com_codename1_impl_ios_IOSNative_isAssistiveTechnologyActive___R_bo
     // public running flag for Voice Control or Full Keyboard Access, so this
     // cannot detect them -- see cn1AccessibilityStatusChanged for how that gap
     // is covered rather than ignored.
+#if TARGET_OS_OSX
     cn1RegisterAccessibilityStatusObservers();
     if(cn1AccessibilityEagerLatched()) {
         return JAVA_TRUE;
     }
-#if TARGET_OS_OSX
     // VoiceOver's own preference domain, which is where macOS records it, and
     // the only assistive technology the platform lets an application ask about.
     // Switch Control and AssistiveTouch have no macOS query and no macOS
@@ -18957,16 +18956,33 @@ JAVA_BOOLEAN com_codename1_impl_ios_IOSNative_isAssistiveTechnologyActive___R_bo
     extern BOOL CN1MacHostIsVoiceOverRunning(void);
     return CN1MacHostIsVoiceOverRunning() ? JAVA_TRUE : JAVA_FALSE;
 #else
-    if(UIAccessibilityIsVoiceOverRunning() || UIAccessibilityIsSwitchControlRunning()) {
-        return JAVA_TRUE;
-    }
-    // iOS 10. Weakly linked, so on an older deployment target the symbol is
-    // null and calling it jumps through nothing -- test the pointer first.
-    if(UIAccessibilityIsAssistiveTouchRunning != NULL &&
-       UIAccessibilityIsAssistiveTouchRunning()) {
-        return JAVA_TRUE;
-    }
-    return JAVA_FALSE;
+    // Called from AccessibilityManager.invalidate while it holds its Java
+    // monitor, usually on the CN1 EDT. UIKit queries belong on Apple's main
+    // thread, but synchronously waiting for it here can deadlock with a native
+    // accessibility query waiting for that same monitor. Initialize once on
+    // the main queue and read only cached state on the Java caller's thread.
+    // Until initialization finishes, keep projecting so no startup tree is lost.
+    static BOOL initiallyActive = YES;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{
+        dispatch_async(dispatch_get_main_queue(), ^{
+            @autoreleasepool {
+                // Register before sampling so a later activation is latched by
+                // the existing status callback. All subsequent transitions keep
+                // eager projection enabled for the rest of the process.
+                cn1RegisterAccessibilityStatusObservers();
+                BOOL active = UIAccessibilityIsVoiceOverRunning()
+                        || UIAccessibilityIsSwitchControlRunning();
+                // iOS 10: do not call an absent weakly-linked function.
+                if(!active && UIAccessibilityIsAssistiveTouchRunning != NULL) {
+                    active = UIAccessibilityIsAssistiveTouchRunning();
+                }
+                __atomic_store_n(&initiallyActive, active, __ATOMIC_RELEASE);
+            }
+        });
+    });
+    return (cn1AccessibilityEagerLatched()
+            || __atomic_load_n(&initiallyActive, __ATOMIC_ACQUIRE)) ? JAVA_TRUE : JAVA_FALSE;
 #endif // TARGET_OS_OSX
 #else
     return JAVA_FALSE;

--- a/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
+++ b/Ports/iOSPort/src/com/codename1/impl/ios/IOSImplementation.java
@@ -15708,9 +15708,9 @@ public class IOSImplementation extends CodenameOneImplementation {
     /// AccessibilityManager.getSnapshot on an idle Mac Catalyst app with no
     /// assistive technology running at all, plus the CPU to build it.
     ///
-    /// Turning VoiceOver on mid-session is picked up on the next invalidation --
-    /// the flag is read per call, and any mutation after that point projects
-    /// normally.
+    /// The native gate caches the initial UIKit status on the main queue.
+    /// Turning VoiceOver on mid-session latches eager projection and schedules
+    /// an invalidation through the status callback below.
     /// Invoked from native when an assistive-technology status notification fires.
     ///
     /// The status flip itself is not a component mutation, so without this nothing

--- a/scripts/ios/accessibility-thread-tests/check.py
+++ b/scripts/ios/accessibility-thread-tests/check.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Run the production accessibility gate with main-thread-checking UIKit stubs.
+
+Requires macOS and Xcode command-line tools; no generated app or signing needed.
+The Java ABI and UIKit queries are stubbed; Foundation and GCD are real.
+"""
+from pathlib import Path
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[3]
+source = (ROOT / 'Ports/iOSPort/nativeSources/IOSNative.m').read_text()
+start = source.index('#if !TARGET_OS_WATCH\nBOOL cn1AccessibilityEagerLatched')
+end = source.index('JAVA_BOOLEAN com_codename1_impl_ios_IOSNative_isDirectToDrawable', start)
+implementation = source[start:end]
+contract = Path(__file__).with_name('contract.m')
+with tempfile.TemporaryDirectory(prefix='cn1-accessibility-thread-') as directory:
+    tmp = Path(directory)
+    (tmp / 'implementation.h').write_text(implementation)
+    for platform, flags in (
+        ('ios', ['-DCN1_TEST_PLATFORM=0']),
+        ('macos', ['-DCN1_TEST_PLATFORM=1']),
+        ('watchos', ['-DCN1_TEST_PLATFORM=2']),
+    ):
+        executable = tmp / platform
+        subprocess.run([
+            'xcrun', 'clang', '-fblocks', '-fno-objc-arc', '-Wall', '-Wextra',
+            '-Wno-unused-parameter', '-Wno-unused-function', '-Wno-unused-variable', '-Werror', '-framework', 'Foundation',
+            '-I', str(tmp), *flags, str(contract), '-o', str(executable),
+        ], check=True, timeout=60)
+        cases = ('none', 'voiceover', 'switch', 'touch', 'unavailable', 'eager')
+        for case in cases:
+            subprocess.run([str(executable), case], check=True, timeout=15)
+        print('PASS: ' + platform + ' (6 scenarios)', flush=True)

--- a/scripts/ios/accessibility-thread-tests/contract.m
+++ b/scripts/ios/accessibility-thread-tests/contract.m
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+#import <Foundation/Foundation.h>
+#import <dispatch/dispatch.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Override the host SDK's platform flags to exercise each production branch.
+#undef TARGET_OS_OSX
+#undef TARGET_OS_WATCH
+#define TARGET_OS_OSX (CN1_TEST_PLATFORM == 1)
+#define TARGET_OS_WATCH (CN1_TEST_PLATFORM == 2)
+
+typedef void *JAVA_OBJECT;
+typedef int JAVA_BOOLEAN;
+#define JAVA_TRUE 1
+#define JAVA_FALSE 0
+#define CN1_THREAD_STATE_MULTI_ARG
+#define CN1_THREAD_GET_STATE_PASS_SINGLE_ARG
+
+static BOOL voiceOver, switchControl, assistiveTouch;
+static int queryCount, notificationCount;
+static NSString *UIAccessibilityVoiceOverStatusDidChangeNotification = @"CN1TestVoiceOver";
+static NSString *UIAccessibilitySwitchControlStatusDidChangeNotification = @"CN1TestSwitchControl";
+static NSString *UIAccessibilityAssistiveTouchStatusDidChangeNotification = @"CN1TestAssistiveTouch";
+
+static BOOL query(BOOL value) {
+    assert([NSThread isMainThread] && "UIKit query ran off Apple's main thread");
+    queryCount++;
+    return value;
+}
+static BOOL UIAccessibilityIsVoiceOverRunning(void) { return query(voiceOver); }
+static BOOL UIAccessibilityIsSwitchControlRunning(void) { return query(switchControl); }
+static BOOL touchQuery(void) { return query(assistiveTouch); }
+// A pointer also exercises an absent weakly-linked iOS 10 function.
+static BOOL (*UIAccessibilityIsAssistiveTouchRunning)(void) = touchQuery;
+BOOL CN1MacHostIsVoiceOverRunning(void) { return voiceOver; }
+void com_codename1_impl_ios_IOSImplementation_assistiveTechnologyStatusChanged__(void) {
+    __atomic_add_fetch(&notificationCount, 1, __ATOMIC_RELAXED);
+}
+
+#include "implementation.h"
+
+static BOOL active(void) {
+    return com_codename1_impl_ios_IOSNative_isAssistiveTechnologyActive___R_boolean(NULL);
+}
+
+// Hold the main thread until every background caller has returned. A sync
+// main-queue hop would time out here, modelling Java's held accessibility lock.
+static void checkBackgroundCalls(BOOL expected) {
+    dispatch_group_t group = dispatch_group_create();
+    for(int i = 0; i < 32; i++) {
+        dispatch_group_async(group, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            @autoreleasepool { assert(active() == expected); }
+        });
+    }
+    assert(dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 3 * NSEC_PER_SEC)) == 0);
+    dispatch_release(group);
+}
+
+static void drainMainQueue(void) {
+    __block BOOL drained = NO;
+    dispatch_async(dispatch_get_main_queue(), ^{ drained = YES; });
+    NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:3];
+    while(!drained && [deadline timeIntervalSinceNow] > 0) {
+        [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
+    }
+    assert(drained);
+}
+
+int main(int argc, const char **argv) {
+    @autoreleasepool {
+        assert(argc == 2);
+        unsetenv("CN1_EAGER_A11Y");
+        voiceOver = strcmp(argv[1], "voiceover") == 0;
+        switchControl = strcmp(argv[1], "switch") == 0;
+        assistiveTouch = strcmp(argv[1], "touch") == 0;
+        BOOL eager = strcmp(argv[1], "eager") == 0;
+        BOOL unavailable = strcmp(argv[1], "unavailable") == 0;
+        if(eager) setenv("CN1_EAGER_A11Y", "1", 1);
+        if(unavailable) {
+            UIAccessibilityIsAssistiveTouchRunning = NULL;
+            UIAccessibilityAssistiveTouchStatusDidChangeNotification = nil;
+        }
+#if TARGET_OS_WATCH
+        checkBackgroundCalls(eager);
+        assert(active() == eager);
+#elif TARGET_OS_OSX
+        checkBackgroundCalls(eager || voiceOver);
+        assert(active() == (eager || voiceOver));
+#else
+        // Before the main queue initializes the cache, conservatively project.
+        checkBackgroundCalls(YES);
+        assert(queryCount == 0);
+        drainMainQueue();
+        BOOL expected = eager || voiceOver || switchControl || assistiveTouch;
+        assert(active() == expected);
+        int initialQueries = queryCount;
+        if(!eager) assert(initialQueries > 0);
+        checkBackgroundCalls(expected);
+        for(int i = 0; i < 1000; i++) assert(active() == expected);
+        drainMainQueue();
+        assert(queryCount == initialQueries && "UI invalidations must use the cache");
+        if(!eager) {
+            // A client query also latches technologies with no public running flag.
+            if(unavailable) {
+                cn1AccessibilityNoteClientQuery();
+                cn1AccessibilityNoteClientQuery();
+                assert(notificationCount == 1);
+            } else {
+                CFNotificationCenterPostNotification(CFNotificationCenterGetLocalCenter(),
+                    (__bridge CFStringRef)UIAccessibilityVoiceOverStatusDidChangeNotification,
+                    NULL, NULL, true);
+                assert(notificationCount == 1);
+            }
+            checkBackgroundCalls(YES);
+            assert(active());
+        }
+#endif
+#if TARGET_OS_WATCH || TARGET_OS_OSX
+        assert(queryCount == 0);
+#endif
+    }
+    return 0;
+}


### PR DESCRIPTION
Accessibility invalidations call `UIAccessibilityIsAssistiveTouchRunning()` from the Codename One EDT, producing the off-main-thread UIKit warnings reported in https://github.com/codenameone/CodenameOne/discussions/5765. The same path also queries VoiceOver and Switch Control directly.

Initialize the UIKit status and notification observers asynchronously on Apple's main queue, then return cached status to Java. Keep eager projection enabled until initialization completes, and retain the existing notification/client-query latch for later activation. Make the shared latch atomic. A synchronous main-queue dispatch would risk deadlock because `AccessibilityManager.invalidate()` holds its Java monitor while calling this gate.

Validation:
- Added a native regression harness using the production accessibility block, real Foundation/GCD, and UIKit stubs that assert main-thread access. All 18 scenarios pass across iOS, macOS, and watchOS guards, including concurrent callers, a blocked main thread, absent weak symbols, startup states, and later activation. The original source fails the off-main-thread assertion.
- Apple Clang syntax checks passed for iOS device/simulator, Mac Catalyst, macOS, watchOS, and tvOS. The existing weak-symbol guard's tautological-comparison warning was suppressed for SDK targets where the API is always available.
- Added a focused macOS CI workflow; copyright and diff checks passed.

No signed device build was run. This fixes the demonstrated UIKit threading issue; it does not establish that the issue caused the reported white screen. The reporter uses Codename One's on-device debugger, so device follow-up should use that workflow.
