### PR TITLE
Read a public key out of a PEM certificate

### DIFF
--- a/CodenameOne/src/com/codename1/security/Pem.java
+++ b/CodenameOne/src/com/codename1/security/Pem.java
@@ -30,8 +30,11 @@ import com.codename1.util.StringUtil;
 /// The platform crypto bridge only accepts X.509/SubjectPublicKeyInfo and
 /// PKCS#8 DER, but the files people actually have on disk are PEM: base64
 /// wrapped in `-----BEGIN ...-----` armor, and often in the older PKCS#1 or
-/// SEC1 container rather than the one the bridge wants. This class absorbs
-/// both differences so callers do not have to run `openssl` first.
+/// SEC1 container rather than the one the bridge wants. A public key is as
+/// likely again to arrive inside the X.509 certificate that carries it --
+/// a server's TLS certificate, a payment gateway's signing certificate, the
+/// `x5c` entry of a JWK -- which is not a key container at all. This class
+/// absorbs all of those so callers do not have to run `openssl` first.
 ///
 /// Validation stops at structure. This class checks what it walks, classifies
 /// on, or rebuilds -- container shape, mandatory fields, element bounds -- so a
@@ -51,9 +54,15 @@ final class Pem {
     private static final int SHAPE_PKCS1_PUBLIC = 2;
     private static final int SHAPE_PKCS1_PRIVATE = 3;
     private static final int SHAPE_SEC1 = 4;
-    private static final int SHAPE_UNKNOWN = 5;
+    private static final int SHAPE_CERTIFICATE = 5;
+    private static final int SHAPE_UNKNOWN = 6;
 
-    private static final String[] PUBLIC_LABELS = {"PUBLIC KEY", "RSA PUBLIC KEY"};
+    /// `X509 CERTIFICATE` is the same DER under the label OpenSSL wrote before
+    /// RFC 7468 settled on the shorter one, and files carrying it are still in
+    /// circulation.
+    private static final String[] PUBLIC_LABELS = {
+        "PUBLIC KEY", "RSA PUBLIC KEY", "CERTIFICATE", "X509 CERTIFICATE"
+    };
     private static final String[] PRIVATE_LABELS = {"PRIVATE KEY", "RSA PRIVATE KEY", "EC PRIVATE KEY"};
 
     private static final String BEGIN = "-----BEGIN ";
@@ -108,6 +117,7 @@ final class Pem {
     /// Decodes `pem` to X.509/SubjectPublicKeyInfo DER.
     ///
     /// Accepts a `PUBLIC KEY` block, a PKCS#1 `RSA PUBLIC KEY` block (rewrapped
+    /// here), a `CERTIFICATE` block (whose subject public key is lifted out
     /// here), or bare base64 with no armor at all.
     static byte[] toSpki(String pem) {
         byte[] der = select(pem, PUBLIC_LABELS, false);
@@ -123,6 +133,9 @@ final class Pem {
             byte[] bitString = new byte[der.length + 1];
             System.arraycopy(der, 0, bitString, 1, der.length);
             return tlv(0x30, concat(rsaAlgorithmIdentifier(), tlv(0x03, bitString)));
+        }
+        if (shape == SHAPE_CERTIFICATE) {
+            return certificateToSpki(der);
         }
         if (shape == SHAPE_UNKNOWN) {
             throw new CryptoException("unrecognized public key container");
@@ -146,6 +159,11 @@ final class Pem {
         }
         if (shape == SHAPE_SEC1) {
             return sec1ToPkcs8(der);
+        }
+        if (shape == SHAPE_CERTIFICATE) {
+            // Reachable through bare base64 only: an armored certificate never
+            // matches PRIVATE_LABELS and is refused by select() by name.
+            throw new CryptoException("this is a certificate, not a private key");
         }
         if (shape == SHAPE_UNKNOWN) {
             throw new CryptoException("unrecognized private key container");
@@ -257,12 +275,28 @@ final class Pem {
             // bounds-checks its length) and nothing may follow it. Peeking at
             // the tag alone accepted a lone 0x03 byte and an empty 03 00.
             c.skip();
+            if (c.hasMore() && c.peek() == 0x03) {
+                // A BIT STRING's first content octet counts unused bits, so a
+                // length of one is metadata and no key material at all.
+                return isBitString(c.read(0x03)) && !c.hasMore() ? SHAPE_SPKI : SHAPE_UNKNOWN;
+            }
+            // Certificate ::= SEQUENCE { tbsCertificate SEQUENCE,
+            // signatureAlgorithm AlgorithmIdentifier, signatureValue BIT STRING }
+            // -- three fields where an SPKI has two, and no other container
+            // here opens with a SEQUENCE at all, so the outer shape separates
+            // the two with nothing left over to collide. Only the outer shape
+            // is read: classifying on the tbsCertificate as well would mean
+            // walking it twice and reporting a certificate this class cannot
+            // read as "unrecognized container" rather than saying what is
+            // wrong with it, so that walk belongs to certificateToSpki.
+            if (!c.hasMore() || c.peek() != 0x30) {
+                return SHAPE_UNKNOWN;
+            }
+            c.skip();
             if (!c.hasMore() || c.peek() != 0x03) {
                 return SHAPE_UNKNOWN;
             }
-            // A BIT STRING's first content octet counts unused bits, so a
-            // length of one is metadata and no key material at all.
-            return isBitString(c.read(0x03)) && !c.hasMore() ? SHAPE_SPKI : SHAPE_UNKNOWN;
+            return isBitString(c.read(0x03)) && !c.hasMore() ? SHAPE_CERTIFICATE : SHAPE_UNKNOWN;
         }
         if (c.peek() != 0x02) {
             return SHAPE_UNKNOWN;
@@ -438,9 +472,15 @@ final class Pem {
             throw new CryptoException("this private key is passphrase-encrypted; decrypt it first with: "
                     + "openssl pkcs8 -topk8 -nocrypt -in key.pem -out key_pkcs8.pem");
         }
-        if (!privateKey && labels.indexOf("CERTIFICATE") >= 0) {
-            throw new CryptoException("this is a certificate, not a public key; "
-                    + "extract the key with: openssl x509 -in cert.pem -pubkey -noout");
+        if (!privateKey && labels.indexOf("TRUSTED CERTIFICATE") >= 0) {
+            // A plain CERTIFICATE is a public key source and matched above. This
+            // one is not the same file: OpenSSL's trusted form appends its trust
+            // settings after the certificate, so the body holds two DER elements
+            // and would be refused for its trailing bytes -- which says nothing
+            // about what the file is or how to get a usable one out of it.
+            throw new CryptoException("this is an OpenSSL trusted certificate, which carries "
+                    + "trust settings after the certificate itself; re-export it with: "
+                    + "openssl x509 -in trusted.pem -out cert.pem");
         }
         throw new CryptoException("no " + (privateKey ? "private" : "public")
                 + " key block in this PEM; it holds: " + labels);
@@ -539,6 +579,145 @@ final class Pem {
         if (c.hasMore()) {
             throw new CryptoException("malformed key: " + (der.length - c.position())
                     + " trailing bytes after the key");
+        }
+    }
+
+    /// Lifts the `subjectPublicKeyInfo` out of an X.509 certificate.
+    ///
+    /// A certificate is the commonest way a public key is handed to a client,
+    /// and it is not a key container: the key sits seven fields deep inside
+    /// `tbsCertificate`, so it has to be walked to. Everything walked past is
+    /// checked, in the order the structure declares it, because this method
+    /// returns a slice of its input and a container it cannot read is one
+    /// whose seventh field is not the key it looks like.
+    ///
+    /// ```text
+    /// Certificate     ::= SEQUENCE { tbsCertificate, signatureAlgorithm, signatureValue }
+    /// TBSCertificate  ::= SEQUENCE {
+    ///     version          [0] EXPLICIT INTEGER DEFAULT v1,
+    ///     serialNumber         INTEGER,
+    ///     signature            AlgorithmIdentifier,
+    ///     issuer               Name,
+    ///     validity             Validity,
+    ///     subject              Name,
+    ///     subjectPublicKeyInfo SubjectPublicKeyInfo,   -- what is wanted
+    ///     issuerUniqueID   [1] IMPLICIT BIT STRING OPTIONAL,
+    ///     subjectUniqueID  [2] IMPLICIT BIT STRING OPTIONAL,
+    ///     extensions       [3] EXPLICIT Extensions OPTIONAL }
+    /// ```
+    ///
+    /// The signature is not checked and cannot be: verifying it needs the
+    /// issuer's key, which is not in the file, and a self-signed certificate
+    /// verifying against itself would say nothing anyway. Neither is the
+    /// validity period -- an expired certificate still names the right key,
+    /// and refusing one here would break an app on a date this class chose.
+    /// Both belong to a trust decision the caller makes elsewhere; all this
+    /// method claims is that the key it returns is the key the file carries.
+    private static byte[] certificateToSpki(byte[] der) {
+        Cursor certificate = new Cursor(der);
+        certificate.enter(0x30);
+        Cursor c = new Cursor(certificate.element());
+        c.enter(0x30);
+        if (c.hasMore() && c.peek() == 0xA0) {
+            requireCertificateVersion(c.element());
+        }
+        // A DER INTEGER always carries at least one content octet, so a serial
+        // number of no bytes is malformed however plausible the rest looks.
+        if (!c.hasMore() || c.peek() != 0x02 || c.consume(0x02) == 0) {
+            throw new CryptoException("malformed certificate: no serial number");
+        }
+        requireTbsSequence(c, "signature algorithm");
+        requireTbsSequence(c, "issuer");
+        requireTbsSequence(c, "validity");
+        requireTbsSequence(c, "subject");
+        if (!c.hasMore() || c.peek() != 0x30) {
+            throw new CryptoException("malformed certificate: no subjectPublicKeyInfo");
+        }
+        byte[] spki = c.element();
+        // The three optional trailers are IMPLICIT [1] and [2] BIT STRINGs and
+        // an EXPLICIT [3], in that order and no other. Stopping at the key
+        // would accept a spliced tbsCertificate on the strength of its first
+        // seven fields.
+        if (c.hasMore() && c.peek() == 0x81 && !isBitString(c.read(0x81))) {
+            throw new CryptoException("malformed certificate: issuerUniqueID is not a BIT STRING");
+        }
+        if (c.hasMore() && c.peek() == 0x82 && !isBitString(c.read(0x82))) {
+            throw new CryptoException("malformed certificate: subjectUniqueID is not a BIT STRING");
+        }
+        if (c.hasMore() && c.peek() == 0xA3) {
+            requireExtensions(c.element());
+        }
+        if (c.hasMore()) {
+            throw new CryptoException("malformed certificate: unexpected field 0x"
+                    + Integer.toHexString(c.peek()) + " after the subject public key");
+        }
+        // The seventh field of a certificate is a SubjectPublicKeyInfo by
+        // position, which is not the same as being one: the tag says SEQUENCE
+        // and nothing else has been read. Classifying it puts what comes out
+        // of a certificate through exactly the checks a PUBLIC KEY block goes
+        // through, rather than trusting where it was found.
+        if (shapeOf(spki) != SHAPE_SPKI) {
+            throw new CryptoException("malformed certificate: the subject public key is not a "
+                    + "well-formed SubjectPublicKeyInfo");
+        }
+        return spki;
+    }
+
+    /// Consumes one of the mandatory `tbsCertificate` SEQUENCEs, naming it if
+    /// it is absent.
+    private static void requireTbsSequence(Cursor c, String field) {
+        if (!c.hasMore() || c.peek() != 0x30) {
+            throw new CryptoException("malformed certificate: no " + field);
+        }
+        c.skip();
+    }
+
+    /// `version [0] EXPLICIT Version` -- an INTEGER of v1 (0), v2 (1) or v3 (2)
+    /// and nothing else in the tag.
+    ///
+    /// The version has no bearing on the key that comes out, so this checks it
+    /// rather than reading it: a `[0]` holding something other than a version
+    /// means the field the walk counts on being the serial number is not, and
+    /// the walk would go on regardless and return whatever sat in the seventh
+    /// position.
+    private static void requireCertificateVersion(byte[] element) {
+        Cursor c = new Cursor(element);
+        c.enter(0xA0);
+        byte[] version = c.read(0x02);
+        if (c.hasMore()) {
+            throw new CryptoException("malformed certificate: [0] holds more than the version");
+        }
+        if (version.length != 1 || version[0] < 0 || version[0] > 2) {
+            throw new CryptoException("unsupported certificate version; X.509 defines only "
+                    + "v1, v2 and v3");
+        }
+    }
+
+    /// `extensions [3] EXPLICIT Extensions`, where `Extensions ::= SEQUENCE
+    /// SIZE (1..MAX) OF Extension`.
+    ///
+    /// Walked to its members rather than skipped whole, because "[3] is
+    /// present" is not the same as "[3] holds a populated SEQUENCE": an empty
+    /// one breaks the size constraint, and a `30 01 06` inside it is a tag with
+    /// no length behind it.
+    private static void requireExtensions(byte[] element) {
+        Cursor c = new Cursor(element);
+        c.enter(0xA3);
+        if (!c.hasMore() || c.peek() != 0x30) {
+            throw new CryptoException("malformed certificate: [3] does not hold an extensions "
+                    + "SEQUENCE");
+        }
+        Cursor extensions = new Cursor(c.element());
+        extensions.enter(0x30);
+        if (!extensions.hasMore()) {
+            throw new CryptoException("malformed certificate: the extensions SEQUENCE is empty");
+        }
+        while (extensions.hasMore()) {
+            extensions.skip();
+        }
+        if (c.hasMore()) {
+            throw new CryptoException("malformed certificate: [3] holds more than the extensions "
+                    + "SEQUENCE");
         }
     }
 

--- a/CodenameOne/src/com/codename1/security/PublicKey.java
+++ b/CodenameOne/src/com/codename1/security/PublicKey.java
@@ -28,8 +28,10 @@ import com.codename1.util.StringUtil;
 /// algorithm name ("RSA" or "EC") and the encoded key bytes.
 ///
 /// PEM files (`-----BEGIN PUBLIC KEY-----`) go through [#fromPem], which
-/// strips the armor and decodes the base64 for you; [#fromX509] is the lower
-/// level entry point for callers that already hold the DER bytes.
+/// strips the armor and decodes the base64 for you, and which also takes the
+/// `-----BEGIN CERTIFICATE-----` file a server or gateway is more likely to
+/// hand out; [#fromX509] is the lower level entry point for callers that
+/// already hold the DER bytes.
 public final class PublicKey extends Key {
     /// RSA algorithm identifier ("RSA").
     public static final String RSA = "RSA";
@@ -65,6 +67,15 @@ public final class PublicKey extends Key {
     /// file -- bare base64 with no `-----BEGIN-----` armor at all. Line
     /// endings, blank lines and text surrounding the block are ignored, and in
     /// a file holding several blocks the first public key is the one used.
+    ///
+    /// A `CERTIFICATE` block is accepted as well, and its subject public key is
+    /// used. That covers the file a backend usually hands out -- a TLS or
+    /// signing certificate rather than a bare key -- without the caller having
+    /// to run `openssl x509 -pubkey -noout` first. In a certificate chain the
+    /// leaf comes first, so the key that comes out is the chain's own. Note
+    /// that nothing is being trusted by doing this: the signature and the
+    /// validity dates are not checked, and the certificate is read only as a
+    /// container for the key it names.
     ///
     /// Throws [CryptoException] if the text is not a public key, if it is
     /// passphrase-encrypted, or if the key is neither RSA nor EC.

--- a/docs/developer-guide/security.asciidoc
+++ b/docs/developer-guide/security.asciidoc
@@ -412,6 +412,10 @@ To use a key that was generated outside the app, feed the DER bytes to the stati
 include::../demos/common/src/main/java/com/codenameone/developerguide/snippets/generated/SecurityJava040Snippet.java[tag=security-java-040,indent=0]
 ----
 
+A key that arrives as a file is usually PEM rather than raw DER -- base64 between `-----BEGIN-----` lines -- so `PublicKey.fromPem` and `PrivateKey.fromPem` take that text, or the bytes of the file straight from `Util.readInputStream`, and work out the algorithm from the key itself.
+
+`fromPem` also reads the containers that aren't the one the platform wants: the older PKCS#1 `RSA PRIVATE KEY` and SEC1 `EC PRIVATE KEY` blocks, and the `-----BEGIN CERTIFICATE-----` file a server or payment gateway is more likely to hand out than a bare key, whose subject public key it uses. It doesn't verify the certificate -- neither its signature nor its dates -- it only reads the key out of it, so a certificate you didn't already trust is no more trustworthy for having been parsed here.
+
 The `Signature` class exposes the JCE algorithm strings as constants: `SHA256_WITH_RSA`, `SHA384_WITH_RSA`, `SHA512_WITH_RSA`, `SHA256_WITH_ECDSA`, `SHA384_WITH_ECDSA`, and `SHA512_WITH_ECDSA`.
 
 ==== JSON Web Tokens
@@ -546,6 +550,8 @@ The string constants exposed by these classes are listed below so you can pick t
 | `HS256`, `HS384`, `HS512`, `RS256`, `RS384`, `RS512`, `ES256`, `ES384`, `ES512`
 | Same as the JWT `alg` header value
 |===
+
+NOTE: `RSA_OAEP_SHA256` uses SHA-256 for the label hash and for MGF1 alike. The JCE reading of that same transformation name leaves MGF1 on SHA-1, so a JVM backend that names the string and nothing else produces a `BadPaddingException` against ciphertext from a Codename One app, and the other way round. Codename One can't follow the JCE here: Web Crypto and Apple's SecKey both take one hash and apply it to both, so the split pairing can't be expressed on the JavaScript or iOS ports at all. Have the other side name SHA-256 for the mask as well, which on a JVM means passing an `OAEPParameterSpec` of `("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT)` to `Cipher.init` rather than relying on the provider default. Dropping to `RSA_PKCS1` also makes the two sides agree, and is the wrong fix: PKCS#1 v1.5 encryption padding is what OAEP exists to replace.
 
 ==== Key sizes and recommended defaults
 

--- a/maven/core-unittests/src/test/java/com/codename1/security/PemKeyTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/security/PemKeyTest.java
@@ -253,6 +253,89 @@ class PemKeyTest extends UITestBase {
             + "/+kk1lZcl5DdXBwSi5mcV2dUxnlnnl6hRANCAAQuvJBWnyj34TNN2JkU/cNhAunw"
             + "rhvng2GP75DM7w4q4AWLdjtYgYy8K+edaMc7afUeVg3aqMhy6ahN75VzSUuj";
 
+    /// A throwaway self-signed X.509 v3 certificate over the RSA key above, as
+    /// `openssl req -x509` writes it: `[0]` version, `[3]` extensions, and the
+    /// same SubjectPublicKeyInfo as RSA_SPKI seven fields in.
+    private static final String CERT_RSA_LABEL = "CERTIFICATE";
+    private static final String CERT_RSA = ""
+            + "MIIDIzCCAgugAwIBAgIURop8Hd6XYlsSLWsG6QhzmE/XF/UwDQYJKoZIhvcNAQEL"
+            + "BQAwIDEeMBwGA1UEAwwVQ29kZW5hbWUgT25lIFBFTSB0ZXN0MCAXDTI2MDkxMTIy"
+            + "MDgwNVoYDzIxMjYwODE4MjIwODA1WjAgMR4wHAYDVQQDDBVDb2RlbmFtZSBPbmUg"
+            + "UEVNIHRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDKbhYepFWu"
+            + "XOHh4TWNdD7dmzDMrurYjI5fJQ5t7JPqblbCVXaxhPH4xmkm0DRfb9XSpiGJMPcV"
+            + "HR4cHW3GYSWiO3SgZer5sahkKzNRUou/Mhw1gEo+rXDedwRk6COyPni6P02R6t+4"
+            + "ayAXpJJmbgzJKrD0eYgWzio6a7UCe6338DsT/viXA7jc3qGuRw3WZgMNUV8itmeE"
+            + "/WnkpQZ871PM8To/5362/ohfCE7wO/9NNiTmNi0yjZxkVbHIbKcaU0qL6ByKGJry"
+            + "HZgtpXYc49mWG+lAfq0+MIAXsr9qugcxHa2MQOVa8ceThbMfEmxFr7f5vLdnSRDD"
+            + "TzTdZA3ieWUTAgMBAAGjUzBRMB0GA1UdDgQWBBRckUl/ziVbuEB8grFjl2z8OJ8D"
+            + "MjAfBgNVHSMEGDAWgBRckUl/ziVbuEB8grFjl2z8OJ8DMjAPBgNVHRMBAf8EBTAD"
+            + "AQH/MA0GCSqGSIb3DQEBCwUAA4IBAQCPLJziv3J7Fd8j5MmfcWIptk9Zi9vfKMMd"
+            + "gjQHtjBcMcDoyLbzuDcX18oZVZm6etWIZMYfm1j7d1A3QwuhfKOrnpDcCKDToUPj"
+            + "6FYbA6aBbJTsOYfmo5MZ8WP1jm8D1ndlvyxcNmuW7dWdq026GBB26FE1X+M7s2wI"
+            + "nsLLGQd2r1PAK05enu2V9VRVS2C2qx49wcOwYc8AT64lRpB3RiHDTAyfX/NYvwhW"
+            + "ML6vHzOSNKWWtZIwDZTsZvPUBs4lu/D8u9cy8Kezyh+Kbb38OL3amlN/af4qZKvm"
+            + "c55CJKvZpIk5up06SNXys6qCXiSQA5+t3FcyfNpFhcKUmHlCorl8";
+
+    /// The same certificate as a v1: no `[0]` version and no `[3]` extensions,
+    /// so the TBSCertificate is the six mandatory fields and nothing else.
+    /// OpenSSL 3 will not write one, so it was made by re-encoding CERT_RSA
+    /// without those two fields -- which invalidates the signature, and nothing
+    /// here verifies signatures.
+    private static final String CERT_RSA_V1 = ""
+            + "MIICyTCCAbECFEaKfB3el2JbEi1rBukIc5hP1xf1MA0GCSqGSIb3DQEBCwUAMCAx"
+            + "HjAcBgNVBAMMFUNvZGVuYW1lIE9uZSBQRU0gdGVzdDAgFw0yNjA5MTEyMjA4MDVa"
+            + "GA8yMTI2MDgxODIyMDgwNVowIDEeMBwGA1UEAwwVQ29kZW5hbWUgT25lIFBFTSB0"
+            + "ZXN0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAym4WHqRVrlzh4eE1"
+            + "jXQ+3ZswzK7q2IyOXyUObeyT6m5WwlV2sYTx+MZpJtA0X2/V0qYhiTD3FR0eHB1t"
+            + "xmElojt0oGXq+bGoZCszUVKLvzIcNYBKPq1w3ncEZOgjsj54uj9NkerfuGsgF6SS"
+            + "Zm4MySqw9HmIFs4qOmu1Anut9/A7E/74lwO43N6hrkcN1mYDDVFfIrZnhP1p5KUG"
+            + "fO9TzPE6P+d+tv6IXwhO8Dv/TTYk5jYtMo2cZFWxyGynGlNKi+gcihia8h2YLaV2"
+            + "HOPZlhvpQH6tPjCAF7K/aroHMR2tjEDlWvHHk4WzHxJsRa+3+by3Z0kQw0803WQN"
+            + "4nllEwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQCPLJziv3J7Fd8j5MmfcWIptk9Z"
+            + "i9vfKMMdgjQHtjBcMcDoyLbzuDcX18oZVZm6etWIZMYfm1j7d1A3QwuhfKOrnpDc"
+            + "CKDToUPj6FYbA6aBbJTsOYfmo5MZ8WP1jm8D1ndlvyxcNmuW7dWdq026GBB26FE1"
+            + "X+M7s2wInsLLGQd2r1PAK05enu2V9VRVS2C2qx49wcOwYc8AT64lRpB3RiHDTAyf"
+            + "X/NYvwhWML6vHzOSNKWWtZIwDZTsZvPUBs4lu/D8u9cy8Kezyh+Kbb38OL3amlN/"
+            + "af4qZKvmc55CJKvZpIk5up06SNXys6qCXiSQA5+t3FcyfNpFhcKUmHlCorl8";
+
+    /// CERT_RSA with an issuerUniqueID `[1]` and a subjectUniqueID `[2]`
+    /// inserted between the key and the extensions -- the two optional fields
+    /// no certificate authority has issued in decades and which the walk still
+    /// has to step over in the right order. Re-encoded, so unsigned.
+    private static final String CERT_RSA_UNIQUE_IDS = ""
+            + "MIIDMTCCAhmgAwIBAgIURop8Hd6XYlsSLWsG6QhzmE/XF/UwDQYJKoZIhvcNAQEL"
+            + "BQAwIDEeMBwGA1UEAwwVQ29kZW5hbWUgT25lIFBFTSB0ZXN0MCAXDTI2MDkxMTIy"
+            + "MDgwNVoYDzIxMjYwODE4MjIwODA1WjAgMR4wHAYDVQQDDBVDb2RlbmFtZSBPbmUg"
+            + "UEVNIHRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDKbhYepFWu"
+            + "XOHh4TWNdD7dmzDMrurYjI5fJQ5t7JPqblbCVXaxhPH4xmkm0DRfb9XSpiGJMPcV"
+            + "HR4cHW3GYSWiO3SgZer5sahkKzNRUou/Mhw1gEo+rXDedwRk6COyPni6P02R6t+4"
+            + "ayAXpJJmbgzJKrD0eYgWzio6a7UCe6338DsT/viXA7jc3qGuRw3WZgMNUV8itmeE"
+            + "/WnkpQZ871PM8To/5362/ohfCE7wO/9NNiTmNi0yjZxkVbHIbKcaU0qL6ByKGJry"
+            + "HZgtpXYc49mWG+lAfq0+MIAXsr9qugcxHa2MQOVa8ceThbMfEmxFr7f5vLdnSRDD"
+            + "TzTdZA3ieWUTAgMBAAGBBQDerb7vggUAyv66vqNTMFEwHQYDVR0OBBYEFFyRSX/O"
+            + "JVu4QHyCsWOXbPw4nwMyMB8GA1UdIwQYMBaAFFyRSX/OJVu4QHyCsWOXbPw4nwMy"
+            + "MA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAI8snOK/cnsV3yPk"
+            + "yZ9xYim2T1mL298owx2CNAe2MFwxwOjItvO4NxfXyhlVmbp61Yhkxh+bWPt3UDdD"
+            + "C6F8o6uekNwIoNOhQ+PoVhsDpoFslOw5h+ajkxnxY/WObwPWd2W/LFw2a5bt1Z2r"
+            + "TboYEHboUTVf4zuzbAiewssZB3avU8ArTl6e7ZX1VFVLYLarHj3Bw7BhzwBPriVG"
+            + "kHdGIcNMDJ9f81i/CFYwvq8fM5I0pZa1kjANlOxm89QGziW78Py71zLwp7PKH4pt"
+            + "vfw4vdqaU39p/ipkq+ZznkIkq9mkiTm6nTpI1fKzqoJeJJADn63cVzJ82kWFwpSY"
+            + "eUKiuXw=";
+
+    /// A throwaway self-signed certificate over the EC key above, so the
+    /// extraction is exercised on a key whose AlgorithmIdentifier names a
+    /// curve rather than being the fixed rsaEncryption one.
+    private static final String CERT_EC = ""
+            + "MIIBnDCCAUOgAwIBAgIUMlgbS+kU8jFnOq++G1M0sd1vC0UwCgYIKoZIzj0EAwIw"
+            + "IzEhMB8GA1UEAwwYQ29kZW5hbWUgT25lIFBFTSB0ZXN0IEVDMCAXDTI2MDkxMTIy"
+            + "MDgwNVoYDzIxMjYwODE4MjIwODA1WjAjMSEwHwYDVQQDDBhDb2RlbmFtZSBPbmUg"
+            + "UEVNIHRlc3QgRUMwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAR16t1j6j5exfNw"
+            + "dOVqh7zavejexeHi22FUegbfDALznA5Ria4r9zik9nRlB1Ef4Y4BeAH6hE1+PxZJ"
+            + "gz2ZKGueo1MwUTAdBgNVHQ4EFgQUFRGLlO0ZooFlgt09RO7prR3f3zQwHwYDVR0j"
+            + "BBgwFoAUFRGLlO0ZooFlgt09RO7prR3f3zQwDwYDVR0TAQH/BAUwAwEB/zAKBggq"
+            + "hkjOPQQDAgNHADBEAiBuBzW+bXdm6gjQ9dta//gSv/kEJBgqFEBUBk3h1F3PrgIg"
+            + "GmQbLi2NUmX4YQ54SeHF4PA9bpOqmgCum17cAzSW+VA=";
+
     private static String pem(String label, String base64) {
         StringBuilder sb = new StringBuilder("-----BEGIN ").append(label).append("-----\n");
         for (int i = 0; i < base64.length(); i += 64) {
@@ -415,11 +498,290 @@ class PemKeyTest extends UITestBase {
         assertTrue(e.getMessage().contains("PUBLIC KEY"), e.getMessage());
     }
 
+    // ---- the second half of the report: the key arrives inside a certificate ----
+
     @Test
-    void certificateIsRejectedWithTheExtractCommand() {
+    void certificateYieldsItsSubjectPublicKey() {
+        // The case from the discussion: the backend hands out a CERTIFICATE and
+        // the key inside it is the one to encrypt to. What comes out has to be
+        // the SubjectPublicKeyInfo byte for byte -- the same bytes a PUBLIC KEY
+        // block holding that key would have produced.
+        PublicKey pub = PublicKey.fromPem(pem(CERT_RSA_LABEL, CERT_RSA));
+
+        assertEquals(PublicKey.RSA, pub.getAlgorithm());
+        assertEquals("X.509", pub.getFormat());
+        assertArrayEquals(der(RSA_SPKI), pub.getEncoded());
+
+        // and it is a usable key, not merely the right bytes
+        PrivateKey priv = PrivateKey.fromPem(pem(RSA_PKCS8_LABEL, RSA_PKCS8));
+        byte[] plaintext = "Secret message".getBytes();
+        byte[] ciphertext = Cipher.rsaEncrypt(Cipher.RSA_OAEP_SHA256, pub, plaintext);
+        assertArrayEquals(plaintext, Cipher.rsaDecrypt(Cipher.RSA_OAEP_SHA256, priv, ciphertext));
+    }
+
+    @Test
+    void certificateWorksForEcKeysToo() {
+        PublicKey pub = PublicKey.fromPem(pem(CERT_RSA_LABEL, CERT_EC));
+        assertEquals(PublicKey.EC, pub.getAlgorithm());
+        assertArrayEquals(der(EC_SPKI), pub.getEncoded());
+    }
+
+    @Test
+    void everyOptionalTbsCertificateFieldIsWalked() {
+        // v1: no [0] version and no [3] extensions at all
+        assertArrayEquals(der(RSA_SPKI),
+                PublicKey.fromPem(pem(CERT_RSA_LABEL, CERT_RSA_V1)).getEncoded());
+
+        // issuerUniqueID [1] and subjectUniqueID [2] sit between the key and
+        // the extensions, so a walk that stops at the key would have taken the
+        // right bytes here by luck and the trailing-field check would not.
+        assertArrayEquals(der(RSA_SPKI),
+                PublicKey.fromPem(pem(CERT_RSA_LABEL, CERT_RSA_UNIQUE_IDS)).getEncoded());
+    }
+
+    @Test
+    void certificateIsAcceptedUnarmoredAndUnderTheOlderLabel() {
+        // bare DER, which is how a certificate arrives in a JWK's x5c entry
+        assertArrayEquals(der(RSA_SPKI), PublicKey.fromPem(CERT_RSA).getEncoded());
+
+        // the label OpenSSL wrote before RFC 7468
+        assertArrayEquals(der(RSA_SPKI),
+                PublicKey.fromPem(pem("X509 CERTIFICATE", CERT_RSA)).getEncoded());
+    }
+
+    @Test
+    void theLeafOfAChainIsTheKeyThatComesOut() {
+        // A chain file is leaf first. Taking any other block would hand back an
+        // intermediate's key, which is a different key that fails much later.
+        String chain = pem(CERT_RSA_LABEL, CERT_RSA) + pem(CERT_RSA_LABEL, CERT_EC);
+        assertArrayEquals(der(RSA_SPKI), PublicKey.fromPem(chain).getEncoded());
+
+        // "openssl x509 -pubkey" writes the extracted key ahead of the
+        // certificate; both blocks name the same key, and the first wins
+        String both = pem(RSA_SPKI_LABEL, RSA_SPKI) + pem(CERT_RSA_LABEL, CERT_RSA);
+        assertArrayEquals(der(RSA_SPKI), PublicKey.fromPem(both).getEncoded());
+    }
+
+    @Test
+    void aCertificateIsNotAPrivateKey() {
+        CryptoException armored = assertThrows(CryptoException.class,
+                () -> PrivateKey.fromPem(pem(CERT_RSA_LABEL, CERT_RSA)));
+        assertTrue(armored.getMessage().contains("CERTIFICATE"), armored.getMessage());
+
+        // unarmored, where there is no label to refuse it by and the shape has
+        // to say so
+        CryptoException bare = assertThrows(CryptoException.class,
+                () -> PrivateKey.fromPem(CERT_RSA));
+        assertTrue(bare.getMessage().contains("certificate"), bare.getMessage());
+    }
+
+    @Test
+    void anOpensslTrustedCertificateSaysWhatItIs() {
+        // Its body is the certificate followed by OpenSSL's trust settings, so
+        // it is two DER elements and cannot be read as a key. Refused for that
+        // reason rather than for the trailing bytes it would otherwise report.
         CryptoException e = assertThrows(CryptoException.class,
-                () -> PublicKey.fromPem(pem("CERTIFICATE", RSA_SPKI)));
+                () -> PublicKey.fromPem(pem("TRUSTED CERTIFICATE", CERT_RSA)));
+        assertTrue(e.getMessage().contains("trusted certificate"), e.getMessage());
         assertTrue(e.getMessage().contains("openssl x509"), e.getMessage());
+    }
+
+    @Test
+    void aTruncatedCertificateIsRefusedRatherThanMisread() {
+        // Every mandatory field before the key is walked, so a certificate that
+        // stops early cannot reach the seventh position and return whatever is
+        // sitting there. Built by cutting fields off the real TBSCertificate.
+        byte[] certificate = der(CERT_RSA);
+        for (int fields = 0; fields < 7; fields++) {
+            byte[] truncated = certificateWithTbsFields(certificate, fields);
+            CryptoException e = assertThrows(CryptoException.class,
+                    () -> PublicKey.fromPem(pem(CERT_RSA_LABEL,
+                            Base64.encodeNoNewline(truncated))),
+                    "a TBSCertificate of " + fields + " fields was accepted");
+            assertTrue(e.getMessage().contains("certificate"), e.getMessage());
+        }
+
+        // and the whole thing still reads, so the loop is not passing because
+        // the fixture is broken
+        assertArrayEquals(der(RSA_SPKI), PublicKey.fromPem(pem(CERT_RSA_LABEL, CERT_RSA))
+                .getEncoded());
+    }
+
+    @Test
+    void aCertificateWhoseSeventhFieldIsNotAKeyIsRefused() {
+        // The position is right and the tag is right; it is the validity period
+        // moved into the key's place. Accepting it on position alone handed a
+        // SEQUENCE of two UTCTimes to the platform as a public key.
+        byte[] certificate = der(CERT_RSA);
+        int[] bounds = tbsFieldBounds(certificate);
+        // field 4 of the TBSCertificate is the validity period
+        byte[] validity = new byte[bounds[9] - bounds[8]];
+        System.arraycopy(certificate, bounds[8], validity, 0, validity.length);
+        byte[] spliced = certificateWithTbs(certificate,
+                concatFields(certificate, bounds, 6), validity);
+
+        CryptoException e = assertThrows(CryptoException.class,
+                () -> PublicKey.fromPem(pem(CERT_RSA_LABEL, Base64.encodeNoNewline(spliced))));
+        assertTrue(e.getMessage().contains("subject public key"), e.getMessage());
+    }
+
+    @Test
+    void nothingMayFollowTheOptionalTrailersOfATbsCertificate() {
+        // The three optional trailers are the end of a TBSCertificate. Stopping
+        // at the key would accept a spliced one on the strength of the seven
+        // fields ahead of the splice, which is the whole reason the walk
+        // continues past the thing it came for.
+        byte[] certificate = der(CERT_RSA);
+        int[] bounds = tbsFieldBounds(certificate);
+        byte[] spliced = certificateWithTbs(certificate,
+                concatFields(certificate, bounds, bounds.length / 2), hex("0500"));
+
+        CryptoException e = assertThrows(CryptoException.class,
+                () -> PublicKey.fromPem(pem(CERT_RSA_LABEL, Base64.encodeNoNewline(spliced))));
+        assertTrue(e.getMessage().contains("unexpected field"), e.getMessage());
+    }
+
+    @Test
+    void theExtensionsTagHasToHoldAPopulatedSequence() {
+        // "[3] is present" is not "[3] holds extensions": an empty SEQUENCE
+        // breaks Extensions' SIZE (1..MAX), and a [3] holding something else
+        // entirely is a certificate that has been rewritten.
+        byte[] certificate = der(CERT_RSA);
+        int[] bounds = tbsFieldBounds(certificate);
+        byte[] withoutExtensions = concatFields(certificate, bounds, 7);
+
+        CryptoException empty = assertThrows(CryptoException.class,
+                () -> PublicKey.fromPem(pem(CERT_RSA_LABEL, Base64.encodeNoNewline(
+                        certificateWithTbs(certificate, withoutExtensions, hex("a3023000"))))));
+        assertTrue(empty.getMessage().contains("extensions"), empty.getMessage());
+
+        CryptoException notASequence = assertThrows(CryptoException.class,
+                () -> PublicKey.fromPem(pem(CERT_RSA_LABEL, Base64.encodeNoNewline(
+                        certificateWithTbs(certificate, withoutExtensions, hex("a3020500"))))));
+        assertTrue(notASequence.getMessage().contains("extensions"), notASequence.getMessage());
+    }
+
+    @Test
+    void aVersionOtherThanV1ToV3IsRefused() {
+        // The version does not change the key that comes out, which is exactly
+        // why it has to be checked: a [0] holding something other than a
+        // version means the field counted on as the serial number is not one,
+        // and the walk would carry on and return the seventh thing it found.
+        byte[] certificate = der(CERT_RSA);
+        byte[] bad = certificate.clone();
+        int at = indexOf(bad, hex("a003020102"));
+        assertTrue(at > 0, "the [0] version was not found in the fixture");
+        bad[at + 4] = 0x07;
+
+        CryptoException e = assertThrows(CryptoException.class,
+                () -> PublicKey.fromPem(pem(CERT_RSA_LABEL, Base64.encodeNoNewline(bad))));
+        assertTrue(e.getMessage().contains("version"), e.getMessage());
+    }
+
+    /// Offsets of the TBSCertificate's fields within `certificate`, as start,
+    /// end pairs -- so field `i` is `[bounds[2 * i], bounds[2 * i + 1])`.
+    private static int[] tbsFieldBounds(byte[] certificate) {
+        int[] out = new int[32];
+        int count = 0;
+        int p = contentStart(certificate, contentStart(certificate, 0));
+        int end = elementEnd(certificate, contentStart(certificate, 0));
+        while (p < end) {
+            int next = elementEnd(certificate, p);
+            out[count++] = p;
+            out[count++] = next;
+            p = next;
+        }
+        int[] trimmed = new int[count];
+        System.arraycopy(out, 0, trimmed, 0, count);
+        return trimmed;
+    }
+
+    private static int contentStart(byte[] der, int at) {
+        int length = der[at + 1] & 0xFF;
+        return length < 0x80 ? at + 2 : at + 2 + (length & 0x7F);
+    }
+
+    private static int elementEnd(byte[] der, int at) {
+        int first = der[at + 1] & 0xFF;
+        if (first < 0x80) {
+            return at + 2 + first;
+        }
+        int count = first & 0x7F;
+        int length = 0;
+        for (int i = 0; i < count; i++) {
+            length = (length << 8) | (der[at + 2 + i] & 0xFF);
+        }
+        return at + 2 + count + length;
+    }
+
+    /// The first `fields` fields of the TBSCertificate, concatenated.
+    private static byte[] concatFields(byte[] certificate, int[] bounds, int fields) {
+        int size = 0;
+        for (int i = 0; i < fields; i++) {
+            size += bounds[2 * i + 1] - bounds[2 * i];
+        }
+        byte[] out = new byte[size];
+        int at = 0;
+        for (int i = 0; i < fields; i++) {
+            int length = bounds[2 * i + 1] - bounds[2 * i];
+            System.arraycopy(certificate, bounds[2 * i], out, at, length);
+            at += length;
+        }
+        return out;
+    }
+
+    /// `certificate` with its TBSCertificate replaced by the first `fields`
+    /// of its own fields, the signature left as it was.
+    private static byte[] certificateWithTbsFields(byte[] certificate, int fields) {
+        return certificateWithTbs(certificate,
+                concatFields(certificate, tbsFieldBounds(certificate), fields), new byte[0]);
+    }
+
+    private static byte[] certificateWithTbs(byte[] certificate, byte[] fields, byte[] extra) {
+        int tbsEnd = elementEnd(certificate, contentStart(certificate, 0));
+        byte[] rest = new byte[certificate.length - tbsEnd];
+        System.arraycopy(certificate, tbsEnd, rest, 0, rest.length);
+        byte[] content = new byte[fields.length + extra.length];
+        System.arraycopy(fields, 0, content, 0, fields.length);
+        System.arraycopy(extra, 0, content, fields.length, extra.length);
+        return tlv(0x30, concat(tlv(0x30, content), rest));
+    }
+
+    private static byte[] tlv(int tag, byte[] content) {
+        byte[] length;
+        if (content.length < 0x80) {
+            length = new byte[] {(byte) content.length};
+        } else if (content.length < 0x100) {
+            length = new byte[] {(byte) 0x81, (byte) content.length};
+        } else {
+            length = new byte[] {(byte) 0x82,
+                (byte) (content.length >> 8), (byte) content.length};
+        }
+        byte[] out = new byte[1 + length.length + content.length];
+        out[0] = (byte) tag;
+        System.arraycopy(length, 0, out, 1, length.length);
+        System.arraycopy(content, 0, out, 1 + length.length, content.length);
+        return out;
+    }
+
+    private static byte[] concat(byte[] a, byte[] b) {
+        byte[] out = new byte[a.length + b.length];
+        System.arraycopy(a, 0, out, 0, a.length);
+        System.arraycopy(b, 0, out, a.length, b.length);
+        return out;
+    }
+
+    private static int indexOf(byte[] haystack, byte[] needle) {
+        for (int i = 0; i + needle.length <= haystack.length; i++) {
+            int j = 0;
+            while (j < needle.length && haystack[i + j] == needle[j]) {
+                j++;
+            }
+            if (j == needle.length) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     @Test


### PR DESCRIPTION
Closes the gap reported in discussion #5703.

## The problem

`PublicKey.fromPem` refused a `-----BEGIN CERTIFICATE-----` block and sent the caller away to run `openssl x509 -pubkey -noout` -- which is exactly the thing `Pem` exists to make unnecessary ("so callers do not have to run `openssl` first", `Pem.java:33`). A certificate is how a public key is usually handed to a client: a server's TLS certificate, a payment gateway's signing certificate, the `x5c` entry of a JWK. The commonest shape was the one shape that needed a shell.

The reporter hit it twice -- first as `DerValue.getOID, not an OID -96` from feeding a whole certificate to `PublicKey.rsa()` (`-96` is `0xA0`, the `[0] version` tag at the head of `tbsCertificate`), then as the explicit refusal once `fromPem` landed.

## What changed

A certificate is not a key container: the key is the seventh field of `tbsCertificate`, so it has to be walked to. Every field walked past is checked in declaration order, because `certificateToSpki` returns a slice of its input and a container it cannot read is one whose seventh field is not the key it looks like. What comes out is then run through `shapeOf`, so a key lifted from a certificate passes exactly the checks a `PUBLIC KEY` block does rather than being trusted for where it was found.

The signature is not verified and cannot be -- that needs the issuer's key, which is not in the file -- and the dates are not checked either, since an expired certificate still names the right key and refusing one here would break an app on a date this class picked. Both belong to a trust decision the caller makes elsewhere. **Nothing is being trusted by parsing**; the only claim is that the key returned is the key the file carries. This is stated in the javadoc and the guide so nobody reads `fromPem` as validation.

`shapeOf` classifies on the outer shape alone -- `SEQUENCE { SEQUENCE, SEQUENCE, BIT STRING }` against an SPKI's two fields, and no other container here opens on a SEQUENCE, so nothing collides. The deep walk stays in `certificateToSpki` so a certificate that cannot be read says what is wrong with it instead of "unrecognized container". Bare base64 goes the same route, which is how a certificate arrives in `x5c`, and `X509 CERTIFICATE` is accepted as the pre-RFC 7468 spelling of the same DER.

The old "this is a certificate" error is retargeted at `TRUSTED CERTIFICATE`, whose body is the certificate followed by OpenSSL's trust settings and so is two DER elements. That one really is unreadable here, and would otherwise have been refused for its trailing bytes -- which says nothing about what the file is.

## Verification

- **154 real certificates**: the 128 roots in the macOS trust store (105 RSA, 23 EC) and 26 certificates from live servers (github.com, google.com, cloudflare.com, apple.com, amazon.com, stackoverflow.com, letsencrypt.org, codenameone.com). Every one extracts **byte-identically** to what the JDK's `CertificateFactory.generateCertificate(...).getPublicKey().getEncoded()` reports for the same file -- an independent oracle, not a baseline seeded from this code.
- **12 new unit tests** (`PemKeyTest` 62 -> 72, all green) covering the round trip, EC, v1 (no `[0]`/`[3]`), `issuerUniqueID`/`subjectUniqueID`, bare DER, the older label, chain-leaf-first, refusal as a private key, trusted certificates, seven truncation points, a spliced seventh field, the extensions tag, and an out-of-range version.
- **Revert probe**: removing each of the four new checks in turn was caught by a named test. The probe initially found one check (`unexpected field after the subject public key`) that no test covered; `nothingMayFollowTheOptionalTrailersOfATbsCertificate` and `theExtensionsTagHasToHoldAPopulatedSequence` were added to close it, and the probe was re-run to confirm they bite.
- **Gates**: SpotBugs 0 findings (report regenerated, not read stale), PMD 0, Checkstyle 0, `generate-quality-report.py` RC 0, copyright / ASCII / control-characters / since-tags / package-info / cast-semantics / Java 25 markdown docs all clean. Guide gates: Vale 0, structure, xrefs, missing-code-blocks, snippets, paragraph capitalization all clean.

`core-unittests` has 13 pre-existing failures in `MockAdProviderTest` (12 failures + 1 error). They reproduce identically on clean master at a9cc555fdf and are unrelated to this change -- flagging separately.

## Also in here

The guide's RSA section never mentioned `fromPem` at all, so it gains that paragraph. And the algorithm-identifier table gains a note that `RSA_OAEP_SHA256` means MGF1-SHA-256 while the JCE reading of the same transformation name leaves MGF1 on SHA-1 -- the mismatch behind the `BadPaddingException` in the same discussion, which the reporter "fixed" by dropping both sides to `RSA_PKCS1`. That is a downgrade from OAEP to the padding OAEP exists to replace, so the note gives the one-line `OAEPParameterSpec` fix instead and says why the fallback is the wrong answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)