### PR TITLE
Make benchmark compilation mandatory with a compatible sample workload

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -246,9 +246,9 @@ jobs:
         # tests to load the library. Also baked into the pr-ci-container image
         # (.ci/container/Dockerfile); this step covers running against the
         # previously published container before the rebuild propagates.
-        # Bounded, because a stalled mirror is a hang rather than a failure: three jobs on this
-        # branch sat in apt until their job limit, two of them for six hours.
-        run: timeout 300 apt-get update -qq && timeout 300 apt-get install -y -qq libdbus-1-3
+        # Skip the network when installed; otherwise use the shared bounded
+        # installer so a stalled mirror can recover without hiding install failures.
+        run: bash scripts/ci/apt-get-install.sh libdbus-1-3
       - name: Run JavaSE port unit tests
         if: ${{ matrix.java-version == 8 }}
         # Surface regressions in the simulator-side helpers (CSSWatcher
@@ -277,8 +277,7 @@ jobs:
         # touch, which no single-platform test would catch, so check ours against the stock
         # sqlcipher client in both directions.
         run: |
-          # Bounded for the same reason as the libdbus install above.
-          timeout 300 apt-get update -qq && timeout 300 apt-get install -y -qq sqlcipher
+          bash scripts/ci/apt-get-install.sh sqlcipher
           scripts/ci/db-cipher-interop.sh
       - name: Determine AI/ad cn1libs to build
         id: cn1libs
@@ -517,11 +516,9 @@ jobs:
         # C it parses the #else branch and reports success. Both are baked into
         # the pr-ci-container image (.ci/container/Dockerfile); this step
         # covers running against the previously published container before the
-        # rebuild propagates. Bounded for the same reason as the libdbus step
-        # above.
-        run: |
-          timeout 300 apt-get update -qq \
-            && timeout 300 apt-get install -y -qq gcc gcc-mingw-w64-x86-64
+        # rebuild propagates. Reuse the installed-package check and bounded
+        # mirror recovery used by the other runtime dependencies above.
+        run: bash scripts/ci/apt-get-install.sh gcc gcc-mingw-w64-x86-64
       # The two platforms whose cn1lib sources need no SDK to check: the C
       # glue the native win32/Linux ports compile into the app, and the
       # JavaScript port implementations, which have no build step at all.

--- a/vm/tests/src/test/java/com/codename1/tools/translator/HeavyLoadBenchmarkCompilationTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/HeavyLoadBenchmarkCompilationTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.codename1.tools.translator;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.tools.ToolProvider;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HeavyLoadBenchmarkCompilationTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void compilesValidSample() throws Exception {
+        Path sources = Files.createDirectory(tempDir.resolve("sources"));
+        Path classes = Files.createDirectory(tempDir.resolve("classes"));
+        Files.write(sources.resolve("Sample.java"),
+                "public class Sample {}".getBytes(StandardCharsets.UTF_8));
+
+        HeavyLoadBenchmarkTest.compileSample(ToolProvider.getSystemJavaCompiler(),
+                classes.toString(), sources, classes);
+
+        assertTrue(Files.isRegularFile(classes.resolve("Sample.class")));
+    }
+
+    @Test
+    void rejectsCompilerErrorsWithDiagnostics() throws Exception {
+        Path sources = Files.createDirectory(tempDir.resolve("sources"));
+        Path classes = Files.createDirectory(tempDir.resolve("classes"));
+        Files.write(sources.resolve("Sample.java"),
+                "public class Sample { MissingType field; }".getBytes(StandardCharsets.UTF_8));
+
+        AssertionError failure = assertThrows(AssertionError.class,
+                () -> HeavyLoadBenchmarkTest.compileSample(ToolProvider.getSystemJavaCompiler(),
+                        classes.toString(), sources, classes));
+
+        assertTrue(failure.getMessage().contains("refusing to benchmark an incomplete workload"));
+        assertTrue(failure.getMessage().contains("MissingType"));
+        assertFalse(Files.exists(classes.resolve("Sample.class")));
+    }
+
+    @Test
+    void rejectsEmptyWorkload() throws Exception {
+        Path sources = Files.createDirectory(tempDir.resolve("sources"));
+        Path classes = Files.createDirectory(tempDir.resolve("classes"));
+
+        AssertionError failure = assertThrows(AssertionError.class,
+                () -> HeavyLoadBenchmarkTest.compileSample(ToolProvider.getSystemJavaCompiler(),
+                        classes.toString(), sources, classes));
+
+        assertTrue(failure.getMessage().contains("contains no Java sources"));
+    }
+}

--- a/vm/tests/src/test/java/com/codename1/tools/translator/HeavyLoadBenchmarkTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/HeavyLoadBenchmarkTest.java
@@ -31,8 +31,10 @@ import org.objectweb.asm.Opcodes;
 
 import javax.tools.JavaCompiler;
 import javax.tools.ToolProvider;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
@@ -43,6 +45,7 @@ import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -70,20 +73,14 @@ public class HeavyLoadBenchmarkTest {
         Path iosBundleJar = findDependencyJar("codenameone-ios-7.0.214-bundle.jar");
         if (iosBundleJar == null) iosBundleJar = findDependencyJar("bundle");
 
-        // Locate HelloCodenameOne sources
-        Path helloSrc = findPath("scripts", "hellocodenameone", "common", "src", "main", "java");
-
         // Ensure jars exist
         Assertions.assertTrue(Files.exists(javaApiJar), "JavaAPI.jar not found at " + javaApiJar);
 
-        boolean hasCore = coreJar != null;
-        if (!hasCore) {
-            System.out.println("WARNING: CodenameOne Core jar not found in dependencies.");
-        }
+        Assertions.assertNotNull(coreJar, "CodenameOne Core jar is required by the benchmark sample");
 
         List<Path> jarsToScan = new ArrayList<>();
         jarsToScan.add(javaApiJar);
-        if (coreJar != null) jarsToScan.add(coreJar);
+        jarsToScan.add(coreJar);
         if (iosPortJar != null) jarsToScan.add(iosPortJar);
 
         System.out.println("Scanning " + jarsToScan.size() + " jars...");
@@ -98,34 +95,22 @@ public class HeavyLoadBenchmarkTest {
 
         // Compile the benchmark main - Setup Compiler
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
-        String cp = javaApiJar.toString();
-        if (hasCore) {
-            cp += File.pathSeparator + coreJar.toString();
-        }
+        String cp = javaApiJar.toString() + File.pathSeparator + coreJar.toString();
         if (iosPortJar != null) {
             cp += File.pathSeparator + iosPortJar.toString();
         }
 
-        // Compile HelloCodenameOne first if available
-        if (helloSrc != null && hasCore) {
-            System.out.println("Compiling HelloCodenameOne from " + helloSrc);
-            List<String> helloSources = Files.walk(helloSrc)
-                    .filter(p -> p.toString().endsWith(".java"))
-                    .map(Path::toString)
-                    .collect(Collectors.toList());
-            if (!helloSources.isEmpty()) {
-                List<String> compileArgs = new ArrayList<>();
-                compileArgs.add("-cp");
-                compileArgs.add(cp);
-                compileArgs.add("-d");
-                compileArgs.add(classesDir.toString());
-                compileArgs.addAll(helloSources);
-                int helloResult = compiler.run(null, null, null, compileArgs.toArray(new String[0]));
-                Assertions.assertEquals(0, helloResult,
-                        "Compilation of HelloCodenameOne failed; refusing to benchmark an incomplete workload");
-                System.out.println("Compiled HelloCodenameOne successfully.");
-            }
+        // Keep the sample compatible with the pinned 7.0.214 jars. The live
+        // hellocodenameone app uses Java 17 and newer framework APIs, so it is
+        // not a reproducible workload for this Java 8 translation benchmark.
+        Path sampleSrc = tempDir.resolve("sample-src");
+        Files.createDirectories(sampleSrc);
+        try (InputStream sample = HeavyLoadBenchmarkTest.class.getResourceAsStream(
+                "/com/codename1/tools/translator/benchmark/HelloCodenameOne.java")) {
+            Assertions.assertNotNull(sample, "Benchmark sample source is missing");
+            Files.copy(sample, sampleSrc.resolve("HelloCodenameOne.java"));
         }
+        compileSample(compiler, cp, sampleSrc, classesDir);
 
         // Scan jars for public classes
         List<String> publicClasses = new ArrayList<>();
@@ -223,6 +208,28 @@ public class HeavyLoadBenchmarkTest {
         writeReport(duration, profiler.getHotspots(20));
     }
 
+    static void compileSample(JavaCompiler compiler, String classpath, Path sourceDir,
+                              Path classesDir) throws IOException {
+        Assertions.assertNotNull(compiler, "A JDK compiler is required for the benchmark sample");
+        List<String> sources;
+        try (Stream<Path> paths = Files.walk(sourceDir)) {
+            sources = paths.filter(p -> Files.isRegularFile(p) && p.toString().endsWith(".java"))
+                    .sorted()
+                    .map(Path::toString)
+                    .collect(Collectors.toList());
+        }
+        Assertions.assertFalse(sources.isEmpty(), "Benchmark sample contains no Java sources");
+        List<String> args = new ArrayList<>(Arrays.asList(
+                "-source", "8", "-target", "8", "-cp", classpath, "-d", classesDir.toString()));
+        args.addAll(sources);
+        ByteArrayOutputStream diagnostics = new ByteArrayOutputStream();
+        int result = compiler.run(null, diagnostics, diagnostics, args.toArray(new String[0]));
+        Assertions.assertEquals(0, result,
+                "Compilation of benchmark sample failed; refusing to benchmark an incomplete workload\n"
+                        + diagnostics.toString("UTF-8"));
+        System.out.println("Compiled benchmark sample successfully.");
+    }
+
     private void runTranslator(String classpath, Path outputDir) throws Exception {
         // This benchmark deliberately translates the PUBLISHED codenameone-ios
         // 7.0.214 jar and its bundled nativeios sources, because it wants a large
@@ -318,27 +325,6 @@ public class HeavyLoadBenchmarkTest {
             }
         }
         return classes;
-    }
-
-    private Path findJar(String... parts) {
-        return findPath(parts);
-    }
-
-    private Path findPath(String... parts) {
-        // Try paths relative to vm/tests, vm, and root
-        Path p = Paths.get("..", "..");
-        for (String part : parts) p = p.resolve(part);
-        if (Files.exists(p)) return p.normalize().toAbsolutePath();
-
-        p = Paths.get("..");
-        for (String part : parts) p = p.resolve(part);
-        if (Files.exists(p)) return p.normalize().toAbsolutePath();
-
-        p = Paths.get(".");
-        for (String part : parts) p = p.resolve(part);
-        if (Files.exists(p)) return p.normalize().toAbsolutePath();
-
-        return null;
     }
 
     private Path findDependencyJar(String namePart) {

--- a/vm/tests/src/test/java/com/codename1/tools/translator/HeavyLoadBenchmarkTest.java
+++ b/vm/tests/src/test/java/com/codename1/tools/translator/HeavyLoadBenchmarkTest.java
@@ -121,11 +121,9 @@ public class HeavyLoadBenchmarkTest {
                 compileArgs.add(classesDir.toString());
                 compileArgs.addAll(helloSources);
                 int helloResult = compiler.run(null, null, null, compileArgs.toArray(new String[0]));
-                if (helloResult == 0) {
-                    System.out.println("Compiled HelloCodenameOne successfully.");
-                } else {
-                    System.out.println("WARNING: Failed to compile HelloCodenameOne.");
-                }
+                Assertions.assertEquals(0, helloResult,
+                        "Compilation of HelloCodenameOne failed; refusing to benchmark an incomplete workload");
+                System.out.println("Compiled HelloCodenameOne successfully.");
             }
         }
 

--- a/vm/tests/src/test/resources/com/codename1/tools/translator/benchmark/HelloCodenameOne.java
+++ b/vm/tests/src/test/resources/com/codename1/tools/translator/benchmark/HelloCodenameOne.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+package com.benchmark.app;
+
+import com.codename1.ui.Button;
+import com.codename1.ui.Dialog;
+import com.codename1.ui.Form;
+import com.codename1.ui.Label;
+import com.codename1.ui.events.ActionEvent;
+import com.codename1.ui.events.ActionListener;
+import com.codename1.ui.layouts.BoxLayout;
+
+/**
+ * Stable Java 8 sample for the translation benchmark's pinned 7.0.214 libraries.
+ * Keep this workload independent of the live demo app and its newer API tests.
+ */
+public class HelloCodenameOne {
+    private Form current;
+
+    public void init(Object context) {
+    }
+
+    public void start() {
+        if (current == null) {
+            current = new Form("Hello Codename One", BoxLayout.y());
+            current.add(new Label("Translation benchmark"));
+            Button button = new Button("Hello");
+            button.addActionListener(new ActionListener<ActionEvent>() {
+                public void actionPerformed(ActionEvent event) {
+                    Dialog.show("Hello", "Hello Codename One", "OK", null);
+                }
+            });
+            current.add(button);
+        }
+        current.show();
+    }
+
+    public void stop() {
+    }
+
+    public void destroy() {
+    }
+}


### PR DESCRIPTION
HeavyLoadBenchmarkTest swallowed HelloCodenameOne compiler failures and passed with an incomplete workload. Its live demo sources now require Java 17 and APIs newer than the benchmark's pinned 7.0.214 libraries, so simply asserting the compiler result exposed a permanently broken setup.

Use a checked-in Java 8 sample compatible with the pinned libraries, and make sample compilation mandatory before translation. Missing sample resources, missing core dependencies, empty source sets, and compiler errors fail the benchmark; compiler diagnostics are included in the failure. The benchmark continues to scan and translate the JavaAPI, core, and iOS library workload. The live demo is no longer this benchmark's input.

Add ordinary JVM regression tests for successful compilation, compiler errors, and an empty workload. These run outside the benchmark tag so failure handling is checked in the regular VM test step.

The PR also routes libdbus, SQLCipher, and C compiler setup through the existing bounded apt installer. The Java 8 CI job previously timed out during an unconditional apt update. Installed packages now avoid that network trip; missing-package installation retains bounded recovery and terminal failure. The Java 8 job passed after this fix.

Validation:
- Java 8: targeted HeavyLoadBenchmarkTest plus HeavyLoadBenchmarkCompilationTest, with CN1_NATIVE_VERIFY=strict and JaCoCo disabled as in the benchmark workflow: 4 tests, 0 failures/errors/skips, BUILD SUCCESS. The full heavy-load translation completed with 958 public classes.
- Regression cases verify invalid source fails with compiler diagnostics and an empty workload cannot pass.
- Apt installer command-stub checks cover installed packages without network access, successful missing-package installation, and persistent errors failing after three attempts.
- Copyright-header, shell syntax, and git diff checks passed.

Related runs: original swallowed compilation errors in https://github.com/codenameone/CodenameOne/actions/runs/34574601097; apt timeout in https://github.com/codenameone/CodenameOne/actions/runs/34582246047; strict assertion exposing the incompatible demo in https://github.com/codenameone/CodenameOne/actions/runs/34585419364.
