### PR TITLE
Developer guide: a diagram for the one sharp edge inside a desktop Window

### DIFF
--- a/docs/developer-guide/Desktop-Windows.asciidoc
+++ b/docs/developer-guide/Desktop-Windows.asciidoc
@@ -92,6 +92,8 @@ anything for a desktop window, whose title and menus belong to the platform chro
 
 ==== getComponentForm() returns null inside a Window
 
+image::img/desktop-window-component-form.svg[Why a component can stop working inside a Window,scaledwidth=95%]
+
 This is the one behavioral sharp edge, and it's worth stating plainly:
 
 [source,java]

--- a/docs/developer-guide/img/desktop-window-component-form.svg
+++ b/docs/developer-guide/img/desktop-window-component-form.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="880" height="366" viewBox="0 0 880 366">
+  <rect x="0" y="0" width="880" height="366" fill="#ffffff"/>
+  <text x="440" y="24" font-family="Arial, sans-serif" font-size="14" font-weight="bold" text-anchor="middle" fill="#222222">Why a component can go quiet inside a desktop Window</text>
+  <text x="440" y="43" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">getComponentForm() names the enclosing Form, and inside a Window the honest answer is none. The chapter calls this</text>
+  <text x="440" y="57" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#333333">the one behavioural sharp edge, and what makes it sharp is that almost nothing throws when it happens.</text>
+  <rect x="16" y="74" width="848" height="46" rx="4" fill="#ffffff" stroke="#8a8a8a" stroke-width="1.5"/>
+  <text x="440" y="94" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#222222">A component asks who it belongs to</text>
+  <text x="440" y="110" font-family="Arial, sans-serif" font-size="9" text-anchor="middle" fill="#888888">the same component, in a Form and in a Window</text>
+  <rect x="16" y="138" width="414" height="134" rx="4" fill="#fbf6f6" stroke="#a33a3a" stroke-width="1.5"/>
+  <text x="30" y="160" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" fill="#a33a3a">getComponentForm()</text>
+  <text x="30" y="176" font-family="Arial, sans-serif" font-size="9" fill="#888888">null inside a Window</text>
+  <text x="30" y="196" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">Most callers are written as</text>
+  <text x="30" y="211" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">Form f = getComponentForm();</text>
+  <text x="30" y="226" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">if (f != null) { ... }</text>
+  <text x="30" y="241" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">so the work is skipped and nothing throws. That is why</text>
+  <text x="30" y="256" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">the symptom is silence.</text>
+  <path d="M 223 120 L 223 138" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
+  <path d="M 218 132 L 223 138 L 228 132" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
+  <rect x="450" y="138" width="414" height="134" rx="4" fill="#ffffff" stroke="#4a7a3d" stroke-width="1.5"/>
+  <text x="464" y="160" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" fill="#4a7a3d">getTopLevelContainer()</text>
+  <text x="464" y="176" font-family="Arial, sans-serif" font-size="9" fill="#888888">the Form, or the Window</text>
+  <text x="464" y="196" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">What Codename One's own components ask, which is why</text>
+  <text x="464" y="211" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">the framework works inside a Window. A third-party</text>
+  <text x="464" y="226" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">component works there once it asks this too.</text>
+  <text x="464" y="241" font-family="Arial, sans-serif" font-size="10.5" fill="#333333"></text>
+  <path d="M 657 120 L 657 138" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
+  <path d="M 652 132 L 657 138 L 662 132" fill="none" stroke="#bbbbbb" stroke-width="1.5"/>
+  <rect x="16" y="290" width="848" height="60" rx="4" fill="#f7f7f9" stroke="#cccccc" stroke-width="1"/>
+  <text x="440" y="310" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#222222">So the thing to look for is behaviour that stopped rather than an exception. A component placed in a Window that</text>
+  <text x="440" y="325" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#222222">will not scroll, will not take focus, or will not animate is almost always calling getComponentForm somewhere</text>
+  <text x="440" y="340" font-family="Arial, sans-serif" font-size="10.5" text-anchor="middle" fill="#222222">and quietly deciding it is detached.</text>
+</svg>


### PR DESCRIPTION
The Desktop Windows chapter is 563 lines with no figures. This draws the thing the chapter itself calls **the one behavioural sharp edge**.

## Why it needs a picture

`getComponentForm()` walks up through `getParent()`, so inside a `Window` there is no `Form` to reach and the honest answer is `null`. The problem is not the null — it is the shape almost every caller is written in:

```java
Form f = getComponentForm();
if (f != null) { ... }
```

That turns the null into **work that simply does not happen**. Nothing throws, nothing logs, and the component just goes quiet.

The figure puts the two accessors side by side because the fix is the contrast rather than either one alone: Codename One's own components ask `getTopLevelContainer()`, which answers with the `Form` *or* the `Window`, and a third-party component starts working inside a `Window` once it asks the same question.

The footer carries the symptom a reader actually arrives with — something that will not scroll, will not take focus, or will not animate, with no exception to explain it.

## Verification

`Component.getComponentForm()` read at the source: it recurses through `getParent()` and returns null when nothing above it is a `Form`. `getTopLevelContainer()` is documented there as returning the `Form` filling the main surface or the `Window` of a native desktop window.

- guide structure (122 documents), xrefs (1691 anchors), links, missing-code-blocks (34 known, none new), unused images, snippets (1107 blocks) — all clean
- `asciidoctor --failure-level WARN` and `asciidoctor-pdf` — clean
- Vale 0 alerts; LanguageTool `status: ok`, `total: 0`
- capitalization and control characters clean; SVG pure ASCII
- headless Chrome render, ink-extent and box-overflow both checked (the latter caught a line past the box border before this went up)