### PR TITLE
Developer guide: two diagrams for the call management chapter

### DIFF
--- a/docs/developer-guide/Call-Management.asciidoc
+++ b/docs/developer-guide/Call-Management.asciidoc
@@ -54,6 +54,8 @@ on a device, with no error anywhere. Use `audioSessionActivated`. The Android
 port synthesizes the same callback when the connection goes active, so the one
 piece of advice is correct everywhere.
 
+image::img/call-audio-session-timing.svg[Where to start call media in the callback sequence,scaledwidth=95%]
+
 *A pushed call is already ringing.* When a call arrives as a VoIP push, iOS
 requires it to be reported to the system _before any of your code runs_ and
 kills the app when it isn't -- so native code does the reporting from a fixed
@@ -158,6 +160,8 @@ from either platform, and it's what apps that offer conferencing actually
 do.
 
 === Actions, And Why They Have To Be Answered
+
+image::img/call-action-contract.svg[How a CallAction is answered, and what an unanswered one costs,scaledwidth=90%]
 
 When the user answers on the lock screen, hangs up from the car, or taps the
 keypad, the request arrives with a `CallAction`. Both platforms require an

--- a/docs/developer-guide/Call-Management.asciidoc
+++ b/docs/developer-guide/Call-Management.asciidoc
@@ -83,7 +83,7 @@ and the user can turn the *Incoming calls* notification channel down in
 Settings. Anything below high importance files the notification in the shade
 instead of ringing, so the port treats it as it treats a revoked
 `POST_NOTIFICATIONS`: `Calls.getAvailability()` answers `NOT_PERMITTED` and
-`reportIncomingCall` is refused, rather than reporting a call that rings
+`Calls.reportIncoming` is refused, rather than reporting a call that rings
 nowhere.
 
 *Implement `providerReset`.* It means every call your app had is gone,

--- a/docs/developer-guide/img/call-action-contract.svg
+++ b/docs/developer-guide/img/call-action-contract.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="820" height="390" viewBox="0 0 820 390">
+  <rect x="0" y="0" width="820" height="390" fill="#ffffff"/>
+  <text x="410" y="24" font-family="Arial, sans-serif" font-size="14" font-weight="bold" text-anchor="middle" fill="#222222">Answering a CallAction, and why almost every app should do nothing</text>
+  <text x="410" y="43" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">Every request from the system arrives with a CallAction that has to be answered within about three seconds.</text>
+  <text x="410" y="57" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">The framework already does that for you, and the one case where you take it over is narrow.</text>
+  <rect x="16" y="74" width="788" height="40" rx="4" fill="#ffffff" stroke="#8a8a8a" stroke-width="1.5"/>
+  <text x="410" y="91" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#222222">An action arrives</text>
+  <text x="410" y="106" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#888888">answerRequested / endRequested / holdRequested / muteRequested / dtmfRequested</text>
+  <rect x="16" y="140" width="384" height="96" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1.5"/>
+  <text x="30" y="162" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" fill="#4a7a3d">You leave it alone</text>
+  <text x="30" y="178" font-family="Arial, sans-serif" font-size="9" fill="#888888">the right answer for almost every app</text>
+  <text x="30" y="198" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">It is settled the moment your callback returns. The dispatch</text>
+  <text x="30" y="213" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">settles in a finally, so a listener that throws settles it too:</text>
+  <text x="30" y="228" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">there is no way to drop one by accident.</text>
+  <path d="M 208 114 L 208 140" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
+  <path d="M 203 134 L 208 140 L 213 134" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
+  <rect x="420" y="140" width="384" height="96" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1.5"/>
+  <text x="434" y="162" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" fill="#4a6fa5">You call defer()</text>
+  <text x="434" y="178" font-family="Arial, sans-serif" font-size="9" fill="#888888">only for slow asynchronous work</text>
+  <text x="434" y="198" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">Now it is yours, and you owe it a fulfill() or a fail(). Worth it</text>
+  <text x="434" y="213" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">only when you cannot yet know whether you can comply --</text>
+  <text x="434" y="228" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">renegotiating a session, say.</text>
+  <path d="M 612 114 L 612 140" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
+  <path d="M 607 134 L 612 140 L 617 134" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
+  <rect x="420" y="254" width="384" height="58" rx="4" fill="#fbf6f6" stroke="#a33a3a" stroke-width="1.5"/>
+  <text x="434" y="274" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#a33a3a">Forget it and the safety net fails it</text>
+  <text x="434" y="292" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">Failed rather than left hanging, because a failed action puts</text>
+  <text x="434" y="306" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">the system UI back where the user can act on it.</text>
+  <path d="M 612 236 L 612 254" fill="none" stroke="#a33a3a" stroke-width="1.5"/>
+  <path d="M 607 248 L 612 254 L 617 248" fill="none" stroke="#a33a3a" stroke-width="1.5"/>
+  <rect x="16" y="330" width="788" height="44" rx="4" fill="#f7f7f9" stroke="#cccccc" stroke-width="1"/>
+  <text x="410" y="348" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#222222">All of it exists to stop one outcome: an action nobody answers times out, and the system UI and your app are</text>
+  <text x="410" y="363" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#222222">left disagreeing about the call, with nothing in the log to say so.</text>
+</svg>

--- a/docs/developer-guide/img/call-action-contract.svg
+++ b/docs/developer-guide/img/call-action-contract.svg
@@ -5,13 +5,13 @@
   <text x="410" y="57" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">The framework already does that for you, and the one case where you take it over is narrow.</text>
   <rect x="16" y="74" width="788" height="40" rx="4" fill="#ffffff" stroke="#8a8a8a" stroke-width="1.5"/>
   <text x="410" y="91" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#222222">An action arrives</text>
-  <text x="410" y="106" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#888888">answerRequested / endRequested / holdRequested / muteRequested / dtmfRequested</text>
+  <text x="410" y="106" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#888888">answerRequested / endRequested / holdRequested / muteRequested / dtmfRequested / startCallRequested</text>
   <rect x="16" y="140" width="384" height="96" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1.5"/>
   <text x="30" y="162" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" fill="#4a7a3d">You leave it alone</text>
   <text x="30" y="178" font-family="Arial, sans-serif" font-size="9" fill="#888888">the right answer for almost every app</text>
   <text x="30" y="198" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">It is settled the moment your callback returns. The dispatch</text>
-  <text x="30" y="213" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">settles in a finally, so a listener that throws settles it too:</text>
-  <text x="30" y="228" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">there is no way to drop one by accident.</text>
+  <text x="30" y="213" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">settles in a finally, so a listener that throws settles it too.</text>
+  <text x="30" y="228" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">One callback settles the other way -- see below.</text>
   <path d="M 208 114 L 208 140" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
   <path d="M 203 134 L 208 140 L 213 134" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
   <rect x="420" y="140" width="384" height="96" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1.5"/>
@@ -22,6 +22,12 @@
   <text x="434" y="228" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">renegotiating a session, say.</text>
   <path d="M 612 114 L 612 140" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
   <path d="M 607 134 L 612 140 L 617 134" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
+  <rect x="16" y="254" width="384" height="58" rx="4" fill="#fbf6f6" stroke="#a33a3a" stroke-width="1.5"/>
+  <text x="30" y="274" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#a33a3a">startCallRequested is the exception</text>
+  <text x="30" y="292" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">Left untouched it is failed rather than fulfilled, and the call</text>
+  <text x="30" y="306" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">ends. The system raises it from Recents, Contacts or an assistant.</text>
+  <path d="M 208 236 L 208 254" fill="none" stroke="#a33a3a" stroke-width="1.5"/>
+  <path d="M 203 248 L 208 254 L 213 248" fill="none" stroke="#a33a3a" stroke-width="1.5"/>
   <rect x="420" y="254" width="384" height="58" rx="4" fill="#fbf6f6" stroke="#a33a3a" stroke-width="1.5"/>
   <text x="434" y="274" font-family="Arial, sans-serif" font-size="11" font-weight="bold" fill="#a33a3a">Forget it and the safety net fails it</text>
   <text x="434" y="292" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">Failed rather than left hanging, because a failed action puts</text>

--- a/docs/developer-guide/img/call-audio-session-timing.svg
+++ b/docs/developer-guide/img/call-audio-session-timing.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="860" height="350" viewBox="0 0 860 350">
+  <rect x="0" y="0" width="860" height="350" fill="#ffffff"/>
+  <text x="430" y="24" font-family="Arial, sans-serif" font-size="14" font-weight="bold" text-anchor="middle" fill="#222222">Starting call media: the callback that looks right, and the one that is</text>
+  <text x="430" y="43" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">The chapter calls this the single most common way to get a calling app wrong, and the reason is the failure mode:</text>
+  <text x="430" y="57" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">the wrong version works in every simulator and produces a silent call on a device, with no error anywhere.</text>
+  <rect x="16" y="78" width="190" height="56" rx="4" fill="#ffffff" stroke="#8a8a8a" stroke-width="1.5"/>
+  <text x="111" y="100" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#333333">The call rings</text>
+  <text x="111" y="124" font-family="Arial, sans-serif" font-size="8.5" text-anchor="middle" fill="#888888">reportIncomingCall</text>
+  <path d="M 206 106 L 228 106" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
+  <path d="M 223 102 L 228 106 L 223 110" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
+  <rect x="228" y="78" width="190" height="56" rx="4" fill="#ffffff" stroke="#8a8a8a" stroke-width="1.5"/>
+  <text x="323" y="100" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#333333">The user answers</text>
+  <text x="323" y="124" font-family="Arial, sans-serif" font-size="8.5" text-anchor="middle" fill="#888888">answerRequested</text>
+  <path d="M 418 106 L 440 106" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
+  <path d="M 435 102 L 440 106 L 435 110" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
+  <rect x="440" y="78" width="190" height="56" rx="4" fill="#ffffff" stroke="#8a8a8a" stroke-width="1.5"/>
+  <text x="535" y="93" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#333333">The system takes</text>
+  <text x="535" y="107" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#333333">the audio session</text>
+  <text x="535" y="124" font-family="Arial, sans-serif" font-size="8.5" text-anchor="middle" fill="#888888">iOS: CallKit</text>
+  <path d="M 630 106 L 652 106" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
+  <path d="M 647 102 L 652 106 L 647 110" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
+  <rect x="652" y="78" width="190" height="56" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1.5"/>
+  <text x="747" y="100" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#4a7a3d">You are told</text>
+  <text x="747" y="124" font-family="Arial, sans-serif" font-size="8.5" text-anchor="middle" fill="#888888">audioSessionActivated</text>
+  <rect x="16" y="168" width="404" height="104" rx="4" fill="#ffffff" stroke="#a33a3a" stroke-width="1.5"/>
+  <text x="30" y="190" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" fill="#a33a3a">Starting media here is the bug</text>
+  <text x="30" y="206" font-family="Arial, sans-serif" font-size="9" fill="#888888">answerRequested</text>
+  <text x="30" y="228" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">The session is not yours yet. On iOS your app</text>
+  <text x="30" y="243" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">configures a category but must not activate it;</text>
+  <text x="30" y="258" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">CallKit does. Nothing throws, the call is silent.</text>
+  <path d="M 323 134 L 323 168" fill="none" stroke="#a33a3a" stroke-width="1.5" stroke-dasharray="5 4"/>
+  <rect x="440" y="168" width="404" height="104" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1.5"/>
+  <text x="454" y="190" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" fill="#4a7a3d">Starting media here works</text>
+  <text x="454" y="206" font-family="Arial, sans-serif" font-size="9" fill="#888888">audioSessionActivated</text>
+  <text x="454" y="228" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">The session is live and handed to you. Android</text>
+  <text x="454" y="243" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">has no CallKit, so the port fires this itself when</text>
+  <text x="454" y="258" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">the connection goes active: one rule, both ports.</text>
+  <path d="M 747 134 L 747 168" fill="none" stroke="#4a7a3d" stroke-width="1.5" stroke-dasharray="5 4"/>
+  <rect x="16" y="292" width="828" height="44" rx="4" fill="#f7f7f9" stroke="#cccccc" stroke-width="1"/>
+  <text x="430" y="310" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#222222">A pushed call is already ringing before any of your code runs, so PushedCall hands you a session you never created</text>
+  <text x="430" y="325" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#222222">and may already be answered. Attaching media to it is the same job, on the same callback.</text>
+</svg>

--- a/docs/developer-guide/img/call-audio-session-timing.svg
+++ b/docs/developer-guide/img/call-audio-session-timing.svg
@@ -5,7 +5,7 @@
   <text x="430" y="57" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">the wrong version works in every simulator and produces a silent call on a device, with no error anywhere.</text>
   <rect x="16" y="78" width="190" height="56" rx="4" fill="#ffffff" stroke="#8a8a8a" stroke-width="1.5"/>
   <text x="111" y="100" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#333333">The call rings</text>
-  <text x="111" y="124" font-family="Arial, sans-serif" font-size="8.5" text-anchor="middle" fill="#888888">reportIncomingCall</text>
+  <text x="111" y="124" font-family="Arial, sans-serif" font-size="8.5" text-anchor="middle" fill="#888888">Calls.reportIncoming</text>
   <path d="M 206 106 L 228 106" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
   <path d="M 223 102 L 228 106 L 223 110" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
   <rect x="228" y="78" width="190" height="56" rx="4" fill="#ffffff" stroke="#8a8a8a" stroke-width="1.5"/>


### PR DESCRIPTION
The Call Management chapter had **zero figures** and six tables. Both of these show *sequencing*, which is the thing a table cannot.

## `call-audio-session-timing.svg`

The chapter nominates this as the single most common way to get a calling app wrong, and what earns it a figure is the failure mode rather than the rule: starting the audio engine in `answerRequested` **works in every simulator and produces a silent call on a device, with no error anywhere**.

The figure puts the two candidate callbacks on the real order of events, so it becomes visible that the system takes the audio session *between* them — which is the whole reason one of them is too early.

Verified in the port rather than taken from the prose: `CN1Connection` fires `audioSessionActivated` as soon as the connection goes active, which is what makes a single rule correct on Android as well as iOS.

## `call-action-contract.svg`

Almost every app should do nothing with a `CallAction`, and the figure leads with that. Confirmed in `Calls`: each arm dispatches inside a `try` and calls `settle(a)` in a `finally`, so an action the listener never touches is answered — and so is one whose listener throws.

`defer()` is the narrow case, and the safety net *fails* a forgotten action rather than dropping it, because a failed action puts the system UI back into a state the user can act on. `SAFETY_MILLIS` is 3500, and the javadoc says "about three seconds", which is what the figure says.

## Verification

Every API name in both figures was read out of the source, not the chapter: `answerRequested`, `endRequested`, `holdRequested`, `muteRequested`, `dtmfRequested`, `audioSessionActivated`, `reportIncomingCall`, `defer`, `fulfill`, `fail`.

Gates, all from the repo root:

- `check-guide-structure.py` (122 documents), `check-guide-xrefs.py` (1691 anchors), `check-guide-links.py`, `check-missing-code-blocks.py` (34 known, none new), `find_unused_images.py`, `validate-guide-snippets.py` (1107 blocks)
- `asciidoctor --failure-level WARN` and `asciidoctor-pdf` — both clean, so prawn-svg renders both
- Vale at `--minAlertLevel=suggestion` — 0 alerts. It caught `it is` in one of my `image::` alt texts, so alt text is linted too
- LanguageTool under JDK 17 — `status: ok`, `total: 0`
- `check_paragraph_capitalization.rb`, `check-control-characters.py` — clean; both SVGs are pure ASCII

Both rendered with headless Chrome at declared size with the ink extent measured, which caught 78px of dead canvas below one of them. The generator measures every string against real Arial metrics.

Conventions follow the existing `certificate-wizard-*-mock.svg` precedent: presentation attributes only, no `<style>`, no `var()`, explicit width/height/viewBox, `font-family="Arial, sans-serif"`, no filters or masks.