### PR TITLE
ComponentGroup: make the segmented control work on the current native themes

### DIFF
--- a/CodenameOne/src/com/codename1/ui/Button.java
+++ b/CodenameOne/src/com/codename1/ui/Button.java
@@ -1091,8 +1091,9 @@ public class Button extends Label implements ReleasableComponent, ActionSource<A
             // the bar its segmented edges, and it does not re-apply that when the
             // UIID changes under it. Resetting it here would strip the member's
             // styling until the next structural or theme update. $origUIID is not
-            // the test for that -- ComponentGroup sets it once and never clears it,
-            // so it says "was grouped at some point" rather than "is grouped now".
+            // the test for that: ComponentGroup clears it when it hands the UIID
+            // back, but sets it from inside updateUIID rather than when ownership
+            // begins, so it still lags the answer groupOwnsUIID gives directly.
             if (!groupOwnsUIID() && isToggleUIID(uiid)) {
                 setUIID(preToggleUIID);
             }

--- a/CodenameOne/src/com/codename1/ui/ComponentGroup.java
+++ b/CodenameOne/src/com/codename1/ui/ComponentGroup.java
@@ -190,6 +190,16 @@ public class ComponentGroup extends Container {
         restoreDeparting(cmp);
     }
 
+    /// Reordering decides which member is First and which is Last, so it belongs to
+    /// the same family as insertion and removal. Container.drop reorders through here
+    /// and starts a layout animation, reaching neither of the other two hooks, so a
+    /// dragged segment kept the UIID of the position it came from.
+    @Override
+    void setComponentIndex(Component cmp, int location) {
+        super.setComponentIndex(cmp, location);
+        updateUIIDs();
+    }
+
     /// Hands a member that has left this group back what the group took from it.
     ///
     /// #### Parameters
@@ -258,8 +268,9 @@ public class ComponentGroup extends Container {
     /// Whether this group is currently renaming its members' UIIDs. updateUIIDs()
     /// does nothing unless the theme constant is on or grouping is forced, and
     /// Button needs the same answer to know whether a member's live UIID belongs
-    /// to the group or to itself. $origUIID cannot answer it: restoreUIID leaves
-    /// that set, so it says "was renamed once", not "is renamed now".
+    /// to the group or to itself. $origUIID cannot answer it either: it is absent
+    /// between memberships and present during one, but it is set from inside
+    /// updateUIID rather than at the moment ownership begins, so it lags.
     ///
     /// #### Returns
     ///
@@ -321,6 +332,10 @@ public class ComponentGroup extends Container {
         String o = (String) c.getClientProperty("$origUIID");
         if (o != null) {
             c.setUIID(o);
+            // Dropped here as well as on departure, because this is the group giving
+            // the UIID back. Kept, a member renamed while the group is inactive is
+            // restored to the name from the previous grouping the next time round.
+            c.putClientProperty("$origUIID", null);
         }
         reverseRadio(c, false);
     }

--- a/CodenameOne/src/com/codename1/ui/ComponentGroup.java
+++ b/CodenameOne/src/com/codename1/ui/ComponentGroup.java
@@ -101,10 +101,30 @@ public class ComponentGroup extends Container {
         return c;
     }
 
-    private void reverseRadio(Component cmp) {
-        if (cmp instanceof ComboBox) {
-            ((ComboBox) cmp).setActAsSpinnerDialog(uiidsDirty);
+    /// A grouped ComboBox opens as a spinner rather than a popup. Leaving the group has
+    /// to put that back, and put back what the application chose rather than false:
+    /// this keyed off the group's own dirty flag, so restoring a combo the application
+    /// had deliberately set to spinner mode silently turned it into a popup.
+    ///
+    /// #### Parameters
+    ///
+    /// - `cmp`: the member whose popup mode should follow the group
+    /// - `grouped`: true while this group owns the member
+    private void reverseRadio(Component cmp, boolean grouped) {
+        if (!(cmp instanceof ComboBox)) {
+            return;
         }
+        ComboBox cb = (ComboBox) cmp;
+        if (grouped) {
+            if (cb.getClientProperty("$origSpinner") == null) {
+                cb.putClientProperty("$origSpinner",
+                        cb.isActAsSpinnerDialog() ? Boolean.TRUE : Boolean.FALSE);
+            }
+            cb.setActAsSpinnerDialog(true);
+            return;
+        }
+        Object o = cb.getClientProperty("$origSpinner");
+        cb.setActAsSpinnerDialog(o instanceof Boolean && ((Boolean) o).booleanValue());
     }
 
     @Override
@@ -133,6 +153,9 @@ public class ComponentGroup extends Container {
         if (o != null) {
             cmp.setUIID((String) o);
         }
+        // and the popup mode with it -- restoring the name alone left a removed
+        // ComboBox opening as a spinner for the rest of its life.
+        reverseRadio(cmp, false);
         updateUIIDs();
     }
 
@@ -173,7 +196,7 @@ public class ComponentGroup extends Container {
             c.putClientProperty("$origUIID", c.getUIID());
         }
         c.setUIID(newUIID);
-        reverseRadio(c);
+        reverseRadio(c, true);
     }
 
     /// Whether this group is currently renaming its members' UIIDs. updateUIIDs()
@@ -243,7 +266,7 @@ public class ComponentGroup extends Container {
         if (o != null) {
             c.setUIID(o);
         }
-        reverseRadio(c);
+        reverseRadio(c, false);
     }
 
     /// Indicates that the component group should be horizontal by using the BoxLayout Y

--- a/CodenameOne/src/com/codename1/ui/ComponentGroup.java
+++ b/CodenameOne/src/com/codename1/ui/ComponentGroup.java
@@ -124,7 +124,17 @@ public class ComponentGroup extends Container {
             return;
         }
         Object o = cb.getClientProperty("$origSpinner");
-        cb.setActAsSpinnerDialog(o instanceof Boolean && ((Boolean) o).booleanValue());
+        if (!(o instanceof Boolean)) {
+            // No snapshot means this group never took the combo's popup mode, so there
+            // is nothing of ours to undo. Treating that as false would take spinner
+            // mode away from an application that had asked for it, merely because the
+            // combo passed through an inert group.
+            return;
+        }
+        cb.setActAsSpinnerDialog(((Boolean) o).booleanValue());
+        // Scoped to one membership. Left set, the next grouping keeps a snapshot taken
+        // before the application's later change and restores the stale value.
+        cb.putClientProperty("$origSpinner", null);
     }
 
     @Override
@@ -148,6 +158,13 @@ public class ComponentGroup extends Container {
     void removeComponentImpl(Component cmp) {
         super.removeComponentImpl(cmp);
 
+        // Re-group what genuinely remains BEFORE restoring the member that left.
+        // An animated removal keeps cmp in the component list until its animation
+        // callback fires, so a restore placed ahead of this is immediately undone --
+        // and that callback goes to Container.removeComponentImplNoAnimationSafety,
+        // which never reaches this class, so nothing would put it back.
+        updateUIIDs();
+
         // restore original UIID
         Object o = cmp.getClientProperty("$origUIID");
         if (o != null) {
@@ -156,7 +173,6 @@ public class ComponentGroup extends Container {
         // and the popup mode with it -- restoring the name alone left a removed
         // ComboBox opening as a spinner for the rest of its life.
         reverseRadio(cmp, false);
-        updateUIIDs();
     }
 
     private String elementPrefix(Component c) {

--- a/CodenameOne/src/com/codename1/ui/ComponentGroup.java
+++ b/CodenameOne/src/com/codename1/ui/ComponentGroup.java
@@ -256,6 +256,18 @@ public class ComponentGroup extends Container {
         }
     }
 
+    /// A member configured through setUIID(portrait, landscape) is only half handled
+    /// here, and deliberately so. getUIID resolves to whichever alias matches the
+    /// current orientation and the one-argument setUIID writes the portrait slot, so
+    /// in landscape the group's name never takes effect and a restore can put a
+    /// landscape alias into the portrait slot.
+    ///
+    /// It is not fixable from this class: Component.landscapeUiid is private with no
+    /// accessor, so there is nothing here to read or put back. Doing it properly means
+    /// giving Component a way to read and swap both aliases together, which is a change
+    /// to core styling rather than to this container. Nothing about it is new -- every
+    /// group that has ever been active has behaved this way -- so it is recorded here
+    /// rather than worked around.
     private void updateUIID(String newUIID, Component c) {
         Object o = c.getClientProperty("$origUIID");
         if (o == null) {

--- a/CodenameOne/src/com/codename1/ui/ComponentGroup.java
+++ b/CodenameOne/src/com/codename1/ui/ComponentGroup.java
@@ -265,26 +265,27 @@ public class ComponentGroup extends Container {
     ///
     /// - `horizontal`: the horizontal to set
     public void setHorizontal(boolean horizontal) {
-        if (horizontal != isHorizontal()) {
-            if (horizontal) {
-                setLayout(new BoxLayout(BoxLayout.X_AXIS));
-                if ("GroupElement".equals(elementUIID)) {
-                    elementUIID = "ToggleButton";
-                    buttonUIID = "ToggleButton";
-                    updateUIIDs();
-                }
-            } else {
-                setLayout(new BoxLayout(BoxLayout.Y_AXIS));
-                if ("ToggleButton".equals(elementUIID)) {
-                    elementUIID = "GroupElement";
-                    buttonUIID = "ButtonGroup";
-                    // Leaving the segmented state can deactivate the group, and updateUIIDs
-                    // only ever renames -- it has no path back. Restore here, or the members
-                    // keep the ToggleButton names a vertical group no longer justifies.
-                    applyOrRestore();
-                }
+        if (horizontal == isHorizontal()) {
+            return;
+        }
+        if (horizontal) {
+            setLayout(new BoxLayout(BoxLayout.X_AXIS));
+            if ("GroupElement".equals(elementUIID)) {
+                elementUIID = "ToggleButton";
+                buttonUIID = "ToggleButton";
+            }
+        } else {
+            setLayout(new BoxLayout(BoxLayout.Y_AXIS));
+            if ("ToggleButton".equals(elementUIID)) {
+                elementUIID = "GroupElement";
+                buttonUIID = "ButtonGroup";
             }
         }
+        // Unconditional, because orientation alone decides this. A group already carrying
+        // the ToggleButton UIID becomes segmented merely by turning horizontal, and the
+        // swap above does not run for it -- so confining this to the swap left such a
+        // group reporting that it owned its members' UIIDs while they kept their own.
+        applyOrRestore();
     }
 
     /// The UIID to apply to the elements within this container

--- a/CodenameOne/src/com/codename1/ui/ComponentGroup.java
+++ b/CodenameOne/src/com/codename1/ui/ComponentGroup.java
@@ -117,17 +117,10 @@ public class ComponentGroup extends Container {
     @Override
     public void refreshTheme(boolean merge) {
         super.refreshTheme(merge);
-        boolean ignoreGroup = getUIManager().isThemeConstant(groupFlag, false);
-        if (ignoreGroup || forceGroup) {
+        if (isGroupingActive()) {
             updateUIIDs();
         } else {
-            if (uiidsDirty) {
-                uiidsDirty = false;
-                int count = getComponentCount();
-                for (int iter = 0; iter < count; iter++) {
-                    restoreUIID(getComponentAt(iter));
-                }
-            }
+            restoreAllUIIDs();
         }
     }
 
@@ -152,7 +145,7 @@ public class ComponentGroup extends Container {
     }
 
     private void updateUIIDs() {
-        if (!(getUIManager().isThemeConstant(groupFlag, false) || forceGroup)) {
+        if (!isGroupingActive()) {
             return;
         }
         int count = getComponentCount();
@@ -193,7 +186,43 @@ public class ComponentGroup extends Container {
     ///
     /// true when this group assigns its members' UIIDs
     boolean isGroupingActive() {
-        return getUIManager().isThemeConstant(groupFlag, false) || forceGroup;
+        return getUIManager().isThemeConstant(groupFlag, false) || forceGroup || isSegmented();
+    }
+
+    /// True when this group is a segmented control: horizontal, and still using the
+    /// ToggleButton UIIDs that setHorizontal installs. Such a group renames its members
+    /// whether or not the theme sets the group flag.
+    ///
+    /// The flag exists so a theme that doesn't want the grouped-row look isn't forced
+    /// into it, and it still governs the vertical GroupElement path. It cannot govern
+    /// this one: neither modern native theme sets the flag, both style
+    /// ToggleButton/First/Last/Only in full, and a segmented control is the only use of
+    /// ComponentGroup those themes have any styling for -- so honouring the flag here
+    /// means setHorizontal(true) silently does nothing on the themes every new app uses.
+    ///
+    /// Renaming to ToggleButton without asking the theme first is what Button.setToggle
+    /// already does, ungated, so an app that uses toggle buttons at all already depends
+    /// on that UIID resolving.
+    ///
+    /// #### Returns
+    ///
+    /// true when this group is a horizontal ToggleButton segmented control
+    private boolean isSegmented() {
+        return isHorizontal() && "ToggleButton".equals(elementUIID);
+    }
+
+    /// Puts every member back to the UIID it had before this group renamed it, if this
+    /// group ever did. updateUIIDs only renames, so every path that can deactivate a
+    /// group needs this as its other half.
+    private void restoreAllUIIDs() {
+        if (!uiidsDirty) {
+            return;
+        }
+        uiidsDirty = false;
+        int count = getComponentCount();
+        for (int iter = 0; iter < count; iter++) {
+            restoreUIID(getComponentAt(iter));
+        }
     }
 
     private void restoreUIID(Component c) {
@@ -236,7 +265,14 @@ public class ComponentGroup extends Container {
                 if ("ToggleButton".equals(elementUIID)) {
                     elementUIID = "GroupElement";
                     buttonUIID = "ButtonGroup";
-                    updateUIIDs();
+                    // Leaving the segmented state can deactivate the group, and updateUIIDs
+                    // only ever renames -- it has no path back. Restore here, or the members
+                    // keep the ToggleButton names a vertical group no longer justifies.
+                    if (isGroupingActive()) {
+                        updateUIIDs();
+                    } else {
+                        restoreAllUIIDs();
+                    }
                 }
             }
         }
@@ -356,6 +392,17 @@ public class ComponentGroup extends Container {
     ///
     /// - `forceGroup`: the forceGroup to set
     public void setForceGroup(boolean forceGroup) {
+        if (this.forceGroup == forceGroup) {
+            return;
+        }
         this.forceGroup = forceGroup;
+        // Assigning the field was the whole method, so the setter only ever took effect
+        // if something else happened to call updateUIIDs afterwards -- adding a component,
+        // or a theme refresh. Turning it off never restored anything at all.
+        if (isGroupingActive()) {
+            updateUIIDs();
+        } else {
+            restoreAllUIIDs();
+        }
     }
 }

--- a/CodenameOne/src/com/codename1/ui/ComponentGroup.java
+++ b/CodenameOne/src/com/codename1/ui/ComponentGroup.java
@@ -199,6 +199,16 @@ public class ComponentGroup extends Container {
         Object o = cmp.getClientProperty("$origUIID");
         if (o != null) {
             cmp.setUIID((String) o);
+            // Cleared on departure, so a later membership snapshots what the component
+            // wears then. Kept, the null check in updateUIID never fires again and a
+            // component that was grouped, given a new UIID, and grouped a second time
+            // is restored to the name it had two memberships ago.
+            //
+            // Only on departure. A group that merely goes inactive still holds the
+            // member, and Button reads this marker while deciding what leaving toggle
+            // mode should restore -- clearing it there would change behaviour that has
+            // its own tests.
+            cmp.putClientProperty("$origUIID", null);
         }
         // and the popup mode with it -- restoring the name alone left a removed
         // ComboBox opening as a spinner for the rest of its life.

--- a/CodenameOne/src/com/codename1/ui/ComponentGroup.java
+++ b/CodenameOne/src/com/codename1/ui/ComponentGroup.java
@@ -137,9 +137,17 @@ public class ComponentGroup extends Container {
         cb.putClientProperty("$origSpinner", null);
     }
 
+    /// Hooked on the Impl rather than on insertComponentAt for the same reason the
+    /// removal side is hooked on removeComponentImplNoAnimationSafety: this is where
+    /// the member genuinely enters the component list, and every route arrives here.
+    /// insertComponentAt only QUEUES the insertion while the AnimationManager is
+    /// animating, so positions recomputed there do not count the arriving member, and
+    /// the queued callback goes straight to Container and never returns to this class.
+    /// replace() reaches this too, which is the only way its incoming member is grouped
+    /// at all -- it never calls insertComponentAt.
     @Override
-    void insertComponentAt(int index, Object con, Component cmp) {
-        super.insertComponentAt(index, con, cmp);
+    void insertComponentAtImpl(int index, Component cmp) {
+        super.insertComponentAtImpl(index, cmp);
         updateUIIDs();
     }
 
@@ -173,9 +181,6 @@ public class ComponentGroup extends Container {
     /// two-element group reading Last rather than Only. The queued callback goes
     /// straight to Container, so nothing else would correct it.
     ///
-    /// Note replace() reaches this but inserts through insertComponentAtImpl, which
-    /// this class does not override, so the incoming component is not grouped. That is
-    /// long-standing and left alone here.
     @Override
     void removeComponentImplNoAnimationSafety(Component cmp) {
         super.removeComponentImplNoAnimationSafety(cmp);

--- a/CodenameOne/src/com/codename1/ui/ComponentGroup.java
+++ b/CodenameOne/src/com/codename1/ui/ComponentGroup.java
@@ -211,6 +211,19 @@ public class ComponentGroup extends Container {
         return isHorizontal() && "ToggleButton".equals(elementUIID);
     }
 
+    /// Applies or undoes this group's renaming to match its current state. Every mutator
+    /// that can change the answer to isGroupingActive has to go through here: updateUIIDs
+    /// only renames and returns early when the group is inactive, so a setter that
+    /// deactivates a group and then calls it leaves the members wearing names from the
+    /// state the group just left.
+    private void applyOrRestore() {
+        if (isGroupingActive()) {
+            updateUIIDs();
+        } else {
+            restoreAllUIIDs();
+        }
+    }
+
     /// Puts every member back to the UIID it had before this group renamed it, if this
     /// group ever did. updateUIIDs only renames, so every path that can deactivate a
     /// group needs this as its other half.
@@ -268,11 +281,7 @@ public class ComponentGroup extends Container {
                     // Leaving the segmented state can deactivate the group, and updateUIIDs
                     // only ever renames -- it has no path back. Restore here, or the members
                     // keep the ToggleButton names a vertical group no longer justifies.
-                    if (isGroupingActive()) {
-                        updateUIIDs();
-                    } else {
-                        restoreAllUIIDs();
-                    }
+                    applyOrRestore();
                 }
             }
         }
@@ -295,7 +304,7 @@ public class ComponentGroup extends Container {
     public void setElementUIID(String elementUIID) {
         this.elementUIID = elementUIID;
         buttonUIID = elementUIID;
-        updateUIIDs();
+        applyOrRestore();
     }
 
     /// {@inheritDoc}
@@ -343,11 +352,14 @@ public class ComponentGroup extends Container {
             return null;
         }
         if ("groupFlag".equals(name)) {
-            setGroupFlag(groupFlag);
+            // Passed the field rather than the value, so setting this property
+            // assigned the flag to itself and the designer's edit was discarded.
+            setGroupFlag((String) value);
             return null;
         }
         if ("forceGroup".equals(name)) {
-            forceGroup = ((Boolean) value).booleanValue();
+            // Assigning the field skips the apply/restore the setter does.
+            setForceGroup(((Boolean) value).booleanValue());
             return null;
         }
         return super.setPropertyValue(name, value);
@@ -372,7 +384,13 @@ public class ComponentGroup extends Container {
     ///
     /// - `groupFlag`: the groupFlag to set
     public void setGroupFlag(String groupFlag) {
+        if (this.groupFlag == null ? groupFlag == null : this.groupFlag.equals(groupFlag)) {
+            return;
+        }
         this.groupFlag = groupFlag;
+        // Naming a different constant can activate or deactivate the group, and
+        // assigning the field was the whole method.
+        applyOrRestore();
     }
 
     /// Component grouping can be an element from the theme but can be forced manually
@@ -399,10 +417,6 @@ public class ComponentGroup extends Container {
         // Assigning the field was the whole method, so the setter only ever took effect
         // if something else happened to call updateUIIDs afterwards -- adding a component,
         // or a theme refresh. Turning it off never restored anything at all.
-        if (isGroupingActive()) {
-            updateUIIDs();
-        } else {
-            restoreAllUIIDs();
-        }
+        applyOrRestore();
     }
 }

--- a/CodenameOne/src/com/codename1/ui/ComponentGroup.java
+++ b/CodenameOne/src/com/codename1/ui/ComponentGroup.java
@@ -32,9 +32,15 @@ import com.codename1.ui.layouts.Layout;
 /// GroupElementFirst/GroupElementLast UIID's applied to them. If a group has only one element
 /// the word "Only" is appended to the element UIID as in GroupElementOnly.
 ///
-/// **Important!!!** A component group does nothing by default unless explicitly activated by
+/// **Important!!!** A *vertical* component group does nothing by default unless explicitly activated by
 /// the theme by enabling the ComponentGroupBool constant (by default, this can be customized via the groupFlag property).
 /// This allows logical grouping without changing the UI for themes that don't need grouping.
+///
+/// A *horizontal* group is the exception and needs no constant. setHorizontal(true) makes it a
+/// segmented control and renames its members to ToggleButton, which the native themes style along
+/// with its First/Last/Only variants, so honouring the constant here would leave setHorizontal(true)
+/// doing nothing on the themes new applications use. The exception is exactly that wide: give the
+/// group your own UIID with setElementUIID and it is theme-gated again, like a vertical one.
 ///
 /// This container uses box X/Y layout (defaults to Y), other layout managers shouldn't be used
 /// since this container relies on the specific behavior of the box layout.
@@ -278,7 +284,8 @@ public class ComponentGroup extends Container {
     }
 
     /// Whether this group is currently renaming its members' UIIDs. updateUIIDs()
-    /// does nothing unless the theme constant is on or grouping is forced, and
+    /// does nothing unless the theme constant is on, grouping is forced, or this is
+    /// a horizontal group still using the ToggleButton UIIDs setHorizontal gives it, and
     /// Button needs the same answer to know whether a member's live UIID belongs
     /// to the group or to itself. $origUIID cannot answer it either: it is absent
     /// between memberships and present during one, but it is set from inside

--- a/CodenameOne/src/com/codename1/ui/ComponentGroup.java
+++ b/CodenameOne/src/com/codename1/ui/ComponentGroup.java
@@ -381,23 +381,32 @@ public class ComponentGroup extends Container {
         if (horizontal == isHorizontal()) {
             return;
         }
+        // The UIID swap comes first and the layout change second, because setLayout is
+        // what reconciles the members now and it has to see the names this group means
+        // to use. Reversed, it would run once against a half-changed group.
         if (horizontal) {
-            setLayout(new BoxLayout(BoxLayout.X_AXIS));
             if ("GroupElement".equals(elementUIID)) {
                 elementUIID = "ToggleButton";
                 buttonUIID = "ToggleButton";
             }
+            setLayout(new BoxLayout(BoxLayout.X_AXIS));
         } else {
-            setLayout(new BoxLayout(BoxLayout.Y_AXIS));
             if ("ToggleButton".equals(elementUIID)) {
                 elementUIID = "GroupElement";
                 buttonUIID = "ButtonGroup";
             }
+            setLayout(new BoxLayout(BoxLayout.Y_AXIS));
         }
-        // Unconditional, because orientation alone decides this. A group already carrying
-        // the ToggleButton UIID becomes segmented merely by turning horizontal, and the
-        // swap above does not run for it -- so confining this to the swap left such a
-        // group reporting that it owned its members' UIIDs while they kept their own.
+    }
+
+    /// Orientation decides activation for a segmented group, and this is public API on
+    /// Container that reaches it without going through setHorizontal: dropping a Y axis
+    /// layout on a populated horizontal group deactivates it, and an X axis one on a
+    /// group already carrying the ToggleButton UIID activates it. Reconciling here
+    /// rather than in setHorizontal covers both routes with one rule.
+    @Override
+    public void setLayout(Layout layout) {
+        super.setLayout(layout);
         applyOrRestore();
     }
 

--- a/CodenameOne/src/com/codename1/ui/ComponentGroup.java
+++ b/CodenameOne/src/com/codename1/ui/ComponentGroup.java
@@ -157,15 +157,40 @@ public class ComponentGroup extends Container {
     @Override
     void removeComponentImpl(Component cmp) {
         super.removeComponentImpl(cmp);
+        // An animated removal only QUEUES the physical removal, so this member can sit
+        // in the component list for the length of the animation. Give it its own UIID
+        // back now rather than at completion, or it spends the animation wearing the
+        // group's -- and if the animation never completes, keeps it.
+        restoreDeparting(cmp);
+    }
 
-        // Re-group what genuinely remains BEFORE restoring the member that left.
-        // An animated removal keeps cmp in the component list until its animation
-        // callback fires, so a restore placed ahead of this is immediately undone --
-        // and that callback goes to Container.removeComponentImplNoAnimationSafety,
-        // which never reaches this class, so nothing would put it back.
+    /// Also hooked here, because this is the point at which the member is genuinely
+    /// out of the component list, and every route arrives at it: the immediate
+    /// removal, the one the AnimationManager queues, and replace().
+    ///
+    /// removeComponentImpl runs BEFORE a queued removal completes, so positional UIIDs
+    /// recomputed there still count the departing member and leave the survivor of a
+    /// two-element group reading Last rather than Only. The queued callback goes
+    /// straight to Container, so nothing else would correct it.
+    ///
+    /// Note replace() reaches this but inserts through insertComponentAtImpl, which
+    /// this class does not override, so the incoming component is not grouped. That is
+    /// long-standing and left alone here.
+    @Override
+    void removeComponentImplNoAnimationSafety(Component cmp) {
+        super.removeComponentImplNoAnimationSafety(cmp);
+        // Survivors first, then the member that left, so nothing re-applies the
+        // group's names to it.
         updateUIIDs();
+        restoreDeparting(cmp);
+    }
 
-        // restore original UIID
+    /// Hands a member that has left this group back what the group took from it.
+    ///
+    /// #### Parameters
+    ///
+    /// - `cmp`: the departing member
+    private void restoreDeparting(Component cmp) {
         Object o = cmp.getClientProperty("$origUIID");
         if (o != null) {
             cmp.setUIID((String) o);

--- a/docs/developer-guide/The-Components-Of-Codename-One.asciidoc
+++ b/docs/developer-guide/The-Components-Of-Codename-One.asciidoc
@@ -775,7 +775,7 @@ Notice the following about the code above and the resulting image:
 
 - When an element is placed alone within a `ComponentGroup` its a special case `UIID`.
 
-IMPORTANT: By default, `ComponentGroup` does *nothing*. You need to explicitly activate it in the theme by setting a theme property to true. Specifically you need to set `ComponentGroupBool` to `true` for `ComponentGroup` to do something otherwise its a box layout container! The `ComponentGroupBool` flag is true by default in the iOS native theme.
+IMPORTANT: A vertical `ComponentGroup` does *nothing* unless the theme sets the `ComponentGroupBool` constant to `true`; without it the group is just a box layout container. The legacy iOS themes set that flag, the current native themes don't, and neither of them styles the `GroupElement` UIIDs a vertical group applies. A *horizontal* group is the exception and needs no constant: it's a segmented control, it renames its members to `ToggleButton`, and both native themes style that UIID and its `First` / `Last` / `Only` variants in full.
 
 When `ComponentGroupBool` is set to true, the component group will change the styles of all components placed within it to match the element UIID given to it (GroupElement by default) with special caveats to the first/last/ elements. For example:
 

--- a/docs/developer-guide/The-Components-Of-Codename-One.asciidoc
+++ b/docs/developer-guide/The-Components-Of-Codename-One.asciidoc
@@ -775,7 +775,7 @@ Notice the following about the code above and the resulting image:
 
 - When an element is placed alone within a `ComponentGroup` its a special case `UIID`.
 
-IMPORTANT: A vertical `ComponentGroup` does *nothing* unless the theme sets the `ComponentGroupBool` constant to `true`; without it the group is just a box layout container. The legacy iOS themes set that flag, the current native themes don't, and neither of them styles the `GroupElement` UIIDs a vertical group applies. A *horizontal* group is the exception and needs no constant: it's a segmented control, it renames its members to `ToggleButton`, and both native themes style that UIID and its `First` / `Last` / `Only` variants in full.
+IMPORTANT: A vertical `ComponentGroup` does *nothing* unless the theme sets the `ComponentGroupBool` constant to `true`; without it the group is just a box layout container. The legacy iOS themes set that flag, the current native themes don't, and neither of them styles the `GroupElement` UIIDs a vertical group applies. A *horizontal* group is the exception, as long as it keeps the UIID `setHorizontal` gives it: it's a segmented control, it renames its members to `ToggleButton`, and both native themes style that UIID and its `First` / `Last` / `Only` variants in full, so it needs no constant. Name your own element UIID with `setElementUIID` and it's theme-gated again, exactly like a vertical one.
 
 When `ComponentGroupBool` is set to true, the component group will change the styles of all components placed within it to match the element UIID given to it (GroupElement by default) with special caveats to the first/last/ elements. For example:
 

--- a/maven/core-unittests/src/test/java/com/codename1/ui/ComponentGroupSegmentedTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/ComponentGroupSegmentedTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2026, Codename One and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Codename One designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Codename One through http://www.codenameone.com/ if you
+ * need additional information or have any questions.
+ */
+
+package com.codename1.ui;
+
+import com.codename1.junit.UITestBase;
+import com.codename1.ui.plaf.UIManager;
+import org.junit.jupiter.api.Test;
+
+import java.util.Hashtable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/// A horizontal ComponentGroup is a segmented control, and it is the only use of
+/// ComponentGroup the current native themes carry any styling for: they style
+/// ToggleButton and its First/Last/Only variants in full and define no GroupElement
+/// or ButtonGroup rule at all. Neither of them sets ComponentGroupBool, so gating the
+/// segmented path on that constant made setHorizontal(true) a no-op everywhere it
+/// actually matters.
+class ComponentGroupSegmentedTest extends UITestBase {
+
+    private static void activateGrouping(boolean on) {
+        Hashtable<String, Object> theme = new Hashtable<String, Object>();
+        if (on) {
+            theme.put("@ComponentGroupBool", "true");
+        }
+        UIManager.getInstance().setThemeProps(theme);
+    }
+
+    @Test
+    void testHorizontalGroupRenamesItsMembersWithoutTheThemeConstant() {
+        activateGrouping(false);
+        ComponentGroup group = new ComponentGroup();
+        group.setHorizontal(true);
+        Button first = new Button("One");
+        Button last = new Button("Two");
+        group.addComponent(first);
+        group.addComponent(last);
+
+        assertEquals("ToggleButtonFirst", first.getUIID(),
+                "a segmented control has to style its edges, or the theme's "
+                        + "ToggleButtonFirst/Last rules are unreachable");
+        assertEquals("ToggleButtonLast", last.getUIID());
+    }
+
+    @Test
+    void testASingleMemberGetsTheOnlyVariant() {
+        activateGrouping(false);
+        ComponentGroup group = new ComponentGroup();
+        group.setHorizontal(true);
+        Button only = new Button("One");
+        group.addComponent(only);
+
+        assertEquals("ToggleButtonOnly", only.getUIID());
+    }
+
+    @Test
+    void testVerticalGroupStillHonoursTheThemeConstant() {
+        // The constant still governs the vertical GroupElement path. That path
+        // flattens Labels, TextFields and Buttons onto one UIID, so a theme that
+        // does not style GroupElement must be able to opt out -- which is the
+        // reason the flag exists and the reason this change does not remove it.
+        activateGrouping(false);
+        ComponentGroup group = new ComponentGroup();
+        Button b = new Button("One");
+        group.addComponent(b);
+
+        assertEquals("Button", b.getUIID(),
+                "an inactive vertical group must leave its members alone");
+    }
+
+    @Test
+    void testHorizontalGroupWithACustomElementUiidStillHonoursTheConstant() {
+        // Activation is deliberately narrow: it recognises the ToggleButton UIIDs
+        // setHorizontal installs, not "horizontal" on its own. An application that
+        // chose its own UIID gets the documented theme-gated behaviour.
+        activateGrouping(false);
+        ComponentGroup group = new ComponentGroup();
+        group.setElementUIID("MyElement");
+        group.setHorizontal(true);
+        Button b = new Button("One");
+        group.addComponent(b);
+
+        assertEquals("Button", b.getUIID(),
+                "a custom element UIID is not the framework's segmented control");
+    }
+
+    @Test
+    void testLeavingHorizontalRestoresTheOriginalUiids() {
+        activateGrouping(false);
+        ComponentGroup group = new ComponentGroup();
+        group.setHorizontal(true);
+        Button b = new Button("One");
+        group.addComponent(b);
+        assertNotEquals("Button", b.getUIID());
+
+        group.setHorizontal(false);
+
+        assertEquals("Button", b.getUIID(),
+                "updateUIIDs only renames, so the path out of the segmented state "
+                        + "has to restore or the member keeps a name nothing styles");
+    }
+
+    @Test
+    void testSetForceGroupAppliesWithoutWaitingForAnotherEvent() {
+        // setForceGroup only assigned the field, so it took effect if and only if
+        // something later happened to call updateUIIDs -- adding a component, or a
+        // theme refresh. On a group already populated it did nothing at all.
+        activateGrouping(false);
+        ComponentGroup group = new ComponentGroup();
+        Button b = new Button("One");
+        group.addComponent(b);
+        assertEquals("Button", b.getUIID());
+
+        group.setForceGroup(true);
+
+        // a Button takes buttonUIID ("ButtonGroup"), not elementUIID -- see elementPrefix
+        assertEquals("ButtonGroupOnly", b.getUIID(),
+                "the setter has to apply the change it records");
+    }
+
+    @Test
+    void testClearingForceGroupRestores() {
+        activateGrouping(false);
+        ComponentGroup group = new ComponentGroup();
+        Button b = new Button("One");
+        group.addComponent(b);
+        group.setForceGroup(true);
+        assertEquals("ButtonGroupOnly", b.getUIID());
+
+        group.setForceGroup(false);
+
+        assertEquals("Button", b.getUIID(),
+                "turning forcing off has to hand the UIID back");
+    }
+
+    @Test
+    void testASegmentedGroupStaysActiveWhenForcingIsCleared() {
+        // Deliberate behaviour change: a horizontal ToggleButton group is active on its
+        // own, so clearing forceGroup no longer deactivates it. Before this, the only
+        // way such a group ever grouped was the flag or forcing, which is the defect.
+        activateGrouping(false);
+        ComponentGroup group = new ComponentGroup();
+        group.setForceGroup(true);
+        group.setHorizontal(true);
+        Button b = new Button("One");
+        group.addComponent(b);
+        assertEquals("ToggleButtonOnly", b.getUIID());
+
+        group.setForceGroup(false);
+
+        assertEquals("ToggleButtonOnly", b.getUIID(),
+                "a segmented control does not stop being one because forcing was cleared");
+    }
+}

--- a/maven/core-unittests/src/test/java/com/codename1/ui/ComponentGroupSegmentedTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/ComponentGroupSegmentedTest.java
@@ -518,4 +518,51 @@ class ComponentGroupSegmentedTest extends UITestBase {
         assertEquals("Custom", b.getUIID(),
                 "the second restore returns the UIID the component actually had");
     }
+
+    @Test
+    void testDeactivatingAlsoDropsTheSavedUiid() {
+        // Deactivating is the group giving the UIID back, so it has to drop the
+        // snapshot for the same reason departing does: kept, a member renamed while
+        // the group is inactive is restored to the earlier name next time round.
+        activateGrouping(false);
+        ComponentGroup group = new ComponentGroup();
+        group.setHorizontal(true);
+        Button b = new Button("One");
+        group.addComponent(b);
+        assertEquals("ToggleButtonOnly", b.getUIID());
+
+        group.setHorizontal(false);
+        assertEquals("Button", b.getUIID(), "deactivating restores");
+
+        b.setUIID("Custom");
+        group.setHorizontal(true);
+        assertEquals("ToggleButtonOnly", b.getUIID(), "and grouping again renames");
+        group.setHorizontal(false);
+
+        assertEquals("Custom", b.getUIID(),
+                "the second restore returns the UIID the component actually had");
+    }
+
+    @Test
+    void testReorderingRefreshesThePositionalUiids() {
+        // Container.drop reorders through setComponentIndex and starts a layout
+        // animation, reaching neither the insertion nor the removal hook, so a dragged
+        // segment kept the UIID of the position it came from.
+        activateGrouping(false);
+        ComponentGroup group = new ComponentGroup();
+        group.setHorizontal(true);
+        Button first = new Button("One");
+        Button last = new Button("Two");
+        group.addComponent(first);
+        group.addComponent(last);
+        assertEquals("ToggleButtonFirst", first.getUIID());
+        assertEquals("ToggleButtonLast", last.getUIID());
+
+        group.setComponentIndex(first, 1);
+
+        assertEquals("ToggleButtonLast", first.getUIID(),
+                "the segment moved to the end is styled as the end");
+        assertEquals("ToggleButtonFirst", last.getUIID(),
+                "and the one now at the start is styled as the start");
+    }
 }

--- a/maven/core-unittests/src/test/java/com/codename1/ui/ComponentGroupSegmentedTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/ComponentGroupSegmentedTest.java
@@ -30,7 +30,9 @@ import org.junit.jupiter.api.Test;
 import java.util.Hashtable;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /// A horizontal ComponentGroup is a segmented control, and it is the only use of
 /// ComponentGroup the current native themes carry any styling for: they style
@@ -280,5 +282,43 @@ class ComponentGroupSegmentedTest extends UITestBase {
 
         assertEquals("ToggleButtonOnly", b.getUIID(),
                 "turning horizontal is what activates this group, so it has to apply");
+    }
+
+    @Test
+    void testRemovingAComboFromASegmentedGroupRestoresItsPopupMode() {
+        // A grouped ComboBox is forced into spinner mode. Removal restored the UIID and
+        // nothing else, so the combo kept opening as a spinner after it had left. The
+        // self-activating segmented group is what makes this reachable with no theme
+        // constant set.
+        activateGrouping(false);
+        ComponentGroup group = new ComponentGroup();
+        group.setHorizontal(true);
+        ComboBox<String> combo = new ComboBox<String>("a", "b");
+        assertFalse(combo.isActAsSpinnerDialog(), "default popup mode");
+        group.addComponent(combo);
+        assertTrue(combo.isActAsSpinnerDialog(), "a grouped combo opens as a spinner");
+
+        group.removeComponent(combo);
+
+        assertFalse(combo.isActAsSpinnerDialog(),
+                "leaving the group has to hand the popup mode back");
+    }
+
+    @Test
+    void testLeavingAGroupRestoresAnApplicationsOwnSpinnerChoice() {
+        // The restore keyed off the group's dirty flag rather than the value the
+        // application chose, so a combo deliberately set to spinner mode came back
+        // as a popup.
+        activateGrouping(false);
+        ComponentGroup group = new ComponentGroup();
+        group.setHorizontal(true);
+        ComboBox<String> combo = new ComboBox<String>("a", "b");
+        combo.setActAsSpinnerDialog(true);
+        group.addComponent(combo);
+
+        group.removeComponent(combo);
+
+        assertTrue(combo.isActAsSpinnerDialog(),
+                "the application asked for spinner mode, so it survives the group");
     }
 }

--- a/maven/core-unittests/src/test/java/com/codename1/ui/ComponentGroupSegmentedTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/ComponentGroupSegmentedTest.java
@@ -400,4 +400,63 @@ class ComponentGroupSegmentedTest extends UITestBase {
         assertEquals("ComboBox", combo.getUIID(),
                 "and its UIID with it");
     }
+
+    @Test
+    void testSurvivorsAreRegroupedAfterAnAnimatedRemovalCompletes() {
+        // removeComponentImpl runs while the AnimationManager still has the departing
+        // member queued, so positional UIIDs recomputed there count it and the survivor
+        // of a two-element group reads Last instead of Only.
+        activateGrouping(false);
+        Form f = new Form("host");
+        ComponentGroup group = new ComponentGroup();
+        group.setHorizontal(true);
+        Button first = new Button("One");
+        Button second = new Button("Two");
+        group.addComponent(first);
+        group.addComponent(second);
+        f.add(group);
+        f.show();
+        assertEquals("ToggleButtonFirst", first.getUIID());
+        assertEquals("ToggleButtonLast", second.getUIID());
+
+        f.getAnimationManager().addAnimation(new ComponentAnimation() {
+            public boolean isInProgress() {
+                return true;
+            }
+
+            protected void updateState() {
+            }
+        });
+        assertTrue(f.getAnimationManager().isAnimating(), "the queued-removal path needs this");
+
+        group.removeComponent(first);
+        f.getAnimationManager().flush();
+
+        assertEquals("ToggleButtonOnly", second.getUIID(),
+                "the last member standing is Only, not Last");
+        assertEquals("Button", first.getUIID(),
+                "and the one that left keeps nothing of the group's");
+    }
+
+    @Test
+    void testReplacingAMemberHandsTheOutgoingOneItsUiidBack() {
+        // replace() goes to removeComponentImplNoAnimationSafety directly, so an
+        // override on removeComponentImpl never saw it and the replaced component kept
+        // the group's UIID for good.
+        activateGrouping(false);
+        ComponentGroup group = new ComponentGroup();
+        group.setHorizontal(true);
+        Button original = new Button("One");
+        group.addComponent(original);
+        assertEquals("ToggleButtonOnly", original.getUIID());
+
+        Button replacement = new Button("Two");
+        group.replace(original, replacement, null);
+
+        assertEquals("Button", original.getUIID(),
+                "a replaced member leaves the group and takes its own UIID with it");
+        // The replacement is deliberately not asserted as grouped: replace() inserts
+        // through insertComponentAtImpl, which this class does not override, so it
+        // never has been. That is long-standing and outside this change.
+    }
 }

--- a/maven/core-unittests/src/test/java/com/codename1/ui/ComponentGroupSegmentedTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/ComponentGroupSegmentedTest.java
@@ -24,6 +24,7 @@
 package com.codename1.ui;
 
 import com.codename1.junit.UITestBase;
+import com.codename1.ui.animations.ComponentAnimation;
 import com.codename1.ui.plaf.UIManager;
 import org.junit.jupiter.api.Test;
 
@@ -320,5 +321,83 @@ class ComponentGroupSegmentedTest extends UITestBase {
 
         assertTrue(combo.isActAsSpinnerDialog(),
                 "the application asked for spinner mode, so it survives the group");
+    }
+
+    @Test
+    void testAnInertGroupDoesNotTakeSpinnerModeAway() {
+        // An inactive group never records a snapshot, so a missing one must not be read
+        // as "it was false". Otherwise passing a combo through an inert ComponentGroup
+        // quietly turns off spinner mode the application asked for.
+        activateGrouping(false);
+        ComponentGroup group = new ComponentGroup();
+        ComboBox<String> combo = new ComboBox<String>("a", "b");
+        combo.setActAsSpinnerDialog(true);
+        group.addComponent(combo);
+        assertTrue(combo.isActAsSpinnerDialog(), "an inert group changes nothing");
+
+        group.removeComponent(combo);
+
+        assertTrue(combo.isActAsSpinnerDialog(),
+                "a group that never grouped it has nothing to restore");
+    }
+
+    @Test
+    void testTheSpinnerSnapshotDoesNotSurviveIntoTheNextMembership() {
+        // The snapshot is per membership. Kept across two, the second restore hands back
+        // a value the application had already changed.
+        activateGrouping(false);
+        ComponentGroup first = new ComponentGroup();
+        first.setHorizontal(true);
+        ComboBox<String> combo = new ComboBox<String>("a", "b");
+        first.addComponent(combo);
+        first.removeComponent(combo);
+        assertFalse(combo.isActAsSpinnerDialog());
+
+        combo.setActAsSpinnerDialog(true);
+        ComponentGroup second = new ComponentGroup();
+        second.setHorizontal(true);
+        second.addComponent(combo);
+        second.removeComponent(combo);
+
+        assertTrue(combo.isActAsSpinnerDialog(),
+                "the second restore has to return what the application set, not the "
+                        + "snapshot the first membership took");
+    }
+
+    @Test
+    void testRemovalDuringAnAnimationStillRestoresTheMember() {
+        // Container.removeComponentImpl queues the physical removal while the
+        // AnimationManager is animating and leaves the child in the component list, so a
+        // restore that runs before updateUIIDs is immediately reapplied -- and the
+        // queued callback goes to removeComponentImplNoAnimationSafety, which never
+        // reaches ComponentGroup, so nothing would put it back.
+        activateGrouping(false);
+        Form f = new Form("host");
+        ComponentGroup group = new ComponentGroup();
+        group.setHorizontal(true);
+        ComboBox<String> combo = new ComboBox<String>("a", "b");
+        Button other = new Button("Two");
+        group.addComponent(combo);
+        group.addComponent(other);
+        f.add(group);
+        f.show();
+        assertTrue(combo.isActAsSpinnerDialog());
+
+        f.getAnimationManager().addAnimation(new ComponentAnimation() {
+            public boolean isInProgress() {
+                return true;
+            }
+
+            protected void updateState() {
+            }
+        });
+        assertTrue(f.getAnimationManager().isAnimating(), "the queued-removal path needs this");
+
+        group.removeComponent(combo);
+
+        assertFalse(combo.isActAsSpinnerDialog(),
+                "a member that leaves during an animation still has to be restored");
+        assertEquals("ComboBox", combo.getUIID(),
+                "and its UIID with it");
     }
 }

--- a/maven/core-unittests/src/test/java/com/codename1/ui/ComponentGroupSegmentedTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/ComponentGroupSegmentedTest.java
@@ -262,4 +262,23 @@ class ComponentGroupSegmentedTest extends UITestBase {
         assertEquals("ButtonGroupOnly", b.getUIID(),
                 "the property setter has to go through setForceGroup");
     }
+
+    @Test
+    void testTurningHorizontalAppliesWhenTheUiidWasAlreadyToggleButton() {
+        // setHorizontal only renamed inside its "GroupElement" branch, so a group that
+        // already carried the ToggleButton UIID became segmented on the orientation
+        // change and applied nothing: isGroupingActive said the group owned its members'
+        // UIIDs while they still wore their own, until an unrelated insert or refresh.
+        activateGrouping(false);
+        ComponentGroup group = new ComponentGroup();
+        Button b = new Button("One");
+        group.addComponent(b);
+        group.setElementUIID("ToggleButton");
+        assertEquals("Button", b.getUIID(), "still vertical, so still inactive");
+
+        group.setHorizontal(true);
+
+        assertEquals("ToggleButtonOnly", b.getUIID(),
+                "turning horizontal is what activates this group, so it has to apply");
+    }
 }

--- a/maven/core-unittests/src/test/java/com/codename1/ui/ComponentGroupSegmentedTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/ComponentGroupSegmentedTest.java
@@ -455,8 +455,44 @@ class ComponentGroupSegmentedTest extends UITestBase {
 
         assertEquals("Button", original.getUIID(),
                 "a replaced member leaves the group and takes its own UIID with it");
-        // The replacement is deliberately not asserted as grouped: replace() inserts
-        // through insertComponentAtImpl, which this class does not override, so it
-        // never has been. That is long-standing and outside this change.
+        assertEquals("ToggleButtonOnly", replacement.getUIID(),
+                "and the one that took its place is grouped -- replace() inserts through "
+                        + "insertComponentAtImpl, which is why that is hooked rather than "
+                        + "insertComponentAt");
+    }
+
+    @Test
+    void testAnInsertionDuringAnAnimationIsGroupedWhenItCompletes() {
+        // insertComponentAt only queues the insertion while the AnimationManager is
+        // animating, so recomputing positions there does not count the arriving member
+        // and the queued callback goes straight to Container.
+        activateGrouping(false);
+        Form f = new Form("host");
+        ComponentGroup group = new ComponentGroup();
+        group.setHorizontal(true);
+        Button first = new Button("One");
+        group.addComponent(first);
+        f.add(group);
+        f.show();
+        assertEquals("ToggleButtonOnly", first.getUIID());
+
+        f.getAnimationManager().addAnimation(new ComponentAnimation() {
+            public boolean isInProgress() {
+                return true;
+            }
+
+            protected void updateState() {
+            }
+        });
+        assertTrue(f.getAnimationManager().isAnimating(), "the queued-insertion path needs this");
+
+        Button second = new Button("Two");
+        group.addComponent(second);
+        f.getAnimationManager().flush();
+
+        assertEquals("ToggleButtonFirst", first.getUIID(),
+                "the member that was Only becomes First once a second one arrives");
+        assertEquals("ToggleButtonLast", second.getUIID(),
+                "and the arrival is grouped rather than left plain");
     }
 }

--- a/maven/core-unittests/src/test/java/com/codename1/ui/ComponentGroupSegmentedTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/ComponentGroupSegmentedTest.java
@@ -495,4 +495,27 @@ class ComponentGroupSegmentedTest extends UITestBase {
         assertEquals("ToggleButtonLast", second.getUIID(),
                 "and the arrival is grouped rather than left plain");
     }
+
+    @Test
+    void testTheSavedUiidDoesNotSurviveIntoTheNextMembership() {
+        // The snapshot is taken only when none is recorded, so one left over from an
+        // earlier membership means the component is restored to the name it wore two
+        // memberships ago rather than the one it has now.
+        activateGrouping(false);
+        ComponentGroup first = new ComponentGroup();
+        first.setHorizontal(true);
+        Button b = new Button("One");
+        first.addComponent(b);
+        first.removeComponent(b);
+        assertEquals("Button", b.getUIID());
+
+        b.setUIID("Custom");
+        ComponentGroup second = new ComponentGroup();
+        second.setHorizontal(true);
+        second.addComponent(b);
+        second.removeComponent(b);
+
+        assertEquals("Custom", b.getUIID(),
+                "the second restore returns the UIID the component actually had");
+    }
 }

--- a/maven/core-unittests/src/test/java/com/codename1/ui/ComponentGroupSegmentedTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/ComponentGroupSegmentedTest.java
@@ -173,4 +173,93 @@ class ComponentGroupSegmentedTest extends UITestBase {
         assertEquals("ToggleButtonOnly", b.getUIID(),
                 "a segmented control does not stop being one because forcing was cleared");
     }
+
+    @Test
+    void testChangingTheElementUiidOffToggleButtonRestores() {
+        // updateUIIDs only renames and returns early once the group is inactive, so a
+        // setter that deactivates the group and then calls it strands the members on
+        // the names they had in the state the group just left.
+        activateGrouping(false);
+        ComponentGroup group = new ComponentGroup();
+        group.setHorizontal(true);
+        Button b = new Button("One");
+        group.addComponent(b);
+        assertEquals("ToggleButtonOnly", b.getUIID());
+
+        group.setElementUIID("MyElement");
+
+        assertEquals("Button", b.getUIID(),
+                "a custom element UIID is theme-gated, so leaving the segmented UIID "
+                        + "has to hand the member back rather than strand it");
+    }
+
+    @Test
+    void testChangingTheGroupFlagToOneTheThemeSetsActivates() {
+        // setGroupFlag assigned the field and did nothing else, so naming a constant the
+        // theme does set never took effect.
+        Hashtable<String, Object> theme = new Hashtable<String, Object>();
+        theme.put("@MyGroupBool", "true");
+        UIManager.getInstance().setThemeProps(theme);
+
+        ComponentGroup group = new ComponentGroup();
+        Button b = new Button("One");
+        group.addComponent(b);
+        assertEquals("Button", b.getUIID());
+
+        group.setGroupFlag("MyGroupBool");
+
+        assertEquals("ButtonGroupOnly", b.getUIID(),
+                "naming a constant the theme sets has to activate the group");
+    }
+
+    @Test
+    void testChangingTheGroupFlagAwayFromOneTheThemeSetsRestores() {
+        Hashtable<String, Object> theme = new Hashtable<String, Object>();
+        theme.put("@ComponentGroupBool", "true");
+        UIManager.getInstance().setThemeProps(theme);
+
+        ComponentGroup group = new ComponentGroup();
+        Button b = new Button("One");
+        group.addComponent(b);
+        assertEquals("ButtonGroupOnly", b.getUIID());
+
+        group.setGroupFlag("SomeConstantNoThemeSets");
+
+        assertEquals("Button", b.getUIID(),
+                "pointing at a constant nothing sets deactivates the group");
+    }
+
+    @Test
+    void testTheGroupFlagPropertySetterUsesItsArgument() {
+        // It passed the field instead of the value, so the property assigned the flag
+        // to itself and a designer edit was silently discarded.
+        Hashtable<String, Object> theme = new Hashtable<String, Object>();
+        theme.put("@MyGroupBool", "true");
+        UIManager.getInstance().setThemeProps(theme);
+
+        ComponentGroup group = new ComponentGroup();
+        Button b = new Button("One");
+        group.addComponent(b);
+
+        group.setPropertyValue("groupFlag", "MyGroupBool");
+
+        assertEquals("MyGroupBool", group.getGroupFlag());
+        assertEquals("ButtonGroupOnly", b.getUIID(),
+                "the property setter has to use the value it was handed");
+    }
+
+    @Test
+    void testTheForceGroupPropertySetterAppliesImmediately() {
+        // It assigned the field directly, so it skipped the apply the real setter does.
+        activateGrouping(false);
+        ComponentGroup group = new ComponentGroup();
+        Button b = new Button("One");
+        group.addComponent(b);
+        assertEquals("Button", b.getUIID());
+
+        group.setPropertyValue("forceGroup", Boolean.TRUE);
+
+        assertEquals("ButtonGroupOnly", b.getUIID(),
+                "the property setter has to go through setForceGroup");
+    }
 }

--- a/maven/core-unittests/src/test/java/com/codename1/ui/ComponentGroupSegmentedTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/ComponentGroupSegmentedTest.java
@@ -25,6 +25,7 @@ package com.codename1.ui;
 
 import com.codename1.junit.UITestBase;
 import com.codename1.ui.animations.ComponentAnimation;
+import com.codename1.ui.layouts.BoxLayout;
 import com.codename1.ui.plaf.UIManager;
 import org.junit.jupiter.api.Test;
 
@@ -564,5 +565,37 @@ class ComponentGroupSegmentedTest extends UITestBase {
                 "the segment moved to the end is styled as the end");
         assertEquals("ToggleButtonFirst", last.getUIID(),
                 "and the one now at the start is styled as the start");
+    }
+
+    @Test
+    void testDroppingAVerticalLayoutOnASegmentedGroupRestores() {
+        // setLayout is public API on Container, so orientation -- and with it activation
+        // -- can change without going through setHorizontal.
+        activateGrouping(false);
+        ComponentGroup group = new ComponentGroup();
+        group.setHorizontal(true);
+        Button b = new Button("One");
+        group.addComponent(b);
+        assertEquals("ToggleButtonOnly", b.getUIID());
+
+        group.setLayout(new BoxLayout(BoxLayout.Y_AXIS));
+
+        assertEquals("Button", b.getUIID(),
+                "a group that is no longer horizontal is no longer segmented");
+    }
+
+    @Test
+    void testDroppingAHorizontalLayoutOnAToggleGroupApplies() {
+        activateGrouping(false);
+        ComponentGroup group = new ComponentGroup();
+        Button b = new Button("One");
+        group.addComponent(b);
+        group.setElementUIID("ToggleButton");
+        assertEquals("Button", b.getUIID(), "still vertical, so still inactive");
+
+        group.setLayout(new BoxLayout(BoxLayout.X_AXIS));
+
+        assertEquals("ToggleButtonOnly", b.getUIID(),
+                "the layout is what makes this a segmented control");
     }
 }

--- a/maven/core-unittests/src/test/java/com/codename1/ui/RadioButtonTest.java
+++ b/maven/core-unittests/src/test/java/com/codename1/ui/RadioButtonTest.java
@@ -198,16 +198,19 @@ class RadioButtonTest extends UITestBase {
         // UIID back but leaves $origUIID set. Reading that marker as ownership
         // therefore kept reporting "the group has it" long after the group had
         // given it back, and the restore was skipped.
+        // Vertical on purpose: a horizontal group is a segmented control and stays
+        // active on its own, so forcing cannot be switched off underneath it. What this
+        // test is about -- the ownership marker outliving the restore -- is the same
+        // either way.
         ComponentGroup group = new ComponentGroup();
         group.setForceGroup(true);
-        group.setHorizontal(true);
         RadioButton radio = new RadioButton("Choice");
         RadioButton other = new RadioButton("Other");
         radio.setToggle(true);
         other.setToggle(true);
         group.addComponent(radio);
         group.addComponent(other);
-        assertEquals("ToggleButtonFirst", radio.getUIID());
+        assertEquals("GroupElementFirst", radio.getUIID());
 
         group.setForceGroup(false);
         group.refreshTheme(false);

--- a/native-themes/ios-modern/theme.css
+++ b/native-themes/ios-modern/theme.css
@@ -456,9 +456,9 @@ ToggleButton.disabled { color: #b0b0b5; background-color: rgba(199,197,198,0.55)
 
 /* ComponentGroup renames the edge controls of a group to <prefix>First,
    <prefix>Last or <prefix>Only, and UIManager does not fall back from those to
-   ToggleButton. iOS sets ComponentGroupBool by default, so a segmented group
-   here would otherwise lose the styling on everything except its middle
-   control. Each state is written out because cn1-derive is read at base level
+   ToggleButton. This theme does not set ComponentGroupBool -- a horizontal
+   ComponentGroup activates itself instead -- so a segmented group here would
+   otherwise lose the styling on everything except its middle control. Each state is written out because cn1-derive is read at base level
    only. */
 ToggleButtonFirst { cn1-derive: ToggleButton; }
 ToggleButtonFirst.selected { color: #1c1c1e; background-color: rgba(199,197,198,0.80); cn1-background-type: cn1-pill-border; padding: 1.1mm 2.6mm 1.1mm 2.6mm; margin: 1mm 0.4mm 1mm 0.4mm; font-family: "native:MainLight"; font-size: 2.7mm; text-align: center; cn1-derive: ToggleButton; border: 0.3mm solid var(--accent-color, #007aff); }


### PR DESCRIPTION
Answering "does `ComponentGroup` still serve a real purpose?" -- mostly no, with one exception that turned out to be broken.

## What the themes actually contain

| | `GroupElement` | `ButtonGroup` | `ToggleButton` | `ComponentGroupBool` |
|---|---|---|---|---|
| `iOS7Theme.res` (legacy) | 212 | 37 | 146 | set |
| `iOSModernTheme` | **0** | **0** | full, 4 states | **not set** |
| `AndroidMaterialTheme` | **0** | **0** | full, 4 states | **not set** |

The original purpose -- iOS 6 style grouped rows with rounded first/last corners -- is gone. Neither current native theme defines a single `GroupElement` or `ButtonGroup` rule.

What survives is the **segmented control**: `setHorizontal(true)` renames members to `ToggleButton` / `First` / `Last` / `Only`, and both themes style exactly those, in full, across all four states.

## The bug

That surviving case did not work. `updateUIIDs` is gated on `ComponentGroupBool`, neither theme sets it, so `setHorizontal(true)` renamed nothing and a segmented group painted as plain buttons on every app using a current native theme. The styling was unreachable through the API that exists to reach it.

**Turning the flag on in those themes is not the fix.** It also governs the vertical path, which flattens Labels, TextFields and Buttons onto one `GroupElement` UIID neither theme styles -- trading an inert segmented control for badly styled vertical groups. The flag stays and still governs that path.

Instead, a group that is horizontal **and still using the `ToggleButton` UIIDs `setHorizontal` installs** is active on its own. The activation is deliberately narrow: it recognises the framework's own UIIDs, not "horizontal" on its own, so an application that set its own element UIID keeps the documented theme-gated behaviour. Renaming to `ToggleButton` without consulting the theme is what `Button.setToggle` already does, ungated, so any app with toggle buttons already depends on that UIID resolving.

## Two more bugs found alongside it

- **`setForceGroup` only assigned the field.** It took effect if and only if something else later called `updateUIIDs` -- adding a component, or a theme refresh -- so on an already-populated group it did nothing, and clearing it never restored anything.
- **Leaving the horizontal state could deactivate a group**, and `updateUIIDs` only renames; it has no path back. Members kept `ToggleButton` names a vertical group no longer justified. The three copies of that restore loop are now one method.

Two false claims corrected: the comment in the iOS theme said that theme sets `ComponentGroupBool` (true of the legacy iOS themes, not of it), and the guide said the same.

## Behaviour change

`setForceGroup(false)` no longer deactivates a **horizontal** group -- it is a segmented control on its own terms now. `RadioButtonTest.testRestoreWorksAfterGroupingIsSwitchedOff` used a horizontal group to reach the restore path and now uses a vertical one; what it tests, the ownership marker outliving the restore, is unchanged.

## Verification

- **Full `core-unittests`: 6695 tests, 0 failures.** SpotBugs report regenerated from scratch: **0 findings**.
- New `ComponentGroupSegmentedTest`, 8 tests. **Probed against pre-fix code: 5 of the 8 fail**, which are the behavioural ones. The 3 that pass are the two deliberate guards (vertical still gated, custom element UIID still gated) and the characterization test for the new `setForceGroup` semantics.
- `check-cast-semantics.sh`, `check-control-characters.py`, `check-copyright-headers.sh` (4 files passed), guide structure / xrefs / missing-code-blocks / unused-images, Vale 0 alerts, LanguageTool `status: ok` `total: 0`.
- Built against a per-checkout Maven repo, not `~/.m2`.