### PR TITLE
Developer guide: two diagrams for state restoration and continuity

### DIFF
--- a/docs/developer-guide/State-Restoration-And-Continuity.asciidoc
+++ b/docs/developer-guide/State-Restoration-And-Continuity.asciidoc
@@ -81,6 +81,8 @@ most an identifier that means nothing on its own.
 
 === Saving and restoring
 
+image::img/continuity-restore-paths.svg[What restore returns for routed and hand-shown screens,scaledwidth=95%]
+
 Two pieces. A `StateProvider` supplies the half the framework can't work out --
 the scroll position, the half-typed message, the record being edited -- and
 installing one turns the framework on:
@@ -126,6 +128,8 @@ include::../demos/common/src/main/java/com/codenameone/developerguide/continuity
 ----
 
 === Continuing on another device
+
+image::img/continuity-payload-journey.svg[Where a continuity payload travels and what it may carry,scaledwidth=95%]
 
 Nothing extra is required for the Apple case. Every checkpoint advertises the
 current state, and a device the user is holding is offered it by the system. What

--- a/docs/developer-guide/img/continuity-payload-journey.svg
+++ b/docs/developer-guide/img/continuity-payload-journey.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="840" height="352" viewBox="0 0 840 352">
+  <rect x="0" y="0" width="840" height="352" fill="#ffffff"/>
+  <text x="420" y="24" font-family="Arial, sans-serif" font-size="14" font-weight="bold" text-anchor="middle" fill="#222222">Where a continuity payload goes, and why that decides what may go in it</text>
+  <text x="420" y="43" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">The type rule looks arbitrary until you follow the journey. A payload is written to disk, handed to an operating</text>
+  <text x="420" y="57" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">system, and possibly opened by a different build of your app on a device you have never seen.</text>
+  <rect x="16" y="74" width="188" height="58" rx="4" fill="#ffffff" stroke="#4a6fa5" stroke-width="1.5"/>
+  <text x="110" y="98" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#4a6fa5">Your app</text>
+  <text x="110" y="115" font-family="Arial, sans-serif" font-size="8.5" text-anchor="middle" fill="#888888">builds an AppState</text>
+  <path d="M 204 103 L 222 103" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
+  <path d="M 217 99 L 222 103 L 217 107" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
+  <rect x="222" y="74" width="188" height="58" rx="4" fill="#ffffff" stroke="#8a8a8a" stroke-width="1.5"/>
+  <text x="316" y="98" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#333333">Written to disk</text>
+  <text x="316" y="115" font-family="Arial, sans-serif" font-size="8.5" text-anchor="middle" fill="#888888">on this device</text>
+  <path d="M 410 103 L 428 103" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
+  <path d="M 423 99 L 428 103 L 423 107" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
+  <rect x="428" y="74" width="188" height="58" rx="4" fill="#ffffff" stroke="#8a8a8a" stroke-width="1.5"/>
+  <text x="522" y="98" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#333333">Carried</text>
+  <text x="522" y="115" font-family="Arial, sans-serif" font-size="8.5" text-anchor="middle" fill="#888888">the OS, or your StateRelay</text>
+  <path d="M 616 103 L 634 103" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
+  <path d="M 629 99 L 634 103 L 629 107" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
+  <rect x="634" y="74" width="188" height="58" rx="4" fill="#ffffff" stroke="#8a8a8a" stroke-width="1.5"/>
+  <text x="728" y="98" font-family="Arial, sans-serif" font-size="11" font-weight="bold" text-anchor="middle" fill="#333333">Opened</text>
+  <text x="728" y="115" font-family="Arial, sans-serif" font-size="8.5" text-anchor="middle" fill="#888888">another build, another device</text>
+  <rect x="16" y="148" width="394" height="112" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1.5"/>
+  <text x="30" y="170" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" fill="#4a7a3d">What a payload admits</text>
+  <text x="30" y="186" font-family="Arial, sans-serif" font-size="9" fill="#888888">String, Integer, Long, Double, Boolean, List, Map</text>
+  <text x="30" y="204" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">Six types and the two containers, because everything</text>
+  <text x="30" y="218" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">above has to survive a round trip through JSON and a</text>
+  <text x="30" y="232" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">build that may not have your classes. Anything else is</text>
+  <text x="30" y="246" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">refused where you produced it, naming the key.</text>
+  <rect x="430" y="148" width="394" height="112" rx="4" fill="#fbf6f6" stroke="#a33a3a" stroke-width="1.5"/>
+  <text x="444" y="170" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" fill="#a33a3a">What does not belong in one</text>
+  <text x="444" y="186" font-family="Arial, sans-serif" font-size="9" fill="#888888">a continuation is not secure storage</text>
+  <text x="444" y="204" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">The payload crosses to another device and the operating</text>
+  <text x="444" y="218" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">system holds it on the way. Tokens and keys go in</text>
+  <text x="444" y="232" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">SecureStorage; the payload carries at most an identifier</text>
+  <text x="444" y="246" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">that means nothing on its own.</text>
+  <rect x="16" y="278" width="808" height="58" rx="4" fill="#f7f7f9" stroke="#cccccc" stroke-width="1"/>
+  <text x="420" y="298" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#222222">Codename One runs no relay server. Continuation between Apple devices is the platform's; iPhone to Android, or two</text>
+  <text x="420" y="313" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#222222">devices never in the same room, goes through a StateRelay you host. Which saved states belong to the same person is</text>
+  <text x="420" y="328" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#222222">your account system's question, and a framework answering it would be guessing about your users.</text>
+</svg>

--- a/docs/developer-guide/img/continuity-restore-paths.svg
+++ b/docs/developer-guide/img/continuity-restore-paths.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="840" height="332" viewBox="0 0 840 332">
+  <rect x="0" y="0" width="840" height="332" fill="#ffffff"/>
+  <text x="420" y="24" font-family="Arial, sans-serif" font-size="14" font-weight="bold" text-anchor="middle" fill="#222222">What Continuity.restore() gives you, and what stays yours</text>
+  <text x="420" y="43" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">Nothing here runs on its own. An app that never calls enable or setStateProvider behaves as it always did, and</text>
+  <text x="420" y="57" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">restore() is never called for you: where restoration belongs in a launch is the one thing only the app knows.</text>
+  <rect x="16" y="74" width="808" height="44" rx="4" fill="#ffffff" stroke="#8a8a8a" stroke-width="1.5"/>
+  <text x="420" y="93" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#222222">You call Continuity.restore() somewhere in your launch</text>
+  <text x="420" y="108" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#888888">there is a saved state, and it is still within maxAge</text>
+  <rect x="16" y="136" width="394" height="118" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1.5"/>
+  <text x="30" y="158" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" fill="#4a7a3d">Your screens use @Route</text>
+  <text x="30" y="174" font-family="Arial, sans-serif" font-size="9" fill="#888888">restore() answers true</text>
+  <text x="30" y="194" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">The framework already wrote the navigation stack down,</text>
+  <text x="30" y="209" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">because it addresses screens by route. It rebuilds the</text>
+  <text x="30" y="224" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">stack and shows it. Show nothing yourself: true means a</text>
+  <text x="30" y="239" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">form is already up.</text>
+  <path d="M 213 118 L 213 136" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
+  <path d="M 208 130 L 213 136 L 218 130" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
+  <rect x="430" y="136" width="394" height="118" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1.5"/>
+  <text x="444" y="158" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" fill="#a56a3a">Your screens use new MyForm().show()</text>
+  <text x="444" y="174" font-family="Arial, sans-serif" font-size="9" fill="#888888">restore() answers false</text>
+  <text x="444" y="194" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">Those moves are not addressable, so there was never a</text>
+  <text x="444" y="209" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">stack to write down. Your payload still arrives, handed</text>
+  <text x="444" y="224" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">to the StateProvider, and showing a screen from it is</text>
+  <text x="444" y="239" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">yours. Both are supported; one is automatic.</text>
+  <path d="M 627 118 L 627 136" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
+  <path d="M 622 130 L 627 136 L 632 130" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
+  <rect x="16" y="272" width="808" height="44" rx="4" fill="#f7f7f9" stroke="#cccccc" stroke-width="1"/>
+  <text x="420" y="290" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#222222">Saving is not something you do on the way out. Every navigation marks the state dirty and a checkpoint is written</text>
+  <text x="420" y="305" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#222222">once per pass of the event loop, so call checkpoint() only for a change no navigation touched.</text>
+</svg>


### PR DESCRIPTION
The State Restoration and Continuity chapter had **six tables and zero figures**. Both of these carry sequencing and consequence, which is what the tables cannot.

## `continuity-restore-paths.svg`

Splits on the one question the prose states but a reader skims past. Screens declared with `@Route` are addressable, so the framework already wrote the navigation stack down: `restore()` rebuilds it and answers **true**. Screens shown with `new MyForm().show()` are not addressable, so there was never a stack to write down: the payload still arrives at the `StateProvider` and `restore()` answers **false**.

That return value is the part worth drawing — showing a form yourself when it answered true gives the user two.

The footer carries the other thing the chapter says once: saving is continuous, not something you do on the way out, so `checkpoint()` is only for a change no navigation touched.

## `continuity-payload-journey.svg`

Makes the type rule follow from the journey instead of looking arbitrary. The payload is written to disk, carried by an operating system or your own `StateRelay`, and opened by a build that may not have your classes — which is exactly why it admits six types and two containers, and refuses anything else *where you produced it*, naming the key.

The same journey is why a token does not belong in one, and why Codename One runs no relay server: deciding which saved states belong to the same person is an account-system question.

## Verification

Every API name was read out of the source, not the chapter: `Continuity.enable`, `setStateProvider`, `restore`, `checkpoint`, `setRelay`, `maxAge`, `AppState`, `StateProvider`, `StateRelay`, and the accepted type set from `StateCodec`.

- `check-guide-structure.py` (122 documents), `check-guide-xrefs.py` (1691 anchors), `check-guide-links.py`, `check-missing-code-blocks.py` (34 known, none new), `find_unused_images.py`, `validate-guide-snippets.py` (1107 blocks)
- `asciidoctor --failure-level WARN` and `asciidoctor-pdf` — both clean
- Vale at `--minAlertLevel=suggestion` — 0 alerts; LanguageTool under JDK 17 — `status: ok`, `total: 0`
- `check_paragraph_capitalization.rb`, `check-control-characters.py` — clean; both SVGs pure ASCII

Rendered with headless Chrome at declared size. I also added a box-overflow check to the generator this round — the ink-extent check catches text running off the *canvas* but not text running past its own *box*, which it was doing in both figures before the heights were corrected.