### PR TITLE
Developer guide: correct the redirect ordering in the App Shield figure

### DIFF
--- a/docs/developer-guide/App-Shield.asciidoc
+++ b/docs/developer-guide/App-Shield.asciidoc
@@ -120,7 +120,7 @@ image::img/app-shield-request-path.svg[The order the shield works through a requ
 Once `init()` has run, `ConnectionRequest`, `Rest`, `RequestBuilder` and anything else built on `NetworkManager` are covered without further code. For a request to a protected host, on the network thread:
 
 * It waits for initialization to finish if a cold start is still in progress, rather than treating "not ready yet" as "not protected."
-* Any token the shield attached earlier is taken back off before the request is reused -- a redirect reuses the same request object, and a bearer token that follows a redirect off a protected host has been handed to whoever the redirect points at. A header your own `onRedirect()` installed under the same name is left alone: the shield removes its token only while the value is still the token it attached.
+* Any token the shield attached earlier is taken back off before the redirected request is sent -- a redirect reuses the same request object, and a bearer token that follows a redirect off a protected host has been handed to whoever the redirect points at. A header your own `onRedirect()` installed under the same name is left alone: the shield removes its token only while the value is still the token it attached.
 * The token is added under the token header, unless the URL isn't `https`, in which case the host's failure mode decides.
 * The certificate chain is collected and checked against the pin set, before any request body is written.
 

--- a/docs/developer-guide/img/app-shield-request-path.svg
+++ b/docs/developer-guide/img/app-shield-request-path.svg
@@ -13,10 +13,10 @@
   <circle cx="32" cy="184" r="13" fill="#ffffff" stroke="#a33a3a" stroke-width="1.5"/>
   <text x="32" y="188" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#a33a3a">2</text>
   <text x="66" y="161" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" fill="#a33a3a">Take back a token it attached earlier</text>
-  <text x="326" y="161" font-family="Arial, sans-serif" font-size="9" fill="#888888">before the request object is reused</text>
+  <text x="326" y="161" font-family="Arial, sans-serif" font-size="9" fill="#888888">before the redirected request is sent</text>
   <text x="66" y="179" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">A redirect reuses the same request, and a bearer token that follows one off a protected host has</text>
-  <text x="66" y="194" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">been handed to whoever the redirect points at. Only the shield's own value is removed -- a header</text>
-  <text x="66" y="209" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">your onRedirect installed under the same name is left alone.</text>
+  <text x="66" y="194" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">been handed to whoever the redirect points at. Your onRedirect has already run by now, which is</text>
+  <text x="66" y="209" font-family="Arial, sans-serif" font-size="10.5" fill="#333333">why a header it installed under the same name survives: only the shield's own value is removed.</text>
   <rect x="54" y="238" width="810" height="72" rx="4" fill="#ffffff" stroke="#a56a3a" stroke-width="1.5"/>
   <circle cx="32" cy="274" r="13" fill="#ffffff" stroke="#a56a3a" stroke-width="1.5"/>
   <text x="32" y="278" font-family="Arial, sans-serif" font-size="11.5" font-weight="bold" text-anchor="middle" fill="#a56a3a">3</text>


### PR DESCRIPTION
Follow-up to #5796. A review comment landed on that PR and it merged before I addressed it — my fault for not keeping a watch on it.

The finding is correct, and it matters because the figure exists to document **ordering**.

## What was wrong

The step-2 caption said the shield takes its token back *"before the request object is reused"*. The actual sequence is the reverse:

- `ConnectionRequest` calls `onRedirect(url)` (line 1324) and then `retry()` (1326)
- only the retry reaches `AppShield.attach()` and `clearAttachedHeaders()` (`AppShield.java:438`)

So the request object has already been reused and potentially reconfigured by the time the cleanup runs. The cleanup happens before the redirected request is **sent**.

## Why this improves the figure rather than just correcting it

That ordering is the *explanation* for the sentence underneath it. The body now draws the connection instead of leaving two facts adjacent: the application's `onRedirect` has already run, which is precisely why a header it installed under the same name survives a cleanup that only removes the shield's own value.

## Verification

`ConnectionRequest.java:1324-1326` and `AppShield.java:438` read directly. Figure re-rendered; `asciidoctor` and `asciidoctor-pdf` clean, control characters clean, unused-image check clean.